### PR TITLE
Ignore .gocache/.gopath and add commit-every-turn rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ oauth_client*.json
 # Python
 __pycache__/
 
+# Go caches
+.gocache/
+.gopath/
+
 # IDE
 .idea/
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 When a task involves multiple steps (e.g., implement + commit + PR), complete ALL steps in sequence without stopping. If creating a branch, committing, and opening a PR, finish the entire chain.
 
+Always commit after every turn. Don't wait for the user to ask — if you made changes, commit them before responding.
+
 ## Project Overview
 
 msgvault is an offline Gmail archive tool that exports and stores email data locally with full-text search capabilities. The goal is to archive 20+ years of Gmail data from multiple accounts, make it searchable, and eventually delete emails from Gmail once safely archived.


### PR DESCRIPTION
## Summary
- Add `.gocache/` and `.gopath/` to `.gitignore` — these are Go build/module cache directories created by CI or local tooling that were showing up as untracked files
- Add instruction to `CLAUDE.md` to always commit after every turn without waiting to be asked

## Test plan
- [x] Verify `git status` is clean after the gitignore addition
- [x] No code changes, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)