### PR TITLE
embed: windowed ETA and oversize-batch downshift

### DIFF
--- a/cmd/msgvault/cmd/embed_progress.go
+++ b/cmd/msgvault/cmd/embed_progress.go
@@ -1,0 +1,76 @@
+package cmd
+
+import "time"
+
+// rateWindow accumulates per-batch (msgs, elapsed) samples in a ring
+// buffer and reports the message-weighted rate over the window:
+//
+//	rate = sum(msgs) / sum(elapsed_seconds)
+//
+// Weighting matters when batch sizes vary a lot, e.g. when the worker
+// downshifts to BatchSize=1 to drain a poison message: a simple mean
+// of per-batch rates would let those tiny batches dominate the
+// displayed throughput. Summing first keeps small batches'
+// contribution proportional to their size.
+type rateWindow struct {
+	msgs    []int
+	elapsed []time.Duration
+	head    int // index of the next write
+	count   int // number of valid entries (<= len(msgs))
+}
+
+// newRateWindow constructs a ring buffer of the given capacity. A
+// non-positive cap is normalized to 1 so callers can always Add and
+// Rate without checking — this matches how applyDefaults treats
+// non-positive ETAWindow values from TOML, but defends against any
+// caller that bypasses defaults.
+func newRateWindow(capacity int) *rateWindow {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &rateWindow{
+		msgs:    make([]int, capacity),
+		elapsed: make([]time.Duration, capacity),
+	}
+}
+
+// Add records one batch sample. Samples with non-positive elapsed are
+// silently skipped: they would either divide by zero (elapsed == 0)
+// or contribute negative time (elapsed < 0, only reachable via clock
+// non-monotonicity in test harnesses). The next legitimate sample
+// re-establishes a healthy window.
+func (w *rateWindow) Add(msgs int, elapsed time.Duration) {
+	if elapsed <= 0 {
+		return
+	}
+	w.msgs[w.head] = msgs
+	w.elapsed[w.head] = elapsed
+	w.head = (w.head + 1) % len(w.msgs)
+	if w.count < len(w.msgs) {
+		w.count++
+	}
+}
+
+// Samples returns the number of valid entries currently in the
+// window. Useful for the printer's "(last K)" annotation when the
+// run hasn't yet emitted enough batches to fill the window.
+func (w *rateWindow) Samples() int { return w.count }
+
+// Rate returns the message-weighted rate in messages per second.
+// Returns 0 when the window is empty so callers can treat 0 as "no
+// estimate yet" and fall back to a no-ETA display branch.
+func (w *rateWindow) Rate() float64 {
+	if w.count == 0 {
+		return 0
+	}
+	var totalMsgs int
+	var totalElapsed time.Duration
+	for i := 0; i < w.count; i++ {
+		totalMsgs += w.msgs[i]
+		totalElapsed += w.elapsed[i]
+	}
+	if totalElapsed <= 0 {
+		return 0
+	}
+	return float64(totalMsgs) / totalElapsed.Seconds()
+}

--- a/cmd/msgvault/cmd/embed_progress_test.go
+++ b/cmd/msgvault/cmd/embed_progress_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestRateWindow_EmptyReturnsZero(t *testing.T) {
+	w := newRateWindow(10)
+	if r := w.Rate(); r != 0 {
+		t.Fatalf("empty Rate: got %v, want 0", r)
+	}
+	if n := w.Samples(); n != 0 {
+		t.Fatalf("empty Samples: got %d, want 0", n)
+	}
+}
+
+func TestRateWindow_PartialFill(t *testing.T) {
+	w := newRateWindow(10)
+	w.Add(50, 1*time.Second)
+	w.Add(100, 1*time.Second)
+	if got, want := w.Samples(), 2; got != want {
+		t.Fatalf("Samples: got %d, want %d", got, want)
+	}
+	// sum(msgs)/sum(seconds) = 150/2 = 75
+	if r := w.Rate(); math.Abs(r-75) > 0.01 {
+		t.Fatalf("Rate: got %v, want ~75", r)
+	}
+}
+
+func TestRateWindow_EvictsOldestOnceFull(t *testing.T) {
+	w := newRateWindow(3)
+	// Fill with low-rate samples.
+	w.Add(10, 1*time.Second) // 10 msg/s
+	w.Add(10, 1*time.Second)
+	w.Add(10, 1*time.Second)
+	if r := w.Rate(); math.Abs(r-10) > 0.01 {
+		t.Fatalf("pre-eviction Rate: got %v, want 10", r)
+	}
+	// Push a high-rate sample; oldest 10/1 should fall out.
+	w.Add(1000, 1*time.Second)
+	// Now window holds three samples: 10, 10, 1000 over 3s -> 340 msg/s.
+	if got, want := w.Samples(), 3; got != want {
+		t.Fatalf("Samples after eviction: got %d, want %d", got, want)
+	}
+	if r := w.Rate(); math.Abs(r-340) > 0.01 {
+		t.Fatalf("post-eviction Rate: got %v, want 340", r)
+	}
+}
+
+func TestRateWindow_WeightedNotMeanOfPerBatchRates(t *testing.T) {
+	// Picking sizes that distinguish weighted from mean-of-rates.
+	//   Batch A: 1 msg in 10s   -> 0.1 msg/s
+	//   Batch B: 100 msgs in 1s -> 100 msg/s
+	//   Mean of rates: 50.05
+	//   Weighted: 101 / 11 = ~9.18
+	w := newRateWindow(2)
+	w.Add(1, 10*time.Second)
+	w.Add(100, 1*time.Second)
+	got := w.Rate()
+	want := 101.0 / 11.0
+	if math.Abs(got-want) > 0.01 {
+		t.Fatalf("weighted Rate: got %v, want ~%v (must NOT equal mean-of-rates ~50)", got, want)
+	}
+}
+
+func TestRateWindow_ZeroElapsedSampleSkipped(t *testing.T) {
+	w := newRateWindow(10)
+	w.Add(10, 1*time.Second)
+	w.Add(50, 0) // skipped: would divide by zero
+	w.Add(20, 1*time.Second)
+	if got, want := w.Samples(), 2; got != want {
+		t.Fatalf("Samples: got %d (zero-elapsed should be skipped), want %d", got, want)
+	}
+	// 30 msgs over 2s = 15.
+	if r := w.Rate(); math.Abs(r-15) > 0.01 {
+		t.Fatalf("Rate: got %v, want 15", r)
+	}
+}
+
+func TestRateWindow_NegativeElapsedSampleSkipped(t *testing.T) {
+	w := newRateWindow(10)
+	w.Add(10, 1*time.Second)
+	w.Add(50, -1*time.Second) // pathological: skip
+	if got, want := w.Samples(), 1; got != want {
+		t.Fatalf("Samples: got %d, want %d", got, want)
+	}
+	// 10 msgs over 1s = 10 — confirms the negative sample didn't slip
+	// into the running totals (a regression where it did would either
+	// pull totalElapsed to zero or leave a stale msg count behind).
+	if r := w.Rate(); math.Abs(r-10) > 0.01 {
+		t.Fatalf("Rate: got %v, want 10", r)
+	}
+}
+
+func TestNewRateWindow_NormalizesNonPositiveCap(t *testing.T) {
+	w := newRateWindow(0)
+	// Should not panic on Add.
+	w.Add(1, 1*time.Second)
+	if got := w.Samples(); got < 1 {
+		t.Fatalf("Samples after Add on zero-cap window: got %d, want >= 1", got)
+	}
+}

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -8,9 +8,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/wesm/msgvault/internal/store"
 	"github.com/wesm/msgvault/internal/vector"
@@ -67,6 +69,11 @@ func runEmbed(ctx context.Context) error {
 		Timeout:    cfg.Vector.Embeddings.Timeout,
 		MaxRetries: cfg.Vector.Embeddings.MaxRetries,
 	})
