### PR TITLE
 Fix search performance regression and TUI race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LDFLAGS := -X github.com/wesm/msgvault/cmd/msgvault/cmd.Version=$(VERSION) \
 
 LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 
-.PHONY: build build-release install clean test test-v fmt lint lint-ci tidy shootout run-shootout install-hooks help
+.PHONY: build build-release install clean test test-v fmt lint lint-ci tidy shootout run-shootout install-hooks bench help
 
 # Build the binary (debug)
 build:
@@ -92,6 +92,10 @@ install-hooks:
 tidy:
 	go mod tidy
 
+# Run benchmarks (query engine smoke test)
+bench:
+	go test -tags fts5 -run=^$$ -bench=. -benchtime=1s -count=1 ./internal/query/
+
 # Build the MIME shootout tool
 shootout:
 	CGO_ENABLED=1 go build -o mimeshootout ./scripts/mimeshootout
@@ -117,5 +121,6 @@ help:
 	@echo "  install-hooks  - Install pre-commit hook via prek"
 	@echo "  clean          - Remove build artifacts"
 	@echo ""
+	@echo "  bench          - Run query engine benchmarks"
 	@echo "  shootout       - Build MIME shootout tool"
 	@echo "  run-shootout   - Run MIME shootout"

--- a/internal/query/benchmark_test.go
+++ b/internal/query/benchmark_test.go
@@ -1,0 +1,510 @@
+package query
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/marcboeker/go-duckdb"
+	"github.com/wesm/msgvault/internal/search"
+)
+
+const benchMessageCount = 100_000
+
+// buildBenchData generates a 100K-message Parquet dataset directly via
+// DuckDB SQL (no Go-side row generation). This produces realistic
+// cardinality: 500 participants across 50 domains, 10 labels,
+// varied subjects/snippets, and 20% attachment rate.
+func buildBenchData(b *testing.B) *DuckDBEngine {
+	b.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "msgvault-bench-*")
+	if err != nil {
+		b.Fatalf("create temp dir: %v", err)
+	}
+	b.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		b.Fatalf("open duckdb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Seed tables as DuckDB views, then COPY to Parquet.
+	seedSQL := fmt.Sprintf(`
+		-- Sources
+		CREATE TABLE bench_sources AS
+		SELECT 1::BIGINT AS id,
+			   'bench@gmail.com' AS identifier,
+			   'gmail' AS source_type;
+
+		-- 500 participants across 50 domains
+		CREATE TABLE bench_domains AS
+		SELECT row_number() OVER () AS idx, domain FROM (VALUES
+			('acme'),('globex'),('initech'),('hooli'),
+			('piedpiper'),('waystar'),('dunder'),('sterling'),
+			('prestige'),('vandelay'),('contoso'),('fabrikam'),
+			('northwind'),('widgetco'),('megacorp'),('cyberdyne'),
+			('umbrella'),('abstergo'),('aperture'),('blackmesa'),
+			('oscorp'),('lexcorp'),('stark'),('wayne'),
+			('genco'),('soylent'),('tyrell'),('weyland'),
+			('momcorp'),('planet'),('capsule'),('zorg'),
+			('omni'),('axiom'),('buyenlarge'),('cybertron'),
+			('starfleet'),('shield'),('hydra'),('dharma'),
+			('oceanic'),('hanso'),('massive'),('ellingson'),
+			('shinra'),('mako'),('jenova'),('umbrellacorp'),
+			('racoon'),('torgue')
+		) d(domain);
+
+		CREATE TABLE bench_participants AS
+		SELECT
+			i::BIGINT AS id,
+			'user' || i || '@' || d.domain || '.com' AS email_address,
+			d.domain || '.com' AS domain,
+			'User ' || i AS display_name,
+			'' AS phone_number
+		FROM generate_series(1, 500) t(i)
+		JOIN bench_domains d ON d.idx = ((i - 1) %% 50) + 1;
+
+		-- 10 labels
+		CREATE TABLE bench_labels AS
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'INBOX'), (2, 'Work'), (3, 'IMPORTANT'),
+			(4, 'SENT'), (5, 'Personal'), (6, 'Promotions'),
+			(7, 'Updates'), (8, 'Social'), (9, 'Finance'),
+			(10, 'Travel')
+		) AS t(id, name);
+
+		-- Subject templates (10 patterns)
+		CREATE TABLE bench_subjects AS
+		SELECT * FROM (VALUES
+			('Q%% budget review meeting notes'),
+			('Re: Project alpha deployment plan'),
+			('Weekly standup summary for team'),
+			('Invoice #%% attached for approval'),
+			('Security advisory: update required'),
+			('Quarterly report financials'),
+			('Team offsite planning logistics'),
+			('PR review: fix authentication bug'),
+			('Database migration rollback plan'),
+			('Customer feedback analysis report')
+		) AS t(template);
+
+		-- 100K messages spanning 2020-2025
+		CREATE TABLE bench_messages AS
+		SELECT
+			i::BIGINT AS id,
+			1::BIGINT AS source_id,
+			'msg' || i AS source_message_id,
+			(200 + (i %% 5000))::BIGINT AS conversation_id,
+			CASE (i %% 10)
+				WHEN 0 THEN 'Q' || (i/10000+1) || ' budget review meeting notes'
+				WHEN 1 THEN 'Re: Project alpha deployment plan #' || i
+				WHEN 2 THEN 'Weekly standup summary for team ' || (i%%20+1)
+				WHEN 3 THEN 'Invoice #' || i || ' attached for approval'
+				WHEN 4 THEN 'Security advisory: update required'
+				WHEN 5 THEN 'Quarterly report Q' || (i%%4+1) || ' financials'
+				WHEN 6 THEN 'Team offsite planning logistics'
+				WHEN 7 THEN 'PR review: fix authentication bug #' || i
+				WHEN 8 THEN 'Database migration rollback plan'
+				ELSE 'Customer feedback analysis report Q' || (i%%4+1)
+			END AS subject,
+			'Preview text for message ' || i || ' about various topics' AS snippet,
+			TIMESTAMP '2020-01-01' + INTERVAL (i * 30) MINUTE AS sent_at,
+			(500 + (i %% 10) * 200)::BIGINT AS size_estimate,
+			(i %% 5 = 0)::BOOLEAN AS has_attachments,
+			NULL::TIMESTAMP AS deleted_from_source_at,
+			(i %% 5 = 0)::INTEGER AS attachment_count,
+			NULL::BIGINT AS sender_id,
+			'email' AS message_type,
+			EXTRACT(YEAR FROM TIMESTAMP '2020-01-01' + INTERVAL (i * 30) MINUTE)::INTEGER AS year,
+			EXTRACT(MONTH FROM TIMESTAMP '2020-01-01' + INTERVAL (i * 30) MINUTE)::INTEGER AS month
+		FROM generate_series(1, %d) t(i);
+
+		-- message_recipients: 1 sender + 1-2 recipients per message
+		CREATE TABLE bench_recipients AS
+		-- sender
+		SELECT
+			m.id AS message_id,
+			((m.id %% 500) + 1)::BIGINT AS participant_id,
+			'from' AS recipient_type,
+			'User ' || ((m.id %% 500) + 1) AS display_name
+		FROM bench_messages m
+		UNION ALL
+		-- primary recipient
+		SELECT
+			m.id AS message_id,
+			(((m.id + 1) %% 500) + 1)::BIGINT AS participant_id,
+			'to' AS recipient_type,
+			'User ' || (((m.id + 1) %% 500) + 1) AS display_name
+		FROM bench_messages m
+		UNION ALL
+		-- cc on 33%% of messages
+		SELECT
+			m.id AS message_id,
+			(((m.id + 2) %% 500) + 1)::BIGINT AS participant_id,
+			'cc' AS recipient_type,
+			'User ' || (((m.id + 2) %% 500) + 1) AS display_name
+		FROM bench_messages m
+		WHERE m.id %% 3 = 0;
+
+		-- message_labels: 1-2 labels per message
+		CREATE TABLE bench_message_labels AS
+		-- every message gets INBOX
+		SELECT m.id AS message_id, 1::BIGINT AS label_id
+		FROM bench_messages m
+		UNION ALL
+		-- second label round-robin (skip label 1 to avoid dups)
+		SELECT m.id AS message_id, ((m.id %% 9) + 2)::BIGINT AS label_id
+		FROM bench_messages m;
+
+		-- attachments on ~20%% of messages
+		CREATE TABLE bench_attachments AS
+		SELECT
+			m.id AS message_id,
+			(1000 + m.id * 10)::BIGINT AS size,
+			'file' || m.id || '.pdf' AS filename
+		FROM bench_messages m
+		WHERE m.id %% 5 = 0;
+
+		-- conversations
+		CREATE TABLE bench_conversations AS
+		SELECT DISTINCT
+			conversation_id AS id,
+			'thread' || conversation_id AS source_conversation_id,
+			'' AS title
+		FROM bench_messages;
+	`, benchMessageCount)
+
+	if _, err := db.Exec(seedSQL); err != nil {
+		b.Fatalf("seed bench data: %v", err)
+	}
+
+	// Write Parquet files in the layout the engine expects.
+	type tableSpec struct {
+		query  string
+		subdir string
+		file   string
+	}
+
+	tables := []tableSpec{
+		{"SELECT id, identifier, source_type FROM bench_sources",
+			"sources", "sources.parquet"},
+		{"SELECT id, email_address, domain, display_name, phone_number FROM bench_participants",
+			"participants", "participants.parquet"},
+		{"SELECT message_id, participant_id, recipient_type, display_name FROM bench_recipients",
+			"message_recipients", "message_recipients.parquet"},
+		{"SELECT id, name FROM bench_labels",
+			"labels", "labels.parquet"},
+		{"SELECT message_id, label_id FROM bench_message_labels",
+			"message_labels", "message_labels.parquet"},
+		{"SELECT message_id, size, filename FROM bench_attachments",
+			"attachments", "attachments.parquet"},
+		{"SELECT id, source_conversation_id, title FROM bench_conversations",
+			"conversations", "conversations.parquet"},
+	}
+
+	for _, t := range tables {
+		dir := filepath.Join(tmpDir, t.subdir)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			b.Fatalf("mkdir %s: %v", dir, err)
+		}
+		path := escapePath(filepath.Join(dir, t.file))
+		q := fmt.Sprintf("COPY (%s) TO '%s' (FORMAT PARQUET)", t.query, path)
+		if _, err := db.Exec(q); err != nil {
+			b.Fatalf("write parquet %s: %v", t.file, err)
+		}
+	}
+
+	// Messages are hive-partitioned by year.
+	msgDir := filepath.Join(tmpDir, "messages")
+	if err := os.MkdirAll(msgDir, 0755); err != nil {
+		b.Fatalf("mkdir messages: %v", err)
+	}
+	msgPath := escapePath(msgDir)
+	msgCopy := fmt.Sprintf(`
+		COPY (
+			SELECT id, source_id, source_message_id, conversation_id,
+				   subject, snippet, sent_at, size_estimate, has_attachments,
+				   deleted_from_source_at, attachment_count, sender_id,
+				   message_type, year, month
+			FROM bench_messages
+		) TO '%s' (FORMAT PARQUET, PARTITION_BY (year), OVERWRITE_OR_IGNORE)
+	`, msgPath)
+	if _, err := db.Exec(msgCopy); err != nil {
+		b.Fatalf("write messages parquet: %v", err)
+	}
+
+	engine, err := NewDuckDBEngine(tmpDir, "", nil)
+	if err != nil {
+		b.Fatalf("NewDuckDBEngine: %v", err)
+	}
+	b.Cleanup(func() { _ = engine.Close() })
+	return engine
+}
+
+func BenchmarkSearchFast(b *testing.B) {
+	engine := buildBenchData(b)
+	ctx := context.Background()
+
+	b.Run("single_term", func(b *testing.B) {
+		q := search.Parse("budget")
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SearchFast(ctx, q,
+				MessageFilter{}, 50, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("multi_term", func(b *testing.B) {
+		q := search.Parse("budget review meeting")
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SearchFast(ctx, q,
+				MessageFilter{}, 50, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("from_filter", func(b *testing.B) {
+		q := search.Parse("from:user5@acme.com budget")
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SearchFast(ctx, q,
+				MessageFilter{}, 50, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("no_match", func(b *testing.B) {
+		q := search.Parse("xyzzynonexistent")
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SearchFast(ctx, q,
+				MessageFilter{}, 50, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("with_sender_filter", func(b *testing.B) {
+		q := search.Parse("report")
+		filter := MessageFilter{
+			Sender: "user1@acme.com",
+		}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SearchFast(ctx, q,
+				filter, 50, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkSearchFastWithStats(b *testing.B) {
+	engine := buildBenchData(b)
+	ctx := context.Background()
+
+	b.Run("single_term", func(b *testing.B) {
+		q := search.Parse("budget")
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SearchFastWithStats(ctx, q,
+				"budget", MessageFilter{},
+				ViewSenders, 50, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("multi_term", func(b *testing.B) {
+		q := search.Parse("quarterly report financials")
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SearchFastWithStats(ctx, q,
+				"quarterly report financials",
+				MessageFilter{}, ViewSenders, 50, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkAggregate(b *testing.B) {
+	engine := buildBenchData(b)
+	ctx := context.Background()
+	opts := AggregateOptions{SortField: SortByCount}
+
+	b.Run("senders", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.Aggregate(ctx, ViewSenders, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("domains", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.Aggregate(ctx, ViewDomains, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("labels", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.Aggregate(ctx, ViewLabels, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("time", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.Aggregate(ctx, ViewTime, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("senders_with_search", func(b *testing.B) {
+		opts := AggregateOptions{
+			SortField:   SortByCount,
+			SearchQuery: "budget",
+		}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.Aggregate(ctx, ViewSenders, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkGetTotalStats(b *testing.B) {
+	engine := buildBenchData(b)
+	ctx := context.Background()
+
+	b.Run("no_filter", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.GetTotalStats(ctx, StatsOptions{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("with_search", func(b *testing.B) {
+		opts := StatsOptions{SearchQuery: "budget review"}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.GetTotalStats(ctx, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkListMessages(b *testing.B) {
+	engine := buildBenchData(b)
+	ctx := context.Background()
+
+	b.Run("no_filter", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.ListMessages(ctx, MessageFilter{})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("sender_filter", func(b *testing.B) {
+		filter := MessageFilter{Sender: "user1@acme.com"}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.ListMessages(ctx, filter)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("domain_filter", func(b *testing.B) {
+		filter := MessageFilter{Domain: "acme.com"}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.ListMessages(ctx, filter)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("label_filter", func(b *testing.B) {
+		filter := MessageFilter{Label: "Work"}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.ListMessages(ctx, filter)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkSubAggregate(b *testing.B) {
+	engine := buildBenchData(b)
+	ctx := context.Background()
+	opts := AggregateOptions{SortField: SortByCount}
+
+	b.Run("sender_to_labels", func(b *testing.B) {
+		filter := MessageFilter{Sender: "user1@acme.com"}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SubAggregate(ctx, filter,
+				ViewLabels, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("domain_to_senders", func(b *testing.B) {
+		filter := MessageFilter{Domain: "acme.com"}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := engine.SubAggregate(ctx, filter,
+				ViewSenders, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -470,32 +470,25 @@ func (e *DuckDBEngine) buildAggregateSearchConditions(searchQuery string, keyCol
 
 	// Text terms: always search subject + sender, plus the view's grouping
 	// key columns when provided (e.g., label name in Labels view).
-	// Uses word-boundary regex (\b) for terms starting with word chars.
-	// Terms starting with non-word chars (e.g., +, @, #) skip \b
-	// since it requires a word/non-word transition that fails at
-	// string start or after whitespace.
+	// Uses ILIKE for performance on Parquet scans.
 	for _, term := range q.TextTerms {
-		escaped := escapeRegex(term)
-		regexPattern := "(?i)" + escaped
-		if startsWithWordChar(term) {
-			regexPattern = "(?i)\\b" + escaped
-		}
+		termPattern := "%" + escapeILIKE(term) + "%"
 		var parts []string
-		parts = append(parts, `regexp_matches(COALESCE(msg.subject, ''), ?)`)
-		args = append(args, regexPattern)
-		parts = append(parts, `regexp_matches(COALESCE(msg.snippet, ''), ?)`)
-		args = append(args, regexPattern)
+		parts = append(parts, `msg.subject ILIKE ? ESCAPE '\'`)
+		args = append(args, termPattern)
+		parts = append(parts, `COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\'`)
+		args = append(args, termPattern)
 		parts = append(parts, `EXISTS (
 			SELECT 1 FROM mr mr_search
 			JOIN p p_search ON p_search.id = mr_search.participant_id
 			WHERE mr_search.message_id = msg.id
 			  AND mr_search.recipient_type = 'from'
-			  AND (regexp_matches(p_search.email_address, ?) OR regexp_matches(COALESCE(p_search.display_name, ''), ?))
+			  AND (p_search.email_address ILIKE ? ESCAPE '\' OR COALESCE(p_search.display_name, '') ILIKE ? ESCAPE '\')
 		)`)
-		args = append(args, regexPattern, regexPattern)
+		args = append(args, termPattern, termPattern)
 		for _, col := range keyColumns {
-			parts = append(parts, `regexp_matches(COALESCE(`+col+`, ''), ?)`)
-			args = append(args, regexPattern)
+			parts = append(parts, col+` ILIKE ? ESCAPE '\'`)
+			args = append(args, termPattern)
 		}
 		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
 	}
@@ -2407,23 +2400,18 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 	}
 
 	// Text search terms - search subject, snippet, and from fields (fast path).
-	// Use word-boundary regex (\b) for terms starting with word chars.
-	// Terms starting with non-word chars skip \b (see startsWithWordChar).
+	// Uses ILIKE for performance on Parquet scans.
 	if len(q.TextTerms) > 0 {
 		for _, term := range q.TextTerms {
-			escaped := escapeRegex(term)
-			regexPattern := "(?i)" + escaped
-			if startsWithWordChar(term) {
-				regexPattern = "(?i)\\b" + escaped
-			}
+			termPattern := "%" + escapeILIKE(term) + "%"
 			conditions = append(conditions, `(
-				regexp_matches(COALESCE(msg.subject, ''), ?) OR
-				regexp_matches(COALESCE(msg.snippet, ''), ?) OR
-				regexp_matches(COALESCE(ms.from_email, ds.from_email, ''), ?) OR
-				regexp_matches(COALESCE(ms.from_name, ds.from_name, ''), ?) OR
-				regexp_matches(COALESCE(ms.from_phone, ds.from_phone, ''), ?)
+				msg.subject ILIKE ? ESCAPE '\' OR
+				COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\' OR
+				COALESCE(ms.from_email, ds.from_email, '') ILIKE ? ESCAPE '\' OR
+				COALESCE(ms.from_name, ds.from_name, '') ILIKE ? ESCAPE '\' OR
+				COALESCE(ms.from_phone, ds.from_phone, '') ILIKE ? ESCAPE '\'
 			)`)
-			args = append(args, regexPattern, regexPattern, regexPattern, regexPattern, regexPattern)
+			args = append(args, termPattern, termPattern, termPattern, termPattern, termPattern)
 		}
 	}
 

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -461,6 +461,24 @@ func (e *DuckDBEngine) buildAggregateSearchConditions(searchQuery string, keyCol
 		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
 	}
 
+	// Append non-text filters (from:, to:, subject:, label:, has:, dates, sizes).
+	nonTextConds, nonTextArgs := e.buildNonTextSearchConditions(q, keyColumns...)
+	conditions = append(conditions, nonTextConds...)
+	args = append(args, nonTextArgs...)
+
+	return conditions, args
+}
+
+// buildNonTextSearchConditions builds WHERE conditions for the non-text
+// portion of a parsed search query (from:, to:, subject:, label:, has:,
+// date/size filters). Extracted from buildAggregateSearchConditions so
+// callers that handle text terms themselves (e.g. buildStatsSearchConditions)
+// can append non-text filters without having to compute how many args
+// the text-term portion produced.
+func (e *DuckDBEngine) buildNonTextSearchConditions(q *search.Query, keyColumns ...string) ([]string, []interface{}) {
+	var conditions []string
+	var args []interface{}
+
 	// from: filter - match sender email
 	for _, from := range q.FromAddrs {
 		fromPattern := "%" + escapeILIKE(from) + "%"
@@ -611,26 +629,13 @@ func (e *DuckDBEngine) buildStatsSearchConditions(searchQuery string, groupBy Vi
 	}
 
 	// Non-text filters (from:, to:, subject:, label:, etc.) are the same
-	// regardless of view — delegate to the standard builder with no key columns.
-	nonTextConds, nonTextArgs := e.buildAggregateSearchConditions(searchQuery)
-	// Remove text-term conditions from the standard builder output (they are
-	// the first len(q.TextTerms) entries). We already handled text terms above.
-	if len(q.TextTerms) > 0 && len(nonTextConds) > len(q.TextTerms) {
-		conditions = append(conditions, nonTextConds[len(q.TextTerms):]...)
-		args = append(args, nonTextArgs[countArgsForTextTerms(len(q.TextTerms)):]...)
-	} else if len(q.TextTerms) == 0 {
-		conditions = append(conditions, nonTextConds...)
-		args = append(args, nonTextArgs...)
-	}
+	// regardless of view — delegate to the non-text helper directly so we
+	// don't have to track how many args the text-term portion emits.
+	nonTextConds, nonTextArgs := e.buildNonTextSearchConditions(q)
+	conditions = append(conditions, nonTextConds...)
+	args = append(args, nonTextArgs...)
 
 	return conditions, args
-}
-
-// countArgsForTextTerms returns the number of args used by N text terms in
-// buildAggregateSearchConditions with no keyColumns (4 args per term:
-// subject + snippet + 2 sender).
-func countArgsForTextTerms(n int) int {
-	return n * 4
 }
 
 // keyColumns are passed through to buildAggregateSearchConditions to control

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -418,38 +418,6 @@ func escapeILIKE(s string) string {
 	return s
 }
 
-// startsWithWordChar reports whether s begins with a regex word character
-// [a-zA-Z0-9_]. Used to decide whether \b is appropriate as a prefix.
-func startsWithWordChar(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-	c := s[0]
-	return (c >= 'a' && c <= 'z') ||
-		(c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') ||
-		c == '_'
-}
-
-// escapeRegex escapes special regex characters for use in DuckDB's regexp_matches function
-func escapeRegex(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, ".", "\\.")
-	s = strings.ReplaceAll(s, "*", "\\*")
-	s = strings.ReplaceAll(s, "+", "\\+")
-	s = strings.ReplaceAll(s, "?", "\\?")
-	s = strings.ReplaceAll(s, "[", "\\[")
-	s = strings.ReplaceAll(s, "]", "\\]")
-	s = strings.ReplaceAll(s, "(", "\\(")
-	s = strings.ReplaceAll(s, ")", "\\)")
-	s = strings.ReplaceAll(s, "{", "\\{")
-	s = strings.ReplaceAll(s, "}", "\\}")
-	s = strings.ReplaceAll(s, "|", "\\|")
-	s = strings.ReplaceAll(s, "^", "\\^")
-	s = strings.ReplaceAll(s, "$", "\\$")
-	return s
-}
-
 // buildWhereClause builds WHERE conditions for Parquet queries.
 // Column references use msg. prefix to be explicit since aggregate queries join multiple CTEs.
 // buildAggregateSearchConditions builds SQL conditions for a search query in aggregate views.

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -1839,7 +1839,7 @@ func TestBuildWhereClause_SearchOperators(t *testing.T) {
 		{
 			name:        "text terms",
 			searchQuery: "hello world",
-			wantClauses: []string{"regexp_matches(COALESCE(msg.subject"},
+			wantClauses: []string{"msg.subject ILIKE"},
 		},
 		{
 			name:        "from operator",
@@ -1899,39 +1899,36 @@ func TestBuildWhereClause_EscapedArgs(t *testing.T) {
 	opts := AggregateOptions{SearchQuery: "100%_off"}
 	_, args := engine.buildWhereClause(opts)
 
-	// With regex search, % and _ are not special so appear unescaped.
-	// Term starts with word char '1', so \b prefix is applied.
+	// With ILIKE search, % and _ are escaped with backslash.
 	found := false
 	for _, arg := range args {
-		if s, ok := arg.(string); ok && strings.Contains(s, "\\b100%_off") {
+		if s, ok := arg.(string); ok && strings.Contains(s, "100\\%\\_off") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected regex pattern containing '\\b100%%_off' in args, got: %v", args)
+		t.Errorf("expected ILIKE pattern containing '100\\%%\\_off' in args, got: %v", args)
 	}
 }
 
-// TestBuildWhereClause_WordBoundaryPrefix verifies that \b is only applied
-// when the search term starts with a word character [a-zA-Z0-9_]. Terms
-// starting with non-word characters (+, @, #, etc.) must not get \b, as it
-// requires a word/non-word transition that fails at string start.
-func TestBuildWhereClause_WordBoundaryPrefix(t *testing.T) {
+// TestBuildWhereClause_ILIKEEscape verifies that search terms are properly
+// escaped for ILIKE patterns in aggregate search conditions.
+func TestBuildWhereClause_ILIKEEscape(t *testing.T) {
 	engine := &DuckDBEngine{}
 
 	tests := []struct {
-		name       string
-		term       string
-		wantPrefix string // expected prefix in the regex arg
+		name    string
+		term    string
+		wantArg string // expected ILIKE arg pattern
 	}{
-		{"word_char_letter", "hello", "(?i)\\bhello"},
-		{"word_char_digit", "123", "(?i)\\b123"},
-		{"word_char_underscore", "_test", "(?i)\\b_test"},
-		{"non_word_plus", "+15551234567", "(?i)\\+15551234567"},
-		{"non_word_at", "@gmail.com", "(?i)@gmail\\.com"},
-		{"non_word_hash", "#bug", "(?i)#bug"},
-		{"non_word_paren", "(test)", "(?i)\\(test\\)"},
+		{"word_char_letter", "hello", "%hello%"},
+		{"word_char_digit", "123", "%123%"},
+		{"word_char_underscore", "_test", "%\\_test%"},
+		{"non_word_plus", "+15551234567", "%+15551234567%"},
+		{"non_word_at", "@gmail.com", "%@gmail.com%"},
+		{"non_word_hash", "#bug", "%#bug%"},
+		{"wildcard_percent", "100%off", "%100\\%off%"},
 	}
 
 	for _, tc := range tests {
@@ -1941,14 +1938,14 @@ func TestBuildWhereClause_WordBoundaryPrefix(t *testing.T) {
 
 			found := false
 			for _, arg := range args {
-				if s, ok := arg.(string); ok && s == tc.wantPrefix {
+				if s, ok := arg.(string); ok && s == tc.wantArg {
 					found = true
 					break
 				}
 			}
 			if !found {
 				t.Errorf("term %q: expected arg %q, got %v",
-					tc.term, tc.wantPrefix, args)
+					tc.term, tc.wantArg, args)
 			}
 		})
 	}
@@ -2049,7 +2046,7 @@ func TestAggregateByLabel_WithLabelSearch(t *testing.T) {
 }
 
 // TestBuildSearchConditions_EscapedWildcards verifies that buildSearchConditions
-// escapes wildcards: regex for TextTerms, ILIKE ESCAPE for operators.
+// escapes wildcards: ILIKE ESCAPE for TextTerms and operators.
 func TestBuildSearchConditions_EscapedWildcards(t *testing.T) {
 	engine := &DuckDBEngine{}
 
@@ -2064,8 +2061,8 @@ func TestBuildSearchConditions_EscapedWildcards(t *testing.T) {
 			query: &search.Query{
 				TextTerms: []string{"100%_off"},
 			},
-			wantClauses: []string{"regexp_matches(COALESCE(msg.subject"},
-			wantInArgs:  []string{"\\b100%_off"},
+			wantClauses: []string{"msg.subject ILIKE"},
+			wantInArgs:  []string{"100\\%\\_off"},
 		},
 		{
 			name: "from: with wildcards",

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -2119,6 +2119,53 @@ func TestBuildSearchConditions_EscapedWildcards(t *testing.T) {
 	}
 }
 
+// TestBuildSearchConditions_UsesILIKENotRegex verifies that the fast search
+// path uses ILIKE (fast on Parquet scans) instead of regexp_matches (slow).
+func TestBuildSearchConditions_UsesILIKENotRegex(t *testing.T) {
+	engine := &DuckDBEngine{}
+
+	q := &search.Query{TextTerms: []string{"hello"}}
+	conditions, args := engine.buildSearchConditions(q, MessageFilter{})
+	where := strings.Join(conditions, " AND ")
+
+	// Must use ILIKE, not regexp_matches
+	if strings.Contains(where, "regexp_matches") {
+		t.Errorf("fast search path should use ILIKE, not regexp_matches\ngot: %s", where)
+	}
+	if !strings.Contains(where, "ILIKE") {
+		t.Errorf("fast search path should contain ILIKE\ngot: %s", where)
+	}
+
+	// Args should be ILIKE patterns (%%term%%), not regex patterns
+	for _, arg := range args {
+		if s, ok := arg.(string); ok && strings.Contains(s, "(?i)") {
+			t.Errorf("fast search args should not contain regex patterns, got: %q", s)
+		}
+	}
+}
+
+// TestBuildAggregateSearchConditions_UsesILIKENotRegex verifies that the
+// aggregate search path also uses ILIKE instead of regexp_matches.
+func TestBuildAggregateSearchConditions_UsesILIKENotRegex(t *testing.T) {
+	engine := &DuckDBEngine{}
+
+	conditions, args := engine.buildAggregateSearchConditions("hello world")
+	where := strings.Join(conditions, " AND ")
+
+	if strings.Contains(where, "regexp_matches") {
+		t.Errorf("aggregate search should use ILIKE, not regexp_matches\ngot: %s", where)
+	}
+	if !strings.Contains(where, "ILIKE") {
+		t.Errorf("aggregate search should contain ILIKE\ngot: %s", where)
+	}
+
+	for _, arg := range args {
+		if s, ok := arg.(string); ok && strings.Contains(s, "(?i)") {
+			t.Errorf("aggregate search args should not contain regex patterns, got: %q", s)
+		}
+	}
+}
+
 // =============================================================================
 // RecipientName tests
 // =============================================================================

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -2391,6 +2391,89 @@ func TestDuckDBEngine_GetTotalStats_GroupByDefault(t *testing.T) {
 	}
 }
 
+// TestBuildStatsSearchConditions_PlaceholderArgCount is a regression test for
+// the mismatch between the number of "?" placeholders emitted and the number
+// of args appended when a stats search mixes text terms with non-text
+// operators (e.g. "hello from:bob@example.com"). Previously,
+// buildStatsSearchConditions called buildAggregateSearchConditions and sliced
+// off the text-term prefix using a hand-tracked arg count — any drift between
+// the count and the actual emit rate would cause aggregate stats queries to
+// fail with unmatched placeholders. The helper now delegates directly to
+// buildNonTextSearchConditions so there is nothing to slice; this test locks
+// the invariant in place by counting "?" placeholders.
+func TestBuildStatsSearchConditions_PlaceholderArgCount(t *testing.T) {
+	engine := &DuckDBEngine{}
+
+	cases := []struct {
+		name    string
+		query   string
+		groupBy ViewType
+	}{
+		{"text only (default)", "hello", ViewSenders},
+		{"text only (recipients)", "hello", ViewRecipients},
+		{"text only (labels)", "hello", ViewLabels},
+		{"text + from (default)", "hello from:bob@example.com", ViewSenders},
+		{"text + from (recipients)", "hello from:bob@example.com", ViewRecipients},
+		{"text + from (labels)", "hello from:bob@example.com", ViewLabels},
+		{"text + from + to", "hello from:a@b.com to:c@d.com", ViewSenders},
+		{"text + subject + label", "hello subject:report label:work", ViewSenders},
+		{"multi-text + from", "hello world from:bob@example.com", ViewSenders},
+		{"non-text only", "from:bob@example.com", ViewSenders},
+		{"empty query", "", ViewSenders},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conditions, args := engine.buildStatsSearchConditions(tc.query, tc.groupBy)
+			where := strings.Join(conditions, " AND ")
+			placeholders := strings.Count(where, "?")
+			if placeholders != len(args) {
+				t.Errorf("placeholder/arg mismatch for query %q (groupBy=%v): %d placeholders vs %d args\nconditions: %s\nargs: %v",
+					tc.query, tc.groupBy, placeholders, len(args), where, args)
+			}
+		})
+	}
+}
+
+// TestBuildAggregateSearchConditions_PlaceholderArgCount locks the same
+// invariant on buildAggregateSearchConditions: the number of "?" placeholders
+// in the emitted WHERE conditions must match the number of args, for any
+// combination of text terms, non-text filters, and keyColumns.
+func TestBuildAggregateSearchConditions_PlaceholderArgCount(t *testing.T) {
+	engine := &DuckDBEngine{}
+
+	cases := []struct {
+		name       string
+		query      string
+		keyColumns []string
+	}{
+		{"text only, no keyColumns", "hello", nil},
+		{"text only, one keyColumn", "hello", []string{"p.email_address"}},
+		{"text only, label keyColumn", "hello", []string{"lbl.name"}},
+		{"text + from", "hello from:bob@example.com", nil},
+		{"text + from + to + subject", "hello from:a@b.com to:c@d.com subject:report", nil},
+		{"text + label (label view)", "hello label:work", []string{"lbl.name"}},
+		{"text + label (non-label view)", "hello label:work", nil},
+		{"multi-text + from + keyColumns", "foo bar from:x@y.com", []string{"p.email_address", "p.display_name"}},
+		{"has:attachment", "has:attachment", nil},
+		{"date filter", "after:2024-01-01 before:2024-12-31", nil},
+		{"size filter", "larger:1000 smaller:5000", nil},
+		{"empty query", "", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conditions, args := engine.buildAggregateSearchConditions(tc.query, tc.keyColumns...)
+			where := strings.Join(conditions, " AND ")
+			placeholders := strings.Count(where, "?")
+			if placeholders != len(args) {
+				t.Errorf("placeholder/arg mismatch for query %q (keyColumns=%v): %d placeholders vs %d args\nconditions: %s\nargs: %v",
+					tc.query, tc.keyColumns, placeholders, len(args), where, args)
+			}
+		})
+	}
+}
+
 // =============================================================================
 // Aggregate and SubAggregate Table-Driven Tests
 // These tests cover the refactored aggregation helpers and time granularity logic.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1187,11 +1187,12 @@ func (m Model) handleSearchDebounce(msg searchDebounceMsg) (tea.Model, tea.Cmd) 
 		m.searchFilter.WithAttachmentsOnly = m.filters.attachmentsOnly
 		m.searchFilter.HideDeletedFromSource = m.filters.hideDeletedFromSource
 		m.searchRequestID++
+		m.loadRequestID++ // Invalidate any in-flight loadMessages to prevent overwriting search results
 		if msg.query == "" {
 			// Empty query: reload unfiltered messages
-			m.loadRequestID++
 			return m, tea.Batch(spinCmd, m.loadMessages())
 		}
+		m.messages = nil // Clear stale messages immediately so they don't show during search
 		return m, tea.Batch(spinCmd, m.loadSearch(msg.query))
 	}
 	// Aggregate views: reload aggregates with search filter

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -1505,5 +1505,86 @@ func TestZeroSearchResultsRendersSearchBar(t *testing.T) {
 	})
 }
 
+// TestStaleLoadMessagesDoesNotOverwriteSearch verifies that an in-flight
+// loadMessages response (e.g., from pressing "a" or "v" before searching)
+// does not overwrite search results. This was a race condition: the TUI would
+// show stale "all messages" results instead of the filtered search results.
+func TestStaleLoadMessagesDoesNotOverwriteSearch(t *testing.T) {
+	allMessages := makeMessages(50)
+	searchResults := []query.MessageSummary{
+		{ID: 901, Subject: "Search Hit 1"},
+		{ID: 902, Subject: "Search Hit 2"},
+	}
+
+	model := NewBuilder().
+		WithMessages(allMessages...).
+		WithLevel(levelMessageList).
+		WithPageSize(20).WithSize(100, 30).
+		Build()
+
+	// Simulate: user presses "v" (sort toggle) which fires loadMessages
+	// with loadRequestID=N.
+	staleLoadRequestID := model.loadRequestID
+
+	// Simulate: user then activates search, which should increment loadRequestID
+	// to invalidate the pending loadMessages.
+	model.searchQuery = "test"
+	model.inlineSearchActive = true
+	model.searchRequestID++
+	model.loadRequestID++ // This is the fix under test
+
+	// Simulate: search results arrive and are applied.
+	model = applySearchResults(t, model, model.searchRequestID, searchResults, 2)
+	if len(model.messages) != 2 {
+		t.Fatalf("expected 2 search results, got %d", len(model.messages))
+	}
+
+	// Simulate: the stale loadMessages response arrives with the OLD requestID.
+	staleMsg := messagesLoadedMsg{
+		messages:  allMessages,
+		requestID: staleLoadRequestID,
+	}
+	model, _ = sendMsg(t, model, staleMsg)
+
+	// The stale response must be ignored — search results should remain.
+	if len(model.messages) != 2 {
+		t.Errorf("stale loadMessages overwrote search results: expected 2 messages, got %d", len(model.messages))
+	}
+	if model.messages[0].Subject != "Search Hit 1" {
+		t.Errorf("expected first message 'Search Hit 1', got %q", model.messages[0].Subject)
+	}
+}
+
+// TestSearchClearsStaleMessages verifies that starting an inline search
+// immediately clears the message list so stale "all messages" results
+// are never visible during the search transition.
+func TestSearchClearsStaleMessages(t *testing.T) {
+	allMessages := makeMessages(50)
+
+	model := NewBuilder().
+		WithMessages(allMessages...).
+		WithLevel(levelMessageList).
+		WithPageSize(20).WithSize(100, 30).
+		Build()
+
+	if len(model.messages) != 50 {
+		t.Fatalf("expected 50 pre-loaded messages, got %d", len(model.messages))
+	}
+
+	// Simulate debounce firing with a search query.
+	debounceMsg := searchDebounceMsg{
+		query:      "test",
+		debounceID: model.inlineSearchDebounce,
+	}
+	model.inlineSearchActive = true
+	model, _ = sendMsg(t, model, debounceMsg)
+
+	// Messages should be nil immediately — not showing stale results while
+	// waiting for the async search to complete.
+	if model.messages != nil {
+		t.Errorf("expected messages to be nil after search starts, got %d messages", len(model.messages))
+	}
+}
+
 // TestHighlightedColumnsAligned verifies that highlighting search terms in
 // aggregate rows doesn't break column alignment.


### PR DESCRIPTION
Tested and ran into a bunch of performance & context issues that surfaced in the TUI. Original approach using ILIKE is better it seems like for large archives. (Note this is a resubmission of #256) 

Changes

- Reverts DuckDB text search from regexp_matches to ILIKE — regexp caused significant performance regression on Parquet scans. ILIKE is natively optimized by DuckDB for columnar data. FTS5 deep search path is unchanged.
- Fixes a TUI race condition where pressing a (all messages) then quickly searching could cause the stale loadMessages response to overwrite search results. Search now invalidates pending loads via loadRequestID.
- Fixes a placeholder/arg count drift in buildStatsSearchConditions — text terms emit 4 args each (subject + snippet + 2 sender) but the arg-slicing helper assumed 3. Extracted buildNonTextSearchConditions to eliminate the brittle offset math entirely. Regression tests lock the placeholder invariant across both search builders.