### PR TITLE
fix: drop ESEARCH RETURN (ALL) for IMAP4rev1 compatibility

### DIFF
--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -238,7 +238,7 @@ func (c *Client) enumerateMailbox(
 
 	searchData, err := c.conn.UIDSearch(
 		&imap.SearchCriteria{},
-		&imap.SearchOptions{ReturnAll: true},
+		nil,
 	).Wait()
 	if err != nil {
 		if isNetworkError(err) {
@@ -254,7 +254,7 @@ func (c *Client) enumerateMailbox(
 			}
 			searchData, err = c.conn.UIDSearch(
 				&imap.SearchCriteria{},
-				&imap.SearchOptions{ReturnAll: true},
+				nil,
 			).Wait()
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Problem

`enumerateMailbox` calls `UIDSearch` with `&imap.SearchOptions{ReturnAll: true}`, which makes go-imap/v2 send:

```
UID SEARCH RETURN (ALL) ALL
```

The `RETURN` keyword is an ESEARCH extension (RFC 4731) that requires IMAP4rev2 or explicit ESEARCH capability advertisement.

IMAP servers that only speak IMAP4rev1 — notably **Proton Mail Bridge** (via gluon) — reject this with `BAD`, which kills the TCP connection and cascades into `use of closed network connection` errors for every subsequent mailbox operation. The sync completes with **0 messages added**.

## Root cause

Proton Bridge capabilities:
```
CAPABILITY AUTH=PLAIN ID IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT
```

No ESEARCH, no IMAP4rev2. The bridge parser treats `RETURN` as an unknown search key:
```
BAD [Error offset=17]: unknown search key 'return'
```

## Fix

Pass `nil` for `SearchOptions` instead of `&imap.SearchOptions{ReturnAll: true}`. This sends plain `UID SEARCH ALL`, which every IMAP server supports.

The go-imap/v2 library still populates `SearchData.All` via the traditional `* SEARCH` response handler (it initializes `All` as `UIDSet` for `UIDSearch` regardless of response type), so the downstream type assertion continues to work unchanged.

## Tested

Against Proton Mail Bridge 03.21.02 — sync went from 0 messages to 3,247 messages ingested.