### PR TITLE
Support Apple Mail V10 sharded .emlx directory layout

### DIFF
--- a/internal/emlx/discover.go
+++ b/internal/emlx/discover.go
@@ -49,16 +49,17 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 
 	// Auto-detect: if the path itself is a mailbox, import just that one.
 	if isMailboxDir(abs) {
-		msgDir, files, err := listEmlxFiles(abs)
-		if err != nil {
-			return nil, err
-		}
-		if len(files) > 0 {
+		mboxes := listAllEmlxFiles(abs)
+		if len(mboxes) > 0 {
 			label := LabelFromPath(filepath.Dir(abs), abs)
-			return []Mailbox{{
-				Path: abs, MsgDir: msgDir,
-				Label: label, Files: files,
-			}}, nil
+			var mailboxes []Mailbox
+			for _, mf := range mboxes {
+				mailboxes = append(mailboxes, Mailbox{
+					Path: abs, MsgDir: mf.Dir,
+					Label: label, Files: mf.Files,
+				})
+			}
+			return mailboxes, nil
 		}
 	}
 
@@ -71,9 +72,21 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 			return nil
 		}
 
-		// listEmlxFiles reads Messages/ directly, so skip walking it.
+		// Skip Messages/ directories (read directly by findAllMessagesDirs).
 		if d.Name() == "Messages" {
 			return filepath.SkipDir
+		}
+
+		// Skip UUID directories that are direct children of .mbox dirs.
+		// These contain Data/ shard subtrees that findAllMessagesDirs
+		// reads directly; walking into them wastes I/O.
+		if isUUID(d.Name()) {
+			parent := filepath.Base(filepath.Dir(path))
+			parentLower := strings.ToLower(parent)
+			if strings.HasSuffix(parentLower, ".mbox") ||
+				strings.HasSuffix(parentLower, ".imapmbox") {
+				return filepath.SkipDir
+			}
 		}
 
 		// Skip non-mailbox directories.
@@ -81,16 +94,18 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 			return nil
 		}
 
-		msgDir, files, listErr := listEmlxFiles(path)
-		if listErr != nil || len(files) == 0 {
+		mboxes := listAllEmlxFiles(path)
+		if len(mboxes) == 0 {
 			return nil
 		}
 
 		label := LabelFromPath(abs, path)
-		mailboxes = append(mailboxes, Mailbox{
-			Path: path, MsgDir: msgDir,
-			Label: label, Files: files,
-		})
+		for _, mf := range mboxes {
+			mailboxes = append(mailboxes, Mailbox{
+				Path: path, MsgDir: mf.Dir,
+				Label: label, Files: mf.Files,
+			})
+		}
 
 		return nil
 	})
@@ -99,7 +114,10 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 	}
 
 	sort.Slice(mailboxes, func(i, j int) bool {
-		return mailboxes[i].Path < mailboxes[j].Path
+		if mailboxes[i].Path != mailboxes[j].Path {
+			return mailboxes[i].Path < mailboxes[j].Path
+		}
+		return mailboxes[i].MsgDir < mailboxes[j].MsgDir
 	})
 	return mailboxes, nil
 }
@@ -161,49 +179,67 @@ func isMailboxDir(path string) bool {
 	return findMessagesDir(path) != ""
 }
 
