### PR TITLE
Bug mime date parse

### DIFF
--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -275,7 +275,9 @@ func parseDate(s string) (time.Time, error) {
 	if baseStr != s {
 		for _, format := range dateFormats {
 			if t, err := time.Parse(format, s); err == nil {
-				return toUTC(t, numericOffset), nil
+				// Recompute numericOffset for the original string since it may
+				// have a different offset than baseStr (e.g., "+0700 (UTC)")
+				return toUTC(t, hasNumericOffset(s)), nil
 			}
 		}
 	}


### PR DESCRIPTION
The original problem was a failing test, described as:

> This commit fixes a bug in MIME date parsing related to named timezones (like "MST"). The issue is that Go's `time.Parse` handles named timezone abbreviations inconsistently across platforms - on some systems the offset is known, on others it's not. The fix detects whether a date string contains a numeric offset (e.g., `+0700`, `-05:00`) or `Z` (UTC), and handles conversion differently:

However, the fix needed an additional fix:

> When parseDate falls back to parsing the original string (with parenthesized timezone), it was using the numericOffset computed from baseStr instead of the original string. This caused incorrect UTC conversion for dates like "Mon, 02 Jan 2006 15:04:05 +0700 (UTC)" where the baseStr has no offset but the original string does.
