### PR TITLE
Update nix flake for v0.11.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
           in
           (pkgs.buildGoModule.override { go = go_pinned; }) {
             pname = "msgvault";
-            version = "0.0.0-dev";
+            version = "0.11.0";
             src = ./.;
             vendorHash = "sha256-o7yjPy1pDkD6Ia1H/4Ny/GYqfwv4Vbsd86bQJY6IiVo=";
             proxyVendor = true;

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -46,7 +46,8 @@ if [ -n "$VERSION_TAG" ]; then
         exit 1
     fi
     echo "==> Updating version to $VERSION..."
-    sed -i.bak -E "s/version = \"[^\"]+\"/version = \"$VERSION\"/" flake.nix
+    # Only replace the msgvault version (after pname), not the Go version
+    sed -i.bak -E '/pname = "msgvault"/,/version = "[^"]+"/ s/version = "[^"]+"/version = "'"$VERSION"'"/' flake.nix
     rm -f flake.nix.bak
 fi
 


### PR DESCRIPTION
## Summary
- Update msgvault version in `flake.nix` to `0.11.0`
- Fix `update-nix-flake.sh` sed command that replaced all `version = "..."` strings in `flake.nix`, including the pinned Go version — scope it to only the msgvault `pname` block

The automated update failed because sed turned Go `1.25.8` into `0.11.0`, causing nix to try downloading `go0.11.0.src.tar.gz` (404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)