### PR TITLE
feat: delete attachment files when removing an account

### DIFF
--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -122,13 +122,23 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("collect attachment paths: %w", err)
 	}
 
+	// Check for active syncs BEFORE RemoveSource. The cascade deletes the
+	// sync_runs rows for this source, which would hide a sync that is still
+	// running on the account being removed from a post-RemoveSource check.
+	skipFileDeletion := syncRunningBeforeRemove(
+		s, cfg.AttachmentsDir(), len(attachmentPaths) > 0,
+	)
+
 	if err := s.RemoveSource(source.ID); err != nil {
 		return fmt.Errorf("remove account: %w", err)
 	}
 
-	deletedFiles, preservedFiles := deleteOrphanedAttachmentFiles(
-		cmd.Context(), s, attachmentPaths, cfg.AttachmentsDir(),
-	)
+	var deletedFiles, preservedFiles int
+	if !skipFileDeletion {
+		deletedFiles, preservedFiles = deleteOrphanedAttachmentFiles(
+			cmd.Context(), s, attachmentPaths, cfg.AttachmentsDir(),
+		)
+	}
 
 	// Remove credentials for the source type.
 	switch source.SourceType {
@@ -211,6 +221,43 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// syncRunningBeforeRemove checks HasAnyActiveSync before RemoveSource runs.
+// Returns true if file deletion should be skipped because some sync is
+// running, or because the check itself failed (fail-safe). Prints a warning
+// in either case when hasPaths is true.
+//
+// This pre-RemoveSource check is required because RemoveSource cascades the
+// sync_runs rows for the account being removed, which would hide an active
+// sync on that same account from a post-RemoveSource HasAnyActiveSync call.
+func syncRunningBeforeRemove(
+	s *store.Store, attachmentsDir string, hasPaths bool,
+) bool {
+	running, err := s.HasAnyActiveSync()
+	if err != nil {
+		if hasPaths {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not check for active syncs: %v; "+
+					"attachment files were not deleted.\n"+
+					"Orphaned files may remain in %s\n",
+				err, attachmentsDir,
+			)
+		}
+		return true
+	}
+	if running {
+		if hasPaths {
+			fmt.Fprintf(os.Stderr,
+				"Warning: a sync is in progress; "+
+					"attachment files were not deleted.\n"+
+					"Orphaned files may remain in %s\n",
+				attachmentsDir,
+			)
+		}
+		return true
+	}
+	return false
+}
+
 // deleteOrphanedAttachmentFiles removes files in paths that are no longer
 // referenced by any attachment row. Returns the count of files actually
 // deleted and the count preserved because a concurrent reference appeared
@@ -218,10 +265,11 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 //
 // The work runs under an exclusive DB write lock so that no new sync can
 // insert an attachment row (and place a file on disk) between the
-// IsAttachmentPathReferenced check and os.Remove. The gap between
-// RemoveSource and lock acquisition is covered by the per-file reference
-// recheck: any sync that started in that window and inserted a row for one
-// of our candidate hashes is detected and that file is preserved.
+// IsAttachmentPathReferenced check and os.Remove. The inside-lock
+// HasAnyActiveSync recheck catches any sync on a different source that
+// started between syncRunningBeforeRemove and lock acquisition; the
+// per-file reference check handles the narrower race where a sync inserts
+// a row for one of our candidate hashes.
 func deleteOrphanedAttachmentFiles(
 	ctx context.Context,
 	s *store.Store,

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,8 +27,8 @@ and mbox), use --type to specify which one to remove.
 The Parquet analytics cache is deleted because it is shared across accounts
 and must be rebuilt. Run 'msgvault build-cache' afterward to rebuild it.
 
-Orphaned participants and attachment files on disk are not cleaned up;
-use 'msgvault gc' (when available) to reclaim that space.
+Attachment files on disk that are not shared with another account are deleted.
+Shared attachments (same content hash across multiple accounts) are kept.
 
 Examples:
   msgvault remove-account you@gmail.com
@@ -114,8 +115,114 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Collect attachment paths unique to this source before the cascade deletes them.
+	attachmentPaths, err := s.AttachmentPathsUniqueToSource(source.ID)
+	if err != nil {
+		return fmt.Errorf("collect attachment paths: %w", err)
+	}
+
 	if err := s.RemoveSource(source.ID); err != nil {
 		return fmt.Errorf("remove account: %w", err)
+	}
+
+	// Delete attachment files that are no longer referenced by any source.
+	// This runs under an exclusive DB lock to prevent races with concurrent
+	// syncs: the lock blocks StartSync() (a write), so no new sync can start
+	// and place a file on disk without a corresponding DB row while we're
+	// checking references and deleting files.
+	attachmentsDir := cfg.AttachmentsDir()
+	var deletedFiles int
+	if len(attachmentPaths) > 0 {
+		cleanDir, err := filepath.Abs(attachmentsDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not resolve attachments dir; "+
+					"skipping file deletion: %v\n"+
+					"Orphaned files may remain in %s\n",
+				err, attachmentsDir,
+			)
+		} else {
+			lockErr := s.WithExclusiveLock(func() error {
+				anySyncRunning, err := s.HasAnyActiveSync()
+				if err != nil {
+					fmt.Fprintf(os.Stderr,
+						"Warning: could not check for active syncs: %v; "+
+							"attachment files were not deleted.\n"+
+							"Orphaned files may remain in %s\n",
+						err, attachmentsDir,
+					)
+					return nil
+				}
+				if anySyncRunning {
+					fmt.Fprintf(os.Stderr,
+						"Warning: a sync is in progress; "+
+							"attachment files were not deleted.\n"+
+							"Orphaned files may remain in %s\n",
+						attachmentsDir,
+					)
+					return nil
+				}
+
+				var failedFiles int
+				for _, relPath := range attachmentPaths {
+					absPath := filepath.Join(cleanDir, relPath)
+
+					rel, err := filepath.Rel(cleanDir, absPath)
+					if err != nil ||
+						rel == ".." ||
+						strings.HasPrefix(
+							rel,
+							".."+string(filepath.Separator),
+						) {
+						fmt.Fprintf(os.Stderr,
+							"Warning: attachment path %q escapes "+
+								"attachments directory, skipping\n",
+							relPath,
+						)
+						failedFiles++
+						continue
+					}
+
+					referenced, err := s.IsAttachmentPathReferenced(
+						relPath,
+					)
+					if err != nil {
+						fmt.Fprintf(os.Stderr,
+							"Warning: could not verify attachment "+
+								"%s is unreferenced: %v\n",
+							relPath, err,
+						)
+						failedFiles++
+						continue
+					}
+					if referenced {
+						continue
+					}
+					if err := os.Remove(absPath); err != nil &&
+						!os.IsNotExist(err) {
+						failedFiles++
+					} else {
+						deletedFiles++
+					}
+				}
+				if failedFiles > 0 {
+					fmt.Fprintf(os.Stderr,
+						"Warning: could not remove %d attachment "+
+							"file(s) from disk.\n",
+						failedFiles,
+					)
+				}
+				return nil
+			})
+			if lockErr != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not acquire exclusive lock; "+
+						"skipping file deletion: %v\n"+
+						"Orphaned files may remain in %s\n",
+					lockErr, attachmentsDir,
+				)
+			}
+		}
 	}
 
 	// Remove credentials for the source type.
