### PR TITLE
feat: add Google service account support for domain-wide delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,22 @@ To switch an existing account to a different OAuth app:
 msgvault add-account you@acme.com --oauth-app acme   # re-authorizes
 ```
 
+### Google Service Accounts
+
+Workspace admins can use a Google service account with domain-wide delegation instead of per-user OAuth tokens:
+
+```toml
+[oauth.apps.acme]
+service_account_key = "/secure/path/service-account.json"
+```
+
+In Google Admin Console, authorize the service account client for `https://www.googleapis.com/auth/gmail.readonly` and `https://www.googleapis.com/auth/gmail.modify`. If you will run `delete-staged` with permanent deletion, also authorize `https://mail.google.com/`. Keep the key file owner-only, for example `chmod 600 /secure/path/service-account.json`.
+
+```bash
+msgvault add-account you@acme.com --oauth-app acme
+msgvault sync-full you@acme.com
+```
+
 ## MCP Server
 
 msgvault includes an MCP server that lets AI assistants search, analyze, and read your archived messages. Connect it to Claude Desktop or any MCP-capable agent and query your full message history conversationally. See the [MCP documentation](https://msgvault.io/usage/chat/) for setup instructions.

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -107,7 +107,45 @@ Examples:
 			}
 		}
 
-		// Resolve client secrets path
+		// Check for service account configuration first
+		if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(resolvedApp); saKeyPath != "" {
+			saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
+			if saErr != nil {
+				return fmt.Errorf("service account: %w", saErr)
+			}
+
+			// Validate access by calling Gmail profile API
+			ts, saErr := saMgr.TokenSource(cmd.Context(), email)
+			if saErr != nil {
+				return fmt.Errorf("service account token for %s: %w", email, saErr)
+			}
+			if saErr := oauth.ValidateTokenEmail(cmd.Context(), ts, email); saErr != nil {
+				return fmt.Errorf("service account validation for %s: %w", email, saErr)
+			}
+
+			// Register source
+			source, saErr := s.GetOrCreateSource("gmail", email)
+			if saErr != nil {
+				return fmt.Errorf("create source: %w", saErr)
+			}
+			if resolvedApp != "" {
+				newApp := sql.NullString{String: resolvedApp, Valid: true}
+				if saErr := s.UpdateSourceOAuthApp(source.ID, newApp); saErr != nil {
+					return fmt.Errorf("update oauth app binding: %w", saErr)
+				}
+			}
+			if accountDisplayName != "" {
+				if saErr := s.UpdateSourceDisplayName(source.ID, accountDisplayName); saErr != nil {
+					return fmt.Errorf("set display name: %w", saErr)
+				}
+			}
+
+			fmt.Printf("Account %s authorized via service account.\n", email)
+			fmt.Println("Next step: msgvault sync-full", email)
+			return nil
+		}
+
+		// Resolve client secrets path (standard OAuth flow)
 		clientSecretsPath, err = cfg.OAuth.ClientSecretsFor(resolvedApp)
 		if err != nil {
 			if !cfg.OAuth.HasAnyConfig() {

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -128,10 +128,19 @@ Examples:
 			if saErr != nil {
 				return fmt.Errorf("create source: %w", saErr)
 			}
+			// Persist the oauth_app binding (set or clear). Mirror the
+			// standard OAuth branch: when --oauth-app was explicitly
+			// changed and resolves to "", clear the stored binding so
+			// later syncs don't keep resolving credentials through the
+			// stale named-app pointer.
 			if resolvedApp != "" {
 				newApp := sql.NullString{String: resolvedApp, Valid: true}
 				if saErr := s.UpdateSourceOAuthApp(source.ID, newApp); saErr != nil {
 					return fmt.Errorf("update oauth app binding: %w", saErr)
+				}
+			} else if bindingChanged {
+				if saErr := s.UpdateSourceOAuthApp(source.ID, sql.NullString{}); saErr != nil {
+					return fmt.Errorf("clear oauth app binding: %w", saErr)
 				}
 			}
 			if accountDisplayName != "" {

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -45,25 +45,6 @@ Examples:
 			return fmt.Errorf("--headless and --force cannot be used together: --force requires browser-based OAuth which is not available in headless mode")
 		}
 
-		// For --headless, try to inherit the stored binding so the
-		// printed instructions include --oauth-app. DB errors are
-		// non-fatal since headless only prints instructions.
-		if headless {
-			app := oauthAppName
-			if !cmd.Flags().Changed("oauth-app") {
-				if s, openErr := store.Open(cfg.DatabaseDSN()); openErr == nil {
-					defer func() { _ = s.Close() }()
-					if initErr := s.InitSchema(); initErr == nil {
-						if src, _ := findGmailSource(s, email); src != nil {
-							app = sourceOAuthApp(src)
-						}
-					}
-				}
-			}
-			oauth.PrintHeadlessInstructions(email, cfg.TokensDir(), app)
-			return nil
-		}
-
 		// Resolve which client secrets to use
 		resolvedApp := oauthAppName
 		oauthAppExplicit := cmd.Flags().Changed("oauth-app")
@@ -107,8 +88,20 @@ Examples:
 			}
 		}
 
+		saKeyPath := cfg.OAuth.ServiceAccountKeyFor(resolvedApp)
+		if headless {
+			if saKeyPath != "" {
+				return fmt.Errorf("service accounts do not use --headless; run add-account without --headless")
+			}
+			oauth.PrintHeadlessInstructions(email, cfg.TokensDir(), resolvedApp)
+			return nil
+		}
+
 		// Check for service account configuration first
-		if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(resolvedApp); saKeyPath != "" {
+		if saKeyPath != "" {
+			if forceReauth {
+				return fmt.Errorf("service accounts do not use --force; tokens are minted on demand from the configured service account key")
+			}
 			saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
 			if saErr != nil {
 				return fmt.Errorf("service account: %w", saErr)
@@ -120,6 +113,20 @@ Examples:
 				return fmt.Errorf("service account token for %s: %w", email, saErr)
 			}
 			if saErr := oauth.ValidateTokenEmail(cmd.Context(), ts, email); saErr != nil {
+				var mismatch *oauth.TokenMismatchError
+				if errors.As(saErr, &mismatch) {
+					existing, lookupErr := findGmailSource(s, email)
+					if lookupErr != nil {
+						return fmt.Errorf("service account validation failed: %w (also: %v)", saErr, lookupErr)
+					}
+					if existing == nil {
+						return fmt.Errorf(
+							"%w\nIf %s is the primary address, re-add with:\n"+
+								"  msgvault add-account %s",
+							saErr, mismatch.Actual, mismatch.Actual,
+						)
+					}
+				}
 				return fmt.Errorf("service account validation for %s: %w", email, saErr)
 			}
 

--- a/cmd/msgvault/cmd/addaccount_test.go
+++ b/cmd/msgvault/cmd/addaccount_test.go
@@ -691,3 +691,115 @@ func TestAddAccount_HeadlessExplicitEmptyOAuthApp(t *testing.T) {
 		)
 	}
 }
