### PR TITLE
Harden security bot robustness

### DIFF
--- a/.github/scripts/security_review.py
+++ b/.github/scripts/security_review.py
@@ -381,10 +381,7 @@ _BOT_MARKER = "<!-- msgvault-security-bot -->"
 
 
 def delete_old_bot_comments(pr, exclude_ids: set[int] | None = None) -> int:
-    """Delete previous security review bot comments to keep noise down.
-
-    Cleans up both issue comments (current consolidated format) and
-    inline review comments (legacy per-finding format) left by the bot.
+    """Delete previous security review bot issue comments to keep noise down.
 
     Args:
         pr: GitHub PR object.
@@ -394,7 +391,6 @@ def delete_old_bot_comments(pr, exclude_ids: set[int] | None = None) -> int:
         exclude_ids = set()
     deleted = 0
 
-    # Clean up issue comments (consolidated format + legacy marker)
     for comment in pr.get_issue_comments():
         if comment.id in exclude_ids:
             continue
@@ -407,22 +403,6 @@ def delete_old_bot_comments(pr, exclude_ids: set[int] | None = None) -> int:
                 deleted += 1
             except Exception as e:
                 print(f"Warning: Failed to delete old issue comment: {e}", file=sys.stderr)
-
-    # Clean up inline review comments (legacy per-finding format)
-    try:
-        for comment in pr.get_review_comments():
-            if comment.id in exclude_ids:
-                continue
-            if comment.user.login == "github-actions[bot]" and (
-                _BOT_MARKER in comment.body or "Powered by Claude" in comment.body
-            ):
-                try:
-                    comment.delete()
-                    deleted += 1
-                except Exception as e:
-                    print(f"Warning: Failed to delete old review comment: {e}", file=sys.stderr)
-    except Exception as e:
-        print(f"Warning: Failed to enumerate review comments: {e}", file=sys.stderr)
 
     return deleted
 


### PR DESCRIPTION
## Summary
- **Comment size splitting**: Split oversized comments (>60K chars) across multiple GitHub comments to avoid 422 errors when many findings are reported, with hard-wrap fallback for single large sections
- **Post-before-delete ordering**: Post new bot comment before deleting old ones, so security context is never lost if posting fails (API error/rate limit/validation)
- **Self-deletion prevention**: Track newly posted comment IDs via `exclude_ids` so the cleanup pass doesn't delete the comment it just posted
- **Stable bot marker**: Embed `<!-- msgvault-security-bot -->` HTML comment in every bot comment (including split continuation chunks) for reliable cleanup matching
- **Unit tests**: 22 tests covering size splitting, hard-wrap, post-then-delete ordering, self-deletion prevention, and integration tests with FakePR

## Test plan
- [x] All 22 Python tests pass (`pytest test_security_review.py`)
- [x] All Go tests pass (`make test`)
- [ ] Verify on a real PR that the bot still posts comments correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)