### PR TITLE
embed: drop empty post-preprocess messages and surface 4xx bodies

### DIFF
--- a/internal/vector/embed/client.go
+++ b/internal/vector/embed/client.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -157,7 +158,15 @@ func (c *Client) doOnce(ctx context.Context, body []byte, want int) ([][]float32
 		return nil, &retryError{err: fmt.Errorf("embed: HTTP %d", resp.StatusCode)}
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("embed: HTTP %d", resp.StatusCode)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if err != nil {
+			return nil, fmt.Errorf("embed: HTTP %d (read error body: %v)", resp.StatusCode, err)
+		}
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			return nil, fmt.Errorf("embed: HTTP %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("embed: HTTP %d: %s", resp.StatusCode, msg)
 	}
 
 	var r embeddingResponse

--- a/internal/vector/embed/client_test.go
+++ b/internal/vector/embed/client_test.go
@@ -132,7 +132,9 @@ func TestClient_Embed_Does_Not_Retry_4xx(t *testing.T) {
 	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts.Add(1)
-		http.Error(w, "bad request", http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"No models loaded"}`))
 	}))
 	defer srv.Close()
 
@@ -146,6 +148,9 @@ func TestClient_Embed_Does_Not_Retry_4xx(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "400") {
 		t.Errorf("error %q should include status 400", err.Error())
+	}
+	if !strings.Contains(err.Error(), "No models loaded") {
+		t.Errorf("error %q should include response body", err.Error())
 	}
 }
 

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -205,17 +205,24 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 			// here counts toward MaxConsecutiveFailures because the
 			// loop would otherwise busy-spin on a stuck claim until
 			// ReclaimStale runs (10 min default).
-			if len(eb.missing) > 0 {
-				w.deps.Log.Warn("pending messages missing from main DB",
-					"gen", gen, "ids", eb.missing)
-				if cerr := w.q.Complete(ctx, gen, token, eb.missing); cerr != nil {
-					res.Failed += len(eb.missing)
-					w.deps.Log.Error("complete missing failed", "error", cerr,
-						"gen", gen, "ids", len(eb.missing))
+			dropIDs := append(append([]int64(nil), eb.missing...), eb.empty...)
+			if len(dropIDs) > 0 {
+				if len(eb.missing) > 0 {
+					w.deps.Log.Warn("pending messages missing from main DB",
+						"gen", gen, "ids", eb.missing)
+				}
+				if len(eb.empty) > 0 {
+					w.deps.Log.Warn("pending messages empty after preprocess",
+						"gen", gen, "ids", eb.empty)
+				}
+				if cerr := w.q.Complete(ctx, gen, token, dropIDs); cerr != nil {
+					res.Failed += len(dropIDs)
+					w.deps.Log.Error("complete drop failed", "error", cerr,
+						"gen", gen, "ids", len(dropIDs))
 					consecutiveFailures++
 					lastErr = cerr
 					orphanDrainErr = cerr
-					orphanDrainCount += len(eb.missing)
+					orphanDrainCount += len(dropIDs)
 					if consecutiveFailures >= w.deps.MaxConsecutiveFailures {
 						return res, fmt.Errorf("embed worker aborting after %d consecutive failures: %w",
 							consecutiveFailures, lastErr)
@@ -268,17 +275,24 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 		// we still own. Failure here still counts as a batch failure
 		// because the orphan rows would stay claimed until
 		// ReclaimStale runs and falsely block the queue.
-		if len(eb.missing) > 0 {
-			w.deps.Log.Warn("pending messages missing from main DB",
-				"gen", gen, "ids", eb.missing)
-			if cerr := w.q.Complete(ctx, gen, token, eb.missing); cerr != nil {
-				res.Failed += len(eb.missing)
-				w.deps.Log.Error("complete missing failed", "error", cerr,
-					"gen", gen, "ids", len(eb.missing))
+		dropIDs := append(append([]int64(nil), eb.missing...), eb.empty...)
+		if len(dropIDs) > 0 {
+			if len(eb.missing) > 0 {
+				w.deps.Log.Warn("pending messages missing from main DB",
+					"gen", gen, "ids", eb.missing)
+			}
+			if len(eb.empty) > 0 {
+				w.deps.Log.Warn("pending messages empty after preprocess",
+					"gen", gen, "ids", eb.empty)
+			}
+			if cerr := w.q.Complete(ctx, gen, token, dropIDs); cerr != nil {
+				res.Failed += len(dropIDs)
+				w.deps.Log.Error("complete drop failed", "error", cerr,
+					"gen", gen, "ids", len(dropIDs))
 				consecutiveFailures++
 				lastErr = cerr
 				orphanDrainErr = cerr
-				orphanDrainCount += len(eb.missing)
+				orphanDrainCount += len(dropIDs)
 				if consecutiveFailures >= w.deps.MaxConsecutiveFailures {
 					// Embedded rows were already counted into
 					// res.Succeeded above; record the orphan-drain
@@ -304,12 +318,14 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 // embedBatchResult carries the output of embedBatch. chunks and
 // embeddedIDs are aligned by position and correspond to messages that
 // were actually fetched and embedded. missing lists ids from the
-// input that had no row in the messages table and so were not sent
-// to the embedder.
+// input that had no row in the messages table; empty lists ids whose
+// content preprocessed to empty and therefore should not be sent to
+// embedders that reject blank strings.
 type embedBatchResult struct {
 	chunks      []vector.Chunk
 	embeddedIDs []int64
 	missing     []int64
+	empty       []int64
 	truncated   int
 }
 
@@ -339,6 +355,7 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 
 	var msgs []msgText
 	var inputs []string
+	var empty []int64
 	fetched := make(map[int64]struct{}, len(ids))
 	for rows.Next() {
 		var id int64
@@ -354,6 +371,11 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 			body = mime.StripHTML(bodyHTML)
 		}
 		txt, trunc := Preprocess(subject, body, w.deps.MaxInputChars, w.deps.Preprocess)
+		fetched[id] = struct{}{}
+		if strings.TrimSpace(txt) == "" {
+			empty = append(empty, id)
+			continue
+		}
 		// Preprocess truncates by runes, so the recorded length must
 		// also be a rune count. Using len(txt) (bytes) inflates
 		// SourceCharLen by 2-4x for CJK / emoji / accented text and
@@ -361,7 +383,6 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 		// input?" reasoning.
 		msgs = append(msgs, msgText{ID: id, Text: txt, Chars: utf8.RuneCountInString(txt), Trunc: trunc})
 		inputs = append(inputs, txt)
-		fetched[id] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
 		return embedBatchResult{}, fmt.Errorf("iterate message rows: %w", err)
@@ -379,7 +400,7 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 	if len(msgs) == 0 {
 		// All claimed ids are missing — return an empty result (no
 		// chunks, no error). Caller handles the drop.
-		return embedBatchResult{missing: missing}, nil
+		return embedBatchResult{missing: missing, empty: empty}, nil
 	}
 
 	start := time.Now()
@@ -413,6 +434,7 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 		chunks:      chunks,
 		embeddedIDs: embeddedIDs,
 		missing:     missing,
+		empty:       empty,
 		truncated:   truncated,
 	}, nil
 }

--- a/internal/vector/embed/worker_test.go
+++ b/internal/vector/embed/worker_test.go
@@ -616,3 +616,75 @@ func TestWorker_MissingMessagesDrainedFromQueue(t *testing.T) {
 		t.Errorf("embeddings = %d, want 1", embedded)
 	}
 }
+
+// TestWorker_EmptyPreprocessedMessagesDrainedFromQueue verifies that
+// messages whose content is stripped to empty are dropped from the
+// queue instead of being sent to embedders that reject empty inputs.
+func TestWorker_EmptyPreprocessedMessagesDrainedFromQueue(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 0)
+
+	// Message 1 becomes empty after quote stripping; message 2 remains
+	// embeddable so the batch must still succeed.
+	if _, err := f.MainDB.ExecContext(ctx,
+		`INSERT INTO messages (id, subject) VALUES (1, ''), (2, 'kept')`); err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+	if _, err := f.MainDB.ExecContext(ctx,
+		`INSERT INTO message_bodies (message_id, body_text) VALUES
+		 (1, '> quoted only'),
+		 (2, 'actual body')`); err != nil {
+		t.Fatalf("insert bodies: %v", err)
+	}
+	if _, err := f.VectorsDB.ExecContext(ctx,
+		`INSERT INTO pending_embeddings (generation_id, message_id, enqueued_at) VALUES
+		 (?, 1, 0),
+		 (?, 2, 0)`,
+		int64(f.BuildingGen), int64(f.BuildingGen)); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		Preprocess:    PreprocessConfig{StripQuotes: true},
+		MaxInputChars: 8000,
+		BatchSize:     2,
+	})
+
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.Succeeded != 1 {
+		t.Errorf("Succeeded=%d, want 1", res.Succeeded)
+	}
+	if len(f.FakeClient.LastInputs) != 1 {
+		t.Fatalf("captured %d inputs, want 1", len(f.FakeClient.LastInputs))
+	}
+	if got := f.FakeClient.LastInputs[0]; strings.TrimSpace(got) == "" {
+		t.Fatalf("embedder received empty input %q", got)
+	}
+
+	var pending int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pending_embeddings WHERE generation_id = ?`,
+		int64(f.BuildingGen)).Scan(&pending); err != nil {
+		t.Fatalf("count pending: %v", err)
+	}
+	if pending != 0 {
+		t.Errorf("pending after drain = %d, want 0", pending)
+	}
+
+	var embedded int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM embeddings WHERE generation_id = ?`,
+		int64(f.BuildingGen)).Scan(&embedded); err != nil {
+		t.Fatalf("count embeddings: %v", err)
+	}
+	if embedded != 1 {
+		t.Errorf("embeddings = %d, want 1", embedded)
+	}
+}


### PR DESCRIPTION
## Motivation

Fixes #291. When one message in a batch preprocesses down to an empty string (subject empty, body left blank after quote/signature stripping), `build-embeddings` was still sending `""` to the embedding endpoint. OpenAI-compatible servers that reject blank inputs — I hit this against a local `/v1/embeddings` — fail the whole batch, so a single pathological message can poison 24-50 otherwise-valid ones and abort the run. On top of that, the client collapsed 4xx responses to a bare `embed: HTTP 400`, which hid the server's actual message (`Invalid embedding input: Input must not be empty`) and made the root cause hard to track down.

## Summary

- **worker**: `embedBatch` now skips messages whose preprocessed text is empty after trimming and returns their IDs in a new `empty` slice on `embedBatchResult`. `RunOnce` drains those rows from `pending_embeddings` alongside ids missing from the main DB, so empty-content messages no longer block a generation from completing. Missing vs. empty are logged separately.
- **client**: `doOnce` now includes a bounded (4 KiB) snippet of the 4xx response body in the returned error, so CLI output surfaces the underlying server message instead of a bare status code.

---
*Authored by @jesserobbins, with Claude Code (Opus 4.7).*