### PR TITLE
Fix Apple Mail V10 import: discover messages in numeric partition directories

### DIFF
--- a/internal/emlx/discover.go
+++ b/internal/emlx/discover.go
@@ -13,7 +13,7 @@ type Mailbox struct {
 	// Path is the absolute path to the .mbox or .imapmbox directory.
 	Path string
 
-	// MsgDir is the absolute path to the Messages/ directory
+	// MsgDir is the absolute path to the primary Messages/ directory
 	// containing .emlx files. In legacy layouts this is Path/Messages;
 	// in modern V10 layouts it is Path/<GUID>/Data/Messages.
 	MsgDir string
@@ -21,8 +21,27 @@ type Mailbox struct {
 	// Label is the derived label for messages in this mailbox.
 	Label string
 
-	// Files contains sorted .emlx filenames within MsgDir.
+	// Files contains sorted .emlx filenames within MsgDir plus any
+	// files discovered in numeric partition subdirectories.
 	Files []string
+
+	// FileIndex maps filename → absolute path of the Messages/ subdirectory
+	// within a numeric partition directory, for V10 partitioned layouts.
+	// Files in MsgDir itself are absent from this map. Nil when no
+	// partition files exist.
+	FileIndex map[string]string
+}
+
+// FilePath returns the absolute path to a .emlx file within this mailbox.
+// For files in numeric partition directories, the path is resolved via
+// FileIndex; all other files are resolved relative to MsgDir.
+func (m *Mailbox) FilePath(fileName string) string {
+	if m.FileIndex != nil {
+		if sub, ok := m.FileIndex[fileName]; ok {
+			return filepath.Join(sub, fileName)
+		}
+	}
+	return filepath.Join(m.MsgDir, fileName)
 }
 
 // DiscoverMailboxes walks an Apple Mail directory tree and returns all
@@ -49,7 +68,7 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 
 	// Auto-detect: if the path itself is a mailbox, import just that one.
 	if isMailboxDir(abs) {
-		msgDir, files, err := listEmlxFiles(abs)
+		msgDir, files, fileIndex, err := listEmlxFiles(abs)
 		if err != nil {
 			return nil, err
 		}
@@ -58,6 +77,7 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 			return []Mailbox{{
 				Path: abs, MsgDir: msgDir,
 				Label: label, Files: files,
+				FileIndex: fileIndex,
 			}}, nil
 		}
 	}
@@ -81,7 +101,7 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 			return nil
 		}
 
-		msgDir, files, listErr := listEmlxFiles(path)
+		msgDir, files, fileIndex, listErr := listEmlxFiles(path)
 		if listErr != nil || len(files) == 0 {
 			return nil
 		}
@@ -90,6 +110,7 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 		mailboxes = append(mailboxes, Mailbox{
 			Path: path, MsgDir: msgDir,
 			Label: label, Files: files,
+			FileIndex: fileIndex,
 		})
 
 		return nil