+
+func TestAddAccount_HeadlessServiceAccountReturnsActionableError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	savedCfg := cfg
+	savedLogger := logger
+	savedHeadless := headless
+	savedOAuthApp := oauthAppName
+	savedForce := forceReauth
+	defer func() {
+		cfg = savedCfg
+		logger = savedLogger
+		headless = savedHeadless
+		oauthAppName = savedOAuthApp
+		forceReauth = savedForce
+	}()
+
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+		OAuth: config.OAuthConfig{
+			Apps: map[string]config.OAuthApp{
+				"workspace": {ServiceAccountKey: filepath.Join(tmpDir, "service-account.json")},
+			},
+		},
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	testCmd := &cobra.Command{
+		Use:  "add-account <email>",
+		Args: cobra.ExactArgs(1),
+		RunE: addAccountCmd.RunE,
+	}
+	testCmd.Flags().StringVar(&oauthAppName, "oauth-app", "", "")
+	testCmd.Flags().BoolVar(&headless, "headless", false, "")
+	testCmd.Flags().BoolVar(&forceReauth, "force", false, "")
+	testCmd.Flags().StringVar(&accountDisplayName, "display-name", "", "")
+
+	root := newTestRootCmd()
+	root.AddCommand(testCmd)
+	root.SetArgs([]string{
+		"add-account", "user@company.com",
+		"--headless", "--oauth-app", "workspace",
+	})
+
+	getOutput := captureStdout(t)
+	err := root.Execute()
+	output := getOutput()
+
+	if err == nil {
+		t.Fatal("expected --headless service account error")
+	}
+	if !strings.Contains(err.Error(), "service accounts do not use --headless") {
+		t.Fatalf("error = %v, want service accounts do not use --headless", err)
+	}
+	if strings.Contains(output, "Headless Server Setup") {
+		t.Fatalf("service account path should not print browser OAuth headless instructions:\n%s", output)
+	}
+}
+
+func TestAddAccount_ForceServiceAccountReturnsActionableError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	savedCfg := cfg
+	savedLogger := logger
+	savedHeadless := headless
+	savedOAuthApp := oauthAppName
+	savedForce := forceReauth
+	defer func() {
+		cfg = savedCfg
+		logger = savedLogger
+		headless = savedHeadless
+		oauthAppName = savedOAuthApp
+		forceReauth = savedForce
+	}()
+
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+		OAuth: config.OAuthConfig{
+			Apps: map[string]config.OAuthApp{
+				"workspace": {ServiceAccountKey: filepath.Join(tmpDir, "service-account.json")},
+			},
+		},
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	testCmd := &cobra.Command{
+		Use:  "add-account <email>",
+		Args: cobra.ExactArgs(1),
+		RunE: addAccountCmd.RunE,
+	}
+	testCmd.Flags().StringVar(&oauthAppName, "oauth-app", "", "")
+	testCmd.Flags().BoolVar(&headless, "headless", false, "")
+	testCmd.Flags().BoolVar(&forceReauth, "force", false, "")
+	testCmd.Flags().StringVar(&accountDisplayName, "display-name", "", "")
+
+	root := newTestRootCmd()
+	root.AddCommand(testCmd)
+	root.SetArgs([]string{
+		"add-account", "user@company.com",
+		"--force", "--oauth-app", "workspace",
+	})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected --force service account error")
+	}
+	if !strings.Contains(err.Error(), "service accounts do not use --force") {
+		t.Fatalf("error = %v, want service accounts do not use --force", err)
+	}
+}

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -421,30 +421,36 @@ Examples:
 
 		// For Gmail, handle scope escalation before building the client.
 		// buildAPIClient uses standard scopes; deletion may need elevated ones.
