### PR TITLE
Update nix flake for v0.12.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       packages = forAllSystems (pkgs: {
         default = (pkgs.buildGoModule.override { go = goPinned pkgs; }) {
           pname = "msgvault";
-          version = "0.12.0";
+          version = "0.12.1";
           src = ./.;
           vendorHash = "sha256-JtfZwLpeyVsX/Yvb3EV7L+Gk/lFYaMJcrmID6eEvz84=";
           proxyVendor = true;


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-JtfZwLpeyVsX/Yvb3EV7L+Gk/lFYaMJcrmID6eEvz84=`
- Updated version to `0.12.1`

Automated update via `scripts/update-nix-flake.sh`.