@@ -183,12 +290,11 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("\nAccount %s removed.\n", email)
+	if deletedFiles > 0 {
+		fmt.Printf("Deleted %d attachment file(s) from disk.\n", deletedFiles)
+	}
 	fmt.Println(
 		"Run 'msgvault build-cache' to rebuild the analytics cache.",
-	)
-	fmt.Println(
-		"Note: attachment files on disk were not removed." +
-			" Use 'msgvault gc' (when available) to reclaim space.",
 	)
 
 	return nil

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -125,105 +126,9 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("remove account: %w", err)
 	}
 
-	// Delete attachment files that are no longer referenced by any source.
-	// This runs under an exclusive DB lock to prevent races with concurrent
-	// syncs: the lock blocks StartSync() (a write), so no new sync can start
-	// and place a file on disk without a corresponding DB row while we're
-	// checking references and deleting files.
-	attachmentsDir := cfg.AttachmentsDir()
-	var deletedFiles int
-	if len(attachmentPaths) > 0 {
-		cleanDir, err := filepath.Abs(attachmentsDir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr,
-				"Warning: could not resolve attachments dir; "+
-					"skipping file deletion: %v\n"+
-					"Orphaned files may remain in %s\n",
-				err, attachmentsDir,
-			)
-		} else {
-			lockErr := s.WithExclusiveLock(func() error {
-				anySyncRunning, err := s.HasAnyActiveSync()
-				if err != nil {
-					fmt.Fprintf(os.Stderr,
-						"Warning: could not check for active syncs: %v; "+
-							"attachment files were not deleted.\n"+
-							"Orphaned files may remain in %s\n",
-						err, attachmentsDir,
-					)
-					return nil
-				}
-				if anySyncRunning {
-					fmt.Fprintf(os.Stderr,
-						"Warning: a sync is in progress; "+
-							"attachment files were not deleted.\n"+
-							"Orphaned files may remain in %s\n",
-						attachmentsDir,
-					)
-					return nil
-				}
-
-				var failedFiles int
-				for _, relPath := range attachmentPaths {
-					absPath := filepath.Join(cleanDir, relPath)
-
-					rel, err := filepath.Rel(cleanDir, absPath)
-					if err != nil ||
-						rel == ".." ||
-						strings.HasPrefix(
-							rel,
-							".."+string(filepath.Separator),
-						) {
-						fmt.Fprintf(os.Stderr,
-							"Warning: attachment path %q escapes "+
-								"attachments directory, skipping\n",
-							relPath,
-						)
-						failedFiles++
-						continue
-					}
-
-					referenced, err := s.IsAttachmentPathReferenced(
-						relPath,
-					)
-					if err != nil {
-						fmt.Fprintf(os.Stderr,
-							"Warning: could not verify attachment "+
-								"%s is unreferenced: %v\n",
-							relPath, err,
-						)
-						failedFiles++
-						continue
-					}
-					if referenced {
-						continue
-					}
-					if err := os.Remove(absPath); err != nil &&
-						!os.IsNotExist(err) {
-						failedFiles++
-					} else {
-						deletedFiles++
-					}
-				}
-				if failedFiles > 0 {
-					fmt.Fprintf(os.Stderr,
-						"Warning: could not remove %d attachment "+
-							"file(s) from disk.\n",
-						failedFiles,
-					)
-				}
-				return nil
-			})
-			if lockErr != nil {
-				fmt.Fprintf(os.Stderr,
-					"Warning: could not acquire exclusive lock; "+
-						"skipping file deletion: %v\n"+
-						"Orphaned files may remain in %s\n",
-					lockErr, attachmentsDir,
-				)
-			}
-		}
-	}
+	deletedFiles, preservedFiles := deleteOrphanedAttachmentFiles(
+		cmd.Context(), s, attachmentPaths, cfg.AttachmentsDir(),
+	)
 
 	// Remove credentials for the source type.
 	switch source.SourceType {
@@ -293,11 +198,135 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 	if deletedFiles > 0 {
 		fmt.Printf("Deleted %d attachment file(s) from disk.\n", deletedFiles)
 	}
+	if preservedFiles > 0 {
+		fmt.Printf(
+			"Preserved %d attachment file(s) shared with other accounts.\n",
+			preservedFiles,
+		)
+	}
 	fmt.Println(
 		"Run 'msgvault build-cache' to rebuild the analytics cache.",
 	)
 
 	return nil
+}
+
+// deleteOrphanedAttachmentFiles removes files in paths that are no longer
+// referenced by any attachment row. Returns the count of files actually
+// deleted and the count preserved because a concurrent reference appeared
+// after the candidate list was collected.
+//
+// The work runs under an exclusive DB write lock so that no new sync can
+// insert an attachment row (and place a file on disk) between the
+// IsAttachmentPathReferenced check and os.Remove. The gap between
+// RemoveSource and lock acquisition is covered by the per-file reference
+// recheck: any sync that started in that window and inserted a row for one
+// of our candidate hashes is detected and that file is preserved.
+func deleteOrphanedAttachmentFiles(
+	ctx context.Context,
+	s *store.Store,
+	paths []string,
+	attachmentsDir string,
+) (deleted, preserved int) {
+	if len(paths) == 0 {
+		return 0, 0
+	}
+
+	cleanDir, err := filepath.Abs(attachmentsDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"Warning: could not resolve attachments dir; "+
+				"skipping file deletion: %v\n"+
+				"Orphaned files may remain in %s\n",
+			err, attachmentsDir,
+		)
+		return 0, 0
+	}
+
+	lockErr := s.WithExclusiveLock(ctx, func() error {
+		running, err := s.HasAnyActiveSync()
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not check for active syncs: %v; "+
+					"attachment files were not deleted.\n"+
+					"Orphaned files may remain in %s\n",
+				err, attachmentsDir,
+			)
+			return nil
+		}
+		if running {
+			fmt.Fprintf(os.Stderr,
+				"Warning: a sync is in progress; "+
+					"attachment files were not deleted.\n"+
+					"Orphaned files may remain in %s\n",
+				attachmentsDir,
+			)
+			return nil
+		}
+
+		var failed int
+		for _, relPath := range paths {
+			d, p, ok := deleteOneAttachmentFile(s, cleanDir, relPath)
+			if !ok {
+				failed++
+				continue
+			}
+			deleted += d
+			preserved += p
+		}
+		if failed > 0 {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not remove %d attachment file(s) "+
+					"from disk.\n",
+				failed,
+			)
+		}
+		return nil
+	})
+	if lockErr != nil {
+		fmt.Fprintf(os.Stderr,
+			"Warning: could not acquire exclusive lock; "+
+				"skipping file deletion: %v\n"+
+				"Orphaned files may remain in %s\n",
+			lockErr, attachmentsDir,
+		)
+	}
+	return deleted, preserved
+}
+
+// deleteOneAttachmentFile checks that relPath is safe to delete and either
+// removes it, preserves it (still referenced), or reports a failure via ok=false.
+func deleteOneAttachmentFile(
+	s *store.Store, cleanDir, relPath string,
+) (deleted, preserved int, ok bool) {
+	absPath := filepath.Join(cleanDir, relPath)
+
+	rel, err := filepath.Rel(cleanDir, absPath)
+	if err != nil || rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		fmt.Fprintf(os.Stderr,
+			"Warning: attachment path %q escapes attachments "+
+				"directory, skipping\n",
+			relPath,
+		)
+		return 0, 0, false
+	}
+
+	referenced, err := s.IsAttachmentPathReferenced(relPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"Warning: could not verify attachment %s is unreferenced: %v\n",
+			relPath, err,
+		)
+		return 0, 0, false
+	}
+	if referenced {
+		return 0, 1, true
+	}
+	if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
+		return 0, 0, false
+	}
+	return 1, 0, true
 }
 
 // resolveSource finds the unique source for the given identifier.

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -122,19 +122,28 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("collect attachment paths: %w", err)
 	}
 
