### PR TITLE
Truncate long MIME parse error messages

### DIFF
--- a/internal/textutil/encoding.go
+++ b/internal/textutil/encoding.go
@@ -136,7 +136,7 @@ func TruncateRunes(s string, maxRunes int) string {
 	return string(runes[:maxRunes-3]) + "..."
 }
 
-// FirstLine returns the first line of a string, capped at 200 characters.
+// FirstLine returns the first line of a string, capped at 200 runes.
 // Useful for extracting clean error messages from multi-line outputs
 // where the first line itself may be excessively long (e.g. enmime
 // includes malformed MIME content in its error messages).
@@ -145,8 +145,5 @@ func FirstLine(s string) string {
 	if idx := strings.Index(s, "\n"); idx >= 0 {
 		s = s[:idx]
 	}
-	if len(s) > 200 {
-		return s[:200] + "..."
-	}
-	return s
+	return TruncateRunes(s, 200)
 }

--- a/internal/textutil/encoding_test.go
+++ b/internal/textutil/encoding_test.go
@@ -486,9 +486,10 @@ func TestFirstLine(t *testing.T) {
 		{"leading carriage return", "\r\nSecond", "Second"},
 		{"mixed leading newlines", "\r\n\n\rThird", "Third"},
 		{"only newlines", "\n\n\n", ""},
-		{"long line truncated", strings.Repeat("x", 250), strings.Repeat("x", 200) + "..."},
-		{"exactly 200 chars", strings.Repeat("y", 200), strings.Repeat("y", 200)},
-		{"long first line of multi", strings.Repeat("z", 250) + "\nSecond", strings.Repeat("z", 200) + "..."},
+		{"long line truncated", strings.Repeat("x", 250), strings.Repeat("x", 197) + "..."},
+		{"exactly 200 runes", strings.Repeat("y", 200), strings.Repeat("y", 200)},
+		{"long first line of multi", strings.Repeat("z", 250) + "\nSecond", strings.Repeat("z", 197) + "..."},
+		{"unicode truncation safe", strings.Repeat("é", 250), strings.Repeat("é", 197) + "..."},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Cap `FirstLine()` output at 200 runes using the existing `TruncateRunes` helper
- Prevents enmime's malformed-MIME error messages (which embed the full email content as a single line) from flooding console output during sync
- Uses rune-safe truncation to avoid splitting multi-byte UTF-8 characters in non-ASCII error text

## Test plan

- [x] Existing `TestFirstLine` tests pass
- [x] New test cases: long ASCII lines, exact boundary (200 runes), long first line of multi-line, and Unicode truncation safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)