### PR TITLE
Fixed path traversal bug

### DIFF
--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -336,8 +336,9 @@ func TestExportAttachments_PartialSuccess(t *testing.T) {
 	// TODO: ExportAttachments should write to a configurable output directory.
 	t.Cleanup(func() { os.Remove("Test_1.zip") })
 
-	// Create a valid attachment file
-	validHash := "abc123def456ghi789"
+	// Create a valid attachment file (must be valid 64-char hex SHA-256 hash)
+	validHash := "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	missingHash := "def456abc123def456abc123def456abc123def456abc123def456abc123def4"
 	attachmentsDir := filepath.Join(env.Dir, "attachments")
 	hashDir := filepath.Join(attachmentsDir, validHash[:2])
 	if err := os.MkdirAll(hashDir, 0o755); err != nil {
@@ -352,7 +353,7 @@ func TestExportAttachments_PartialSuccess(t *testing.T) {
 		Subject: "Test",
 		Attachments: []query.AttachmentInfo{
 			{ID: 1, Filename: "valid.pdf", ContentHash: validHash},
-			{ID: 2, Filename: "missing.pdf", ContentHash: "nonexistent12345"},
+			{ID: 2, Filename: "missing.pdf", ContentHash: missingHash},
 		},
 	}
 	selection := map[int]bool{0: true, 1: true}
@@ -387,8 +388,8 @@ func TestExportAttachments_FullSuccess(t *testing.T) {
 	// TODO: ExportAttachments should write to a configurable output directory.
 	t.Cleanup(func() { os.Remove("Test_1.zip") })
 
-	// Create a valid attachment file
-	validHash := "abc123def456ghi789"
+	// Create a valid attachment file (must be valid 64-char hex SHA-256 hash)
+	validHash := "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
 	attachmentsDir := filepath.Join(env.Dir, "attachments")
 	hashDir := filepath.Join(attachmentsDir, validHash[:2])
 	if err := os.MkdirAll(hashDir, 0o755); err != nil {


### PR DESCRIPTION
  Vulnerability Fixed: Path traversal in attachment export (internal/export/attachments.go:118)

  Changes made:

  1. Added ValidateContentHash() function (internal/export/attachments.go:22-36) - Validates that content hashes are exactly 64 hexadecimal characters (valid SHA-256 hash format). This prevents path traversal attacks like ../../../etc/passwd.
  2. Updated Attachments() function to use the new validation instead of the minimal len < 2 check.
  3. Added two new tests:
    - TestPathTraversalInContentHash - Demonstrates the attack is blocked
    - TestContentHashValidation - Table-driven tests covering valid hashes, path traversal sequences, slashes, backslashes, wrong lengths, non-hex chars, and null bytes
  4. Updated existing tests to use valid 64-char hex hashes in both internal/export/attachments_test.go and internal/tui/actions_test.go.