### PR TITLE
fix: improve log slow/error SQL with args and accurate streaming durations

### DIFF
--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -600,7 +600,7 @@ func (s *Store) searchMessagesLike(query string, offset, limit int) ([]APIMessag
 
 // scanMessageRows scans the standard 8-column message row set.
 // Uses string scanning for dates to handle all SQLite datetime formats robustly.
-func scanMessageRows(rows *sql.Rows) ([]APIMessage, []int64, error) {
+func scanMessageRows(rows *loggedRows) ([]APIMessage, []int64, error) {
 	var messages []APIMessage
 	var ids []int64
 	for rows.Next() {

--- a/internal/store/db_logger.go
+++ b/internal/store/db_logger.go
@@ -294,25 +294,33 @@ type loggedRows struct {
 // and emits the SQL log line. Mirrors the threshold and
 // full-trace behaviour of logStmt so a streaming query that
 // runs slowly inside Next still gets promoted to WARN.
+//
+// If Close itself returns nil, we also surface any iteration
+// error from Rows.Err() — context cancellation or driver-level
+// scan failures land there, not on Close. Without this the log
+// would record a slow/failing scan as a successful query.
 func (r *loggedRows) Close() error {
 	if r.closed {
 		return nil
 	}
 	r.closed = true
 	err := r.Rows.Close()
-	logStmtWith("query", r.query, r.args, err, time.Since(r.start))
+	logErr := err
+	if logErr == nil {
+		logErr = r.Rows.Err()
+	}
+	logStmtWith("query", r.query, r.args, logErr, time.Since(r.start))
 	return err
 }
 
 // logStmtWith is the explicit form that lets callers add extra
 // structured attributes (used by Exec to report rows_affected).
 //
-// args is attached only to WARN-level lines (slow + error). On
-// Info/Debug the count alone is enough; full args on every line
-// would be a large volume of PII (subjects, addresses, IDs) and
-// noisy in --verbose / --full-trace mode where the existing
-// nargs is sufficient. On the WARN paths args are essential —
-// a slow or failing query is unreproducible without them.
+// On WARN-level lines (slow + error) we attach a redacted shape
+// summary of the bound args (type + length, no raw values) so
+// the query is debuggable without persisting subjects, body
+// excerpts, addresses, tokens, or other potentially sensitive
+// values. Info/Debug get only nargs.
 func logStmtWith(
 	kind, query string, args []any,
 	err error, elapsed time.Duration, extra ...slog.Attr,
@@ -341,11 +349,11 @@ func logStmtWith(
 			// spam WARN in the per-run log for every startup.
 			slog.Debug("sql benign error", attrs...)
 		} else {
-			attrs = append(attrs, "args", formatArgs(args))
+			attrs = append(attrs, "args_shape", formatArgsShape(args))
 			slog.Warn("sql error", attrs...)
 		}
 	case slowMs > 0 && ms >= slowMs:
-		attrs = append(attrs, "args", formatArgs(args))
+		attrs = append(attrs, "args_shape", formatArgsShape(args))
 		slog.Warn("sql slow", attrs...)
 	case fullTrace:
 		slog.Info("sql", attrs...)
@@ -357,48 +365,33 @@ func logStmtWith(
 	}
 }
 
-// formatArgs renders a query's bound parameters as a compact,
-// single-line slog attr value. Strings are quoted and truncated
-// at 64 characters so a long subject or body excerpt doesn't
-// dominate the log line; non-strings use their Go default
-// representation. Returns "" for the no-args case so the attr
-// is still present (consistent shape) but visually empty.
-func formatArgs(args []any) string {
+// formatArgsShape renders bound parameters as a redacted shape
+// summary — type plus, where meaningful, length — without ever
+// emitting the raw value. Strings, []byte, and nil are shaped;
+// numerics and bools are shown as their type name only. Lets a
+// slow/failing query be diagnosed (placeholder count, a NULL
+// bind in the wrong slot, an unexpectedly huge string) without
+// persisting addresses, subjects, tokens, or message bodies.
+func formatArgsShape(args []any) string {
 	if len(args) == 0 {
 		return ""
 	}
 	var b strings.Builder
-	b.Grow(len(args) * 16)
+	b.Grow(len(args) * 12)
 	b.WriteByte('[')
 	for i, a := range args {
 		if i > 0 {
 			b.WriteByte(' ')
 		}
 		switch v := a.(type) {
-		case string:
-			s := v
-			if utf8.RuneCountInString(s) > 64 {
-				// Back up to a rune boundary at the 64-rune mark.
-				n := 0
-				for i := range s {
-					if n == 64 {
-						s = s[:i] + "..."
-						break
-					}
-					n++
-				}
-			}
-			b.WriteByte('"')
-			b.WriteString(s)
-			b.WriteByte('"')
-		case []byte:
-			// Don't dump raw bytes; show length so a
-			// blob-bound query is still recognizable.
-			fmt.Fprintf(&b, "<%d bytes>", len(v))
 		case nil:
 			b.WriteString("nil")
+		case string:
+			fmt.Fprintf(&b, "string(len=%d)", utf8.RuneCountInString(v))
+		case []byte:
+			fmt.Fprintf(&b, "bytes(len=%d)", len(v))
 		default:
-			fmt.Fprintf(&b, "%v", v)
+			fmt.Fprintf(&b, "%T", v)
 		}
 	}
 	b.WriteByte(']')
@@ -421,16 +414,21 @@ func isBenignMigrationError(err error) bool {
 }
 
 // normalizeStmt collapses whitespace in a SQL statement and
-// truncates it to maxChars. When truncation is needed it keeps
-// roughly the first 60% and last 40% of the budget joined by
-// " ... ", so the WHERE / GROUP BY / ORDER BY tail — usually
-// the part that distinguishes one logged query from another —
-// survives. Intended for human log reading; not for
-// reconstructing the exact SQL.
+// truncates it to maxChars (measured in runes, not bytes, so
+// multi-byte UTF-8 in literals or comments is never split).
+// When truncation is needed it keeps roughly the first 60% and
+// last 40% of the budget joined by " ... ", so the WHERE /
+// GROUP BY / ORDER BY tail — usually the part that
+// distinguishes one logged query from another — survives.
+// Intended for human log reading; not for reconstructing the
+// exact SQL.
 func normalizeStmt(q string, maxChars int) string {
 	// Fast path: if there's no whitespace to collapse AND the
-	// statement is within budget, skip the allocation.
-	if len(q) <= maxChars && !strings.ContainsAny(q, "\n\t") {
+	// statement is within budget (by rune count), skip the
+	// allocation. utf8.RuneCountInString is O(n) on the bytes
+	// but no allocation, same as strings.ContainsAny.
+	if !strings.ContainsAny(q, "\n\t") &&
+		(maxChars <= 0 || utf8.RuneCountInString(q) <= maxChars) {
 		return strings.TrimSpace(q)
 	}
 
@@ -450,17 +448,21 @@ func normalizeStmt(q string, maxChars int) string {
 		}
 	}
 	s := strings.TrimSpace(b.String())
-	if maxChars <= 0 || len(s) <= maxChars {
+	if maxChars <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxChars {
 		return s
 	}
 	const sep = " ... "
 	// Refuse the head+tail split if the budget can't carry both
 	// ends meaningfully; fall back to head-only truncation.
 	if maxChars <= len(sep)+8 {
-		return s[:maxChars] + "..."
+		return string(runes[:maxChars]) + "..."
 	}
 	budget := maxChars - len(sep)
 	headLen := budget * 6 / 10
 	tailLen := budget - headLen
-	return s[:headLen] + sep + s[len(s)-tailLen:]
+	return string(runes[:headLen]) + sep + string(runes[len(runes)-tailLen:])
 }

--- a/internal/store/db_logger.go
+++ b/internal/store/db_logger.go
@@ -277,40 +277,70 @@ func (t *loggedTx) QueryRowContext(
 // even when the full scan took hundreds of milliseconds.
 //
 // loggedRows embeds *sql.Rows so callers continue to use it
-// like a raw *sql.Rows: Next, Scan, Err, and Columns are all
-// satisfied by the embedded pointer. Only Close is overridden,
-// to record the elapsed time and emit the log line. Close is
-// idempotent — repeated calls (e.g. an early-return defer plus
-// an explicit close before that) only emit one log line.
+// like a raw *sql.Rows: Scan, Err, and Columns are satisfied
+// by the embedded pointer. Next and Close are overridden:
+//
+//   - Next finalizes the timing log when iteration ends
+//     (Next returns false), so duration_ms reflects scan
+//     completion rather than whatever happens between the last
+//     row and the deferred Close (count queries, batchPopulate,
+//     etc).
+//   - Close finalizes too, covering early returns where the
+//     caller breaks out of the loop before exhausting rows.
+//
+// Both paths route through finalize, which is idempotent — only
+// the first caller emits a log line.
 type loggedRows struct {
 	*sql.Rows
-	query  string
-	args   []any
-	start  time.Time
-	closed bool
+	query     string
+	args      []any
+	start     time.Time
+	finalized bool
 }
 
-// Close records the total elapsed time since Query returned
-// and emits the SQL log line. Mirrors the threshold and
-// full-trace behaviour of logStmt so a streaming query that
-// runs slowly inside Next still gets promoted to WARN.
-//
-// If Close itself returns nil, we also surface any iteration
-// error from Rows.Err() — context cancellation or driver-level
-// scan failures land there, not on Close. Without this the log
-// would record a slow/failing scan as a successful query.
-func (r *loggedRows) Close() error {
-	if r.closed {
-		return nil
+// Next delegates to the embedded *sql.Rows but, on the first
+// false return, runs the timing finalizer so duration_ms is
+// captured at end-of-scan rather than at deferred Close. The
+// caller's existing Close defer still fires; the finalizer
+// guard makes that a no-op.
+func (r *loggedRows) Next() bool {
+	if r.Rows == nil {
+		return false
 	}
-	r.closed = true
+	if r.Rows.Next() {
+		return true
+	}
+	r.finalize(nil)
+	return false
+}
+
+// Close finalizes timing for the early-exit path (caller broke
+// out of the Next loop) and always closes the underlying Rows.
+// Repeated calls remain safe: finalize is idempotent and
+// *sql.Rows.Close is documented to be safe to call multiple
+// times.
+func (r *loggedRows) Close() error {
 	err := r.Rows.Close()
-	logErr := err
+	r.finalize(err)
+	return err
+}
+
+// finalize emits the timing log line exactly once. closeErr is
+// the error returned by Rows.Close on the explicit-Close path
+// and nil on the end-of-scan path; either way, when no close
+// error is present we still consult Rows.Err() so iteration
+// failures (context cancellation, driver scan errors) get
+// logged as "sql error" instead of as a successful query.
+func (r *loggedRows) finalize(closeErr error) {
+	if r.finalized {
+		return
+	}
+	r.finalized = true
+	logErr := closeErr
 	if logErr == nil {
 		logErr = r.Rows.Err()
 	}
 	logStmtWith("query", r.query, r.args, logErr, time.Since(r.start))
-	return err
 }
 
 // logStmtWith is the explicit form that lets callers add extra

--- a/internal/store/db_logger.go
+++ b/internal/store/db_logger.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync/atomic"
@@ -106,13 +107,13 @@ func (d *loggedDB) QueryContext(
 	start := time.Now()
 	rows, err := d.DB.QueryContext(ctx, query, args...)
 	if err != nil {
-		logStmt("query", query, len(args), err, time.Since(start))
+		logStmt("query", query, args, err, time.Since(start))
 		return nil, err
 	}
 	return &loggedRows{
 		Rows:  rows,
 		query: query,
-		nargs: len(args),
+		args:  args,
 		start: start,
 	}, nil
 }
@@ -132,7 +133,7 @@ func (d *loggedDB) QueryRowContext(
 	query = d.rebind(query)
 	start := time.Now()
 	row := d.DB.QueryRowContext(ctx, query, args...)
-	logStmt("queryrow", query, len(args), nil, time.Since(start))
+	logStmt("queryrow", query, args, nil, time.Since(start))
 	return row
 }
 
@@ -158,7 +159,7 @@ func (d *loggedDB) ExecContext(
 			rowsAffected = n
 		}
 	}
-	logStmtWith("exec", query, len(args), err, elapsed,
+	logStmtWith("exec", query, args, err, elapsed,
 		slog.Int64("rows_affected", rowsAffected),
 	)
 	return res, err
@@ -222,13 +223,13 @@ func (t *loggedTx) Query(
 	start := time.Now()
 	rows, err := t.Tx.Query(query, args...)
 	if err != nil {
-		logStmt("query", query, len(args), err, time.Since(start))
+		logStmt("query", query, args, err, time.Since(start))
 		return nil, err
 	}
 	return &loggedRows{
 		Rows:  rows,
 		query: query,
-		nargs: len(args),
+		args:  args,
 		start: start,
 	}, nil
 }
@@ -241,13 +242,13 @@ func (t *loggedTx) QueryContext(
 	start := time.Now()
 	rows, err := t.Tx.QueryContext(ctx, query, args...)
 	if err != nil {
-		logStmt("query", query, len(args), err, time.Since(start))
+		logStmt("query", query, args, err, time.Since(start))
 		return nil, err
 	}
 	return &loggedRows{
 		Rows:  rows,
 		query: query,
-		nargs: len(args),
+		args:  args,
 		start: start,
 	}, nil
 }
@@ -283,7 +284,7 @@ func (t *loggedTx) QueryRowContext(
 type loggedRows struct {
 	*sql.Rows
 	query  string
-	nargs  int
+	args   []any
 	start  time.Time
 	closed bool
 }
@@ -298,22 +299,29 @@ func (r *loggedRows) Close() error {
 		return err
 	}
 	r.closed = true
-	logStmt("query", r.query, r.nargs, err, time.Since(r.start))
+	logStmt("query", r.query, r.args, err, time.Since(r.start))
 	return err
 }
 
 // logStmt is the common emitter used by Query / Exec / QueryRow.
 func logStmt(
-	kind, query string, nargs int,
+	kind, query string, args []any,
 	err error, elapsed time.Duration,
 ) {
-	logStmtWith(kind, query, nargs, err, elapsed)
+	logStmtWith(kind, query, args, err, elapsed)
 }
 
 // logStmtWith is the explicit form that lets callers add extra
 // structured attributes (used by Exec to report rows_affected).
+//
+// args is attached only to WARN-level lines (slow + error). On
+// Info/Debug the count alone is enough; full args on every line
+// would be a large volume of PII (subjects, addresses, IDs) and
+// noisy in --verbose / --full-trace mode where the existing
+// nargs is sufficient. On the WARN paths args are essential —
+// a slow or failing query is unreproducible without them.
 func logStmtWith(
-	kind, query string, nargs int,
+	kind, query string, args []any,
 	err error, elapsed time.Duration, extra ...slog.Attr,
 ) {
 	stmt := normalizeStmt(query, int(sqlLogMaxChars.Load()))
@@ -325,7 +333,7 @@ func logStmtWith(
 	attrs := []any{
 		"kind", kind,
 		"stmt", stmt,
-		"nargs", nargs,
+		"nargs", len(args),
 		"duration_ms", ms,
 	}
 	for _, a := range extra {
@@ -340,9 +348,11 @@ func logStmtWith(
 			// spam WARN in the per-run log for every startup.
 			slog.Debug("sql benign error", attrs...)
 		} else {
+			attrs = append(attrs, "args", formatArgs(args))
 			slog.Warn("sql error", attrs...)
 		}
 	case slowMs > 0 && ms >= slowMs:
+		attrs = append(attrs, "args", formatArgs(args))
 		slog.Warn("sql slow", attrs...)
 	case fullTrace:
 		slog.Info("sql", attrs...)
@@ -352,6 +362,46 @@ func logStmtWith(
 		// when the handler short-circuits on Enabled().
 		slog.Debug("sql", attrs...)
 	}
+}
+
+// formatArgs renders a query's bound parameters as a compact,
+// single-line slog attr value. Strings are quoted and truncated
+// at 64 characters so a long subject or body excerpt doesn't
+// dominate the log line; non-strings use their Go default
+// representation. Returns "" for the no-args case so the attr
+// is still present (consistent shape) but visually empty.
+func formatArgs(args []any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(args) * 16)
+	b.WriteByte('[')
+	for i, a := range args {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		switch v := a.(type) {
+		case string:
+			s := v
+			if len(s) > 64 {
+				s = s[:64] + "..."
+			}
+			b.WriteByte('"')
+			b.WriteString(s)
+			b.WriteByte('"')
+		case []byte:
+			// Don't dump raw bytes; show length so a
+			// blob-bound query is still recognizable.
+			fmt.Fprintf(&b, "<%d bytes>", len(v))
+		case nil:
+			b.WriteString("nil")
+		default:
+			fmt.Fprintf(&b, "%v", v)
+		}
+	}
+	b.WriteByte(']')
+	return b.String()
 }
 
 // isBenignMigrationError returns true for SQLite errors that the
@@ -370,9 +420,12 @@ func isBenignMigrationError(err error) bool {
 }
 
 // normalizeStmt collapses whitespace in a SQL statement and
-// truncates it to maxChars. Truncation is marked with an
-// ellipsis so the log consumer can tell. Intended for human log
-// reading — not for reconstructing the exact SQL.
+// truncates it to maxChars. When truncation is needed it keeps
+// roughly the first 60% and last 40% of the budget joined by
+// " ... ", so the WHERE / GROUP BY / ORDER BY tail — usually
+// the part that distinguishes one logged query from another —
+// survives. Intended for human log reading; not for
+// reconstructing the exact SQL.
 func normalizeStmt(q string, maxChars int) string {
 	// Fast path: if there's no whitespace to collapse AND the
 	// statement is within budget, skip the allocation.
@@ -396,8 +449,17 @@ func normalizeStmt(q string, maxChars int) string {
 		}
 	}
 	s := strings.TrimSpace(b.String())
-	if maxChars > 0 && len(s) > maxChars {
-		s = s[:maxChars] + "..."
+	if maxChars <= 0 || len(s) <= maxChars {
+		return s
 	}
-	return s
+	const sep = " ... "
+	// Refuse the head+tail split if the budget can't carry both
+	// ends meaningfully; fall back to head-only truncation.
+	if maxChars <= len(sep)+8 {
+		return s[:maxChars] + "..."
+	}
+	budget := maxChars - len(sep)
+	headLen := budget * 6 / 10
+	tailLen := budget - headLen
+	return s[:headLen] + sep + s[len(s)-tailLen:]
 }

--- a/internal/store/db_logger.go
+++ b/internal/store/db_logger.go
@@ -89,19 +89,32 @@ func identityRebind(q string) string { return q }
 // sql.DB.Query semantics.
 func (d *loggedDB) Query(
 	query string, args ...any,
-) (*sql.Rows, error) {
+) (*loggedRows, error) {
 	return d.QueryContext(context.Background(), query, args...)
 }
 
-// QueryContext logs the statement and delegates.
+// QueryContext returns a *loggedRows whose Close emits the
+// real wall-clock duration of prepare + scan. The immediate
+// post-Query log line is emitted only on error, because the
+// success-case duration that matters is the one measured at
+// Close — most queries return *sql.Rows in microseconds and
+// then spend their real time inside rows.Next.
 func (d *loggedDB) QueryContext(
 	ctx context.Context, query string, args ...any,
-) (*sql.Rows, error) {
+) (*loggedRows, error) {
 	query = d.rebind(query)
 	start := time.Now()
 	rows, err := d.DB.QueryContext(ctx, query, args...)
-	logStmt("query", query, len(args), err, time.Since(start))
-	return rows, err
+	if err != nil {
+		logStmt("query", query, len(args), err, time.Since(start))
+		return nil, err
+	}
+	return &loggedRows{
+		Rows:  rows,
+		query: query,
+		nargs: len(args),
+		start: start,
+	}, nil
 }
 
 // QueryRow logs and delegates. sql.Row does not expose its error
@@ -198,18 +211,45 @@ func (t *loggedTx) ExecContext(
 	return t.Tx.ExecContext(ctx, t.rebind(query), args...)
 }
 
-// Query rebinds before delegating.
+// Query rebinds and returns *loggedRows so transactional
+// queries also get accurate scan-close timing. The wrapper
+// only logs on Close; if Query itself fails we surface the
+// error without a wrapper since there are no rows to scan.
 func (t *loggedTx) Query(
 	query string, args ...any,
-) (*sql.Rows, error) {
-	return t.Tx.Query(t.rebind(query), args...)
+) (*loggedRows, error) {
+	query = t.rebind(query)
+	start := time.Now()
+	rows, err := t.Tx.Query(query, args...)
+	if err != nil {
+		logStmt("query", query, len(args), err, time.Since(start))
+		return nil, err
+	}
+	return &loggedRows{
+		Rows:  rows,
+		query: query,
+		nargs: len(args),
+		start: start,
+	}, nil
 }
 
-// QueryContext rebinds before delegating.
+// QueryContext rebinds and returns *loggedRows.
 func (t *loggedTx) QueryContext(
 	ctx context.Context, query string, args ...any,
-) (*sql.Rows, error) {
-	return t.Tx.QueryContext(ctx, t.rebind(query), args...)
+) (*loggedRows, error) {
+	query = t.rebind(query)
+	start := time.Now()
+	rows, err := t.Tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		logStmt("query", query, len(args), err, time.Since(start))
+		return nil, err
+	}
+	return &loggedRows{
+		Rows:  rows,
+		query: query,
+		nargs: len(args),
+		start: start,
+	}, nil
 }
 
 // QueryRow rebinds before delegating.
@@ -224,6 +264,42 @@ func (t *loggedTx) QueryRowContext(
 	ctx context.Context, query string, args ...any,
 ) *sql.Row {
 	return t.Tx.QueryRowContext(ctx, t.rebind(query), args...)
+}
+
+// loggedRows wraps *sql.Rows so the timing log emitted for a
+// streaming query reflects total wall-clock time (prepare +
+// scan), not just the time db.Query took to return. Without
+// this wrapper, every duration_ms reported for a SELECT was
+// effectively the cost of preparing the statement and reading
+// the first row from the driver — typically sub-millisecond
+// even when the full scan took hundreds of milliseconds.
+//
+// loggedRows embeds *sql.Rows so callers continue to use it
+// like a raw *sql.Rows: Next, Scan, Err, and Columns are all
+// satisfied by the embedded pointer. Only Close is overridden,
+// to record the elapsed time and emit the log line. Close is
+// idempotent — repeated calls (e.g. an early-return defer plus
+// an explicit close before that) only emit one log line.
+type loggedRows struct {
+	*sql.Rows
+	query  string
+	nargs  int
+	start  time.Time
+	closed bool
+}
+
+// Close records the total elapsed time since Query returned
+// and emits the SQL log line. Mirrors the threshold and
+// full-trace behaviour of logStmt so a streaming query that
+// runs slowly inside Next still gets promoted to WARN.
+func (r *loggedRows) Close() error {
+	err := r.Rows.Close()
+	if r.closed {
+		return err
+	}
+	r.closed = true
+	logStmt("query", r.query, r.nargs, err, time.Since(r.start))
+	return err
 }
 
 // logStmt is the common emitter used by Query / Exec / QueryRow.

--- a/internal/store/db_logger.go
+++ b/internal/store/db_logger.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 )
 
 // SQLLogOptions controls the store-level SQL logging behaviour.
@@ -107,7 +108,7 @@ func (d *loggedDB) QueryContext(
 	start := time.Now()
 	rows, err := d.DB.QueryContext(ctx, query, args...)
 	if err != nil {
-		logStmt("query", query, args, err, time.Since(start))
+		logStmtWith("query", query, args, err, time.Since(start))
 		return nil, err
 	}
 	return &loggedRows{
@@ -133,7 +134,7 @@ func (d *loggedDB) QueryRowContext(
 	query = d.rebind(query)
 	start := time.Now()
 	row := d.DB.QueryRowContext(ctx, query, args...)
-	logStmt("queryrow", query, args, nil, time.Since(start))
+	logStmtWith("queryrow", query, args, nil, time.Since(start))
 	return row
 }
 
@@ -223,7 +224,7 @@ func (t *loggedTx) Query(
 	start := time.Now()
 	rows, err := t.Tx.Query(query, args...)
 	if err != nil {
-		logStmt("query", query, args, err, time.Since(start))
+		logStmtWith("query", query, args, err, time.Since(start))
 		return nil, err
 	}
 	return &loggedRows{
@@ -242,7 +243,7 @@ func (t *loggedTx) QueryContext(
 	start := time.Now()
 	rows, err := t.Tx.QueryContext(ctx, query, args...)
 	if err != nil {
-		logStmt("query", query, args, err, time.Since(start))
+		logStmtWith("query", query, args, err, time.Since(start))
 		return nil, err
 	}
 	return &loggedRows{
@@ -294,21 +295,13 @@ type loggedRows struct {
 // full-trace behaviour of logStmt so a streaming query that
 // runs slowly inside Next still gets promoted to WARN.
 func (r *loggedRows) Close() error {
-	err := r.Rows.Close()
 	if r.closed {
-		return err
+		return nil
 	}
 	r.closed = true
-	logStmt("query", r.query, r.args, err, time.Since(r.start))
+	err := r.Rows.Close()
+	logStmtWith("query", r.query, r.args, err, time.Since(r.start))
 	return err
-}
-
-// logStmt is the common emitter used by Query / Exec / QueryRow.
-func logStmt(
-	kind, query string, args []any,
-	err error, elapsed time.Duration,
-) {
-	logStmtWith(kind, query, args, err, elapsed)
 }
 
 // logStmtWith is the explicit form that lets callers add extra
@@ -384,8 +377,16 @@ func formatArgs(args []any) string {
 		switch v := a.(type) {
 		case string:
 			s := v
-			if len(s) > 64 {
-				s = s[:64] + "..."
+			if utf8.RuneCountInString(s) > 64 {
+				// Back up to a rune boundary at the 64-rune mark.
+				n := 0
+				for i := range s {
+					if n == 64 {
+						s = s[:i] + "..."
+						break
+					}
+					n++
+				}
 			}
 			b.WriteByte('"')
 			b.WriteString(s)

--- a/internal/store/db_logger_test.go
+++ b/internal/store/db_logger_test.go
@@ -265,6 +265,117 @@ func TestLoggedRows_QueryErrorLogsImmediately(t *testing.T) {
 	}
 }
 
+// TestLoggedRows_FinalizesAtEndOfScan verifies that duration_ms
+// is captured when iteration ends (Next returns false), not when
+// Close is eventually called. Most callers defer Close, so any
+// time spent between the last row and the deferred Close (count
+// queries, batchPopulate, unrelated work) would otherwise be
+// charged to the streaming query. The end-of-Next finalizer
+// keeps the timing honest.
+func TestLoggedRows_FinalizesAtEndOfScan(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
+	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
+
+	buf := captureSlog(t, slog.LevelDebug)
+	db := openLoggedMem(t)
+	if _, err := db.Exec(
+		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	buf.Reset()
+
+	rows, err := db.Query("SELECT val FROM t ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+	}
+	// The log line must be emitted by the time Next returns
+	// false, before any deferred Close fires.
+	rec := findLogLine(t, buf, "sql")
+	if rec["kind"] != "query" {
+		t.Errorf("kind = %v, want query", rec["kind"])
+	}
+	durAtEndOfScan := rec["duration_ms"].(float64)
+
+	// Simulate caller doing unrelated work between end-of-scan
+	// and the deferred Close. The log line must not be re-emitted
+	// and the duration must already be recorded.
+	time.Sleep(50 * time.Millisecond)
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	count := 0
+	var lastDuration float64
+	for _, r := range decodeAll(t, buf) {
+		if r["msg"] == "sql" && r["kind"] == "query" {
+			count++
+			lastDuration = r["duration_ms"].(float64)
+		}
+	}
+	if count != 1 {
+		t.Errorf("got %d query log lines, want exactly 1", count)
+	}
+	// Duration recorded at end-of-scan must not include the 50ms
+	// of post-iteration work — give a generous ceiling so a slow
+	// CI host doesn't flake.
+	if lastDuration != durAtEndOfScan {
+		t.Errorf("duration_ms changed after Close: %v -> %v",
+			durAtEndOfScan, lastDuration)
+	}
+	if lastDuration >= 40 {
+		t.Errorf("duration_ms %v includes post-iteration sleep; "+
+			"finalizer should run at end-of-Next", lastDuration)
+	}
+}
+
+// TestLoggedRows_EarlyExitFinalizesOnClose covers the path where
+// the caller breaks out of the Next loop without exhausting rows.
+// The finalizer must run from Close on that path so the log line
+// is still emitted exactly once.
+func TestLoggedRows_EarlyExitFinalizesOnClose(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
+	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
+
+	buf := captureSlog(t, slog.LevelDebug)
+	db := openLoggedMem(t)
+	if _, err := db.Exec(
+		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	buf.Reset()
+
+	rows, err := db.Query("SELECT val FROM t ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	// Read a single row and break — finalizer should not fire yet.
+	if !rows.Next() {
+		t.Fatalf("expected at least one row")
+	}
+	var v string
+	if err := rows.Scan(&v); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if findLogLineByMsg(t, buf, "sql") != nil {
+		t.Fatalf("log line emitted before Close on early-exit path")
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	rec := findLogLine(t, buf, "sql")
+	if rec["kind"] != "query" {
+		t.Errorf("kind = %v, want query", rec["kind"])
+	}
+}
+
 // TestLoggedRows_IterationErrorSurfacedOnClose verifies that a
 // context cancellation discovered during rows.Next() is logged
 // as an error on Close, even when Rows.Close() itself returns

--- a/internal/store/db_logger_test.go
+++ b/internal/store/db_logger_test.go
@@ -88,7 +88,7 @@ func TestLogStmt_SlowQueryPromotedToWarn(t *testing.T) {
 
 	buf := captureSlog(t, slog.LevelDebug)
 	logStmtWith(
-		"exec", "INSERT INTO t VALUES (?)", 1,
+		"exec", "INSERT INTO t VALUES (?)", []any{"v"},
 		nil, 100*time.Millisecond,
 	)
 
@@ -264,6 +264,82 @@ func TestLoggedRows_QueryErrorLogsImmediately(t *testing.T) {
 	}
 }
 
+// TestLogStmt_SlowQueryIncludesArgs verifies that a slow query
+// renders bound parameters as an "args" attr so the log line is
+// reproducible. Without this, only nargs is recorded and a slow
+// query is unidentifiable in production.
+func TestLogStmt_SlowQueryIncludesArgs(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{SlowMs: 50})
+	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
+
+	buf := captureSlog(t, slog.LevelDebug)
+	logStmtWith(
+		"query", "SELECT * FROM t WHERE id = ? AND src = ?",
+		[]any{int64(42), "gmail"},
+		nil, 100*time.Millisecond,
+	)
+
+	rec := findLogLineByMsg(t, buf, "sql slow")
+	if rec == nil {
+		t.Fatalf("no sql slow line; buf=%s", buf.String())
+	}
+	gotArgs, ok := rec["args"].(string)
+	if !ok {
+		t.Fatalf("args attr missing or wrong type: %v", rec["args"])
+	}
+	if !strings.Contains(gotArgs, "42") || !strings.Contains(gotArgs, "gmail") {
+		t.Errorf("args missing values: %q", gotArgs)
+	}
+}
+
+// TestLogStmt_FullTraceOmitsArgs verifies that --full-trace mode
+// does not attach args. nargs is enough at high-volume Info level;
+// args carry PII (subjects, addresses) and would be a privacy
+// regression if logged on every successful query.
+func TestLogStmt_FullTraceOmitsArgs(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
+	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
+
+	buf := captureSlog(t, slog.LevelDebug)
+	logStmtWith(
+		"query", "SELECT * FROM t WHERE id = ?",
+		[]any{int64(42)},
+		nil, 1*time.Millisecond,
+	)
+
+	rec := findLogLine(t, buf, "sql")
+	if _, present := rec["args"]; present {
+		t.Errorf("args should not be present on info/full-trace lines: %v", rec)
+	}
+	if rec["nargs"].(float64) != 1 {
+		t.Errorf("nargs = %v, want 1", rec["nargs"])
+	}
+}
+
+// TestFormatArgs_TruncatesLongStrings ensures a multi-KB string
+// argument (e.g. a body excerpt or large IN-list element) does
+// not blow up the log line.
+func TestFormatArgs_TruncatesLongStrings(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	got := formatArgs([]any{long})
+	if !strings.Contains(got, "...") {
+		t.Errorf("expected truncation marker in %q", got)
+	}
+	if len(got) > 100 {
+		t.Errorf("formatted args too long: %d chars", len(got))
+	}
+}
+
+// TestFormatArgs_HandlesByteSlices ensures raw blob arguments
+// don't dump binary into the log; we only show the length.
+func TestFormatArgs_HandlesByteSlices(t *testing.T) {
+	got := formatArgs([]any{[]byte("hello world")})
+	want := "[<11 bytes>]"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
 func TestNormalizeStmt_CollapsesWhitespace(t *testing.T) {
 	in := "SELECT\n  *\nFROM\n\tt WHERE id = ?"
 	got := normalizeStmt(in, 0)
@@ -274,11 +350,50 @@ func TestNormalizeStmt_CollapsesWhitespace(t *testing.T) {
 }
 
 func TestNormalizeStmt_TruncatesLong(t *testing.T) {
+	// Long uniform input gets a head + " ... " + tail split.
+	// The truncation budget includes the separator, so the
+	// final string is exactly maxChars long.
 	in := strings.Repeat("a", 500)
 	got := normalizeStmt(in, 100)
-	if len(got) != 103 || !strings.HasSuffix(got, "...") {
-		t.Errorf("bad truncation: len=%d tail=%q",
-			len(got), got[len(got)-3:])
+	const sep = " ... "
+	if !strings.Contains(got, sep) {
+		t.Errorf("missing separator: %q", got)
+	}
+	if len(got) != 100 {
+		t.Errorf("bad length: len=%d want=%d", len(got), 100)
+	}
+}
+
+// TestNormalizeStmt_KeepsWhereClause is the guard for the bug
+// that motivated head+tail truncation: a long SELECT whose only
+// distinguishing feature is the WHERE clause must remain
+// distinguishable in the logs.
+func TestNormalizeStmt_KeepsWhereClause(t *testing.T) {
+	in := "SELECT m.id, m.source_id, s.source_type, s.identifier, " +
+		"m.source_message_id, COALESCE(m.subject, ''), m.sent_at, " +
+		"m.archived_at, (CASE WHEN mr.message_id IS NOT NULL THEN 1 " +
+		"ELSE 0 END) AS has_raw, (SELECT COUNT(*) FROM message_labels " +
+		"ml WHERE ml.message_id = m.id) AS label_count, " +
+		"COALESCE(m.is_from_me, 0) AS is_from_me " +
+		"FROM messages m JOIN sources s ON s.id = m.source_id " +
+		"WHERE m.rfc822_message_id = ? AND m.deleted_at IS NULL"
+	got := normalizeStmt(in, 300)
+	if !strings.Contains(got, "WHERE m.rfc822_message_id") {
+		t.Errorf("WHERE clause missing from truncated stmt: %q", got)
+	}
+}
+
+// TestNormalizeStmt_TinyBudgetFallsBackToHead protects the
+// edge case where the budget is too small for a meaningful
+// head+tail split.
+func TestNormalizeStmt_TinyBudgetFallsBackToHead(t *testing.T) {
+	in := strings.Repeat("a", 50)
+	got := normalizeStmt(in, 8)
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("expected trailing ellipsis on tiny budget; got %q", got)
+	}
+	if strings.Contains(got, " ... ") {
+		t.Errorf("did not expect head+tail split on tiny budget; got %q", got)
 	}
 }
 

--- a/internal/store/db_logger_test.go
+++ b/internal/store/db_logger_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -264,11 +265,49 @@ func TestLoggedRows_QueryErrorLogsImmediately(t *testing.T) {
 	}
 }
 
-// TestLogStmt_SlowQueryIncludesArgs verifies that a slow query
-// renders bound parameters as an "args" attr so the log line is
-// reproducible. Without this, only nargs is recorded and a slow
-// query is unidentifiable in production.
-func TestLogStmt_SlowQueryIncludesArgs(t *testing.T) {
+// TestLoggedRows_IterationErrorSurfacedOnClose verifies that a
+// context cancellation discovered during rows.Next() is logged
+// as an error on Close, even when Rows.Close() itself returns
+// nil. Without checking Rows.Err(), a cancelled scan would log
+// as a successful query.
+func TestLoggedRows_IterationErrorSurfacedOnClose(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{})
+	buf := captureSlog(t, slog.LevelDebug)
+	db := openLoggedMem(t)
+	if _, err := db.Exec(
+		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	buf.Reset()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rows, err := db.QueryContext(ctx, "SELECT val FROM t ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	// Cancel before iterating; Next() will see the cancellation
+	// and stop, leaving the error on Rows.Err(), not Close().
+	cancel()
+	for rows.Next() {
+	}
+	_ = rows.Close()
+
+	rec := findLogLineByMsg(t, buf, "sql error")
+	if rec == nil {
+		t.Fatalf("expected sql error line for cancelled scan; buf=%s", buf.String())
+	}
+	if errStr, _ := rec["error"].(string); errStr == "" {
+		t.Errorf("error attr missing or empty: %v", rec)
+	}
+}
+
+// TestLogStmt_SlowQueryIncludesArgsShape verifies that a slow
+// query attaches an "args_shape" attr describing each bound
+// parameter's type and length, but never the raw value. Raw
+// values can carry PII (addresses, subjects, tokens) and must
+// not be persisted in logs by default.
+func TestLogStmt_SlowQueryIncludesArgsShape(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{SlowMs: 50})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
@@ -283,19 +322,33 @@ func TestLogStmt_SlowQueryIncludesArgs(t *testing.T) {
 	if rec == nil {
 		t.Fatalf("no sql slow line; buf=%s", buf.String())
 	}
-	gotArgs, ok := rec["args"].(string)
+	gotShape, ok := rec["args_shape"].(string)
 	if !ok {
-		t.Fatalf("args attr missing or wrong type: %v", rec["args"])
+		t.Fatalf("args_shape attr missing or wrong type: %v", rec["args_shape"])
 	}
-	if !strings.Contains(gotArgs, "42") || !strings.Contains(gotArgs, "gmail") {
-		t.Errorf("args missing values: %q", gotArgs)
+	// Type info present.
+	if !strings.Contains(gotShape, "int64") {
+		t.Errorf("args_shape missing int64 type: %q", gotShape)
+	}
+	if !strings.Contains(gotShape, "string(len=5)") {
+		t.Errorf("args_shape missing string length: %q", gotShape)
+	}
+	// Raw values must not appear.
+	if strings.Contains(gotShape, "42") {
+		t.Errorf("args_shape leaked numeric value: %q", gotShape)
+	}
+	if strings.Contains(gotShape, "gmail") {
+		t.Errorf("args_shape leaked string value: %q", gotShape)
+	}
+	// Legacy "args" attr must not be present.
+	if _, present := rec["args"]; present {
+		t.Errorf("legacy args attr should not be set: %v", rec)
 	}
 }
 
 // TestLogStmt_FullTraceOmitsArgs verifies that --full-trace mode
-// does not attach args. nargs is enough at high-volume Info level;
-// args carry PII (subjects, addresses) and would be a privacy
-// regression if logged on every successful query.
+// does not attach args or args_shape. nargs is enough at
+// high-volume Info level.
 func TestLogStmt_FullTraceOmitsArgs(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
@@ -311,32 +364,39 @@ func TestLogStmt_FullTraceOmitsArgs(t *testing.T) {
 	if _, present := rec["args"]; present {
 		t.Errorf("args should not be present on info/full-trace lines: %v", rec)
 	}
+	if _, present := rec["args_shape"]; present {
+		t.Errorf("args_shape should not be present on info/full-trace lines: %v", rec)
+	}
 	if rec["nargs"].(float64) != 1 {
 		t.Errorf("nargs = %v, want 1", rec["nargs"])
 	}
 }
 
-// TestFormatArgs_TruncatesLongStrings ensures a multi-KB string
-// argument (e.g. a body excerpt or large IN-list element) does
-// not blow up the log line.
-func TestFormatArgs_TruncatesLongStrings(t *testing.T) {
+// TestFormatArgsShape_RedactsValues ensures the shape formatter
+// emits type and length only, never raw values, even for long
+// strings that could carry sensitive content.
+func TestFormatArgsShape_RedactsValues(t *testing.T) {
 	long := strings.Repeat("x", 200)
-	got := formatArgs([]any{long})
-	if !strings.Contains(got, "...") {
-		t.Errorf("expected truncation marker in %q", got)
+	got := formatArgsShape([]any{long, "secret-token", []byte("hello world"), nil, int64(42)})
+	if strings.Contains(got, "x") || strings.Contains(got, "secret-token") {
+		t.Errorf("shape leaked raw string: %q", got)
 	}
-	if len(got) > 100 {
-		t.Errorf("formatted args too long: %d chars", len(got))
+	if strings.Contains(got, "hello world") {
+		t.Errorf("shape leaked raw bytes: %q", got)
 	}
-}
-
-// TestFormatArgs_HandlesByteSlices ensures raw blob arguments
-// don't dump binary into the log; we only show the length.
-func TestFormatArgs_HandlesByteSlices(t *testing.T) {
-	got := formatArgs([]any{[]byte("hello world")})
-	want := "[<11 bytes>]"
-	if got != want {
-		t.Errorf("got %q want %q", got, want)
+	if strings.Contains(got, "42") {
+		t.Errorf("shape leaked raw numeric: %q", got)
+	}
+	for _, want := range []string{
+		"string(len=200)",
+		"string(len=12)",
+		"bytes(len=11)",
+		"nil",
+		"int64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("shape missing %q: %q", want, got)
+		}
 	}
 }
 
@@ -394,6 +454,24 @@ func TestNormalizeStmt_TinyBudgetFallsBackToHead(t *testing.T) {
 	}
 	if strings.Contains(got, " ... ") {
 		t.Errorf("did not expect head+tail split on tiny budget; got %q", got)
+	}
+}
+
+// TestNormalizeStmt_UTF8Safe ensures truncation respects rune
+// boundaries — multi-byte characters in SQL literals or comments
+// must not be split, which would emit invalid UTF-8 to logs.
+func TestNormalizeStmt_UTF8Safe(t *testing.T) {
+	// Each "café — 漢" is 13 bytes / 7 runes; repeat to exceed
+	// any reasonable budget.
+	in := strings.Repeat("café — 漢 ", 30)
+	got := normalizeStmt(in, 50)
+	if !utf8.ValidString(got) {
+		t.Errorf("normalizeStmt returned invalid UTF-8: %q", got)
+	}
+	// Tiny-budget head-only path.
+	got2 := normalizeStmt(in, 8)
+	if !utf8.ValidString(got2) {
+		t.Errorf("tiny-budget normalizeStmt returned invalid UTF-8: %q", got2)
 	}
 }
 

--- a/internal/store/db_logger_test.go
+++ b/internal/store/db_logger_test.go
@@ -167,6 +167,103 @@ func TestLoggedDB_QueryRowLogsButNoError(t *testing.T) {
 	}
 }
 
+// TestLoggedRows_LogsAtClose verifies that the timing log line
+// for a streaming Query is emitted on Close, not at QueryContext
+// return. This is the behaviour change that gives streaming queries
+// honest duration_ms numbers.
+func TestLoggedRows_LogsAtClose(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
+	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
+
+	buf := captureSlog(t, slog.LevelDebug)
+	db := openLoggedMem(t)
+	if _, err := db.Exec(
+		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Reset buffer so we only see the post-Query log line(s).
+	buf.Reset()
+
+	rows, err := db.Query("SELECT val FROM t ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if findLogLineByMsg(t, buf, "sql") != nil {
+		t.Fatalf("query log emitted before Close; want only at Close. buf=%s",
+			buf.String())
+	}
+
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	rec := findLogLine(t, buf, "sql")
+	if rec["kind"] != "query" {
+		t.Errorf("kind = %v, want query", rec["kind"])
+	}
+}
+
+// TestLoggedRows_CloseIdempotent verifies that double-Close
+// (e.g. an early-return defer plus an explicit close) does not
+// emit two log lines.
+func TestLoggedRows_CloseIdempotent(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
+	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
+
+	buf := captureSlog(t, slog.LevelDebug)
+	db := openLoggedMem(t)
+	rows, err := db.Query("SELECT 1")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for rows.Next() {
+		var n int
+		_ = rows.Scan(&n)
+	}
+	_ = rows.Close()
+	_ = rows.Close()
+
+	count := 0
+	for _, rec := range decodeAll(t, buf) {
+		if rec["msg"] == "sql" && rec["kind"] == "query" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("got %d query log lines, want 1", count)
+	}
+}
+
+// TestLoggedRows_QueryErrorLogsImmediately verifies that an
+// error returned from db.Query (e.g. bad SQL, no such table)
+// is logged at the QueryContext call site, not deferred to a
+// Close call that would never happen because no rows handle
+// is returned.
+func TestLoggedRows_QueryErrorLogsImmediately(t *testing.T) {
+	ConfigureSQLLogging(SQLLogOptions{})
+	buf := captureSlog(t, slog.LevelDebug)
+	db := openLoggedMem(t)
+
+	_, err := db.Query("SELECT * FROM no_such_table")
+	if err == nil {
+		t.Fatal("expected query error")
+	}
+	rec := findLogLineByMsg(t, buf, "sql error")
+	if rec == nil {
+		t.Fatalf("no sql error line; buf=%s", buf.String())
+	}
+}
+
 func TestNormalizeStmt_CollapsesWhitespace(t *testing.T) {
 	in := "SELECT\n  *\nFROM\n\tt WHERE id = ?"
 	got := normalizeStmt(in, 0)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -71,7 +71,7 @@ func (s *Store) MessageExistsBatch(sourceID int64, sourceMessageIDs []string) (m
 	result := make(map[string]int64)
 	err := queryInChunks(s.db, sourceMessageIDs, []interface{}{sourceID},
 		`SELECT source_message_id, id FROM messages WHERE source_id = ? AND source_message_id IN (%s)`,
-		func(rows *sql.Rows) error {
+		func(rows *loggedRows) error {
 			var srcID string
 			var id int64
 			if err := rows.Scan(&srcID, &id); err != nil {
@@ -138,7 +138,7 @@ func (s *Store) MessageExistsWithRawBatch(sourceID int64, sourceMessageIDs []str
 		 FROM messages m
 		 JOIN message_raw mr ON mr.message_id = m.id
 		 WHERE m.source_id = ? AND m.source_message_id IN (%s)`,
-		func(rows *sql.Rows) error {
+		func(rows *loggedRows) error {
 			var srcID string
 			var id int64
 			if err := rows.Scan(&srcID, &id); err != nil {
@@ -418,7 +418,7 @@ func (s *Store) EnsureParticipantsBatch(addresses []mime.Address) (map[string]in
 
 	err := queryInChunks(s.db, emails, nil,
 		`SELECT email_address, id FROM participants WHERE email_address IN (%s)`,
-		func(rows *sql.Rows) error {
+		func(rows *loggedRows) error {
 			var email string
 			var id int64
 			if err := rows.Scan(&email, &id); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -262,15 +262,15 @@ func (s *Store) withTx(fn func(tx *loggedTx) error) error {
 // SQLite's parameter limit. queryTemplate must contain a single %s placeholder
 // for the comma-separated "?" list. The prefix args are prepended before each
 // chunk's args (e.g., a source_id filter).
-// chunkQuerier abstracts the subset of *sql.DB that queryInChunks
-// and execInChunks actually use, so the helpers accept either a
-// raw *sql.DB (tests) or the logging wrapper (production path).
+// chunkQuerier abstracts the subset of *loggedDB that queryInChunks
+// and execInChunks actually use. The Query path returns *loggedRows
+// so streaming-query timing reflects scan-close, not just prepare.
 type chunkQuerier interface {
-	Query(query string, args ...any) (*sql.Rows, error)
+	Query(query string, args ...any) (*loggedRows, error)
 	Exec(query string, args ...any) (sql.Result, error)
 }
 
-func queryInChunks[T any](db chunkQuerier, ids []T, prefixArgs []interface{}, queryTemplate string, fn func(*sql.Rows) error) error {
+func queryInChunks[T any](db chunkQuerier, ids []T, prefixArgs []interface{}, queryTemplate string, fn func(*loggedRows) error) error {
 	const chunkSize = 500
 	for i := 0; i < len(ids); i += chunkSize {
 		end := i + chunkSize

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -338,7 +338,7 @@ func (s *Store) UpdateSourceSyncCursor(sourceID int64, cursor string) error {
 // ListSources returns all sources, optionally filtered by source type.
 // Pass an empty string to return all sources.
 func (s *Store) ListSources(sourceType string) ([]*Source, error) {
-	var rows *sql.Rows
+	var rows *loggedRows
 	var err error
 
 	if sourceType != "" {


### PR DESCRIPTION
## Motivation

(Deliberately not affected by & mergable with #304) This PR enhances #263 by sharpening the SQL logger so slow and failing queries actually tell you what happened. Three things change. First, streaming queries now record their duration at `rows.Close` instead of when `db.Query` returns, because the work happens while you read rows, not when you get the handle. Second, slow and errored queries log their bound args, and the statement truncation preserves the `WHERE` clause, so you can see what ran with what values without the diagnostic part getting cut off. Third, a few small correctness fixes: `loggedRows.Close` ordering, UTF-8-safe arg truncation, and `logStmt` inlined where it belongs.

## Summary

- Log streaming-query duration at `rows.Close`, not at `db.Query` return
- Log args on slow/error queries; preserve the `WHERE` clause when truncating long statements
- Fix `loggedRows.Close` ordering, make arg truncation UTF-8-safe, inline `logStmt`