+		// Service-account flows get scopes via the JWT assertion (no stored
+		// token), so the scope-escalation prompt only applies to browser OAuth.
 		var clientSecretsPath string
 		if src.SourceType == "gmail" {
 			if !cfg.OAuth.HasAnyConfig() {
 				return errOAuthNotConfigured()
 			}
 			appName := sourceOAuthApp(src)
-			clientSecretsPath, err = cfg.OAuth.ClientSecretsFor(appName)
-			if err != nil {
-				return err
-			}
+			isServiceAccount := cfg.OAuth.ServiceAccountKeyFor(appName) != ""
 
-			needsBatchDelete := !deleteTrash
-			if needsBatchDelete {
-				requiredScopes := oauth.ScopesDeletion
-				oauthMgr, err := oauth.NewManagerWithScopes(clientSecretsPath, cfg.TokensDir(), logger, requiredScopes)
+			if !isServiceAccount {
+				clientSecretsPath, err = cfg.OAuth.ClientSecretsFor(appName)
 				if err != nil {
-					return wrapOAuthError(fmt.Errorf("create oauth manager: %w", err))
+					return err
 				}
-				if !oauthMgr.HasScope(account, "https://mail.google.com/") && oauthMgr.HasScopeMetadata(account) {
-					if err := promptScopeEscalation(ctx, oauthMgr, account, needsBatchDelete, clientSecretsPath); err != nil {
-						if errors.Is(err, errUserCanceled) {
-							return nil
+
+				needsBatchDelete := !deleteTrash
+				if needsBatchDelete {
+					requiredScopes := oauth.ScopesDeletion
+					oauthMgr, err := oauth.NewManagerWithScopes(clientSecretsPath, cfg.TokensDir(), logger, requiredScopes)
+					if err != nil {
+						return wrapOAuthError(fmt.Errorf("create oauth manager: %w", err))
+					}
+					if !oauthMgr.HasScope(account, "https://mail.google.com/") && oauthMgr.HasScopeMetadata(account) {
+						if err := promptScopeEscalation(ctx, oauthMgr, account, needsBatchDelete, clientSecretsPath); err != nil {
+							if errors.Is(err, errUserCanceled) {
+								return nil
+							}
+							return err
 						}
-						return err
 					}
 				}
 			}

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -466,7 +466,13 @@ Examples:
 			}
 			return oauth.NewManagerWithScopes(secretsPath, cfg.TokensDir(), logger, scopes)
 		}
-		client, err := buildAPIClient(ctx, src, getOAuthMgr)
+		// For permanent deletion (not trash), service-account flows need the
+		// elevated mail.google.com scope; trash-only uses the standard set.
+		saScopes := oauth.Scopes
+		if !deleteTrash {
+			saScopes = oauth.ScopesDeletion
+		}
+		client, err := buildAPIClient(ctx, src, getOAuthMgr, saScopes)
 		if err != nil {
 			return err
 		}

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -522,6 +522,14 @@ Examples:
 
 				// Check if this is a scope error - offer to re-authorize (Gmail only)
 				if src.SourceType == "gmail" && isInsufficientScopeError(execErr) {
+					if cfg.OAuth.ServiceAccountKeyFor(sourceOAuthApp(src)) != "" {
+						return fmt.Errorf(
+							"service account lacks required Gmail deletion scope for %s: "+
+								"authorize https://mail.google.com/ for the service account client "+
+								"in Google Admin Console, then run delete-staged again",
+							account,
+						)
+					}
 					oauthMgr, mgrErr := getOAuthMgr(sourceOAuthApp(src))
 					if mgrErr != nil {
 						return mgrErr

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/wesm/msgvault/internal/search"
 	"github.com/wesm/msgvault/internal/store"
 	"github.com/wesm/msgvault/internal/sync"
+	"golang.org/x/oauth2"
 )
 
 var serveCmd = &cobra.Command{
@@ -342,19 +343,34 @@ func runScheduledSync(ctx context.Context, email string, s *store.Store, getOAut
 		appName = sourceOAuthApp(src)
 	}
 
-	oauthMgr, err := getOAuthMgr(appName)
-	if err != nil {
-		return fmt.Errorf("resolve OAuth credentials for %s: %w", email, err)
-	}
+	var tokenSource oauth2.TokenSource
+	var tsErr error
 
-	// Get token source — intentionally not using getTokenSourceWithReauth here
-	// because serve runs as a daemon and cannot open a browser for OAuth.
-	tokenSource, err := oauthMgr.TokenSource(ctx, email)
-	if err != nil {
-		if oauthMgr.HasToken(email) {
-			return fmt.Errorf("get token source: %w (token may be expired; run 'sync %s' or 'verify %s' from an interactive terminal to re-authorize)", err, email, email)
+	// Check for service account configuration
+	if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(appName); saKeyPath != "" {
+		saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
+		if saErr != nil {
+			return fmt.Errorf("service account for %s: %w", email, saErr)
 		}
-		return fmt.Errorf("get token source: %w (run 'add-account %s' first)", err, email)
+		tokenSource, tsErr = saMgr.TokenSource(ctx, email)
+		if tsErr != nil {
+			return fmt.Errorf("service account token for %s: %w", email, tsErr)
+		}
+	} else {
+		oauthMgr, oaErr := getOAuthMgr(appName)
+		if oaErr != nil {
+			return fmt.Errorf("resolve OAuth credentials for %s: %w", email, oaErr)
+		}
+
+		// Get token source — intentionally not using getTokenSourceWithReauth here
+		// because serve runs as a daemon and cannot open a browser for OAuth.
+		tokenSource, tsErr = oauthMgr.TokenSource(ctx, email)
+		if tsErr != nil {
+			if oauthMgr.HasToken(email) {
+				return fmt.Errorf("get token source: %w (token may be expired; run 'sync %s' or 'verify %s' from an interactive terminal to re-authorize)", tsErr, email, email)
+			}
+			return fmt.Errorf("get token source: %w (run 'add-account %s' first)", tsErr, email)
+		}
 	}
 
 	// Create Gmail client

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/wesm/msgvault/internal/oauth"
 	"github.com/wesm/msgvault/internal/store"
 	"github.com/wesm/msgvault/internal/sync"
+	"golang.org/x/oauth2"
 )
 
 var syncIncrementalCmd = &cobra.Command{
@@ -128,18 +129,22 @@ Examples:
 						fmt.Printf("Skipping %s (OAuth not configured)\n", src.Identifier)
 						continue
 					}
-					mgr, mgrErr := getOAuthMgr(sourceOAuthApp(src))
-					if mgrErr != nil {
-						syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, mgrErr))
-						continue
-					}
+					appName := sourceOAuthApp(src)
 					if !src.SyncCursor.Valid || src.SyncCursor.String == "" {
 						fmt.Printf("Skipping %s (no history ID - run 'sync-full' first)\n", src.Identifier)
 						continue
 					}
-					if !mgr.HasToken(src.Identifier) {
-						fmt.Printf("Skipping %s (no OAuth token - run 'add-account' first)\n", src.Identifier)
-						continue
+					// Service accounts are always ready
+					if saKey := cfg.OAuth.ServiceAccountKeyFor(appName); saKey == "" {
+						mgr, mgrErr := getOAuthMgr(appName)
+						if mgrErr != nil {
+							syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, mgrErr))
+							continue
+						}
+						if !mgr.HasToken(src.Identifier) {
+							fmt.Printf("Skipping %s (no OAuth token - run 'add-account' first)\n", src.Identifier)
+							continue
+						}
 					}
 					gmailTargets = append(gmailTargets, syncTarget{source: src, email: src.Identifier})
 				case "imap":
@@ -214,17 +219,31 @@ func runIncrementalSync(ctx context.Context, s *store.Store, getOAuthMgr func(st
 		return fmt.Errorf("no history ID - run 'sync-full' first")
 	}
 
-	oauthMgr, err := getOAuthMgr(sourceOAuthApp(source))
-	if err != nil {
-		return err
-	}
-
 	email := source.Identifier
-	interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
-		isatty.IsCygwinTerminal(os.Stdin.Fd())
-	tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email, interactive)
-	if err != nil {
-		return err
+	appName := sourceOAuthApp(source)
+	var tokenSource oauth2.TokenSource
+	var tsErr error
+
+	if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(appName); saKeyPath != "" {
+		saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
+		if saErr != nil {
+			return fmt.Errorf("service account: %w", saErr)
+		}
+		tokenSource, tsErr = saMgr.TokenSource(ctx, email)
+		if tsErr != nil {
+			return tsErr
+		}
+	} else {
+		oauthMgr, oaErr := getOAuthMgr(appName)
+		if oaErr != nil {
+			return oaErr
+		}
+		interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
+			isatty.IsCygwinTerminal(os.Stdin.Fd())
+		tokenSource, tsErr = getTokenSourceWithReauth(ctx, oauthMgr, email, interactive)
+		if tsErr != nil {
+			return tsErr
+		}
 	}
 
 	// Create Gmail client

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -224,8 +224,13 @@ Examples:
 	},
 }
 
-// buildAPIClient creates the appropriate gmail.API client for the given source.
-func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(string) (*oauth.Manager, error)) (gmail.API, error) {
+// buildAPIClient creates the appropriate gmail.API client for the given
+// source. saScopes is used when the resolved oauth_app is backed by a
+// service account key; for browser-OAuth sources, scopes flow through the
+// caller-provided getOAuthMgr factory. Pass nil to use oauth.Scopes; pass
+// oauth.ScopesDeletion (or another set) for workflows that need elevated
+// access.
+func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(string) (*oauth.Manager, error), saScopes []string) (gmail.API, error) {
 	switch src.SourceType {
 	case "gmail", "":
 		appName := sourceOAuthApp(src)
@@ -233,7 +238,11 @@ func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(str
 
 		// Check for service account configuration
 		if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(appName); saKeyPath != "" {
-			saMgr, err := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
+			scopes := saScopes
+			if len(scopes) == 0 {
+				scopes = oauth.Scopes
+			}
+			saMgr, err := oauth.NewServiceAccountManager(saKeyPath, scopes)
 			if err != nil {
 				return nil, fmt.Errorf("service account: %w", err)
 			}
@@ -321,7 +330,7 @@ func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(str
 }
 
 func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), src *store.Source, vf *vectorFeatures) error {
-	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr)
+	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wesm/msgvault/internal/oauth"
 	"github.com/wesm/msgvault/internal/store"
 	"github.com/wesm/msgvault/internal/sync"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -118,14 +119,20 @@ Examples:
 						fmt.Printf("Skipping %s (OAuth not configured)\n", src.Identifier)
 						continue
 					}
-					mgr, err := getOAuthMgr(sourceOAuthApp(src))
-					if err != nil {
-						syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, err))
-						continue
-					}
-					if !mgr.HasToken(src.Identifier) {
-						fmt.Printf("Skipping %s (no OAuth token - run 'add-account' first)\n", src.Identifier)
-						continue
+					appName := sourceOAuthApp(src)
+					// Service accounts are always ready — no per-user token needed
+					if saKey := cfg.OAuth.ServiceAccountKeyFor(appName); saKey != "" {
+						// Service account configured, skip token check
+					} else {
+						mgr, err := getOAuthMgr(appName)
+						if err != nil {
+							syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, err))
+							continue
+						}
+						if !mgr.HasToken(src.Identifier) {
+							fmt.Printf("Skipping %s (no OAuth token - run 'add-account' first)\n", src.Identifier)
+							continue
+						}
 					}
 				case "imap":
 					skipMsg, parseErr := imapSkipReason(src)
