### PR TITLE
feat: expose HTML email content and inline MIME parts via API

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wesm/msgvault/internal/fileutil"
 	"github.com/wesm/msgvault/internal/mime"
 	"github.com/wesm/msgvault/internal/query"
+	"github.com/wesm/msgvault/internal/remote"
 	"github.com/wesm/msgvault/internal/scheduler"
 	"github.com/wesm/msgvault/internal/search"
 	"github.com/wesm/msgvault/internal/store"
@@ -170,6 +171,73 @@ func writeError(w http.ResponseWriter, status int, err string, message string) {
 	writeJSON(w, status, ErrorResponse{Error: err, Message: message})
 }
 
+// messageDetailFromQuery builds a MessageDetail response from a query-engine
+// MessageDetail, formatting addresses the same way the store path does and
+// emitting body_html alongside body when both are present.
+func messageDetailFromQuery(qMsg *query.MessageDetail) MessageDetail {
+	from := ""
+	if len(qMsg.From) > 0 {
+		if qMsg.From[0].Name != "" {
+			from = fmt.Sprintf("%s <%s>", qMsg.From[0].Name, qMsg.From[0].Email)
+		} else {
+			from = qMsg.From[0].Email
+		}
+	}
+
+	toAddrs := make([]string, 0, len(qMsg.To))
+	for _, a := range qMsg.To {
+		toAddrs = append(toAddrs, a.Email)
+	}
+	ccAddrs := make([]string, 0, len(qMsg.Cc))
+	for _, a := range qMsg.Cc {
+		ccAddrs = append(ccAddrs, a.Email)
+	}
+	bccAddrs := make([]string, 0, len(qMsg.Bcc))
+	for _, a := range qMsg.Bcc {
+		bccAddrs = append(bccAddrs, a.Email)
+	}
+
+	labels := qMsg.Labels
+	if labels == nil {
+		labels = []string{}
+	}
+
+	body := qMsg.BodyText
+	if body == "" {
+		body = qMsg.BodyHTML
+	}
+
+	attachments := make([]AttachmentInfo, 0, len(qMsg.Attachments))
+	for _, att := range qMsg.Attachments {
+		attachments = append(attachments, AttachmentInfo{
+			Filename: att.Filename,
+			MimeType: att.MimeType,
+			Size:     att.Size,
+		})
+	}
+
+	return MessageDetail{
+		MessageSummary: MessageSummary{
+			ID:             qMsg.ID,
+			ConversationID: qMsg.ConversationID,
+			Subject:        qMsg.Subject,
+			From:           from,
+			To:             toAddrs,
+			Cc:             ccAddrs,
+			Bcc:            bccAddrs,
+			SentAt:         qMsg.SentAt.UTC().Format(time.RFC3339),
+			DeletedAt:      formatDeletedAt(qMsg.DeletedAt),
+			Snippet:        qMsg.Snippet,
+			Labels:         labels,
+			HasAttach:      qMsg.HasAttachments,
+			SizeBytes:      qMsg.SizeEstimate,
+		},
+		Body:        body,
+		BodyHTML:    qMsg.BodyHTML,
+		Attachments: attachments,
+	}
+}
+
 // toMessageSummary converts an APIMessage to a MessageSummary for API responses.
 func toMessageSummary(m APIMessage) MessageSummary {
 	to := m.To
@@ -282,80 +350,21 @@ func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 
 	if s.engine != nil {
 		qMsg, err := s.engine.GetMessage(r.Context(), id)
-		if err != nil {
+		switch {
+		case err != nil && !isEngineUnsupported(err):
 			s.logger.Error("failed to get message via engine", "id", id, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to retrieve message")
 			return
-		}
-		if qMsg == nil {
+		case err == nil && qMsg == nil:
 			writeError(w, http.StatusNotFound, "not_found", "Message not found")
 			return
+		case err == nil:
+			writeJSON(w, http.StatusOK, messageDetailFromQuery(qMsg))
+			return
 		}
-
-		from := ""
-		if len(qMsg.From) > 0 {
-			if qMsg.From[0].Name != "" {
-				from = fmt.Sprintf("%s <%s>", qMsg.From[0].Name, qMsg.From[0].Email)
-			} else {
-				from = qMsg.From[0].Email
-			}
-		}
-
-		toAddrs := make([]string, 0, len(qMsg.To))
-		for _, a := range qMsg.To {
-			toAddrs = append(toAddrs, a.Email)
-		}
-		ccAddrs := make([]string, 0, len(qMsg.Cc))
-		for _, a := range qMsg.Cc {
-			ccAddrs = append(ccAddrs, a.Email)
-		}
-		bccAddrs := make([]string, 0, len(qMsg.Bcc))
-		for _, a := range qMsg.Bcc {
-			bccAddrs = append(bccAddrs, a.Email)
-		}
-
-		labels := qMsg.Labels
-		if labels == nil {
-			labels = []string{}
-		}
-
-		body := qMsg.BodyText
-		if body == "" {
-			body = qMsg.BodyHTML
-		}
-
-		detail := MessageDetail{
-			MessageSummary: MessageSummary{
-				ID:             qMsg.ID,
-				ConversationID: qMsg.ConversationID,
-				Subject:        qMsg.Subject,
-				From:           from,
-				To:             toAddrs,
-				Cc:             ccAddrs,
-				Bcc:            bccAddrs,
-				SentAt:         qMsg.SentAt.UTC().Format(time.RFC3339),
-				DeletedAt:      formatDeletedAt(qMsg.DeletedAt),
-				Snippet:        qMsg.Snippet,
-				Labels:         labels,
-				HasAttach:      qMsg.HasAttachments,
-				SizeBytes:      qMsg.SizeEstimate,
-			},
-			Body:     body,
-			BodyHTML: qMsg.BodyHTML,
-		}
-
-		attachments := make([]AttachmentInfo, 0, len(qMsg.Attachments))
-		for _, att := range qMsg.Attachments {
-			attachments = append(attachments, AttachmentInfo{
-				Filename: att.Filename,
-				MimeType: att.MimeType,
-				Size:     att.Size,
-			})
-		}
-		detail.Attachments = attachments
-
-		writeJSON(w, http.StatusOK, detail)
-		return
+		// err is unsupported sentinel — fall through to store path so
+		// engines that don't implement GetMessage still serve detail
+		// requests via the underlying SQLite store.
 	}
 
 	if s.store == nil {
@@ -1604,6 +1613,15 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// isEngineUnsupported reports whether err indicates the configured query
+// engine cannot satisfy the requested operation. Postgres and remote engines
+// both have methods that return sentinel errors instead of data; mapping
+// those to a stable status code keeps the API honest about engine
+// capabilities rather than emitting 500 for predictable misses.
+func isEngineUnsupported(err error) bool {
+	return errors.Is(err, query.ErrNotImplemented) || errors.Is(err, remote.ErrNotSupported)
+}
+
 // handleMessageInline serves a CID-referenced inline MIME part (e.g. an
 // embedded image) from the raw message data. The CID is passed as a `cid`
 // query parameter so values containing `/` (legal per RFC 5322) round-trip
@@ -1629,6 +1647,10 @@ func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 
 	raw, err := s.engine.GetMessageRaw(r.Context(), id)
 	if err != nil {
+		if isEngineUnsupported(err) {
+			writeError(w, http.StatusNotImplemented, "not_supported", "Inline MIME parts are not available on this engine")
+			return
+		}
 		s.logger.Error("failed to get raw MIME for inline part", "error", err, "id", id, "cid", cidParam)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load message")
 		return

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/wesm/msgvault/internal/config"
 	"github.com/wesm/msgvault/internal/fileutil"
+	"github.com/wesm/msgvault/internal/mime"
 	"github.com/wesm/msgvault/internal/query"
 	"github.com/wesm/msgvault/internal/scheduler"
 	"github.com/wesm/msgvault/internal/search"
@@ -91,6 +92,7 @@ type MessageSummary struct {
 type MessageDetail struct {
 	MessageSummary
 	Body        string           `json:"body"`
+	BodyHTML    string           `json:"body_html,omitempty"`
 	Attachments []AttachmentInfo `json:"attachments"`
 }
 
@@ -268,16 +270,95 @@ func (s *Server) handleListMessages(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleGetMessage returns a single message by ID.
+// When the query engine is available, it returns separate body_html for rich
+// rendering; otherwise it falls back to the store layer (plain Body only).
 func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "store_unavailable", "Database not available")
-		return
-	}
-
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_id", "Message ID must be a number")
+		return
+	}
+
+	if s.engine != nil {
+		qMsg, err := s.engine.GetMessage(r.Context(), id)
+		if err != nil {
+			s.logger.Error("failed to get message via engine", "id", id, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to retrieve message")
+			return
+		}
+		if qMsg == nil {
+			writeError(w, http.StatusNotFound, "not_found", "Message not found")
+			return
+		}
+
+		from := ""
+		if len(qMsg.From) > 0 {
+			if qMsg.From[0].Name != "" {
+				from = fmt.Sprintf("%s <%s>", qMsg.From[0].Name, qMsg.From[0].Email)
+			} else {
+				from = qMsg.From[0].Email
+			}
+		}
+
+		toAddrs := make([]string, 0, len(qMsg.To))
+		for _, a := range qMsg.To {
+			toAddrs = append(toAddrs, a.Email)
+		}
+		ccAddrs := make([]string, 0, len(qMsg.Cc))
+		for _, a := range qMsg.Cc {
+			ccAddrs = append(ccAddrs, a.Email)
+		}
+		bccAddrs := make([]string, 0, len(qMsg.Bcc))
+		for _, a := range qMsg.Bcc {
+			bccAddrs = append(bccAddrs, a.Email)
+		}
+
+		labels := qMsg.Labels
+		if labels == nil {
+			labels = []string{}
+		}
+
+		body := qMsg.BodyText
+		if body == "" {
+			body = qMsg.BodyHTML
+		}
+
+		detail := MessageDetail{
+			MessageSummary: MessageSummary{
+				ID:             qMsg.ID,
+				ConversationID: qMsg.ConversationID,
+				Subject:        qMsg.Subject,
+				From:           from,
+				To:             toAddrs,
+				Cc:             ccAddrs,
+				Bcc:            bccAddrs,
+				SentAt:         qMsg.SentAt.UTC().Format(time.RFC3339),
+				Snippet:        qMsg.Snippet,
+				Labels:         labels,
+				HasAttach:      qMsg.HasAttachments,
+				SizeBytes:      qMsg.SizeEstimate,
+			},
+			Body:     body,
+			BodyHTML: qMsg.BodyHTML,
+		}
+
+		attachments := make([]AttachmentInfo, 0, len(qMsg.Attachments))
+		for _, att := range qMsg.Attachments {
+			attachments = append(attachments, AttachmentInfo{
+				Filename: att.Filename,
+				MimeType: att.MimeType,
+				Size:     att.Size,
+			})
+		}
+		detail.Attachments = attachments
+
+		writeJSON(w, http.StatusOK, detail)
+		return
+	}
+
+	if s.store == nil {
+		writeError(w, http.StatusServiceUnavailable, "store_unavailable", "Database not available")
 		return
 	}
 
@@ -1520,4 +1601,60 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		"offset":   offset,
 		"limit":    limit,
 	})
+}
+
+// handleMessageInline serves a CID-referenced inline MIME part (e.g. an
+// embedded image) from the raw message data.
+func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
+	if s.engine == nil {
+		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_id", "Message ID must be a number")
+		return
+	}
+
+	cidParam := chi.URLParam(r, "cid")
+	if cidParam == "" {
+		writeError(w, http.StatusBadRequest, "missing_cid", "Missing content ID")
+		return
+	}
+
+	raw, err := s.engine.GetMessageRaw(r.Context(), id)
+	if err != nil {
+		s.logger.Error("failed to get raw MIME for inline part", "error", err, "id", id)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load message")
+		return
+	}
+	if raw == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Message raw data not found")
+		return
+	}
+
+	parsed, err := mime.Parse(raw)
+	if err != nil {
+		s.logger.Error("failed to parse MIME for inline part", "error", err, "id", id)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to parse message")
+		return
+	}
+
+	for _, att := range parsed.Attachments {
+		if att.ContentID == cidParam {
+			contentType := att.ContentType
+			if contentType == "" {
+				contentType = "application/octet-stream"
+			}
+			w.Header().Set("Content-Type", contentType)
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			_, _ = w.Write(att.Content)
+			return
+		}
+	}
+
+	writeError(w, http.StatusNotFound, "not_found", "Inline part not found")
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1604,7 +1604,9 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleMessageInline serves a CID-referenced inline MIME part (e.g. an
-// embedded image) from the raw message data.
+// embedded image) from the raw message data. The CID is passed as a `cid`
+// query parameter so values containing `/` (legal per RFC 5322) round-trip
+// without ambiguity in the routing layer.
 func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 	if s.engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
@@ -1618,9 +1620,9 @@ func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cidParam := chi.URLParam(r, "cid")
+	cidParam := r.URL.Query().Get("cid")
 	if cidParam == "" {
-		writeError(w, http.StatusBadRequest, "missing_cid", "Missing content ID")
+		writeError(w, http.StatusBadRequest, "missing_cid", "Missing 'cid' query parameter")
 		return
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -334,6 +334,7 @@ func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 				Cc:             ccAddrs,
 				Bcc:            bccAddrs,
 				SentAt:         qMsg.SentAt.UTC().Format(time.RFC3339),
+				DeletedAt:      formatDeletedAt(qMsg.DeletedAt),
 				Snippet:        qMsg.Snippet,
 				Labels:         labels,
 				HasAttach:      qMsg.HasAttachments,

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1626,7 +1626,7 @@ func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 
 	raw, err := s.engine.GetMessageRaw(r.Context(), id)
 	if err != nil {
-		s.logger.Error("failed to get raw MIME for inline part", "error", err, "id", id)
+		s.logger.Error("failed to get raw MIME for inline part", "error", err, "id", id, "cid", cidParam)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load message")
 		return
 	}
@@ -1637,7 +1637,7 @@ func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 
 	parsed, err := mime.Parse(raw)
 	if err != nil {
-		s.logger.Error("failed to parse MIME for inline part", "error", err, "id", id)
+		s.logger.Error("failed to parse MIME for inline part", "error", err, "id", id, "cid", cidParam)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to parse message")
 		return
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1643,17 +1643,20 @@ func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, att := range parsed.Attachments {
-		if att.ContentID == cidParam {
-			contentType := att.ContentType
-			if contentType == "" {
-				contentType = "application/octet-stream"
-			}
-			w.Header().Set("Content-Type", contentType)
-			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-			w.Header().Set("X-Content-Type-Options", "nosniff")
-			_, _ = w.Write(att.Content)
+		if !att.IsInline || att.ContentID != cidParam {
+			continue
+		}
+		ct := strings.ToLower(strings.TrimSpace(att.ContentType))
+		if !strings.HasPrefix(ct, "image/") || strings.HasPrefix(ct, "image/svg") {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_type", "Inline content type not permitted")
 			return
 		}
+		w.Header().Set("Content-Type", ct)
+		w.Header().Set("Content-Disposition", "inline")
+		w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		_, _ = w.Write(att.Content)
+		return
 	}
 
 	writeError(w, http.StatusNotFound, "not_found", "Inline part not found")

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -2091,6 +2093,13 @@ func TestHandleStats_VectorEnabledWithActive(t *testing.T) {
 	}
 }
 
+// inlineURL builds the inline endpoint URL for a given message ID and CID,
+// URL-encoding the CID so values with reserved characters (including `/`)
+// round-trip correctly.
+func inlineURL(id int64, cid string) string {
+	return fmt.Sprintf("/api/v1/messages/%d/inline?cid=%s", id, url.QueryEscape(cid))
+}
+
 // rawMIMEWithImagePart returns a multipart MIME message containing a single
 // image part with the given Content-ID, content type, and Content-Disposition
 // (typically "inline" or "attachment").
@@ -2129,7 +2138,7 @@ func TestHandleMessageInline_ImagePNG(t *testing.T) {
 	}
 	srv := newTestServerWithEngine(t, engine)
 
-	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/logo@example", nil)
+	req := httptest.NewRequest("GET", inlineURL(1, "logo@example"), nil)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
@@ -2165,7 +2174,7 @@ func TestHandleMessageInline_NonInlineSkipped(t *testing.T) {
 	}
 	srv := newTestServerWithEngine(t, engine)
 
-	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/logo@example", nil)
+	req := httptest.NewRequest("GET", inlineURL(1, "logo@example"), nil)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
@@ -2182,7 +2191,7 @@ func TestHandleMessageInline_RejectsXHTML(t *testing.T) {
 	}
 	srv := newTestServerWithEngine(t, engine)
 
-	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/evil@nasty", nil)
+	req := httptest.NewRequest("GET", inlineURL(1, "evil@nasty"), nil)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
@@ -2199,7 +2208,7 @@ func TestHandleMessageInline_RejectsSVG(t *testing.T) {
 	}
 	srv := newTestServerWithEngine(t, engine)
 
-	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/vuln@svg", nil)
+	req := httptest.NewRequest("GET", inlineURL(1, "vuln@svg"), nil)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
@@ -2216,7 +2225,7 @@ func TestHandleMessageInline_CIDNotFound(t *testing.T) {
 	}
 	srv := newTestServerWithEngine(t, engine)
 
-	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/nonexistent@cid", nil)
+	req := httptest.NewRequest("GET", inlineURL(1, "nonexistent@cid"), nil)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
@@ -2228,7 +2237,7 @@ func TestHandleMessageInline_CIDNotFound(t *testing.T) {
 func TestHandleMessageInline_NoEngine(t *testing.T) {
 	srv, _ := newTestServerWithMockStore(t)
 
-	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/any@cid", nil)
+	req := httptest.NewRequest("GET", inlineURL(1, "any@cid"), nil)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
@@ -2243,11 +2252,52 @@ func TestHandleMessageInline_MessageNotFound(t *testing.T) {
 	}
 	srv := newTestServerWithEngine(t, engine)
 
-	req := httptest.NewRequest("GET", "/api/v1/messages/999/inline/any@cid", nil)
+	req := httptest.NewRequest("GET", inlineURL(999, "any@cid"), nil)
 	w := httptest.NewRecorder()
 	srv.Router().ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+// TestHandleMessageInline_CIDWithSlash verifies that Content-IDs containing
+// `/` round-trip correctly through the query parameter.
+func TestHandleMessageInline_CIDWithSlash(t *testing.T) {
+	cid := "path/with/slashes@example.com"
+	imgData := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	raw := rawMIMEWithInlineImage(cid, "image/png", imgData)
+
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{1: raw},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", inlineURL(1, cid), nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !bytes.Equal(w.Body.Bytes(), imgData) {
+		t.Errorf("response body = %x, want %x", w.Body.Bytes(), imgData)
+	}
+}
+
+// TestHandleMessageInline_MissingCID verifies that a request without the
+// `cid` query parameter returns 400.
+func TestHandleMessageInline_MissingCID(t *testing.T) {
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{1: rawMIMEWithInlineImage("logo@example", "image/png", []byte{0x89})},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d for missing cid", w.Code, http.StatusBadRequest)
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wesm/msgvault/internal/config"
 	"github.com/wesm/msgvault/internal/query"
 	"github.com/wesm/msgvault/internal/query/querytest"
+	"github.com/wesm/msgvault/internal/remote"
 	"github.com/wesm/msgvault/internal/vector"
 	"github.com/wesm/msgvault/internal/vector/hybrid"
 )
@@ -2339,5 +2340,64 @@ func TestHandleMessageInline_MissingCID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d for missing cid", w.Code, http.StatusBadRequest)
+	}
+}
+
+// TestHandleMessageInline_UnsupportedEngine verifies that engines which
+// can't fetch raw MIME (Postgres scaffold, remote engine) surface a stable
+// 501 instead of a generic 500.
+func TestHandleMessageInline_UnsupportedEngine(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ErrNotImplemented", query.ErrNotImplemented},
+		{"ErrNotSupported", remote.ErrNotSupported},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &querytest.MockEngine{
+				GetMessageRawFunc: func(_ context.Context, _ int64) ([]byte, error) {
+					return nil, tc.err
+				},
+			}
+			srv := newTestServerWithEngine(t, engine)
+
+			req := httptest.NewRequest("GET", inlineURL(1, "logo@example"), nil)
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+
+			if w.Code != http.StatusNotImplemented {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusNotImplemented)
+			}
+		})
+	}
+}
+
+// TestHandleGetMessage_EngineUnsupportedFallsBackToStore verifies that when
+// the configured engine reports the operation is unsupported, the handler
+// falls through to the store path so engine-only errors don't break detail
+// responses for engines that don't implement GetMessage.
+func TestHandleGetMessage_EngineUnsupportedFallsBackToStore(t *testing.T) {
+	engine := &querytest.MockEngine{
+		GetMessageFunc: func(_ context.Context, _ int64) (*query.MessageDetail, error) {
+			return nil, query.ErrNotImplemented
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["subject"] != "Test Subject" {
+		t.Errorf("subject = %q, want %q (store path response)", resp["subject"], "Test Subject")
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -277,6 +277,46 @@ func TestHandleGetMessage_EngineBodyHTML(t *testing.T) {
 	if resp["from"] != "Sender <sender@example.com>" {
 		t.Errorf("from = %q, want %q", resp["from"], "Sender <sender@example.com>")
 	}
+	if _, ok := resp["deleted_at"]; ok {
+		t.Errorf("deleted_at should be omitted for live message, got %v", resp["deleted_at"])
+	}
+}
+
+// TestHandleGetMessage_EngineDeletedAt verifies the engine path surfaces
+// deleted_at in the response when the underlying message has a
+// deleted_from_source_at timestamp.
+func TestHandleGetMessage_EngineDeletedAt(t *testing.T) {
+	deletedAt := time.Date(2024, 7, 1, 9, 30, 0, 0, time.UTC)
+	engine := &querytest.MockEngine{
+		Messages: map[int64]*query.MessageDetail{
+			42: {
+				ID:        42,
+				Subject:   "Deleted",
+				From:      []query.Address{{Email: "sender@example.com"}},
+				SentAt:    time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
+				DeletedAt: &deletedAt,
+				BodyText:  "hello",
+			},
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/42", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	want := deletedAt.Format(time.RFC3339)
+	if got := resp["deleted_at"]; got != want {
+		t.Errorf("deleted_at = %v, want %q", got, want)
+	}
 }
 
 func TestHandleSearchMissingQuery(t *testing.T) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -232,6 +232,49 @@ func TestHandleGetMessageInvalidID(t *testing.T) {
 	}
 }
 
+func TestHandleGetMessage_EngineBodyHTML(t *testing.T) {
+	engine := &querytest.MockEngine{
+		Messages: map[int64]*query.MessageDetail{
+			42: {
+				ID:       42,
+				Subject:  "HTML Email",
+				From:     []query.Address{{Email: "sender@example.com", Name: "Sender"}},
+				To:       []query.Address{{Email: "rcpt@example.com"}},
+				SentAt:   time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
+				Labels:   []string{"INBOX"},
+				BodyText: "plain fallback",
+				BodyHTML: "<p>Hello</p>",
+			},
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/42", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if resp["body"] != "plain fallback" {
+		t.Errorf("body = %q, want %q", resp["body"], "plain fallback")
+	}
+	if resp["body_html"] != "<p>Hello</p>" {
+		t.Errorf("body_html = %q, want %q", resp["body_html"], "<p>Hello</p>")
+	}
+	if resp["subject"] != "HTML Email" {
+		t.Errorf("subject = %q, want %q", resp["subject"], "HTML Email")
+	}
+	if resp["from"] != "Sender <sender@example.com>" {
+		t.Errorf("from = %q, want %q", resp["from"], "Sender <sender@example.com>")
+	}
+}
+
 func TestHandleSearchMissingQuery(t *testing.T) {
 	srv, _ := newTestServerWithMockStore(t)
 
@@ -2043,5 +2086,177 @@ func TestHandleStats_VectorEnabledWithActive(t *testing.T) {
 
 	if _, exists := vs["building_generation"]; exists {
 		t.Error("expected 'building_generation' to be absent when there is no building generation")
+	}
+}
+
+// rawMIMEWithInlineImage returns a multipart MIME message with an inline
+// image part identified by the given CID and content type.
+func rawMIMEWithInlineImage(cid, contentType string, body []byte) []byte {
+	boundary := "test-boundary-123"
+	var b strings.Builder
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: multipart/related; boundary=\"" + boundary + "\"\r\n")
+	b.WriteString("Subject: test\r\n")
+	b.WriteString("\r\n")
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: text/html; charset=utf-8\r\n\r\n")
+	b.WriteString("<html><body><img src=\"cid:" + cid + "\"></body></html>\r\n")
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: " + contentType + "\r\n")
+	b.WriteString("Content-Disposition: inline\r\n")
+	b.WriteString("Content-ID: <" + cid + ">\r\n")
+	b.WriteString("Content-Transfer-Encoding: base64\r\n")
+	b.WriteString("\r\n")
+	// Encode body as base64
+	encoded := make([]byte, 0, len(body)*2)
+	for i := 0; i < len(body); i += 57 {
+		end := i + 57
+		if end > len(body) {
+			end = len(body)
+		}
+		chunk := body[i:end]
+		dst := make([]byte, (len(chunk)*4+2)/3+4)
+		n := copy(dst, []byte(encodeBase64(chunk)))
+		encoded = append(encoded, dst[:n]...)
+		encoded = append(encoded, '\r', '\n')
+	}
+	b.Write(encoded)
+	b.WriteString("--" + boundary + "--\r\n")
+	return []byte(b.String())
+}
+
+func encodeBase64(data []byte) string {
+	const table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	var out []byte
+	for i := 0; i < len(data); i += 3 {
+		var val uint32
+		remaining := len(data) - i
+		for j := 0; j < 3; j++ {
+			val <<= 8
+			if j < remaining {
+				val |= uint32(data[i+j])
+			}
+		}
+		out = append(out, table[(val>>18)&0x3F])
+		out = append(out, table[(val>>12)&0x3F])
+		if remaining > 1 {
+			out = append(out, table[(val>>6)&0x3F])
+		} else {
+			out = append(out, '=')
+		}
+		if remaining > 2 {
+			out = append(out, table[val&0x3F])
+		} else {
+			out = append(out, '=')
+		}
+	}
+	return string(out)
+}
+
+func TestHandleMessageInline_ImagePNG(t *testing.T) {
+	imgData := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	raw := rawMIMEWithInlineImage("logo@example", "image/png", imgData)
+
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{1: raw},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/logo@example", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+	if cc := w.Header().Get("Cache-Control"); !strings.Contains(cc, "private") {
+		t.Errorf("Cache-Control = %q, should contain 'private'", cc)
+	}
+	if cc := w.Header().Get("Cache-Control"); strings.Contains(cc, "public") {
+		t.Errorf("Cache-Control = %q, must not contain 'public'", cc)
+	}
+	if cd := w.Header().Get("Content-Disposition"); cd != "inline" {
+		t.Errorf("Content-Disposition = %q, want 'inline'", cd)
+	}
+}
+
+func TestHandleMessageInline_RejectsXHTML(t *testing.T) {
+	raw := rawMIMEWithInlineImage("evil@nasty", "application/xhtml+xml", []byte("<script>alert(1)</script>"))
+
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{1: raw},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/evil@nasty", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("status = %d, want %d for application/xhtml+xml inline part", w.Code, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestHandleMessageInline_RejectsSVG(t *testing.T) {
+	raw := rawMIMEWithInlineImage("vuln@svg", "image/svg+xml", []byte("<svg onload='alert(1)'/>"))
+
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{1: raw},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/vuln@svg", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("status = %d, want %d for image/svg+xml inline part", w.Code, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestHandleMessageInline_CIDNotFound(t *testing.T) {
+	raw := rawMIMEWithInlineImage("logo@example", "image/png", []byte{0x89, 'P', 'N', 'G'})
+
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{1: raw},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/nonexistent@cid", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleMessageInline_NoEngine(t *testing.T) {
+	srv, _ := newTestServerWithMockStore(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/any@cid", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestHandleMessageInline_MessageNotFound(t *testing.T) {
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/999/inline/any@cid", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -2089,9 +2091,10 @@ func TestHandleStats_VectorEnabledWithActive(t *testing.T) {
 	}
 }
 
-// rawMIMEWithInlineImage returns a multipart MIME message with an inline
-// image part identified by the given CID and content type.
-func rawMIMEWithInlineImage(cid, contentType string, body []byte) []byte {
+// rawMIMEWithImagePart returns a multipart MIME message containing a single
+// image part with the given Content-ID, content type, and Content-Disposition
+// (typically "inline" or "attachment").
+func rawMIMEWithImagePart(cid, contentType, disposition string, body []byte) []byte {
 	boundary := "test-boundary-123"
 	var b strings.Builder
 	b.WriteString("MIME-Version: 1.0\r\n")
@@ -2103,54 +2106,18 @@ func rawMIMEWithInlineImage(cid, contentType string, body []byte) []byte {
 	b.WriteString("<html><body><img src=\"cid:" + cid + "\"></body></html>\r\n")
 	b.WriteString("--" + boundary + "\r\n")
 	b.WriteString("Content-Type: " + contentType + "\r\n")
-	b.WriteString("Content-Disposition: inline\r\n")
+	b.WriteString("Content-Disposition: " + disposition + "\r\n")
 	b.WriteString("Content-ID: <" + cid + ">\r\n")
 	b.WriteString("Content-Transfer-Encoding: base64\r\n")
 	b.WriteString("\r\n")
-	// Encode body as base64
-	encoded := make([]byte, 0, len(body)*2)
-	for i := 0; i < len(body); i += 57 {
-		end := i + 57
-		if end > len(body) {
-			end = len(body)
-		}
-		chunk := body[i:end]
-		dst := make([]byte, (len(chunk)*4+2)/3+4)
-		n := copy(dst, []byte(encodeBase64(chunk)))
-		encoded = append(encoded, dst[:n]...)
-		encoded = append(encoded, '\r', '\n')
-	}
-	b.Write(encoded)
-	b.WriteString("--" + boundary + "--\r\n")
+	b.WriteString(base64.StdEncoding.EncodeToString(body))
+	b.WriteString("\r\n--" + boundary + "--\r\n")
 	return []byte(b.String())
 }
 
-func encodeBase64(data []byte) string {
-	const table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-	var out []byte
-	for i := 0; i < len(data); i += 3 {
-		var val uint32
-		remaining := len(data) - i
-		for j := 0; j < 3; j++ {
-			val <<= 8
-			if j < remaining {
-				val |= uint32(data[i+j])
-			}
-		}
-		out = append(out, table[(val>>18)&0x3F])
-		out = append(out, table[(val>>12)&0x3F])
-		if remaining > 1 {
-			out = append(out, table[(val>>6)&0x3F])
-		} else {
-			out = append(out, '=')
-		}
-		if remaining > 2 {
-			out = append(out, table[val&0x3F])
-		} else {
-			out = append(out, '=')
-		}
-	}
-	return string(out)
+// rawMIMEWithInlineImage is a convenience wrapper for the common inline case.
+func rawMIMEWithInlineImage(cid, contentType string, body []byte) []byte {
+	return rawMIMEWithImagePart(cid, contentType, "inline", body)
 }
 
 func TestHandleMessageInline_ImagePNG(t *testing.T) {
@@ -2180,6 +2147,30 @@ func TestHandleMessageInline_ImagePNG(t *testing.T) {
 	}
 	if cd := w.Header().Get("Content-Disposition"); cd != "inline" {
 		t.Errorf("Content-Disposition = %q, want 'inline'", cd)
+	}
+	if !bytes.Equal(w.Body.Bytes(), imgData) {
+		t.Errorf("response body = %x, want %x", w.Body.Bytes(), imgData)
+	}
+}
+
+// TestHandleMessageInline_NonInlineSkipped ensures that a part with a matching
+// Content-ID but Content-Disposition: attachment is not served via the inline
+// endpoint — only parts flagged IsInline by the MIME parser should be reachable.
+func TestHandleMessageInline_NonInlineSkipped(t *testing.T) {
+	imgData := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	raw := rawMIMEWithImagePart("logo@example", "image/png", "attachment", imgData)
+
+	engine := &querytest.MockEngine{
+		RawMessages: map[int64][]byte{1: raw},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest("GET", "/api/v1/messages/1/inline/logo@example", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d for non-inline attachment", w.Code, http.StatusNotFound)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -164,6 +164,7 @@ func (s *Server) setupRouter() chi.Router {
 		// Messages
 		r.Get("/messages", s.handleListMessages)
 		r.Get("/messages/{id}", s.handleGetMessage)
+		r.Get("/messages/{id}/inline/{cid}", s.handleMessageInline)
 
 		// Search
 		r.Get("/search", s.handleSearch)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -164,7 +164,7 @@ func (s *Server) setupRouter() chi.Router {
 		// Messages
 		r.Get("/messages", s.handleListMessages)
 		r.Get("/messages/{id}", s.handleGetMessage)
-		r.Get("/messages/{id}/inline/{cid}", s.handleMessageInline)
+		r.Get("/messages/{id}/inline", s.handleMessageInline)
 
 		// Search
 		r.Get("/search", s.handleSearch)

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1448,6 +1448,14 @@ func (e *DuckDBEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 	return nil, fmt.Errorf("GetAttachment requires SQLite: pass sqliteDB to NewDuckDBEngine")
 }
 
+// GetMessageRaw returns the decompressed raw MIME data for a message.
+func (e *DuckDBEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
+	if e.sqliteDB != nil {
+		return getMessageRawShared(ctx, e.sqliteDB, "", id)
+	}
+	return nil, fmt.Errorf("GetMessageRaw requires SQLite: pass sqliteDB to NewDuckDBEngine")
+}
+
 func (e *DuckDBEngine) getMessageByQuery(ctx context.Context, whereClause string, args ...interface{}) (*MessageDetail, error) {
 	return getMessageByQueryShared(ctx, e.db, "sqlite_db.", whereClause, args...)
 }

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -28,6 +28,10 @@ type Engine interface {
 	GetMessageBySourceID(ctx context.Context, sourceMessageID string) (*MessageDetail, error)
 	GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error)
 
+	// GetMessageRaw returns the decompressed raw MIME data for a message.
+	// Returns nil, nil if no raw data is stored for the given ID.
+	GetMessageRaw(ctx context.Context, id int64) ([]byte, error)
+
 	// GetMessageSummariesByIDs returns summary-level rows (no body, no
 	// raw MIME) for the supplied IDs in the same order as ids. Missing
 	// IDs are silently dropped — callers loop over IDs from a search

--- a/internal/query/models.go
+++ b/internal/query/models.go
@@ -50,6 +50,7 @@ type MessageDetail struct {
 	Snippet              string     `json:"snippet"`
 	SentAt               time.Time  `json:"sent_at"`
 	ReceivedAt           *time.Time `json:"received_at,omitempty"`
+	DeletedAt            *time.Time `json:"deleted_at,omitempty"` // When message was deleted from source (nil if not deleted)
 	SizeEstimate         int64      `json:"size_estimate"`
 	HasAttachments       bool       `json:"has_attachments"`
 

--- a/internal/query/postgres.go
+++ b/internal/query/postgres.go
@@ -84,6 +84,15 @@ func (e *PostgreSQLEngine) GetMessageBySourceID(ctx context.Context, sourceMessa
 	return nil, ErrNotImplemented
 }
 
+// GetMessageRaw returns the decompressed raw MIME data for a message.
+//
+// Returns ErrNotImplemented: the PostgreSQL store does not yet populate
+// message_raw, so there is nothing to read. Wired up alongside the rest of
+// the message-detail path.
+func (e *PostgreSQLEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
 // GetAttachment retrieves attachment metadata by ID.
 func (e *PostgreSQLEngine) GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error) {
 	var att AttachmentInfo

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -38,7 +38,10 @@ type MockEngine struct {
 	GetGmailIDsByFilterFunc      func(context.Context, query.MessageFilter) ([]string, error)
 	SearchByDomainsFunc          func(context.Context, []string, *time.Time, *time.Time, int, int) ([]query.MessageSummary, error)
 	SearchFastWithStatsFunc      func(context.Context, *search.Query, string, query.MessageFilter, query.ViewType, int, int) (*query.SearchFastResult, error)
+	GetMessageRawFunc            func(context.Context, int64) ([]byte, error)
 	GetMessageSummariesByIDsFunc func(context.Context, []int64) ([]query.MessageSummary, error)
+
+	RawMessages map[int64][]byte
 }
 
 // Compile-time check.
@@ -118,6 +121,18 @@ func (m *MockEngine) GetAttachment(_ context.Context, id int64) (*query.Attachme
 	if m.Attachments != nil {
 		if a, ok := m.Attachments[id]; ok {
 			return a, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *MockEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
+	if m.GetMessageRawFunc != nil {
+		return m.GetMessageRawFunc(ctx, id)
+	}
+	if m.RawMessages != nil {
+		if raw, ok := m.RawMessages[id]; ok {
+			return raw, nil
 		}
 	}
 	return nil, nil

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -196,16 +196,20 @@ func getMessageRawShared(ctx context.Context, db *sql.DB, tablePrefix string, me
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query message_raw for id %d: %w", messageID, err)
 	}
 
 	if compression.Valid && compression.String == "zlib" {
 		r, err := zlib.NewReader(bytes.NewReader(compressed))
 		if err != nil {
-			return nil, fmt.Errorf("zlib reader: %w", err)
+			return nil, fmt.Errorf("zlib reader for id %d: %w", messageID, err)
 		}
 		defer func() { _ = r.Close() }()
-		return io.ReadAll(r)
+		raw, err := io.ReadAll(r)
+		if err != nil {
+			return nil, fmt.Errorf("zlib decompress message_raw id %d: %w", messageID, err)
+		}
+		return raw, nil
 	}
 
 	return compressed, nil

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -184,14 +184,19 @@ func extractBodyFromRawShared(ctx context.Context, db *sql.DB, tablePrefix strin
 }
 
 // getMessageRawShared retrieves and decompresses raw MIME data for a message.
-// Returns nil, nil if no raw data is stored.
+// Returns nil, nil if no raw data is stored, or if the message has been
+// deleted from source — the listing/search endpoints hide deleted-from-source
+// messages, so the raw-MIME path stays aligned and refuses to serve them.
 func getMessageRawShared(ctx context.Context, db *sql.DB, tablePrefix string, messageID int64) ([]byte, error) {
 	var compressed []byte
 	var compression sql.NullString
 
 	err := db.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT raw_data, compression FROM %smessage_raw WHERE message_id = ?
-	`, tablePrefix), messageID).Scan(&compressed, &compression)
+		SELECT mr.raw_data, mr.compression
+		FROM %smessage_raw mr
+		JOIN %smessages m ON m.id = mr.message_id
+		WHERE mr.message_id = ? AND m.deleted_from_source_at IS NULL
+	`, tablePrefix, tablePrefix), messageID).Scan(&compressed, &compression)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -229,14 +234,15 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string
 			m.sent_at,
 			m.received_at,
 			COALESCE(m.size_estimate, 0),
-			m.has_attachments
+			m.has_attachments,
+			m.deleted_from_source_at
 		FROM %smessages m
 		LEFT JOIN %sconversations conv ON conv.id = m.conversation_id
 		WHERE %s
 	`, tablePrefix, tablePrefix, whereClause)
 
 	var msg MessageDetail
-	var sentAt, receivedAt sql.NullTime
+	var sentAt, receivedAt, deletedAt sql.NullTime
 	err := db.QueryRowContext(ctx, query, args...).Scan(
 		&msg.ID,
 		&msg.SourceMessageID,
@@ -248,6 +254,7 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string
 		&receivedAt,
 		&msg.SizeEstimate,
 		&msg.HasAttachments,
+		&deletedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -262,6 +269,10 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string
 	if receivedAt.Valid {
 		t := receivedAt.Time
 		msg.ReceivedAt = &t
+	}
+	if deletedAt.Valid {
+		t := deletedAt.Time
+		msg.DeletedAt = &t
 	}
 
 	// Fetch body from separate table (PK lookup, avoids scanning large body B-tree)

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -183,6 +183,34 @@ func extractBodyFromRawShared(ctx context.Context, db *sql.DB, tablePrefix strin
 	return parsed.GetBodyText(), nil
 }
 
+// getMessageRawShared retrieves and decompresses raw MIME data for a message.
+// Returns nil, nil if no raw data is stored.
+func getMessageRawShared(ctx context.Context, db *sql.DB, tablePrefix string, messageID int64) ([]byte, error) {
+	var compressed []byte
+	var compression sql.NullString
+
+	err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT raw_data, compression FROM %smessage_raw WHERE message_id = ?
+	`, tablePrefix), messageID).Scan(&compressed, &compression)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if compression.Valid && compression.String == "zlib" {
+		r, err := zlib.NewReader(bytes.NewReader(compressed))
+		if err != nil {
+			return nil, fmt.Errorf("zlib reader: %w", err)
+		}
+		defer func() { _ = r.Close() }()
+		return io.ReadAll(r)
+	}
+
+	return compressed, nil
+}
+
 // getMessageByQueryShared retrieves a full message detail by an arbitrary WHERE clause.
 // tablePrefix is "" for direct SQLite or "sqlite_db." for DuckDB's sqlite_scan.
 func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string, whereClause string, args ...interface{}) (*MessageDetail, error) {

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -837,6 +837,11 @@ func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 	return &att, nil
 }
 
+// GetMessageRaw returns the decompressed raw MIME data for a message.
+func (e *SQLiteEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
+	return getMessageRawShared(ctx, e.db, "", id)
+}
+
 // ListAccounts returns all source accounts.
 func (e *SQLiteEngine) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
 	rows, err := e.db.QueryContext(ctx, `

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/wesm/msgvault/internal/search"
@@ -1129,5 +1130,39 @@ func TestGetTotalStatsWithSearchQuery_Combined(t *testing.T) {
 	}
 	if stats.TotalSize != 2000 {
 		t.Errorf("SearchQuery+WithAttachments: expected total size 2000, got %d", stats.TotalSize)
+	}
+}
+
+func TestGetMessageRaw(t *testing.T) {
+	env := newTestEnv(t)
+	rawMIME := []byte("From: test@example.com\r\nSubject: Test\r\n\r\nHello")
+
+	msgID := env.AddMessage(dbtest.MessageOpts{Subject: "Raw Test", SentAt: "2024-06-01 12:00:00"})
+	_, err := env.DB.Exec(
+		`INSERT INTO message_raw (message_id, raw_data, raw_format, compression) VALUES (?, ?, 'mime', 'none')`,
+		msgID, rawMIME,
+	)
+	if err != nil {
+		t.Fatalf("insert message_raw: %v", err)
+	}
+
+	got, err := env.Engine.GetMessageRaw(env.Ctx, msgID)
+	if err != nil {
+		t.Fatalf("GetMessageRaw: %v", err)
+	}
+	if !bytes.Equal(got, rawMIME) {
+		t.Errorf("GetMessageRaw = %q, want %q", got, rawMIME)
+	}
+}
+
+func TestGetMessageRaw_NotFound(t *testing.T) {
+	env := newTestEnv(t)
+
+	got, err := env.Engine.GetMessageRaw(env.Ctx, 999999)
+	if err != nil {
+		t.Fatalf("GetMessageRaw unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetMessageRaw = %q, want nil", got)
 	}
 }

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -1166,3 +1166,60 @@ func TestGetMessageRaw_NotFound(t *testing.T) {
 		t.Errorf("GetMessageRaw = %q, want nil", got)
 	}
 }
+
+// TestGetMessageRaw_FiltersDeletedFromSource verifies that GetMessageRaw
+// refuses to serve raw MIME for messages whose deleted_from_source_at is
+// set, keeping the raw-MIME endpoint aligned with how list/search hide
+// deleted-from-source messages.
+func TestGetMessageRaw_FiltersDeletedFromSource(t *testing.T) {
+	env := newTestEnv(t)
+	rawMIME := []byte("From: test@example.com\r\nSubject: Test\r\n\r\nHello")
+
+	msgID := env.AddMessage(dbtest.MessageOpts{Subject: "Deleted", SentAt: "2024-06-01 12:00:00"})
+	if _, err := env.DB.Exec(
+		`INSERT INTO message_raw (message_id, raw_data, raw_format, compression) VALUES (?, ?, 'mime', 'none')`,
+		msgID, rawMIME,
+	); err != nil {
+		t.Fatalf("insert message_raw: %v", err)
+	}
+	if _, err := env.DB.Exec(
+		`UPDATE messages SET deleted_from_source_at = '2024-06-02 12:00:00' WHERE id = ?`,
+		msgID,
+	); err != nil {
+		t.Fatalf("mark deleted: %v", err)
+	}
+
+	got, err := env.Engine.GetMessageRaw(env.Ctx, msgID)
+	if err != nil {
+		t.Fatalf("GetMessageRaw: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for deleted-from-source message, got %d bytes", len(got))
+	}
+}
+
+// TestGetMessage_PopulatesDeletedAt verifies that the engine's GetMessage
+// surfaces deleted_from_source_at via MessageDetail.DeletedAt so the API
+// can include it in detail responses.
+func TestGetMessage_PopulatesDeletedAt(t *testing.T) {
+	env := newTestEnv(t)
+
+	msgID := env.AddMessage(dbtest.MessageOpts{Subject: "Soft-deleted", SentAt: "2024-06-01 12:00:00"})
+	if _, err := env.DB.Exec(
+		`UPDATE messages SET deleted_from_source_at = '2024-06-02 12:00:00' WHERE id = ?`,
+		msgID,
+	); err != nil {
+		t.Fatalf("mark deleted: %v", err)
+	}
+
+	msg, err := env.Engine.GetMessage(env.Ctx, msgID)
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg == nil {
+		t.Fatal("GetMessage returned nil for deleted message; expected the message with DeletedAt set")
+	}
+	if msg.DeletedAt == nil {
+		t.Errorf("DeletedAt = nil, want non-nil for deleted message")
+	}
+}

--- a/internal/remote/engine.go
+++ b/internal/remote/engine.go
@@ -569,6 +569,12 @@ func (e *Engine) GetMessageSummariesByIDs(ctx context.Context, ids []int64) ([]q
 	return out, nil
 }
 
+// GetMessageRaw returns raw MIME data for a message.
+// This operation is not supported in remote mode.
+func (e *Engine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
+	return nil, ErrNotSupported
+}
+
 // GetAttachment returns attachment metadata by ID.
 // This operation is not supported in remote mode.
 func (e *Engine) GetAttachment(ctx context.Context, id int64) (*query.AttachmentInfo, error) {


### PR DESCRIPTION
## Summary

- Add `GetMessageRaw` to the query engine interface for raw MIME retrieval with zlib decompression (SQLite, DuckDB, remote stub, mock)
- When the engine is available, `GET /messages/{id}` returns `body_html` alongside `body` for rich email rendering
- Add `GET /messages/{id}/inline/{cid}` endpoint for serving CID-referenced inline images embedded in HTML emails
- Inline endpoint blocks SVG/XHTML content types, sets `Cache-Control: private`, and filters on `IsInline` flag

## Motivation

`query.MessageDetail` already has separate `BodyText` and `BodyHTML` fields, but the API collapses them into a single `body` via the store layer. Clients that want to render rich HTML emails need the HTML body and access to inline MIME parts (images referenced via `cid:` URLs). This adds both without touching the store layer — the engine path is preferred when available, with a clean fallback to the existing store path.

## Changed files

| Layer | Files | Change |
|-------|-------|--------|
| Engine interface | `engine.go`, `shared.go`, `sqlite.go`, `duckdb.go`, `remote/engine.go`, `mock_engine.go` | `GetMessageRaw` method + shared zlib decompression |
| API handlers | `handlers.go`, `server.go` | Engine-path `body_html` in message detail, inline MIME endpoint |
| Tests | `sqlite_crud_test.go`, `handlers_test.go` | `GetMessageRaw` CRUD tests, inline endpoint tests (PNG, SVG rejection, XHTML rejection, CID not found, no engine, message not found), engine-path `body_html` test |