### PR TITLE
Update nix flake for v0.13.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       packages = forAllSystems (pkgs: {
         default = (pkgs.buildGoModule.override { go = goPinned pkgs; }) {
           pname = "msgvault";
-          version = "0.13.0";
+          version = "0.13.1";
           src = ./.;
           vendorHash = "sha256-TfrbpW6x2g/dcE9VSAy3ktT3knalC0QQgI3q77RCqQc=";
           proxyVendor = true;


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-TfrbpW6x2g/dcE9VSAy3ktT3knalC0QQgI3q77RCqQc=`
- Updated version to `0.13.1`

Automated update via `scripts/update-nix-flake.sh`.