### PR TITLE
Support IMAP accounts in delete-staged command

### DIFF
--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -361,16 +361,23 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("look up source for %s: %w", account, err)
 			}
-			var found *store.Source
+			var syncable []*store.Source
 			for _, c := range resolved {
 				if c.SourceType == "gmail" || c.SourceType == "imap" {
-					found = c
-					break
+					syncable = append(syncable, c)
 				}
 			}
-			if found == nil {
+			if len(syncable) == 0 {
 				return fmt.Errorf("no gmail or imap source found for %s", account)
 			}
+			if len(syncable) > 1 {
+				var types []string
+				for _, c := range syncable {
+					types = append(types, fmt.Sprintf("%s (%s)", c.Identifier, c.SourceType))
+				}
+				return fmt.Errorf("multiple accounts match %q: %s\nUse the full identifier with --account to disambiguate", account, strings.Join(types, ", "))
+			}
+			found := syncable[0]
 			// Canonicalize to stored identifier so manifest
 			// comparisons work for IMAP display-name lookups.
 			account = found.Identifier


### PR DESCRIPTION
_Human note: this fixed my use case (processing a ton of iCloud-hosted emails). Code _looks_ reasonable to me, but I don't know golang. iCloud (IMAP) path is tested, Gmail path is untested (I don't have a gmail)._

===========

## Summary

- `delete-staged` now detects account type and routes IMAP accounts through the IMAP client path instead of always assuming Gmail OAuth
- Reuses the existing `buildAPIClient` factory (same one used by sync) to avoid duplicating IMAP client construction
- Preserves full Gmail scope escalation behavior (both proactive and reactive paths)

Closes #221

## Testing

Tested end-to-end on a real iCloud IMAP account:

- **10-message batch**: 10/10 succeeded, 0 failed (8s). Batch delete correctly fell back to per-message `UID STORE \Deleted` + `UID EXPUNGE`.
- **741-message batch**: 741/741 succeeded, 0 failed (~7min). Confirmed the fallback path handles large batches reliably.
- `--dry-run` works correctly for IMAP accounts
- All existing tests pass (`make test`)
- `go fmt` and `go vet` clean