-	// Check for active syncs BEFORE RemoveSource. The cascade deletes the
-	// sync_runs rows for this source, which would hide a sync that is still
-	// running on the account being removed from a post-RemoveSource check.
-	skipFileDeletion := syncRunningBeforeRemove(
-		s, cfg.AttachmentsDir(), len(attachmentPaths) > 0,
-	)
-
-	if err := s.RemoveSource(source.ID); err != nil {
+	// RemoveSourceSerialized runs the active-sync check and the cascade
+	// under a single exclusive write lock. StartSync blocks on that lock,
+	// so a sync started between our check and the delete is either seen
+	// as active (we skip file deletion) or fails after we commit because
+	// the source is gone.
+	hadActiveSync, err := s.RemoveSourceSerialized(cmd.Context(), source.ID)
+	if err != nil {
 		return fmt.Errorf("remove account: %w", err)
 	}
 
 	var deletedFiles, preservedFiles int
-	if !skipFileDeletion {
+	switch {
+	case hadActiveSync:
+		if len(attachmentPaths) > 0 {
+			fmt.Fprintf(os.Stderr,
+				"Warning: a sync is in progress; "+
+					"attachment files were not deleted.\n"+
+					"Orphaned files may remain in %s\n",
+				cfg.AttachmentsDir(),
+			)
+		}
+	default:
 		deletedFiles, preservedFiles = deleteOrphanedAttachmentFiles(
 			cmd.Context(), s, attachmentPaths, cfg.AttachmentsDir(),
 		)
@@ -221,43 +230,6 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// syncRunningBeforeRemove checks HasAnyActiveSync before RemoveSource runs.
-// Returns true if file deletion should be skipped because some sync is
-// running, or because the check itself failed (fail-safe). Prints a warning
-// in either case when hasPaths is true.
-//
-// This pre-RemoveSource check is required because RemoveSource cascades the
-// sync_runs rows for the account being removed, which would hide an active
-// sync on that same account from a post-RemoveSource HasAnyActiveSync call.
-func syncRunningBeforeRemove(
-	s *store.Store, attachmentsDir string, hasPaths bool,
-) bool {
-	running, err := s.HasAnyActiveSync()
-	if err != nil {
-		if hasPaths {
-			fmt.Fprintf(os.Stderr,
-				"Warning: could not check for active syncs: %v; "+
-					"attachment files were not deleted.\n"+
-					"Orphaned files may remain in %s\n",
-				err, attachmentsDir,
-			)
-		}
-		return true
-	}
-	if running {
-		if hasPaths {
-			fmt.Fprintf(os.Stderr,
-				"Warning: a sync is in progress; "+
-					"attachment files were not deleted.\n"+
-					"Orphaned files may remain in %s\n",
-				attachmentsDir,
-			)
-		}
-		return true
-	}
-	return false
-}
-
 // deleteOrphanedAttachmentFiles removes files in paths that are no longer
 // referenced by any attachment row. Returns the count of files actually
 // deleted and the count preserved because a concurrent reference appeared
@@ -267,9 +239,9 @@ func syncRunningBeforeRemove(
 // insert an attachment row (and place a file on disk) between the
 // IsAttachmentPathReferenced check and os.Remove. The inside-lock
 // HasAnyActiveSync recheck catches any sync on a different source that
-// started between syncRunningBeforeRemove and lock acquisition; the
-// per-file reference check handles the narrower race where a sync inserts
-// a row for one of our candidate hashes.
+// started between RemoveSourceSerialized releasing its lock and this
+// helper acquiring its own; the per-file reference check handles the
+// narrower race where a sync inserts a row for one of our candidate hashes.
 func deleteOrphanedAttachmentFiles(
 	ctx context.Context,
 	s *store.Store,

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -200,6 +200,66 @@ func TestRemoveAccountCmd_SkipsDeletionDuringActiveSync(t *testing.T) {
 	}
 }
 
+// Regression test: if the account being removed has its own active sync,
+// RemoveSource's cascade deletes that sync_runs row. A post-RemoveSource
+// HasAnyActiveSync would return false and the deletion loop would run even
+// though the sync worker may still be writing attachment files. The
+// pre-RemoveSource check must catch this and skip file deletion.
+func TestRemoveAccountCmd_SkipsDeletionWhenRemovedAccountHasActiveSync(t *testing.T) {
+	tmpDir := t.TempDir()
+	attachmentsDir := filepath.Join(tmpDir, "attachments")
+
+	s, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	seedMessageWithAttachment(t, s,
+		"alice@example.com", "thread-a", "msg-a",
+		"dd/hashA", "hashA")
+	aliceSrc, err := s.GetSourceByIdentifier("alice@example.com")
+	if err != nil {
+		t.Fatalf("GetSourceByIdentifier: %v", err)
+	}
+	if aliceSrc == nil {
+		t.Fatal("expected alice source to exist")
+	}
+	// Active sync on the account being removed — this is the row that
+	// RemoveSource cascades away.
+	if _, err := s.StartSync(aliceSrc.ID, "full"); err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	_ = s.Close()
+
+	filePath := seedAttachmentFile(t, attachmentsDir, "dd/hashA", "content-a")
+
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountCmd())
+	// --yes bypasses the initial GetActiveSync guard so we exercise the
+	// later file-deletion path.
+	root.SetArgs([]string{"remove-account", "alice@example.com", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("remove-account: %v", err)
+	}
+
+	if _, err := os.Stat(filePath); err != nil {
+		t.Errorf(
+			"attachment file should be preserved when the removed account "+
+				"has an active sync, err = %v",
+			err,
+		)
+	}
+}
+
 func TestRemoveAccountCmd_RejectsPathTraversal(t *testing.T) {
 	tmpDir := t.TempDir()
 	attachmentsDir := filepath.Join(tmpDir, "attachments")

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -11,6 +11,243 @@ import (
 	"github.com/wesm/msgvault/internal/store"
 )
 
+// seedAttachmentFile creates a file under attachmentsDir at relPath and returns
+// its absolute path. Intermediate directories are created as needed.
+func seedAttachmentFile(t *testing.T, attachmentsDir, relPath, content string) string {
+	t.Helper()
+	absPath := filepath.Join(attachmentsDir, relPath)
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(absPath), err)
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", absPath, err)
+	}
+	return absPath
+}
+
+// seedMessageWithAttachment creates a source (if new), conversation, message, and
+// attachment row for use in remove-account tests. Returns nothing; callers that
+// need IDs should read them back via the store.
+func seedMessageWithAttachment(
+	t *testing.T, s *store.Store,
+	email, threadKey, msgKey, storagePath, contentHash string,
+) {
+	t.Helper()
+	src, err := s.GetOrCreateSource("gmail", email)
+	if err != nil {
+		t.Fatalf("GetOrCreateSource(%s): %v", email, err)
+	}
+	convID, err := s.EnsureConversation(src.ID, threadKey, "Thread")
+	if err != nil {
+		t.Fatalf("EnsureConversation: %v", err)
+	}
+	msgID, err := s.UpsertMessage(&store.Message{
+		ConversationID:  convID,
+		SourceID:        src.ID,
+		SourceMessageID: msgKey,
+		MessageType:     "email",
+	})
+	if err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+	if err := s.UpsertAttachment(msgID, "a.pdf", "application/pdf",
+		storagePath, contentHash, 0); err != nil {
+		t.Fatalf("UpsertAttachment: %v", err)
+	}
+}
+
+func TestRemoveAccountCmd_DeletesUniqueAttachmentFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	attachmentsDir := filepath.Join(tmpDir, "attachments")
+
+	s, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	seedMessageWithAttachment(t, s,
+		"alice@example.com", "thread-a", "msg-a",
+		"aa/hashA", "hashA")
+	_ = s.Close()
+
+	filePath := seedAttachmentFile(t, attachmentsDir, "aa/hashA", "content-a")
+
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountCmd())
+	root.SetArgs([]string{"remove-account", "alice@example.com", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("remove-account: %v", err)
+	}
+
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Errorf("expected attachment file deleted, err = %v", err)
+	}
+}
+
+func TestRemoveAccountCmd_PreservesSharedAttachments(t *testing.T) {
+	tmpDir := t.TempDir()
+	attachmentsDir := filepath.Join(tmpDir, "attachments")
+
+	s, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	// Both accounts reference the same content_hash/storage_path.
+	seedMessageWithAttachment(t, s,
+		"alice@example.com", "thread-a", "msg-a",
+		"bb/sharedhash", "sharedhash")
+	seedMessageWithAttachment(t, s,
+		"bob@example.com", "thread-b", "msg-b",
+		"bb/sharedhash", "sharedhash")
+	_ = s.Close()
+
+	filePath := seedAttachmentFile(t, attachmentsDir, "bb/sharedhash", "shared-content")
+
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountCmd())
+	root.SetArgs([]string{"remove-account", "alice@example.com", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("remove-account: %v", err)
+	}
+
+	if _, err := os.Stat(filePath); err != nil {
+		t.Errorf("shared attachment file should be preserved, err = %v", err)
+	}
+}
+
+func TestRemoveAccountCmd_SkipsDeletionDuringActiveSync(t *testing.T) {
+	tmpDir := t.TempDir()
+	attachmentsDir := filepath.Join(tmpDir, "attachments")
+
+	s, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	seedMessageWithAttachment(t, s,
+		"alice@example.com", "thread-a", "msg-a",
+		"cc/hashA", "hashA")
+	// Simulate a concurrent sync on an unrelated source.
+	otherSrc, err := s.GetOrCreateSource("gmail", "bob@example.com")
+	if err != nil {
+		t.Fatalf("create other source: %v", err)
+	}
+	if _, err := s.StartSync(otherSrc.ID, "full"); err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	_ = s.Close()
+
+	filePath := seedAttachmentFile(t, attachmentsDir, "cc/hashA", "content-a")
+
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountCmd())
+	root.SetArgs([]string{"remove-account", "alice@example.com", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("remove-account: %v", err)
+	}
+
+	// File should remain because an active sync on another source blocks deletion.
+	if _, err := os.Stat(filePath); err != nil {
+		t.Errorf(
+			"attachment file should be preserved while another sync is active, err = %v",
+			err,
+		)
+	}
+
+	// DB cleanup still runs — account is gone.
+	s2, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if err := s2.InitSchema(); err != nil {
+		t.Fatalf("reinit schema: %v", err)
+	}
+	src, err := s2.GetSourceByIdentifier("alice@example.com")
+	if err != nil {
+		t.Fatalf("GetSourceByIdentifier: %v", err)
+	}
+	if src != nil {
+		t.Error("source should have been removed from DB despite skipped file deletion")
+	}
+}
+
+func TestRemoveAccountCmd_RejectsPathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	attachmentsDir := filepath.Join(tmpDir, "attachments")
+	if err := os.MkdirAll(attachmentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir attachments: %v", err)
+	}
+
+	// Create a file outside the attachments directory that MUST NOT be deleted.
+	outsidePath := filepath.Join(tmpDir, "escape.txt")
+	if err := os.WriteFile(outsidePath, []byte("do not delete"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	s, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	// Craft a storage_path that escapes the attachments directory.
+	seedMessageWithAttachment(t, s,
+		"alice@example.com", "thread-a", "msg-a",
+		"../escape.txt", "evilhash")
+	_ = s.Close()
+
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountCmd())
+	root.SetArgs([]string{"remove-account", "alice@example.com", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("remove-account: %v", err)
+	}
+
+	if _, err := os.Stat(outsidePath); err != nil {
+		t.Errorf(
+			"file outside attachments dir must not be deleted, err = %v",
+			err,
+		)
+	}
+}
+
 func TestRemoveAccountCmd_RequiresEmail(t *testing.T) {
 	root := newTestRootCmd()
 	root.AddCommand(newRemoveAccountCmd())

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -1224,6 +1224,62 @@ func (s *Store) UpsertMessageRawWithFormat(messageID int64, rawData []byte, form
 	return err
 }
 
+// AttachmentPathsUniqueToSource returns storage_path values for attachments
+// belonging to sourceID whose content_hash is not shared with any other source.
+// Call this before RemoveSource so the cascade hasn't run yet.
+//
+// Note: thumbnail_path values are not included. No sync/import code currently
+// writes thumbnail files to disk, so there are no thumbnail files to clean up.
+// If thumbnail storage is added in the future, this function and the delete
+// loop in remove_account.go must be extended to cover thumbnail_path as well.
+func (s *Store) AttachmentPathsUniqueToSource(sourceID int64) ([]string, error) {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT a.storage_path
+		FROM attachments a
+		JOIN messages m ON m.id = a.message_id
+		WHERE m.source_id = ?
+		  AND a.content_hash IS NOT NULL
+		  AND a.storage_path IS NOT NULL
+		  AND a.storage_path != ''
+		  AND NOT EXISTS (
+		      SELECT 1 FROM attachments a2
+		      JOIN messages m2 ON m2.id = a2.message_id
+		      WHERE a2.content_hash = a.content_hash
+		        AND m2.source_id != ?
+		  )
+	`, sourceID, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		paths = append(paths, p)
+	}
+	return paths, rows.Err()
+}
+
+// IsAttachmentPathReferenced returns true if any attachment record still
+// points to the given storage_path. Use this immediately before deleting a
+// file to guard against a concurrent sync that added a new reference after
+// the candidate list was collected.
+func (s *Store) IsAttachmentPathReferenced(storagePath string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM attachments WHERE storage_path = ?`,
+		storagePath,
+	).Scan(&count)
+	if err != nil {
+		return true, err // fail safe: treat error as referenced
+	}
+	return count > 0, nil
+}
+
 // UpsertAttachment stores an attachment record.
 func (s *Store) UpsertAttachment(messageID int64, filename, mimeType, storagePath, contentHash string, size int) error {
 	// Check if attachment already exists (by message_id and content_hash)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -1236,16 +1236,20 @@ func (s *Store) AttachmentPathsUniqueToSource(sourceID int64) ([]string, error) 
 	rows, err := s.db.Query(`
 		SELECT DISTINCT a.storage_path
 		FROM attachments a
-		JOIN messages m ON m.id = a.message_id
-		WHERE m.source_id = ?
+		WHERE EXISTS (
+		    SELECT 1 FROM messages m
+		    WHERE m.id = a.message_id AND m.source_id = ?
+		  )
 		  AND a.content_hash IS NOT NULL
 		  AND a.storage_path IS NOT NULL
 		  AND a.storage_path != ''
 		  AND NOT EXISTS (
 		      SELECT 1 FROM attachments a2
-		      JOIN messages m2 ON m2.id = a2.message_id
 		      WHERE a2.content_hash = a.content_hash
-		        AND m2.source_id != ?
+		        AND EXISTS (
+		            SELECT 1 FROM messages m2
+		            WHERE m2.id = a2.message_id AND m2.source_id != ?
+		        )
 		  )
 	`, sourceID, sourceID)
 	if err != nil {

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -357,6 +357,7 @@ CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id);
 -- Attachments
 CREATE INDEX IF NOT EXISTS idx_attachments_message ON attachments(message_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_hash ON attachments(content_hash);
+CREATE INDEX IF NOT EXISTS idx_attachments_storage_path ON attachments(storage_path);
 
 -- Labels
 CREATE INDEX IF NOT EXISTS idx_labels_source ON labels(source_id);

--- a/internal/store/sources.go
+++ b/internal/store/sources.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -98,28 +99,94 @@ func (s *Store) GetSourcesByDisplayName(displayName string) ([]*Source, error) {
 // Orphaned participants are left for a future `gc` command.
 func (s *Store) RemoveSource(sourceID int64) error {
 	return s.withTx(func(tx *loggedTx) error {
-		if s.fts5Available {
-			_, err := tx.Exec(s.dialect.FTSDeleteSQL(), sourceID)
-			if err != nil {
-				return fmt.Errorf("delete FTS rows: %w", err)
-			}
-		}
-
-		res, err := tx.Exec(
-			`DELETE FROM sources WHERE id = ?`, sourceID,
-		)
-		if err != nil {
-			return fmt.Errorf("delete source: %w", err)
-		}
-
-		rows, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("check rows affected: %w", err)
-		}
-		if rows == 0 {
-			return fmt.Errorf("source %d not found", sourceID)
-		}
-
-		return nil
+		return s.removeSourceExec(tx, sourceID)
 	})
+}
+
+// RemoveSourceSerialized deletes a source while holding an exclusive write
+// lock, and reports whether any sync was running at the moment the lock was
+// acquired. Callers use hadActiveSync to gate follow-up operations (such as
+// attachment file deletion) that must not race with a sync worker.
+//
+// Running the active-sync check and the cascade in the same transaction
+// closes the race where a sync starts between a pre-check and RemoveSource:
+// StartSync blocks on our exclusive lock, so either (a) it committed before
+// us and we observe the running row, or (b) it has not yet started and will
+// fail after we commit because the source is gone.
+func (s *Store) RemoveSourceSerialized(
+	ctx context.Context, sourceID int64,
+) (hadActiveSync bool, err error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return false, fmt.Errorf("acquire connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN EXCLUSIVE"); err != nil {
+		return false, fmt.Errorf("begin exclusive: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	var count int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sync_runs WHERE status = 'running'`,
+	).Scan(&count); err != nil {
+		return false, fmt.Errorf("check active syncs: %w", err)
+	}
+	hadActiveSync = count > 0
+
+	if s.fts5Available {
+		if _, err := conn.ExecContext(
+			ctx, s.dialect.FTSDeleteSQL(), sourceID,
+		); err != nil {
+			return hadActiveSync, fmt.Errorf("delete FTS rows: %w", err)
+		}
+	}
+
+	res, err := conn.ExecContext(
+		ctx, `DELETE FROM sources WHERE id = ?`, sourceID,
+	)
+	if err != nil {
+		return hadActiveSync, fmt.Errorf("delete source: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return hadActiveSync, fmt.Errorf("check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return hadActiveSync, fmt.Errorf("source %d not found", sourceID)
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return hadActiveSync, fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+	return hadActiveSync, nil
+}
+
+// removeSourceExec performs the FTS + sources DELETE on a generic executor
+// (either a *loggedTx or *sql.Conn under a manual transaction).
+func (s *Store) removeSourceExec(tx *loggedTx, sourceID int64) error {
+	if s.fts5Available {
+		if _, err := tx.Exec(s.dialect.FTSDeleteSQL(), sourceID); err != nil {
+			return fmt.Errorf("delete FTS rows: %w", err)
+		}
+	}
+	res, err := tx.Exec(`DELETE FROM sources WHERE id = ?`, sourceID)
+	if err != nil {
+		return fmt.Errorf("delete source: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("source %d not found", sourceID)
+	}
+	return nil
 }

--- a/internal/store/sources_test.go
+++ b/internal/store/sources_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"context"
 	"database/sql"
 	"path/filepath"
 	"testing"
@@ -176,6 +177,82 @@ func TestStore_RemoveSource_CascadesConversations(t *testing.T) {
 	testutil.MustNoErr(t, err, "count message_recipients")
 	if recipCount != 0 {
 		t.Errorf("message_recipients count = %d, want 0", recipCount)
+	}
+}
+
+func TestStore_RemoveSourceSerialized_NoActiveSync(t *testing.T) {
+	f := storetest.New(t)
+	f.CreateMessage("msg-1")
+
+	had, err := f.Store.RemoveSourceSerialized(context.Background(), f.Source.ID)
+	testutil.MustNoErr(t, err, "RemoveSourceSerialized")
+	if had {
+		t.Error("hadActiveSync = true, want false")
+	}
+
+	src, err := f.Store.GetSourceByIdentifier("test@example.com")
+	testutil.MustNoErr(t, err, "GetSourceByIdentifier")
+	if src != nil {
+		t.Error("source should be removed")
+	}
+}
+
+func TestStore_RemoveSourceSerialized_ActiveSyncSameSource(t *testing.T) {
+	f := storetest.New(t)
+	f.CreateMessage("msg-1")
+	// Active sync on the source being removed — this row would be cascaded
+	// by the DELETE. The serialized check must still observe it.
+	f.StartSync()
+
+	had, err := f.Store.RemoveSourceSerialized(context.Background(), f.Source.ID)
+	testutil.MustNoErr(t, err, "RemoveSourceSerialized")
+	if !had {
+		t.Error("hadActiveSync = false, want true for sync on removed source")
+	}
+
+	src, err := f.Store.GetSourceByIdentifier("test@example.com")
+	testutil.MustNoErr(t, err, "GetSourceByIdentifier")
+	if src != nil {
+		t.Error("source should still be removed even when sync was active")
+	}
+}
+
+func TestStore_RemoveSourceSerialized_ActiveSyncOtherSource(t *testing.T) {
+	f := storetest.New(t)
+
+	// Create a second source with its own running sync.
+	otherSrc, err := f.Store.GetOrCreateSource("gmail", "other@example.com")
+	testutil.MustNoErr(t, err, "create other source")
+	_, err = f.Store.StartSync(otherSrc.ID, "full")
+	testutil.MustNoErr(t, err, "start other sync")
+
+	had, err := f.Store.RemoveSourceSerialized(context.Background(), f.Source.ID)
+	testutil.MustNoErr(t, err, "RemoveSourceSerialized")
+	if !had {
+		t.Error("hadActiveSync = false, want true for sync on another source")
+	}
+
+	// Original source is gone.
+	src, err := f.Store.GetSourceByIdentifier("test@example.com")
+	testutil.MustNoErr(t, err, "GetSourceByIdentifier")
+	if src != nil {
+		t.Error("test source should be removed")
+	}
+
+	// Other source (with the active sync) is untouched.
+	other, err := f.Store.GetSourceByIdentifier("other@example.com")
+	testutil.MustNoErr(t, err, "GetSourceByIdentifier other")
+	if other == nil {
+		t.Error("other source should remain")
+	}
+}
+
+func TestStore_RemoveSourceSerialized_NotFound(t *testing.T) {
+	st := testutil.NewTestStore(t)
+
+	_, err := st.RemoveSourceSerialized(context.Background(), 99999)
+	if err == nil {
+		t.Fatal("RemoveSourceSerialized should error for nonexistent ID")
 	}
 }
 

--- a/internal/store/sources_test.go
+++ b/internal/store/sources_test.go
@@ -179,6 +179,91 @@ func TestStore_RemoveSource_CascadesConversations(t *testing.T) {
 	}
 }
 
+func TestStore_AttachmentPathsUniqueToSource(t *testing.T) {
+	f := storetest.New(t)
+
+	// Create a second source with its own conversation.
+	otherSrc, err := f.Store.GetOrCreateSource("gmail", "other@example.com")
+	testutil.MustNoErr(t, err, "create other source")
+	otherConv, err := f.Store.EnsureConversation(otherSrc.ID, "other-thread", "Other")
+	testutil.MustNoErr(t, err, "ensure other conv")
+	otherMsgID, err := f.Store.UpsertMessage(&store.Message{
+		ConversationID:  otherConv,
+		SourceID:        otherSrc.ID,
+		SourceMessageID: "other-msg-1",
+		MessageType:     "email",
+	})
+	testutil.MustNoErr(t, err, "create other message")
+
+	// Attachment unique to the default source.
+	uniqueMsg := f.CreateMessage("msg-unique")
+	err = f.Store.UpsertAttachment(uniqueMsg, "u.pdf", "application/pdf",
+		"aa/uniquehash", "uniquehash", 10)
+	testutil.MustNoErr(t, err, "upsert unique attachment")
+
+	// Attachment shared with another source (same content_hash).
+	sharedMsg := f.CreateMessage("msg-shared")
+	err = f.Store.UpsertAttachment(sharedMsg, "s.pdf", "application/pdf",
+		"bb/sharedhash", "sharedhash", 20)
+	testutil.MustNoErr(t, err, "upsert shared attachment in default source")
+	err = f.Store.UpsertAttachment(otherMsgID, "s.pdf", "application/pdf",
+		"bb/sharedhash", "sharedhash", 20)
+	testutil.MustNoErr(t, err, "upsert shared attachment in other source")
+
+	// Attachment with NULL content_hash (must be excluded).
+	nullHashMsg := f.CreateMessage("msg-null-hash")
+	_, err = f.Store.DB().Exec(
+		`INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, created_at)
+		 VALUES (?, 'n.pdf', 'application/pdf', 'cc/x', NULL, 30, CURRENT_TIMESTAMP)`,
+		nullHashMsg,
+	)
+	testutil.MustNoErr(t, err, "insert null-hash attachment")
+
+	// Attachment with empty storage_path (must be excluded).
+	emptyPathMsg := f.CreateMessage("msg-empty-path")
+	err = f.Store.UpsertAttachment(emptyPathMsg, "e.pdf", "application/pdf",
+		"", "emptypathhash", 40)
+	testutil.MustNoErr(t, err, "upsert empty-path attachment")
+
+	// Two messages in the default source referencing the same unique hash
+	// should collapse to a single storage_path in the result.
+	dupMsg := f.CreateMessage("msg-dup-hash")
+	err = f.Store.UpsertAttachment(dupMsg, "u.pdf", "application/pdf",
+		"aa/uniquehash", "uniquehash", 10)
+	testutil.MustNoErr(t, err, "upsert duplicate-of-unique attachment")
+
+	paths, err := f.Store.AttachmentPathsUniqueToSource(f.Source.ID)
+	testutil.MustNoErr(t, err, "AttachmentPathsUniqueToSource")
+
+	if len(paths) != 1 {
+		t.Fatalf("got %d paths, want 1: %v", len(paths), paths)
+	}
+	if paths[0] != "aa/uniquehash" {
+		t.Errorf("path[0] = %q, want aa/uniquehash", paths[0])
+	}
+}
+
+func TestStore_IsAttachmentPathReferenced(t *testing.T) {
+	f := storetest.New(t)
+
+	msgID := f.CreateMessage("msg-ref-1")
+	err := f.Store.UpsertAttachment(msgID, "a.pdf", "application/pdf",
+		"aa/hash1", "hash1", 10)
+	testutil.MustNoErr(t, err, "UpsertAttachment")
+
+	referenced, err := f.Store.IsAttachmentPathReferenced("aa/hash1")
+	testutil.MustNoErr(t, err, "IsAttachmentPathReferenced (hit)")
+	if !referenced {
+		t.Error("expected true for referenced path")
+	}
+
+	referenced, err = f.Store.IsAttachmentPathReferenced("zz/nothere")
+	testutil.MustNoErr(t, err, "IsAttachmentPathReferenced (miss)")
+	if referenced {
+		t.Error("expected false for unreferenced path")
+	}
+}
+
 func TestInitSchema_MigratesOAuthAppColumn(t *testing.T) {
 	// Simulate a pre-migration database that lacks the oauth_app column.
 	dbPath := filepath.Join(t.TempDir(), "legacy.db")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -186,9 +186,10 @@ func (s *Store) DB() *sql.DB {
 // database. In WAL mode this blocks concurrent writers (e.g. StartSync) while
 // allowing reads (e.g. IsAttachmentPathReferenced) to proceed. Use this to
 // serialize destructive file operations against concurrent sync attachment
-// ingestion.
-func (s *Store) WithExclusiveLock(fn func() error) error {
-	ctx := context.Background()
+// ingestion. The context controls both lock acquisition and the lifetime of
+// the underlying connection; cancelling it aborts a pending BEGIN EXCLUSIVE
+// and rolls back any held transaction.
+func (s *Store) WithExclusiveLock(ctx context.Context, fn func() error) error {
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return fmt.Errorf("acquire connection: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,6 +2,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"errors"
@@ -179,6 +180,41 @@ func (s *Store) CheckpointWAL() error {
 // at a different abstraction layer.
 func (s *Store) DB() *sql.DB {
 	return s.db.DB
+}
+
+// WithExclusiveLock executes fn while holding an exclusive write lock on the
+// database. In WAL mode this blocks concurrent writers (e.g. StartSync) while
+// allowing reads (e.g. IsAttachmentPathReferenced) to proceed. Use this to
+// serialize destructive file operations against concurrent sync attachment
+// ingestion.
+func (s *Store) WithExclusiveLock(fn func() error) error {
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN EXCLUSIVE"); err != nil {
+		return fmt.Errorf("begin exclusive: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	if err := fn(); err != nil {
+		return err
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("commit exclusive: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 // withTx executes fn within a database transaction. If fn returns an error,

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -236,6 +236,20 @@ func (s *Store) GetActiveSync(sourceID int64) (*SyncRun, error) {
 	return run, err
 }
 
+// HasAnyActiveSync returns true if any source currently has a running sync.
+// Use this as a safety gate before performing destructive file operations that
+// could race with concurrent attachment ingestion.
+func (s *Store) HasAnyActiveSync() (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sync_runs WHERE status = 'running'`,
+	).Scan(&count)
+	if err != nil {
+		return true, err // fail safe
+	}
+	return count > 0, nil
+}
+
 // GetLastSuccessfulSync returns the most recent successful sync for a source.
 func (s *Store) GetLastSuccessfulSync(sourceID int64) (*SyncRun, error) {
 	row := s.db.QueryRow(`

--- a/internal/store/sync_test.go
+++ b/internal/store/sync_test.go
@@ -191,3 +191,44 @@ func TestScanSource_NullRequiredTimestamp(t *testing.T) {
 		t.Errorf("error should mention field and NULL status, got: %s", errStr)
 	}
 }
+
+func TestStore_HasAnyActiveSync(t *testing.T) {
+	f := storetest.New(t)
+
+	running, err := f.Store.HasAnyActiveSync()
+	testutil.MustNoErr(t, err, "HasAnyActiveSync (initial)")
+	if running {
+		t.Error("expected no active sync on fresh DB")
+	}
+
+	syncID := f.StartSync()
+
+	running, err = f.Store.HasAnyActiveSync()
+	testutil.MustNoErr(t, err, "HasAnyActiveSync (after StartSync)")
+	if !running {
+		t.Error("expected active sync after StartSync")
+	}
+
+	// A second StartSync on the same source marks the prior one failed, but
+	// itself is running.
+	_ = f.StartSync()
+	running, err = f.Store.HasAnyActiveSync()
+	testutil.MustNoErr(t, err, "HasAnyActiveSync (after second StartSync)")
+	if !running {
+		t.Error("expected an active sync after second StartSync")
+	}
+
+	// Mark the latest sync as completed.
+	_, err = f.Store.DB().Exec(
+		`UPDATE sync_runs SET status = 'completed' WHERE status = 'running'`,
+	)
+	testutil.MustNoErr(t, err, "mark sync completed")
+
+	running, err = f.Store.HasAnyActiveSync()
+	testutil.MustNoErr(t, err, "HasAnyActiveSync (after completion)")
+	if running {
+		t.Error("expected no active sync after completion")
+	}
+
+	_ = syncID
+}


### PR DESCRIPTION
`remove-account` now deletes attachment files on disk that belong only to the account being removed. Files whose `content_hash` is shared with another account are preserved.

If any sync is running when the command starts, file deletion is skipped; the account's database rows are still removed.

Output now reports the number of files deleted and the number preserved. The "Use 'msgvault gc' (when available)" note is removed.