@@ -183,11 +190,14 @@ Examples:
 				break
 			}
 
-			// Ensure the OAuth manager is initialized before syncing Gmail sources.
+			// Ensure credentials are available before syncing Gmail sources.
 			if src.SourceType == "gmail" || src.SourceType == "" {
-				if _, err := getOAuthMgr(sourceOAuthApp(src)); err != nil {
-					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, err))
-					continue
+				appName := sourceOAuthApp(src)
+				if cfg.OAuth.ServiceAccountKeyFor(appName) == "" {
+					if _, err := getOAuthMgr(appName); err != nil {
+						syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, err))
+						continue
+					}
 				}
 			}
 
@@ -218,15 +228,30 @@ Examples:
 func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(string) (*oauth.Manager, error)) (gmail.API, error) {
 	switch src.SourceType {
 	case "gmail", "":
-		oauthMgr, err := getOAuthMgr(sourceOAuthApp(src))
-		if err != nil {
-			return nil, err
-		}
-		interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
-			isatty.IsCygwinTerminal(os.Stdin.Fd())
-		tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, src.Identifier, interactive)
-		if err != nil {
-			return nil, err
+		appName := sourceOAuthApp(src)
+		var tokenSource oauth2.TokenSource
+
+		// Check for service account configuration
+		if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(appName); saKeyPath != "" {
+			saMgr, err := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
+			if err != nil {
+				return nil, fmt.Errorf("service account: %w", err)
+			}
+			tokenSource, err = saMgr.TokenSource(ctx, src.Identifier)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			oauthMgr, err := getOAuthMgr(appName)
+			if err != nil {
+				return nil, err
+			}
+			interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
+				isatty.IsCygwinTerminal(os.Stdin.Fd())
+			tokenSource, err = getTokenSourceWithReauth(ctx, oauthMgr, src.Identifier, interactive)
+			if err != nil {
+				return nil, err
+			}
 		}
 		rateLimiter := gmail.NewRateLimiter(float64(cfg.Sync.RateLimitQPS))
 		return gmail.NewClient(tokenSource,

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -121,9 +121,7 @@ Examples:
 					}
 					appName := sourceOAuthApp(src)
 					// Service accounts are always ready — no per-user token needed
-					if saKey := cfg.OAuth.ServiceAccountKeyFor(appName); saKey != "" {
-						// Service account configured, skip token check
-					} else {
+					if cfg.OAuth.ServiceAccountKeyFor(appName) == "" {
 						mgr, err := getOAuthMgr(appName)
 						if err != nil {
 							syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, err))

--- a/cmd/msgvault/cmd/verify.go
+++ b/cmd/msgvault/cmd/verify.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wesm/msgvault/internal/mime"
 	"github.com/wesm/msgvault/internal/oauth"
 	"github.com/wesm/msgvault/internal/store"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -91,19 +92,8 @@ Examples:
 			appName = sourceOAuthApp(src)
 		}
 
-		// Resolve OAuth credentials
-		clientSecretsPath, err := cfg.OAuth.ClientSecretsFor(appName)
-		if err != nil {
-			if !cfg.OAuth.HasAnyConfig() {
-				return errOAuthNotConfigured()
-			}
-			return err
-		}
-
-		// Create OAuth manager and get token source
-		oauthMgr, err := oauth.NewManager(clientSecretsPath, cfg.TokensDir(), logger)
-		if err != nil {
-			return wrapOAuthError(fmt.Errorf("create oauth manager: %w", err))
+		if !cfg.OAuth.HasAnyConfig() {
+			return errOAuthNotConfigured()
 		}
 
 		// Set up context with cancellation
@@ -119,11 +109,34 @@ Examples:
 			cancel()
 		}()
 
-		interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
-			isatty.IsCygwinTerminal(os.Stdin.Fd())
-		tokenSource, err := getTokenSourceWithReauth(ctx, oauthMgr, email, interactive)
-		if err != nil {
-			return err
+		// Resolve a Gmail token source. Service-account-bound sources mint
+		// a fresh JWT-based token on demand; browser-OAuth sources reuse
+		// the stored refresh token (and may prompt for re-auth in TTY).
+		var tokenSource oauth2.TokenSource
+		if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(appName); saKeyPath != "" {
+			saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
+			if saErr != nil {
+				return fmt.Errorf("service account: %w", saErr)
+			}
+			tokenSource, err = saMgr.TokenSource(ctx, email)
+			if err != nil {
+				return fmt.Errorf("service account token for %s: %w", email, err)
+			}
+		} else {
+			clientSecretsPath, secretsErr := cfg.OAuth.ClientSecretsFor(appName)
+			if secretsErr != nil {
+				return secretsErr
+			}
+			oauthMgr, mgrErr := oauth.NewManager(clientSecretsPath, cfg.TokensDir(), logger)
+			if mgrErr != nil {
+				return wrapOAuthError(fmt.Errorf("create oauth manager: %w", mgrErr))
+			}
+			interactive := isatty.IsTerminal(os.Stdin.Fd()) ||
+				isatty.IsCygwinTerminal(os.Stdin.Fd())
+			tokenSource, err = getTokenSourceWithReauth(ctx, oauthMgr, email, interactive)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Create Gmail client (no rate limiter needed for single call)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,13 +129,15 @@ type DataConfig struct {
 
 // OAuthApp holds configuration for a named OAuth application.
 type OAuthApp struct {
-	ClientSecrets string `toml:"client_secrets"`
+	ClientSecrets     string `toml:"client_secrets"`
+	ServiceAccountKey string `toml:"service_account_key"`
 }
 
 // OAuthConfig holds OAuth configuration.
 type OAuthConfig struct {
-	ClientSecrets string              `toml:"client_secrets"`
-	Apps          map[string]OAuthApp `toml:"apps"`
+	ClientSecrets     string              `toml:"client_secrets"`
+	ServiceAccountKey string              `toml:"service_account_key"`
+	Apps              map[string]OAuthApp `toml:"apps"`
 }
 
 // ClientSecretsFor returns the client secrets path for the given app name.
@@ -160,14 +162,27 @@ func (o *OAuthConfig) ClientSecretsFor(name string) (string, error) {
 	return app.ClientSecrets, nil
 }
 
+// ServiceAccountKeyFor returns the service account key path for the given app name.
+// Empty name returns the default. Non-empty name looks up Apps[name].
+// Returns "" if no service account key is configured for the given app.
+func (o *OAuthConfig) ServiceAccountKeyFor(name string) string {
+	if name == "" {
+		return o.ServiceAccountKey
+	}
+	if app, ok := o.Apps[name]; ok {
+		return app.ServiceAccountKey
+	}
+	return ""
+}
+
 // HasAnyConfig returns true if any OAuth configuration exists
 // (default or named apps).
 func (o *OAuthConfig) HasAnyConfig() bool {
-	if o.ClientSecrets != "" {
+	if o.ClientSecrets != "" || o.ServiceAccountKey != "" {
 		return true
 	}
 	for _, app := range o.Apps {
-		if app.ClientSecrets != "" {
+		if app.ClientSecrets != "" || app.ServiceAccountKey != "" {
 			return true
 		}
 	}
@@ -292,9 +307,11 @@ func Load(path, homeDir string) (*Config, error) {
 	cfg.Data.DataDir = expandPath(cfg.Data.DataDir)
 	cfg.Log.Dir = expandPath(cfg.Log.Dir)
 	cfg.OAuth.ClientSecrets = expandPath(cfg.OAuth.ClientSecrets)
+	cfg.OAuth.ServiceAccountKey = expandPath(cfg.OAuth.ServiceAccountKey)
 	cfg.Vector.DBPath = expandPath(cfg.Vector.DBPath)
 	for name, app := range cfg.OAuth.Apps {
 		app.ClientSecrets = expandPath(app.ClientSecrets)
+		app.ServiceAccountKey = expandPath(app.ServiceAccountKey)
 		cfg.OAuth.Apps[name] = app
 	}
 
@@ -304,9 +321,11 @@ func Load(path, homeDir string) (*Config, error) {
 		cfg.Data.DataDir = resolveRelative(cfg.Data.DataDir, cfg.HomeDir)
 		cfg.Log.Dir = resolveRelative(cfg.Log.Dir, cfg.HomeDir)
 		cfg.OAuth.ClientSecrets = resolveRelative(cfg.OAuth.ClientSecrets, cfg.HomeDir)
+		cfg.OAuth.ServiceAccountKey = resolveRelative(cfg.OAuth.ServiceAccountKey, cfg.HomeDir)
 		cfg.Vector.DBPath = resolveRelative(cfg.Vector.DBPath, cfg.HomeDir)
 		for name, app := range cfg.OAuth.Apps {
 			app.ClientSecrets = resolveRelative(app.ClientSecrets, cfg.HomeDir)
+			app.ServiceAccountKey = resolveRelative(app.ServiceAccountKey, cfg.HomeDir)
 			cfg.OAuth.Apps[name] = app
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1208,6 +1208,35 @@ func TestOAuthConfig_ClientSecretsFor(t *testing.T) {
 	}
 }
 
+func TestOAuthConfig_ServiceAccountKeyFor(t *testing.T) {
+	cfg := OAuthConfig{
+		ServiceAccountKey: "/keys/default.json",
+		Apps: map[string]OAuthApp{
+			"workspace": {ServiceAccountKey: "/keys/workspace.json"},
+			"oauth":     {ClientSecrets: "/secrets/oauth.json"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		appName string
+		want    string
+	}{
+		{"default", "", "/keys/default.json"},
+		{"named app", "workspace", "/keys/workspace.json"},
+		{"named app without service account", "oauth", ""},
+		{"missing app", "missing", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cfg.ServiceAccountKeyFor(tt.appName); got != tt.want {
+				t.Errorf("ServiceAccountKeyFor(%q) = %q, want %q", tt.appName, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOAuthConfig_HasAnyConfig(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1241,6 +1270,30 @@ func TestOAuthConfig_HasAnyConfig(t *testing.T) {
 				},
 			},
 			want: false,
+		},
+		{
+			name:   "default service account only",
+			config: OAuthConfig{ServiceAccountKey: "/path/to/service-account.json"},
+			want:   true,
+		},
+		{
+			name: "named service account only",
+			config: OAuthConfig{
+				Apps: map[string]OAuthApp{
+					"workspace": {ServiceAccountKey: "/path/to/workspace.json"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "mixed oauth and service account",
+			config: OAuthConfig{
+				ClientSecrets: "/path/to/default.json",
+				Apps: map[string]OAuthApp{
+					"workspace": {ServiceAccountKey: "/path/to/workspace.json"},
+				},
+			},
+			want: true,
 		},
 	}
 
@@ -1453,6 +1506,76 @@ client_secrets = "secrets/acme.json"
 	}
 	if acme.ClientSecrets != expectedAcme {
 		t.Errorf("Apps[acme].ClientSecrets = %q, want %q", acme.ClientSecrets, expectedAcme)
+	}
+}
+
+func TestLoadWithServiceAccountKeysExpandsPaths(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("MSGVAULT_HOME", tmpDir)
+
+	configContent := `
+[oauth]
+service_account_key = "~/keys/default-service-account.json"
+
+[oauth.apps.workspace]
+service_account_key = "~/keys/workspace-service-account.json"
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg, err := Load("", "")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	expectedDefault := filepath.Join(home, "keys/default-service-account.json")
+	if cfg.OAuth.ServiceAccountKey != expectedDefault {
+		t.Errorf("ServiceAccountKey = %q, want %q", cfg.OAuth.ServiceAccountKey, expectedDefault)
+	}
+
+	expectedWorkspace := filepath.Join(home, "keys/workspace-service-account.json")
+	workspace := cfg.OAuth.Apps["workspace"]
+	if workspace.ServiceAccountKey != expectedWorkspace {
+		t.Errorf("Apps[workspace].ServiceAccountKey = %q, want %q", workspace.ServiceAccountKey, expectedWorkspace)
+	}
+}
+
+func TestLoadWithServiceAccountKeysResolvesRelativePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configContent := `
+[oauth]
+service_account_key = "keys/default-service-account.json"
+
+[oauth.apps.workspace]
+service_account_key = "keys/workspace-service-account.json"
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg, err := Load(configPath, "")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	expectedDefault := filepath.Join(tmpDir, "keys/default-service-account.json")
+	if cfg.OAuth.ServiceAccountKey != expectedDefault {
+		t.Errorf("ServiceAccountKey = %q, want %q", cfg.OAuth.ServiceAccountKey, expectedDefault)
+	}
+
+	expectedWorkspace := filepath.Join(tmpDir, "keys/workspace-service-account.json")
+	workspace := cfg.OAuth.Apps["workspace"]
+	if workspace.ServiceAccountKey != expectedWorkspace {
+		t.Errorf("Apps[workspace].ServiceAccountKey = %q, want %q", workspace.ServiceAccountKey, expectedWorkspace)
 	}
 }
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -702,6 +702,44 @@ func TokenFilePath(tokensDir, email string) string {
 	return filepath.Join(tokensDir, safe+".json")
 }
 
+// ValidateTokenEmail calls the Gmail profile API to confirm that the token
+// source can access the given email account. Used by service account flows
+// where no Manager is available.
+func ValidateTokenEmail(ctx context.Context, ts oauth2.TokenSource, email string) error {
+	valCtx, cancel := context.WithTimeout(ctx, resolveTimeout)
+	defer cancel()
+
+	client := oauth2.NewClient(valCtx, ts)
+	req, err := http.NewRequestWithContext(valCtx, "GET", defaultProfileURL, nil)
+	if err != nil {
+		return fmt.Errorf("create profile request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("verify access to %s: %w", email, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Gmail API returned HTTP %d for %s: %s", resp.StatusCode, email, string(body))
+	}
+
+	var profile struct {
+		EmailAddress string `json:"emailAddress"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&profile); err != nil {
+		return fmt.Errorf("parse profile for %s: %w", email, err)
+	}
+
+	if !sameGoogleAccount(email, profile.EmailAddress) {
+		return &TokenMismatchError{Expected: email, Actual: profile.EmailAddress}
+	}
+
+	return nil
+}
+
 // DeleteToken removes the token file for the given email.
 func (m *Manager) DeleteToken(email string) error {
 	path := m.tokenPath(email)

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -307,56 +307,12 @@ const resolveTimeout = 10 * time.Second
 func (m *Manager) resolveTokenEmail(
 	ctx context.Context, email string, token *oauth2.Token,
 ) (string, error) {
-	valCtx, cancel := context.WithTimeout(ctx, resolveTimeout)
-	defer cancel()
-
-	ts := m.config.TokenSource(valCtx, token)
-	client := oauth2.NewClient(valCtx, ts)
-
 	profileURL := m.profileURL
 	if profileURL == "" {
 		profileURL = defaultProfileURL
 	}
-	req, err := http.NewRequestWithContext(valCtx, "GET", profileURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("create profile request: %w", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf(
-			"could not verify token belongs to %s: %w "+
-				"(re-run the command to try again)", email, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf(
-			"could not verify token belongs to %s: "+
-				"Gmail API returned HTTP %d: %s "+
-				"(re-run the command to try again)",
-			email, resp.StatusCode, string(body))
-	}
-
-	var profile struct {
-		EmailAddress string `json:"emailAddress"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&profile); err != nil {
-		return "", fmt.Errorf(
-			"could not verify token belongs to %s: "+
-				"failed to parse profile response: %w "+
-				"(re-run the command to try again)", email, err)
-	}
-
-	if !sameGoogleAccount(email, profile.EmailAddress) {
-		return "", &TokenMismatchError{
-			Expected: email,
-			Actual:   profile.EmailAddress,
-		}
-	}
-
-	return profile.EmailAddress, nil
+	ts := m.config.TokenSource(ctx, token)
+	return fetchTokenProfileEmail(ctx, ts, profileURL, email, tokenProfileErrorOAuth)
 }
 
 // sameGoogleAccount returns true if two email addresses belong to the
@@ -702,42 +658,78 @@ func TokenFilePath(tokensDir, email string) string {
 	return filepath.Join(tokensDir, safe+".json")
 }
 
-// ValidateTokenEmail calls the Gmail profile API to confirm that the token
-// source can access the given email account. Used by service account flows
-// where no Manager is available.
-func ValidateTokenEmail(ctx context.Context, ts oauth2.TokenSource, email string) error {
+type tokenProfileErrorMode int
+
+const (
+	tokenProfileErrorOAuth tokenProfileErrorMode = iota
+	tokenProfileErrorServiceAccount
+)
+
+func fetchTokenProfileEmail(
+	ctx context.Context,
+	ts oauth2.TokenSource,
+	profileURL string,
+	email string,
+	mode tokenProfileErrorMode,
+) (string, error) {
 	valCtx, cancel := context.WithTimeout(ctx, resolveTimeout)
 	defer cancel()
 
 	client := oauth2.NewClient(valCtx, ts)
-	req, err := http.NewRequestWithContext(valCtx, "GET", defaultProfileURL, nil)
+	req, err := http.NewRequestWithContext(valCtx, "GET", profileURL, nil)
 	if err != nil {
-		return fmt.Errorf("create profile request: %w", err)
+		return "", fmt.Errorf("create profile request: %w", err)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("verify access to %s: %w", email, err)
+		if mode == tokenProfileErrorOAuth {
+			return "", fmt.Errorf(
+				"could not verify token belongs to %s: %w "+
+					"(re-run the command to try again)", email, err)
+		}
+		return "", fmt.Errorf("verify access to %s: %w", email, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("Gmail API returned HTTP %d for %s: %s", resp.StatusCode, email, string(body))
+		if mode == tokenProfileErrorOAuth {
+			return "", fmt.Errorf(
+				"could not verify token belongs to %s: "+
+					"Gmail API returned HTTP %d: %s "+
+					"(re-run the command to try again)",
+				email, resp.StatusCode, string(body))
+		}
+		return "", fmt.Errorf("gmail API returned HTTP %d for %s: %s", resp.StatusCode, email, string(body))
 	}
 
 	var profile struct {
 		EmailAddress string `json:"emailAddress"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&profile); err != nil {
-		return fmt.Errorf("parse profile for %s: %w", email, err)
+		if mode == tokenProfileErrorOAuth {
+			return "", fmt.Errorf(
+				"could not verify token belongs to %s: "+
+					"failed to parse profile response: %w "+
+					"(re-run the command to try again)", email, err)
+		}
+		return "", fmt.Errorf("parse profile for %s: %w", email, err)
 	}
 
 	if !sameGoogleAccount(email, profile.EmailAddress) {
-		return &TokenMismatchError{Expected: email, Actual: profile.EmailAddress}
+		return "", &TokenMismatchError{Expected: email, Actual: profile.EmailAddress}
 	}
 
-	return nil
+	return profile.EmailAddress, nil
+}
+
+// ValidateTokenEmail calls the Gmail profile API to confirm that the token
+// source can access the given email account. Used by service account flows
+// where no Manager is available.
+func ValidateTokenEmail(ctx context.Context, ts oauth2.TokenSource, email string) error {
+	_, err := fetchTokenProfileEmail(ctx, ts, defaultProfileURL, email, tokenProfileErrorServiceAccount)
+	return err
 }
 
 // DeleteToken removes the token file for the given email.

--- a/internal/oauth/profile_test.go
+++ b/internal/oauth/profile_test.go
@@ -1,0 +1,94 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestFetchTokenProfileEmail(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantEmail  string
+		wantErr    string
+		wantMis    bool
+	}{
+		{
+			name:       "happy path",
+			statusCode: http.StatusOK,
+			body:       `{"emailAddress":"user@gmail.com"}`,
+			wantEmail:  "user@gmail.com",
+		},
+		{
+			name:       "mismatch",
+			statusCode: http.StatusOK,
+			body:       `{"emailAddress":"other@gmail.com"}`,
+			wantErr:    "token mismatch",
+			wantMis:    true,
+		},
+		{
+			name:       "http error",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":"invalid credentials"}`,
+			wantErr:    "gmail API returned HTTP 401",
+		},
+		{
+			name:       "decode failure",
+			statusCode: http.StatusOK,
+			body:       `not json`,
+			wantErr:    "parse profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+					t.Errorf("Authorization = %q, want Bearer test-token", got)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			defer srv.Close()
+
+			ts := oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+			})
+			got, err := fetchTokenProfileEmail(
+				context.Background(),
+				ts,
+				srv.URL,
+				"user@gmail.com",
+				tokenProfileErrorServiceAccount,
+			)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("error = nil, want %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want %q", err, tt.wantErr)
+				}
+				var mismatch *TokenMismatchError
+				if errors.As(err, &mismatch) != tt.wantMis {
+					t.Fatalf("TokenMismatchError presence = %v, want %v", errors.As(err, &mismatch), tt.wantMis)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fetchTokenProfileEmail: %v", err)
+			}
+			if got != tt.wantEmail {
+				t.Errorf("email = %q, want %q", got, tt.wantEmail)
+			}
+		})
+	}
+}

--- a/internal/oauth/serviceaccount.go
+++ b/internal/oauth/serviceaccount.go
@@ -1,0 +1,45 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// ServiceAccountManager provides OAuth2 token sources via a Google service
+// account with domain-wide delegation. No per-user token storage is needed —
+// JWTConfig.TokenSource handles JWT signing and automatic refresh.
+type ServiceAccountManager struct {
+	keyData []byte
+	scopes  []string
+}
+
+// NewServiceAccountManager creates a manager from a service account JSON key file.
+func NewServiceAccountManager(keyPath string, scopes []string) (*ServiceAccountManager, error) {
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read service account key: %w", err)
+	}
+
+	// Validate that the key parses as a service account
+	if _, err := google.JWTConfigFromJSON(data, scopes...); err != nil {
+		return nil, fmt.Errorf("parse service account key: %w", err)
+	}
+
+	return &ServiceAccountManager{keyData: data, scopes: scopes}, nil
+}
+
+// TokenSource returns an oauth2.TokenSource that impersonates the given user
+// via domain-wide delegation. The returned source automatically handles JWT
+// signing and token refresh (tokens are ~1 hour, re-signed transparently).
+func (m *ServiceAccountManager) TokenSource(ctx context.Context, email string) (oauth2.TokenSource, error) {
+	conf, err := google.JWTConfigFromJSON(m.keyData, m.scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("parse service account key: %w", err)
+	}
+	conf.Subject = email
+	return conf.TokenSource(ctx), nil
+}

--- a/internal/oauth/serviceaccount.go
+++ b/internal/oauth/serviceaccount.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -19,6 +20,22 @@ type ServiceAccountManager struct {
 
 // NewServiceAccountManager creates a manager from a service account JSON key file.
 func NewServiceAccountManager(keyPath string, scopes []string) (*ServiceAccountManager, error) {
+	if len(scopes) == 0 {
+		return nil, fmt.Errorf("service account requires at least one scope")
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("read service account key: %w", err)
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			return nil, fmt.Errorf(
+				"service account key permissions for %s are too open (%04o); use chmod 600 %s",
+				keyPath, info.Mode().Perm(), keyPath,
+			)
+		}
+	}
+
 	data, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, fmt.Errorf("read service account key: %w", err)
@@ -29,7 +46,10 @@ func NewServiceAccountManager(keyPath string, scopes []string) (*ServiceAccountM
 		return nil, fmt.Errorf("parse service account key: %w", err)
 	}
 
-	return &ServiceAccountManager{keyData: data, scopes: scopes}, nil
+	return &ServiceAccountManager{
+		keyData: data,
+		scopes:  append([]string(nil), scopes...),
+	}, nil
 }
 
 // TokenSource returns an oauth2.TokenSource that impersonates the given user

--- a/internal/oauth/serviceaccount_test.go
+++ b/internal/oauth/serviceaccount_test.go
@@ -1,0 +1,106 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeServiceAccountKey(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	pemKey := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	})
+
+	data, err := json.Marshal(map[string]string{
+		"type":           "service_account",
+		"project_id":     "test-project",
+		"private_key_id": "test-key-id",
+		"private_key":    string(pemKey),
+		"client_email":   "svc@test-project.iam.gserviceaccount.com",
+		"client_id":      "123456789",
+		"token_uri":      "https://oauth2.googleapis.com/token",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, perm); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(path, perm); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+	}
+}
+
+func TestNewServiceAccountManagerRejectsInsecureKeyPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "service-account.json")
+	writeServiceAccountKey(t, path, 0644)
+
+	_, err := NewServiceAccountManager(path, Scopes)
+	if err == nil {
+		t.Fatal("expected insecure permission error")
+	}
+	if !strings.Contains(err.Error(), "service account key permissions") {
+		t.Fatalf("error = %v, want service account key permissions", err)
+	}
+}
+
+func TestNewServiceAccountManagerAcceptsOwnerOnlyKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "service-account.json")
+	writeServiceAccountKey(t, path, 0600)
+
+	if _, err := NewServiceAccountManager(path, Scopes); err != nil {
+		t.Fatalf("NewServiceAccountManager: %v", err)
+	}
+}
+
+func TestNewServiceAccountManagerRejectsEmptyScopes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "service-account.json")
+	writeServiceAccountKey(t, path, 0600)
+
+	_, err := NewServiceAccountManager(path, nil)
+	if err == nil {
+		t.Fatal("expected empty scopes error")
+	}
+	if !strings.Contains(err.Error(), "at least one scope") {
+		t.Fatalf("error = %v, want at least one scope", err)
+	}
+}
+
+func TestNewServiceAccountManagerRejectsMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "service-account.json")
+	if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := NewServiceAccountManager(path, Scopes)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse service account key") {
+		t.Fatalf("error = %v, want parse service account key", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds optional Google service account auth (with domain-wide delegation) alongside the existing browser-OAuth flow. A single service-account key can sync any user in a Google Workspace domain — no per-user browser consent, no token files, no headless-server token-copying.

## Why

The existing OAuth flow is great for personal Gmail and small teams, but for archiving a whole Workspace domain it has friction:

- Each user needs to interactively authorize at least once
- Headless servers can't do device flow (Google blocks Gmail scopes from device flow)
- Tokens expire/get revoked, requiring re-auth

Domain-wide delegation is the standard Google answer: one service account, one key file, impersonate any user in the domain. msgvault's `oauth2.TokenSource` abstraction already absorbs the difference — only the credential plumbing needed to grow.

## Configuration

```toml
# Existing browser-OAuth flow still works exactly as before.
[oauth]
client_secrets = "/path/to/client_secret.json"

# New: a named app backed by a service-account key.
[oauth.apps.workspace]
service_account_key = "/path/to/service-account.json"
```

Either `client_secrets` or `service_account_key` (or both) can be set per app.

## Usage

```
msgvault add-account user@company.com --oauth-app workspace
# → "Account user@company.com authorized via service account."
# (no browser, no token file)

msgvault sync-full user@company.com
# uses the service account key to impersonate user@company.com
```

## Implementation

- **`internal/oauth/serviceaccount.go`** *(new)* — `ServiceAccountManager.TokenSource(email)` returns an `oauth2.TokenSource` via `google.JWTConfigFromJSON` with `Subject = email`. Auto-refreshes; no per-user storage needed.
- **`internal/oauth/oauth.go`** — adds `ValidateTokenEmail()` so callers without a `*Manager` can run the same Gmail-profile email check before persisting a source.
- **`internal/config/config.go`** — `OAuthConfig.ServiceAccountKey` and `OAuthApp.ServiceAccountKey`, plus `ServiceAccountKeyFor(name)`. `HasAnyConfig()` recognises service-account-only configs. Path expansion (`~/...`) and config-relative resolution apply to both fields.
- **`cmd/msgvault/cmd/addaccount.go`** — when the resolved app has `service_account_key`, skip the browser flow, validate access via the Gmail profile API, register the source.
- **`cmd/msgvault/cmd/{syncfull,sync,serve}.go`** — when a source is bound to a service-account app, build the `TokenSource` via `ServiceAccountManager` instead of `Manager.TokenSource`. The Gmail client is unchanged because both sides return `oauth2.TokenSource`.

The deletions in the diff are existing OAuth-flow lines wrapped into `else` branches — no functionality removed.

## Test plan

- [x] `make test` — all tests pass
- [x] Field-tested by adding 24 Workspace accounts on a real msgvault deployment with no per-user browser auth
- [x] `add-account --oauth-app workspace foo@domain` validates by hitting `/gmail/v1/users/me/profile`
- [x] Mismatched impersonation (e.g. wrong email) surfaces as `TokenMismatchError`
- [x] Mixed setup (per-user OAuth for one account, service account for the rest) works in the same daemon