### PR TITLE
Add Gmail thread ID to queries, harden cache validation, and clean up API layer

### DIFF
--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -55,7 +55,7 @@ Add to Claude Desktop config:
 		var engine query.Engine
 		analyticsDir := cfg.AnalyticsDir()
 
-		if !mcpForceSQL && query.HasParquetData(analyticsDir) {
+		if !mcpForceSQL && query.HasCompleteParquetData(analyticsDir) {
 			var duckOpts query.DuckDBOptions
 			if mcpNoSQLiteScanner {
 				duckOpts.DisableSQLiteScanner = true

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -20,7 +20,6 @@ client_secrets = "/path/to/secrets.json"
 [server]
 api_port = 9090
 api_key = "test-key"
-mcp_enabled = true
 
 [[accounts]]
 email = "user1@gmail.com"
@@ -53,9 +52,6 @@ enabled = false
 	}
 	if cfg.Server.APIKey != "test-key" {
 		t.Errorf("APIKey = %q, want test-key", cfg.Server.APIKey)
-	}
-	if !cfg.Server.MCPEnabled {
-		t.Error("MCPEnabled = false, want true")
 	}
 
 	// Verify scheduled accounts

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -92,7 +92,7 @@ Performance:
 		// Determine query engine to use
 		var engine query.Engine
 
-		if !forceSQL && query.HasParquetData(analyticsDir) {
+		if !forceSQL && query.HasCompleteParquetData(analyticsDir) {
 			// Use DuckDB for fast Parquet queries
 			var duckOpts query.DuckDBOptions
 			if noSQLiteScanner {
@@ -178,6 +178,11 @@ func cacheNeedsBuild(dbPath, analyticsDir string) (bool, string) {
 	files, _ := filepath.Glob(filepath.Join(messagesDir, "*", "*.parquet"))
 	if len(files) == 0 {
 		return true, "cache directory empty"
+	}
+
+	// Check for required parquet tables (e.g. conversations added in a newer version)
+	if missingRequiredParquet(analyticsDir) {
+		return true, "cache missing required tables"
 	}
 
 	return false, ""

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wesm/msgvault/internal/store"
 )
 
 // StatsResponse represents the archive statistics.
@@ -19,28 +20,12 @@ type StatsResponse struct {
 	DatabaseSize  int64 `json:"database_size_bytes"`
 }
 
-// APIMessage represents a message from the store.
-type APIMessage struct {
-	ID             int64
-	Subject        string
-	From           string
-	To             []string
-	SentAt         time.Time
-	Snippet        string
-	Labels         []string
-	HasAttachments bool
-	SizeEstimate   int64
-	Body           string
-	Headers        map[string]string
-	Attachments    []APIAttachment
-}
+// APIMessage is an alias for store.APIMessage — single source of truth for
+// the message DTO shared between the store and API layers.
+type APIMessage = store.APIMessage
 
-// APIAttachment represents attachment metadata.
-type APIAttachment struct {
-	Filename string
-	MimeType string
-	Size     int64
-}
+// APIAttachment is an alias for store.APIAttachment.
+type APIAttachment = store.APIAttachment
 
 // AccountInfo represents an account in list responses.
 type AccountInfo struct {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/wesm/msgvault/internal/config"
+	"github.com/wesm/msgvault/internal/scheduler"
+	"github.com/wesm/msgvault/internal/store"
 )
 
 // MessageStore defines the store operations the API needs.
@@ -23,15 +25,8 @@ type MessageStore interface {
 	SearchMessages(query string, offset, limit int) ([]APIMessage, int64, error)
 }
 
-// StoreStats holds aggregate statistics from the store.
-type StoreStats struct {
-	MessageCount    int64
-	ThreadCount     int64
-	SourceCount     int64
-	LabelCount      int64
-	AttachmentCount int64
-	DatabaseSize    int64
-}
+// StoreStats is an alias for store.Stats — single source of truth.
+type StoreStats = store.Stats
 
 // SyncScheduler defines the scheduler operations the API needs.
 type SyncScheduler interface {
@@ -41,15 +36,8 @@ type SyncScheduler interface {
 	IsRunning() bool
 }
 
-// AccountStatus represents the sync status of a scheduled account.
-type AccountStatus struct {
-	Email     string    `json:"email"`
-	Running   bool      `json:"running"`
-	LastRun   time.Time `json:"last_run,omitempty"`
-	NextRun   time.Time `json:"next_run"`
-	Schedule  string    `json:"schedule"`
-	LastError string    `json:"last_error,omitempty"`
-}
+// AccountStatus is an alias for scheduler.AccountStatus — single source of truth.
+type AccountStatus = scheduler.AccountStatus
 
 // Server represents the HTTP API server.
 type Server struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,6 @@ type ServerConfig struct {
 	APIPort         int      `toml:"api_port"`         // HTTP server port (default: 8080)
 	BindAddr        string   `toml:"bind_addr"`        // Bind address (default: 127.0.0.1)
 	APIKey          string   `toml:"api_key"`          // API authentication key
-	MCPEnabled      bool     `toml:"mcp_enabled"`      // Enable MCP server endpoint
 	AllowInsecure   bool     `toml:"allow_insecure"`   // Allow unauthenticated non-loopback access
 	CORSOrigins     []string `toml:"cors_origins"`     // Allowed CORS origins (empty = disabled)
 	CORSCredentials bool     `toml:"cors_credentials"` // Allow credentials in CORS
@@ -121,9 +120,8 @@ func NewDefaultConfig() *Config {
 			MaxResults: 20,
 		},
 		Server: ServerConfig{
-			APIPort:    8080,
-			BindAddr:   "127.0.0.1",
-			MCPEnabled: false,
+			APIPort:  8080,
+			BindAddr: "127.0.0.1",
 		},
 		Accounts: []AccountSchedule{},
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -89,7 +89,7 @@ func runToolExpectError(t *testing.T, name string, fn toolHandler, args map[stri
 func TestSearchMessages(t *testing.T) {
 	eng := &querytest.MockEngine{
 		SearchFastResults: []query.MessageSummary{
-			testutil.NewMessageSummary(1).WithSubject("Hello").WithFromEmail("alice@example.com").Build(),
+			testutil.NewMessageSummary(1).WithSubject("Hello").WithFromEmail("alice@example.com").WithSourceConversationID("thread-abc").Build(),
 		},
 	}
 	h := newTestHandlers(eng)
@@ -98,6 +98,9 @@ func TestSearchMessages(t *testing.T) {
 		msgs := runTool[[]query.MessageSummary](t, "search_messages", h.searchMessages, map[string]any{"query": "from:alice"})
 		if len(msgs) != 1 || msgs[0].Subject != "Hello" {
 			t.Fatalf("unexpected result: %v", msgs)
+		}
+		if msgs[0].SourceConversationID != "thread-abc" {
+			t.Fatalf("expected SourceConversationID 'thread-abc', got %q", msgs[0].SourceConversationID)
 		}
 	})
 
@@ -124,7 +127,7 @@ func TestSearchFallbackToFTS(t *testing.T) {
 func TestGetMessage(t *testing.T) {
 	eng := &querytest.MockEngine{
 		Messages: map[int64]*query.MessageDetail{
-			42: testutil.NewMessageDetail(42).WithSubject("Test Message").WithBodyText("Hello world").BuildPtr(),
+			42: testutil.NewMessageDetail(42).WithSubject("Test Message").WithBodyText("Hello world").WithSourceConversationID("thread-xyz").BuildPtr(),
 		},
 	}
 	h := newTestHandlers(eng)
@@ -133,6 +136,9 @@ func TestGetMessage(t *testing.T) {
 		msg := runTool[query.MessageDetail](t, "get_message", h.getMessage, map[string]any{"id": float64(42)})
 		if msg.Subject != "Test Message" {
 			t.Fatalf("unexpected subject: %s", msg.Subject)
+		}
+		if msg.SourceConversationID != "thread-xyz" {
+			t.Fatalf("expected SourceConversationID 'thread-xyz', got %q", msg.SourceConversationID)
 		}
 	})
 
@@ -212,7 +218,7 @@ func TestAggregate(t *testing.T) {
 func TestListMessages(t *testing.T) {
 	eng := &querytest.MockEngine{
 		ListResults: []query.MessageSummary{
-			testutil.NewMessageSummary(1).WithSubject("Test").WithFromEmail("alice@example.com").Build(),
+			testutil.NewMessageSummary(1).WithSubject("Test").WithFromEmail("alice@example.com").WithSourceConversationID("thread-list").Build(),
 		},
 	}
 	h := newTestHandlers(eng)
@@ -225,6 +231,9 @@ func TestListMessages(t *testing.T) {
 		})
 		if len(msgs) != 1 {
 			t.Fatalf("expected 1 message, got %d", len(msgs))
+		}
+		if msgs[0].SourceConversationID != "thread-list" {
+			t.Fatalf("expected SourceConversationID 'thread-list', got %q", msgs[0].SourceConversationID)
 		}
 	})
 

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -2087,7 +2087,11 @@ func TestDuckDBEngine_AggregateByRecipientName_EmptyStringFallback(t *testing.T)
 		`).
 		addEmptyTable("labels", "labels", "labels.parquet", labelsCols, `(1::BIGINT, 'x')`).
 		addEmptyTable("message_labels", "message_labels", "message_labels.parquet", messageLabelsCols, `(1::BIGINT, 1::BIGINT)`).
-		addEmptyTable("attachments", "attachments", "attachments.parquet", attachmentsCols, `(1::BIGINT, 100::BIGINT, 'x')`))
+		addEmptyTable("attachments", "attachments", "attachments.parquet", attachmentsCols, `(1::BIGINT, 100::BIGINT, 'x')`).
+		addTable("conversations", "conversations", "conversations.parquet", conversationsCols, `
+			(100::BIGINT, 'thread100'),
+			(101::BIGINT, 'thread101')
+		`))
 
 	ctx := context.Background()
 	results, err := engine.Aggregate(ctx, ViewRecipientNames, DefaultAggregateOptions())
@@ -2132,7 +2136,11 @@ func TestDuckDBEngine_ListMessages_MatchEmptyRecipientName(t *testing.T) {
 		`).
 		addEmptyTable("labels", "labels", "labels.parquet", labelsCols, `(1::BIGINT, 'x')`).
 		addEmptyTable("message_labels", "message_labels", "message_labels.parquet", messageLabelsCols, `(1::BIGINT, 1::BIGINT)`).
-		addEmptyTable("attachments", "attachments", "attachments.parquet", attachmentsCols, `(1::BIGINT, 100::BIGINT, 'x')`))
+		addEmptyTable("attachments", "attachments", "attachments.parquet", attachmentsCols, `(1::BIGINT, 100::BIGINT, 'x')`).
+		addTable("conversations", "conversations", "conversations.parquet", conversationsCols, `
+			(100::BIGINT, 'thread100'),
+			(101::BIGINT, 'thread101')
+		`))
 
 	ctx := context.Background()
 	filter := MessageFilter{EmptyValueTargets: map[ViewType]bool{ViewRecipientNames: true}}
@@ -2724,7 +2732,11 @@ func TestDuckDBEngine_VARCHARParquetColumns(t *testing.T) {
 		`).
 		addEmptyTable("labels", "labels", "labels.parquet", labelsCols, `(1::BIGINT, 'x')`).
 		addEmptyTable("message_labels", "message_labels", "message_labels.parquet", messageLabelsCols, `(1::BIGINT, 1::BIGINT)`).
-		addEmptyTable("attachments", "attachments", "attachments.parquet", attachmentsCols, `(1::BIGINT, '100', 'x')`))
+		addEmptyTable("attachments", "attachments", "attachments.parquet", attachmentsCols, `(1::BIGINT, '100', 'x')`).
+		addTable("conversations", "conversations", "conversations.parquet", conversationsCols, `
+			(100::BIGINT, 'thread100'),
+			(101::BIGINT, 'thread101')
+		`))
 
 	ctx := context.Background()
 

--- a/internal/query/models.go
+++ b/internal/query/models.go
@@ -20,32 +20,34 @@ type AggregateRow struct {
 // MessageSummary represents a message in list views.
 // Contains enough information for display without fetching the full body.
 type MessageSummary struct {
-	ID              int64
-	SourceMessageID string
-	ConversationID  int64
-	Subject         string
-	Snippet         string
-	FromEmail       string
-	FromName        string
-	SentAt          time.Time
-	SizeEstimate    int64
-	HasAttachments  bool
-	AttachmentCount int
-	Labels          []string
-	DeletedAt       *time.Time // When message was deleted from server (nil if not deleted)
+	ID                   int64
+	SourceMessageID      string
+	ConversationID       int64
+	SourceConversationID string // Gmail Thread ID
+	Subject              string
+	Snippet              string
+	FromEmail            string
+	FromName             string
+	SentAt               time.Time
+	SizeEstimate         int64
+	HasAttachments       bool
+	AttachmentCount      int
+	Labels               []string
+	DeletedAt            *time.Time // When message was deleted from server (nil if not deleted)
 }
 
 // MessageDetail represents a full message with body and attachments.
 type MessageDetail struct {
-	ID              int64
-	SourceMessageID string
-	ConversationID  int64
-	Subject         string
-	Snippet         string
-	SentAt          time.Time
-	ReceivedAt      *time.Time
-	SizeEstimate    int64
-	HasAttachments  bool
+	ID                   int64
+	SourceMessageID      string
+	ConversationID       int64
+	SourceConversationID string // Gmail Thread ID
+	Subject              string
+	Snippet              string
+	SentAt               time.Time
+	ReceivedAt           *time.Time
+	SizeEstimate         int64
+	HasAttachments       bool
 
 	// Participants
 	From []Address

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -521,6 +521,7 @@ func (e *SQLiteEngine) ListMessages(ctx context.Context, filter MessageFilter) (
 			m.id,
 			m.source_message_id,
 			m.conversation_id,
+			COALESCE(conv.source_conversation_id, ''),
 			COALESCE(m.subject, ''),
 			COALESCE(m.snippet, ''),
 			COALESCE(p_sender.email_address, ''),
@@ -533,6 +534,7 @@ func (e *SQLiteEngine) ListMessages(ctx context.Context, filter MessageFilter) (
 		FROM messages m
 		LEFT JOIN message_recipients mr_sender ON mr_sender.message_id = m.id AND mr_sender.recipient_type = 'from'
 		LEFT JOIN participants p_sender ON p_sender.id = mr_sender.participant_id
+		LEFT JOIN conversations conv ON conv.id = m.conversation_id
 		%s
 		WHERE %s
 		ORDER BY %s
@@ -556,6 +558,7 @@ func (e *SQLiteEngine) ListMessages(ctx context.Context, filter MessageFilter) (
 			&msg.ID,
 			&msg.SourceMessageID,
 			&msg.ConversationID,
+			&msg.SourceConversationID,
 			&msg.Subject,
 			&msg.Snippet,
 			&msg.FromEmail,
@@ -655,6 +658,7 @@ func (e *SQLiteEngine) getMessageByQuery(ctx context.Context, whereClause string
 			m.id,
 			m.source_message_id,
 			m.conversation_id,
+			COALESCE(conv.source_conversation_id, ''),
 			COALESCE(m.subject, ''),
 			COALESCE(m.snippet, ''),
 			m.sent_at,
@@ -662,6 +666,7 @@ func (e *SQLiteEngine) getMessageByQuery(ctx context.Context, whereClause string
 			COALESCE(m.size_estimate, 0),
 			m.has_attachments
 		FROM messages m
+		LEFT JOIN conversations conv ON conv.id = m.conversation_id
 		WHERE %s
 	`, whereClause)
 
@@ -671,6 +676,7 @@ func (e *SQLiteEngine) getMessageByQuery(ctx context.Context, whereClause string
 		&msg.ID,
 		&msg.SourceMessageID,
 		&msg.ConversationID,
+		&msg.SourceConversationID,
 		&msg.Subject,
 		&msg.Snippet,
 		&sentAt,
@@ -1344,6 +1350,7 @@ func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offse
 			m.id,
 			m.source_message_id,
 			m.conversation_id,
+			COALESCE(conv.source_conversation_id, ''),
 			COALESCE(m.subject, ''),
 			COALESCE(m.snippet, ''),
 			COALESCE(p_sender.email_address, ''),
@@ -1356,6 +1363,7 @@ func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offse
 		FROM messages m
 		LEFT JOIN message_recipients mr_sender ON mr_sender.message_id = m.id AND mr_sender.recipient_type = 'from'
 		LEFT JOIN participants p_sender ON p_sender.id = mr_sender.participant_id
+		LEFT JOIN conversations conv ON conv.id = m.conversation_id
 		%s
 		%s
 		WHERE %s
@@ -1380,6 +1388,7 @@ func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offse
 			&msg.ID,
 			&msg.SourceMessageID,
 			&msg.ConversationID,
+			&msg.SourceConversationID,
 			&msg.Subject,
 			&msg.Snippet,
 			&msg.FromEmail,

--- a/internal/testutil/builders.go
+++ b/internal/testutil/builders.go
@@ -78,6 +78,11 @@ func (b *MessageSummaryBuilder) WithConversationID(id int64) *MessageSummaryBuil
 	return b
 }
 
+func (b *MessageSummaryBuilder) WithSourceConversationID(id string) *MessageSummaryBuilder {
+	b.s.SourceConversationID = id
+	return b
+}
+
 func (b *MessageSummaryBuilder) WithDeletedAt(t *time.Time) *MessageSummaryBuilder {
 	b.s.DeletedAt = t
 	return b
@@ -179,6 +184,11 @@ func (b *MessageDetailBuilder) WithSourceMessageID(id string) *MessageDetailBuil
 
 func (b *MessageDetailBuilder) WithConversationID(id int64) *MessageDetailBuilder {
 	b.d.ConversationID = id
+	return b
+}
+
+func (b *MessageDetailBuilder) WithSourceConversationID(id string) *MessageDetailBuilder {
+	b.d.SourceConversationID = id
 	return b
 }
 


### PR DESCRIPTION
## Summary

This started as adding Gmail thread IDs to MCP responses but grew to include cache validation hardening and API cleanup that came up along the way.

### 1. Gmail Thread ID (`source_conversation_id`) in query layer
- Add `SourceConversationID` field to `MessageSummary` and `MessageDetail` models
- DuckDB engine joins `conversations` parquet table; SQLite engine joins `conversations` table
- Export `conversations` table to Parquet in `build-cache` (including Windows CSV fallback path)
- MCP tools (`list_messages`, `get_message`, `search_messages`) now return `source_conversation_id`

### 2. Cache validation hardening
- Shared `RequiredParquetDirs` list used by cache builder, TUI, and MCP startup
- `HasCompleteParquetData()` checks all required tables exist (not just messages)
- TUI and MCP use `HasCompleteParquetData` instead of `HasParquetData` — prevents DuckDB errors when tables like `conversations` are missing
- `missingRequiredParquet()` detects partial/broken caches and triggers full rebuild (handles hive-partitioned messages layout)
- `buildCacheMu` mutex prevents concurrent cache writes from parallel syncs
- `maxID > 0` gate avoids infinite rebuild loops for zero-message accounts
- +482 lines of test coverage for cache edge cases

### 3. Remove dead config field and eliminate DTO duplication
- Remove unused `server.mcp_enabled` config field (MCP is always available via `msgvault mcp`)
- Replace duplicate `APIMessage`, `APIAttachment`, `StoreStats`, `AccountStatus` structs in `internal/api` with type aliases to `store`/`scheduler` types
- Collapse ~80 lines of field-by-field adapter boilerplate in `serve.go` to direct pass-throughs
- Add backward-compat test for old configs that still contain `mcp_enabled`

## Test plan
- [x] All existing tests pass
- [x] New cache tests cover: backfill missing conversations, backfill missing messages, zero-message skip, incremental no-duplicates, hive-partitioned detection
- [x] MCP tests verify `source_conversation_id` in search/get/list responses
- [x] Config backward-compat test for deprecated `mcp_enabled`

Originally PR #76 (from @robelkin), squashed and rebased cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)