### PR TITLE
Handle expired/revoked OAuth tokens with auto-reauth and --force flag

### DIFF
--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -23,7 +23,8 @@ By default, opens a browser for authorization. Use --headless to see instruction
 for authorizing on headless servers (Google does not support Gmail in device flow).
 
 If a token already exists, the command skips authorization. Use --force to delete
-the existing token and re-authorize (useful when a token has expired or been revoked).
+the existing token and start a fresh OAuth flow (most token issues are handled
+automatically during sync and verify).
 
 Examples:
   msgvault add-account you@gmail.com
@@ -95,7 +96,6 @@ Examples:
 			}
 			fmt.Printf("Account %s is already authorized.\n", email)
 			fmt.Println("Next step: msgvault sync-full", email)
-			fmt.Println("To re-authorize (e.g., expired token), run: msgvault add-account", email, "--force")
 			return nil
 		}
 
@@ -128,7 +128,7 @@ Examples:
 
 func init() {
 	addAccountCmd.Flags().BoolVar(&headless, "headless", false, "Show instructions for headless server setup")
-	addAccountCmd.Flags().BoolVar(&forceReauth, "force", false, "Delete existing token and re-authorize (use when token is expired or revoked)")
+	addAccountCmd.Flags().BoolVar(&forceReauth, "force", false, "Delete existing token and re-authorize")
 	addAccountCmd.Flags().StringVar(&accountDisplayName, "display-name", "", "Display name for the account (e.g., \"Work\", \"Personal\")")
 	rootCmd.AddCommand(addAccountCmd)
 }

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/wesm/msgvault/internal/deletion"
 	"github.com/wesm/msgvault/internal/gmail"
@@ -410,9 +411,11 @@ Examples:
 			// If no scope metadata at all (legacy token), fall through to reactive detection
 		}
 
-		tokenSource, err := oauthMgr.TokenSource(ctx, account)
+		interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
+			isatty.IsCygwinTerminal(os.Stdin.Fd())
+		tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, account, interactive)
 		if err != nil {
-			return fmt.Errorf("get token source: %w", err)
+			return err
 		}
 
 		// Create Gmail client

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -244,7 +244,7 @@ func runScheduledSync(ctx context.Context, email string, s *store.Store, oauthMg
 	tokenSource, err := oauthMgr.TokenSource(ctx, email)
 	if err != nil {
 		if oauthMgr.HasToken(email) {
-			return fmt.Errorf("get token source: %w (token may be expired; run 'add-account %s --force' to re-authorize)", err, email)
+			return fmt.Errorf("get token source: %w (token may be expired; run 'sync %s' or 'verify %s' from an interactive terminal to re-authorize)", err, email, email)
 		}
 		return fmt.Errorf("get token source: %w (run 'add-account %s' first)", err, email)
 	}

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/wesm/msgvault/internal/gmail"
 	"github.com/wesm/msgvault/internal/oauth"
@@ -137,7 +138,9 @@ func runIncrementalSync(ctx context.Context, s *store.Store, oauthMgr *oauth.Man
 		return fmt.Errorf("no history ID - run 'sync-full' first")
 	}
 
-	tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email)
+	interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
+		isatty.IsCygwinTerminal(os.Stdin.Fd())
+	tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email, interactive)
 	if err != nil {
 		return err
 	}

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/wesm/msgvault/internal/gmail"
 	"github.com/wesm/msgvault/internal/oauth"
@@ -135,7 +136,9 @@ Examples:
 }
 
 func runFullSync(ctx context.Context, s *store.Store, oauthMgr *oauth.Manager, email string) error {
-	tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email)
+	interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
+		isatty.IsCygwinTerminal(os.Stdin.Fd())
+	tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email, interactive)
 	if err != nil {
 		return err
 	}

--- a/cmd/msgvault/cmd/verify.go
+++ b/cmd/msgvault/cmd/verify.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/wesm/msgvault/internal/gmail"
 	"github.com/wesm/msgvault/internal/mime"
@@ -67,7 +68,9 @@ Examples:
 			cancel()
 		}()
 
-		tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email)
+		interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
+			isatty.IsCygwinTerminal(os.Stdin.Fd())
+		tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email, interactive)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Add `--force` flag to `add-account` for manual token deletion and re-authorization
- Auto-reauth expired tokens during `sync`, `sync-full`, `verify`, and `delete-staged` — detects `invalid_grant`, deletes the stale token, and re-runs the browser OAuth flow in interactive sessions
- Guard auto-reauth against transient errors (network, context cancellation) and non-interactive sessions (cron, CI)
- Reject `--headless --force` flag combination (--force requires browser OAuth)
- Test coverage for `isAuthInvalidError` (8 cases) and `getTokenSourceWithReauth` (9 cases) via extracted `tokenReauthorizer` interface

## Test plan

- [x] `go test -tags fts5 ./cmd/msgvault/cmd/... -run "TestIsAuthInvalidError|TestGetTokenSourceWithReauth" -v` — all 17 cases pass
- [x] `make test` — full suite passes
- [x] `make lint` — no new issues
- [ ] Manual: `add-account --force` deletes token and re-authorizes
- [ ] Manual: `sync` with expired token triggers auto-reauth in interactive terminal
- [ ] Manual: `sync` with expired token in non-interactive session returns actionable error

Fix for Issue #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)