### PR TITLE
query: hide deleted rows in SearchByDomains

### DIFF
--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1160,6 +1160,9 @@ func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, af
 	}
 
 	conditions := []string{emailOnlyFilterM}
+	// Hide dedup losers (deleted_at) and source-deleted rows so this MCP-facing
+	// surface matches the visibility rules of Search/SearchFast.
+	conditions = append(conditions, store.LiveMessagesWhere("m", true))
 	conditions = append(conditions, fmt.Sprintf(`EXISTS (
 		SELECT 1 FROM message_recipients mr_dom
 		JOIN participants p_dom ON p_dom.id = mr_dom.participant_id

--- a/internal/query/sqlite_search_test.go
+++ b/internal/query/sqlite_search_test.go
@@ -464,6 +464,45 @@ func TestMergeFilterIntoQuery_SliceAliasingMutation(t *testing.T) {
 	}
 }
 
+// TestSearchByDomains_HidesDeleted verifies SearchByDomains applies the
+// same live-message filter as Search/SearchFast: dedup losers (deleted_at)
+// are always hidden, and source-deleted rows (deleted_from_source_at) are
+// hidden too. Without the predicate this MCP-facing surface would surface
+// rows that every other read path suppresses.
+func TestSearchByDomains_HidesDeleted(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := context.Background()
+
+	all, err := env.Engine.SearchByDomains(ctx, []string{"example.com"}, nil, nil, 100, 0)
+	if err != nil {
+		t.Fatalf("SearchByDomains baseline: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("baseline result count: got %d, want 5", len(all))
+	}
+
+	// Dedup-soft-delete one message — must always be hidden.
+	env.MarkDedupLoserByID(1)
+	// Source-delete another — also hidden by the full live-message predicate.
+	env.MarkDeletedByID(2)
+
+	results, err := env.Engine.SearchByDomains(ctx, []string{"example.com"}, nil, nil, 100, 0)
+	if err != nil {
+		t.Fatalf("SearchByDomains after deletes: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("after deletes: got %d, want 3", len(results))
+	}
+	for _, r := range results {
+		if r.ID == 1 {
+			t.Error("dedup-loser message 1 leaked into results")
+		}
+		if r.ID == 2 {
+			t.Error("source-deleted message 2 leaked into results")
+		}
+	}
+}
+
 func TestSearch_HideDeleted(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/internal/testutil/dbtest/dbtest.go
+++ b/internal/testutil/dbtest/dbtest.go
@@ -445,6 +445,17 @@ func (tdb *TestDB) MarkDeletedByID(id int64) {
 	}
 }
 
+// MarkDedupLoserByID sets deleted_at on a message, mirroring what
+// store.Deduplicate does to soft-delete the losing duplicate row.
+// User-facing read paths must always exclude these.
+func (tdb *TestDB) MarkDedupLoserByID(id int64) {
+	tdb.T.Helper()
+	_, err := tdb.DB.Exec("UPDATE messages SET deleted_at = datetime('now') WHERE id = ?", id)
+	if err != nil {
+		tdb.T.Fatalf("mark dedup loser by id %d: %v", id, err)
+	}
+}
+
 // MarkDeletedBySourceID marks a message as deleted by its source message ID.
 func (tdb *TestDB) MarkDeletedBySourceID(sourceID string) {
 	tdb.T.Helper()


### PR DESCRIPTION
SearchByDomains skipped `store.LiveMessagesWhere`, so the MCP `search_by_domains` tool could surface dedup losers (`deleted_at`) and source-deleted rows that every other read path suppresses.

Apply `LiveMessagesWhere("m", true)` — same predicate `Search`/`SearchFast` use — so dedup losers are always hidden alongside source-deleted rows. Adds a regression test that soft-deletes one message of each kind and verifies neither leaks, plus `dbtest.MarkDedupLoserByID` for setting `deleted_at` directly.