### PR TITLE
fix: suggest repair-encoding when invalid string encoding is encountered

### DIFF
--- a/cmd/msgvault/cmd/list_domains.go
+++ b/cmd/msgvault/cmd/list_domains.go
@@ -40,7 +40,7 @@ Examples:
 		// Execute aggregation
 		results, err := engine.Aggregate(cmd.Context(), query.ViewDomains, opts)
 		if err != nil {
-			return fmt.Errorf("aggregate by domain: %w", err)
+			return query.HintRepairEncoding(fmt.Errorf("aggregate by domain: %w", err))
 		}
 
 		if len(results) == 0 {

--- a/cmd/msgvault/cmd/list_labels.go
+++ b/cmd/msgvault/cmd/list_labels.go
@@ -40,7 +40,7 @@ Examples:
 		// Execute aggregation
 		results, err := engine.Aggregate(cmd.Context(), query.ViewLabels, opts)
 		if err != nil {
-			return fmt.Errorf("aggregate by label: %w", err)
+			return query.HintRepairEncoding(fmt.Errorf("aggregate by label: %w", err))
 		}
 
 		if len(results) == 0 {

--- a/cmd/msgvault/cmd/list_senders.go
+++ b/cmd/msgvault/cmd/list_senders.go
@@ -40,7 +40,7 @@ Examples:
 		// Execute aggregation
 		results, err := engine.Aggregate(cmd.Context(), query.ViewSenders, opts)
 		if err != nil {
-			return fmt.Errorf("aggregate by sender: %w", err)
+			return query.HintRepairEncoding(fmt.Errorf("aggregate by sender: %w", err))
 		}
 
 		if len(results) == 0 {

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -81,7 +81,7 @@ Examples:
 		results, err := engine.Search(cmd.Context(), q, searchLimit, searchOffset)
 		fmt.Fprintf(os.Stderr, "\r            \r")
 		if err != nil {
-			return fmt.Errorf("search: %w", err)
+			return query.HintRepairEncoding(fmt.Errorf("search: %w", err))
 		}
 
 		if len(results) == 0 {

--- a/internal/query/encoding_hint.go
+++ b/internal/query/encoding_hint.go
@@ -1,0 +1,26 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+// encodingErrorSubstring is the error text emitted by DuckDB when it encounters
+// invalid UTF-8 in a Parquet file.
+const encodingErrorSubstring = "Invalid string encoding found in Parquet file"
+
+// IsEncodingError reports whether err contains the DuckDB invalid-string-encoding
+// error that can be resolved by running `msgvault repair-encoding`.
+func IsEncodingError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), encodingErrorSubstring)
+}
+
+// HintRepairEncoding wraps err with a user-facing hint suggesting
+// `msgvault repair-encoding` when the error is an encoding error.
+// If err is nil or unrelated, it is returned unchanged.
+func HintRepairEncoding(err error) error {
+	if !IsEncodingError(err) {
+		return err
+	}
+	return fmt.Errorf("%w\nHint: try running 'msgvault repair-encoding' to fix encoding issues", err)
+}

--- a/internal/query/encoding_hint_test.go
+++ b/internal/query/encoding_hint_test.go
@@ -1,0 +1,83 @@
+package query
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsEncodingError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"unrelated error", errors.New("connection refused"), false},
+		{"encoding error", errors.New("Invalid string encoding found in Parquet file"), true},
+		{"wrapped encoding error", fmt.Errorf("aggregate query: %w", errors.New("Invalid string encoding found in Parquet file")), true},
+		{"encoding error substring", errors.New("scan: Invalid string encoding found in Parquet file foo.parquet"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEncodingError(tt.err); got != tt.want {
+				t.Errorf("IsEncodingError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHintRepairEncoding(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		if got := HintRepairEncoding(nil); got != nil {
+			t.Errorf("HintRepairEncoding(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("unrelated error passes through", func(t *testing.T) {
+		orig := errors.New("something else")
+		got := HintRepairEncoding(orig)
+		if got != orig {
+			t.Errorf("HintRepairEncoding should return original error unchanged, got %v", got)
+		}
+	})
+
+	t.Run("encoding error gets hint", func(t *testing.T) {
+		orig := errors.New("Invalid string encoding found in Parquet file")
+		got := HintRepairEncoding(orig)
+		if got == nil {
+			t.Fatal("HintRepairEncoding returned nil")
+		}
+		msg := got.Error()
+		if want := "repair-encoding"; !containsSubstring(msg, want) {
+			t.Errorf("expected hint containing %q, got: %s", want, msg)
+		}
+		// Original error should be preserved in the chain
+		if !errors.Is(got, orig) {
+			t.Error("wrapped error should preserve original via errors.Is")
+		}
+	})
+
+	t.Run("wrapped encoding error gets hint", func(t *testing.T) {
+		inner := errors.New("Invalid string encoding found in Parquet file")
+		wrapped := fmt.Errorf("aggregate query: %w", inner)
+		got := HintRepairEncoding(wrapped)
+		msg := got.Error()
+		if want := "repair-encoding"; !containsSubstring(msg, want) {
+			t.Errorf("expected hint containing %q, got: %s", want, msg)
+		}
+	})
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && contains(s, sub))
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -767,7 +767,7 @@ func (m Model) handleDataLoaded(msg dataLoadedMsg) (tea.Model, tea.Cmd) {
 	m.loading = false
 	m.inlineSearchLoading = false
 	if msg.err != nil {
-		m.err = msg.err
+		m.err = query.HintRepairEncoding(msg.err)
 		m.restorePosition = false // Clear flag on error to prevent stale state
 		return m, nil
 	}
@@ -845,7 +845,7 @@ func (m Model) handleMessagesLoaded(msg messagesLoadedMsg) (tea.Model, tea.Cmd) 
 	m.inlineSearchLoading = false
 	m.msgListLoadingMore = false
 	if msg.err != nil {
-		m.err = msg.err
+		m.err = query.HintRepairEncoding(msg.err)
 		m.restorePosition = false // Clear flag on error to prevent stale state
 	} else {
 		m.err = nil // Clear any previous error
@@ -881,7 +881,7 @@ func (m Model) handleMessageDetailLoaded(msg messageDetailLoadedMsg) (tea.Model,
 	m.transitionBuffer = "" // Unfreeze view now that data is ready
 	m.loading = false
 	if msg.err != nil {
-		m.err = msg.err
+		m.err = query.HintRepairEncoding(msg.err)
 	} else {
 		m.err = nil // Clear any previous error
 		m.messageDetail = msg.detail
@@ -901,7 +901,7 @@ func (m Model) handleThreadMessagesLoaded(msg threadMessagesLoadedMsg) (tea.Mode
 	m.transitionBuffer = "" // Unfreeze view now that data is ready
 	m.loading = false
 	if msg.err != nil {
-		m.err = msg.err
+		m.err = query.HintRepairEncoding(msg.err)
 	} else {
 		m.err = nil
 		m.threadMessages = msg.messages
@@ -925,7 +925,7 @@ func (m Model) handleSearchResults(msg searchResultsMsg) (tea.Model, tea.Cmd) {
 	m.inlineSearchLoading = false
 	m.searchLoadingMore = false
 	if msg.err != nil {
-		m.err = msg.err
+		m.err = query.HintRepairEncoding(msg.err)
 		return m, nil
 	}
 


### PR DESCRIPTION
## Summary

When users encounter an `Invalid string encoding found in Parquet file` error in the TUI or CLI commands, they currently see an opaque error with no guidance on how to fix it. This PR adds a user-friendly hint suggesting `msgvault repair-encoding` whenever this specific error is detected.

Closes #95

## Changes

- **`internal/query/encoding_hint.go`**: New helper functions `IsEncodingError()` and `HintRepairEncoding()` that detect the DuckDB encoding error string and wrap it with the hint:
  ```
  Hint: try running 'msgvault repair-encoding' to fix encoding issues
  ```

- **`internal/tui/model.go`**: Applied `HintRepairEncoding()` to all five TUI error handlers (aggregate data, message list, message detail, thread messages, search results) so the hint appears inline in the TUI error display.

- **CLI commands**: Applied `HintRepairEncoding()` to error paths in `search`, `list-senders`, `list-domains`, and `list-labels` commands.

- **`internal/query/encoding_hint_test.go`**: Unit tests covering nil errors, unrelated errors, direct encoding errors, and wrapped encoding errors — verifying both detection and hint injection with proper error chain preservation.

## Design

The approach uses string matching on the error message (`"Invalid string encoding found in Parquet file"`) since this error originates from the DuckDB C library at runtime and is not available as a typed error. The hint is appended via `fmt.Errorf("%w\nHint: ...")` to preserve the original error chain for `errors.Is`/`errors.As` compatibility.