### PR TITLE
Enhance search functionality with regex, FTS5, snippets, and sorting

### DIFF
--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -418,6 +418,19 @@ func escapeILIKE(s string) string {
 	return s
 }
 
+// startsWithWordChar reports whether s begins with a regex word character
+// [a-zA-Z0-9_]. Used to decide whether \b is appropriate as a prefix.
+func startsWithWordChar(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	c := s[0]
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_'
+}
+
 // escapeRegex escapes special regex characters for use in DuckDB's regexp_matches function
 func escapeRegex(s string) string {
 	s = strings.ReplaceAll(s, "\\", "\\\\")
@@ -457,9 +470,16 @@ func (e *DuckDBEngine) buildAggregateSearchConditions(searchQuery string, keyCol
 
 	// Text terms: always search subject + sender, plus the view's grouping
 	// key columns when provided (e.g., label name in Labels view).
-	// Uses word-boundary regex (\b) to match whole words only.
+	// Uses word-boundary regex (\b) for terms starting with word chars.
+	// Terms starting with non-word chars (e.g., +, @, #) skip \b
+	// since it requires a word/non-word transition that fails at
+	// string start or after whitespace.
 	for _, term := range q.TextTerms {
-		regexPattern := "(?i)\\b" + escapeRegex(term)
+		escaped := escapeRegex(term)
+		regexPattern := "(?i)" + escaped
+		if startsWithWordChar(term) {
+			regexPattern = "(?i)\\b" + escaped
+		}
 		var parts []string
 		parts = append(parts, `regexp_matches(COALESCE(msg.subject, ''), ?)`)
 		args = append(args, regexPattern)
@@ -2387,11 +2407,15 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 	}
 
 	// Text search terms - search subject, snippet, and from fields (fast path).
-	// Use word-boundary regex (\b) to match whole words only.
-	// Case-insensitive via (?i).
+	// Use word-boundary regex (\b) for terms starting with word chars.
+	// Terms starting with non-word chars skip \b (see startsWithWordChar).
 	if len(q.TextTerms) > 0 {
 		for _, term := range q.TextTerms {
-			regexPattern := "(?i)\\b" + escapeRegex(term)
+			escaped := escapeRegex(term)
+			regexPattern := "(?i)" + escaped
+			if startsWithWordChar(term) {
+				regexPattern = "(?i)\\b" + escaped
+			}
 			conditions = append(conditions, `(
 				regexp_matches(COALESCE(msg.subject, ''), ?) OR
 				regexp_matches(COALESCE(msg.snippet, ''), ?) OR

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -418,6 +418,25 @@ func escapeILIKE(s string) string {
 	return s
 }
 
+// escapeRegex escapes special regex characters for use in DuckDB's regexp_matches function
+func escapeRegex(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, ".", "\\.")
+	s = strings.ReplaceAll(s, "*", "\\*")
+	s = strings.ReplaceAll(s, "+", "\\+")
+	s = strings.ReplaceAll(s, "?", "\\?")
+	s = strings.ReplaceAll(s, "[", "\\[")
+	s = strings.ReplaceAll(s, "]", "\\]")
+	s = strings.ReplaceAll(s, "(", "\\(")
+	s = strings.ReplaceAll(s, ")", "\\)")
+	s = strings.ReplaceAll(s, "{", "\\{")
+	s = strings.ReplaceAll(s, "}", "\\}")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "^", "\\^")
+	s = strings.ReplaceAll(s, "$", "\\$")
+	return s
+}
+
 // buildWhereClause builds WHERE conditions for Parquet queries.
 // Column references use msg. prefix to be explicit since aggregate queries join multiple CTEs.
 // buildAggregateSearchConditions builds SQL conditions for a search query in aggregate views.
@@ -438,24 +457,25 @@ func (e *DuckDBEngine) buildAggregateSearchConditions(searchQuery string, keyCol
 
 	// Text terms: always search subject + sender, plus the view's grouping
 	// key columns when provided (e.g., label name in Labels view).
+	// Uses word-boundary regex (\b) to match whole words only.
 	for _, term := range q.TextTerms {
-		termPattern := "%" + escapeILIKE(term) + "%"
+		regexPattern := "(?i)\\b" + escapeRegex(term)
 		var parts []string
-		parts = append(parts, `msg.subject ILIKE ? ESCAPE '\'`)
-		args = append(args, termPattern)
-		parts = append(parts, `COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\'`)
-		args = append(args, termPattern)
+		parts = append(parts, `regexp_matches(COALESCE(msg.subject, ''), ?)`)
+		args = append(args, regexPattern)
+		parts = append(parts, `regexp_matches(COALESCE(msg.snippet, ''), ?)`)
+		args = append(args, regexPattern)
 		parts = append(parts, `EXISTS (
 			SELECT 1 FROM mr mr_search
 			JOIN p p_search ON p_search.id = mr_search.participant_id
 			WHERE mr_search.message_id = msg.id
 			  AND mr_search.recipient_type = 'from'
-			  AND (p_search.email_address ILIKE ? ESCAPE '\' OR p_search.display_name ILIKE ? ESCAPE '\')
+			  AND (regexp_matches(p_search.email_address, ?) OR regexp_matches(COALESCE(p_search.display_name, ''), ?))
 		)`)
-		args = append(args, termPattern, termPattern)
+		args = append(args, regexPattern, regexPattern)
 		for _, col := range keyColumns {
-			parts = append(parts, col+` ILIKE ? ESCAPE '\'`)
-			args = append(args, termPattern)
+			parts = append(parts, `regexp_matches(COALESCE(`+col+`, ''), ?)`)
+			args = append(args, regexPattern)
 		}
 		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
 	}
@@ -1438,10 +1458,10 @@ func (e *DuckDBEngine) getMessageByQuery(ctx context.Context, whereClause string
 // Search performs a Gmail-style search query.
 // Uses direct SQLite connection for FTS5 support when available,
 // falls back to LIKE queries via sqlite_scan otherwise.
-func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
+func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
 	// Prefer direct SQLite for FTS5 support
 	if e.sqliteEngine != nil {
-		return e.sqliteEngine.Search(ctx, q, limit, offset)
+		return e.sqliteEngine.Search(ctx, q, sorting, limit, offset)
 	}
 
 	// Fall back to sqlite_scan with LIKE queries (no FTS)
@@ -1836,7 +1856,7 @@ type ParquetSyncState struct {
 // SearchFast searches message metadata in Parquet files (no body text).
 // This is much faster than FTS search for large archives.
 // Searches: subject, sender email/name (case-insensitive).
-func (e *DuckDBEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
+func (e *DuckDBEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
 	conditions, args := e.buildSearchConditions(q, filter)
 
 	if limit == 0 {
@@ -2190,7 +2210,7 @@ func (e *DuckDBEngine) computeSearchStats(ctx context.Context) *TotalStats {
 // is served directly from the cached temp table. A new search invalidates the
 // old cache.
 func (e *DuckDBEngine) SearchFastWithStats(ctx context.Context, q *search.Query, queryStr string,
-	filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
+	filter MessageFilter, sorting MessageSorting, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
 
 	conditions, args := e.buildSearchConditions(q, filter)
 
@@ -2366,18 +2386,20 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 		args = append(args, filter.TimeRange.Period)
 	}
 
-	// Text search terms - search subject, snippet, and sender fields (fast path)
+	// Text search terms - search subject, snippet, and from fields (fast path).
+	// Use word-boundary regex (\b) to match whole words only.
+	// Case-insensitive via (?i).
 	if len(q.TextTerms) > 0 {
 		for _, term := range q.TextTerms {
-			termPattern := "%" + escapeILIKE(term) + "%"
+			regexPattern := "(?i)\\b" + escapeRegex(term)
 			conditions = append(conditions, `(
-				msg.subject ILIKE ? ESCAPE '\' OR
-				COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\' OR
-				COALESCE(ms.from_email, ds.from_email, '') ILIKE ? ESCAPE '\' OR
-				COALESCE(ms.from_name, ds.from_name, '') ILIKE ? ESCAPE '\' OR
-				COALESCE(ms.from_phone, ds.from_phone, '') ILIKE ? ESCAPE '\'
+				regexp_matches(COALESCE(msg.subject, ''), ?) OR
+				regexp_matches(COALESCE(msg.snippet, ''), ?) OR
+				regexp_matches(COALESCE(ms.from_email, ds.from_email, ''), ?) OR
+				regexp_matches(COALESCE(ms.from_name, ds.from_name, ''), ?) OR
+				regexp_matches(COALESCE(ms.from_phone, ds.from_phone, ''), ?)
 			)`)
-			args = append(args, termPattern, termPattern, termPattern, termPattern, termPattern)
+			args = append(args, regexPattern, regexPattern, regexPattern, regexPattern, regexPattern)
 		}
 	}
 

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1458,10 +1458,10 @@ func (e *DuckDBEngine) getMessageByQuery(ctx context.Context, whereClause string
 // Search performs a Gmail-style search query.
 // Uses direct SQLite connection for FTS5 support when available,
 // falls back to LIKE queries via sqlite_scan otherwise.
-func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
+func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
 	// Prefer direct SQLite for FTS5 support
 	if e.sqliteEngine != nil {
-		return e.sqliteEngine.Search(ctx, q, sorting, limit, offset)
+		return e.sqliteEngine.Search(ctx, q, limit, offset)
 	}
 
 	// Fall back to sqlite_scan with LIKE queries (no FTS)
@@ -1856,7 +1856,7 @@ type ParquetSyncState struct {
 // SearchFast searches message metadata in Parquet files (no body text).
 // This is much faster than FTS search for large archives.
 // Searches: subject, sender email/name (case-insensitive).
-func (e *DuckDBEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
+func (e *DuckDBEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
 	conditions, args := e.buildSearchConditions(q, filter)
 
 	if limit == 0 {
@@ -2210,7 +2210,7 @@ func (e *DuckDBEngine) computeSearchStats(ctx context.Context) *TotalStats {
 // is served directly from the cached temp table. A new search invalidates the
 // old cache.
 func (e *DuckDBEngine) SearchFastWithStats(ctx context.Context, q *search.Query, queryStr string,
-	filter MessageFilter, sorting MessageSorting, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
+	filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
 
 	conditions, args := e.buildSearchConditions(q, filter)
 

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -1913,6 +1913,47 @@ func TestBuildWhereClause_EscapedArgs(t *testing.T) {
 	}
 }
 
+// TestBuildWhereClause_WordBoundaryPrefix verifies that \b is only applied
+// when the search term starts with a word character [a-zA-Z0-9_]. Terms
+// starting with non-word characters (+, @, #, etc.) must not get \b, as it
+// requires a word/non-word transition that fails at string start.
+func TestBuildWhereClause_WordBoundaryPrefix(t *testing.T) {
+	engine := &DuckDBEngine{}
+
+	tests := []struct {
+		name       string
+		term       string
+		wantPrefix string // expected prefix in the regex arg
+	}{
+		{"word_char_letter", "hello", "(?i)\\bhello"},
+		{"word_char_digit", "123", "(?i)\\b123"},
+		{"word_char_underscore", "_test", "(?i)\\b_test"},
+		{"non_word_plus", "+15551234567", "(?i)\\+15551234567"},
+		{"non_word_at", "@gmail.com", "(?i)@gmail\\.com"},
+		{"non_word_hash", "#bug", "(?i)#bug"},
+		{"non_word_paren", "(test)", "(?i)\\(test\\)"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := AggregateOptions{SearchQuery: tc.term}
+			_, args := engine.buildWhereClause(opts)
+
+			found := false
+			for _, arg := range args {
+				if s, ok := arg.(string); ok && s == tc.wantPrefix {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("term %q: expected arg %q, got %v",
+					tc.term, tc.wantPrefix, args)
+			}
+		})
+	}
+}
+
 // TestAggregateBySender_WithSearchQuery verifies that aggregate queries respect
 // search query filters.
 func TestAggregateBySender_WithSearchQuery(t *testing.T) {

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -1839,7 +1839,7 @@ func TestBuildWhereClause_SearchOperators(t *testing.T) {
 		{
 			name:        "text terms",
 			searchQuery: "hello world",
-			wantClauses: []string{"msg.subject ILIKE", "ESCAPE"},
+			wantClauses: []string{"regexp_matches(COALESCE(msg.subject"},
 		},
 		{
 			name:        "from operator",
@@ -1899,16 +1899,17 @@ func TestBuildWhereClause_EscapedArgs(t *testing.T) {
 	opts := AggregateOptions{SearchQuery: "100%_off"}
 	_, args := engine.buildWhereClause(opts)
 
-	// The escaped pattern should appear in args
+	// With regex search, % and _ are not special so appear unescaped.
+	// Term starts with word char '1', so \b prefix is applied.
 	found := false
 	for _, arg := range args {
-		if s, ok := arg.(string); ok && strings.Contains(s, "100\\%\\_off") {
+		if s, ok := arg.(string); ok && strings.Contains(s, "\\b100%_off") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected escaped pattern '100\\%%\\_off' in args, got: %v", args)
+		t.Errorf("expected regex pattern containing '\\b100%%_off' in args, got: %v", args)
 	}
 }
 
@@ -2007,7 +2008,7 @@ func TestAggregateByLabel_WithLabelSearch(t *testing.T) {
 }
 
 // TestBuildSearchConditions_EscapedWildcards verifies that buildSearchConditions
-// escapes ILIKE wildcards and uses ESCAPE clause for all text patterns.
+// escapes wildcards: regex for TextTerms, ILIKE ESCAPE for operators.
 func TestBuildSearchConditions_EscapedWildcards(t *testing.T) {
 	engine := &DuckDBEngine{}
 
@@ -2022,8 +2023,8 @@ func TestBuildSearchConditions_EscapedWildcards(t *testing.T) {
 			query: &search.Query{
 				TextTerms: []string{"100%_off"},
 			},
-			wantClauses: []string{"ESCAPE '\\'"},
-			wantInArgs:  []string{"100\\%\\_off"},
+			wantClauses: []string{"regexp_matches(COALESCE(msg.subject"},
+			wantInArgs:  []string{"\\b100%_off"},
 		},
 		{
 			name: "from: with wildcards",

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -28,13 +28,13 @@ type Engine interface {
 	GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error)
 
 	// Search - full-text search using FTS5 (includes message body)
-	Search(ctx context.Context, query *search.Query, limit, offset int) ([]MessageSummary, error)
+	Search(ctx context.Context, query *search.Query, sorting MessageSorting, limit, offset int) ([]MessageSummary, error)
 
 	// SearchFast searches message metadata only (no body text).
 	// This is much faster for large archives as it queries Parquet files directly.
 	// Searches: subject, sender email/name (case-insensitive).
 	// The filter parameter allows contextual search within a drill-down.
-	SearchFast(ctx context.Context, query *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error)
+	SearchFast(ctx context.Context, query *search.Query, filter MessageFilter, sorting MessageSorting, limit, offset int) ([]MessageSummary, error)
 
 	// SearchFastCount returns the total count of messages matching a search query.
 	// This is used for pagination UI to show "N of M results".
@@ -49,7 +49,7 @@ type Engine interface {
 	// queryStr is the raw search string (needed for stats; search.Query doesn't store it).
 	// statsGroupBy controls which view's key columns are used for stats search filtering.
 	SearchFastWithStats(ctx context.Context, query *search.Query, queryStr string,
-		filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error)
+		filter MessageFilter, sorting MessageSorting, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error)
 
 	// GetGmailIDsByFilter returns Gmail message IDs (source_message_id) matching a filter.
 	// This is useful for batch operations like staging messages for deletion.

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -28,13 +28,13 @@ type Engine interface {
 	GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error)
 
 	// Search - full-text search using FTS5 (includes message body)
-	Search(ctx context.Context, query *search.Query, sorting MessageSorting, limit, offset int) ([]MessageSummary, error)
+	Search(ctx context.Context, query *search.Query, limit, offset int) ([]MessageSummary, error)
 
 	// SearchFast searches message metadata only (no body text).
 	// This is much faster for large archives as it queries Parquet files directly.
 	// Searches: subject, sender email/name (case-insensitive).
 	// The filter parameter allows contextual search within a drill-down.
-	SearchFast(ctx context.Context, query *search.Query, filter MessageFilter, sorting MessageSorting, limit, offset int) ([]MessageSummary, error)
+	SearchFast(ctx context.Context, query *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error)
 
 	// SearchFastCount returns the total count of messages matching a search query.
 	// This is used for pagination UI to show "N of M results".
@@ -49,7 +49,7 @@ type Engine interface {
 	// queryStr is the raw search string (needed for stats; search.Query doesn't store it).
 	// statsGroupBy controls which view's key columns are used for stats search filtering.
 	SearchFastWithStats(ctx context.Context, query *search.Query, queryStr string,
-		filter MessageFilter, sorting MessageSorting, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error)
+		filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error)
 
 	// GetGmailIDsByFilter returns Gmail message IDs (source_message_id) matching a filter.
 	// This is useful for batch operations like staging messages for deletion.

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1167,15 +1167,11 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 			ftsJoin = "JOIN messages_fts fts ON fts.rowid = m.id"
 			ftsTerms := make([]string, len(q.TextTerms))
 			for i, term := range q.TextTerms {
-				// Strip FTS5 special chars to prevent query injection
+				// Quote all terms to prevent FTS5 special chars
+				// (-, :, (, ), etc.) from being parsed as query syntax.
 				term = strings.ReplaceAll(term, "\"", "\"\"")
 				term = strings.ReplaceAll(term, "*", "")
-				if strings.Contains(term, " ") {
-					// Phrase query — quoted with prefix on last token
-					ftsTerms[i] = fmt.Sprintf("\"%s\"*", term)
-				} else {
-					ftsTerms[i] = term + "*"
-				}
+				ftsTerms[i] = fmt.Sprintf("\"%s\"*", term)
 			}
 			conditions = append(conditions, "messages_fts MATCH ?")
 			args = append(args, strings.Join(ftsTerms, " "))

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1204,14 +1204,14 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 	return conditions, args, joins, ftsJoin
 }
 
-func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
+func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
 	conditions, args, joins, ftsJoin := e.buildSearchQueryParts(ctx, q)
 	return e.executeSearchQuery(ctx, conditions, args, joins, ftsJoin, limit, offset)
 }
 
 // SearchFast searches using the same FTS5 path as Search but merges
 // MessageFilter context into the query (drill-down filters, hide-deleted, etc.).
-func (e *SQLiteEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
+func (e *SQLiteEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
 	mergedQuery := MergeFilterIntoQuery(q, filter)
 	conditions, args, joins, ftsJoin := e.buildSearchQueryParts(ctx, mergedQuery)
 	return e.executeSearchQuery(ctx, conditions, args, joins, ftsJoin, limit, offset)
@@ -1468,9 +1468,9 @@ func (e *SQLiteEngine) SearchFastCount(ctx context.Context, q *search.Query, fil
 // SQLite doesn't benefit from temp table materialization, so we just call the
 // existing methods independently.
 func (e *SQLiteEngine) SearchFastWithStats(ctx context.Context, q *search.Query, queryStr string,
-	filter MessageFilter, sorting MessageSorting, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
+	filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
 
-	results, err := e.SearchFast(ctx, q, filter, sorting, limit, offset)
+	results, err := e.SearchFast(ctx, q, filter, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1161,17 +1161,20 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 	// Full-text search: use FTS5 if available, fall back to LIKE
 	if len(q.TextTerms) > 0 {
 		if e.hasFTSTable(ctx) {
-			// Use FTS5 for efficient full-text search
+			// Use FTS5 for efficient full-text search.
+			// Prefix matching (*) enables partial word matches.
+			// Multiple terms are AND-ed: all must appear (in any column).
 			ftsJoin = "JOIN messages_fts fts ON fts.rowid = m.id"
-			// Build FTS match expression
 			ftsTerms := make([]string, len(q.TextTerms))
 			for i, term := range q.TextTerms {
-				// Escape special characters for FTS5
+				// Strip FTS5 special chars to prevent query injection
 				term = strings.ReplaceAll(term, "\"", "\"\"")
+				term = strings.ReplaceAll(term, "*", "")
 				if strings.Contains(term, " ") {
-					ftsTerms[i] = fmt.Sprintf("\"%s\"", term)
+					// Phrase query — quoted with prefix on last token
+					ftsTerms[i] = fmt.Sprintf("\"%s\"*", term)
 				} else {
-					ftsTerms[i] = term
+					ftsTerms[i] = term + "*"
 				}
 			}
 			conditions = append(conditions, "messages_fts MATCH ?")
@@ -1201,14 +1204,14 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 	return conditions, args, joins, ftsJoin
 }
 
-func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
+func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
 	conditions, args, joins, ftsJoin := e.buildSearchQueryParts(ctx, q)
 	return e.executeSearchQuery(ctx, conditions, args, joins, ftsJoin, limit, offset)
 }
 
 // SearchFast searches using the same FTS5 path as Search but merges
 // MessageFilter context into the query (drill-down filters, hide-deleted, etc.).
-func (e *SQLiteEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
+func (e *SQLiteEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, sorting MessageSorting, limit, offset int) ([]MessageSummary, error) {
 	mergedQuery := MergeFilterIntoQuery(q, filter)
 	conditions, args, joins, ftsJoin := e.buildSearchQueryParts(ctx, mergedQuery)
 	return e.executeSearchQuery(ctx, conditions, args, joins, ftsJoin, limit, offset)
@@ -1465,9 +1468,9 @@ func (e *SQLiteEngine) SearchFastCount(ctx context.Context, q *search.Query, fil
 // SQLite doesn't benefit from temp table materialization, so we just call the
 // existing methods independently.
 func (e *SQLiteEngine) SearchFastWithStats(ctx context.Context, q *search.Query, queryStr string,
-	filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
+	filter MessageFilter, sorting MessageSorting, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
 
-	results, err := e.SearchFast(ctx, q, filter, limit, offset)
+	results, err := e.SearchFast(ctx, q, filter, sorting, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/query/sqlite_search_test.go
+++ b/internal/query/sqlite_search_test.go
@@ -133,6 +133,35 @@ func TestSearch_WithFTS(t *testing.T) {
 	}
 }
 
+// TestSearch_WithFTS_SpecialChars verifies that FTS5 special characters in
+// search terms don't cause syntax errors. Without quoting, these characters
+// are interpreted as FTS5 operators (- = NOT, : = column filter, () = grouping).
+func TestSearch_WithFTS_SpecialChars(t *testing.T) {
+	env := newTestEnv(t)
+	env.EnableFTS()
+
+	tests := []struct {
+		name string
+		term string
+	}{
+		{"colon", "Re:"},
+		{"hyphen", "foo-bar"},
+		{"parens", "(test)"},
+		{"mixed_special", "re:hello-world"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &search.Query{TextTerms: []string{tc.term}}
+			_, err := env.Engine.Search(env.Ctx, q, 100, 0)
+			if err != nil {
+				t.Errorf("FTS5 search for %q should not error: %v",
+					tc.term, err)
+			}
+		})
+	}
+}
+
 func TestHasFTSTable(t *testing.T) {
 	env := newTestEnv(t)
 


### PR DESCRIPTION
Fix and Improve search accuracy and performance across full-text, fast (Parquet), and aggregate query paths with word-boundary matching, better snippet handling, and consistent result sorting.

###   Problem

While importing my old 1990's era email archives, I discovered a number of issues with search

  1. Substring matching causes false positives — Text search matches partial strings within words, returning irrelevant results
  2. Body text invisible in fast search — Messages where search terms only appear in the body don't show in TUI unless user switches to deep search mode (which I feel is underdocumented but that's a separate issue) 
  3. Inconsistent sort behavior — Search results don't respect the user's selected sort field (Name/Count/Size)

###  Proposed Solution

  - Word-boundary regex (\b) for text search to match exact words, not substrings
  - Prefix matching in FTS5 (* operator) for partial word matches within the deep search path
  - Snippet inclusion in fast search conditions so body text matches appear immediately in TUI

###   Changes

  - internal/query/sqlite.go — FTS5 prefix matching
  - internal/query/duckdb.go — Word-boundary regex,
  snippet inclusion, sort parameter, escapeRegex helper

  Testing

  - Text search with word boundaries prevents false
  substring matches
  - Parquet fast search now catches body text matches
