### PR TITLE
feat: add rebuild-fts command for FTS5 shadow-table corruption (#287)

### DIFF
--- a/cmd/msgvault/cmd/rebuild_fts.go
+++ b/cmd/msgvault/cmd/rebuild_fts.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wesm/msgvault/internal/store"
+)
+
+var rebuildFTSCmd = &cobra.Command{
+	Use:   "rebuild-fts",
+	Short: "Rebuild the full-text search index from scratch",
+	Long: `Drop and recreate the messages_fts virtual table, then repopulate it
+from messages / message_bodies / message_recipients / participants.
+
+Use this to recover from FTS5 shadow-table corruption that surfaces as
+"malformed inverted index for FTS5 table main.messages_fts" in
+'msgvault verify' output. SQLite's own 'rebuild' pragma reads from the
+same corrupt shadow tables and cannot clear this state.
+
+This command only fixes the derived search index. Core-table corruption
+(e.g., "Rowid out of order" in messages / message_bodies B-trees) requires
+a different recovery path — see 'msgvault verify' output.
+
+Peak extra disk usage is roughly the size of the FTS5 shadow tables
+(a few percent of the SQLite database). Stop 'msgvault serve' and any
+MCP clients before running this command — it needs an exclusive write lock.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbPath := cfg.DatabaseDSN()
+		s, err := store.Open(dbPath)
+		if err != nil {
+			return fmt.Errorf("open database: %w", err)
+		}
+		defer func() { _ = s.Close() }()
+
+		if err := s.InitSchema(); err != nil {
+			return fmt.Errorf("init schema: %w", err)
+		}
+
+		fmt.Fprintln(os.Stderr, "Rebuilding full-text search index...")
+		n, err := s.RebuildFTS(func(done, total int64) {
+			if total <= 0 {
+				return
+			}
+			if done > total {
+				done = total
+			}
+			pct := int(done * 100 / total)
+			barWidth := 30
+			filled := barWidth * pct / 100
+			bar := strings.Repeat("=", filled) +
+				strings.Repeat(" ", barWidth-filled)
+			fmt.Fprintf(os.Stderr, "\r  [%s] %3d%%", bar, pct)
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr)
+			if s.IsBusyError(err) {
+				return fmt.Errorf(
+					"database is busy — stop 'msgvault serve' and any MCP " +
+						"clients, then retry",
+				)
+			}
+			return fmt.Errorf("rebuild FTS: %w", err)
+		}
+		fmt.Fprintf(os.Stderr,
+			"\r  [%s] 100%%  %d messages indexed.\n",
+			strings.Repeat("=", 30), n)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rebuildFTSCmd)
+}

--- a/cmd/msgvault/cmd/verify.go
+++ b/cmd/msgvault/cmd/verify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/mattn/go-isatty"
@@ -53,6 +54,33 @@ Examples:
 			return fmt.Errorf("init schema: %w", err)
 		}
 
+		// Run SQLite integrity check before any Gmail work. Users with a
+		// corrupt database should see the repair hint even if their OAuth
+		// token is expired or the network is down.
+		var dbCorrupt bool
+		if !verifySkipDBCheck {
+			fmt.Println("Running database integrity check...")
+			integrityErrors, err := runIntegrityCheck(s)
+			if err != nil {
+				return fmt.Errorf("integrity check failed: %w", err)
+			}
+			if len(integrityErrors) == 0 {
+				fmt.Println("  Database integrity: OK")
+			} else {
+				dbCorrupt = true
+				fmt.Printf("  Database integrity: FAILED (%d errors)\n", len(integrityErrors))
+				for i, ie := range integrityErrors {
+					if i >= 10 {
+						fmt.Printf("  ... and %d more errors\n", len(integrityErrors)-10)
+						break
+					}
+					fmt.Printf("  - %s\n", ie)
+				}
+				printIntegrityRecoveryHint(integrityErrors)
+			}
+			fmt.Println()
+		}
+
 		// Look up source to get OAuth app binding
 		appName := ""
 		src, srcErr := findGmailSource(s, email)
@@ -70,10 +98,6 @@ Examples:
 				return errOAuthNotConfigured()
 			}
 			return err
-		}
-
-		if err := s.InitSchema(); err != nil {
-			return fmt.Errorf("init schema: %w", err)
 		}
 
 		// Create OAuth manager and get token source
@@ -105,35 +129,6 @@ Examples:
 		// Create Gmail client (no rate limiter needed for single call)
 		client := gmail.NewClient(tokenSource, gmail.WithLogger(logger))
 		defer func() { _ = client.Close() }()
-
-		// Run SQLite integrity check first (offline, no Gmail needed)
-		var dbCorrupt bool
-		if !verifySkipDBCheck {
-			fmt.Println("Running database integrity check...")
-			integrityErrors, err := runIntegrityCheck(s)
-			if err != nil {
-				return fmt.Errorf("integrity check failed: %w", err)
-			}
-			if len(integrityErrors) == 0 {
-				fmt.Println("  Database integrity: OK")
-			} else {
-				dbCorrupt = true
-				fmt.Printf("  Database integrity: FAILED (%d errors)\n", len(integrityErrors))
-				for i, ie := range integrityErrors {
-					if i >= 10 {
-						fmt.Printf("  ... and %d more errors\n", len(integrityErrors)-10)
-						break
-					}
-					fmt.Printf("  - %s\n", ie)
-				}
-				fmt.Println()
-				fmt.Println("  The database has corruption. Consider:")
-				fmt.Println("    1. Back up the database file before any repair attempts")
-				fmt.Println("    2. Run: sqlite3 msgvault.db '.recover' | sqlite3 recovered.db")
-				fmt.Println("    3. Or export to SQL and reimport: sqlite3 msgvault.db .dump | sqlite3 new.db")
-			}
-			fmt.Println()
-		}
 
 		// Get Gmail profile
 		profile, err := client.GetProfile(ctx)
@@ -284,6 +279,49 @@ func runIntegrityCheck(s *store.Store) ([]string, error) {
 		}
 	}
 	return errors, rows.Err()
+}
+
+// printIntegrityRecoveryHint prints repair guidance tailored to the kind of
+// corruption reported. FTS5 shadow-table corruption is fixable with the
+// lightweight `rebuild-fts` command; core B-tree corruption needs `.recover`,
+// which requires free disk roughly equal to the database size.
+func printIntegrityRecoveryHint(integrityErrors []string) {
+	var ftsErrs, coreErrs int
+	for _, e := range integrityErrors {
+		if isFTSIntegrityError(e) {
+			ftsErrs++
+		} else {
+			coreErrs++
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("  Back up msgvault.db before attempting any repair.")
+	fmt.Println()
+
+	if ftsErrs > 0 {
+		fmt.Println("  Search index (FTS5) corruption:")
+		fmt.Println("    Run: msgvault rebuild-fts")
+		fmt.Println("    Drops and recreates messages_fts from the core tables.")
+		fmt.Println("    SQLite's 'rebuild' pragma reads from the corrupt shadow")
+		fmt.Println("    tables and cannot clear this state.")
+		fmt.Println()
+	}
+
+	if coreErrs > 0 {
+		fmt.Println("  Core table corruption (e.g., Rowid out of order in messages")
+		fmt.Println("  or message_bodies):")
+		fmt.Println("    Run: sqlite3 msgvault.db '.recover' | sqlite3 recovered.db")
+		fmt.Println("    (requires free disk roughly equal to the database size)")
+		fmt.Println("    Alternative: sqlite3 msgvault.db .dump | sqlite3 new.db")
+	}
+}
+
+// isFTSIntegrityError reports whether an integrity-check line describes
+// corruption in the FTS5 search index rather than the core tables.
+func isFTSIntegrityError(msg string) bool {
+	return strings.Contains(msg, "messages_fts") ||
+		strings.Contains(msg, "FTS5")
 }
 
 func init() {

--- a/cmd/msgvault/cmd/verify_test.go
+++ b/cmd/msgvault/cmd/verify_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import "testing"
+
+// TestIsFTSIntegrityError_Classification verifies that the hint-classifier
+// cleanly separates FTS5 shadow-table errors (which rebuild-fts can fix)
+// from core-table errors (which need .recover). Messages come from real
+// PRAGMA integrity_check output; the shapes below are what users will see.
+func TestIsFTSIntegrityError_Classification(t *testing.T) {
+	tests := []struct {
+		msg    string
+		wantFT bool
+	}{
+		{
+			msg:    "malformed inverted index for FTS5 table main.messages_fts",
+			wantFT: true,
+		},
+		{
+			msg:    "row 42 missing from index messages_fts_idx",
+			wantFT: true,
+		},
+		{
+			msg:    "Tree 26 page 8231140 cell 2: Rowid 421177 out of order",
+			wantFT: false,
+		},
+		{
+			msg:    "non-unique entry in index sqlite_autoindex_messages_1",
+			wantFT: false,
+		},
+		{
+			msg:    "",
+			wantFT: false,
+		},
+	}
+
+	for _, tc := range tests {
+		if got := isFTSIntegrityError(tc.msg); got != tc.wantFT {
+			t.Errorf("isFTSIntegrityError(%q) = %v, want %v", tc.msg, got, tc.wantFT)
+		}
+	}
+}

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -1,0 +1,87 @@
+# Database Recovery
+
+`msgvault verify you@gmail.com` runs `PRAGMA integrity_check` against the
+SQLite database before the Gmail comparison step. When that check fails,
+the recovery path depends on which part of the database is affected.
+
+## Search-index (FTS5) corruption
+
+Symptom (from `msgvault verify` output):
+
+```
+malformed inverted index for FTS5 table main.messages_fts
+```
+
+Fix:
+
+```
+msgvault rebuild-fts
+```
+
+This drops `messages_fts` and recreates it from the core tables
+(`messages`, `message_bodies`, `message_recipients`, `participants`). Peak
+extra disk usage is roughly the size of the FTS5 shadow tables — a few
+percent of the SQLite database.
+
+Stop `msgvault serve` and any MCP clients before running; `rebuild-fts`
+needs an exclusive write lock and will fail with a "database is busy"
+message otherwise.
+
+### Why SQLite's own rebuild pragma does not work
+
+`INSERT INTO messages_fts(messages_fts) VALUES('rebuild')` regenerates the
+FTS5 inverted index from the contentful shadow tables themselves. If those
+shadow tables are already malformed, the pragma reads the corruption right
+back out.
+
+`INSERT INTO messages_fts(messages_fts) VALUES('delete-all')` is rejected
+with `'delete-all' may only be used with a contentless or external content
+fts5 table`. msgvault's `messages_fts` is contentful by design (it stores
+its own copy of the searchable text), so `delete-all` is not available.
+
+`rebuild-fts` sidesteps both: it drops the virtual table entirely — which
+removes the shadow tables — then recreates it fresh and repopulates from
+the core tables.
+
+## Core-table corruption
+
+Symptom:
+
+```
+Tree 26 page 8231140 cell 2: Rowid 421177 out of order
+non-unique entry in index sqlite_autoindex_messages_1
+```
+
+Fix (requires free disk roughly equal to the size of the database):
+
+```
+sqlite3 ~/.msgvault/msgvault.db '.recover' | sqlite3 ~/.msgvault/recovered.db
+mv ~/.msgvault/msgvault.db ~/.msgvault/msgvault.db.bak
+mv ~/.msgvault/recovered.db ~/.msgvault/msgvault.db
+msgvault verify you@gmail.com
+```
+
+A leaner alternative that works on cleaner corruption:
+
+```
+sqlite3 ~/.msgvault/msgvault.db .dump | sqlite3 ~/.msgvault/new.db
+```
+
+If free disk is tight, individual corrupt rows can sometimes be repaired
+by hand — delete and re-insert the affected row(s) from their source
+(MIME blob, etc.). This is a last resort and only advisable if you can
+identify the specific rows flagged by `integrity_check`.
+
+## Before any repair
+
+Back up the database file. If the repair tool is interrupted or makes
+things worse, the backup is the only way back:
+
+```
+cp ~/.msgvault/msgvault.db ~/.msgvault/msgvault.db.bak
+```
+
+If the database has any activity, also copy the `-wal` and `-shm` sidecar
+files at the same instant (or run `msgvault` once to checkpoint the WAL
+into the main file before copying). A bare `.db` copy without its sidecars
+can itself be a source of corruption.

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -90,6 +90,14 @@ type Dialect interface {
 	// (e.g., PostgreSQL includes tsvector in its main schema).
 	SchemaFTS() string
 
+	// FTSRebuildSchema tears down and recreates the FTS infrastructure from
+	// scratch — the caller is expected to follow up with a full backfill.
+	// Used to recover from malformed FTS shadow-table state that in-place
+	// rebuild operations (e.g., SQLite's rebuild pragma) cannot clear.
+	// SQLite: DROP TABLE IF EXISTS messages_fts + re-execute schema_sqlite.sql.
+	// PostgreSQL: TODO (REINDEX / recompute tsvector column).
+	FTSRebuildSchema(db *sql.DB) error
+
 	// Connection lifecycle
 
 	// InitConn performs driver-specific connection initialization.
@@ -128,4 +136,10 @@ type Dialect interface {
 	// This handles SQLite < 3.35 which doesn't support RETURNING.
 	// Always false for PostgreSQL (which always supports RETURNING).
 	IsReturningError(err error) bool
+
+	// IsBusyError returns true if the error indicates the database is held
+	// by another connection, either busy (SQLITE_BUSY) or locked
+	// (SQLITE_LOCKED). Used to surface actionable errors from maintenance
+	// commands that need exclusive access.
+	IsBusyError(err error) bool
 }

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -2,7 +2,10 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 // SQLiteDialect implements Dialect for SQLite (the default backend).
@@ -106,6 +109,30 @@ func (d *SQLiteDialect) SchemaFTS() string {
 	return "schema_sqlite.sql"
 }
 
+// FTSRebuildSchema drops and recreates the messages_fts virtual table. The
+// DROP pathway discards FTS5 shadow tables in their entirety, which is the
+// only reliable fix when those shadow tables are malformed — the `rebuild`
+// pragma reads from them and `delete-all` is rejected on contentful tables.
+func (d *SQLiteDialect) FTSRebuildSchema(db *sql.DB) error {
+	if _, err := db.Exec("DROP TABLE IF EXISTS messages_fts"); err != nil {
+		return fmt.Errorf("drop messages_fts: %w", err)
+	}
+	schema, err := schemaFS.ReadFile("schema_sqlite.sql")
+	if err != nil {
+		return fmt.Errorf("read schema_sqlite.sql: %w", err)
+	}
+	if _, err := db.Exec(string(schema)); err != nil {
+		if d.IsNoSuchModuleError(err) {
+			return fmt.Errorf(
+				"cannot rebuild FTS: this msgvault binary was built without " +
+					"FTS5 support (rebuild with `-tags fts5`)",
+			)
+		}
+		return fmt.Errorf("create messages_fts: %w", err)
+	}
+	return nil
+}
+
 // InitConn is a no-op for SQLite — PRAGMAs are set via DSN parameters.
 func (d *SQLiteDialect) InitConn(db *sql.DB) error { return nil }
 
@@ -158,4 +185,23 @@ func (d *SQLiteDialect) IsNoSuchModuleError(err error) bool {
 // IsReturningError returns true if the error indicates RETURNING is not supported.
 func (d *SQLiteDialect) IsReturningError(err error) bool {
 	return isSQLiteError(err, "RETURNING")
+}
+
+// IsBusyError returns true for SQLITE_BUSY and SQLITE_LOCKED. Matching on
+// the result code is more robust than substring matching: BUSY surfaces as
+// "database is locked" but LOCKED surfaces as "database table is locked",
+// so a single substring cannot catch both.
+func (d *SQLiteDialect) IsBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var serr sqlite3.Error
+	if errors.As(err, &serr) {
+		return serr.Code == sqlite3.ErrBusy || serr.Code == sqlite3.ErrLocked
+	}
+	var serrPtr *sqlite3.Error
+	if errors.As(err, &serrPtr) && serrPtr != nil {
+		return serrPtr.Code == sqlite3.ErrBusy || serrPtr.Code == sqlite3.ErrLocked
+	}
+	return false
 }

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -2,3 +2,10 @@ package store
 
 // ParseDBTime is exported for testing unexported timestamp parsing behavior.
 var ParseDBTime = parseDBTime
+
+// SetFTS5AvailableForTest flips the cached availability flag. Tests use this
+// to exercise the guarantee that RebuildFTS works even when FTS5 looks
+// unavailable — the symptom that motivates a rebuild in the first place.
+func SetFTS5AvailableForTest(s *Store, v bool) {
+	s.fts5Available = v
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -969,29 +969,81 @@ func (s *Store) UpsertFTS(messageID int64, subject, bodyText, fromAddr, toAddrs,
 // (position in ID range, total ID range). Each batch is committed
 // independently so partial progress is preserved if interrupted.
 // Returns the number of rows inserted. No-op if FTS5 is not available.
+//
+// BackfillFTS clears FTS rows with DELETE before inserting. If the FTS5
+// shadow tables are themselves malformed, that DELETE will either fail or
+// leave corruption in place — callers recovering from shadow-table
+// corruption should use RebuildFTS instead.
 func (s *Store) BackfillFTS(progress func(done, total int64)) (int64, error) {
 	if !s.fts5Available {
 		return 0, nil
 	}
 
-	const batchSize = 5000
-
-	// Use MIN/MAX (instant B-tree lookups) instead of COUNT(*) (full scan)
-	var minID, maxID int64
-	err := s.db.QueryRow("SELECT COALESCE(MIN(id),0), COALESCE(MAX(id),0) FROM messages").Scan(&minID, &maxID)
+	minID, maxID, err := s.messageIDRange()
 	if err != nil {
-		return 0, fmt.Errorf("get message ID range: %w", err)
+		return 0, err
 	}
 	if maxID == 0 {
 		return 0, nil
 	}
-	idRange := maxID - minID + 1
 
-	// Clear existing FTS data
 	if _, err := s.db.Exec(s.dialect.FTSClearSQL()); err != nil {
 		return 0, fmt.Errorf("clear FTS: %w", err)
 	}
 
+	return s.backfillFTSRange(minID, maxID, progress)
+}
+
+// RebuildFTS fully recreates the FTS index from the underlying message
+// tables. Unlike BackfillFTS (DELETE + INSERT), this drops and recreates
+// the FTS table itself so malformed FTS5 shadow tables are fully replaced.
+//
+// Ignores the cached fts5Available flag: a corrupt shadow table causes the
+// availability probe to fail, which is precisely the symptom this method
+// exists to recover from. On successful completion, fts5Available is set to
+// true. Returns an error if the binary was built without FTS5 support.
+func (s *Store) RebuildFTS(progress func(done, total int64)) (int64, error) {
+	if err := s.dialect.FTSRebuildSchema(s.db.DB); err != nil {
+		return 0, err
+	}
+
+	minID, maxID, err := s.messageIDRange()
+	if err != nil {
+		return 0, err
+	}
+	if maxID == 0 {
+		s.fts5Available = true
+		return 0, nil
+	}
+
+	indexed, err := s.backfillFTSRange(minID, maxID, progress)
+	if err != nil {
+		return indexed, err
+	}
+	s.fts5Available = true
+	return indexed, nil
+}
+
+// messageIDRange returns (minID, maxID) using MIN/MAX B-tree lookups
+// rather than COUNT(*), which would scan the whole table.
+func (s *Store) messageIDRange() (int64, int64, error) {
+	var minID, maxID int64
+	err := s.db.QueryRow(
+		"SELECT COALESCE(MIN(id),0), COALESCE(MAX(id),0) FROM messages",
+	).Scan(&minID, &maxID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("get message ID range: %w", err)
+	}
+	return minID, maxID, nil
+}
+
+// backfillFTSRange inserts FTS rows for all messages with id in [minID, maxID],
+// in batches. Shared between BackfillFTS (DELETE+fill) and RebuildFTS
+// (DROP+CREATE+fill). Each batch is committed independently so partial
+// progress is preserved if interrupted.
+func (s *Store) backfillFTSRange(minID, maxID int64, progress func(done, total int64)) (int64, error) {
+	const batchSize = 5000
+	idRange := maxID - minID + 1
 	var indexed int64
 	cursor := minID
 
@@ -1012,7 +1064,6 @@ func (s *Store) BackfillFTS(progress func(done, total int64)) (int64, error) {
 			progress(pos, idRange)
 		}
 	}
-
 	return indexed, nil
 }
 

--- a/internal/store/rebuild_fts_test.go
+++ b/internal/store/rebuild_fts_test.go
@@ -1,0 +1,163 @@
+package store_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/wesm/msgvault/internal/store"
+	"github.com/wesm/msgvault/internal/testutil"
+	"github.com/wesm/msgvault/internal/testutil/storetest"
+)
+
+// TestStore_RebuildFTS_HappyPath verifies RebuildFTS on a healthy database
+// recreates the FTS index with correct searchable content.
+func TestStore_RebuildFTS_HappyPath(t *testing.T) {
+	f := storetest.New(t)
+	if !f.Store.FTS5Available() {
+		t.Skip("FTS5 not available")
+	}
+
+	msgID1 := f.CreateMessage("rebuild-msg-1")
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msgID1,
+		sql.NullString{String: "apple pie filling", Valid: true}, sql.NullString{}),
+		"UpsertMessageBody 1")
+
+	pid1 := f.EnsureParticipant("alice@example.com", "Alice", "example.com")
+	testutil.MustNoErr(t, f.Store.ReplaceMessageRecipients(msgID1, "from",
+		[]int64{pid1}, []string{"Alice"}), "ReplaceMessageRecipients")
+
+	msgID2 := f.CreateMessage("rebuild-msg-2")
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msgID2,
+		sql.NullString{String: "banana bread recipe", Valid: true}, sql.NullString{}),
+		"UpsertMessageBody 2")
+
+	n, err := f.Store.RebuildFTS(nil)
+	testutil.MustNoErr(t, err, "RebuildFTS")
+	if n != 2 {
+		t.Errorf("RebuildFTS rows = %d, want 2", n)
+	}
+
+	var count int
+	testutil.MustNoErr(t, f.Store.DB().QueryRow(
+		"SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'banana'").Scan(&count),
+		"FTS MATCH banana")
+	if count != 1 {
+		t.Errorf("match 'banana' = %d, want 1", count)
+	}
+
+	testutil.MustNoErr(t, f.Store.DB().QueryRow(
+		"SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'alice'").Scan(&count),
+		"FTS MATCH alice")
+	if count != 1 {
+		t.Errorf("match 'alice' = %d, want 1", count)
+	}
+}
+
+// TestStore_RebuildFTS_BypassesAvailabilityFlag verifies the critical
+// guarantee that RebuildFTS ignores the cached fts5Available flag. A corrupt
+// FTS5 shadow table causes the availability probe to fail, which is exactly
+// when the rebuild is needed — BackfillFTS would short-circuit here, but
+// RebuildFTS must not.
+func TestStore_RebuildFTS_BypassesAvailabilityFlag(t *testing.T) {
+	f := storetest.New(t)
+	if !f.Store.FTS5Available() {
+		t.Skip("FTS5 not available")
+	}
+
+	msgID := f.CreateMessage("rebuild-bypass")
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msgID,
+		sql.NullString{String: "cherry tart dessert", Valid: true}, sql.NullString{}),
+		"UpsertMessageBody")
+
+	// Force the cached flag false to simulate a probe that saw a corrupt
+	// shadow table and returned false at InitSchema time.
+	store.SetFTS5AvailableForTest(f.Store, false)
+
+	n, err := f.Store.RebuildFTS(nil)
+	testutil.MustNoErr(t, err, "RebuildFTS")
+	if n != 1 {
+		t.Errorf("RebuildFTS rows = %d, want 1", n)
+	}
+
+	if !f.Store.FTS5Available() {
+		t.Error("FTS5Available() = false after rebuild, want true")
+	}
+
+	var count int
+	testutil.MustNoErr(t, f.Store.DB().QueryRow(
+		"SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'cherry'").Scan(&count),
+		"FTS MATCH cherry")
+	if count != 1 {
+		t.Errorf("match 'cherry' = %d, want 1", count)
+	}
+}
+
+// TestStore_RebuildFTS_AfterTableDropped verifies that RebuildFTS recreates
+// messages_fts from scratch when the table is missing entirely — the
+// post-DROP state from the manual recovery procedure in issue #287.
+func TestStore_RebuildFTS_AfterTableDropped(t *testing.T) {
+	f := storetest.New(t)
+	if !f.Store.FTS5Available() {
+		t.Skip("FTS5 not available")
+	}
+
+	msgID := f.CreateMessage("rebuild-dropped")
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msgID,
+		sql.NullString{String: "date square confection", Valid: true}, sql.NullString{}),
+		"UpsertMessageBody")
+
+	_, err := f.Store.DB().Exec("DROP TABLE messages_fts")
+	testutil.MustNoErr(t, err, "DROP TABLE messages_fts")
+
+	n, err := f.Store.RebuildFTS(nil)
+	testutil.MustNoErr(t, err, "RebuildFTS")
+	if n != 1 {
+		t.Errorf("RebuildFTS rows = %d, want 1", n)
+	}
+
+	var count int
+	testutil.MustNoErr(t, f.Store.DB().QueryRow(
+		"SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'confection'").Scan(&count),
+		"FTS MATCH confection")
+	if count != 1 {
+		t.Errorf("match 'confection' = %d, want 1", count)
+	}
+}
+
+// TestStore_RebuildFTS_ReportsProgress verifies the progress callback is
+// invoked with monotonic (done, total) values.
+func TestStore_RebuildFTS_ReportsProgress(t *testing.T) {
+	f := storetest.New(t)
+	if !f.Store.FTS5Available() {
+		t.Skip("FTS5 not available")
+	}
+
+	ids := f.CreateMessages(3)
+	for i, id := range ids {
+		testutil.MustNoErr(t, f.Store.UpsertMessageBody(id,
+			sql.NullString{String: "progress body", Valid: true}, sql.NullString{}),
+			"UpsertMessageBody")
+		_ = i
+	}
+
+	var calls int
+	var lastDone, lastTotal int64
+	_, err := f.Store.RebuildFTS(func(done, total int64) {
+		calls++
+		if total <= 0 {
+			t.Errorf("progress total = %d, want > 0", total)
+		}
+		if done < lastDone {
+			t.Errorf("progress done went backwards: %d -> %d", lastDone, done)
+		}
+		lastDone, lastTotal = done, total
+	})
+	testutil.MustNoErr(t, err, "RebuildFTS")
+
+	if calls == 0 {
+		t.Error("progress callback never invoked")
+	}
+	if lastDone != lastTotal {
+		t.Errorf("final progress = (%d/%d), want done == total", lastDone, lastTotal)
+	}
+}

--- a/internal/store/sqlite_error_test.go
+++ b/internal/store/sqlite_error_test.go
@@ -77,6 +77,33 @@ func TestIsSQLiteError_NilError(t *testing.T) {
 	}
 }
 
+func TestSQLiteDialect_IsBusyError(t *testing.T) {
+	d := &SQLiteDialect{}
+
+	busy := sqlite3.Error{Code: sqlite3.ErrBusy}
+	if !d.IsBusyError(fmt.Errorf("wrapped: %w", busy)) {
+		t.Error("IsBusyError should match SQLITE_BUSY")
+	}
+
+	locked := sqlite3.Error{Code: sqlite3.ErrLocked}
+	if !d.IsBusyError(fmt.Errorf("wrapped: %w", locked)) {
+		t.Error("IsBusyError should match SQLITE_LOCKED")
+	}
+
+	constraint := sqlite3.Error{Code: sqlite3.ErrConstraint}
+	if d.IsBusyError(fmt.Errorf("wrapped: %w", constraint)) {
+		t.Error("IsBusyError should not match non-busy sqlite errors")
+	}
+
+	if d.IsBusyError(errors.New("plain error")) {
+		t.Error("IsBusyError should not match non-sqlite errors")
+	}
+
+	if d.IsBusyError(nil) {
+		t.Error("IsBusyError should not match nil")
+	}
+}
+
 // typedNilError is a helper type that implements error and allows
 // errors.As to extract a typed nil *sqlite3.Error
 type typedNilError struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -388,6 +388,14 @@ func (s *Store) FTS5Available() bool {
 	return s.fts5Available
 }
 
+// IsBusyError reports whether err indicates another process holds the
+// database (SQLITE_BUSY or SQLITE_LOCKED). Callers running maintenance
+// operations that need exclusive access can use this to produce a
+// user-actionable "stop other processes and retry" message.
+func (s *Store) IsBusyError(err error) bool {
+	return s.dialect.IsBusyError(err)
+}
+
 // SchemaStale checks whether the database schema is missing columns
 // added by recent migrations. Returns (stale, column, err). Only
 // reports stale when the query succeeds and the column is absent;


### PR DESCRIPTION
Closes #287.

## What this adds

- **`msgvault rebuild-fts`** — drops and recreates `messages_fts`, then repopulates it from `messages` / `message_bodies` / `message_recipients` / `participants` via the existing batched backfill. Recovery path for `malformed inverted index for FTS5 table main.messages_fts` in `verify` output — the case where SQLite's own `rebuild` pragma and `delete-all` don't help on a contentful FTS5 table. Wraps `SQLITE_BUSY`/`SQLITE_LOCKED` as "stop msgvault serve / MCP and retry."
- **`verify` ordering** — integrity check now runs before OAuth setup, so corrupt databases surface the repair hint even with an expired token.
- **`verify` hints** — split between FTS-only corruption (points at `rebuild-fts`) and core-table corruption (points at `.recover`).
- **`docs/recovery.md`** — covers both paths and the contentful-FTS5 caveat.

## What this does not cover

- Core-table B-tree corruption (e.g., `Rowid out of order` in `messages` / `message_bodies`). `rebuild-fts` is strictly for the derived index; core corruption still needs `.recover`.
- `_synchronous=FULL` default. Worth considering as archival-durability hardening in a separate PR; not framed as the fix for #287.

## Usage

```
msgvault rebuild-fts
```

Stop `msgvault serve` and MCP clients first — needs an exclusive write lock. Peak extra disk ≈ size of the FTS5 shadow tables (a few percent of the DB).