### PR TITLE
Add missing rows.Err() check in EnsureParticipantsBatch

### DIFF
--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -325,6 +325,9 @@ func (s *Store) EnsureParticipantsBatch(addresses []mime.Address) (map[string]in
 			result[email] = id
 		}
 		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
Go best practices: also matches the pattern used in MessageExistsBatch 20 lines above. 