@@ -164,7 +185,7 @@ func isMailboxDir(path string) bool {
 // findMessagesDir locates the Messages/ directory within a .mbox.
 // Returns "" if none found. Checks both legacy (Messages/) and
 // modern V10 (<GUID>/Data/Messages/) layouts. When both exist,
-// prefers whichever contains .emlx files.
+// prefers whichever contains .emlx files (directly or in partitions).
 func findMessagesDir(mailboxPath string) string {
 	var candidates []string
 
@@ -175,17 +196,24 @@ func findMessagesDir(mailboxPath string) string {
 	}
 
 	// Modern V10: <subdir>/Data/Messages/ subdirectory.
+	// Also handles partition-only layouts where Data/Messages/ doesn't exist.
 	entries, err := os.ReadDir(mailboxPath)
 	if err == nil {
 		for _, e := range entries {
 			if !e.IsDir() || e.Name() == "Messages" {
 				continue
 			}
-			modern := filepath.Join(
-				mailboxPath, e.Name(), "Data", "Messages",
-			)
-			info, statErr := os.Stat(modern)
-			if statErr == nil && info.IsDir() {
+			dataDir := filepath.Join(mailboxPath, e.Name(), "Data")
+			dataStat, statErr := os.Stat(dataDir)
+			if statErr != nil || !dataStat.IsDir() {
+				continue
+			}
+			modern := filepath.Join(dataDir, "Messages")
+			msgStat, statErr := os.Stat(modern)
+			if statErr == nil && msgStat.IsDir() {
+				candidates = append(candidates, modern)
+			} else if hasEmlxFilesInPartitions(dataDir) {
+				// Partition-only: Data/Messages/ absent but partitions exist.
 				candidates = append(candidates, modern)
 			}
 		}
@@ -195,9 +223,16 @@ func findMessagesDir(mailboxPath string) string {
 		return ""
 	}
 
-	// Prefer the first candidate that has .emlx files.
+	// Prefer the first candidate that has .emlx files directly or
+	// within numeric partition subdirectories (V10 only).
 	for _, dir := range candidates {
 		if hasEmlxFiles(dir) {
+			return dir
+		}
+		// For V10 layout the parent is Data/; check partitions there.
+		dataDir := filepath.Dir(dir)
+		if filepath.Base(dataDir) == "Data" &&
+			hasEmlxFilesInPartitions(dataDir) {
 			return dir
 		}
 	}
@@ -214,13 +249,33 @@ func hasEmlxFiles(dir string) bool {
 		return false
 	}
 	for _, e := range entries {
-		if e.IsDir() {
+		if !e.IsDir() && isEmlxFile(e.Name()) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasEmlxFilesInPartitions returns true if dir contains .emlx files
+// within Messages/ subdirectories or nested numeric partition dirs (0-9).
+func hasEmlxFilesInPartitions(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
 			continue
 		}
-		lower := strings.ToLower(e.Name())
-		if strings.HasSuffix(lower, ".emlx") &&
-			!strings.HasSuffix(lower, ".partial.emlx") {
-			return true
+		name := e.Name()
+		if name == "Messages" {
+			if hasEmlxFiles(filepath.Join(dir, name)) {
+				return true
+			}
+		} else if isDigitDir(name) {
+			if hasEmlxFilesInPartitions(filepath.Join(dir, name)) {
+				return true
+			}
 		}
 	}
 	return false
@@ -249,6 +304,16 @@ func isUUID(s string) bool {
 	return true
 }
 
+func isDigitDir(name string) bool {
+	return len(name) == 1 && name[0] >= '0' && name[0] <= '9'
+}
+
+func isEmlxFile(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".emlx") &&
+		!strings.HasSuffix(lower, ".partial.emlx")
+}
+
 func stripMailboxSuffix(name string) string {
 	lower := strings.ToLower(name)
 	if strings.HasSuffix(lower, ".imapmbox") {
@@ -260,43 +325,91 @@ func stripMailboxSuffix(name string) string {
 	return name
 }
 
-// listEmlxFiles returns the Messages directory path and sorted .emlx
-// filenames within it, excluding .partial.emlx. Returns ("", nil, nil)
-// if no Messages directory is found.
+// listEmlxFiles returns the Messages directory path, sorted .emlx
+// filenames (from both the primary Messages/ dir and numeric partition
+// subdirectories), and a FileIndex mapping partition filenames to their
+// containing subdirectory. Returns ("", nil, nil, nil) if no Messages
+// directory is found.
 func listEmlxFiles(
 	mailboxPath string,
-) (string, []string, error) {
+) (string, []string, map[string]string, error) {
 	msgDir := findMessagesDir(mailboxPath)
 	if msgDir == "" {
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 
 	entries, err := os.ReadDir(msgDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil, nil
+		if !os.IsNotExist(err) {
+			return "", nil, nil, fmt.Errorf("read Messages dir: %w", err)
 		}
-		return "", nil, fmt.Errorf("read Messages dir: %w", err)
+		// Primary Messages/ dir absent (partition-only layout); continue
+		// so that partition files are still collected below.
+		entries = nil
 	}
 
 	var files []string
 	for _, e := range entries {
-		if e.IsDir() {
-			continue
+		if !e.IsDir() && isEmlxFile(e.Name()) {
+			files = append(files, e.Name())
 		}
-		name := e.Name()
-		if !strings.HasSuffix(strings.ToLower(name), ".emlx") {
-			continue
+	}
+
+	// Walk numeric partition dirs in Data/ (parent of Messages/).
+	// Only enter digit dirs (0-9) to avoid re-collecting from the
+	// primary Messages/ dir which was already handled above.
+	var fileIndex map[string]string
+	dataDir := filepath.Dir(msgDir)
+	if filepath.Base(dataDir) == "Data" {
+		result := make(map[string]string)
+		topEntries, readErr := os.ReadDir(dataDir)
+		if readErr == nil {
+			for _, e := range topEntries {
+				if e.IsDir() && isDigitDir(e.Name()) {
+					collectPartitionFiles(
+						filepath.Join(dataDir, e.Name()), result,
+					)
+				}
+			}
 		}
-		// Skip .partial.emlx files (Apple Mail temp files).
-		if strings.HasSuffix(
-			strings.ToLower(name), ".partial.emlx",
-		) {
-			continue
+		if len(result) > 0 {
+			fileIndex = result
+			for name := range result {
+				files = append(files, name)
+			}
 		}
-		files = append(files, name)
 	}
 
 	sort.Strings(files)
-	return msgDir, files, nil
+	return msgDir, files, fileIndex, nil
+}
+
+// collectPartitionFiles recursively walks dir for Messages/ subdirs and
+// numeric partition dirs (0-9), collecting .emlx files into result
+// (filename → absolute Messages/ dir path).
+func collectPartitionFiles(dir string, result map[string]string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == "Messages" {
+			msgDir := filepath.Join(dir, name)
+			msgs, err := os.ReadDir(msgDir)
+			if err != nil {
+				continue
+			}
+			for _, m := range msgs {
+				if !m.IsDir() && isEmlxFile(m.Name()) {
+					result[m.Name()] = msgDir
+				}
+			}
+		} else if isDigitDir(name) {
+			collectPartitionFiles(filepath.Join(dir, name), result)
+		}
+	}
 }

--- a/internal/emlx/discover_test.go
+++ b/internal/emlx/discover_test.go
@@ -422,6 +422,191 @@ func TestDiscoverMailboxes_MixedLegacyAndV10(t *testing.T) {
 	}
 }
 
+// mkV10PartitionedMailbox creates a V10 mailbox with .emlx files in
+// both the primary Messages/ directory and in numeric partition
+// subdirectories at various nesting depths.
+//
+// Layout created:
+//
+//	base/<guid>/Data/Messages/1.emlx       (top-level)
+//	base/<guid>/Data/0/3/Messages/123.emlx (2-level partition)
+//	base/<guid>/Data/9/Messages/456.emlx   (1-level partition)
+func mkV10PartitionedMailbox(t *testing.T, base, guid string) {
+	t.Helper()
+	dataDir := filepath.Join(base, guid, "Data")
+
+	writeEmlxFile := func(dir, name string) {
+		t.Helper()
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatalf("mkdir %q: %v", dir, err)
+		}
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("10\nFrom: x\r\n\r\n"), 0600); err != nil {
+			t.Fatalf("write %q: %v", path, err)
+		}
+	}
+
+	writeEmlxFile(filepath.Join(dataDir, "Messages"), "1.emlx")
+	writeEmlxFile(filepath.Join(dataDir, "0", "3", "Messages"), "123.emlx")
+	writeEmlxFile(filepath.Join(dataDir, "9", "Messages"), "456.emlx")
+}
+
+func TestDiscoverMailboxes_V10Partitioned(t *testing.T) {
+	root := t.TempDir()
+	guid := "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
+	mboxDir := filepath.Join(root, "INBOX.mbox")
+	mkV10PartitionedMailbox(t, mboxDir, guid)
+
+	mailboxes, err := DiscoverMailboxes(mboxDir)
+	if err != nil {
+		t.Fatalf("DiscoverMailboxes: %v", err)
+	}
+	if len(mailboxes) != 1 {
+		t.Fatalf("got %d mailboxes, want 1", len(mailboxes))
+	}
+
+	mb := mailboxes[0]
+	if mb.Label != "INBOX" {
+		t.Errorf("Label = %q, want %q", mb.Label, "INBOX")
+	}
+
+	// Should find all 3 files: 1 top-level + 2 from partitions.
+	if len(mb.Files) != 3 {
+		t.Fatalf("Files = %v (len %d), want 3 files", mb.Files, len(mb.Files))
+	}
+
+	// Verify all expected filenames are present.
+	fileSet := make(map[string]bool)
+	for _, f := range mb.Files {
+		fileSet[f] = true
+	}
+	for _, want := range []string{"1.emlx", "123.emlx", "456.emlx"} {
+		if !fileSet[want] {
+			t.Errorf("missing file %q in Files: %v", want, mb.Files)
+		}
+	}
+
+	// Verify FilePath resolves to an existing file for each entry.
+	for _, fileName := range mb.Files {
+		path := mb.FilePath(fileName)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("FilePath(%q) = %q: stat failed: %v", fileName, path, err)
+		}
+	}
+
+	// Top-level file should NOT be in FileIndex.
+	if mb.FileIndex != nil {
+		if _, inIndex := mb.FileIndex["1.emlx"]; inIndex {
+			t.Errorf("top-level 1.emlx should not be in FileIndex")
+		}
+	}
+
+	// Partition files should be in FileIndex.
+	if mb.FileIndex == nil {
+		t.Fatal("FileIndex is nil but partition files were found")
+	}
+	for _, pf := range []string{"123.emlx", "456.emlx"} {
+		if _, ok := mb.FileIndex[pf]; !ok {
+			t.Errorf("partition file %q missing from FileIndex", pf)
+		}
+	}
+}
+
+func TestDiscoverMailboxes_V10PartitionedOnly(t *testing.T) {
+	root := t.TempDir()
+	guid := "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
+	mboxDir := filepath.Join(root, "INBOX.mbox")
+
+	// Create the primary Messages/ dir but leave it empty.
+	// (Tests the case where Messages/ exists but is empty.)
+	primaryMsg := filepath.Join(mboxDir, guid, "Data", "Messages")
+	if err := os.MkdirAll(primaryMsg, 0700); err != nil {
+		t.Fatalf("mkdir %q: %v", primaryMsg, err)
+	}
+
+	// Place files only in partition dirs.
+	partDir := filepath.Join(mboxDir, guid, "Data", "3", "Messages")
+	if err := os.MkdirAll(partDir, 0700); err != nil {
+		t.Fatalf("mkdir %q: %v", partDir, err)
+	}
+	for _, name := range []string{"100.emlx", "200.emlx"} {
+		path := filepath.Join(partDir, name)
+		if err := os.WriteFile(path, []byte("10\nFrom: x\r\n\r\n"), 0600); err != nil {
+			t.Fatalf("write %q: %v", path, err)
+		}
+	}
+
+	mailboxes, err := DiscoverMailboxes(mboxDir)
+	if err != nil {
+		t.Fatalf("DiscoverMailboxes: %v", err)
+	}
+	if len(mailboxes) != 1 {
+		t.Fatalf("got %d mailboxes, want 1 (partitioned-only mailbox should be detected)", len(mailboxes))
+	}
+
+	mb := mailboxes[0]
+	if len(mb.Files) != 2 {
+		t.Fatalf("Files = %v (len %d), want 2", mb.Files, len(mb.Files))
+	}
+
+	for _, fileName := range mb.Files {
+		path := mb.FilePath(fileName)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("FilePath(%q) = %q: stat failed: %v", fileName, path, err)
+		}
+	}
+}
+
+// TestDiscoverMailboxes_V10NoTopLevelMessages tests the case where
+// Data/Messages/ does not exist at all — only numeric partition dirs.
+// This matches real Apple Mail behavior for large mailboxes.
+func TestDiscoverMailboxes_V10NoTopLevelMessages(t *testing.T) {
+	root := t.TempDir()
+	guid := "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
+	mboxDir := filepath.Join(root, "Sent Messages.mbox")
+
+	// Do NOT create Data/Messages/ — only create partition dirs.
+	for _, partPath := range []string{
+		filepath.Join(mboxDir, guid, "Data", "9", "9", "Messages"),
+		filepath.Join(mboxDir, guid, "Data", "0", "0", "1", "Messages"),
+	} {
+		if err := os.MkdirAll(partPath, 0700); err != nil {
+			t.Fatalf("mkdir %q: %v", partPath, err)
+		}
+	}
+	files := map[string]string{
+		"500.emlx": filepath.Join(mboxDir, guid, "Data", "9", "9", "Messages"),
+		"600.emlx": filepath.Join(mboxDir, guid, "Data", "0", "0", "1", "Messages"),
+		"700.emlx": filepath.Join(mboxDir, guid, "Data", "0", "0", "1", "Messages"),
+	}
+	for name, dir := range files {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("10\nFrom: x\r\n\r\n"), 0600); err != nil {
+			t.Fatalf("write %q: %v", path, err)
+		}
+	}
+
+	mailboxes, err := DiscoverMailboxes(mboxDir)
+	if err != nil {
+		t.Fatalf("DiscoverMailboxes: %v", err)
+	}
+	if len(mailboxes) != 1 {
+		t.Fatalf("got %d mailboxes, want 1 (no Data/Messages/ dir)", len(mailboxes))
+	}
+
+	mb := mailboxes[0]
+	if len(mb.Files) != 3 {
+		t.Fatalf("Files = %v, want 3", mb.Files)
+	}
+
+	for _, fileName := range mb.Files {
+		path := mb.FilePath(fileName)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("FilePath(%q) = %q: stat failed: %v", fileName, path, err)
+		}
+	}
+}
+
 func TestIsUUID(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/importer/emlx_import.go
+++ b/internal/importer/emlx_import.go
@@ -416,7 +416,7 @@ func ImportEmlxDir(
 				}
 			}
 
-			filePath := filepath.Join(mb.MsgDir, fileName)
+			filePath := mb.FilePath(fileName)
 
 			// Check file size before reading to avoid OOM on oversized files.
 			fi, statErr := os.Stat(filePath)


### PR DESCRIPTION
This is a vibecoded fix for [#157](https://github.com/wesm/msgvault/issues/157)

```
msgvault v0.9.0
  commit:  4801588b
  built:   2026-02-26T20:45:45Z
  go:      go1.25.7
  os/arch: darwin/amd64
```

## Summary

- Discover `.emlx` files in V10 numeric partition subdirectories (`Data/0/3/Messages/`, `Data/9/Messages/`, etc.) at arbitrary nesting depths
- Handle partition-only mailboxes where `Data/Messages/` does not exist at all
- Resolve partition file paths transparently via `FileIndex` map + `FilePath()` method, requiring only a one-line change in the importer

## Problem

Apple Mail V10 splits large mailboxes across single-digit numeric partition directories under `Data/`. A real-world mailbox might look like:

```
~/Library/Mail/V10/<account-GUID>/Sent Messages.mbox/
  <GUID>/Data/
    Messages/           <- top-level (may be empty or absent)
      1.emlx
    0/
      3/
        Messages/       <- 2-level partition
          123.emlx
          124.emlx
    9/
      Messages/         <- 1-level partition
        456.emlx
      9/
        Messages/       <- 2-level partition
          500.emlx
```

Real `tree -d` output from a 20-year Inbox.mbox (Attachments dirs omitted):

```
~/Library/Mail/V10/<account-GUID>/Inbox.mbox/<GUID>/Data
├── 0
│   ├── 1
│   │   └── Messages
│   ├── 3
│   │   └── Messages
│   ├── 4
│   │   └── Messages
│   ├── 6
│   │   └── Messages
│   └── 7
│       └── Messages
├── 1
│   ├── 1
│   │   └── Messages
│   ├── 3
│   │   └── Messages
│   ├── 4
│   │   └── Messages
│   ├── 6
│   │   └── Messages
│   ├── 7
│   │   └── Messages
│   └── 8
│       └── Messages
├── 2
│   ├── 3
│   │   └── Messages
│   ├── 4
│   │   └── Messages
│   ├── 7
│   │   └── Messages
│   ├── 8
│   │   └── Messages
│   ├── 9
│   │   └── Messages
│   └── Messages
...
└── Messages

108 directories
```

The previous code only looked for `.emlx` files in `Data/Messages/`. It had no awareness of numeric partition directories at all. This meant:

1. **Missing messages**: Any `.emlx` file stored in a partition directory (e.g., `Data/0/3/Messages/123.emlx`) was silently skipped. On a real 20-year Apple Mail archive (~6 accounts), only **363 files across 5 mailboxes** were found instead of the full **39,417 files across 32 mailboxes** — 99% of messages were invisible.

2. **Invisible mailboxes**: Some mailboxes have *no* top-level `Data/Messages/` directory. Every message lives in partitions. These mailboxes were not detected at all by `findMessagesDir` (it checked `os.Stat(Data/Messages)` and gave up if that directory didn't exist), so `isMailboxDir` returned false and the entire mailbox was skipped during discovery.

3. **Path resolution assumed flat structure**: The importer used `filepath.Join(mb.MsgDir, fileName)` to build file paths, which only works when all `.emlx` files are in a single `Messages/` directory. Partition files live in different `Messages/` directories at different paths, so this produced incorrect paths that would fail on `os.Stat`.

## Solution

The fix adds partition awareness at two levels: **discovery** (finding files) and **resolution** (building paths).

### Discovery

`findMessagesDir` now checks for partition directories when `Data/Messages/` is absent or empty. It calls `hasEmlxFilesInPartitions`, which recursively walks single-digit subdirectories (0-9) looking for `Messages/` dirs that contain `.emlx` files. This lets `isMailboxDir` return true for partition-only mailboxes.

`listEmlxFiles` now collects files from both the primary `Messages/` dir and all partition `Messages/` dirs. It calls `collectPartitionFiles`, which recursively descends digit directories and collects every `.emlx` file it finds in any nested `Messages/` directory, building a map from filename to the absolute path of its containing directory.

Both recursive functions (`hasEmlxFilesInPartitions` and `collectPartitionFiles`) follow the same pattern: at each directory level, enter `Messages/` to check/collect files, and recurse into any single-digit subdirectory. This mirrors Apple Mail's actual partition structure, which nests digit dirs arbitrarily deep (observed up to 3 levels in real data).

### Resolution

The `Mailbox` struct gains a `FileIndex` field (map of filename to its `Messages/` directory path) and a `FilePath()` method. For files in the primary `Messages/` dir, `FileIndex` has no entry and `FilePath` falls back to `filepath.Join(MsgDir, fileName)` — identical to the old behavior. For partition files, `FileIndex` maps the filename to its specific `Messages/` directory, and `FilePath` joins that path with the filename.

The importer change is a single line: `filepath.Join(mb.MsgDir, fileName)` becomes `mb.FilePath(fileName)`. No other importer logic changes because the `Files` slice already contains all filenames (both top-level and partition) and they sort/deduplicate identically.

### Code consolidation

Shared logic is extracted into two small helpers to avoid duplication:

- `isDigitDir(name)` — checks if a directory name is a single digit 0-9 (used in 4 places)
- `isEmlxFile(name)` — checks `.emlx` suffix excluding `.partial.emlx` (used in 3 places)

The recursive walks for existence checking (`hasEmlxFilesInPartitions`) and file collection (`collectPartitionFiles`) are each a single function rather than being split across multiple wrappers.

## Tests

Three new tests cover the distinct partition scenarios encountered in real Apple Mail data:

**`TestDiscoverMailboxes_V10Partitioned`** — The mixed case: a mailbox has files in both the primary `Data/Messages/` and in partition directories at different depths (`Data/0/3/Messages/`, `Data/9/Messages/`). Verifies that all 3 files are discovered, that `FilePath()` resolves each to an existing file on disk, that top-level files are *not* in `FileIndex` (they resolve via `MsgDir`), and that partition files *are* in `FileIndex`.

**`TestDiscoverMailboxes_V10PartitionedOnly`** — The empty-primary case: `Data/Messages/` exists but contains no `.emlx` files; all messages are in `Data/3/Messages/`. Verifies the mailbox is detected and both partition files are found. This catches a regression where `findMessagesDir` would find the empty `Messages/` dir, `listEmlxFiles` would return zero files, and the mailbox would be silently skipped.

**`TestDiscoverMailboxes_V10NoTopLevelMessages`** — The most extreme case: `Data/Messages/` does not exist at all. Messages are in partitions at 2-3 levels deep (`Data/9/9/Messages/`, `Data/0/0/1/Messages/`). This is the scenario that motivated the `hasEmlxFilesInPartitions` check in `findMessagesDir` — without it, `os.Stat(Data/Messages)` fails and the mailbox is invisible. Verifies all 3 files across two separate partition paths are found and resolve correctly.

All existing tests continue to pass unchanged, confirming no regression in legacy or standard V10 layouts.

## Verification against real data

Tested against a real Apple Mail archive spanning 20+ years (~6 accounts, 39,417 `.emlx` files on disk):

| Metric | Before | After |
|--------|--------|-------|
| Mailboxes discovered | 5 | 32 |
| Files found | 363 | 39,417 |

The 5 mailboxes found before were the only ones with any `.emlx` files in the top-level `Data/Messages/` directory. The remaining 27 mailboxes stored all messages exclusively in partition directories and were completely invisible.

## Future simplification

The current `Mailbox.Files` field stores bare filenames (e.g., `"123.emlx"`), with a separate `FileIndex` map to resolve partition files back to their containing directory. This two-layer design exists because `Files` predates partition support — when all files lived in a single `Messages/` dir, filenames alone were sufficient.

A cleaner approach would be to store full absolute paths in `Files` directly and drop `FileIndex`/`FilePath()` entirely. The discovery walk already knows the full path of every file it finds; the current code discards that information and reconstructs it later via the map lookup. Storing full paths would simplify the `Mailbox` struct, eliminate `FileIndex`, and make the recursive walk simpler (just collect paths, no map needed). The importer would use the path directly instead of calling `FilePath()`. The main thing to watch is that resume checkpoints currently store the last processed filename — that format would need to change to full paths.
