### PR TITLE
Strip surrounding quotes from CLI paths for Windows CMD

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -244,7 +245,9 @@ func expandPath(path string) string {
 		return path
 	}
 	// Strip surrounding quotes left by Windows CMD (e.g. --home 'C:\Users\foo').
-	if len(path) >= 2 &&
+	// Only on Windows — Unix shells strip quotes before the process sees them,
+	// and literal quote characters in Unix paths are valid (if unusual).
+	if runtime.GOOS == "windows" && len(path) >= 2 &&
 		((path[0] == '\'' && path[len(path)-1] == '\'') ||
 			(path[0] == '"' && path[len(path)-1] == '"')) {
 		path = path[1 : len(path)-1]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,10 +15,11 @@ func TestExpandPath(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		input    string
-		expected string
-		unixOnly bool // skip on Windows (uses Unix-style absolute paths)
+		name        string
+		input       string
+		expected    string
+		unixOnly    bool // skip on Windows (uses Unix-style absolute paths)
+		windowsOnly bool // skip on non-Windows (quote stripping is Windows-only)
 	}{
 		{
 			name:     "empty string",
@@ -51,19 +52,22 @@ func TestExpandPath(t *testing.T) {
 			expected: filepath.Join(home, "foo"),
 		},
 		{
-			name:     "single-quoted path (Windows CMD)",
-			input:    `'C:\Users\wesmc\testing'`,
-			expected: `C:\Users\wesmc\testing`,
+			name:        "single-quoted path (Windows CMD)",
+			input:       `'C:\Users\wesmc\testing'`,
+			expected:    `C:\Users\wesmc\testing`,
+			windowsOnly: true,
 		},
 		{
-			name:     "double-quoted path (Windows CMD)",
-			input:    `"C:\Users\wesmc\testing"`,
-			expected: `C:\Users\wesmc\testing`,
+			name:        "double-quoted path (Windows CMD)",
+			input:       `"C:\Users\wesmc\testing"`,
+			expected:    `C:\Users\wesmc\testing`,
+			windowsOnly: true,
 		},
 		{
-			name:     "single-quoted tilde path",
-			input:    "'~/custom-data'",
-			expected: filepath.Join(home, "custom-data"),
+			name:        "single-quoted tilde path",
+			input:       "'~/custom-data'",
+			expected:    filepath.Join(home, "custom-data"),
+			windowsOnly: true,
 		},
 		{
 			name:     "mismatched quotes not stripped",
@@ -103,6 +107,9 @@ func TestExpandPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.unixOnly && runtime.GOOS == "windows" {
 				t.Skip("skipping Unix-specific path test on Windows")
+			}
+			if tt.windowsOnly && runtime.GOOS != "windows" {
+				t.Skip("skipping Windows-specific path test on non-Windows")
 			}
 			got := expandPath(tt.input)
 			if got != tt.expected {


### PR DESCRIPTION
## Summary

Fixes #86

- Windows CMD does not strip single quotes from arguments, so `--home 'C:\Users\foo'` passes the literal value `'C:\Users\foo'` (quotes included), producing broken paths like `'C:\Users\foo'\config.toml`
- `expandPath()` now strips matching surrounding single or double quotes before processing, covering `--home`, `--config`, and `MSGVAULT_HOME` paths

## Test plan

- [x] `TestExpandPath` — new cases for single-quoted, double-quoted, mismatched, and single-char inputs
- [x] `make lint` — clean
- [x] `make test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)