### PR TITLE
Update nix flake for v0.14.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       packages = forAllSystems (pkgs: {
         default = (pkgs.buildGoModule.override { go = goPinned pkgs; }) {
           pname = "msgvault";
-          version = "0.14.0";
+          version = "0.14.1";
           src = ./.;
           vendorHash = "sha256-cY8Ooixv9GQtOsryCtWdK6iCqzMCK1/x/26/TLJ5+bs=";
           proxyVendor = true;


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-cY8Ooixv9GQtOsryCtWdK6iCqzMCK1/x/26/TLJ5+bs=`
- Updated version to `0.14.1`

Automated update via `scripts/update-nix-flake.sh`.