### PR TITLE
feat: add search_by_domains MCP tool for multi-domain participant search

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1009,3 +1009,44 @@ func (h *handlers) stageDeletion(ctx context.Context, req mcp.CallToolRequest) (
 
 	return jsonResult(resp)
 }
+
+func (h *handlers) searchByDomains(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	domainsStr, _ := args["domains"].(string)
+	domainsStr = strings.TrimSpace(domainsStr)
+	if domainsStr == "" {
+		return mcp.NewToolResultError("domains is required"), nil
+	}
+
+	// Split and clean domain list
+	var domains []string
+	for _, d := range strings.Split(domainsStr, ",") {
+		d = strings.TrimSpace(d)
+		if d != "" {
+			domains = append(domains, d)
+		}
+	}
+	if len(domains) == 0 {
+		return mcp.NewToolResultError("at least one domain is required"), nil
+	}
+
+	limit := limitArg(args, "limit", 100)
+	offset := limitArg(args, "offset", 0)
+
+	afterDate, err := getDateArg(args, "after")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	beforeDate, err := getDateArg(args, "before")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	results, err := h.engine.SearchByDomains(ctx, domains, afterDate, beforeDate, limit, offset)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("search by domains failed: %v", err)), nil
+	}
+
+	return jsonResult(results)
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -21,6 +21,7 @@ const (
 	ToolGetStats            = "get_stats"
 	ToolAggregate           = "aggregate"
 	ToolStageDeletion       = "stage_deletion"
+	ToolSearchByDomains     = "search_by_domains"
 	ToolFindSimilarMessages = "find_similar_messages"
 )
 
@@ -122,6 +123,7 @@ func ServeWithOptions(ctx context.Context, opts ServeOptions) error {
 	s.AddTool(getStatsTool(), h.getStats)
 	s.AddTool(aggregateTool(), h.aggregate)
 	s.AddTool(stageDeletionTool(), h.stageDeletion)
+	s.AddTool(searchByDomainsTool(), h.searchByDomains)
 	if opts.Backend != nil {
 		s.AddTool(findSimilarMessagesTool(), h.findSimilarMessages)
 	}
@@ -245,6 +247,21 @@ func aggregateTool() mcp.Tool {
 		),
 		withAccount(),
 		withLimit("50"),
+		withAfter(),
+		withBefore(),
+	)
+}
+
+func searchByDomainsTool() mcp.Tool {
+	return mcp.NewTool(ToolSearchByDomains,
+		mcp.WithDescription("Find emails where any participant (from, to, or cc) belongs to one of the given domains. Useful for finding all communication with a company regardless of direction."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("domains",
+			mcp.Required(),
+			mcp.Description("Comma-separated domain names (e.g. 'gobright.com,ascentae.com')"),
+		),
+		withLimit("100"),
+		withOffset(),
 		withAfter(),
 		withBefore(),
 	)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1542,3 +1542,107 @@ func TestFindSimilarMessages_NoActiveGeneration(t *testing.T) {
 		t.Fatalf("expected 'no_active_generation' error, got: %s", txt)
 	}
 }
+
+func TestSearchByDomains(t *testing.T) {
+	eng := &querytest.MockEngine{
+		SearchResults: []query.MessageSummary{
+			testutil.NewMessageSummary(1).WithSubject("From Acme").WithFromEmail("alice@acme.com").Build(),
+			testutil.NewMessageSummary(2).WithSubject("To Acme").WithFromEmail("bob@example.com").Build(),
+		},
+	}
+	h := newTestHandlers(eng)
+
+	t.Run("valid domains", func(t *testing.T) {
+		msgs := runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+			map[string]any{"domains": "acme.com,example.com"})
+		if len(msgs) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(msgs))
+		}
+	})
+
+	t.Run("domains with whitespace", func(t *testing.T) {
+		msgs := runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+			map[string]any{"domains": " acme.com , example.com "})
+		if len(msgs) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(msgs))
+		}
+	})
+
+	t.Run("missing domains", func(t *testing.T) {
+		runToolExpectError(t, "search_by_domains", h.searchByDomains, map[string]any{})
+	})
+
+	t.Run("empty domains string", func(t *testing.T) {
+		runToolExpectError(t, "search_by_domains", h.searchByDomains,
+			map[string]any{"domains": ""})
+	})
+
+	t.Run("whitespace-only domains", func(t *testing.T) {
+		runToolExpectError(t, "search_by_domains", h.searchByDomains,
+			map[string]any{"domains": "  ,  , "})
+	})
+
+	t.Run("arguments forwarded correctly", func(t *testing.T) {
+		var capturedDomains []string
+		var capturedLimit, capturedOffset int
+		eng := &querytest.MockEngine{
+			SearchByDomainsFunc: func(_ context.Context, domains []string, after, before *time.Time, limit, offset int) ([]query.MessageSummary, error) {
+				capturedDomains = domains
+				capturedLimit = limit
+				capturedOffset = offset
+				if after == nil {
+					t.Fatal("expected after to be set")
+				}
+				if before == nil {
+					t.Fatal("expected before to be set")
+				}
+				return []query.MessageSummary{
+					testutil.NewMessageSummary(1).WithSubject("Match").Build(),
+				}, nil
+			},
+		}
+		h := newTestHandlers(eng)
+
+		msgs := runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+			map[string]any{
+				"domains": "acme.com,globex.com",
+				"limit":   float64(50),
+				"offset":  float64(10),
+				"after":   "2024-01-01",
+				"before":  "2024-12-31",
+			})
+		if len(msgs) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(msgs))
+		}
+		if len(capturedDomains) != 2 || capturedDomains[0] != "acme.com" || capturedDomains[1] != "globex.com" {
+			t.Fatalf("unexpected domains: %v", capturedDomains)
+		}
+		if capturedLimit != 50 {
+			t.Fatalf("expected limit 50, got %d", capturedLimit)
+		}
+		if capturedOffset != 10 {
+			t.Fatalf("expected offset 10, got %d", capturedOffset)
+		}
+	})
+
+	t.Run("default limit and offset", func(t *testing.T) {
+		var capturedLimit, capturedOffset int
+		eng := &querytest.MockEngine{
+			SearchByDomainsFunc: func(_ context.Context, _ []string, _, _ *time.Time, limit, offset int) ([]query.MessageSummary, error) {
+				capturedLimit = limit
+				capturedOffset = offset
+				return nil, nil
+			},
+		}
+		h := newTestHandlers(eng)
+
+		runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+			map[string]any{"domains": "acme.com"})
+		if capturedLimit != 100 {
+			t.Fatalf("expected default limit 100, got %d", capturedLimit)
+		}
+		if capturedOffset != 0 {
+			t.Fatalf("expected default offset 0, got %d", capturedOffset)
+		}
+	})
+}

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1654,6 +1654,15 @@ func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offse
 // This method delegates to SQLite for authoritative deletion status.
 // The Parquet cache may be stale if messages were deleted after the last cache build,
 // so we use SQLite directly to ensure deleted messages are properly excluded.
