### PR TITLE
Remove obsolete version field from docker-compose template

### DIFF
--- a/cmd/msgvault/cmd/setup.go
+++ b/cmd/msgvault/cmd/setup.go
@@ -272,9 +272,7 @@ rate_limit_qps = 5
 	}
 
 	// Create docker-compose.yml
-	dockerCompose := fmt.Sprintf(`version: "3.8"
-
-services:
+	dockerCompose := fmt.Sprintf(`services:
   msgvault:
     image: ghcr.io/wesm/msgvault:latest
     container_name: msgvault


### PR DESCRIPTION
## Summary

- Remove deprecated `version: "3.8"` from the generated `docker-compose.yml` template in the setup wizard
- Docker Compose v2+ ignores this field and emits a warning when it's present

## Test plan

- [ ] Run `msgvault setup` with remote NAS config and verify generated `docker-compose.yml` has no `version` key
- [ ] Existing `TestCreateNASBundle` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)