### PR TITLE
Fix IMAP IPv6 host parsing in add-imap

### DIFF
--- a/internal/imap/config.go
+++ b/internal/imap/config.go
@@ -4,8 +4,10 @@ package imap
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // Config holds connection settings for an IMAP server.
@@ -27,7 +29,7 @@ func (c *Config) Addr() string {
 			port = 143
 		}
 	}
-	return fmt.Sprintf("%s:%d", c.Host, port)
+	return net.JoinHostPort(normalizeHost(c.Host), strconv.Itoa(port))
 }
 
 // Identifier returns a canonical string like "imaps://user@host:port".
@@ -48,7 +50,18 @@ func (c *Config) Identifier() string {
 			port = 143
 		}
 	}
-	return fmt.Sprintf("%s://%s@%s:%d", scheme, url.PathEscape(c.Username), c.Host, port)
+	return fmt.Sprintf(
+		"%s://%s@%s",
+		scheme,
+		url.PathEscape(c.Username),
+		net.JoinHostPort(normalizeHost(c.Host), strconv.Itoa(port)),
+	)
+}
+
+// normalizeHost strips surrounding IPv6 brackets so callers can pass either
+// "::1" or "[::1]" and still get a valid host:port from net.JoinHostPort.
+func normalizeHost(host string) string {
+	return strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 }
 
 // ToJSON serializes the config to JSON.

--- a/internal/imap/config_test.go
+++ b/internal/imap/config_test.go
@@ -33,12 +33,50 @@ func TestIdentifier(t *testing.T) {
 			cfg:  Config{Host: "mail.example.com", Username: "user"},
 			want: "imap://user@mail.example.com:143",
 		},
+		{
+			name: "IPv6 host unbracketed",
+			cfg:  Config{Host: "::1", Port: 1993, Username: "user"},
+			want: "imap://user@[::1]:1993",
+		},
+		{
+			name: "IPv6 host bracketed",
+			cfg:  Config{Host: "[::1]", Port: 1993, Username: "user"},
+			want: "imap://user@[::1]:1993",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.cfg.Identifier()
 			if got != tt.want {
 				t.Errorf("Identifier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddr_IPv6(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "unbracketed",
+			cfg:  Config{Host: "::1", Port: 1993},
+			want: "[::1]:1993",
+		},
+		{
+			name: "bracketed",
+			cfg:  Config{Host: "[::1]", Port: 1993},
+			want: "[::1]:1993",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.Addr()
+			if got != tt.want {
+				t.Errorf("Addr() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**_This was written by Cursor.  I don't know Go at all, so I am not claiming it's correct or not._**

## What this fixes

`add-imap` failed with IPv6 hosts passed to `--host` due to invalid address construction (`::1:1993`), causing:

- `dial tcp: address ::1:1993: too many colons in address`

## Root cause

IMAP config built `host:port` with string formatting instead of proper host/port joining, so raw IPv6 literals were not bracketed.

## Change

- Use Go's `net.JoinHostPort` when building IMAP addresses/identifiers.
- Normalize optional IPv6 brackets in `--host` input so both forms are accepted:
  - `::1`
  - `[::1]`

## Tests

Added/updated unit tests to verify:

- IPv6 unbracketed host works.
- IPv6 bracketed host works.
- Both normalize to the same valid output.