+	totalPending, err := pendingCount(ctx, backend.DB(), gen)
+	if err != nil {
+		return fmt.Errorf("count pending: %w", err)
+	}
+
 	worker := embed.NewWorker(embed.WorkerDeps{
 		Backend:   backend,
 		VectorsDB: backend.DB(),
@@ -80,6 +87,8 @@ func runEmbed(ctx context.Context) error {
 		BatchSize:       cfg.Vector.Embeddings.BatchSize,
 		EmbedTimeout:    cfg.Vector.Embeddings.Timeout,
 		EmbedMaxRetries: cfg.Vector.Embeddings.MaxRetries,
+		TotalPending:    totalPending,
+		Progress:        newProgressPrinter(os.Stderr, totalPending, cfg.Vector.Embeddings.ETAWindow),
 	})
 
 	if n, err := worker.ReclaimStale(ctx); err != nil {
@@ -242,6 +251,77 @@ func pendingCount(ctx context.Context, db *sql.DB, gen vector.GenerationID) (int
 		return 0, fmt.Errorf("query pending: %w", err)
 	}
 	return n, nil
+}
+
+// newProgressPrinter returns an embed.Worker Progress callback that
+// emits a rate-limited one-line summary to w. Rate limit is ~2s to
+// keep stderr quiet on fast backends (ANE sustains ~500 msg/s at
+// batch=100, which would be 5 updates/sec unthrottled). total is the
+// pending snapshot at run start; zero disables ETA/percent.
+// windowSize controls how many recent batches are used for the
+// windowed rate estimate shown in the "(last K)" annotation.
+func newProgressPrinter(w io.Writer, total int, windowSize int) func(embed.ProgressReport) {
+	const minInterval = 2 * time.Second
+	var lastPrint time.Time
+	window := newRateWindow(windowSize)
+	return func(p embed.ProgressReport) {
+		now := time.Now()
+		isFinal := total > 0 && p.Done >= total
+		if !isFinal && now.Sub(lastPrint) < minInterval {
+			return
+		}
+		lastPrint = now
+
+		window.Add(p.BatchMsgs, p.BatchElapsed)
+		windowedRate := window.Rate()
+		samples := window.Samples()
+
+		msPerMsg := float64(p.BatchElapsed.Milliseconds()) / float64(max1(p.BatchMsgs))
+		usPerChar := float64(p.BatchElapsed.Microseconds()) / float64(max1(p.BatchChars))
+
+		if total > 0 && windowedRate > 0 {
+			remaining := total - p.Done
+			if remaining < 0 {
+				remaining = 0
+			}
+			eta := time.Duration(float64(remaining)/windowedRate) * time.Second
+			pct := 100 * float64(p.Done) / float64(total)
+			fmt.Fprintf(w,
+				"progress: %d/%d (%.1f%%) — %.0f msg/s (last %d), %.1f ms/msg, %.2f µs/char, ETA %s\n",
+				p.Done, total, pct, windowedRate, samples, msPerMsg, usPerChar, formatETA(eta))
+		} else {
+			fmt.Fprintf(w,
+				"progress: %d embedded — %.0f msg/s (last %d), %.1f ms/msg, %.2f µs/char\n",
+				p.Done, windowedRate, samples, msPerMsg, usPerChar)
+		}
+	}
+}
+
+// max1 floors a denominator at 1 so per-unit averages never divide by
+// zero on the rare empty or single-char batch.
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// formatETA renders a duration as h:mm:ss or m:ss, dropping leading
+// zero components so "3 hours" reads as "3h02m18s" and "45 seconds"
+// as "45s". Rounds to whole seconds.
+func formatETA(d time.Duration) string {
+	d = d.Round(time.Second)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	switch {
+	case h > 0:
+		return fmt.Sprintf("%dh%02dm%02ds", h, m, s)
+	case m > 0:
+		return fmt.Sprintf("%dm%02ds", m, s)
+	default:
+		return fmt.Sprintf("%ds", s)
+	}
 }
 
 // confirmEmbed reads a y/N answer from stdin. Default is no.

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -261,7 +261,10 @@ func pendingCount(ctx context.Context, db *sql.DB, gen vector.GenerationID) (int
 // windowSize controls how many recent batches are used for the
 // windowed rate estimate shown in the "(last K)" annotation.
 func newProgressPrinter(w io.Writer, total int, windowSize int) func(embed.ProgressReport) {
-	const minInterval = 2 * time.Second
+	return newProgressPrinterWithMinInterval(w, total, windowSize, 2*time.Second)
+}
+
+func newProgressPrinterWithMinInterval(w io.Writer, total int, windowSize int, minInterval time.Duration) func(embed.ProgressReport) {
 	var lastPrint time.Time
 	window := newRateWindow(windowSize)
 	return func(p embed.ProgressReport) {
@@ -273,8 +276,7 @@ func newProgressPrinter(w io.Writer, total int, windowSize int) func(embed.Progr
 		window.Add(p.BatchMsgs, p.BatchElapsed)
 
 		now := time.Now()
-		isFinal := total > 0 && p.Done >= total
-		if !isFinal && now.Sub(lastPrint) < minInterval {
+		if now.Sub(lastPrint) < minInterval {
 			return
 		}
 		lastPrint = now

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -265,6 +265,13 @@ func newProgressPrinter(w io.Writer, total int, windowSize int) func(embed.Progr
 	var lastPrint time.Time
 	window := newRateWindow(windowSize)
 	return func(p embed.ProgressReport) {
+		// Always feed the window — including events the throttle is
+		// about to suppress. Otherwise a fast downshift drain (where
+		// each singleton report arrives much faster than the 2s
+		// throttle) would leak almost all of its samples and the
+		// "(last K)" annotation would never reflect drain throughput.
+		window.Add(p.BatchMsgs, p.BatchElapsed)
+
 		now := time.Now()
 		isFinal := total > 0 && p.Done >= total
 		if !isFinal && now.Sub(lastPrint) < minInterval {
@@ -272,7 +279,6 @@ func newProgressPrinter(w io.Writer, total int, windowSize int) func(embed.Progr
 		}
 		lastPrint = now
 
-		window.Add(p.BatchMsgs, p.BatchElapsed)
 		windowedRate := window.Rate()
 		samples := window.Samples()
 

--- a/cmd/msgvault/cmd/embed_vector_test.go
+++ b/cmd/msgvault/cmd/embed_vector_test.go
@@ -488,9 +488,9 @@ func (s *buildingShim) BuildingGeneration(ctx context.Context) (*vector.Generati
 
 func TestNewProgressPrinter_UsesWindowedRate(t *testing.T) {
 	var buf bytes.Buffer
-	// window=2, total=210 so the percent path runs and the final
-	// event bypasses the throttle.
-	print := newProgressPrinter(&buf, 210, 2)
+	// window=2, total=210 so the percent path runs. The zero
+	// interval keeps the test deterministic without sleeping.
+	print := newProgressPrinterWithMinInterval(&buf, 210, 2, 0)
 
 	// Three calls. Pick values so the windowed rate at the final
 	// event is different from the cumulative rate the old printer
@@ -499,12 +499,10 @@ func TestNewProgressPrinter_UsesWindowedRate(t *testing.T) {
 	//
 	//   call 1: Done=100, BatchMsgs=100, BatchElapsed=1s (lastPrint
 	//           starts zero, so this emits and Adds).
-	//   call 2: Done=200, BatchMsgs=100, BatchElapsed=1s (throttled
-	//           out by the 2s minInterval; not emitted, not Added).
-	//   call 3: Done=210, BatchMsgs=10, BatchElapsed=5s, isFinal
-	//           (Done==total, bypasses throttle; emits and Adds).
+	//   call 2: Done=200, BatchMsgs=100, BatchElapsed=1s.
+	//   call 3: Done=210, BatchMsgs=10, BatchElapsed=5s.
 	//
-	// After call 3 the window holds two samples: (100,1s) and
+	// After call 3 the window holds the last two samples: (100,1s) and
 	// (10,5s) → windowed rate = 110/6 ≈ 18.33 → printed "18 msg/s".
 	// The old cumulative implementation would have printed
 	// 210/RunElapsed=7s = 30 → "30 msg/s". Asserting on the final
@@ -543,5 +541,28 @@ func TestNewProgressPrinter_UsesWindowedRate(t *testing.T) {
 	}
 	if strings.Contains(finalLine, "30 msg/s") {
 		t.Errorf("final line shows cumulative rate `30 msg/s`; windowed implementation should not produce this:\n%s", finalLine)
+	}
+}
+
+func TestNewProgressPrinter_DoesNotBypassThrottleAfterInitialTotal(t *testing.T) {
+	var buf bytes.Buffer
+	print := newProgressPrinter(&buf, 2, 2)
+
+	print(embed.ProgressReport{
+		Done: 2, TotalPending: 2,
+		BatchMsgs: 2, BatchChars: 20,
+		BatchElapsed: 1 * time.Second,
+		RunElapsed:   1 * time.Second,
+	})
+	print(embed.ProgressReport{
+		Done: 3, TotalPending: 2,
+		BatchMsgs: 1, BatchChars: 10,
+		BatchElapsed: 1 * time.Second,
+		RunElapsed:   2 * time.Second,
+	})
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("progress emitted %d lines, want 1 throttled line after initial total:\n%s", len(lines), buf.String())
 	}
 }

--- a/cmd/msgvault/cmd/embed_vector_test.go
+++ b/cmd/msgvault/cmd/embed_vector_test.go
@@ -9,9 +9,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/wesm/msgvault/internal/vector"
+	"github.com/wesm/msgvault/internal/vector/embed"
 	"github.com/wesm/msgvault/internal/vector/sqlitevec"
 )
 
@@ -481,4 +484,64 @@ type buildingShim struct {
 
 func (s *buildingShim) BuildingGeneration(ctx context.Context) (*vector.Generation, error) {
 	return s.forceBuilding, nil
+}
+
+func TestNewProgressPrinter_UsesWindowedRate(t *testing.T) {
+	var buf bytes.Buffer
+	// window=2, total=210 so the percent path runs and the final
+	// event bypasses the throttle.
+	print := newProgressPrinter(&buf, 210, 2)
+
+	// Three calls. Pick values so the windowed rate at the final
+	// event is different from the cumulative rate the old printer
+	// would have shown — that way a regression to cumulative would
+	// fail the assertion below, not just pass coincidentally.
+	//
+	//   call 1: Done=100, BatchMsgs=100, BatchElapsed=1s (lastPrint
+	//           starts zero, so this emits and Adds).
+	//   call 2: Done=200, BatchMsgs=100, BatchElapsed=1s (throttled
+	//           out by the 2s minInterval; not emitted, not Added).
+	//   call 3: Done=210, BatchMsgs=10, BatchElapsed=5s, isFinal
+	//           (Done==total, bypasses throttle; emits and Adds).
+	//
+	// After call 3 the window holds two samples: (100,1s) and
+	// (10,5s) → windowed rate = 110/6 ≈ 18.33 → printed "18 msg/s".
+	// The old cumulative implementation would have printed
+	// 210/RunElapsed=7s = 30 → "30 msg/s". Asserting on the final
+	// line distinguishes the two.
+	print(embed.ProgressReport{
+		Done: 100, TotalPending: 210,
+		BatchMsgs: 100, BatchChars: 1000,
+		BatchElapsed: 1 * time.Second,
+		RunElapsed:   1 * time.Second,
+	})
+	print(embed.ProgressReport{
+		Done: 200, TotalPending: 210,
+		BatchMsgs: 100, BatchChars: 1000,
+		BatchElapsed: 1 * time.Second,
+		RunElapsed:   2 * time.Second,
+	})
+	print(embed.ProgressReport{
+		Done: 210, TotalPending: 210,
+		BatchMsgs: 10, BatchChars: 100,
+		BatchElapsed: 5 * time.Second,
+		RunElapsed:   7 * time.Second,
+	})
+
+	out := buf.String()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 emitted lines, got:\n%s", out)
+	}
+	finalLine := lines[len(lines)-1]
+
+	if !strings.Contains(finalLine, "(last 2)") {
+		t.Errorf("expected `(last 2)` annotation on final line, got:\n%s", finalLine)
+	}
+	if !strings.Contains(finalLine, "18 msg/s") {
+		t.Errorf("expected windowed `18 msg/s` on final line, got:\n%s", finalLine)
+	}
+	if strings.Contains(finalLine, "30 msg/s") {
+		t.Errorf("final line shows cumulative rate `30 msg/s`; windowed implementation should not produce this:\n%s", finalLine)
+	}
 }

--- a/internal/scheduler/embed_job.go
+++ b/internal/scheduler/embed_job.go
@@ -172,7 +172,19 @@ func (j *EmbedJob) pickTarget(ctx context.Context, log *slog.Logger) (vector.Gen
 		return 0, false, false
 	}
 	if bg != nil {
-		if j.Fingerprint != "" && bg.Fingerprint != j.Fingerprint {
+		if j.Fingerprint == "" {
+			// Without a configured fingerprint we cannot tell
+			// whether this building generation matches the model
+			// the daemon is supposed to be using. Draining (and
+			// thus auto-activating) it could silently swap the
+			// production index to a different model. Refuse;
+			// resolution requires the CLI, where pickEmbedGeneration
+			// enforces a fingerprint match.
+			log.Warn("embed: in-flight rebuild present but no configured fingerprint — refusing to drain",
+				"building_fingerprint", bg.Fingerprint)
+			return 0, false, false
+		}
+		if bg.Fingerprint != j.Fingerprint {
 			log.Warn("embed: in-flight rebuild fingerprint differs from config — leaving for CLI to resolve",
 				"building_fingerprint", bg.Fingerprint, "config_fingerprint", j.Fingerprint)
 			return 0, false, false

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -152,8 +152,11 @@ func (s *Scheduler) RemoveAccount(email string) {
 // post-sync hook when runAfterSync is true). Replacing a previously-set
 // job removes the old cron entry. Passing nil clears any existing job.
 //
-// If schedule is non-empty and invalid, the previous job and cron entry
-// are preserved and an error is returned — the call is all-or-nothing.
+// A schedule rejected by ValidateCronExpr is caught before any state
+// mutates, so the previous job and cron entry are preserved. An
+// internal AddFunc failure after that point is treated as an invariant
+// violation (ValidateCronExpr already accepted the expression) and
+// clears the embed job rather than restoring the prior one.
 func (s *Scheduler) SetEmbedJob(job *EmbedJob, schedule string, runAfterSync bool) error {
 	// Validate the cron expression before mutating any state so a bad
 	// schedule can't leave the scheduler with a half-removed previous

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -602,23 +602,28 @@ func TestEmbedJob_Run_ActiveGeneration(t *testing.T) {
 	}
 }
 
-func TestEmbedJob_Run_BuildingFallback(t *testing.T) {
-	building := &vector.Generation{ID: 7, State: vector.GenerationBuilding}
+func TestEmbedJob_Run_BuildingRefusedWithoutFingerprint(t *testing.T) {
+	// A daemon with no configured Fingerprint cannot tell whether a
+	// building generation matches the model it is supposed to be
+	// using; draining (and thus auto-activating) it could silently
+	// swap the production index to a different model. pickTarget
+	// must refuse, leaving the build for the CLI to resolve.
+	building := &vector.Generation{ID: 7, State: vector.GenerationBuilding, Fingerprint: "old-model:512"}
 	backend := &fakeBackend{
 		activeErr: vector.ErrNoActiveGeneration,
 		building:  building,
 	}
 	runner := &fakeRunner{}
-	job := &EmbedJob{Worker: runner, Backend: backend}
+	job := &EmbedJob{Worker: runner, Backend: backend} // Fingerprint left empty
 
 	job.Run(context.Background())
 
-	_, run, gen := runner.calls()
-	if run != 1 {
-		t.Errorf("RunOnce calls = %d, want 1", run)
+	_, run, _ := runner.calls()
+	if run != 0 {
+		t.Errorf("RunOnce calls = %d, want 0 (refuse to drain without fingerprint)", run)
 	}
-	if gen != 7 {
-		t.Errorf("RunOnce gen = %d, want 7", gen)
+	if got := backend.activations(); len(got) != 0 {
+		t.Errorf("ActivateGeneration calls = %v, want none", got)
 	}
 }
 

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -33,6 +33,7 @@ type EmbeddingsConfig struct {
 	Timeout       time.Duration `toml:"timeout"`
 	MaxRetries    int           `toml:"max_retries"`
 	MaxInputChars int           `toml:"max_input_chars"`
+	ETAWindow     int           `toml:"eta_window"`
 }
 
 // PreprocessConfig controls message text preprocessing before embedding.
@@ -151,6 +152,9 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.Embeddings.MaxInputChars == 0 {
 		c.Embeddings.MaxInputChars = 32768
+	}
+	if c.Embeddings.ETAWindow <= 0 {
+		c.Embeddings.ETAWindow = 10
 	}
 	if c.Search.RRFK == 0 {
 		c.Search.RRFK = 60

--- a/internal/vector/config_test.go
+++ b/internal/vector/config_test.go
@@ -263,6 +263,25 @@ func TestApplyDefaults_PreservesExplicitMaxPageSizeHybridZero(t *testing.T) {
 	}
 }
 
+func TestEmbeddingsConfig_ETAWindowDefault(t *testing.T) {
+	var c Config
+	c.Embeddings.Endpoint = "http://localhost:1234/v1"
+	c.ApplyDefaults()
+	if c.Embeddings.ETAWindow != 10 {
+		t.Fatalf("ETAWindow default: got %d, want 10", c.Embeddings.ETAWindow)
+	}
+}
+
+func TestEmbeddingsConfig_ETAWindowExplicit(t *testing.T) {
+	var c Config
+	c.Embeddings.Endpoint = "http://localhost:1234/v1"
+	c.Embeddings.ETAWindow = 25
+	c.ApplyDefaults()
+	if c.Embeddings.ETAWindow != 25 {
+		t.Fatalf("ETAWindow explicit: got %d, want 25", c.Embeddings.ETAWindow)
+	}
+}
+
 // TestSearchConfig_PointerSemantics_FromTOML rounds out the
 // pointer-semantic guarantee at the TOML decode layer: omitted →
 // nil → ApplyDefaults fills 50; explicit 0 → preserved; explicit

--- a/internal/vector/embed/client.go
+++ b/internal/vector/embed/client.go
@@ -16,6 +16,13 @@ import (
 	"time"
 )
 
+// ErrPermanent4xx marks a non-retryable HTTP 4xx response from the
+// embeddings endpoint. Use errors.Is(err, ErrPermanent4xx) to detect
+// it; the error message still carries the status code and a bounded
+// response body. 429 (rate-limited) and 5xx are NOT wrapped — they
+// flow through the retry loop as transient errors.
+var ErrPermanent4xx = errors.New("embed: non-retryable 4xx response")
+
 // Config controls an embeddings Client. The zero value is not usable; callers
 // must set Endpoint, Model, and Dimension at a minimum.
 type Config struct {
@@ -99,7 +106,14 @@ func (c *Client) Embed(ctx context.Context, inputs []string) ([][]float32, error
 		if attempt == c.cfg.MaxRetries {
 			break
 		}
-		backoff := time.Duration(1<<attempt) * 100 * time.Millisecond
+		// Clamp the shift so a misconfigured MaxRetries can't
+		// produce a backoff measured in hours, and so attempt >= 63
+		// can't trigger the undefined shift behavior on int. 1<<8 *
+		// 100ms = 25.6s, which is plenty for transient-error backoff
+		// on an HTTP embedding endpoint; the retry cap (MaxRetries)
+		// bounds total wait time more naturally than the shift does.
+		shift := min(attempt, 8)
+		backoff := time.Duration(1<<shift) * 100 * time.Millisecond
 		// retryAfterSet distinguishes a successfully parsed
 		// "Retry-After: 0" (immediate retry) from "no usable header".
 		// Without the flag we'd fall back to exponential backoff when
@@ -160,13 +174,15 @@ func (c *Client) doOnce(ctx context.Context, body []byte, want int) ([][]float32
 	if resp.StatusCode >= 400 {
 		body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if err != nil {
-			return nil, fmt.Errorf("embed: HTTP %d (read error body: %v)", resp.StatusCode, err)
+			return nil, fmt.Errorf("embed: HTTP %d (read error body: %v): %w",
+				resp.StatusCode, err, ErrPermanent4xx)
 		}
 		msg := strings.TrimSpace(string(body))
 		if msg == "" {
-			return nil, fmt.Errorf("embed: HTTP %d", resp.StatusCode)
+			return nil, fmt.Errorf("embed: HTTP %d: %w", resp.StatusCode, ErrPermanent4xx)
 		}
-		return nil, fmt.Errorf("embed: HTTP %d: %s", resp.StatusCode, msg)
+		return nil, fmt.Errorf("embed: HTTP %d: %s: %w",
+			resp.StatusCode, msg, ErrPermanent4xx)
 	}
 
 	var r embeddingResponse

--- a/internal/vector/embed/client_test.go
+++ b/internal/vector/embed/client_test.go
@@ -450,6 +450,65 @@ func TestClient_Embed_RetryAfterZero_RetriesImmediately(t *testing.T) {
 	}
 }
 
+func TestClient_Embed_4xxIsPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"Invalid input"}}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{
+		Endpoint: srv.URL, Model: "m", Dimension: 4, MaxRetries: 3,
+	})
+	_, err := c.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatalf("expected error on 400")
+	}
+	if !errors.Is(err, ErrPermanent4xx) {
+		t.Fatalf("expected errors.Is(err, ErrPermanent4xx), got %v", err)
+	}
+	// Existing contract: body must still be in the message.
+	if !strings.Contains(err.Error(), "Invalid input") {
+		t.Errorf("expected body in error, got %v", err)
+	}
+}
+
+func TestClient_Embed_5xxNotPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{
+		Endpoint: srv.URL, Model: "m", Dimension: 4, MaxRetries: 2,
+	})
+	_, err := c.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatalf("expected error after retries exhausted")
+	}
+	if errors.Is(err, ErrPermanent4xx) {
+		t.Fatalf("5xx should NOT match ErrPermanent4xx, got %v", err)
+	}
+}
+
+func TestClient_Embed_429NotPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		http.Error(w, "slow down", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{
+		Endpoint: srv.URL, Model: "m", Dimension: 4, MaxRetries: 2,
+	})
+	_, err := c.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatalf("expected error after retries exhausted")
+	}
+	if errors.Is(err, ErrPermanent4xx) {
+		t.Fatalf("429 should NOT match ErrPermanent4xx, got %v", err)
+	}
+}
+
 func TestClient_Embed_InvalidIndex(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Return index 5 for a 1-input request.

--- a/internal/vector/embed/testsupport_test.go
+++ b/internal/vector/embed/testsupport_test.go
@@ -205,6 +205,12 @@ type fakeEmbeddingClient struct {
 	// letting tests assert what text the worker actually sent to the
 	// embedder (e.g. body_text vs HTML-stripped body_html).
 	LastInputs []string
+
+	// OnEmbed, if non-nil, replaces the default Embed behavior with
+	// a caller-provided closure. Used by tests that need to vary
+	// returned errors per call (e.g. fail multi-msg batches with
+	// ErrPermanent4xx, succeed on singletons).
+	OnEmbed func(inputs []string) ([][]float32, error)
 }
 
 // FailNext forces the next n Embed calls to return an error.
@@ -213,6 +219,13 @@ func (c *fakeEmbeddingClient) FailNext(n int) { c.failN = n }
 // Embed returns one deterministic, non-zero vector per input.
 func (c *fakeEmbeddingClient) Embed(_ context.Context, inputs []string) ([][]float32, error) {
 	c.calls++
+	if c.OnEmbed != nil {
+		out, err := c.OnEmbed(inputs)
+		if err == nil {
+			c.LastInputs = append(c.LastInputs[:0], inputs...)
+		}
+		return out, err
+	}
 	if c.failN > 0 {
 		c.failN--
 		return nil, fmt.Errorf("simulated embed failure (call %d)", c.calls)

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -374,6 +374,12 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 				lastErr = cerr
 				orphanDrainErr = cerr
 				orphanDrainCount += len(dropIDs)
+				batchChars := 0
+				for _, c := range eb.chunks {
+					batchChars += c.SourceCharLen
+				}
+				completedRows += len(eb.embeddedIDs)
+				w.reportProgress(completedRows, len(eb.embeddedIDs), batchChars, time.Since(batchStart))
 				if consecutiveFailures >= w.deps.MaxConsecutiveFailures {
 					// Embedded rows were already counted into
 					// res.Succeeded above; record the orphan-drain
@@ -564,9 +570,12 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 //     The caller increments consecutiveFailures and the cap will
 //     eventually trip, surfacing the original 4xx body.
 //   - non-nil non-4xx interruption: transient errors that exhausted
-//     retries inside embedBatch, upsert/complete failures, ctx
-//     cancellation. Deferred and unprocessed IDs stay claimed for
-//     ReclaimStale to recover.
+//     retries inside embedBatch, upsert/complete failures, or a
+//     cancellation seen after embedBatch starts. Deferred and
+//     unprocessed IDs are released before returning so a later run
+//     can retry them promptly. A cancellation observed before the
+//     next singleton starts returns ctx.Err without releasing; those
+//     rows remain claimed for ReclaimStale to recover.
 //   - nil: drain completed cleanly. If `embedded > 0` and there were
 //     deferred IDs, they were Completed as message-specific drops.
 func (w *Worker) downshiftDrain(

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -3,6 +3,7 @@ package embed
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -81,8 +82,9 @@ type ProgressReport struct {
 // parallelize, construct multiple workers that share the same Backend
 // and DB handles.
 type Worker struct {
-	deps WorkerDeps
-	q    *Queue
+	deps     WorkerDeps
+	q        *Queue
+	runStart time.Time // valid only during a RunOnce call
 }
 
 // NewWorker constructs a Worker, applying defaults for BatchSize (32),
@@ -179,7 +181,7 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 	var res RunResult
 	consecutiveFailures := 0
 	var lastErr error
-	runStart := time.Now()
+	w.runStart = time.Now()
 	// orphanDrainErr/orphanDrainCount preserve the latest orphan-drain
 	// failure across iterations so we can surface it on the empty-claim
 	// exit. Without this, a Complete() failure on orphan rows would be
@@ -210,13 +212,61 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 
 		eb, err := w.embedBatch(ctx, ids)
 		if err != nil {
+			consecutiveFailures++
+			lastErr = err
+			w.deps.Log.Warn("embed batch failed", "gen", gen, "ids", len(ids), "error", err)
+
+			if errors.Is(err, ErrPermanent4xx) {
+				// Walk the claimed IDs one at a time. Drain decides
+				// per-ID whether to drop (if some embed, the 4xxs are
+				// message-specific) or release (if none embed,
+				// endpoint-wide failure can't be ruled out).
+				w.deps.Log.Info("embed: downshifting to BatchSize=1 to drain failing batch",
+					"gen", gen, "batch_size", len(ids))
+				embedded, dropped, drainErr := w.downshiftDrain(ctx, gen, token, ids, &res)
+				res.Succeeded += embedded
+				if drainErr != nil {
+					w.deps.Log.Info("embed: downshift drain returned error",
+						"gen", gen, "batch_size", len(ids),
+						"embedded", embedded, "dropped", dropped,
+						"error", drainErr)
+				} else {
+					w.deps.Log.Info("embed: downshift drain complete; resuming configured batch size",
+						"gen", gen, "batch_size", len(ids),
+						"embedded", embedded, "dropped", dropped)
+				}
+
+				// Forward progress resets the cap. Same rule as the
+				// all-clean main-loop success path.
+				if embedded > 0 {
+					consecutiveFailures = 0
+				}
+
+				if drainErr != nil {
+					// Distinguish "drain confirms upstream 4xx"
+					// (every singleton returned the same
+					// ErrPermanent4xx — same failure as the upstream
+					// batch, already counted) from "drain hit an
+					// independent error" (transient-after-retries,
+					// upsert/complete failure, ctx cancel — a fresh
+					// failure that should also count).
+					lastErr = drainErr
+					if !errors.Is(drainErr, ErrPermanent4xx) {
+						consecutiveFailures++
+					}
+					if consecutiveFailures >= w.deps.MaxConsecutiveFailures {
+						return res, fmt.Errorf("embed worker aborting after %d consecutive failures: %w",
+							consecutiveFailures, lastErr)
+					}
+				}
+				continue
+			}
+
+			// Non-4xx error: original release-and-fail path.
 			res.Failed += len(ids)
 			if rerr := w.q.Release(ctx, gen, token, ids); rerr != nil {
 				w.deps.Log.Error("release after embed failure", "error", rerr)
 			}
-			w.deps.Log.Warn("embed batch failed", "gen", gen, "ids", len(ids), "error", err)
-			consecutiveFailures++
-			lastErr = err
 			if consecutiveFailures >= w.deps.MaxConsecutiveFailures {
 				return res, fmt.Errorf("embed worker aborting after %d consecutive failures: %w",
 					consecutiveFailures, lastErr)
@@ -226,10 +276,11 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 		res.Truncated += eb.truncated
 
 		if len(eb.chunks) == 0 {
-			// Nothing fetched (all ids in this batch were missing
-			// from main DB). Drop the orphans and move on; failure
-			// here counts toward MaxConsecutiveFailures because the
-			// loop would otherwise busy-spin on a stuck claim until
+			// Nothing to embed (every claimed id was missing from
+			// main DB or preprocessed to empty). Drop the orphans
+			// and move on; failure here counts toward
+			// MaxConsecutiveFailures because the loop would
+			// otherwise busy-spin on a stuck claim until
 			// ReclaimStale runs (10 min default).
 			dropIDs := append(append([]int64(nil), eb.missing...), eb.empty...)
 			if len(dropIDs) > 0 {
@@ -328,11 +379,18 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 						consecutiveFailures, lastErr)
 				}
 				// Even though the orphan drain failed, the embedded
-				// rows ARE done — count them. The orphan rows stay
-				// claimed; orphanDrainErr is now set so the empty-
-				// claim exit will surface the failure to the caller
-				// instead of falsely reporting a clean drain.
+				// rows ARE done — count them and reset the cap.
+				// Forward progress on real messages should reset
+				// consecutiveFailures the same way it does in the
+				// downshift drain path and the all-clean success
+				// path. The orphan-drop Complete failure has its
+				// own surfacing channel via orphanDrainErr (the
+				// empty-claim exit returns it instead of nil), so
+				// we don't need consecutiveFailures to escalate
+				// orphan failures into an abort. The orphan rows
+				// stay claimed and ReclaimStale recovers them.
 				res.Succeeded += len(eb.embeddedIDs)
+				consecutiveFailures = 0
 				continue
 			}
 		}
@@ -349,7 +407,7 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 				BatchMsgs:    len(eb.embeddedIDs),
 				BatchChars:   batchChars,
 				BatchElapsed: time.Since(batchStart),
-				RunElapsed:   time.Since(runStart),
+				RunElapsed:   time.Since(w.runStart),
 			})
 		}
 	}
@@ -477,6 +535,141 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 		empty:       empty,
 		truncated:   truncated,
 	}, nil
+}
+
+// downshiftDrain handles a non-retryable 4xx on a claimed batch by
+// walking the same already-claimed IDs one at a time. The IDs remain
+// owned under the caller's claim_token throughout the drain, so we
+// never re-Claim them — that would race other workers.
+//
+// Singleton 4xxs are NOT eagerly Completed. ErrPermanent4xx covers
+// both message-specific failures (413 payload-too-large, 422
+// Unprocessable, 400 invalid-input) and endpoint/config-wide
+// failures (401 bad-key, 403 forbidden, 404 invalid-model, 400
+// malformed-shared-config) — the two are indistinguishable at the
+// call site. If we Complete-deleted on every singleton 4xx, a
+// misconfigured endpoint would silently destroy work. Instead we
+// defer the drop decision: collect the 4xxing IDs, and at end of
+// drain decide based on whether anything embedded.
+//
+// Returned `embedded` is the count of singletons that successfully
+// embedded.
+//
+// Returned `dropped` is the count of singletons whose drop was
+// confirmed (Complete succeeded). A drain that releases its deferred
+// IDs back to the queue (because no singleton embedded) returns
+// `dropped == 0`.
+//
+// Returned `err`:
+//   - non-nil all-drop: every singleton 4xxd, no embeds. Deferred
+//     IDs were Released back to the queue (so a misconfigured
+//     endpoint does not lose work) and the wrapped 4xx is returned.
+//     The caller increments consecutiveFailures and the cap will
+//     eventually trip, surfacing the original 4xx body.
+//   - non-nil non-4xx interruption: transient errors that exhausted
+//     retries inside embedBatch, upsert/complete failures, ctx
+//     cancellation. Deferred and unprocessed IDs stay claimed for
+//     ReclaimStale to recover.
+//   - nil: drain completed cleanly. If `embedded > 0` and there were
+//     deferred IDs, they were Completed as message-specific drops.
+func (w *Worker) downshiftDrain(
+	ctx context.Context,
+	gen vector.GenerationID,
+	token string,
+	ids []int64,
+	res *RunResult,
+) (embedded int, dropped int, err error) {
+	var deferredDrops []int64
+	var lastDeferredErr error
+
+	for _, id := range ids {
+		select {
+		case <-ctx.Done():
+			return embedded, dropped, ctx.Err()
+		default:
+		}
+
+		batchStart := time.Now()
+		eb, e := w.embedBatch(ctx, []int64{id})
+		if e != nil {
+			if errors.Is(e, ErrPermanent4xx) {
+				// Defer the drop decision. See function-level
+				// comment for the endpoint-vs-message distinction.
+				deferredDrops = append(deferredDrops, id)
+				lastDeferredErr = e
+				continue
+			}
+			return embedded, dropped, e
+		}
+		if len(eb.chunks) == 0 {
+			drop := append(append([]int64(nil), eb.missing...), eb.empty...)
+			if len(drop) > 0 {
+				if cerr := w.q.Complete(ctx, gen, token, drop); cerr != nil {
+					res.Failed += len(drop)
+					return embedded, dropped, fmt.Errorf("complete drop: %w", cerr)
+				}
+				dropped += len(drop)
+			}
+			continue
+		}
+		if uerr := w.deps.Backend.Upsert(ctx, gen, eb.chunks); uerr != nil {
+			return embedded, dropped, fmt.Errorf("upsert: %w", uerr)
+		}
+		if cerr := w.q.Complete(ctx, gen, token, eb.embeddedIDs); cerr != nil {
+			return embedded, dropped, fmt.Errorf("complete: %w", cerr)
+		}
+		res.Truncated += eb.truncated
+		embedded += len(eb.embeddedIDs)
+
+		if w.deps.Progress != nil {
+			batchChars := 0
+			for _, c := range eb.chunks {
+				batchChars += c.SourceCharLen
+			}
+			w.deps.Progress(ProgressReport{
+				Done:         res.Succeeded + embedded,
+				TotalPending: w.deps.TotalPending,
+				BatchMsgs:    len(eb.embeddedIDs),
+				BatchChars:   batchChars,
+				BatchElapsed: time.Since(batchStart),
+				RunElapsed:   time.Since(w.runStart),
+			})
+		}
+	}
+
+	// Drain finished. Decide deferred-drop fate.
+	if len(deferredDrops) == 0 {
+		return embedded, dropped, nil
+	}
+	if embedded > 0 {
+		// Endpoint works for some messages, so the 4xxs are
+		// message-specific (oversize input, malformed input, etc.).
+		// Drop them.
+		for _, id := range deferredDrops {
+			w.deps.Log.Warn("dropping pending message after singleton 4xx",
+				"gen", gen, "id", id, "error", lastDeferredErr)
+		}
+		if cerr := w.q.Complete(ctx, gen, token, deferredDrops); cerr != nil {
+			res.Failed += len(deferredDrops)
+			return embedded, dropped, fmt.Errorf("complete drop: %w", cerr)
+		}
+		dropped += len(deferredDrops)
+		return embedded, dropped, nil
+	}
+	// embedded == 0. We can't distinguish endpoint-wide failure from a
+	// batch where every message just happened to be unembeddable.
+	// Release the deferred IDs (rather than Completing them) so a
+	// misconfigured endpoint does not silently destroy work, and
+	// return the wrapped 4xx so the caller surfaces it. The released
+	// IDs go back to the pending queue and will be re-claimed; if the
+	// underlying problem persists, the consecutive-failure cap will
+	// eventually trip with the same 4xx body in lastErr.
+	if rerr := w.q.Release(ctx, gen, token, deferredDrops); rerr != nil {
+		w.deps.Log.Error("release after all-drop drain", "error", rerr,
+			"gen", gen, "ids", len(deferredDrops))
+	}
+	return embedded, dropped, fmt.Errorf("downshift all-drop: every singleton returned non-retryable 4xx (released %d row(s) back to queue): %w",
+		len(deferredDrops), lastDeferredErr)
 }
 
 func totalChars(ms []msgText) int {

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -55,19 +55,19 @@ type WorkerDeps struct {
 	// callback (if any) to report percent done and ETA. Zero disables
 	// the denominator — Progress still fires but leaves ETA empty.
 	TotalPending int
-	// Progress, if non-nil, is called once after each fully-successful
-	// batch (upsert + complete both ok) with cumulative and per-batch
-	// stats. Failed or partially-drained batches do not fire Progress,
-	// keeping the semantics of "this many messages are now embedded"
-	// unambiguous. Callbacks run on the worker goroutine; rate-limit
-	// inside the callback if output is expensive.
+	// Progress, if non-nil, is called after queue rows are durably
+	// completed, whether they produced embeddings or were intentionally
+	// dropped as missing/empty/unembeddable. Done and BatchMsgs count
+	// completed queue rows so they can be compared to TotalPending.
+	// Callbacks run on the worker goroutine; rate-limit inside the
+	// callback if output is expensive.
 	Progress func(ProgressReport)
 }
 
-// ProgressReport captures the state of a RunOnce at the completion of
-// one successful batch. BatchElapsed is end-to-end for the batch
-// (fetch + preprocess + embed + upsert + complete), matching what
-// RunElapsed accumulates — so the two ratios agree.
+// ProgressReport captures RunOnce progress after a set of queue rows
+// has been completed. Done and BatchMsgs count completed pending rows;
+// BatchChars counts source chars for rows that actually embedded.
+// BatchElapsed is end-to-end for that progress unit.
 type ProgressReport struct {
 	Done         int
 	TotalPending int
@@ -181,6 +181,7 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 	var res RunResult
 	consecutiveFailures := 0
 	var lastErr error
+	completedRows := 0
 	w.runStart = time.Now()
 	// orphanDrainErr/orphanDrainCount preserve the latest orphan-drain
 	// failure across iterations so we can surface it on the empty-claim
@@ -223,7 +224,7 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 				// endpoint-wide failure can't be ruled out).
 				w.deps.Log.Info("embed: downshifting to BatchSize=1 to drain failing batch",
 					"gen", gen, "batch_size", len(ids))
-				embedded, dropped, drainErr := w.downshiftDrain(ctx, gen, token, ids, &res)
+				embedded, dropped, drainErr := w.downshiftDrain(ctx, gen, token, ids, &res, &completedRows)
 				res.Succeeded += embedded
 				if drainErr != nil {
 					w.deps.Log.Info("embed: downshift drain returned error",
@@ -249,10 +250,10 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 					// batch, already counted) from "drain hit an
 					// independent error" (transient-after-retries,
 					// upsert/complete failure, ctx cancel — a fresh
-					// failure that should also count).
+					// failure that should fail this run immediately.
 					lastErr = drainErr
 					if !errors.Is(drainErr, ErrPermanent4xx) {
-						consecutiveFailures++
+						return res, fmt.Errorf("downshift drain: %w", drainErr)
 					}
 					if consecutiveFailures >= w.deps.MaxConsecutiveFailures {
 						return res, fmt.Errorf("embed worker aborting after %d consecutive failures: %w",
@@ -304,7 +305,10 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 						return res, fmt.Errorf("embed worker aborting after %d consecutive failures: %w",
 							consecutiveFailures, lastErr)
 					}
+					continue
 				}
+				completedRows += len(dropIDs)
+				w.reportProgress(completedRows, len(dropIDs), 0, time.Since(batchStart))
 			}
 			continue
 		}
@@ -396,20 +400,13 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 		}
 		res.Succeeded += len(eb.embeddedIDs)
 		consecutiveFailures = 0
-		if w.deps.Progress != nil {
-			batchChars := 0
-			for _, c := range eb.chunks {
-				batchChars += c.SourceCharLen
-			}
-			w.deps.Progress(ProgressReport{
-				Done:         res.Succeeded,
-				TotalPending: w.deps.TotalPending,
-				BatchMsgs:    len(eb.embeddedIDs),
-				BatchChars:   batchChars,
-				BatchElapsed: time.Since(batchStart),
-				RunElapsed:   time.Since(w.runStart),
-			})
+		batchProcessed := len(eb.embeddedIDs) + len(dropIDs)
+		completedRows += batchProcessed
+		batchChars := 0
+		for _, c := range eb.chunks {
+			batchChars += c.SourceCharLen
 		}
+		w.reportProgress(completedRows, batchProcessed, batchChars, time.Since(batchStart))
 	}
 }
 
@@ -578,11 +575,12 @@ func (w *Worker) downshiftDrain(
 	token string,
 	ids []int64,
 	res *RunResult,
+	completedRows *int,
 ) (embedded int, dropped int, err error) {
 	var deferredDrops []int64
 	var lastDeferredErr error
 
-	for _, id := range ids {
+	for i, id := range ids {
 		select {
 		case <-ctx.Done():
 			return embedded, dropped, ctx.Err()
@@ -599,6 +597,7 @@ func (w *Worker) downshiftDrain(
 				lastDeferredErr = e
 				continue
 			}
+			w.releaseDownshiftRemainder(ctx, gen, token, append(append([]int64(nil), deferredDrops...), ids[i:]...))
 			return embedded, dropped, e
 		}
 		if len(eb.chunks) == 0 {
@@ -606,35 +605,31 @@ func (w *Worker) downshiftDrain(
 			if len(drop) > 0 {
 				if cerr := w.q.Complete(ctx, gen, token, drop); cerr != nil {
 					res.Failed += len(drop)
+					w.releaseDownshiftRemainder(ctx, gen, token, append(append([]int64(nil), deferredDrops...), ids[i:]...))
 					return embedded, dropped, fmt.Errorf("complete drop: %w", cerr)
 				}
 				dropped += len(drop)
+				*completedRows += len(drop)
+				w.reportProgress(*completedRows, len(drop), 0, time.Since(batchStart))
 			}
 			continue
 		}
 		if uerr := w.deps.Backend.Upsert(ctx, gen, eb.chunks); uerr != nil {
+			w.releaseDownshiftRemainder(ctx, gen, token, append(append([]int64(nil), deferredDrops...), ids[i:]...))
 			return embedded, dropped, fmt.Errorf("upsert: %w", uerr)
 		}
 		if cerr := w.q.Complete(ctx, gen, token, eb.embeddedIDs); cerr != nil {
+			w.releaseDownshiftRemainder(ctx, gen, token, append(append([]int64(nil), deferredDrops...), ids[i:]...))
 			return embedded, dropped, fmt.Errorf("complete: %w", cerr)
 		}
 		res.Truncated += eb.truncated
 		embedded += len(eb.embeddedIDs)
-
-		if w.deps.Progress != nil {
-			batchChars := 0
-			for _, c := range eb.chunks {
-				batchChars += c.SourceCharLen
-			}
-			w.deps.Progress(ProgressReport{
-				Done:         res.Succeeded + embedded,
-				TotalPending: w.deps.TotalPending,
-				BatchMsgs:    len(eb.embeddedIDs),
-				BatchChars:   batchChars,
-				BatchElapsed: time.Since(batchStart),
-				RunElapsed:   time.Since(w.runStart),
-			})
+		*completedRows += len(eb.embeddedIDs)
+		batchChars := 0
+		for _, c := range eb.chunks {
+			batchChars += c.SourceCharLen
 		}
+		w.reportProgress(*completedRows, len(eb.embeddedIDs), batchChars, time.Since(batchStart))
 	}
 
 	// Drain finished. Decide deferred-drop fate.
@@ -649,11 +644,14 @@ func (w *Worker) downshiftDrain(
 			w.deps.Log.Warn("dropping pending message after singleton 4xx",
 				"gen", gen, "id", id, "error", lastDeferredErr)
 		}
+		dropStart := time.Now()
 		if cerr := w.q.Complete(ctx, gen, token, deferredDrops); cerr != nil {
 			res.Failed += len(deferredDrops)
 			return embedded, dropped, fmt.Errorf("complete drop: %w", cerr)
 		}
 		dropped += len(deferredDrops)
+		*completedRows += len(deferredDrops)
+		w.reportProgress(*completedRows, len(deferredDrops), 0, time.Since(dropStart))
 		return embedded, dropped, nil
 	}
 	// embedded == 0. We can't distinguish endpoint-wide failure from a
@@ -670,6 +668,30 @@ func (w *Worker) downshiftDrain(
 	}
 	return embedded, dropped, fmt.Errorf("downshift all-drop: every singleton returned non-retryable 4xx (released %d row(s) back to queue): %w",
 		len(deferredDrops), lastDeferredErr)
+}
+
+func (w *Worker) releaseDownshiftRemainder(ctx context.Context, gen vector.GenerationID, token string, ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	if rerr := w.q.Release(ctx, gen, token, ids); rerr != nil {
+		w.deps.Log.Error("release after downshift interruption", "error", rerr,
+			"gen", gen, "ids", len(ids))
+	}
+}
+
+func (w *Worker) reportProgress(done, batchMsgs, batchChars int, batchElapsed time.Duration) {
+	if w.deps.Progress == nil {
+		return
+	}
+	w.deps.Progress(ProgressReport{
+		Done:         done,
+		TotalPending: w.deps.TotalPending,
+		BatchMsgs:    batchMsgs,
+		BatchChars:   batchChars,
+		BatchElapsed: batchElapsed,
+		RunElapsed:   time.Since(w.runStart),
+	})
 }
 
 func totalChars(ms []msgText) int {

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -50,6 +50,30 @@ type WorkerDeps struct {
 	// Default 5.
 	MaxConsecutiveFailures int
 	Log                    *slog.Logger
+	// TotalPending is the queue depth at run start, used by a Progress
+	// callback (if any) to report percent done and ETA. Zero disables
+	// the denominator — Progress still fires but leaves ETA empty.
+	TotalPending int
+	// Progress, if non-nil, is called once after each fully-successful
+	// batch (upsert + complete both ok) with cumulative and per-batch
+	// stats. Failed or partially-drained batches do not fire Progress,
+	// keeping the semantics of "this many messages are now embedded"
+	// unambiguous. Callbacks run on the worker goroutine; rate-limit
+	// inside the callback if output is expensive.
+	Progress func(ProgressReport)
+}
+
+// ProgressReport captures the state of a RunOnce at the completion of
+// one successful batch. BatchElapsed is end-to-end for the batch
+// (fetch + preprocess + embed + upsert + complete), matching what
+// RunElapsed accumulates — so the two ratios agree.
+type ProgressReport struct {
+	Done         int
+	TotalPending int
+	BatchMsgs    int
+	BatchChars   int
+	BatchElapsed time.Duration
+	RunElapsed   time.Duration
 }
 
 // Worker drives one building generation from claimed pending rows to
@@ -155,6 +179,7 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 	var res RunResult
 	consecutiveFailures := 0
 	var lastErr error
+	runStart := time.Now()
 	// orphanDrainErr/orphanDrainCount preserve the latest orphan-drain
 	// failure across iterations so we can surface it on the empty-claim
 	// exit. Without this, a Complete() failure on orphan rows would be
@@ -168,6 +193,7 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 		if err := ctx.Err(); err != nil {
 			return res, fmt.Errorf("RunOnce: %w", err)
 		}
+		batchStart := time.Now()
 		ids, token, err := w.q.Claim(ctx, gen, w.deps.BatchSize)
 		if err != nil {
 			return res, fmt.Errorf("claim: %w", err)
@@ -312,6 +338,20 @@ func (w *Worker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResul
 		}
 		res.Succeeded += len(eb.embeddedIDs)
 		consecutiveFailures = 0
+		if w.deps.Progress != nil {
+			batchChars := 0
+			for _, c := range eb.chunks {
+				batchChars += c.SourceCharLen
+			}
+			w.deps.Progress(ProgressReport{
+				Done:         res.Succeeded,
+				TotalPending: w.deps.TotalPending,
+				BatchMsgs:    len(eb.embeddedIDs),
+				BatchChars:   batchChars,
+				BatchElapsed: time.Since(batchStart),
+				RunElapsed:   time.Since(runStart),
+			})
+		}
 	}
 }
 

--- a/internal/vector/embed/worker_test.go
+++ b/internal/vector/embed/worker_test.go
@@ -497,6 +497,7 @@ func TestWorker_OrphanCompleteFailureDoesNotStrandValidWork(t *testing.T) {
 		t.Fatalf("install trigger: %v", err)
 	}
 
+	var reports []ProgressReport
 	w := NewWorker(WorkerDeps{
 		Backend:                f.Backend,
 		VectorsDB:              f.VectorsDB,
@@ -504,6 +505,10 @@ func TestWorker_OrphanCompleteFailureDoesNotStrandValidWork(t *testing.T) {
 		Client:                 f.FakeClient,
 		BatchSize:              2,
 		MaxConsecutiveFailures: 5, // generous so the orphan drain failure does not abort mid-loop
+		TotalPending:           2,
+		Progress: func(p ProgressReport) {
+			reports = append(reports, p)
+		},
 	})
 
 	res, err := w.RunOnce(ctx, f.BuildingGen)
@@ -521,6 +526,16 @@ func TestWorker_OrphanCompleteFailureDoesNotStrandValidWork(t *testing.T) {
 	}
 	if res.Failed == 0 {
 		t.Errorf("Failed=%d, want > 0 (orphan drain failure should be reported)", res.Failed)
+	}
+	if len(reports) == 0 {
+		t.Fatalf("expected progress for valid embedded row even though orphan drain failed")
+	}
+	final := reports[len(reports)-1]
+	if final.Done != 1 {
+		t.Errorf("final progress Done=%d, want 1 durable embedded row", final.Done)
+	}
+	if final.BatchMsgs != 1 {
+		t.Errorf("final progress BatchMsgs=%d, want 1 durable embedded row", final.BatchMsgs)
 	}
 
 	// The valid message's pending row must be GONE (Complete succeeded).

--- a/internal/vector/embed/worker_test.go
+++ b/internal/vector/embed/worker_test.go
@@ -688,3 +688,61 @@ func TestWorker_EmptyPreprocessedMessagesDrainedFromQueue(t *testing.T) {
 		t.Errorf("embeddings = %d, want 1", embedded)
 	}
 }
+
+// Progress fires once per fully-successful batch and carries cumulative
+// Done, batch size, and char counts — enough for an ETA printer to work
+// off of without peeking at worker internals.
+func TestWorker_ProgressCalledPerSuccessfulBatch(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 5)
+
+	var reports []ProgressReport
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		Preprocess:    PreprocessConfig{},
+		MaxInputChars: 8000,
+		BatchSize:     2,
+		TotalPending:  5,
+		Progress: func(p ProgressReport) {
+			reports = append(reports, p)
+		},
+	})
+
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.Succeeded != 5 {
+		t.Fatalf("succeeded=%d, want 5", res.Succeeded)
+	}
+	// 5 messages, batch=2 → batches of 2, 2, 1 → three Progress calls.
+	if len(reports) != 3 {
+		t.Fatalf("progress called %d times, want 3", len(reports))
+	}
+
+	wantDone := []int{2, 4, 5}
+	wantBatchMsgs := []int{2, 2, 1}
+	for i, p := range reports {
+		if p.Done != wantDone[i] {
+			t.Errorf("report[%d].Done=%d, want %d", i, p.Done, wantDone[i])
+		}
+		if p.BatchMsgs != wantBatchMsgs[i] {
+			t.Errorf("report[%d].BatchMsgs=%d, want %d", i, p.BatchMsgs, wantBatchMsgs[i])
+		}
+		if p.TotalPending != 5 {
+			t.Errorf("report[%d].TotalPending=%d, want 5", i, p.TotalPending)
+		}
+		if p.BatchChars <= 0 {
+			t.Errorf("report[%d].BatchChars=%d, want >0 (non-empty fixture bodies)", i, p.BatchChars)
+		}
+		if p.BatchElapsed < 0 {
+			t.Errorf("report[%d].BatchElapsed=%s, want >=0", i, p.BatchElapsed)
+		}
+		if p.RunElapsed < p.BatchElapsed {
+			t.Errorf("report[%d].RunElapsed=%s < BatchElapsed=%s", i, p.RunElapsed, p.BatchElapsed)
+		}
+	}
+}

--- a/internal/vector/embed/worker_test.go
+++ b/internal/vector/embed/worker_test.go
@@ -748,6 +748,53 @@ func TestWorker_ProgressCalledPerSuccessfulBatch(t *testing.T) {
 	}
 }
 
+func TestWorker_ProgressCountsDroppedRowsTowardTotal(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 3)
+
+	const missingID = 2
+	if _, err := f.MainDB.ExecContext(ctx,
+		`DELETE FROM messages WHERE id = ?`, missingID); err != nil {
+		t.Fatalf("delete missing message: %v", err)
+	}
+	if _, err := f.MainDB.ExecContext(ctx,
+		`DELETE FROM message_bodies WHERE message_id = ?`, missingID); err != nil {
+		t.Fatalf("delete missing body: %v", err)
+	}
+
+	var reports []ProgressReport
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		MaxInputChars: 8000,
+		BatchSize:     3,
+		TotalPending:  3,
+		Progress: func(p ProgressReport) {
+			reports = append(reports, p)
+		},
+	})
+
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.Succeeded != 2 {
+		t.Fatalf("succeeded=%d, want 2 embedded rows", res.Succeeded)
+	}
+	if len(reports) == 0 {
+		t.Fatalf("expected progress report for mixed embed/drop batch")
+	}
+	final := reports[len(reports)-1]
+	if final.Done != 3 {
+		t.Fatalf("final progress Done=%d, want 3 pending rows processed", final.Done)
+	}
+	if final.BatchMsgs != 3 {
+		t.Fatalf("final progress BatchMsgs=%d, want 3 pending rows processed in batch", final.BatchMsgs)
+	}
+}
+
 // TestWorker_DownshiftDrain_HappyPath_AllSingletonsSucceed verifies
 // that when a multi-message batch returns ErrPermanent4xx (e.g. one
 // message in the batch is too long for the model), the worker walks
@@ -968,4 +1015,43 @@ func TestWorker_DownshiftDrain_CtxCancelMidDrain(t *testing.T) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 	assertPending(t, f.VectorsDB, int64(f.BuildingGen), 2)
+}
+
+func TestWorker_DownshiftDrain_TransientErrorReleasesRemainingAndErrors(t *testing.T) {
+	f := newWorkerFixture(t, 3)
+	var singletonCalls int
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		if len(inputs) > 1 {
+			return nil, fmt.Errorf("embed: HTTP 400: %w", ErrPermanent4xx)
+		}
+		singletonCalls++
+		if singletonCalls == 2 {
+			return nil, fmt.Errorf("temporary network failure")
+		}
+		v := make([]float32, 4)
+		v[0] = 1
+		return [][]float32{v}, nil
+	}
+	w := NewWorker(WorkerDeps{
+		Backend:   f.Backend,
+		VectorsDB: f.VectorsDB,
+		MainDB:    f.MainDB,
+		Client:    f.FakeClient,
+		BatchSize: 3,
+	})
+
+	res, err := w.RunOnce(context.Background(), f.BuildingGen)
+	if err == nil {
+		t.Fatalf("expected transient mid-drain error, got nil")
+	}
+	if !strings.Contains(err.Error(), "temporary network failure") {
+		t.Fatalf("expected original transient error, got %v", err)
+	}
+	if res.Succeeded != 1 {
+		t.Fatalf("Succeeded=%d, want 1 completed singleton before transient error", res.Succeeded)
+	}
+	assertPending(t, f.VectorsDB, int64(f.BuildingGen), 2)
+	if available := countAvailable(t, f.VectorsDB, int64(f.BuildingGen)); available != 2 {
+		t.Fatalf("available pending rows=%d, want 2 released rows", available)
+	}
 }

--- a/internal/vector/embed/worker_test.go
+++ b/internal/vector/embed/worker_test.go
@@ -4,6 +4,7 @@ package embed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -745,4 +746,226 @@ func TestWorker_ProgressCalledPerSuccessfulBatch(t *testing.T) {
 			t.Errorf("report[%d].RunElapsed=%s < BatchElapsed=%s", i, p.RunElapsed, p.BatchElapsed)
 		}
 	}