+func (e *DuckDBEngine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]MessageSummary, error) {
+	// Delegate to SQLite — domain search requires JOINs across participants
+	// and message_recipients which are not available in the Parquet cache.
+	if e.sqliteEngine != nil {
+		return e.sqliteEngine.SearchByDomains(ctx, domains, after, before, limit, offset)
+	}
+	return nil, fmt.Errorf("SearchByDomains requires SQLite engine (participant data not in Parquet cache)")
+}
+
 func (e *DuckDBEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFilter) ([]string, error) {
 	// Delegate to SQLite for authoritative deletion status.
 	// Parquet cache may be stale if deletions occurred after the last build.

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"time"
 
 	"github.com/wesm/msgvault/internal/search"
 )
@@ -63,6 +64,10 @@ type Engine interface {
 	// GetGmailIDsByFilter returns Gmail message IDs (source_message_id) matching a filter.
 	// This is useful for batch operations like staging messages for deletion.
 	GetGmailIDsByFilter(ctx context.Context, filter MessageFilter) ([]string, error)
+
+	// SearchByDomains returns messages where any participant (from, to, cc, or bcc)
+	// belongs to one of the given domains.
+	SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]MessageSummary, error)
 
 	// Account queries
 	ListAccounts(ctx context.Context) ([]AccountInfo, error)

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -4,6 +4,7 @@ package querytest
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/wesm/msgvault/internal/query"
 	"github.com/wesm/msgvault/internal/search"
@@ -35,6 +36,7 @@ type MockEngine struct {
 	ListMessagesFunc             func(context.Context, query.MessageFilter) ([]query.MessageSummary, error)
 	SearchFastCountFunc          func(context.Context, *search.Query, query.MessageFilter) (int64, error)
 	GetGmailIDsByFilterFunc      func(context.Context, query.MessageFilter) ([]string, error)
+	SearchByDomainsFunc          func(context.Context, []string, *time.Time, *time.Time, int, int) ([]query.MessageSummary, error)
 	SearchFastWithStatsFunc      func(context.Context, *search.Query, string, query.MessageFilter, query.ViewType, int, int) (*query.SearchFastResult, error)
 	GetMessageSummariesByIDsFunc func(context.Context, []int64) ([]query.MessageSummary, error)
 }
@@ -159,6 +161,13 @@ func (m *MockEngine) GetGmailIDsByFilter(ctx context.Context, filter query.Messa
 		return m.GetGmailIDsByFilterFunc(ctx, filter)
 	}
 	return m.GmailIDs, nil