-// findMessagesDir locates the Messages/ directory within a .mbox.
-// Returns "" if none found. Checks both legacy (Messages/) and
-// modern V10 (<GUID>/Data/Messages/) layouts. When both exist,
-// prefers whichever contains .emlx files.
-func findMessagesDir(mailboxPath string) string {
-	var candidates []string
+// findAllMessagesDirs locates all Messages/ directories within a .mbox.
+// Checks legacy (Messages/), modern V10 (<GUID>/Data/Messages/), and
+// sharded V10 (<GUID>/Data/<num>/<num>/<num>/Messages/) layouts.
+func findAllMessagesDirs(mailboxPath string) []string {
+	var dirs []string
 
 	// Legacy: direct Messages/ subdirectory.
 	legacy := filepath.Join(mailboxPath, "Messages")
 	if info, err := os.Stat(legacy); err == nil && info.IsDir() {
-		candidates = append(candidates, legacy)
+		dirs = append(dirs, legacy)
 	}
 
-	// Modern V10: <subdir>/Data/Messages/ subdirectory.
+	// Modern V10: walk <subdir>/Data/ looking for Messages/ directories.
+	// Handles both flat (<GUID>/Data/Messages/) and sharded
+	// (<GUID>/Data/<num>/<num>/<num>/Messages/) layouts.
 	entries, err := os.ReadDir(mailboxPath)
-	if err == nil {
-		for _, e := range entries {
-			if !e.IsDir() || e.Name() == "Messages" {
-				continue
-			}
-			modern := filepath.Join(
-				mailboxPath, e.Name(), "Data", "Messages",
-			)
-			info, statErr := os.Stat(modern)
-			if statErr == nil && info.IsDir() {
-				candidates = append(candidates, modern)
-			}
+	if err != nil {
+		return dirs
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == "Messages" {
+			continue
 		}
+		dataDir := filepath.Join(mailboxPath, e.Name(), "Data")
+		info, statErr := os.Stat(dataDir)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		_ = filepath.WalkDir(dataDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() && d.Name() == "Messages" {
+				dirs = append(dirs, path)
+				return filepath.SkipDir
+			}
+			return nil
+		})
 	}
 
-	if len(candidates) == 0 {
+	return dirs
+}
+
+// findMessagesDir locates the Messages/ directory within a .mbox.
+// Returns "" if none found. When multiple directories exist (sharded
+// V10 layout), returns the first one that contains .emlx files.
+func findMessagesDir(mailboxPath string) string {
+	dirs := findAllMessagesDirs(mailboxPath)
+	if len(dirs) == 0 {
 		return ""
 	}
 
 	// Prefer the first candidate that has .emlx files.
-	for _, dir := range candidates {
+	for _, dir := range dirs {
 		if hasEmlxFiles(dir) {
 			return dir
 		}
 	}
 
 	// No candidate has files; return first for isMailboxDir.
-	return candidates[0]
+	return dirs[0]
 }
 
 // hasEmlxFiles returns true if dir contains at least one
@@ -260,23 +296,33 @@ func stripMailboxSuffix(name string) string {
 	return name
 }
 
-// listEmlxFiles returns the Messages directory path and sorted .emlx
-// filenames within it, excluding .partial.emlx. Returns ("", nil, nil)
-// if no Messages directory is found.
-func listEmlxFiles(
-	mailboxPath string,
-) (string, []string, error) {
-	msgDir := findMessagesDir(mailboxPath)
-	if msgDir == "" {
-		return "", nil, nil
-	}
+// msgDirFiles holds a Messages directory path and its sorted .emlx filenames.
+type msgDirFiles struct {
+	Dir   string
+	Files []string
+}
 
+// listAllEmlxFiles returns all (Messages dir, sorted files) pairs for a
+// mailbox, supporting sharded V10 layouts where .emlx files are spread
+// across multiple Messages/ directories. Only returns entries with files.
+func listAllEmlxFiles(mailboxPath string) []msgDirFiles {
+	dirs := findAllMessagesDirs(mailboxPath)
+	var result []msgDirFiles
+	for _, dir := range dirs {
+		files := readEmlxDir(dir)
+		if len(files) > 0 {
+			result = append(result, msgDirFiles{Dir: dir, Files: files})
+		}
+	}
+	return result
+}
+
+// readEmlxDir reads sorted .emlx filenames from a single Messages
+// directory, excluding .partial.emlx files.
+func readEmlxDir(msgDir string) []string {
 	entries, err := os.ReadDir(msgDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil, nil
-		}
-		return "", nil, fmt.Errorf("read Messages dir: %w", err)
+		return nil
 	}
 
 	var files []string
@@ -298,5 +344,5 @@ func listEmlxFiles(
 	}
 
 	sort.Strings(files)
-	return msgDir, files, nil
+	return files
 }

--- a/internal/emlx/discover_test.go
+++ b/internal/emlx/discover_test.go
@@ -422,6 +422,113 @@ func TestDiscoverMailboxes_MixedLegacyAndV10(t *testing.T) {
 	}
 }
 
+// mkV10ShardedMailbox creates a V10-style mailbox with the sharded
+// numeric directory layout: <GUID>/Data/<num>/<num>/<num>/Messages/*.emlx
+// Each shard is specified as a path like "7/8/1" with its .emlx files.
+func mkV10ShardedMailbox(
+	t *testing.T, base, guid string,
+	shards map[string][]string, // shard path → emlx filenames
+) {
+	t.Helper()
+	for shard, files := range shards {
+		msgDir := filepath.Join(base, guid, "Data", shard, "Messages")
+		if err := os.MkdirAll(msgDir, 0700); err != nil {
+			t.Fatalf("mkdir %q: %v", msgDir, err)
+		}
+		for _, name := range files {
+			data := "10\nFrom: x\r\n\r\n"
+			path := filepath.Join(msgDir, name)
+			if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+				t.Fatalf("write %q: %v", path, err)
+			}
+		}
+	}
+}
+
+func TestDiscoverMailboxes_V10ShardedLayout(t *testing.T) {
+	root := t.TempDir()
+	v10 := filepath.Join(root, "V10")
+	acctGUID := "4D2B4360-8B60-47A1-877F-A598BDB2175E"
+	mboxGUID := "62CDA93A-BD7E-4582-A5A7-78BA9EBB4E70"
+	acctDir := filepath.Join(v10, acctGUID)
+
+	// Simulate a sharded V10 layout like macOS Ventura+.
+	mkV10ShardedMailbox(t,
+		filepath.Join(acctDir, "INBOX.mbox"),
+		mboxGUID,
+		map[string][]string{
+			"7/8/1": {"186735.emlx"},
+			"5/7/1": {"175577.emlx", "175578.emlx"},
+			"1/9/1": {"190001.emlx"},
+		},
+	)
+	mkV10ShardedMailbox(t,
+		filepath.Join(acctDir, "Sent.mbox"),
+		mboxGUID,
+		map[string][]string{
+			"3/9/1": {"200001.emlx", "200002.emlx"},
+		},
+	)
+
+	mailboxes, err := DiscoverMailboxes(v10)
+	if err != nil {
+		t.Fatalf("DiscoverMailboxes: %v", err)
+	}
+
+	// Count total files per label.
+	labelFiles := make(map[string]int)
+	for _, mb := range mailboxes {
+		labelFiles[mb.Label] += len(mb.Files)
+	}
+
+	if labelFiles["INBOX"] != 4 {
+		t.Errorf("INBOX: got %d files, want 4", labelFiles["INBOX"])
+	}
+	if labelFiles["Sent"] != 2 {
+		t.Errorf("Sent: got %d files, want 2", labelFiles["Sent"])
+	}
+
+	// Verify each Mailbox has a valid MsgDir that ends in Messages.
+	for _, mb := range mailboxes {
+		if filepath.Base(mb.MsgDir) != "Messages" {
+			t.Errorf("MsgDir %q does not end in Messages", mb.MsgDir)
+		}
+		if len(mb.Files) == 0 {
+			t.Errorf("Mailbox %q has no files", mb.Label)
+		}
+	}
+}
+
+func TestDiscoverMailboxes_V10ShardedSingleMailbox(t *testing.T) {
+	root := t.TempDir()
+	mboxGUID := "62CDA93A-BD7E-4582-A5A7-78BA9EBB4E70"
+	mboxDir := filepath.Join(root, "INBOX.mbox")
+
+	mkV10ShardedMailbox(t, mboxDir, mboxGUID,
+		map[string][]string{
+			"7/8/1": {"1.emlx", "2.emlx"},
+			"3/9/1": {"3.emlx"},
+		},
+	)
+
+	// Point directly at the .mbox directory.
+	mailboxes, err := DiscoverMailboxes(mboxDir)
+	if err != nil {
+		t.Fatalf("DiscoverMailboxes: %v", err)
+	}
+
+	totalFiles := 0
+	for _, mb := range mailboxes {
+		totalFiles += len(mb.Files)
+		if mb.Label != "INBOX" {
+			t.Errorf("Label = %q, want %q", mb.Label, "INBOX")
+		}
+	}
+	if totalFiles != 3 {
+		t.Errorf("total files = %d, want 3", totalFiles)
+	}
+}
+
 func TestIsUUID(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/importer/emlx_import.go
+++ b/internal/importer/emlx_import.go
@@ -68,10 +68,11 @@ type EmlxImportSummary struct {
 }
 
 type emlxCheckpoint struct {
-	RootDir      string `json:"root_dir"`
-	MailboxIndex int    `json:"mailbox_index"`
-	MailboxPath  string `json:"mailbox_path,omitempty"`
-	LastFile     string `json:"last_file"`
+	RootDir       string `json:"root_dir"`
+	MailboxIndex  int    `json:"mailbox_index"`
+	MailboxPath   string `json:"mailbox_path,omitempty"`
+	MailboxMsgDir string `json:"mailbox_msgdir,omitempty"`
+	LastFile      string `json:"last_file"`
 }
 
 const defaultMaxEmlxBytes int64 = 128 << 20 // 128 MiB
@@ -173,6 +174,16 @@ func ImportEmlxDir(
 							mailboxes[ecp.MailboxIndex].Path,
 						)
 					}
+					// Validate MsgDir if present (sharded V10 layouts
+					// produce multiple entries per .mbox path).
+					if ecp.MailboxMsgDir != "" &&
+						mailboxes[ecp.MailboxIndex].MsgDir != ecp.MailboxMsgDir {
+						return nil, fmt.Errorf(
+							"mailbox at index %d MsgDir changed (%q -> %q); rerun with --no-resume to start fresh",
+							ecp.MailboxIndex, ecp.MailboxMsgDir,
+							mailboxes[ecp.MailboxIndex].MsgDir,
+						)
+					}
 					syncID = active.ID
 					cp.MessagesProcessed = active.MessagesProcessed
 					cp.MessagesAdded = active.MessagesAdded
@@ -202,14 +213,15 @@ func ImportEmlxDir(
 	hardErrors := false
 
 	type pendingEmlxMsg struct {
-		Raw       []byte
-		RawHash   string
-		SourceMsg string
-		LabelIDs  []int64
-		Fallback  time.Time
-		MboxIdx   int
-		MboxPath  string
-		FileName  string
+		Raw        []byte
+		RawHash    string
+		SourceMsg  string
+		LabelIDs   []int64
+		Fallback   time.Time
+		MboxIdx    int
+		MboxPath   string
+		MboxMsgDir string
+		FileName   string
 	}
 
 	const (
@@ -222,8 +234,10 @@ func ImportEmlxDir(
 	pendingIdx := make(map[string]int) // SourceMsg → index in pending
 	lastCpMbox := startMbox
 	lastCpMboxPath := ""
+	lastCpMboxMsgDir := ""
 	if startMbox < len(mailboxes) {
 		lastCpMboxPath = mailboxes[startMbox].Path
+		lastCpMboxMsgDir = mailboxes[startMbox].MsgDir
 	}
 	lastCpFile := startAfter
 	checkpointBlocked := false
@@ -231,7 +245,7 @@ func ImportEmlxDir(
 	// Save initial checkpoint.
 	if err := saveEmlxCheckpoint(
 		st, syncID, absRoot, startMbox, lastCpMboxPath,
-		startAfter, &cp,
+		lastCpMboxMsgDir, startAfter, &cp,
 	); err != nil {
 		cp.ErrorsCount++
 		summary.Errors++
@@ -269,7 +283,7 @@ func ImportEmlxDir(
 				summary.Duration = time.Since(start)
 				if err := saveEmlxCheckpoint(
 					st, syncID, absRoot, lastCpMbox,
-					lastCpMboxPath, lastCpFile, &cp,
+					lastCpMboxPath, lastCpMboxMsgDir, lastCpFile, &cp,
 				); err != nil {
 					log.Warn("checkpoint save failed", "error", err)
 				}
@@ -322,11 +336,12 @@ func ImportEmlxDir(
 				if !checkpointBlocked {
 					lastCpMbox = p.MboxIdx
 					lastCpMboxPath = p.MboxPath
+					lastCpMboxMsgDir = p.MboxMsgDir
 					lastCpFile = p.FileName
 					checkpointIfDue(
 						&cp, summary, opts.CheckpointInterval,
 						st, syncID, absRoot, lastCpMbox,
-						lastCpMboxPath, lastCpFile, log,
+						lastCpMboxPath, lastCpMboxMsgDir, lastCpFile, log,
 					)
 				}
 				continue
@@ -366,11 +381,12 @@ func ImportEmlxDir(
 			if !checkpointBlocked {
 				lastCpMbox = p.MboxIdx
 				lastCpMboxPath = p.MboxPath
+				lastCpMboxMsgDir = p.MboxMsgDir
 				lastCpFile = p.FileName
 				checkpointIfDue(
 					&cp, summary, opts.CheckpointInterval,
 					st, syncID, absRoot, lastCpMbox,
-					lastCpMboxPath, lastCpFile, log,
+					lastCpMboxPath, lastCpMboxMsgDir, lastCpFile, log,
 				)
 			}
 		}
@@ -479,14 +495,15 @@ func ImportEmlxDir(
 			} else {
 				pendingIdx[sourceMsgID] = len(pending)
 				pending = append(pending, pendingEmlxMsg{
-					Raw:       msg.Raw,
-					RawHash:   rawHash,
-					SourceMsg: sourceMsgID,
-					LabelIDs:  labelIDs,
-					Fallback:  fallbackDate,
-					MboxIdx:   mboxIdx,
-					MboxPath:  mb.Path,
-					FileName:  fileName,
+					Raw:        msg.Raw,
+					RawHash:    rawHash,
+					SourceMsg:  sourceMsgID,
+					LabelIDs:   labelIDs,
+					Fallback:   fallbackDate,
+					MboxIdx:    mboxIdx,
+					MboxPath:   mb.Path,
+					MboxMsgDir: mb.MsgDir,
+					FileName:   fileName,
 				})
 				pendingBytes += int64(len(msg.Raw))
 			}
@@ -522,7 +539,7 @@ func ImportEmlxDir(
 	// Final checkpoint.
 	if err := saveEmlxCheckpoint(
 		st, syncID, absRoot, lastCpMbox, lastCpMboxPath,
-		lastCpFile, &cp,
+		lastCpMboxMsgDir, lastCpFile, &cp,
 	); err != nil {
 		cp.ErrorsCount++
 		summary.Errors++
@@ -563,14 +580,15 @@ func ImportEmlxDir(
 
 func saveEmlxCheckpoint(
 	st *store.Store, syncID int64,
-	rootDir string, mboxIdx int, mboxPath string,
+	rootDir string, mboxIdx int, mboxPath, mboxMsgDir string,
 	lastFile string, cp *store.Checkpoint,
 ) error {
 	b, err := json.Marshal(emlxCheckpoint{
-		RootDir:      rootDir,
-		MailboxIndex: mboxIdx,
-		MailboxPath:  mboxPath,
-		LastFile:     lastFile,
+		RootDir:       rootDir,
+		MailboxIndex:  mboxIdx,
+		MailboxPath:   mboxPath,
+		MailboxMsgDir: mboxMsgDir,
+		LastFile:      lastFile,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal checkpoint: %w", err)
@@ -583,14 +601,14 @@ func checkpointIfDue(
 	cp *store.Checkpoint, summary *EmlxImportSummary,
 	interval int,
 	st *store.Store, syncID int64,
-	rootDir string, mboxIdx int, mboxPath string,
+	rootDir string, mboxIdx int, mboxPath, mboxMsgDir string,
 	lastFile string, log *slog.Logger,
 ) {
 	if cp.MessagesProcessed%int64(interval) != 0 {
 		return
 	}
 	if err := saveEmlxCheckpoint(
-		st, syncID, rootDir, mboxIdx, mboxPath, lastFile, cp,
+		st, syncID, rootDir, mboxIdx, mboxPath, mboxMsgDir, lastFile, cp,
 	); err != nil {
 		cp.ErrorsCount++
 		summary.Errors++

--- a/internal/importer/emlx_import_test.go
+++ b/internal/importer/emlx_import_test.go
@@ -622,7 +622,7 @@ func TestImportEmlxDir_MailboxPathMismatchRejectsResume(t *testing.T) {
 	}
 	if err := saveEmlxCheckpoint(
 		st, syncID, absRoot, 0,
-		"/old/path/to/OtherMailbox.mbox", "",
+		"/old/path/to/OtherMailbox.mbox", "", "",
 		&store.Checkpoint{},
 	); err != nil {
 		t.Fatalf("save checkpoint: %v", err)
@@ -730,7 +730,7 @@ func TestImportEmlxDir_RootMismatchRejectsResume(t *testing.T) {
 		t.Fatalf("abs root A: %v", err)
 	}
 	if err := saveEmlxCheckpoint(
-		st, syncID, absRootA, 0, "", "", &store.Checkpoint{},
+		st, syncID, absRootA, 0, "", "", "", &store.Checkpoint{},
 	); err != nil {
 		t.Fatalf("save checkpoint: %v", err)
 	}

--- a/scripts/import-all.sh
+++ b/scripts/import-all.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+usage() {
+  echo "Usage: $0 <account-email> <mail-dir>"
+  echo
+  echo "Import all Apple Mail account directories from a V10 (or similar) mail directory."
+  echo
+  echo "Arguments:"
+  echo "  account-email   Email address to associate with imported messages"
+  echo "  mail-dir        Path to Apple Mail directory containing account GUIDs"
+  echo "                  (e.g. ~/Library/Mail/V10)"
+  echo
+  echo "Example:"
+  echo "  $0 me@gmail.com ~/Library/Mail/V10"
+  exit 1
+}
+
+if [ $# -ne 2 ]; then
+  usage
+fi
+
+ACCOUNT="$1"
+MAIL_DIR="$2"
+MSGVAULT="${MSGVAULT:-./msgvault}"
+
+if [ ! -d "$MAIL_DIR" ]; then
+  echo "Error: mail directory not found: $MAIL_DIR" >&2
+  exit 1
+fi
+
+if [ ! -x "$MSGVAULT" ]; then
+  echo "Error: msgvault binary not found at $MSGVAULT" >&2
+  echo "Set MSGVAULT env var or run from the project root after 'make build'" >&2
+  exit 1
+fi
+
+imported=0
+failed=0
+
+for dir in "$MAIL_DIR"/*/; do
+  # Skip if not a directory
+  [ -d "$dir" ] || continue
+
+  name=$(basename "$dir")
+
+  # Skip known non-account directories
+  case "$name" in
+    Signatures|MailData|Bundles|"RSS") continue ;;
+  esac
+
+  echo "=== Importing $name ==="
+  if "$MSGVAULT" import-emlx "$ACCOUNT" "$dir"; then
+    imported=$((imported + 1))
+  else
+    echo "  (failed or empty, continuing)"
+    failed=$((failed + 1))
+  fi
+  echo
+done
+
+echo "Done. Imported: $imported, Failed/empty: $failed"


### PR DESCRIPTION
> [!NOTE]
> Alternate fix for #157. See also #166 (partition discovery with `FileIndex` map) and #172 (auto-resolve accounts via `Accounts4.sqlite`, builds on #166). This PR takes a simpler architectural approach — one `Mailbox` per `Messages/` dir using the existing `MsgDir` field — and adds checkpoint tracking for correct resume across shards. The `import-all.sh` script is a lightweight shell equivalent of the native auto-discovery in #172. These could be combined depending on maintainer preference.

## Summary

- **Sharded V10 discovery**: Apple Mail on macOS Ventura+ stores `.emlx` files in a sharded numeric directory layout (`<GUID>/Data/<num>/<num>/<num>/Messages/*.emlx`). The existing discovery code only checked for flat `Messages/` and `<GUID>/Data/Messages/` paths, returning 0 mailboxes for sharded accounts. `findAllMessagesDirs()` now recursively walks `Data/` subtrees to find all `Messages/` directories.
- **Multi-shard mailbox support**: Each `Messages/` directory within a `.mbox` becomes its own `Mailbox` entry with a distinct `MsgDir`, so the importer processes every shard. Sort order uses `(Path, MsgDir)` for deterministic ordering.
- **Checkpoint correctness**: The emlx importer checkpoint now tracks `MsgDir` alongside `Path`, so resume after interrupt correctly skips already-imported shards rather than re-importing or skipping the wrong ones.
- **Import-all script**: New `scripts/import-all.sh` convenience script iterates all account GUID directories under a V10 mail root, skipping known non-account dirs (Signatures, MailData, etc.).

## Test plan

- [x] Unit tests pass (`TestDiscoverMailboxes_V10ShardedLayout`, `TestDiscoverMailboxes_V10ShardedSingleMailbox`)
- [x] Tested against real Apple Mail V10 data on macOS Ventura (Proton Mail Bridge account)
- [ ] Verify incremental import resumes correctly after interruption mid-shard