+}
+
+// TestWorker_DownshiftDrain_HappyPath_AllSingletonsSucceed verifies
+// that when a multi-message batch returns ErrPermanent4xx (e.g. one
+// message in the batch is too long for the model), the worker walks
+// the same already-claimed IDs one at a time and embeds the rest.
+func TestWorker_DownshiftDrain_HappyPath_AllSingletonsSucceed(t *testing.T) {
+	f := newWorkerFixture(t, 3)
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		if len(inputs) > 1 {
+			return nil, fmt.Errorf("embed: HTTP 400: too long: %w", ErrPermanent4xx)
+		}
+		v := make([]float32, 4)
+		v[0] = 1
+		return [][]float32{v}, nil
+	}
+	w := NewWorker(WorkerDeps{
+		Backend:   f.Backend,
+		VectorsDB: f.VectorsDB,
+		MainDB:    f.MainDB,
+		Client:    f.FakeClient,
+		BatchSize: 3,
+	})
+	res, err := w.RunOnce(context.Background(), f.BuildingGen)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.Succeeded != 3 {
+		t.Fatalf("Succeeded: got %d, want 3", res.Succeeded)
+	}
+	if res.Failed != 0 {
+		t.Fatalf("Failed: got %d, want 0", res.Failed)
+	}
+	assertPending(t, f.VectorsDB, int64(f.BuildingGen), 0)
+}
+
+// TestWorker_DownshiftDrain_PartialDrop verifies that singleton 4xxs
+// inside a drain are dropped (Completed without an embedding) while
+// the rest of the drain proceeds normally.
+func TestWorker_DownshiftDrain_PartialDrop(t *testing.T) {
+	f := newWorkerFixture(t, 3)
+	var singletonSeen int
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		if len(inputs) > 1 {
+			return nil, fmt.Errorf("embed: HTTP 400: too long: %w", ErrPermanent4xx)
+		}
+		singletonSeen++
+		if singletonSeen == 2 {
+			return nil, fmt.Errorf("embed: HTTP 400: blocked: %w", ErrPermanent4xx)
+		}
+		v := make([]float32, 4)
+		v[0] = 1
+		return [][]float32{v}, nil
+	}
+	w := NewWorker(WorkerDeps{
+		Backend:   f.Backend,
+		VectorsDB: f.VectorsDB,
+		MainDB:    f.MainDB,
+		Client:    f.FakeClient,
+		BatchSize: 3,
+	})
+	res, err := w.RunOnce(context.Background(), f.BuildingGen)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.Succeeded != 2 {
+		t.Errorf("Succeeded: got %d, want 2", res.Succeeded)
+	}
+	// Singleton 4xx drops are NOT counted as Failed — Complete
+	// succeeded, so the worker treated the unembeddable message
+	// the same way the main loop treats missing/empty drops.
+	// res.Failed is reserved for genuine processing failures
+	// (Complete errors, transient embed failures, etc.).
+	if res.Failed != 0 {
+		t.Errorf("Failed (no Complete errors expected): got %d, want 0", res.Failed)
+	}
+	assertPending(t, f.VectorsDB, int64(f.BuildingGen), 0)
+}
+
+// TestWorker_DownshiftDrain_AllDrop_StillTripsCap verifies that a
+// fully misconfigured endpoint (every message rejected as 4xx) still
+// trips the consecutive-failure cap so the worker aborts instead of
+// silently dropping every message.
+func TestWorker_DownshiftDrain_AllDrop_StillTripsCap(t *testing.T) {
+	f := newWorkerFixture(t, 6)
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		return nil, fmt.Errorf("embed: HTTP 400: misconfigured: %w", ErrPermanent4xx)
+	}
+	w := NewWorker(WorkerDeps{
+		Backend:                f.Backend,
+		VectorsDB:              f.VectorsDB,
+		MainDB:                 f.MainDB,
+		Client:                 f.FakeClient,
+		BatchSize:              3,
+		MaxConsecutiveFailures: 2,
+	})
+	_, err := w.RunOnce(context.Background(), f.BuildingGen)
+	if err == nil {
+		t.Fatalf("expected abort error, got nil")
+	}
+	if !strings.Contains(err.Error(), "consecutive failures") {
+		t.Errorf("expected abort message, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "misconfigured") {
+		t.Errorf("expected original 4xx body in error, got %v", err)
+	}
+}
+
+// TestWorker_DownshiftDrain_AllDropClean_NoSilentDelete covers the
+// most dangerous failure mode: a misconfigured endpoint (bad API
+// key, wrong model, malformed shared request config) returns 4xx
+// for every input. ErrPermanent4xx is indistinguishable from a
+// message-specific 4xx at the call site, so the worker MUST NOT
+// Complete-delete pending rows when no singleton in the drain
+// embedded — it must release them so the cap eventually trips and
+// the operator sees the failure with the original 4xx body intact
+// AND the rows still in the queue for retry after fixing the
+// config.
+func TestWorker_DownshiftDrain_AllDropClean_NoSilentDelete(t *testing.T) {
+	f := newWorkerFixture(t, 4)
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		return nil, fmt.Errorf("embed: HTTP 401: bad-api-key: %w", ErrPermanent4xx)
+	}
+	// BatchSize=2, default MaxConsecutiveFailures=5. Each iteration:
+	// upstream 4xx (cf+1), drain walks both singletons, both 4xx,
+	// drain returns wrapped ErrPermanent4xx (no double-count since
+	// the drain confirms the upstream failure rather than adding a
+	// new one), drain releases the 2 deferred IDs back to the queue.
+	// After 5 iterations the cap trips. Pending count stays at 4
+	// throughout because rows are released, not Completed.
+	w := NewWorker(WorkerDeps{
+		Backend:   f.Backend,
+		VectorsDB: f.VectorsDB,
+		MainDB:    f.MainDB,
+		Client:    f.FakeClient,
+		BatchSize: 2,
+	})
+	res, err := w.RunOnce(context.Background(), f.BuildingGen)
+	if err == nil {
+		t.Fatalf("expected cap-trip error on misconfigured endpoint, got nil")
+	}
+	if res.Succeeded != 0 {
+		t.Errorf("Succeeded: got %d, want 0 (no embeds during all-drop)", res.Succeeded)
+	}
+	if !strings.Contains(err.Error(), "consecutive failures") {
+		t.Errorf("expected cap-trip error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "bad-api-key") {
+		t.Errorf("expected original 4xx body in error, got %v", err)
+	}
+	// Critical: rows must NOT have been silently deleted. They
+	// should still be in pending_embeddings (released back, not
+	// Completed) so a corrected config can re-claim them on the
+	// next run.
+	assertPending(t, f.VectorsDB, int64(f.BuildingGen), 4)
+}
+
+// TestWorker_SingletonBatch_4xx_NoSilentDelete verifies that a
+// BatchSize=1 claim returning ErrPermanent4xx does NOT silently
+// delete the row. The drain walks the single ID, defers the drop,
+// finds embedded == 0, releases the row back to the queue, and
+// returns the wrapped 4xx. The caller sees errors.Is(err,
+// ErrPermanent4xx) so the drain return doesn't double-count, but
+// the upstream batch failure still increments consecutiveFailures
+// once per iteration. With MaxConsecutiveFailures=3 the cap trips
+// after 3 iterations and the row remains in pending_embeddings.
+func TestWorker_SingletonBatch_4xx_NoSilentDelete(t *testing.T) {
+	f := newWorkerFixture(t, 1)
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		return nil, fmt.Errorf("embed: HTTP 400: bad: %w", ErrPermanent4xx)
+	}
+	w := NewWorker(WorkerDeps{
+		Backend:                f.Backend,
+		VectorsDB:              f.VectorsDB,
+		MainDB:                 f.MainDB,
+		Client:                 f.FakeClient,
+		BatchSize:              1,
+		MaxConsecutiveFailures: 3,
+	})
+	_, err := w.RunOnce(context.Background(), f.BuildingGen)
+	if err == nil {
+		t.Fatalf("expected abort after cap, got nil")
+	}
+	if !strings.Contains(err.Error(), "consecutive failures") {
+		t.Errorf("expected cap abort message, got %v", err)
+	}
+	assertPending(t, f.VectorsDB, int64(f.BuildingGen), 1)
+}
+
+// TestWorker_DownshiftDrain_CtxCancelMidDrain verifies that
+// cancellation during the drain returns ctx.Err() and the remaining
+// claimed rows are not lost (they remain in pending_embeddings to be
+// recovered by ReclaimStale).
+func TestWorker_DownshiftDrain_CtxCancelMidDrain(t *testing.T) {
+	f := newWorkerFixture(t, 3)
+	ctx, cancel := context.WithCancel(context.Background())
+	var singletonCalls int
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		if len(inputs) > 1 {
+			return nil, fmt.Errorf("embed: HTTP 400: %w", ErrPermanent4xx)
+		}
+		singletonCalls++
+		if singletonCalls == 2 {
+			cancel()
+			return nil, context.Canceled
+		}
+		v := make([]float32, 4)
+		v[0] = 1
+		return [][]float32{v}, nil
+	}
+	w := NewWorker(WorkerDeps{
+		Backend:   f.Backend,
+		VectorsDB: f.VectorsDB,
+		MainDB:    f.MainDB,
+		Client:    f.FakeClient,
+		BatchSize: 3,
+	})
+	_, err := w.RunOnce(ctx, f.BuildingGen)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	assertPending(t, f.VectorsDB, int64(f.BuildingGen), 2)
 }


### PR DESCRIPTION
Closes #295 (feature), closes #296 (bug).

`build-embeddings` was silent until it returned and aborted when a single oversize message poisoned a multi-message batch — both unworkable on long mailbox backfills against [`maclocal-api`](https://github.com/scouzi1966/maclocal-api) (a local OpenAI-compatible shim over Apple Foundation Models prerelease embeddings).

Two scopes, one commit each, independently cherry-pickable:

1. **Per-batch progress reporting with windowed-rate ETA.** A stderr line about every two seconds with rate, ms/msg, µs/char, and ETA computed over a sliding window of the last N successful batches.
2. **Drain oversize batches one message at a time on non-retryable 4xx.** New `embed.ErrPermanent4xx` sentinel; the worker splits the failing batch and walks IDs one at a time instead of failing the whole batch and tripping the abort cap.

## How to use

- Progress prints to stderr automatically; nothing to enable.
- Tune the smoothing with `eta_window = 10` (default) under `[vector.embeddings]`.
- Downshift on oversize batches is automatic; entry/exit/interrupt are logged at Info level (`embed: downshifting to BatchSize=1 …`, `embed: downshift drain complete …`).

Full motivation, design choices, counter rules, and verification are in the two commit messages.