+}
+
+func (m *MockEngine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]query.MessageSummary, error) {
+	if m.SearchByDomainsFunc != nil {
+		return m.SearchByDomainsFunc(ctx, domains, after, before, limit, offset)
+	}
+	return m.SearchResults, nil
 }
 
 func (m *MockEngine) ListAccounts(_ context.Context) ([]query.AccountInfo, error) {

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1134,31 +1134,29 @@ func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 }
 
 // SearchByDomains returns messages where any participant (from, to, cc, or bcc)
-// belongs to one of the given domains.
+// belongs to one of the given domains. Uses the shared executeSearchQuery
+// path so results carry the same fields as Search/SearchFast (including
+// deleted_at, conversation_title, message_type, and labels).
 func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]MessageSummary, error) {
 	if len(domains) == 0 {
 		return nil, nil
 	}
 
-	// Build domain placeholders
+	// Lower-cased placeholders for case-insensitive domain matching.
 	placeholders := make([]string, len(domains))
-	args := make([]interface{}, len(domains))
+	args := make([]interface{}, 0, len(domains)+2)
 	for i, d := range domains {
 		placeholders[i] = "?"
-		args[i] = strings.ToLower(d)
+		args = append(args, strings.ToLower(d))
 	}
-	domainList := strings.Join(placeholders, ", ")
 
-	var conditions []string
-	conditions = append(conditions, emailOnlyFilterM)
-
-	// Any participant with matching domain
+	conditions := []string{emailOnlyFilterM}
 	conditions = append(conditions, fmt.Sprintf(`EXISTS (
 		SELECT 1 FROM message_recipients mr_dom
 		JOIN participants p_dom ON p_dom.id = mr_dom.participant_id
 		WHERE mr_dom.message_id = m.id
-		AND LOWER(p_dom.domain) IN (%s)
-	)`, domainList))
+		  AND LOWER(p_dom.domain) IN (%s)
+	)`, strings.Join(placeholders, ", ")))
 
 	if after != nil {
 		conditions = append(conditions, "m.sent_at >= ?")
@@ -1176,48 +1174,7 @@ func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, af
 		limit = 1000
 	}
 
-	query := fmt.Sprintf(`
-		SELECT m.id, m.source_message_id, m.conversation_id, m.subject, m.snippet,
-			COALESCE(p_from.email_address, '') as from_email,
-			COALESCE(mr_from.display_name, p_from.display_name, '') as from_name,
-			m.sent_at, m.size_estimate, m.has_attachments, m.attachment_count
-		FROM messages m
-		LEFT JOIN message_recipients mr_from ON mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
-		LEFT JOIN participants p_from ON p_from.id = mr_from.participant_id
-		WHERE %s
-		ORDER BY m.sent_at DESC, m.id DESC
-		LIMIT ? OFFSET ?
-	`, strings.Join(conditions, " AND "))
-
-	args = append(args, limit, offset)
-
-	rows, err := e.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("search by domains: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var results []MessageSummary
-	for rows.Next() {
-		var msg MessageSummary
-		var sentAt string
-		if err := rows.Scan(
-			&msg.ID, &msg.SourceMessageID, &msg.ConversationID,
-			&msg.Subject, &msg.Snippet,
-			&msg.FromEmail, &msg.FromName,
-			&sentAt, &msg.SizeEstimate,
-			&msg.HasAttachments, &msg.AttachmentCount,
-		); err != nil {
-			return nil, fmt.Errorf("scan: %w", err)
-		}
-		if t, err := time.Parse("2006-01-02 15:04:05+00:00", sentAt); err == nil {
-			msg.SentAt = t
-		} else if t, err := time.Parse("2006-01-02T15:04:05Z", sentAt); err == nil {
-			msg.SentAt = t
-		}
-		results = append(results, msg)
-	}
-	return results, rows.Err()
+	return e.executeSearchQuery(ctx, conditions, args, nil, "", limit, offset)
 }
 
 // Search performs a Gmail-style search query.

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1133,6 +1133,93 @@ func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 	return collectGmailIDs(rows)
 }
 
+// SearchByDomains returns messages where any participant (from, to, cc, or bcc)
+// belongs to one of the given domains.
+func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]MessageSummary, error) {
+	if len(domains) == 0 {
+		return nil, nil
+	}
+
+	// Build domain placeholders
+	placeholders := make([]string, len(domains))
+	args := make([]interface{}, len(domains))
+	for i, d := range domains {
+		placeholders[i] = "?"
+		args[i] = strings.ToLower(d)
+	}
+	domainList := strings.Join(placeholders, ", ")
+
+	var conditions []string
+	conditions = append(conditions, emailOnlyFilterM)
+
+	// Any participant with matching domain
+	conditions = append(conditions, fmt.Sprintf(`EXISTS (
+		SELECT 1 FROM message_recipients mr_dom
+		JOIN participants p_dom ON p_dom.id = mr_dom.participant_id
+		WHERE mr_dom.message_id = m.id
+		AND LOWER(p_dom.domain) IN (%s)
+	)`, domainList))
+
+	if after != nil {
+		conditions = append(conditions, "m.sent_at >= ?")
+		args = append(args, after.Format("2006-01-02"))
+	}
+	if before != nil {
+		conditions = append(conditions, "m.sent_at < ?")
+		args = append(args, before.Format("2006-01-02"))
+	}
+
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	query := fmt.Sprintf(`
+		SELECT m.id, m.source_message_id, m.conversation_id, m.subject, m.snippet,
+			COALESCE(p_from.email_address, '') as from_email,
+			COALESCE(mr_from.display_name, p_from.display_name, '') as from_name,
+			m.sent_at, m.size_estimate, m.has_attachments, m.attachment_count
+		FROM messages m
+		LEFT JOIN message_recipients mr_from ON mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
+		LEFT JOIN participants p_from ON p_from.id = mr_from.participant_id
+		WHERE %s
+		ORDER BY m.sent_at DESC, m.id DESC
+		LIMIT ? OFFSET ?
+	`, strings.Join(conditions, " AND "))
+
+	args = append(args, limit, offset)
+
+	rows, err := e.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search by domains: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []MessageSummary
+	for rows.Next() {
+		var msg MessageSummary
+		var sentAt string
+		if err := rows.Scan(
+			&msg.ID, &msg.SourceMessageID, &msg.ConversationID,
+			&msg.Subject, &msg.Snippet,
+			&msg.FromEmail, &msg.FromName,
+			&sentAt, &msg.SizeEstimate,
+			&msg.HasAttachments, &msg.AttachmentCount,
+		); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		if t, err := time.Parse("2006-01-02 15:04:05+00:00", sentAt); err == nil {
+			msg.SentAt = t
+		} else if t, err := time.Parse("2006-01-02T15:04:05Z", sentAt); err == nil {
+			msg.SentAt = t
+		}
+		results = append(results, msg)
+	}
+	return results, rows.Err()
+}
+
 // Search performs a Gmail-style search query.
 // buildSearchQueryParts builds the WHERE conditions, args, joins, and FTS join
 // for a search query. This is shared between Search and SearchFastCount.

--- a/internal/remote/engine.go
+++ b/internal/remote/engine.go
@@ -689,6 +689,10 @@ func (e *Engine) GetGmailIDsByFilter(ctx context.Context, filter query.MessageFi
 	return nil, ErrNotSupported
 }
 
+func (e *Engine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]query.MessageSummary, error) {
+	return nil, ErrNotSupported
+}
+
 // ListAccounts returns all configured accounts.
 func (e *Engine) ListAccounts(ctx context.Context) ([]query.AccountInfo, error) {
 	accounts, err := e.store.ListAccounts()


### PR DESCRIPTION
## Summary

Adds a new MCP tool, `search_by_domains`, that finds emails where **any participant** (from, to, cc, or bcc) belongs to one of the given domains. Useful for finding all communication with a company regardless of direction — sent, received, or CC'd.

This complements the existing `search_messages` tool, which only matches against the sender. `search_by_domains` is the right tool when you want "show me everything involving @example.com" rather than "show me mail from @example.com".

## Tool signature

```
search_by_domains(
  domains: "acme.com,globex.com"   // comma-separated, required
  limit:   100,                     // default 100, max 1000
  offset:  0,
  after:   "2024-01-01",            // optional date range
  before:  "2024-12-31",
)
```

## Implementation

- `internal/query/engine.go` — `SearchByDomains` added to the Engine interface
- `internal/query/sqlite.go` — EXISTS subquery against `message_recipients` + `participants` (semi-join, no duplicates)
- `internal/query/duckdb.go` — delegates to SQLite (participant/recipient data isn't in the Parquet cache)
- `internal/remote/engine.go` — returns `ErrNotSupported` (matches existing remote-engine pattern)
- `internal/query/querytest/mock_engine.go` — mock support with an override hook
- `internal/mcp/server.go` / `handlers.go` — tool definition + handler that parses comma-separated domains, validates non-empty, forwards limit/offset/after/before
- `internal/mcp/server_test.go` — 7 subtests (valid input, whitespace handling, missing/empty domains, argument forwarding, defaults)

## Test plan

- [x] `make test` — all tests pass
- [x] Field-tested against a 2M-message production archive: returns correct results including BCC matches that `search_messages` misses
- [x] Case-insensitive domain matching verified
- [x] Multi-domain (`acme.com,globex.com`) and date filters verified