### PR TITLE
fix(imap): fall back to plain UID SEARCH when server lacks ESEARCH

### DIFF
--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -236,9 +236,16 @@ func (c *Client) enumerateMailbox(
 		}
 	}
 
+	// Use ESEARCH RETURN (ALL) when the server supports it for compact
+	// UID set responses; fall back to plain UID SEARCH ALL otherwise.
+	var searchOpts *imap.SearchOptions
+	if c.conn.Caps().Has(imap.CapESearch) {
+		searchOpts = &imap.SearchOptions{ReturnAll: true}
+	}
+
 	searchData, err := c.conn.UIDSearch(
 		&imap.SearchCriteria{},
-		&imap.SearchOptions{ReturnAll: true},
+		searchOpts,
 	).Wait()
 	if err != nil {
 		if isNetworkError(err) {
@@ -254,7 +261,7 @@ func (c *Client) enumerateMailbox(
 			}
 			searchData, err = c.conn.UIDSearch(
 				&imap.SearchCriteria{},
-				&imap.SearchOptions{ReturnAll: true},
+				searchOpts,
 			).Wait()
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Problem

The IMAP sync unconditionally uses `SEARCH RETURN (ALL)` syntax from RFC 4731 (ESEARCH extension) without checking whether the server advertises the `ESEARCH` capability. Servers that don't support ESEARCH — notably Protonmail Bridge's gluon IMAP backend — reject the `RETURN` keyword with a `BAD` response:

```
Failed to parse IMAP command  error="[Error offset=15]: unknown search key 'return'"
```

This cascades into connection failures and causes the entire sync to return zero messages. Every mailbox is skipped with `imap: BAD [Error] <unknown>`.

## Fix

Check for `imap.CapESearch` before using `SearchOptions{ReturnAll: true}`. When the capability is absent, pass `nil` options so `go-imap` sends a plain `UID SEARCH ALL` command that all IMAP servers support. The `SearchData.All` field is populated identically in both code paths, so no other changes are needed.

## Testing

Tested against Protonmail Bridge v3.22.0 (which uses gluon as its IMAP backend and does not advertise ESEARCH). Before the fix: 0 messages synced, all mailboxes skipped. After the fix: 5,072 messages synced successfully in 53 seconds.