### PR TITLE
  Fix missing bounds check in MCP handlers

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -151,6 +151,10 @@ func (h *handlers) getAttachment(ctx context.Context, req mcp.CallToolRequest) (
 		return mcp.NewToolResultError("attachments directory not configured"), nil
 	}
 
+	if att.Size > maxAttachmentSize {
+		return mcp.NewToolResultError(fmt.Sprintf("attachment too large: %d bytes (max %d)", att.Size, maxAttachmentSize)), nil
+	}
+
 	data, err := h.readAttachmentFile(att.ContentHash)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -211,6 +215,10 @@ func (h *handlers) exportAttachment(ctx context.Context, req mcp.CallToolRequest
 
 	if h.attachmentsDir == "" {
 		return mcp.NewToolResultError("attachments directory not configured"), nil
+	}
+
+	if att.Size > maxAttachmentSize {
+		return mcp.NewToolResultError(fmt.Sprintf("attachment too large: %d bytes (max %d)", att.Size, maxAttachmentSize)), nil
 	}
 
 	data, err := h.readAttachmentFile(att.ContentHash)


### PR DESCRIPTION
  The getAttachment and exportAttachment MCP handlers had att.Size (database metadata) available but never checked it against maxAttachmentSize before calling readAttachmentFile. This meant:
  - Unnecessary file I/O (open + stat) for attachments already known to be too large
  - Misleading error messages ("file not available" instead of "too large")
  - If the file existed, the full stat + LimitReader pipeline would execute before rejecting

  The Fix (2 lines of logic, added to 2 call sites)

  Added a pre-flight att.Size > maxAttachmentSize check in both getAttachment (line 153) and exportAttachment (line 219), immediately after confirming the attachments directory is configured and before any file I/O.

  Changes Made

  - internal/mcp/handlers.go: Added pre-flight size check in both handlers (2x 3 lines)
  - internal/mcp/server_test.go: Added TestGetAttachment_RejectsOversizedBeforeFileIO and TestExportAttachment_RejectsOversizedBeforeFileIO (44 lines)