### PR TITLE
vector: chunk long messages instead of truncating

### DIFF
--- a/internal/vector/backend.go
+++ b/internal/vector/backend.go
@@ -35,14 +35,25 @@ type Generation struct {
 	MessageCount int64
 }
 
-// Chunk is a pre-computed embedding to persist in the index. In MVP
-// there is one chunk per message; multi-chunk support (§13 future
-// work) would extend this with a chunk sequence id.
+// Chunk is a pre-computed embedding to persist in the index. A long
+// message produces multiple chunks distinguished by ChunkIndex (0-based,
+// dense, gap-free). Short messages produce exactly one chunk with
+// ChunkIndex=0, which is the legacy single-vector behavior.
+//
+// Backends key vectors by (GenerationID, MessageID, ChunkIndex). Search
+// returns at most one Hit per MessageID; if multiple chunks of the same
+// message match, the backend keeps the best-scoring chunk and discards
+// the rest. ChunkCharStart/ChunkCharEnd are 0-based offsets into the
+// preprocessed text and are stored for debugging only — search results
+// do not currently surface "which chunk matched".
 type Chunk struct {
-	MessageID     int64
-	Vector        []float32
-	SourceCharLen int
-	Truncated     bool
+	MessageID      int64
+	ChunkIndex     int
+	Vector         []float32
+	SourceCharLen  int
+	ChunkCharStart int
+	ChunkCharEnd   int
+	Truncated      bool
 }
 
 // Filter carries the structured filters pushed into both signal CTEs

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -22,6 +22,21 @@ import (
 // inconsistently-prepared vectors in one generation.
 const preprocessVersion = 1
 
+// embedPolicyVersion identifies the embed-worker output layout for a
+// given Preprocess result. Bump whenever a change to internal/vector/
+// embed/worker.go (or its chunking helpers) would shift the set of
+// vectors written for the same Preprocess output — for example: the
+// switch from single-vector-per-message to multi-chunk-per-message, a
+// change to the chunk window/overlap derivation, or a change to the
+// per-message chunk cap. Like preprocessVersion this is folded into
+// GenerationFingerprint so flipping the policy stales the active
+// index and forces --full-rebuild rather than mixing single-vector
+// and chunked entries inside one generation.
+//
+// v1: chunked layout (the worker passes maxChars=0 to Preprocess and
+// splits the result into MaxInputChars-bounded chunks via ChunkText).
+const embedPolicyVersion = 1
+
 // Config is the top-level vector-search configuration, loaded from the
 // [vector] TOML table.
 type Config struct {
@@ -204,22 +219,30 @@ func (e EmbeddingsConfig) Fingerprint() string {
 
 // GenerationFingerprint returns the full identifier used to compare an
 // index generation against the configured policy. Format:
-// "<model>:<dimension>:<preprocess>:c<max_input_chars>". Every segment
-// is derived from the effective config, so changing the embedding
-// model/dimension, any preprocessing toggle, OR the truncation cap
-// produces a new fingerprint and the ResolveActiveForFingerprint check
-// forces a --full-rebuild rather than silently embedding new messages
-// under a policy different from the already-active vectors.
+// "<model>:<dimension>:<preprocess>:c<max_input_chars>:e<embed_policy>".
+// Every segment is derived from the effective config (or a code-level
+// version constant), so changing the embedding model/dimension, any
+// preprocessing toggle, the truncation cap, or the embed-worker output
+// layout produces a new fingerprint and the ResolveActiveForFingerprint
+// check forces a --full-rebuild rather than silently embedding new
+// messages under a policy different from the already-active vectors.
 //
-// max_input_chars is part of the policy because the embed worker
-// passes it straight into Preprocess() as the rune-bounded truncation
-// cap (see Worker.run); raising or lowering it changes the embedded
-// text for any message whose preprocessed form exceeds the previous
-// cap, so two cap values produce two different embedding spaces and
-// must not share one generation.
+// max_input_chars is part of the policy because the embed worker uses
+// it as the per-chunk rune cap fed into ChunkText (and, before
+// chunking, as the rune-bounded truncation cap fed into Preprocess);
+// raising or lowering it changes which chunks a long message produces,
+// so two cap values produce two different embedding layouts and must
+// not share one generation.
+//
+// embed_policy (the embedPolicyVersion constant) covers worker-side
+// changes that shift the vector layout for the same Preprocess output
+// — most notably the switch from one-vector-per-message-with-truncation
+// to N-vectors-per-message-via-ChunkText. Without folding this version
+// in, an active generation built under the old single-vector policy
+// would silently accept new chunked entries from an upgraded worker.
 func (c Config) GenerationFingerprint() string {
-	return fmt.Sprintf("%s:%s:c%d",
-		c.Embeddings.Fingerprint(), c.Preprocess.Fingerprint(), c.Embeddings.MaxInputChars)
+	return fmt.Sprintf("%s:%s:c%d:e%d",
+		c.Embeddings.Fingerprint(), c.Preprocess.Fingerprint(), c.Embeddings.MaxInputChars, embedPolicyVersion)
 }
 
 // Validate returns a descriptive error if the config is unusable.

--- a/internal/vector/config_test.go
+++ b/internal/vector/config_test.go
@@ -1,6 +1,7 @@
 package vector
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -433,16 +434,18 @@ func TestPreprocessConfig_FingerprintChangesPerToggle(t *testing.T) {
 }
 
 // TestConfig_GenerationFingerprintFolds checks the full identifier
-// composition. The shape is "<model>:<dim>:<preprocess>:c<maxchars>"
-// — every segment must contribute so an operator switching the model,
-// any preprocess toggle, or the truncation cap stales the existing
-// index instead of silently mixing inconsistently-prepared vectors.
+// composition. The shape is
+// "<model>:<dim>:<preprocess>:c<maxchars>:e<embed_policy>" — every
+// segment must contribute so an operator switching the model, any
+// preprocess toggle, the truncation cap, or the embed-worker output
+// layout stales the existing index instead of silently mixing
+// inconsistently-prepared vectors.
 func TestConfig_GenerationFingerprintFolds(t *testing.T) {
 	base := Config{
 		Embeddings: EmbeddingsConfig{Model: "nomic-embed", Dimension: 768, MaxInputChars: 6000},
 	}
 	got := base.GenerationFingerprint()
-	want := "nomic-embed:768:p1-111111:c6000"
+	want := fmt.Sprintf("nomic-embed:768:p1-111111:c6000:e%d", embedPolicyVersion)
 	if got != want {
 		t.Errorf("GenerationFingerprint() = %q, want %q", got, want)
 	}
@@ -495,5 +498,23 @@ func TestConfig_GenerationFingerprint_IncludesMaxInputChars(t *testing.T) {
 	if zeroed.GenerationFingerprint() == baseline {
 		t.Errorf("GenerationFingerprint() did not change when MaxInputChars went 6000→0 (still %q)",
 			baseline)
+	}
+}
+
+// TestConfig_GenerationFingerprint_IncludesEmbedPolicyVersion pins the
+// trailing :e<embedPolicyVersion> segment. The embed worker switched
+// from one-vector-per-message-with-truncation to N-vectors-per-message-
+// via-ChunkText; without this segment an active generation seeded
+// under the old single-vector policy would silently accept new chunked
+// entries from an upgraded worker, mixing two incompatible vector
+// layouts inside one generation.
+func TestConfig_GenerationFingerprint_IncludesEmbedPolicyVersion(t *testing.T) {
+	base := Config{
+		Embeddings: EmbeddingsConfig{Model: "m", Dimension: 8, MaxInputChars: 6000},
+	}
+	got := base.GenerationFingerprint()
+	suffix := fmt.Sprintf(":e%d", embedPolicyVersion)
+	if !strings.HasSuffix(got, suffix) {
+		t.Errorf("GenerationFingerprint() = %q, want suffix %q", got, suffix)
 	}
 }

--- a/internal/vector/embed/chunk.go
+++ b/internal/vector/embed/chunk.go
@@ -1,0 +1,240 @@
+package embed
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// ChunkSpan describes one window into the preprocessed source text.
+// CharStart / CharEnd are rune offsets (not byte offsets) into the
+// input string passed to ChunkText, so a backend can recover the exact
+// substring later for highlighting. Text is that substring, already
+// extracted; callers feed Text directly to the embedder.
+type ChunkSpan struct {
+	Text      string
+	CharStart int
+	CharEnd   int
+}
+
+// ChunkText splits text into windows of at most maxRunes runes each,
+// overlapping by overlapRunes runes between consecutive windows. The
+// goal is twofold:
+//
+//  1. Every span fits inside the embedder's context window. A message
+//     longer than maxRunes that would otherwise be truncated (and lose
+//     its tail) instead produces multiple spans, each individually
+//     embedded.
+//  2. A query term that lives near a window boundary can still match.
+//     The overlap means a sentence straddling the cut shows up
+//     verbatim in both spans, so the ANN search retrieves whichever
+//     span scores higher.
+//
+// When the input fits, ChunkText returns a single span covering the
+// whole text. When it doesn't, ChunkText prefers to cut at the last
+// paragraph break (\n\n) inside the final 25% of the window, falling
+// back to a sentence terminator (". "/"! "/"? "/"\n"), then to a word
+// boundary (space), then to a hard rune cut. This avoids slicing the
+// embedder's input mid-word, which materially helps recall on prose.
+//
+// maxRunes <= 0 disables chunking and returns a single span. The
+// overlap is clamped so it never exceeds maxRunes/2 — an overlap as
+// large as the window itself would loop forever.
+//
+// maxSpans caps the number of returned spans, dropping tail content
+// from any message that would otherwise produce more chunks. <= 0
+// disables the cap. The cap exists for a real-world failure mode:
+// system-generated error dumps and stack traces can exceed 10 MB of
+// body text and would chunk into thousands of spans, blowing past the
+// embedder's batch-size assumptions and pushing the whole batch over
+// the API timeout. Most callers should pass a generous cap (50–100)
+// — enough to cover any legitimate long-form email while keeping
+// pathological inputs bounded.
+//
+// The returned tailDropped is true when ChunkText dropped content past
+// the last emitted span — either because the input was first truncated
+// by the maxSpans*maxRunes pre-cap, or because the maxSpans cap fired
+// inside the main loop while more chunks would otherwise have been
+// emitted. Callers use this to mark the message as truncated for
+// downstream metrics, regardless of whether the last emitted chunk
+// happened to land on a clean soft break (in which case the
+// per-chunk Trunc-on-hard-cut signal would not fire).
+func ChunkText(text string, maxRunes, overlapRunes, maxSpans int) (spans []ChunkSpan, tailDropped bool) {
+	if text == "" {
+		return nil, false
+	}
+	if maxRunes <= 0 {
+		return []ChunkSpan{{Text: text, CharStart: 0, CharEnd: utf8.RuneCountInString(text)}}, false
+	}
+
+	// Cap text early. Without this, a sync that lands a multi-megabyte
+	// body forces buildRuneByteOffsets to allocate ~8 bytes per rune
+	// for the whole input — a 15 MB email becomes a ~120 MB allocation
+	// even though only the first maxSpans*maxRunes worth of content
+	// can possibly be emitted. The chunker only ever reads ahead
+	// within a window of maxRunes runes, so this cap is lossless for
+	// the spans it would otherwise emit; the tail beyond the cap
+	// would have been dropped on the floor by the maxSpans guard
+	// inside the loop anyway.
+	if maxSpans > 0 {
+		keep := maxSpans * maxRunes
+		walked := 0
+		for i := range text {
+			if walked >= keep {
+				text = text[:i]
+				tailDropped = true
+				break
+			}
+			walked++
+		}
+	}
+
+	totalRunes := utf8.RuneCountInString(text)
+	if totalRunes <= maxRunes {
+		return []ChunkSpan{{Text: text, CharStart: 0, CharEnd: totalRunes}}, tailDropped
+	}
+	if overlapRunes < 0 {
+		overlapRunes = 0
+	}
+	if overlapRunes >= maxRunes {
+		overlapRunes = maxRunes / 2
+	}
+
+	// Pre-compute byte offsets for every rune so each window slice is
+	// O(window) rather than O(text). Slice indices live in rune space;
+	// byte conversion happens once via runeByteOffsets[i].
+	runeByteOffsets := buildRuneByteOffsets(text)
+	// runeByteOffsets has one entry per rune plus a sentinel for the
+	// trailing position, so len-1 == totalRunes.
+	if len(runeByteOffsets)-1 != totalRunes {
+		// Defensive: out-of-band UTF-8 should never reach here, but
+		// fall back to a single span rather than panic on a bad input.
+		return []ChunkSpan{{Text: text, CharStart: 0, CharEnd: totalRunes}}, tailDropped
+	}
+
+	cursor := 0
+	for cursor < totalRunes {
+		if maxSpans > 0 && len(spans) >= maxSpans {
+			// Hit the per-message cap. The tail of the message is
+			// dropped; the spans collected so far already cover the
+			// head, which is what semantic search cares about. We
+			// could synthesize a final "remaining content omitted"
+			// span here, but that would just feed the embedder a
+			// content-free string. Flag tailDropped so the caller
+			// knows the message wasn't fully covered, regardless of
+			// where the last emitted chunk landed (the per-chunk
+			// Trunc flag only fires on hard cuts).
+			tailDropped = true
+			break
+		}
+		windowEnd := cursor + maxRunes
+		if windowEnd > totalRunes {
+			windowEnd = totalRunes
+		}
+		// Look for a soft break in the back quarter of the window;
+		// if found, cut there instead of the hard end. Skip this when
+		// the window already reaches the end of text — no need to find
+		// a "nice" cut for the final span.
+		cut := windowEnd
+		if windowEnd < totalRunes {
+			searchFloor := cursor + (maxRunes * 3 / 4)
+			if searchFloor < cursor+1 {
+				searchFloor = cursor + 1
+			}
+			cut = findSoftBreak(text, runeByteOffsets, searchFloor, windowEnd)
+		}
+
+		startByte := runeByteOffsets[cursor]
+		endByte := runeByteOffsets[cut]
+		span := ChunkSpan{
+			Text:      text[startByte:endByte],
+			CharStart: cursor,
+			CharEnd:   cut,
+		}
+		spans = append(spans, span)
+
+		if cut >= totalRunes {
+			break
+		}
+		// Advance the cursor by (window - overlap), but never less
+		// than 1 rune — guards against pathological inputs where the
+		// soft break sits inside the overlap zone.
+		advance := (cut - cursor) - overlapRunes
+		if advance < 1 {
+			advance = 1
+		}
+		cursor += advance
+	}
+	return spans, tailDropped
+}
+
+// buildRuneByteOffsets returns a slice of length runeCount+1 where
+// entry i is the byte offset of rune i (and the final entry is len(s)).
+// Used by ChunkText to map rune-space slice indices back to byte slices
+// without walking the string twice per window.
+func buildRuneByteOffsets(s string) []int {
+	out := make([]int, 0, len(s)/2+1)
+	for i := range s {
+		out = append(out, i)
+	}
+	out = append(out, len(s))
+	return out
+}
+
+// findSoftBreak scans runeByteOffsets[floor:ceil] for the last
+// preferred break — paragraph, sentence, or word — and returns its
+// rune index. Returns ceil if no soft break is found in the search
+// window. Ordering: paragraph beats sentence beats word, so a "good"
+// boundary near the end wins over a "great" one near the beginning of
+// the search window. This keeps each chunk closer to maxRunes; cutting
+// far short to chase a paragraph break would waste budget.
+func findSoftBreak(text string, runeByteOffsets []int, floor, ceil int) int {
+	// Examine bytes between floor and ceil. We compare against fixed
+	// ASCII byte patterns — none of the break sequences span multi-byte
+	// runes, so byte-level lookups give the same answer as rune-level
+	// without the per-iteration UTF-8 decode.
+	byteFloor := runeByteOffsets[floor]
+	byteCeil := runeByteOffsets[ceil]
+	window := text[byteFloor:byteCeil]
+
+	paragraph := strings.LastIndex(window, "\n\n")
+	if paragraph >= 0 {
+		// Cut after the "\n\n" so the new chunk does not begin with
+		// blank lines.
+		return byteToRune(runeByteOffsets, byteFloor+paragraph+2)
+	}
+
+	// Sentence terminators followed by space/newline. Check ". " /
+	// "? " / "! " / ".\n" / "?\n" / "!\n".
+	bestSentence := -1
+	for _, term := range []string{". ", "? ", "! ", ".\n", "?\n", "!\n"} {
+		if idx := strings.LastIndex(window, term); idx > bestSentence {
+			bestSentence = idx + len(term)
+		}
+	}
+	if bestSentence > 0 {
+		return byteToRune(runeByteOffsets, byteFloor+bestSentence)
+	}
+
+	// Word boundary — last space in the window.
+	if space := strings.LastIndexByte(window, ' '); space > 0 {
+		return byteToRune(runeByteOffsets, byteFloor+space+1)
+	}
+
+	return ceil
+}
+
+// byteToRune converts a byte offset into the rune index by binary
+// searching runeByteOffsets. Faster than a linear scan when the offset
+// is far from either end of the string.
+func byteToRune(runeByteOffsets []int, b int) int {
+	lo, hi := 0, len(runeByteOffsets)-1
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if runeByteOffsets[mid] < b {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}

--- a/internal/vector/embed/chunk_test.go
+++ b/internal/vector/embed/chunk_test.go
@@ -1,0 +1,288 @@
+package embed
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestChunkText(t *testing.T) {
+	t.Run("EmptyInputReturnsNil", func(t *testing.T) {
+		if got, _ := ChunkText("", 100, 10, 0); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("ShortInputReturnsSingleSpan", func(t *testing.T) {
+		got, _ := ChunkText("hello world", 100, 10, 0)
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		if got[0].Text != "hello world" {
+			t.Errorf("Text = %q, want %q", got[0].Text, "hello world")
+		}
+		if got[0].CharStart != 0 || got[0].CharEnd != 11 {
+			t.Errorf("span = [%d,%d), want [0,11)", got[0].CharStart, got[0].CharEnd)
+		}
+	})
+
+	t.Run("MaxRunesZeroDisablesChunking", func(t *testing.T) {
+		text := strings.Repeat("x", 1000)
+		got, _ := ChunkText(text, 0, 10, 0)
+		if len(got) != 1 || got[0].Text != text {
+			t.Errorf("expected single span covering whole text")
+		}
+	})
+
+	t.Run("CutsAtParagraphBreakInBackQuarter", func(t *testing.T) {
+		// Build 100 chars of text where a "\n\n" sits at offset 80.
+		// The back quarter of a 100-rune window starts at offset 75,
+		// so the cut should land at the paragraph break (offset 82,
+		// right after "\n\n").
+		first := strings.Repeat("a", 80)
+		second := strings.Repeat("b", 50)
+		text := first + "\n\n" + second
+		got, _ := ChunkText(text, 100, 10, 0)
+		if len(got) < 2 {
+			t.Fatalf("expected >= 2 chunks, got %d", len(got))
+		}
+		if got[0].CharEnd != 82 {
+			t.Errorf("first chunk ends at %d, want 82 (right after \\n\\n)", got[0].CharEnd)
+		}
+		if !strings.HasSuffix(got[0].Text, "\n\n") {
+			t.Errorf("first chunk should end with paragraph break; got %q", got[0].Text[len(got[0].Text)-5:])
+		}
+	})
+
+	t.Run("CutsAtSentenceBoundaryWhenNoParagraph", func(t *testing.T) {
+		first := strings.Repeat("a", 80)
+		// Sentence terminator at offset 80 ("end. ").
+		text := first + ". " + strings.Repeat("b", 50)
+		got, _ := ChunkText(text, 100, 10, 0)
+		if len(got) < 2 {
+			t.Fatalf("expected >= 2 chunks")
+		}
+		// findSoftBreak returns the index *after* ". " (so 82).
+		if got[0].CharEnd != 82 {
+			t.Errorf("first chunk ends at %d, want 82", got[0].CharEnd)
+		}
+	})
+
+	t.Run("CutsAtWordBoundaryWhenNoSentence", func(t *testing.T) {
+		// Construct a 100-rune window where the back quarter has only
+		// a space (no sentence terminator). Cut should land at the
+		// last space inside [75, 100).
+		text := strings.Repeat("a", 90) + " " + strings.Repeat("b", 50)
+		got, _ := ChunkText(text, 100, 10, 0)
+		if len(got) < 2 {
+			t.Fatalf("expected >= 2 chunks")
+		}
+		if got[0].CharEnd != 91 {
+			t.Errorf("first chunk ends at %d, want 91 (one past space at 90)", got[0].CharEnd)
+		}
+	})
+
+	t.Run("HardCutsWhenNoSoftBreakInBackQuarter", func(t *testing.T) {
+		// 1000 unbroken non-space chars; no soft break anywhere. Each
+		// window should land on the hard cut at maxRunes.
+		text := strings.Repeat("a", 1000)
+		got, _ := ChunkText(text, 100, 0, 0)
+		if len(got) != 10 {
+			t.Fatalf("len = %d, want 10", len(got))
+		}
+		for i, s := range got {
+			if s.CharEnd-s.CharStart != 100 {
+				t.Errorf("chunk %d: %d runes, want 100", i, s.CharEnd-s.CharStart)
+			}
+		}
+	})
+
+	t.Run("OverlapBetweenConsecutiveChunks", func(t *testing.T) {
+		text := strings.Repeat("a", 300)
+		got, _ := ChunkText(text, 100, 20, 0)
+		if len(got) < 2 {
+			t.Fatalf("expected >= 2 chunks")
+		}
+		// With overlap=20, the second chunk should start 80 runes
+		// after the first chunk's start.
+		if got[1].CharStart != 80 {
+			t.Errorf("chunk[1] starts at %d, want 80", got[1].CharStart)
+		}
+	})
+
+	t.Run("OverlapClampedToHalfWindow", func(t *testing.T) {
+		// overlap >= maxRunes would mean cursor never advances —
+		// the function must clamp it. With maxRunes=100 and
+		// overlap=500, effective overlap should be 50.
+		text := strings.Repeat("a", 300)
+		got, _ := ChunkText(text, 100, 500, 0)
+		if len(got) == 0 {
+			t.Fatal("got no chunks (overlap not clamped → infinite loop)")
+		}
+		// With effective overlap=50, chunk[1] starts at 50.
+		if len(got) >= 2 && got[1].CharStart != 50 {
+			t.Errorf("chunk[1] starts at %d, want 50", got[1].CharStart)
+		}
+	})
+
+	t.Run("AllSpansHaveValidUTF8AndCorrectText", func(t *testing.T) {
+		// Mixed-script input with multi-byte runes scattered through.
+		var b strings.Builder
+		for i := 0; i < 50; i++ {
+			b.WriteString("Hello world. ")
+			b.WriteString("こんにちは世界。")
+		}
+		text := b.String()
+		got, _ := ChunkText(text, 80, 10, 0)
+		if len(got) < 2 {
+			t.Fatalf("expected >= 2 chunks")
+		}
+		for i, s := range got {
+			if !utf8.ValidString(s.Text) {
+				t.Errorf("chunk %d: invalid UTF-8 in span text", i)
+			}
+			// Span text must match the substring derived from the
+			// CharStart/CharEnd offsets — guards against off-by-one in
+			// the byte/rune translation.
+			runes := []rune(text)
+			if s.CharStart < 0 || s.CharEnd > len(runes) || s.CharStart >= s.CharEnd {
+				t.Errorf("chunk %d: invalid span [%d, %d)", i, s.CharStart, s.CharEnd)
+				continue
+			}
+			expect := string(runes[s.CharStart:s.CharEnd])
+			if s.Text != expect {
+				t.Errorf("chunk %d: Text != runes[Start:End]", i)
+			}
+		}
+	})
+
+	t.Run("MaxSpansCapsInputBytesProcessed", func(t *testing.T) {
+		// Roborev regression on e83967b: a multi-megabyte body must
+		// not cause the chunker to walk the entire input before
+		// maxSpans takes effect. With maxSpans=3 and maxRunes=100,
+		// the chunker should look at at most ~300 runes regardless
+		// of how long the input is. Use a 10M-rune input; if
+		// buildRuneByteOffsets ever ran over the whole thing, this
+		// test would dominate the suite at ~100ms+; with the early
+		// cap it stays at the same cost as the 1K-rune cases below.
+		text := strings.Repeat("a", 10_000_000)
+		got, _ := ChunkText(text, 100, 0, 3)
+		if len(got) != 3 {
+			t.Fatalf("len = %d, want 3 (input cap kicks in before allocating offsets for 10M runes)", len(got))
+		}
+		// All emitted spans come from the head of the input.
+		for i, s := range got {
+			if s.CharEnd > 300 {
+				t.Errorf("chunk %d ends at %d, want <= 300 (the cap window)", i, s.CharEnd)
+			}
+		}
+	})
+
+	t.Run("MaxSpansCapsOutputAndDropsTail", func(t *testing.T) {
+		// A pathological input — 10× window with no soft breaks — would
+		// normally chunk into 10 spans. With maxSpans=3 we get exactly 3
+		// covering the head, and the tail beyond the third chunk's end
+		// is dropped on the floor (real semantic search doesn't gain
+		// from embedding system-generated dumps).
+		text := strings.Repeat("a", 1000)
+		got, _ := ChunkText(text, 100, 0, 3)
+		if len(got) != 3 {
+			t.Fatalf("len = %d, want 3 (capped)", len(got))
+		}
+		if got[0].CharStart != 0 {
+			t.Errorf("first chunk should start at 0, got %d", got[0].CharStart)
+		}
+		last := got[len(got)-1]
+		if last.CharEnd >= 1000 {
+			t.Errorf("last capped chunk ends at %d; expected dropped tail beyond it", last.CharEnd)
+		}
+	})
+
+	t.Run("TailDroppedFlagsCapWhenLastChunkLandsOnSoftBreak", func(t *testing.T) {
+		// Roborev regression: when maxSpans caps the output but the
+		// last emitted chunk happens to land on a clean soft break
+		// (so the per-chunk hard-cut Trunc signal stays false), the
+		// caller would otherwise have no way to know the message
+		// lost tail content. The returned tailDropped bool surfaces
+		// the cap so downstream metrics record the truncation.
+		var b strings.Builder
+		// 5 chunks worth of prose, each ending neatly with "X. " so
+		// findSoftBreak returns a sentence boundary near windowEnd
+		// and Trunc stays false on every chunk. With maxSpans=2 we
+		// emit 2 chunks and drop the rest — tailDropped must be true.
+		for i := 0; i < 5; i++ {
+			b.WriteString(strings.Repeat("a", 85))
+			b.WriteString(". ")
+		}
+		text := b.String()
+		got, tailDropped := ChunkText(text, 90, 0, 2)
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2 (maxSpans cap)", len(got))
+		}
+		if !tailDropped {
+			t.Errorf("tailDropped = false, want true (maxSpans dropped %d runes past chunk[1].CharEnd=%d)",
+				utf8.RuneCountInString(text)-got[1].CharEnd, got[1].CharEnd)
+		}
+	})
+
+	t.Run("TailDroppedFalseWhenAllContentEmitted", func(t *testing.T) {
+		// Counter-test for the above: a short input that fits in
+		// fewer than maxSpans chunks must not flag tailDropped.
+		text := strings.Repeat("a", 150)
+		got, tailDropped := ChunkText(text, 100, 0, 10)
+		if len(got) < 1 {
+			t.Fatalf("expected >= 1 chunk")
+		}
+		if tailDropped {
+			t.Errorf("tailDropped = true on a short input that fit in %d chunks; should be false", len(got))
+		}
+	})
+
+	t.Run("MaxSpansZeroIsUnlimited", func(t *testing.T) {
+		text := strings.Repeat("a", 1000)
+		got, _ := ChunkText(text, 100, 0, 0)
+		if len(got) != 10 {
+			t.Errorf("len = %d, want 10 (no cap)", len(got))
+		}
+	})
+
+	t.Run("MaxSpansLargerThanNaturalChunkCountIsNoop", func(t *testing.T) {
+		text := strings.Repeat("a", 300)
+		got, _ := ChunkText(text, 100, 0, 100)
+		if len(got) != 3 {
+			t.Errorf("len = %d, want 3 (cap above natural)", len(got))
+		}
+	})
+
+	t.Run("ConcatenationCoversInputModuloOverlap", func(t *testing.T) {
+		// Stitching the chunks back together (advancing by stride =
+		// window - overlap from each chunk's start) must reconstruct
+		// the input verbatim. This is the property the overlap
+		// guarantee depends on for recall.
+		text := strings.Repeat("Lorem ipsum dolor sit amet. ", 200)
+		spans, _ := ChunkText(text, 200, 30, 0)
+		if len(spans) < 2 {
+			t.Fatalf("need >= 2 chunks to test stitching")
+		}
+		// Each chunk starts at spans[i].CharStart; the unique part of
+		// chunk i (not seen in chunk i-1) starts at spans[i].CharStart
+		// + overlap-with-prev. For correctness it's enough to verify
+		// spans cover [0, totalRunes) end-to-end.
+		if spans[0].CharStart != 0 {
+			t.Errorf("first chunk should start at 0, got %d", spans[0].CharStart)
+		}
+		last := spans[len(spans)-1]
+		runeCount := utf8.RuneCountInString(text)
+		if last.CharEnd != runeCount {
+			t.Errorf("last chunk ends at %d, want %d (end of text)", last.CharEnd, runeCount)
+		}
+		// Every gap between consecutive chunks must be <= window so
+		// no input runes are dropped on the floor.
+		for i := 1; i < len(spans); i++ {
+			if spans[i].CharStart > spans[i-1].CharEnd {
+				t.Errorf("chunks %d,%d leave a gap [%d, %d)",
+					i-1, i, spans[i-1].CharEnd, spans[i].CharStart)
+			}
+		}
+	})
+}

--- a/internal/vector/embed/preprocess.go
+++ b/internal/vector/embed/preprocess.go
@@ -18,6 +18,16 @@ import (
 )
 
 // PreprocessConfig controls pre-embedding transformations.
+//
+// MaxBodyRunes, when > 0, applies a rune-count cap on the body
+// *between* the cheap pollution-removal pass (CRLF normalize +
+// StripBase64) and the heavier regex transforms (StripHTML,
+// StripURLTracking, quote/signature, whitespace collapse). The
+// ordering matters: a body whose first megabyte is an inline base64
+// PNG would be capped to "just the base64" if the cap fired on raw
+// input, losing every meaningful word that follows the blob. Doing
+// the cheap strip first reclaims that space for the prose tail
+// before the cap looks at the result.
 type PreprocessConfig struct {
 	StripQuotes        bool
 	StripSignatures    bool
@@ -25,6 +35,7 @@ type PreprocessConfig struct {
 	StripBase64        bool
 	StripURLTracking   bool
 	CollapseWhitespace bool
+	MaxBodyRunes       int
 }
 
 var (
@@ -184,11 +195,26 @@ func Preprocess(subject, body string, maxChars int, cfg PreprocessConfig) (strin
 	// `<img src="data:image/...;base64,...">` (which can exceed
 	// reHTMLTag's 500-char bound and slip past the tag stripper) loses
 	// its payload first, leaving a small enough tag for reHTMLTag to
-	// then sweep up.
+	// then sweep up. This pass is also "cheap pollution removal"
+	// relative to MaxBodyRunes — by running it before the cap, a
+	// body whose noise dominates the first megabyte gets its prose
+	// tail preserved instead of chopped off with the blob.
 	if cfg.StripBase64 {
 		s = reDataURI.ReplaceAllString(s, " ")
 		s = reBase64Blob.ReplaceAllString(s, " ")
 		s = reBase64BlobWithSlash.ReplaceAllString(s, " ")
+	}
+	bodyTruncated := false
+	if cfg.MaxBodyRunes > 0 {
+		walked := 0
+		for i := range s {
+			if walked >= cfg.MaxBodyRunes {
+				s = s[:i]
+				bodyTruncated = true
+				break
+			}
+			walked++
+		}
 	}
 	if cfg.StripHTML {
 		s = reStyleBlock.ReplaceAllString(s, " ")
@@ -220,13 +246,13 @@ func Preprocess(subject, body string, maxChars int, cfg PreprocessConfig) (strin
 	combined := prefix + s
 
 	if maxChars <= 0 {
-		return combined, false
+		return combined, bodyTruncated
 	}
 	// Fast path: if every byte is ASCII, len == rune count and we
 	// can skip the scan. Otherwise walk runes forward to find the
 	// cut point at rune boundary maxChars.
 	if len(combined) <= maxChars {
-		return combined, false
+		return combined, bodyTruncated
 	}
 	byteOffset, runes := 0, 0
 	for byteOffset < len(combined) && runes < maxChars {
@@ -236,11 +262,11 @@ func Preprocess(subject, body string, maxChars int, cfg PreprocessConfig) (strin
 	}
 	if runes < maxChars {
 		// Fewer runes than the cap — nothing to truncate.
-		return combined, false
+		return combined, bodyTruncated
 	}
 	if byteOffset == len(combined) {
 		// Exactly maxChars runes and no more — no truncation.
-		return combined, false
+		return combined, bodyTruncated
 	}
 	return combined[:byteOffset], true
 }

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -149,13 +149,32 @@ type RunResult struct {
 	Claimed, Succeeded, Failed, Truncated int
 }
 
-// msgText is the per-message preprocessed input to the embedder, carried
-// from fetch through to Chunk construction.
+// msgText is the per-message preprocessed input to the chunker, carried
+// from fetch through ChunkText. One msgText fans out to one or more
+// inputChunks below. BodyTruncated tracks whether Preprocess hit its
+// MaxBodyRunes cap and silently dropped tail content; we propagate
+// this onto every chunk's Truncated flag so downstream accounting
+// records the message as truncated regardless of which chunk surfaces
+// it.
 type msgText struct {
-	ID    int64
-	Text  string
-	Chars int
-	Trunc bool
+	ID            int64
+	Text          string
+	Chars         int
+	BodyTruncated bool
+}
+
+// inputChunk is one window into a message's preprocessed text, fed
+// 1:1 to the embedding client and turned into a vector.Chunk on the
+// way back. The (ID, ChunkIndex) pair is the durable key the backend
+// stores. ChunkIndex is dense and 0-based.
+type inputChunk struct {
+	ID         int64
+	ChunkIndex int
+	Text       string
+	Chars      int
+	CharStart  int
+	CharEnd    int
+	Trunc      bool
 }
 
 // ReclaimStale releases claims older than StaleThreshold so crashed
@@ -455,7 +474,6 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 	defer func() { _ = rows.Close() }()
 
 	var msgs []msgText
-	var inputs []string
 	var empty []int64
 	fetched := make(map[int64]struct{}, len(ids))
 	for rows.Next() {
@@ -471,19 +489,32 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 		if body == "" && bodyHTML != "" {
 			body = mime.StripHTML(bodyHTML)
 		}
-		txt, trunc := Preprocess(subject, body, w.deps.MaxInputChars, w.deps.Preprocess)
+		// Sized to give Preprocess a generous-but-bounded budget: the
+		// chunker emits at most maxSpansPerMessage * MaxInputChars
+		// runes of *post-sanitize* output, and sanitize routinely
+		// strips 10x of HTML/base64 noise from polluted bodies; the
+		// rawBodyMultiplier covers the worst case. Preprocess applies
+		// this cap *between* its cheap pollution-removal pass (CRLF
+		// normalize + base64 strip) and the heavier regex transforms,
+		// so a body whose first MB is an inline base64 image still
+		// gets its prose tail through the cap.
+		preprocessCfg := w.deps.Preprocess
+		if preprocessCfg.MaxBodyRunes == 0 && w.deps.MaxInputChars > 0 {
+			preprocessCfg.MaxBodyRunes = w.deps.MaxInputChars * maxSpansPerMessage * rawBodyMultiplier
+		}
+		// Pass maxChars=0 so Preprocess does NOT truncate the final
+		// output by character count. Chunking (below) takes the full
+		// preprocessed text and divides it into windows of at most
+		// MaxInputChars runes each, so output truncation would just
+		// throw away tail content that ChunkText would otherwise
+		// embed in a later chunk.
+		txt, bodyTrunc := Preprocess(subject, body, 0, preprocessCfg)
 		fetched[id] = struct{}{}
 		if strings.TrimSpace(txt) == "" {
 			empty = append(empty, id)
 			continue
 		}
-		// Preprocess truncates by runes, so the recorded length must
-		// also be a rune count. Using len(txt) (bytes) inflates
-		// SourceCharLen by 2-4x for CJK / emoji / accented text and
-		// breaks any downstream "did we truncate?" / "how big was the
-		// input?" reasoning.
-		msgs = append(msgs, msgText{ID: id, Text: txt, Chars: utf8.RuneCountInString(txt), Trunc: trunc})
-		inputs = append(inputs, txt)
+		msgs = append(msgs, msgText{ID: id, Text: txt, Chars: utf8.RuneCountInString(txt), BodyTruncated: bodyTrunc})
 	}
 	if err := rows.Err(); err != nil {
 		return embedBatchResult{}, fmt.Errorf("iterate message rows: %w", err)
@@ -504,32 +535,120 @@ func (w *Worker) embedBatch(ctx context.Context, ids []int64) (embedBatchResult,
 		return embedBatchResult{missing: missing, empty: empty}, nil
 	}
 
+	// Chunk every message into windows of at most MaxInputChars runes.
+	// Short messages produce exactly one chunk; long ones produce N.
+	// Each chunk becomes one input to the embedder. The per-message
+	// span cap protects the batch from pathological inputs (10+ MB
+	// system error dumps, base64 blobs that survived sanitize): one
+	// such message could otherwise produce thousands of chunks and
+	// blow the batch past the embedder's request-time budget.
+	chunkWindow := w.deps.MaxInputChars
+	overlap := chunkOverlapFor(chunkWindow)
+	maxSpans := maxSpansPerMessage
+	var pieces []inputChunk
+	var inputs []string
+	for _, m := range msgs {
+		spans, chunkTail := ChunkText(m.Text, chunkWindow, overlap, maxSpans)
+		// A message is "truncated" if any of its content was dropped:
+		//   - body hit Preprocess's MaxBodyRunes cap, OR
+		//   - ChunkText dropped tail past maxSpans (regardless of
+		//     whether the last emitted chunk happened to land on a
+		//     soft break, in which case the per-chunk hard-cut flag
+		//     wouldn't fire).
+		msgTrunc := m.BodyTruncated || chunkTail
+		for j, sp := range spans {
+			ic := inputChunk{
+				ID:         m.ID,
+				ChunkIndex: j,
+				Text:       sp.Text,
+				Chars:      sp.CharEnd - sp.CharStart,
+				CharStart:  sp.CharStart,
+				CharEnd:    sp.CharEnd,
+				// Trunc flags either: a hard-cut chunk where a
+				// sentence may have been split across the boundary
+				// (overlap exists to recover from this), or any
+				// chunk of a message that was truncated upstream.
+				// Both feed embeddings.truncated and the per-message
+				// counter so users see a faithful picture of which
+				// embeddings cover their full source content.
+				Trunc: msgTrunc ||
+					(chunkWindow > 0 && (sp.CharEnd-sp.CharStart) == chunkWindow && j < len(spans)-1),
+			}
+			pieces = append(pieces, ic)
+			inputs = append(inputs, sp.Text)
+		}
+	}
+
+	// Split chunk inputs into sub-batches of at most BatchSize so a
+	// long-form message that fans out to many chunks doesn't push a
+	// single embed call past the provider's per-request limit (Ollama
+	// stops responding around 250 inputs; OpenAI caps at 2048; either
+	// way, payload size + request-timeout grow with the input count).
+	// The pending queue stays per-message — a message completes only
+	// after every one of its chunks has been embedded and upserted in
+	// this same call, so partial-failure semantics are unchanged.
+	embedSubBatchSize := w.deps.BatchSize
+	if embedSubBatchSize <= 0 {
+		embedSubBatchSize = len(inputs)
+	}
 	start := time.Now()
-	vecs, err := w.deps.Client.Embed(ctx, inputs)
-	if err != nil {
-		return embedBatchResult{}, fmt.Errorf("embed: %w", err)
+	vecs := make([][]float32, 0, len(inputs))
+	for i := 0; i < len(inputs); i += embedSubBatchSize {
+		end := i + embedSubBatchSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		got, err := w.deps.Client.Embed(ctx, inputs[i:end])
+		if err != nil {
+			return embedBatchResult{}, fmt.Errorf("embed: %w", err)
+		}
+		if len(got) != end-i {
+			return embedBatchResult{}, fmt.Errorf(
+				"embedder returned %d vectors for %d inputs in sub-batch [%d:%d)",
+				len(got), end-i, i, end)
+		}
+		vecs = append(vecs, got...)
 	}
 	w.deps.Log.Debug("embed batch",
-		"count", len(vecs), "chars", totalChars(msgs), "duration_ms", time.Since(start).Milliseconds())
+		"messages", len(msgs), "chunks", len(pieces),
+		"chars", totalPieceChars(pieces),
+		"sub_batches", (len(inputs)+embedSubBatchSize-1)/embedSubBatchSize,
+		"duration_ms", time.Since(start).Milliseconds())
 
-	if len(vecs) != len(msgs) {
-		return embedBatchResult{}, fmt.Errorf("embedder returned %d vectors for %d inputs", len(vecs), len(msgs))
+	if len(vecs) != len(pieces) {
+		return embedBatchResult{}, fmt.Errorf("embedder returned %d vectors for %d chunk inputs", len(vecs), len(pieces))
 	}
 
 	truncated := 0
 	chunks := make([]vector.Chunk, 0, len(vecs))
-	embeddedIDs := make([]int64, 0, len(vecs))
-	for i, m := range msgs {
-		if m.Trunc {
-			truncated++
-		}
+	embeddedIDs := make([]int64, 0, len(msgs))
+	seenMsg := make(map[int64]struct{}, len(msgs))
+	truncatedMsg := make(map[int64]struct{}, len(msgs))
+	for i, p := range pieces {
 		chunks = append(chunks, vector.Chunk{
-			MessageID:     m.ID,
-			Vector:        vecs[i],
-			SourceCharLen: m.Chars,
-			Truncated:     m.Trunc,
+			MessageID:      p.ID,
+			ChunkIndex:     p.ChunkIndex,
+			Vector:         vecs[i],
+			SourceCharLen:  p.Chars,
+			ChunkCharStart: p.CharStart,
+			ChunkCharEnd:   p.CharEnd,
+			Truncated:      p.Trunc,
 		})
-		embeddedIDs = append(embeddedIDs, m.ID)
+		if _, ok := seenMsg[p.ID]; !ok {
+			seenMsg[p.ID] = struct{}{}
+			embeddedIDs = append(embeddedIDs, p.ID)
+		}
+		// Count each truncated message once, not once per truncated
+		// chunk. truncated feeds RunResult.Truncated which the caller
+		// compares against Succeeded (a per-message count): keeping
+		// both metrics in the same units lets "what fraction was
+		// truncated" actually be a fraction.
+		if p.Trunc {
+			if _, seen := truncatedMsg[p.ID]; !seen {
+				truncatedMsg[p.ID] = struct{}{}
+				truncated++
+			}
+		}
 	}
 	return embedBatchResult{
 		chunks:      chunks,
@@ -703,10 +822,60 @@ func (w *Worker) reportProgress(done, batchMsgs, batchChars int, batchElapsed ti
 	})
 }
 
-func totalChars(ms []msgText) int {
+// totalPieceChars sums the rune counts of every chunk in the batch, for
+// debug logging — distinct from totalChars because a long message
+// contributes one msgText row but several inputChunk rows.
+func totalPieceChars(pieces []inputChunk) int {
 	n := 0
-	for _, m := range ms {
-		n += m.Chars
+	for _, p := range pieces {
+		n += p.Chars
 	}
 	return n
+}
+
+// rawBodyMultiplier is how much pre-sanitize body the worker is
+// willing to feed into Preprocess relative to what the chunker can
+// ultimately emit. The chunker keeps at most maxSpansPerMessage *
+// MaxInputChars runes of *post-sanitize* output; sanitize strips a
+// large but not unbounded fraction of HTML/base64/URL noise — 10x
+// is the empirical ceiling for HTML-heavy newsletters with inline
+// images. 16x gives comfortable headroom for the long tail without
+// letting a pathological 100 MB body burn CPU on regex passes that
+// would never produce additional retrievable content.
+const rawBodyMultiplier = 16
+
+// maxSpansPerMessage caps the number of chunks emitted for any single
+// message. Picked empirically: typical email is under 5 chunks at a
+// 4 KB window; long-form prose (50–100 KB) tops out at 20–25; the cap
+// at 64 covers every legitimate case but stops 10+ MB system error
+// dumps and stack-trace forwards from generating thousands of chunks
+// that would push a single embed call past the API timeout. Set
+// statically rather than via config because the failure mode it
+// addresses is universal across embedding backends, not a tuning
+// knob users are expected to touch.
+const maxSpansPerMessage = 64
+
+// chunkOverlapFor returns the rune count of overlap between consecutive
+// chunks. The overlap exists so a sentence or phrase that straddles a
+// window boundary survives in at least one chunk verbatim — without it,
+// a query term that lives on a cut would be invisible to ANN search.
+//
+// A fixed-fraction overlap (≈3% of the window, floored at 0 for small
+// windows) gives roughly one sentence of margin at typical chunk sizes
+// without materially padding the corpus. Hardcoded here rather than
+// pulled from config because the overlap is an implementation detail
+// of how chunks recover boundary content — making it tunable would let
+// users degrade recall in exchange for marginal storage savings, and
+// nobody has asked for that knob yet.
+func chunkOverlapFor(maxRunes int) int {
+	if maxRunes <= 0 {
+		return 0
+	}
+	if maxRunes < 200 {
+		// For very small windows the proportional overlap (~3%) is
+		// under a couple of dozen runes — not enough to recover a
+		// sentence — so fall back to "no overlap" rather than pretend.
+		return 0
+	}
+	return maxRunes / 30
 }

--- a/internal/vector/embed/worker_test.go
+++ b/internal/vector/embed/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestDerivedStaleThreshold(t *testing.T) {
@@ -37,6 +38,343 @@ func TestDerivedStaleThreshold(t *testing.T) {
 					tc.timeout, tc.maxRetries, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestWorker_SplitsChunkInputsAcrossSubBatches verifies that a
+// message whose chunk fan-out exceeds BatchSize is sent to the
+// embedder across multiple sub-batched Embed calls. Without the
+// split, a 64-chunk message claimed via BatchSize=8 would flatten
+// into a single 64-input request, exceeding provider per-request
+// limits and tripping API timeouts (the very failure mode caught by
+// roborev #323).
+func TestWorker_SplitsChunkInputsAcrossSubBatches(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 1)
+
+	// Build a body large enough to produce ~12 chunks at
+	// MaxInputChars=80 with the worker's overlap heuristic. Any value
+	// well above BatchSize would do; 12 is comfortably enough to
+	// exercise multiple sub-batches.
+	var body string
+	for i := 0; i < 40; i++ {
+		body += "lorem ipsum dolor sit amet consectetur adipiscing elit. "
+	}
+	if _, err := f.MainDB.Exec(`UPDATE message_bodies SET body_text = ? WHERE message_id = 1`, body); err != nil {
+		t.Fatalf("update body: %v", err)
+	}
+
+	// Capture the size of every Embed call so we can prove the split
+	// happened and that no sub-batch exceeded BatchSize.
+	const batchSize = 4
+	var sizes []int
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		sizes = append(sizes, len(inputs))
+		out := make([][]float32, len(inputs))
+		for i := range inputs {
+			v := make([]float32, 4)
+			v[0] = float32(len(inputs[i])%4 + 1)
+			out[i] = v
+		}
+		return out, nil
+	}
+
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		Preprocess:    PreprocessConfig{},
+		MaxInputChars: 80,
+		BatchSize:     batchSize,
+	})
+	if _, err := w.RunOnce(ctx, f.BuildingGen); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(sizes) < 2 {
+		t.Fatalf("expected >= 2 sub-batches, got %d (sizes=%v)", len(sizes), sizes)
+	}
+	for i, n := range sizes {
+		if n > batchSize {
+			t.Errorf("sub-batch %d had %d inputs, want <= %d", i, n, batchSize)
+		}
+		if n == 0 {
+			t.Errorf("sub-batch %d was empty", i)
+		}
+	}
+}
+
+// TestWorker_CapsRawBodyBeforePreprocess is the roborev #323 (717ac4c)
+// regression: a 5 MB body must not be handed to Preprocess in full.
+// Preprocess runs O(input) regex passes; without an upstream cap the
+// embedding worker pays seconds of CPU and tens of MB of scratch
+// allocs on every multi-megabyte body before the chunker drops the
+// tail anyway. The cap should be derived from MaxInputChars and
+// maxSpansPerMessage so it scales with what the chunker can actually
+// emit.
+func TestWorker_CapsRawBodyBeforePreprocess(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 1)
+
+	// 5 million chars of unbroken letters. Far larger than the
+	// raw-body cap (which at MaxInputChars=100 is 100 * 64 * 16 =
+	// 102,400 runes), but well-defined under regex passes if those
+	// run unbounded.
+	hugeBody := strings.Repeat("a", 5_000_000)
+	if _, err := f.MainDB.Exec(`UPDATE message_bodies SET body_text = ? WHERE message_id = 1`, hugeBody); err != nil {
+		t.Fatalf("update body: %v", err)
+	}
+
+	// Capture every input the worker hands to the embedder. The
+	// individual input slices together represent the chunker's
+	// output; the total must come from at most the cap window.
+	var observed []string
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		observed = append(observed, inputs...)
+		out := make([][]float32, len(inputs))
+		for i := range inputs {
+			v := make([]float32, 4)
+			v[0] = float32(len(inputs[i])%4 + 1)
+			out[i] = v
+		}
+		return out, nil
+	}
+
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		Preprocess:    PreprocessConfig{},
+		MaxInputChars: 100,
+		BatchSize:     8,
+	})
+	if _, err := w.RunOnce(ctx, f.BuildingGen); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// All inputs must fit within the chunker's output window
+	// (maxSpansPerMessage * MaxInputChars = 6400 runes). The raw
+	// body cap means Preprocess only ever saw ~102K runes, not 5M.
+	totalRunes := 0
+	for _, s := range observed {
+		totalRunes += utf8.RuneCountInString(s)
+	}
+	if totalRunes > maxSpansPerMessage*100 {
+		t.Errorf("total embedder input runes = %d, want <= %d (chunker window)", totalRunes, maxSpansPerMessage*100)
+	}
+}
+
+// TestWorker_PrefixBase64DoesNotHidePoseTail is the roborev #323
+// (2d8f45d) regression: a body whose first megabyte is an inline
+// base64 PNG must still get its prose tail to the embedder. Earlier
+// versions capped the raw body before sanitize, so the cap chopped
+// the base64 blob before StripBase64 could strip it — the prose
+// past the cap never reached Preprocess. The fix runs the cheap
+// pollution removal (CRLF + StripBase64) BEFORE the cap and the
+// heavy regex passes (StripHTML, URL tracking, whitespace) AFTER,
+// so blob-prefixed bodies preserve the prose.
+func TestWorker_PrefixBase64DoesNotHidePoseTail(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 1)
+
+	const sentinel = "QUICKFOX-MARKER-IS-THE-PROSE-TAIL"
+	// 2M chars of base64-shaped padding (no slashes; matches the
+	// strip regex), then 100 bytes of prose containing the
+	// sentinel.
+	hugeBase64 := strings.Repeat("A", 2_000_000)
+	body := "data:image/png;base64," + hugeBase64 + " " + sentinel + " end."
+	if _, err := f.MainDB.Exec(`UPDATE message_bodies SET body_text = ? WHERE message_id = 1`, body); err != nil {
+		t.Fatalf("update body: %v", err)
+	}
+
+	var observed []string
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		observed = append(observed, inputs...)
+		out := make([][]float32, len(inputs))
+		for i := range inputs {
+			v := make([]float32, 4)
+			v[0] = float32(len(inputs[i])%4 + 1)
+			out[i] = v
+		}
+		return out, nil
+	}
+
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		Preprocess:    PreprocessConfig{StripBase64: true},
+		MaxInputChars: 100,
+		BatchSize:     8,
+	})
+	if _, err := w.RunOnce(ctx, f.BuildingGen); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// The sentinel — sitting past 2 MB of base64 in the raw body —
+	// must appear in at least one chunk handed to the embedder.
+	// Without the cheap-strip-first ordering, the cap would have
+	// chopped before the prose ever surfaced.
+	found := false
+	for _, s := range observed {
+		if strings.Contains(s, sentinel) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("sentinel %q absent from embedder inputs; the prose tail was lost behind the base64 blob", sentinel)
+	}
+}
+
+// TestWorker_TruncatedCountedPerMessageNotPerChunk pins the
+// roborev #323 (717ac4c) metric-accounting fix: when a single long
+// message produces multiple truncated chunks, RunResult.Truncated
+// must record one message, not one per chunk. Otherwise progress
+// metrics inflate (a single oversized message could read as N
+// truncations in a Succeeded=1 batch).
+func TestWorker_TruncatedCountedPerMessageNotPerChunk(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 1)
+
+	// Long unbroken text: ChunkText's hard-cut path marks all but
+	// the last span as Trunc=true. With MaxInputChars=100 the body
+	// produces several truncated chunks before maxSpans caps it.
+	body := strings.Repeat("a", 600)
+	if _, err := f.MainDB.Exec(`UPDATE message_bodies SET body_text = ? WHERE message_id = 1`, body); err != nil {
+		t.Fatalf("update body: %v", err)
+	}
+
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		Preprocess:    PreprocessConfig{},
+		MaxInputChars: 100,
+		BatchSize:     8,
+	})
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.Succeeded != 1 {
+		t.Errorf("Succeeded = %d, want 1", res.Succeeded)
+	}
+	// Confirm the chunks table actually has multiple truncated
+	// rows for this message — otherwise the test wouldn't be
+	// exercising the per-message-vs-per-chunk distinction.
+	var truncChunks int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM embeddings WHERE message_id = 1 AND truncated = 1`).Scan(&truncChunks); err != nil {
+		t.Fatalf("count truncated chunks: %v", err)
+	}
+	if truncChunks < 2 {
+		t.Fatalf("test produced %d truncated chunks, expected >= 2 to exercise the metric", truncChunks)
+	}
+	if res.Truncated != 1 {
+		t.Errorf("Truncated = %d, want 1 (one message, regardless of %d truncated chunks)", res.Truncated, truncChunks)
+	}
+}
+
+// TestWorker_FansOutLongMessageIntoMultipleChunks confirms the
+// chunking path: a single pending message whose preprocessed body
+// exceeds MaxInputChars produces N > 1 embedder inputs, all of which
+// land in the embeddings table with distinct chunk_index values, and
+// the queue is drained in one shot (not N times) — Complete is
+// keyed on message_id, not on (message_id, chunk_index).
+func TestWorker_FansOutLongMessageIntoMultipleChunks(t *testing.T) {
+	ctx := context.Background()
+	f := newWorkerFixture(t, 1)
+
+	// Replace the seeded message's body with one long enough to need
+	// multiple chunks at MaxInputChars=200. Each "paragraph" is ~150
+	// chars; six paragraphs ≈ 900 chars → at least 4 chunks.
+	body := ""
+	for i := 0; i < 6; i++ {
+		body += "lorem ipsum dolor sit amet consectetur adipiscing elit. " +
+			"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+			"ut enim ad minim veniam quis nostrud exercitation. " +
+			"\n\n"
+	}
+	if _, err := f.MainDB.Exec(`UPDATE message_bodies SET body_text = ? WHERE message_id = 1`, body); err != nil {
+		t.Fatalf("update body: %v", err)
+	}
+
+	w := NewWorker(WorkerDeps{
+		Backend:       f.Backend,
+		VectorsDB:     f.VectorsDB,
+		MainDB:        f.MainDB,
+		Client:        f.FakeClient,
+		Preprocess:    PreprocessConfig{},
+		MaxInputChars: 200, // forces multi-chunk fan-out
+		BatchSize:     8,
+	})
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.Succeeded != 1 {
+		t.Errorf("succeeded=%d, want 1 (one distinct message embedded)", res.Succeeded)
+	}
+	if res.Failed != 0 {
+		t.Errorf("failed=%d, want 0", res.Failed)
+	}
+
+	// embeddings should hold N > 1 rows for the message, with
+	// consecutive chunk_index values starting at 0.
+	var rowCount int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM embeddings WHERE generation_id = ? AND message_id = 1`,
+		int64(f.BuildingGen)).Scan(&rowCount); err != nil {
+		t.Fatalf("count chunks: %v", err)
+	}
+	if rowCount < 2 {
+		t.Fatalf("expected >= 2 chunk rows, got %d", rowCount)
+	}
+	var distinctCI int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT chunk_index) FROM embeddings WHERE generation_id = ? AND message_id = 1`,
+		int64(f.BuildingGen)).Scan(&distinctCI); err != nil {
+		t.Fatalf("count distinct chunk_index: %v", err)
+	}
+	if distinctCI != rowCount {
+		t.Errorf("distinct chunk_index=%d, want %d (each chunk should be uniquely indexed)", distinctCI, rowCount)
+	}
+	var minCI, maxCI int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT MIN(chunk_index), MAX(chunk_index) FROM embeddings WHERE generation_id = ?`,
+		int64(f.BuildingGen)).Scan(&minCI, &maxCI); err != nil {
+		t.Fatalf("min/max chunk_index: %v", err)
+	}
+	if minCI != 0 || maxCI != rowCount-1 {
+		t.Errorf("chunk_index range = [%d, %d], want [0, %d]", minCI, maxCI, rowCount-1)
+	}
+	// message_count tracks distinct messages, so it must read as 1
+	// despite the multi-chunk fan-out.
+	var msgCount int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT message_count FROM index_generations WHERE id = ?`,
+		int64(f.BuildingGen)).Scan(&msgCount); err != nil {
+		t.Fatalf("read message_count: %v", err)
+	}
+	if msgCount != 1 {
+		t.Errorf("message_count = %d, want 1", msgCount)
+	}
+	// Queue is fully drained: Complete is keyed on message_id, so all
+	// chunks of message 1 finish together when its singleton pending
+	// row is removed.
+	var pending int
+	if err := f.VectorsDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pending_embeddings WHERE generation_id = ?`,
+		int64(f.BuildingGen)).Scan(&pending); err != nil {
+		t.Fatalf("count pending: %v", err)
+	}
+	if pending != 0 {
+		t.Errorf("pending remaining: %d", pending)
 	}
 }
 

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -821,6 +821,27 @@ func (b *Backend) Search(ctx context.Context, gen vector.GenerationID, queryVec 
 		return nil, nil
 	}
 
+	// Filtered-message ceiling: count distinct filtered messages
+	// that have at least one chunk in this generation. The widening
+	// loop below uses this as an early exit so a selective filter
+	// (few matching messages) doesn't drive the loop all the way to
+	// the generation-wide chunkCeiling: once len(hits) reaches the
+	// filtered-message count, every filtered message is in the
+	// result set with its best-distance chunk (further iterations
+	// only fetch chunks with worse distances, so neither the set of
+	// messages nor each message's MIN(distance) can change).
+	filteredMessageCeiling := chunkCeiling // empty-filter falls through to the fast path above; this clause runs only for non-empty filters
+	ceilingSQL := `SELECT COUNT(DISTINCT message_id) FROM embeddings e WHERE e.generation_id = ? ` + idClause
+	ceilingArgs := make([]any, 0, 1+len(filterArgs))
+	ceilingArgs = append(ceilingArgs, int64(gen))
+	ceilingArgs = append(ceilingArgs, filterArgs...)
+	if err := b.db.QueryRowContext(ctx, ceilingSQL, ceilingArgs...).Scan(&filteredMessageCeiling); err != nil {
+		return nil, fmt.Errorf("lookup filtered message count: %w", err)
+	}
+	if filteredMessageCeiling == 0 {
+		return nil, nil
+	}
+
 	q := fmt.Sprintf(`
 		SELECT e.message_id, MIN(v.distance) AS distance
 		  FROM %s v
@@ -849,7 +870,16 @@ func (b *Backend) Search(ctx context.Context, gen vector.GenerationID, queryVec 
 		if err != nil {
 			return nil, err
 		}
-		if len(hits) >= k || fetch >= chunkCeiling {
+		// Exit when either: we have k distinct messages (caller is
+		// satisfied), every filtered message has been found (no new
+		// messages will appear regardless of further iterations —
+		// see filteredMessageCeiling comment above), or we've
+		// scanned the entire generation. Without the middle
+		// condition, a selective filter that matches m < k messages
+		// would drive the loop all the way to chunkCeiling doing
+		// wasted ANN work; with it, the loop terminates as soon as
+		// the filtered universe has been fully resolved.
+		if len(hits) >= k || len(hits) >= filteredMessageCeiling || fetch >= chunkCeiling {
 			if len(hits) > k {
 				hits = hits[:k]
 			}
@@ -1208,8 +1238,20 @@ func (b *Backend) Stats(ctx context.Context, gen vector.GenerationID) (vector.St
 	// denominator, generation summary, etc.) is "how many messages are
 	// embedded" — counting rows would inflate by avg_chunks_per_msg
 	// and break Done/Total invariants in internal/vector/stats.go.
-	if err := b.db.QueryRowContext(ctx,
-		`SELECT COUNT(DISTINCT message_id) FROM embeddings `+where, args...).Scan(&s.EmbeddingCount); err != nil {
+	//
+	// The aggregate path (gen == 0) counts DISTINCT (generation_id,
+	// message_id) pairs rather than DISTINCT message_id alone: a
+	// message that lives in both the active and a building generation
+	// represents two units of embedded work, and the aggregate Stats
+	// view exists precisely so operators can see total work done
+	// across generations. Per-generation paths are already constrained
+	// by the WHERE clause, so DISTINCT message_id there has no
+	// undercount hazard.
+	embeddingCountSQL := `SELECT COUNT(DISTINCT message_id) FROM embeddings ` + where
+	if gen == 0 {
+		embeddingCountSQL = `SELECT COUNT(*) FROM (SELECT DISTINCT generation_id, message_id FROM embeddings)`
+	}
+	if err := b.db.QueryRowContext(ctx, embeddingCountSQL, args...).Scan(&s.EmbeddingCount); err != nil {
 		return s, fmt.Errorf("count embeddings: %w", err)
 	}
 	if err := b.db.QueryRowContext(ctx,

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -459,8 +459,8 @@ func (b *Backend) Upsert(ctx context.Context, gen vector.GenerationID, chunks []
 	}
 	for _, c := range chunks {
 		if len(c.Vector) != dim {
-			return fmt.Errorf("%w: chunk for msg %d has %d dims, gen has %d",
-				vector.ErrDimensionMismatch, c.MessageID, len(c.Vector), dim)
+			return fmt.Errorf("%w: chunk %d for msg %d has %d dims, gen has %d",
+				vector.ErrDimensionMismatch, c.ChunkIndex, c.MessageID, len(c.Vector), dim)
 		}
 	}
 
@@ -470,16 +470,13 @@ func (b *Backend) Upsert(ctx context.Context, gen vector.GenerationID, chunks []
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Count how many of these message_ids already have a row in
-	// embeddings for this generation, so we can apply an O(1) delta to
-	// index_generations.message_count instead of rescanning the whole
-	// table after every Upsert. Touches len(chunks) rows via the PK
-	// index, not the entire generation.
-	chunkIDs := make([]int64, len(chunks))
-	for i, c := range chunks {
-		chunkIDs[i] = c.MessageID
-	}
-	preexisting, err := countExistingEmbeddings(ctx, tx, gen, chunkIDs)
+	// message_count tracks distinct messages, not chunks. Count how
+	// many of the message_ids in this batch already have any row in
+	// the generation so we can apply an O(1) delta instead of
+	// rescanning the table. The "distinct" semantics matter because a
+	// single upsert may carry multiple chunks for the same message.
+	distinctIDs := distinctMessageIDs(chunks)
+	preexisting, err := countExistingMessages(ctx, tx, gen, distinctIDs)
 	if err != nil {
 		return err
 	}
@@ -487,24 +484,30 @@ func (b *Backend) Upsert(ctx context.Context, gen vector.GenerationID, chunks []
 	now := time.Now().Unix()
 	vecTable := VectorTableName(dim)
 
-	embedStmt, err := tx.PrepareContext(ctx, `INSERT OR REPLACE INTO embeddings
-		(generation_id, message_id, embedded_at, source_char_len, truncated)
-		VALUES (?, ?, ?, ?, ?)`)
+	// Idempotency: clear any prior rows for the message_ids we're
+	// about to replace. Chunking is not stable across upserts (the
+	// same message may have produced 3 chunks last time and 2 this
+	// time, e.g. after a preprocess change), so partial replacement
+	// would leave orphaned tail chunks behind. Delete from vec0 first
+	// — it references embedding_id values that vanish from embeddings
+	// next.
+	if err := deleteForMessageIDs(ctx, tx, vecTable, gen, distinctIDs); err != nil {
+		return err
+	}
+
+	embedInsertStmt, err := tx.PrepareContext(ctx, `INSERT INTO embeddings
+		(generation_id, message_id, chunk_index, embedded_at,
+		 source_char_len, chunk_char_start, chunk_char_end, truncated)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING embedding_id`)
 	if err != nil {
 		return fmt.Errorf("prepare embeddings insert: %w", err)
 	}
-	defer func() { _ = embedStmt.Close() }()
+	defer func() { _ = embedInsertStmt.Close() }()
 
 	// vecTable name comes from VectorTableName(dim) where dim is sourced from index_generations; safe to interpolate.
-	vecDeleteStmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
-		`DELETE FROM %s WHERE generation_id = ? AND message_id = ?`, vecTable))
-	if err != nil {
-		return fmt.Errorf("prepare vec delete: %w", err)
-	}
-	defer func() { _ = vecDeleteStmt.Close() }()
-
 	vecStmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
-		`INSERT INTO %s (generation_id, message_id, embedding) VALUES (?, ?, ?)`, vecTable))
+		`INSERT INTO %s (generation_id, embedding_id, embedding) VALUES (?, ?, ?)`, vecTable))
 	if err != nil {
 		return fmt.Errorf("prepare vec insert: %w", err)
 	}
@@ -515,24 +518,71 @@ func (b *Backend) Upsert(ctx context.Context, gen vector.GenerationID, chunks []
 		if c.Truncated {
 			truncFlag = 1
 		}
-		if _, err := embedStmt.ExecContext(ctx, int64(gen), c.MessageID, now, c.SourceCharLen, truncFlag); err != nil {
-			return fmt.Errorf("insert embedding: %w", err)
+		var embeddingID int64
+		if err := embedInsertStmt.QueryRowContext(ctx,
+			int64(gen), c.MessageID, c.ChunkIndex, now,
+			c.SourceCharLen, c.ChunkCharStart, c.ChunkCharEnd, truncFlag,
+		).Scan(&embeddingID); err != nil {
+			return fmt.Errorf("insert embedding (msg %d chunk %d): %w", c.MessageID, c.ChunkIndex, err)
 		}
-		// vec0 virtual tables do not support INSERT OR REPLACE for updates,
-		// so delete any existing row first, then insert.
-		if _, err := vecDeleteStmt.ExecContext(ctx, int64(gen), c.MessageID); err != nil {
-			return fmt.Errorf("delete existing vector: %w", err)
-		}
-		if _, err := vecStmt.ExecContext(ctx, int64(gen), c.MessageID, float32SliceBlob(c.Vector)); err != nil {
-			return fmt.Errorf("insert vector: %w", err)
+		if _, err := vecStmt.ExecContext(ctx, int64(gen), embeddingID, float32SliceBlob(c.Vector)); err != nil {
+			return fmt.Errorf("insert vector (msg %d chunk %d): %w", c.MessageID, c.ChunkIndex, err)
 		}
 	}
 
-	delta := len(chunks) - preexisting
+	delta := len(distinctIDs) - preexisting
 	if err := applyMessageCountDelta(ctx, tx, gen, delta); err != nil {
 		return err
 	}
 	return tx.Commit()
+}
+
+// distinctMessageIDs returns the unique message_ids referenced by
+// chunks, preserving first-seen order. Order is irrelevant for
+// idempotency but stable iteration helps in tests.
+func distinctMessageIDs(chunks []vector.Chunk) []int64 {
+	seen := make(map[int64]struct{}, len(chunks))
+	out := make([]int64, 0, len(chunks))
+	for _, c := range chunks {
+		if _, ok := seen[c.MessageID]; ok {
+			continue
+		}
+		seen[c.MessageID] = struct{}{}
+		out = append(out, c.MessageID)
+	}
+	return out
+}
+
+// deleteForMessageIDs removes every chunk (in both vec0 and embeddings)
+// belonging to the given message_ids under gen. The vec0 delete runs
+// first so its rowids (which equal embeddings.embedding_id) still exist
+// for the subquery to resolve. Used by Upsert for idempotent replace.
+func deleteForMessageIDs(ctx context.Context, tx *sql.Tx, vecTable string, gen vector.GenerationID, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	blob, err := json.Marshal(ids)
+	if err != nil {
+		return fmt.Errorf("encode msg ids: %w", err)
+	}
+	// vec0 partition-aware filter (generation_id) so the engine can
+	// prune by partition before scanning, then embedding_id IN (...).
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		DELETE FROM %s WHERE generation_id = ? AND embedding_id IN (
+			SELECT embedding_id FROM embeddings
+			WHERE generation_id = ?
+			  AND message_id IN (SELECT value FROM json_each(?))
+		)`, vecTable), int64(gen), int64(gen), string(blob)); err != nil {
+		return fmt.Errorf("delete vectors: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM embeddings
+		WHERE generation_id = ?
+		  AND message_id IN (SELECT value FROM json_each(?))`,
+		int64(gen), string(blob)); err != nil {
+		return fmt.Errorf("delete embeddings: %w", err)
+	}
+	return nil
 }
 
 // applyMessageCountDelta nudges index_generations.message_count by
@@ -553,14 +603,13 @@ func applyMessageCountDelta(ctx context.Context, tx *sql.Tx, gen vector.Generati
 	return nil
 }
 
-// countExistingEmbeddings returns how many of ids already have a row
-// in embeddings for the given generation. The query touches len(ids)
-// rows via the (generation_id, message_id) PK index, not the whole
-// generation, so callers can compute an O(1) message_count delta. ids
-// is JSON-encoded and consumed via json_each so the bind-parameter
-// count stays at 2 regardless of batch size (matches the pattern used
-// by resolveFilter for the same reason).
-func countExistingEmbeddings(ctx context.Context, tx *sql.Tx, gen vector.GenerationID, ids []int64) (int, error) {
+// countExistingMessages returns how many of ids already have at least
+// one row in embeddings for the given generation. Note "messages" not
+// "embeddings": message_count tracks distinct messages, so a message
+// with 5 chunks counts once. Used by Upsert to compute the O(1)
+// message_count delta. ids is JSON-encoded and consumed via json_each
+// so the bind-parameter count stays at 2 regardless of batch size.
+func countExistingMessages(ctx context.Context, tx *sql.Tx, gen vector.GenerationID, ids []int64) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
@@ -570,12 +619,12 @@ func countExistingEmbeddings(ctx context.Context, tx *sql.Tx, gen vector.Generat
 	}
 	var n int
 	err = tx.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM embeddings
+		`SELECT COUNT(DISTINCT message_id) FROM embeddings
 		  WHERE generation_id = ?
 		    AND message_id IN (SELECT value FROM json_each(?))`,
 		int64(gen), string(blob)).Scan(&n)
 	if err != nil {
-		return 0, fmt.Errorf("count existing embeddings: %w", err)
+		return 0, fmt.Errorf("count existing messages: %w", err)
 	}
 	return n, nil
 }
@@ -617,9 +666,20 @@ func (b *Backend) LoadVector(ctx context.Context, messageID int64) ([]float32, e
 	if err != nil {
 		return nil, err
 	}
-	// vecTable name derives from VectorTableName(active.Dimension) where dimension is sourced from index_generations; safe to interpolate.
-	q := fmt.Sprintf(
-		`SELECT embedding FROM %s WHERE generation_id = ? AND message_id = ?`,
+	// Return the chunk_index=0 vector — the head of the message,
+	// which always exists for any embedded message regardless of how
+	// many additional chunks it has. find_similar callers (the only
+	// consumer of LoadVector today) want one representative vector;
+	// they treat embeddings as message-level. vecTable name derives
+	// from VectorTableName(active.Dimension) where dimension is sourced
+	// from index_generations; safe to interpolate.
+	q := fmt.Sprintf(`
+		SELECT v.embedding
+		  FROM %s v
+		  JOIN embeddings e ON e.embedding_id = v.embedding_id
+		 WHERE v.generation_id = ?
+		   AND e.message_id = ?
+		   AND e.chunk_index = 0`,
 		VectorTableName(active.Dimension))
 	var blob []byte
 	err = b.db.QueryRowContext(ctx, q, int64(active.ID), messageID).Scan(&blob)
@@ -669,30 +729,52 @@ func (b *Backend) Search(ctx context.Context, gen vector.GenerationID, queryVec 
 	// always terminates: each iteration either satisfies k or grows
 	// fetch toward the fixed ceiling.
 	if filter.IsEmpty() {
-		var embeddedCount int
+		// chunkCeiling is the actual number of rows in vec0 for this
+		// generation — the upper bound for the over-fetch loop. Using
+		// message_count (distinct messages) instead would under-shoot
+		// when avg_chunks_per_msg > chunkOverfetchFactor and could
+		// short-return when soft-deletions cluster densely. Counting
+		// embeddings rows uses the existing idx_embeddings_gen_msg
+		// index — O(rows-for-gen) but in practice fast because
+		// SQLite optimises COUNT(*) on a covered index.
+		var chunkCeiling int
 		if err := b.db.QueryRowContext(ctx,
-			`SELECT message_count FROM index_generations WHERE id = ?`,
-			int64(gen)).Scan(&embeddedCount); err != nil {
-			return nil, fmt.Errorf("lookup message count: %w", err)
+			`SELECT COUNT(*) FROM embeddings WHERE generation_id = ?`,
+			int64(gen)).Scan(&chunkCeiling); err != nil {
+			return nil, fmt.Errorf("lookup chunk count: %w", err)
 		}
-		if embeddedCount == 0 {
+		if chunkCeiling == 0 {
 			return nil, nil
 		}
+		// Group by message_id (each message may have multiple chunks);
+		// MIN(distance) keeps the best-scoring chunk and discards the
+		// rest. Order applies after the group, so the ranking is by
+		// best-chunk distance per message.
 		q := fmt.Sprintf(`
-			SELECT message_id, distance
-			  FROM %s
-			 WHERE generation_id = ?
-			   AND embedding MATCH ?
+			SELECT e.message_id, MIN(v.distance) AS distance
+			  FROM %s v
+			  JOIN embeddings e ON e.embedding_id = v.embedding_id
+			 WHERE v.generation_id = ?
+			   AND v.embedding MATCH ?
 			   AND k = ?
+			 GROUP BY e.message_id
 			 ORDER BY distance ASC
 		`, vecTable)
-		fetch := k * deletedOverfetchFactor
+		// Two over-fetch dimensions stacked:
+		//   - chunk-level: with N chunks/msg, a top-k by chunk could
+		//     pack the result with one or two messages' tail chunks.
+		//     Multiply by chunkOverfetchFactor so the GROUP BY can
+		//     still pick out k distinct messages.
+		//   - deletion-level: existing soft-delete filter may shrink
+		//     the result; the doubling loop below already handles
+		//     this dimension.
+		fetch := k * chunkOverfetchFactor * deletedOverfetchFactor
 		if fetch < k {
 			fetch = k // guard against overflow or degenerate small k
 		}
 		for {
-			if fetch > embeddedCount {
-				fetch = embeddedCount
+			if fetch > chunkCeiling {
+				fetch = chunkCeiling
 			}
 			hits, err := b.scanHits(ctx, q, int64(gen), float32SliceBlob(queryVec), fetch)
 			if err != nil {
@@ -702,7 +784,7 @@ func (b *Backend) Search(ctx context.Context, gen vector.GenerationID, queryVec 
 			if err != nil {
 				return nil, err
 			}
-			if len(filtered) >= k || fetch >= embeddedCount {
+			if len(filtered) >= k || fetch >= chunkCeiling {
 				if len(filtered) > k {
 					filtered = filtered[:k]
 				}
@@ -723,22 +805,67 @@ func (b *Backend) Search(ctx context.Context, gen vector.GenerationID, queryVec 
 		return nil, err
 	}
 
+	// The filtered path's GROUP BY hides the same hazard as the
+	// empty-filter path: a few messages with many matching chunks
+	// could pack the top-k chunk pool and collapse below k distinct
+	// messages once grouped. Widen the chunk fetch with the same
+	// doubling loop, bounded by the actual chunk count in the
+	// generation so the loop always terminates.
+	var chunkCeiling int
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM embeddings WHERE generation_id = ?`,
+		int64(gen)).Scan(&chunkCeiling); err != nil {
+		return nil, fmt.Errorf("lookup chunk count: %w", err)
+	}
+	if chunkCeiling == 0 {
+		return nil, nil
+	}
+
 	q := fmt.Sprintf(`
-		SELECT message_id, distance
-		  FROM %s
-		 WHERE generation_id = ?
-		   AND embedding MATCH ?
+		SELECT e.message_id, MIN(v.distance) AS distance
+		  FROM %s v
+		  JOIN embeddings e ON e.embedding_id = v.embedding_id
+		 WHERE v.generation_id = ?
+		   AND v.embedding MATCH ?
 		   AND k = ?
 		   %s
+		 GROUP BY e.message_id
 		 ORDER BY distance ASC
 	`, vecTable, idClause)
 
-	allArgs := make([]any, 0, 3+len(filterArgs))
-	allArgs = append(allArgs, int64(gen), float32SliceBlob(queryVec), k)
-	allArgs = append(allArgs, filterArgs...)
+	fetch := k * chunkOverfetchFactor
+	if fetch < k {
+		fetch = k
+	}
+	for {
+		if fetch > chunkCeiling {
+			fetch = chunkCeiling
+		}
+		allArgs := make([]any, 0, 3+len(filterArgs))
+		allArgs = append(allArgs, int64(gen), float32SliceBlob(queryVec), fetch)
+		allArgs = append(allArgs, filterArgs...)
 
-	return b.scanHits(ctx, q, allArgs...)
+		hits, err := b.scanHits(ctx, q, allArgs...)
+		if err != nil {
+			return nil, err
+		}
+		if len(hits) >= k || fetch >= chunkCeiling {
+			if len(hits) > k {
+				hits = hits[:k]
+			}
+			return hits, nil
+		}
+		fetch *= 2
+	}
 }
+
+// chunkOverfetchFactor multiplies the requested k when fetching from
+// the vec0 table so the message-level GROUP BY downstream still has
+// enough chunks to surface k distinct messages. Most messages produce
+// a single chunk; this factor only matters for the long tail. 4× is
+// generous for typical email corpora (avg ~1.1 chunks/msg) and cheap
+// — sqlite-vec returns the top-N rows in O(N log N) regardless.
+const chunkOverfetchFactor = 4
 
 // scanHits runs an ANN query and materializes hits in distance order
 // (higher score = better). Extracted so Search can share the scan
@@ -769,30 +896,37 @@ func (b *Backend) scanHits(ctx context.Context, query string, args ...any) ([]ve
 	return hits, nil
 }
 
-// resolveFilter returns a SQL fragment constraining message_id to the
-// set of messages that pass the structured filter, along with the args
-// to bind. For a populated filter this also enforces the deletion check
-// inline via filteredMessageIDs; empty filters take the fast path in
-// Search and post-filter deletions on the smaller hit set instead of
-// materializing the entire corpus ID list here.
+// resolveFilter returns a SQL fragment constraining the JOINed
+// embeddings.message_id to the set of messages that pass the structured
+// filter, along with the args to bind. For a populated filter this
+// also enforces the deletion check inline via filteredMessageIDs;
+// empty filters take the fast path in Search and post-filter deletions
+// on the smaller hit set instead of materializing the entire corpus ID
+// list here.
 //
 // The fragment uses json_each over a single JSON-encoded id list, so
 // the bind-parameter count is O(1) no matter how many messages match
 // — this keeps broad filters (one account, one common label, wide
 // date range) under SQLite's ~999-parameter practical cap.
+//
+// The fragment qualifies `message_id` with the `e.` alias from Search's
+// SELECT (`embeddings e JOIN vectors_vec_dN v ...`) so the column is
+// unambiguous: the vec0 table itself no longer carries `message_id`
+// post-chunking, but a stray reference here would have read as
+// "embeddings.message_id" by accident, masking the chunking change.
 func (b *Backend) resolveFilter(ctx context.Context, filter vector.Filter) (string, []any, error) {
 	ids, err := b.filteredMessageIDs(ctx, filter)
 	if err != nil {
 		return "", nil, err
 	}
 	if len(ids) == 0 {
-		return "AND message_id IN (SELECT NULL WHERE 0)", nil, nil
+		return "AND e.message_id IN (SELECT NULL WHERE 0)", nil, nil
 	}
 	blob, err := json.Marshal(ids)
 	if err != nil {
 		return "", nil, fmt.Errorf("encode filter ids: %w", err)
 	}
-	return "AND message_id IN (SELECT value FROM json_each(?))", []any{string(blob)}, nil
+	return "AND e.message_id IN (SELECT value FROM json_each(?))", []any{string(blob)}, nil
 }
 
 // deletedOverfetchFactor is the starting multiplier applied to k on
@@ -1017,38 +1151,23 @@ func (b *Backend) Delete(ctx context.Context, gen vector.GenerationID, messageID
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Count rows that will actually be removed before issuing the
-	// per-id deletes so we can apply a precise message_count delta.
-	// Counting up-front (rather than summing RowsAffected from each
-	// per-id stmt) keeps the helper symmetric with the Upsert path
-	// and avoids a second pass.
-	willDelete, err := countExistingEmbeddings(ctx, tx, gen, messageIDs)
+	// Count distinct messages that will actually be removed before
+	// issuing the deletes so we can apply a precise message_count
+	// delta. Counting up-front keeps the helper symmetric with the
+	// Upsert path and works correctly for multi-chunk messages — one
+	// message contributes one to message_count regardless of how many
+	// chunks it has.
+	willDelete, err := countExistingMessages(ctx, tx, gen, messageIDs)
 	if err != nil {
 		return err
 	}
 
-	embedStmt, err := tx.PrepareContext(ctx,
-		`DELETE FROM embeddings WHERE generation_id = ? AND message_id = ?`)
-	if err != nil {
-		return fmt.Errorf("prepare embeddings delete: %w", err)
-	}
-	defer func() { _ = embedStmt.Close() }()
-
-	// vecTable name derives from VectorTableName(dim) where dim is sourced from index_generations; safe to interpolate.
-	vecStmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
-		`DELETE FROM %s WHERE generation_id = ? AND message_id = ?`, VectorTableName(dim)))
-	if err != nil {
-		return fmt.Errorf("prepare vec delete: %w", err)
-	}
-	defer func() { _ = vecStmt.Close() }()
-
-	for _, id := range messageIDs {
-		if _, err := embedStmt.ExecContext(ctx, int64(gen), id); err != nil {
-			return fmt.Errorf("delete embedding: %w", err)
-		}
-		if _, err := vecStmt.ExecContext(ctx, int64(gen), id); err != nil {
-			return fmt.Errorf("delete vector: %w", err)
-		}
+	// deleteForMessageIDs handles vec0 (via the embedding_id subquery)
+	// and embeddings together. Both the vec0 and embeddings deletes
+	// take a single JSON-each batch rather than per-id statements, so
+	// the call count stays at 2 even for a large messageIDs list.
+	if err := deleteForMessageIDs(ctx, tx, VectorTableName(dim), gen, messageIDs); err != nil {
+		return err
 	}
 	if err := applyMessageCountDelta(ctx, tx, gen, -willDelete); err != nil {
 		return err
@@ -1083,8 +1202,14 @@ func (b *Backend) Stats(ctx context.Context, gen vector.GenerationID) (vector.St
 		}
 	}
 
+	// Count distinct messages, not rows. After chunking each long
+	// message occupies multiple rows in the embeddings table, but the
+	// "EmbeddingCount" semantic across the codebase (progress bar
+	// denominator, generation summary, etc.) is "how many messages are
+	// embedded" — counting rows would inflate by avg_chunks_per_msg
+	// and break Done/Total invariants in internal/vector/stats.go.
 	if err := b.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM embeddings `+where, args...).Scan(&s.EmbeddingCount); err != nil {
+		`SELECT COUNT(DISTINCT message_id) FROM embeddings `+where, args...).Scan(&s.EmbeddingCount); err != nil {
 		return s, fmt.Errorf("count embeddings: %w", err)
 	}
 	if err := b.db.QueryRowContext(ctx,

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -463,7 +463,9 @@ func TestBackend_Upsert_WritesEmbeddingAndVector(t *testing.T) {
 	}
 
 	if err := b.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM vectors_vec_d768 WHERE generation_id = ? AND message_id = 1`, gid).Scan(&n); err != nil {
+		`SELECT COUNT(*) FROM vectors_vec_d768 v
+		   JOIN embeddings e ON e.embedding_id = v.embedding_id
+		  WHERE v.generation_id = ? AND e.message_id = 1`, gid).Scan(&n); err != nil {
 		t.Fatalf("count vectors_vec_d768: %v", err)
 	}
 	if n != 1 {
@@ -584,6 +586,116 @@ func TestBackend_Upsert_MultiChunkAndTruncated(t *testing.T) {
 	}
 }
 
+// TestBackend_Upsert_MultiChunkMessage exercises the new
+// per-chunk-row layout: one upsert with two chunks for the same
+// message id must produce two embeddings rows (with chunk_index 0
+// and 1) and two vec0 rows, joined back through embedding_id.
+func TestBackend_Upsert_MultiChunkMessage(t *testing.T) {
+	b, ctx := newBackendForTest(t)
+	gid, err := b.CreateGeneration(ctx, "m", 768)
+	if err != nil {
+		t.Fatalf("CreateGeneration: %v", err)
+	}
+	v0 := make([]float32, 768)
+	v1 := make([]float32, 768)
+	for i := range v0 {
+		v0[i] = 0.25
+		v1[i] = 0.75
+	}
+	if err := b.Upsert(ctx, gid, []vector.Chunk{
+		{MessageID: 7, ChunkIndex: 0, Vector: v0, SourceCharLen: 100,
+			ChunkCharStart: 0, ChunkCharEnd: 100},
+		{MessageID: 7, ChunkIndex: 1, Vector: v1, SourceCharLen: 90,
+			ChunkCharStart: 80, ChunkCharEnd: 170},
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	var n int
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM embeddings WHERE generation_id = ? AND message_id = 7`, gid).Scan(&n); err != nil {
+		t.Fatalf("count embeddings: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("embeddings rows = %d, want 2", n)
+	}
+	// Each chunk_index appears exactly once.
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT chunk_index) FROM embeddings WHERE generation_id = ? AND message_id = 7`, gid).Scan(&n); err != nil {
+		t.Fatalf("count distinct chunk_index: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("distinct chunk_index = %d, want 2", n)
+	}
+	// vec0 has two rows, joined back through embedding_id.
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM vectors_vec_d768 v
+		   JOIN embeddings e ON e.embedding_id = v.embedding_id
+		  WHERE v.generation_id = ? AND e.message_id = 7`, gid).Scan(&n); err != nil {
+		t.Fatalf("count vectors: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("vec rows = %d, want 2", n)
+	}
+	// message_count counts distinct messages, not chunks: a two-chunk
+	// message contributes exactly one.
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT message_count FROM index_generations WHERE id = ?`, gid).Scan(&n); err != nil {
+		t.Fatalf("read message_count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("message_count = %d, want 1 (one distinct message)", n)
+	}
+}
+
+// TestBackend_Upsert_ReplaceFewerChunks confirms idempotency when the
+// chunk fan-out shrinks across upserts: re-upserting a message with
+// only chunk 0 must remove the chunk 1 left from a previous call.
+// Half-replace would leave an orphan row pointing at stale text.
+func TestBackend_Upsert_ReplaceFewerChunks(t *testing.T) {
+	b, ctx := newBackendForTest(t)
+	gid, err := b.CreateGeneration(ctx, "m", 768)
+	if err != nil {
+		t.Fatalf("CreateGeneration: %v", err)
+	}
+	v0 := make([]float32, 768)
+	v1 := make([]float32, 768)
+	for i := range v0 {
+		v0[i] = 0.1
+		v1[i] = 0.9
+	}
+	// First upsert: two chunks.
+	if err := b.Upsert(ctx, gid, []vector.Chunk{
+		{MessageID: 5, ChunkIndex: 0, Vector: v0, SourceCharLen: 100},
+		{MessageID: 5, ChunkIndex: 1, Vector: v1, SourceCharLen: 90},
+	}); err != nil {
+		t.Fatalf("first Upsert: %v", err)
+	}
+	// Second upsert: only chunk 0. Idempotent replace should also
+	// vacate the stale chunk 1 row.
+	if err := b.Upsert(ctx, gid, []vector.Chunk{
+		{MessageID: 5, ChunkIndex: 0, Vector: v0, SourceCharLen: 999},
+	}); err != nil {
+		t.Fatalf("second Upsert: %v", err)
+	}
+	var n int
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM embeddings WHERE generation_id = ? AND message_id = 5`, gid).Scan(&n); err != nil {
+		t.Fatalf("count embeddings: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("embeddings rows = %d, want 1 (chunk 1 should be vacated)", n)
+	}
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM vectors_vec_d768 v
+		   JOIN embeddings e ON e.embedding_id = v.embedding_id
+		  WHERE v.generation_id = ? AND e.message_id = 5`, gid).Scan(&n); err != nil {
+		t.Fatalf("count vectors: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("vec rows = %d, want 1 (chunk 1 vec should be vacated)", n)
+	}
+}
+
 func TestBackend_Upsert_ReplacesExisting(t *testing.T) {
 	b, ctx := newBackendForTest(t)
 	gid, err := b.CreateGeneration(ctx, "m", 768, "")
@@ -626,7 +738,9 @@ func TestBackend_Upsert_ReplacesExisting(t *testing.T) {
 	}
 
 	if err := b.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM vectors_vec_d768 WHERE generation_id = ? AND message_id = 1`, gid).Scan(&n); err != nil {
+		`SELECT COUNT(*) FROM vectors_vec_d768 v
+		   JOIN embeddings e ON e.embedding_id = v.embedding_id
+		  WHERE v.generation_id = ? AND e.message_id = 1`, gid).Scan(&n); err != nil {
 		t.Fatalf("count vectors_vec_d768: %v", err)
 	}
 	if n != 1 {
@@ -1415,7 +1529,7 @@ func TestBackend_Delete_RemovesFromAllTables(t *testing.T) {
 		t.Errorf("embeddings remaining: %d", n)
 	}
 	if err := b.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM vectors_vec_d768 WHERE message_id = 1`).Scan(&n); err != nil {
+		`SELECT COUNT(*) FROM vectors_vec_d768`).Scan(&n); err != nil {
 		t.Fatalf("count vectors: %v", err)
 	}
 	if n != 0 {

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -592,7 +592,7 @@ func TestBackend_Upsert_MultiChunkAndTruncated(t *testing.T) {
 // and 1) and two vec0 rows, joined back through embedding_id.
 func TestBackend_Upsert_MultiChunkMessage(t *testing.T) {
 	b, ctx := newBackendForTest(t)
-	gid, err := b.CreateGeneration(ctx, "m", 768)
+	gid, err := b.CreateGeneration(ctx, "m", 768, "")
 	if err != nil {
 		t.Fatalf("CreateGeneration: %v", err)
 	}
@@ -653,7 +653,7 @@ func TestBackend_Upsert_MultiChunkMessage(t *testing.T) {
 // Half-replace would leave an orphan row pointing at stale text.
 func TestBackend_Upsert_ReplaceFewerChunks(t *testing.T) {
 	b, ctx := newBackendForTest(t)
-	gid, err := b.CreateGeneration(ctx, "m", 768)
+	gid, err := b.CreateGeneration(ctx, "m", 768, "")
 	if err != nil {
 		t.Fatalf("CreateGeneration: %v", err)
 	}
@@ -1605,6 +1605,57 @@ func TestBackend_Stats_AggregateAcrossGenerations(t *testing.T) {
 	}
 	if s.EmbeddingCount != 1 {
 		t.Errorf("aggregate EmbeddingCount=%d want 1", s.EmbeddingCount)
+	}
+}
+
+// TestBackend_Stats_AggregateCountsPerGenerationDuplicates pins the
+// fix for the aggregate undercount: when one message exists in both
+// the active generation and an in-flight building generation, the
+// aggregate path should report two units of embedded work (one per
+// generation) rather than collapsing to one via DISTINCT message_id.
+func TestBackend_Stats_AggregateCountsPerGenerationDuplicates(t *testing.T) {
+	b, ctx := newBackendForTest(t)
+
+	// First generation: embed message 1, then activate so the next
+	// CreateGeneration produces a building gen alongside it instead of
+	// reusing the same row.
+	genA := seedAndEmbed(t, b, map[int64][]float32{1: unitVec(768, 0)})
+	if err := b.ActivateGeneration(ctx, genA); err != nil {
+		t.Fatalf("ActivateGeneration(genA): %v", err)
+	}
+
+	// Second generation: re-embed the same message 1, mirroring the
+	// "rebuild in progress" state where every message is dual-embedded
+	// across active + building.
+	genB, err := b.CreateGeneration(ctx, "m", 768, "fp-b")
+	if err != nil {
+		t.Fatalf("CreateGeneration(genB): %v", err)
+	}
+	if err := b.Upsert(ctx, genB, []vector.Chunk{
+		{MessageID: 1, Vector: unitVec(768, 1)},
+	}); err != nil {
+		t.Fatalf("Upsert into genB: %v", err)
+	}
+
+	s, err := b.Stats(ctx, vector.GenerationID(0))
+	if err != nil {
+		t.Fatalf("Stats(0): %v", err)
+	}
+	if s.EmbeddingCount != 2 {
+		t.Errorf("aggregate EmbeddingCount=%d want 2 (one (gen, msg) pair per generation)", s.EmbeddingCount)
+	}
+
+	// Per-generation counts remain semantically "distinct messages in
+	// this generation", so each gen still reports 1.
+	if sa, err := b.Stats(ctx, genA); err != nil {
+		t.Fatalf("Stats(genA): %v", err)
+	} else if sa.EmbeddingCount != 1 {
+		t.Errorf("genA EmbeddingCount=%d want 1", sa.EmbeddingCount)
+	}
+	if sb, err := b.Stats(ctx, genB); err != nil {
+		t.Fatalf("Stats(genB): %v", err)
+	} else if sb.EmbeddingCount != 1 {
+		t.Errorf("genB EmbeddingCount=%d want 1", sb.EmbeddingCount)
 	}
 }
 

--- a/internal/vector/sqlitevec/fused.go
+++ b/internal/vector/sqlitevec/fused.go
@@ -125,7 +125,34 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	// unused K+1 row exists only so the outer query can report whether
 	// the pool was full.
 	kPlus1 := req.KPerSignal + 1
-	query := fmt.Sprintf(`
+	// Two over-fetch dimensions stacked on the ANN side:
+	//   - chunk-level: vec0 returns top-K chunks; with N chunks/msg
+	//     the top-K could pack from a few messages' tail chunks. Multiply
+	//     by chunkOverfetchFactor so the GROUP BY can still recover
+	//     KPerSignal distinct messages. The widening loop below grows
+	//     this further when the initial multiplier under-shoots.
+	//   - K+1 probe: the trailing +1 (kPlus1) lets ann_used report
+	//     saturation when the pool runs full, identical to the BM25 side.
+	chunkK := kPlus1 * chunkOverfetchFactor
+
+	// Look up the upper bound for the widening loop: total chunks in
+	// this generation. Without this ceiling the loop could grow
+	// chunkK unboundedly when the corpus genuinely has fewer than
+	// KPerSignal distinct vector matches.
+	var chunkCeiling int
+	if req.QueryVec != nil {
+		if err := b.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM embeddings WHERE generation_id = ?`,
+			int64(req.Generation)).Scan(&chunkCeiling); err != nil {
+			return nil, false, fmt.Errorf("lookup chunk count: %w", err)
+		}
+	}
+	// buildQuery interpolates a fresh query string for a given chunkK,
+	// so the widening loop below can re-issue the fused CTE with a
+	// growing ANN over-fetch when the first pass collapses to fewer
+	// than KPerSignal distinct messages after GROUP BY.
+	buildQuery := func(currentChunkK int) string {
+		return fmt.Sprintf(`
 WITH
   filtered AS (
     SELECT m.id
@@ -159,16 +186,25 @@ WITH
   bm25_used AS (
     SELECT * FROM bm25 WHERE rnk <= %d
   ),
-  ann AS (
-    SELECT v.message_id,
-           v.distance AS vec_dist,
-           ROW_NUMBER() OVER (ORDER BY v.distance) AS rnk
+  ann_chunks AS (
+    SELECT ve.message_id, MIN(v.distance) AS vec_dist
       FROM %s v
+      JOIN vec.embeddings ve ON ve.embedding_id = v.embedding_id
      WHERE :query_vec IS NOT NULL
        AND v.generation_id = :gen
-       AND v.message_id IN (SELECT id FROM filtered)
+       AND v.embedding_id IN (
+            SELECT embedding_id FROM vec.embeddings
+             WHERE generation_id = :gen
+               AND message_id IN (SELECT id FROM filtered)
+       )
        AND v.embedding MATCH :query_vec
        AND k = %d
+     GROUP BY ve.message_id
+  ),
+  ann AS (
+    SELECT message_id, vec_dist,
+           ROW_NUMBER() OVER (ORDER BY vec_dist) AS rnk
+      FROM ann_chunks
   ),
   ann_used AS (
     SELECT * FROM ann WHERE rnk <= %d
@@ -189,7 +225,8 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
  ORDER BY rrf_score DESC, message_id ASC
  LIMIT :limit
 `, store.LiveMessagesWhere("m", true), senderGroupSQL, toGroupSQL, ccGroupSQL, bccGroupSQL, labelGroupSQL,
-		kPlus1, req.KPerSignal, vecTable, kPlus1, req.KPerSignal)
+			kPlus1, req.KPerSignal, vecTable, currentChunkK, req.KPerSignal)
+	}
 
 	var queryVecArg any
 	if req.QueryVec != nil {
@@ -240,53 +277,83 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
 	args = append(args, bccGroupArgs...)
 	args = append(args, labelGroupArgs...)
 
-	rows, err := conn.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, false, fmt.Errorf("fused query: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
+	// Loop the fused query with growing chunkK until either the ANN
+	// pool covers req.KPerSignal+1 distinct messages (so saturation
+	// detection on the ANN side is accurate) or the chunk fetch
+	// reaches the corpus ceiling. Without this loop, a query whose
+	// top chunks pile up onto a few long messages collapses to far
+	// fewer than KPerSignal distinct vector candidates and the
+	// caller sees an under-populated ANN pool even when more
+	// matching messages exist further down the chunk-distance
+	// ordering. Bounded by chunkCeiling so the loop always
+	// terminates; usually fires once.
+	var (
+		hits         []vector.FusedHit
+		bm25PoolSize int
+		annPoolSize  int
+	)
+	for {
+		query := buildQuery(chunkK)
+		rows, err := conn.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, false, fmt.Errorf("fused query: %w", err)
+		}
 
-	var hits []vector.FusedHit
-	// bm25_pool_size and ann_pool_size are correlated subqueries that
-	// evaluate to the same value on every row of the result. We only
-	// need them once, so capture from the first row (they are
-	// otherwise redundantly assigned per-iteration). When the result
-	// set is empty, both pools are empty by construction:
-	//
-	//   fused = bm25_used FULL OUTER JOIN ann_used
-	//   bm25_used = bm25 WHERE rnk <= KPerSignal       (rnk starts at 1)
-	//   ann_used  = ann  WHERE rnk <= KPerSignal
-	//
-	// FULL OUTER JOIN of two empty sets is empty, and bm25_used/ann_used
-	// cannot be empty unless their parent CTE was — so an empty `fused`
-	// implies both pools were empty post-filter, which means saturation
-	// is provably false. Default-zero pool sizes are correct in that case.
-	var bm25PoolSize, annPoolSize int
-	var poolSizeRead bool
-	for rows.Next() {
-		var h vector.FusedHit
-		var bm, vec sql.NullFloat64
-		var bmPool, annPool int
-		if err := rows.Scan(&h.MessageID, &h.RRFScore, &bm, &vec, &bmPool, &annPool); err != nil {
-			return nil, false, fmt.Errorf("scan fused hit: %w", err)
+		hits = hits[:0]
+		// bm25_pool_size and ann_pool_size are correlated subqueries
+		// that evaluate to the same value on every row of the result.
+		// We only need them once, so capture from the first row.
+		// When the result set is empty, both pools are empty by
+		// construction (fused = bm25_used FULL OUTER JOIN ann_used,
+		// both capped at KPerSignal), so default-zero is correct.
+		bm25PoolSize, annPoolSize = 0, 0
+		poolSizeRead := false
+		for rows.Next() {
+			var h vector.FusedHit
+			var bm, vec sql.NullFloat64
+			var bmPool, annPool int
+			if err := rows.Scan(&h.MessageID, &h.RRFScore, &bm, &vec, &bmPool, &annPool); err != nil {
+				_ = rows.Close()
+				return nil, false, fmt.Errorf("scan fused hit: %w", err)
+			}
+			if !poolSizeRead {
+				bm25PoolSize = bmPool
+				annPoolSize = annPool
+				poolSizeRead = true
+			}
+			h.BM25Score = math.NaN()
+			if bm.Valid {
+				h.BM25Score = bm.Float64
+			}
+			h.VectorScore = math.NaN()
+			if vec.Valid {
+				h.VectorScore = vec.Float64
+			}
+			hits = append(hits, h)
 		}
-		if !poolSizeRead {
-			bm25PoolSize = bmPool
-			annPoolSize = annPool
-			poolSizeRead = true
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, false, fmt.Errorf("iterate fused hits: %w", err)
 		}
-		h.BM25Score = math.NaN()
-		if bm.Valid {
-			h.BM25Score = bm.Float64
+		_ = rows.Close()
+
+		// Decide whether to widen. Only the ANN side benefits — the
+		// BM25 side is per-message-rowid and never collapses.
+		// Stop when the ANN pool covered req.KPerSignal+1 distinct
+		// messages (so saturation is observable), or when there's
+		// no query vector to widen for, or when we've fetched the
+		// whole chunk corpus.
+		if req.QueryVec == nil || annPoolSize >= kPlus1 || chunkK >= chunkCeiling {
+			break
 		}
-		h.VectorScore = math.NaN()
-		if vec.Valid {
-			h.VectorScore = vec.Float64
+		next := chunkK * 2
+		if next > chunkCeiling {
+			next = chunkCeiling
 		}
-		hits = append(hits, h)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, false, fmt.Errorf("iterate fused hits: %w", err)
+		if next == chunkK {
+			break
+		}
+		chunkK = next
 	}
 
 	if boostActive {

--- a/internal/vector/sqlitevec/fused.go
+++ b/internal/vector/sqlitevec/fused.go
@@ -135,29 +135,12 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	//     saturation when the pool runs full, identical to the BM25 side.
 	chunkK := kPlus1 * chunkOverfetchFactor
 
-	// Look up the upper bound for the widening loop: total chunks in
-	// this generation. Without this ceiling the loop could grow
-	// chunkK unboundedly when the corpus genuinely has fewer than
-	// KPerSignal distinct vector matches.
-	var chunkCeiling int
-	if req.QueryVec != nil {
-		if err := b.db.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM embeddings WHERE generation_id = ?`,
-			int64(req.Generation)).Scan(&chunkCeiling); err != nil {
-			return nil, false, fmt.Errorf("lookup chunk count: %w", err)
-		}
-	}
-	// buildQuery interpolates a fresh query string for a given chunkK,
-	// so the widening loop below can re-issue the fused CTE with a
-	// growing ANN over-fetch when the first pass collapses to fewer
-	// than KPerSignal distinct messages after GROUP BY.
-	buildQuery := func(currentChunkK int) string {
-		return fmt.Sprintf(`
-WITH
-  filtered AS (
-    SELECT m.id
-      FROM messages m
-     WHERE %s
+	// filterWhere is the WHERE clause shared by both the chunk-ceiling
+	// pre-query and the `filtered` CTE inside the fused query: this
+	// guarantees the ceiling's "is this message included" predicate
+	// stays bit-for-bit aligned with the live one without forcing
+	// callers (or the test suite) to keep two copies in sync.
+	filterWhere := fmt.Sprintf(`%s
        AND (:source_ids IS NULL OR m.source_id IN (SELECT value FROM json_each(:source_ids)))
        %s
        %s
@@ -171,7 +154,20 @@ WITH
        AND (:subject_patterns IS NULL OR NOT EXISTS (
              SELECT 1 FROM json_each(:subject_patterns) sp
               WHERE m.subject IS NULL OR m.subject NOT LIKE sp.value ESCAPE '\'))
-       %s
+       %s`,
+		store.LiveMessagesWhere("m", true), senderGroupSQL, toGroupSQL, ccGroupSQL, bccGroupSQL, labelGroupSQL)
+
+	// buildQuery interpolates a fresh query string for a given chunkK,
+	// so the widening loop below can re-issue the fused CTE with a
+	// growing ANN over-fetch when the first pass collapses to fewer
+	// than KPerSignal distinct messages after GROUP BY.
+	buildQuery := func(currentChunkK int) string {
+		return fmt.Sprintf(`
+WITH
+  filtered AS (
+    SELECT m.id
+      FROM messages m
+     WHERE %s
   ),
   bm25 AS (
     SELECT fts.rowid AS message_id,
@@ -224,8 +220,7 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
   FROM fused
  ORDER BY rrf_score DESC, message_id ASC
  LIMIT :limit
-`, store.LiveMessagesWhere("m", true), senderGroupSQL, toGroupSQL, ccGroupSQL, bccGroupSQL, labelGroupSQL,
-			kPlus1, req.KPerSignal, vecTable, currentChunkK, req.KPerSignal)
+`, filterWhere, kPlus1, req.KPerSignal, vecTable, currentChunkK, req.KPerSignal)
 	}
 
 	var queryVecArg any
@@ -257,7 +252,12 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
 		}
 	}
 
-	args := []any{
+	// Filter-only named args feed both the chunk-ceiling pre-query
+	// and the main fused query. The split keeps the ceiling query
+	// from binding fts_query / query_vec / rrf_k / limit (none of
+	// which it references) — the go-sqlite3 driver rejects extra
+	// named binds when its placeholder count check fails.
+	filterArgs := []any{
 		sql.Named("source_ids", sourceIDs),
 		sql.Named("has_attachment", hasAttachment),
 		sql.Named("after", after),
@@ -265,24 +265,62 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
 		sql.Named("larger_than", largerThan),
 		sql.Named("smaller_than", smallerThan),
 		sql.Named("subject_patterns", subjectPatterns),
+		sql.Named("gen", int64(req.Generation)),
+	}
+	filterArgs = append(filterArgs, senderGroupArgs...)
+	filterArgs = append(filterArgs, toGroupArgs...)
+	filterArgs = append(filterArgs, ccGroupArgs...)
+	filterArgs = append(filterArgs, bccGroupArgs...)
+	filterArgs = append(filterArgs, labelGroupArgs...)
+
+	// Two ceilings bound the widening loop. The generation-wide
+	// chunkCeiling is the hard upper bound on currentChunkK so the
+	// loop terminates even when the BM25/ANN signals disagree
+	// completely. The filteredMessageCeiling is an early-exit:
+	// once the ANN pool covers every filtered message with at
+	// least one chunk, no further iteration can introduce a new
+	// message (a chunk fetched at higher rank has a worse distance
+	// than what's already in MIN(v.distance) per message, so neither
+	// the pool's membership nor its rankings can change). Without
+	// this early exit, a tight filter that matches a handful of
+	// messages drives the loop all the way to chunkCeiling doing
+	// wasted ANN+JOIN work on every pass.
+	var chunkCeiling, filteredMessageCeiling int
+	if req.QueryVec != nil {
+		if err := b.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM embeddings WHERE generation_id = ?`,
+			int64(req.Generation)).Scan(&chunkCeiling); err != nil {
+			return nil, false, fmt.Errorf("lookup chunk count: %w", err)
+		}
+		ceilingSQL := fmt.Sprintf(`
+			SELECT COUNT(DISTINCT ve.message_id) FROM vec.embeddings ve
+			 WHERE ve.generation_id = :gen
+			   AND ve.message_id IN (
+			       SELECT m.id FROM messages m WHERE %s
+			   )`, filterWhere)
+		if err := conn.QueryRowContext(ctx, ceilingSQL, filterArgs...).Scan(&filteredMessageCeiling); err != nil {
+			return nil, false, fmt.Errorf("lookup filtered message count: %w", err)
+		}
+	}
+
+	// Query-specific named args: only the main fused query
+	// references these. Concatenated onto filterArgs at the end so
+	// both args slices share storage for the filter-side names.
+	args := make([]any, 0, len(filterArgs)+4)
+	args = append(args, filterArgs...)
+	args = append(args,
 		sql.Named("fts_query", ftsArg),
 		sql.Named("query_vec", queryVecArg),
-		sql.Named("gen", int64(req.Generation)),
 		sql.Named("rrf_k", req.RRFK),
 		sql.Named("limit", sqlLimit),
-	}
-	args = append(args, senderGroupArgs...)
-	args = append(args, toGroupArgs...)
-	args = append(args, ccGroupArgs...)
-	args = append(args, bccGroupArgs...)
-	args = append(args, labelGroupArgs...)
+	)
 
 	// Loop the fused query with growing chunkK until either the ANN
 	// pool covers req.KPerSignal+1 distinct messages (so saturation
 	// detection on the ANN side is accurate) or the chunk fetch
-	// reaches the corpus ceiling. Without this loop, a query whose
-	// top chunks pile up onto a few long messages collapses to far
-	// fewer than KPerSignal distinct vector candidates and the
+	// reaches the filtered chunk ceiling. Without this loop, a query
+	// whose top chunks pile up onto a few long messages collapses to
+	// far fewer than KPerSignal distinct vector candidates and the
 	// caller sees an under-populated ANN pool even when more
 	// matching messages exist further down the chunk-distance
 	// ordering. Bounded by chunkCeiling so the loop always
@@ -340,10 +378,15 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
 		// Decide whether to widen. Only the ANN side benefits — the
 		// BM25 side is per-message-rowid and never collapses.
 		// Stop when the ANN pool covered req.KPerSignal+1 distinct
-		// messages (so saturation is observable), or when there's
-		// no query vector to widen for, or when we've fetched the
-		// whole chunk corpus.
-		if req.QueryVec == nil || annPoolSize >= kPlus1 || chunkK >= chunkCeiling {
+		// messages (so saturation is observable), when the ANN
+		// pool has reached the filtered-message ceiling (no further
+		// iteration can introduce a new filtered message), when
+		// there's no query vector to widen for, or when we've
+		// fetched the whole chunk corpus.
+		if req.QueryVec == nil ||
+			annPoolSize >= kPlus1 ||
+			annPoolSize >= filteredMessageCeiling ||
+			chunkK >= chunkCeiling {
 			break
 		}
 		next := chunkK * 2

--- a/internal/vector/sqlitevec/migrate.go
+++ b/internal/vector/sqlitevec/migrate.go
@@ -19,6 +19,14 @@ var schemaSQL string
 // PRAGMA foreign_keys is applied per-connection by the ConnectHook
 // registered in RegisterExtension; it is intentionally not run here.
 func Migrate(ctx context.Context, db *sql.DB, defaultDim int) error {
+	// Migrate legacy embeddings + vec0 tables to the chunked layout
+	// BEFORE running the baseline schema. The baseline CREATE TABLE IF
+	// NOT EXISTS would skip the new columns on a legacy DB, and the
+	// embeddings table rename relies on the legacy columns still being
+	// present.
+	if err := migrateEmbeddingsToChunked(ctx, db); err != nil {
+		return fmt.Errorf("migrate embeddings to chunked layout: %w", err)
+	}
 	if _, err := db.ExecContext(ctx, schemaSQL); err != nil {
 		return fmt.Errorf("apply schema: %w", err)
 	}
@@ -39,7 +47,348 @@ func Migrate(ctx context.Context, db *sql.DB, defaultDim int) error {
 	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
 		return fmt.Errorf("enable WAL: %w", err)
 	}
+	if err := migrateVecTablesToChunked(ctx, db); err != nil {
+		return fmt.Errorf("migrate vec tables to chunked layout: %w", err)
+	}
 	return EnsureVectorTable(ctx, db, defaultDim)
+}
+
+// migrateEmbeddingsToChunked detects the pre-chunking schema (no
+// embedding_id column) and rewrites the embeddings table in place:
+// adds embedding_id as the AUTOINCREMENT rowid, populates it from
+// existing rows (preserving message_id == embedding_id so the
+// dimension-specific vec0 table's rowid stays valid through
+// migrateVecTablesToChunked), and adds chunk_index/chunk_char_start/
+// chunk_char_end with their zero defaults so legacy rows become
+// chunk 0 of their message.
+//
+// All schema mutation and the copy happen inside one transaction.
+// If the process crashes mid-way SQLite rolls back atomically, so a
+// subsequent retry of Migrate() observes the unchanged legacy schema
+// and runs the migration cleanly. Crucially, this prevents the
+// pathological half-state where the new embeddings table exists,
+// looks "already migrated" by the column probe, but is empty —
+// silently dropping every legacy row.
+//
+// Idempotent: a freshly-initialized DB has no `embeddings` table at
+// migrate time, and an already-migrated DB has the new layout — both
+// paths return nil with no SQL executed. A leftover `embeddings_legacy`
+// from a previous failed run (theoretically impossible with the
+// transactional approach, but defensive against schema state left by
+// older migration code) is also handled.
+func migrateEmbeddingsToChunked(ctx context.Context, db *sql.DB) error {
+	exists, err := tableExists(ctx, db, "embeddings")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	hasNew, err := columnExists(ctx, db, "embeddings", "embedding_id")
+	if err != nil {
+		return err
+	}
+	if hasNew {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin migration tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE embeddings RENAME TO embeddings_legacy`); err != nil {
+		return fmt.Errorf("rename legacy embeddings: %w", err)
+	}
+	// SQLite preserves index NAMES across ALTER TABLE RENAME (only the
+	// indexed table reference is rewritten), so the legacy
+	// `idx_embeddings_msg` still occupies the namespace and would
+	// collide with the new index of the same name below. Drop it
+	// explicitly — the legacy table is going away in this same tx
+	// anyway, so dropping its index has no separate consequence.
+	if _, err := tx.ExecContext(ctx, `DROP INDEX IF EXISTS idx_embeddings_msg`); err != nil {
+		return fmt.Errorf("drop legacy idx_embeddings_msg: %w", err)
+	}
+	// Create the new embeddings table inline (cannot re-run the full
+	// schemaSQL inside the tx because it would also try to recreate
+	// the vec0 tables, which can't be created mid-transaction with
+	// vec0-internal state). The DDL must match schema.sql exactly so
+	// the subsequent CREATE TABLE IF NOT EXISTS after the tx is a
+	// genuine no-op.
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE embeddings (
+		embedding_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+		generation_id    INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+		message_id       INTEGER NOT NULL,
+		chunk_index      INTEGER NOT NULL DEFAULT 0,
+		embedded_at      INTEGER NOT NULL,
+		source_char_len  INTEGER NOT NULL,
+		chunk_char_start INTEGER NOT NULL DEFAULT 0,
+		chunk_char_end   INTEGER NOT NULL DEFAULT 0,
+		truncated        INTEGER NOT NULL DEFAULT 0,
+		UNIQUE (generation_id, message_id, chunk_index)
+	)`); err != nil {
+		return fmt.Errorf("create new embeddings table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE INDEX idx_embeddings_msg ON embeddings(message_id)`); err != nil {
+		return fmt.Errorf("recreate idx_embeddings_msg: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE INDEX idx_embeddings_gen_msg ON embeddings(generation_id, message_id)`); err != nil {
+		return fmt.Errorf("create idx_embeddings_gen_msg: %w", err)
+	}
+	// Copy without specifying embedding_id so AUTOINCREMENT allocates
+	// a fresh, globally-unique rowid for each legacy row. The legacy
+	// embeddings PK was (generation_id, message_id), which allows the
+	// same message_id to appear under multiple generations (e.g. one
+	// active + one building); equating embedding_id with message_id
+	// would have collided on the new UNIQUE constraint in that case.
+	// chunk_char_start/_end default to 0 — they describe the
+	// preprocessed-text span used at embed time and we don't have
+	// that information for already-embedded rows. chunk_char_* is
+	// debug-only metadata, so a zero placeholder is acceptable.
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO embeddings
+			(generation_id, message_id, chunk_index,
+			 embedded_at, source_char_len, chunk_char_start, chunk_char_end, truncated)
+		SELECT generation_id, message_id, 0,
+			   embedded_at, source_char_len, 0, source_char_len, truncated
+		FROM embeddings_legacy`); err != nil {
+		return fmt.Errorf("copy legacy embeddings: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE embeddings_legacy`); err != nil {
+		return fmt.Errorf("drop embeddings_legacy: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit migration tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// migrateVecTablesToChunked rebuilds every existing vec0 table whose
+// schema names the second column "message_id" (pre-chunking) into the
+// new layout where that column is "embedding_id". The data is copied
+// 1:1 because migrateEmbeddingsToChunked preserved embedding_id ==
+// message_id for legacy rows, so each vec0 row's rowid is still the
+// correct embedding_id under the new schema; only the column name
+// changes.
+//
+// Idempotent: skips tables already on the new layout.
+func migrateVecTablesToChunked(ctx context.Context, db *sql.DB) error {
+	// Only the user-facing vec0 virtual tables — `sqlite_master.sql`
+	// names them via `CREATE VIRTUAL TABLE ... USING vec0`. The
+	// associated shadow tables (`vectors_vec_dN_chunks`,
+	// `vectors_vec_dN_info`, `vectors_vec_dN_rowids`,
+	// `vectors_vec_dN_vector_chunks00`, ...) are sqlite-vec internals
+	// that come along when the virtual table is created and disappear
+	// when it's dropped. Filtering by type='table' alone would catch
+	// them and try to ALTER their internal schemas; matching on the
+	// CREATE statement keeps us to the parent table only.
+	rows, err := db.QueryContext(ctx, `
+		SELECT name FROM sqlite_master
+		WHERE type = 'table'
+		  AND name LIKE 'vectors_vec_d%'
+		  AND sql LIKE '%USING vec0%'`)
+	if err != nil {
+		return fmt.Errorf("list vec tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return fmt.Errorf("scan vec table name: %w", err)
+		}
+		names = append(names, n)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate vec tables: %w", err)
+	}
+	for _, name := range names {
+		hasNew, err := columnExists(ctx, db, name, "embedding_id")
+		if err != nil {
+			return err
+		}
+		if hasNew {
+			continue
+		}
+		// Pull the dimension out of the table name (vectors_vec_dN).
+		// We do not parse the CREATE statement — the name is the
+		// authoritative source for the dim everywhere else in the
+		// code.
+		var dim int
+		if _, err := fmt.Sscanf(name, "vectors_vec_d%d", &dim); err != nil || dim <= 0 {
+			return fmt.Errorf("decode dim from %q: %w", name, err)
+		}
+		// vec0 virtual tables cannot be ALTERed and cannot be RENAMEd
+		// (the rename does not carry the shadow tables — *_rowids,
+		// *_info, *_chunks, *_vector_chunks00 — that vec0 maintains
+		// alongside the virtual table). Instead: stream every row out
+		// into memory, DROP the virtual table (which cleanly removes
+		// its shadow tables too), recreate it under the new schema,
+		// and re-INSERT. Acceptable because the data is small
+		// (~3 KB/row at 768 dims) and the migration runs once per
+		// existing database.
+		if err := rebuildVecTableForChunking(ctx, db, name, dim); err != nil {
+			return fmt.Errorf("rebuild %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// rebuildVecTableForChunking drops the legacy vec0 table named `name`
+// and recreates it under the new schema (embedding_id PRIMARY KEY in
+// place of message_id PRIMARY KEY), preserving every row.
+//
+// The new vec0 rowid is the AUTOINCREMENT embedding_id allocated by
+// migrateEmbeddingsToChunked, looked up here via the (generation_id,
+// message_id) of each legacy row. This mapping is required because
+// the legacy embeddings PK allows the same message_id under multiple
+// generations, so a simple rowid=message_id carry-over would collide;
+// the explicit lookup keeps each generation's vectors disjoint in
+// the rebuilt vec0 table.
+//
+// The drop + create + re-insert sequence runs inside a single
+// transaction. SQLite supports transactional DDL on virtual tables;
+// sqlite-vec's vec0 cooperates because its shadow tables (chunks,
+// info, rowids, vector_chunks00) are regular tables under the same
+// transaction boundary. A crash mid-rebuild rolls back to the legacy
+// state, so a subsequent Migrate() retry observes the unchanged
+// schema and runs cleanly.
+func rebuildVecTableForChunking(ctx context.Context, db *sql.DB, name string, dim int) error {
+	type vecRow struct {
+		gen   int64
+		msgID int64
+		blob  []byte
+	}
+	// Read every legacy row up-front, *outside* the transaction. The
+	// virtual-table reader returns a custom iterator implementation;
+	// holding it open across a DDL operation against the same table
+	// (the DROP that follows) deadlocks or panics depending on the
+	// build. Materializing into memory is cheap (one vec is ~3 KB at
+	// 768 dims; even 100K vecs is ~300 MB and pre-chunking deployments
+	// are typically much smaller — the user's vault has ~12K vecs).
+	rows, err := db.QueryContext(ctx,
+		fmt.Sprintf(`SELECT generation_id, message_id, embedding FROM %s`, name))
+	if err != nil {
+		return fmt.Errorf("read legacy rows: %w", err)
+	}
+	var legacyRows []vecRow
+	for rows.Next() {
+		var r vecRow
+		if err := rows.Scan(&r.gen, &r.msgID, &r.blob); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan legacy row: %w", err)
+		}
+		legacyRows = append(legacyRows, r)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close legacy rows: %w", err)
+	}
+
+	// Build (generation_id, message_id) -> embedding_id mapping from
+	// the already-migrated embeddings table. The migration above
+	// inserted exactly one chunk_index=0 row per legacy embedding, so
+	// every legacy vec0 row has a corresponding embedding_id.
+	type key struct{ gen, msg int64 }
+	mapping := make(map[key]int64, len(legacyRows))
+	mapRows, err := db.QueryContext(ctx,
+		`SELECT generation_id, message_id, embedding_id FROM embeddings WHERE chunk_index = 0`)
+	if err != nil {
+		return fmt.Errorf("read embedding_id mapping: %w", err)
+	}
+	for mapRows.Next() {
+		var g, m, eid int64
+		if err := mapRows.Scan(&g, &m, &eid); err != nil {
+			_ = mapRows.Close()
+			return fmt.Errorf("scan embedding_id mapping: %w", err)
+		}
+		mapping[key{g, m}] = eid
+	}
+	if err := mapRows.Close(); err != nil {
+		return fmt.Errorf("close mapping rows: %w", err)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin rebuild tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE %s`, name)); err != nil {
+		return fmt.Errorf("drop legacy %s: %w", name, err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIRTUAL TABLE %s USING vec0(
+		generation_id INTEGER PARTITION KEY,
+		embedding_id  INTEGER PRIMARY KEY,
+		embedding     FLOAT[%d]
+	)`, name, dim)); err != nil {
+		return fmt.Errorf("create new %s: %w", name, err)
+	}
+	if len(legacyRows) > 0 {
+		stmt, err := tx.PrepareContext(ctx,
+			fmt.Sprintf(`INSERT INTO %s (generation_id, embedding_id, embedding) VALUES (?, ?, ?)`, name))
+		if err != nil {
+			return fmt.Errorf("prepare reinsert: %w", err)
+		}
+		defer func() { _ = stmt.Close() }()
+		for _, r := range legacyRows {
+			eid, ok := mapping[key{r.gen, r.msgID}]
+			if !ok {
+				// Defensive: every legacy vec0 row should have a
+				// matching embeddings row from the prior migration
+				// step. If not, we'd silently drop the vector — flag
+				// it loudly instead so the operator can investigate.
+				return fmt.Errorf("no embedding_id mapping for gen=%d msg=%d (legacy embeddings/vec0 out of sync)", r.gen, r.msgID)
+			}
+			if _, err := stmt.ExecContext(ctx, r.gen, eid, r.blob); err != nil {
+				return fmt.Errorf("reinsert row gen=%d msg=%d eid=%d: %w", r.gen, r.msgID, eid, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit rebuild tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// tableExists is a thin wrapper that asks sqlite_master whether a
+// regular or virtual table with `name` exists in the connected DB.
+func tableExists(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type IN ('table','virtual') AND name = ?`, name,
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("probe %s: %w", name, err)
+	}
+	return n > 0, nil
+}
+
+// columnExists asks pragma_table_info whether `column` is one of the
+// columns of `table`. Works for both regular tables and vec0 virtual
+// tables (which expose their declared columns via the same pragma).
+func columnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM pragma_table_info('%s') WHERE name = ?`, table), column,
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("probe %s.%s: %w", table, column, err)
+	}
+	return n > 0, nil
 }
 
 // isDuplicateColumnErr matches SQLite's "duplicate column name" error
@@ -54,14 +403,17 @@ func isDuplicateColumnErr(err error) bool {
 }
 
 // EnsureVectorTable creates vectors_vec_dN for the given dimension if
-// it does not already exist. Idempotent.
+// it does not already exist. The PARTITION KEY scopes rows by
+// generation; the PRIMARY KEY rowid is embedding_id, which joins back
+// to the embeddings metadata table to recover (message_id,
+// chunk_index). Idempotent.
 func EnsureVectorTable(ctx context.Context, db *sql.DB, dim int) error {
 	if dim <= 0 {
 		return fmt.Errorf("invalid dimension %d", dim)
 	}
 	q := fmt.Sprintf(`CREATE VIRTUAL TABLE IF NOT EXISTS vectors_vec_d%d USING vec0(
 		generation_id INTEGER PARTITION KEY,
-		message_id    INTEGER PRIMARY KEY,
+		embedding_id  INTEGER PRIMARY KEY,
 		embedding     FLOAT[%d]
 	)`, dim, dim)
 	if _, err := db.ExecContext(ctx, q); err != nil {

--- a/internal/vector/sqlitevec/migrate_test.go
+++ b/internal/vector/sqlitevec/migrate_test.go
@@ -39,6 +39,312 @@ func TestMigrate_FreshAndIdempotent(t *testing.T) {
 	}
 }
 
+// TestMigrate_LegacyToChunked builds a pre-chunking vectors.db
+// (embeddings keyed by (generation_id, message_id), vec0 with
+// `message_id INTEGER PRIMARY KEY`), runs Migrate, and asserts:
+//
+//   - the embeddings table picks up the new columns
+//     (embedding_id, chunk_index, chunk_char_start, chunk_char_end);
+//   - legacy rows are preserved as chunk_index=0 with
+//     embedding_id == legacy message_id;
+//   - the vec0 table is rebuilt with embedding_id as its rowid,
+//     keeping all rows so existing embeddings remain searchable;
+//   - the AUTOINCREMENT counter is bumped past every legacy
+//     embedding_id so new inserts don't collide with retained
+//     rowids;
+//   - a second Migrate is a no-op (idempotent).
+func TestMigrate_LegacyToChunked(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	db := openTestDB(t, path)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Hand-build the pre-chunking schema. Mirrors schema.sql as it
+	// shipped at PR #277 / spec §5.2.
+	legacyDDL := []string{
+		`CREATE TABLE schema_version (version INTEGER PRIMARY KEY)`,
+		`INSERT INTO schema_version VALUES (1)`,
+		`CREATE TABLE index_generations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			model TEXT NOT NULL, dimension INTEGER NOT NULL,
+			fingerprint TEXT NOT NULL, started_at INTEGER NOT NULL,
+			completed_at INTEGER, activated_at INTEGER,
+			state TEXT NOT NULL, message_count INTEGER NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE embeddings (
+			generation_id INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+			message_id INTEGER NOT NULL,
+			embedded_at INTEGER NOT NULL,
+			source_char_len INTEGER NOT NULL,
+			truncated INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (generation_id, message_id)
+		)`,
+		`CREATE INDEX idx_embeddings_msg ON embeddings(message_id)`,
+		`CREATE TABLE pending_embeddings (
+			generation_id INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+			message_id INTEGER NOT NULL,
+			enqueued_at INTEGER NOT NULL,
+			claimed_at INTEGER, claim_token TEXT,
+			PRIMARY KEY (generation_id, message_id)
+		)`,
+		`CREATE TABLE embed_runs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			generation_id INTEGER NOT NULL REFERENCES index_generations(id),
+			started_at INTEGER NOT NULL, ended_at INTEGER,
+			claimed INTEGER NOT NULL DEFAULT 0,
+			succeeded INTEGER NOT NULL DEFAULT 0,
+			failed INTEGER NOT NULL DEFAULT 0,
+			truncated INTEGER NOT NULL DEFAULT 0,
+			error TEXT
+		)`,
+		`CREATE VIRTUAL TABLE vectors_vec_d768 USING vec0(
+			generation_id INTEGER PARTITION KEY,
+			message_id    INTEGER PRIMARY KEY,
+			embedding     FLOAT[768]
+		)`,
+	}
+	for _, q := range legacyDDL {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("seed legacy DDL %q: %v", q, err)
+		}
+	}
+	// Seed one generation and two embedded rows. message_count =
+	// 2 to mirror what the pre-chunking Upsert path would have left
+	// behind.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO index_generations (id, model, dimension, fingerprint, started_at, state, message_count)
+		 VALUES (1, 'm', 768, 'm:768', 100, 'active', 2)`); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO embeddings (generation_id, message_id, embedded_at, source_char_len, truncated)
+		 VALUES (1, 10, 100, 50, 0), (1, 20, 100, 75, 1)`); err != nil {
+		t.Fatalf("seed embeddings: %v", err)
+	}
+	// vec0 demands its rowid match the second PK column; here the
+	// legacy schema uses message_id, so 10 and 20 both go in directly.
+	blob := func(v []float32) []byte { return float32SliceBlob(v) }
+	v10 := make([]float32, 768)
+	v20 := make([]float32, 768)
+	for i := range v10 {
+		v10[i] = 0.1
+		v20[i] = 0.2
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO vectors_vec_d768 (generation_id, message_id, embedding) VALUES (1, 10, ?)`, blob(v10)); err != nil {
+		t.Fatalf("seed vec rowid 10: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO vectors_vec_d768 (generation_id, message_id, embedding) VALUES (1, 20, ?)`, blob(v20)); err != nil {
+		t.Fatalf("seed vec rowid 20: %v", err)
+	}
+
+	// Run the migration.
+	if err := Migrate(ctx, db, 768); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// embeddings now has the chunked-layout columns, and the legacy
+	// rows survived as chunk_index=0 with embedding_id == old message_id.
+	rows, err := db.QueryContext(ctx,
+		`SELECT embedding_id, message_id, chunk_index, source_char_len, truncated
+		   FROM embeddings ORDER BY message_id`)
+	if err != nil {
+		t.Fatalf("select embeddings: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	type row struct {
+		eid, mid, ci, charLen, trunc int64
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.eid, &r.mid, &r.ci, &r.charLen, &r.trunc); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, r)
+	}
+	// AUTOINCREMENT allocates fresh embedding_ids — they must be
+	// distinct and positive. The actual values depend on insertion
+	// order, so verify the *shape* (distinct, all > 0) rather than
+	// pin specific numbers.
+	if len(got) != 2 {
+		t.Fatalf("rows = %d, want 2 (%v)", len(got), got)
+	}
+	if got[0].mid != 10 || got[0].ci != 0 || got[0].charLen != 50 || got[0].trunc != 0 {
+		t.Errorf("row[0] non-eid fields = %+v, want mid=10 ci=0 charLen=50 trunc=0", got[0])
+	}
+	if got[1].mid != 20 || got[1].ci != 0 || got[1].charLen != 75 || got[1].trunc != 1 {
+		t.Errorf("row[1] non-eid fields = %+v, want mid=20 ci=0 charLen=75 trunc=1", got[1])
+	}
+	if got[0].eid <= 0 || got[1].eid <= 0 || got[0].eid == got[1].eid {
+		t.Errorf("embedding_ids = %d, %d; want distinct positive values", got[0].eid, got[1].eid)
+	}
+
+	// vec0 rowid is now the AUTOINCREMENT embedding_id (not the
+	// legacy message_id). Verify the rebuild used the mapping so
+	// every legacy vec0 row joins back to its embedding.
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM vectors_vec_d768 v
+		   JOIN embeddings e ON e.embedding_id = v.embedding_id
+		  WHERE v.generation_id = 1`).Scan(&n); err != nil {
+		t.Fatalf("join count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("joined vec rows = %d, want 2", n)
+	}
+
+	// Idempotent: a second Migrate must do nothing and leave the rows
+	// untouched.
+	if err := Migrate(ctx, db, 768); err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM embeddings`).Scan(&n); err != nil {
+		t.Fatalf("post-2nd count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("post-2nd embeddings = %d, want 2", n)
+	}
+}
+
+// TestMigrate_LegacyToChunked_MultiGenerationCollision is the
+// regression test for roborev #323's high-risk finding: the legacy
+// embeddings PK was (generation_id, message_id), so the same
+// message_id could legitimately appear in two generations (one
+// active, one building). An earlier draft of the migration mapped
+// embedding_id := message_id, which collided on the new UNIQUE
+// constraint as soon as that case arose. This test reproduces that
+// shape and asserts the migration succeeds, allocating distinct
+// embedding_ids per (gen, msg) pair and preserving every legacy
+// vec0 row through the rebuild.
+func TestMigrate_LegacyToChunked_MultiGenerationCollision(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	db := openTestDB(t, path)
+	t.Cleanup(func() { _ = db.Close() })
+
+	legacyDDL := []string{
+		`CREATE TABLE schema_version (version INTEGER PRIMARY KEY)`,
+		`INSERT INTO schema_version VALUES (1)`,
+		`CREATE TABLE index_generations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			model TEXT NOT NULL, dimension INTEGER NOT NULL,
+			fingerprint TEXT NOT NULL, started_at INTEGER NOT NULL,
+			completed_at INTEGER, activated_at INTEGER,
+			state TEXT NOT NULL, message_count INTEGER NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE embeddings (
+			generation_id INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+			message_id INTEGER NOT NULL,
+			embedded_at INTEGER NOT NULL,
+			source_char_len INTEGER NOT NULL,
+			truncated INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (generation_id, message_id)
+		)`,
+		`CREATE INDEX idx_embeddings_msg ON embeddings(message_id)`,
+		`CREATE TABLE pending_embeddings (
+			generation_id INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+			message_id INTEGER NOT NULL,
+			enqueued_at INTEGER NOT NULL,
+			claimed_at INTEGER, claim_token TEXT,
+			PRIMARY KEY (generation_id, message_id)
+		)`,
+		`CREATE TABLE embed_runs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			generation_id INTEGER NOT NULL REFERENCES index_generations(id),
+			started_at INTEGER NOT NULL, ended_at INTEGER,
+			claimed INTEGER NOT NULL DEFAULT 0,
+			succeeded INTEGER NOT NULL DEFAULT 0,
+			failed INTEGER NOT NULL DEFAULT 0,
+			truncated INTEGER NOT NULL DEFAULT 0,
+			error TEXT
+		)`,
+		`CREATE VIRTUAL TABLE vectors_vec_d768 USING vec0(
+			generation_id INTEGER PARTITION KEY,
+			message_id    INTEGER PRIMARY KEY,
+			embedding     FLOAT[768]
+		)`,
+	}
+	for _, q := range legacyDDL {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("seed legacy DDL %q: %v", q, err)
+		}
+	}
+	// Two generations: gen 1 active, gen 2 building. Both contain
+	// embeddings rows for message 10 (the realistic case: an active
+	// gen has it embedded; a building gen seeded it again because the
+	// worker re-embeds the whole corpus per generation). The vec0
+	// table only carries the gen 1 vector — vec0's rowid uniqueness
+	// would have rejected the gen 2 row at write time under the
+	// legacy code, so historical databases at most carry conflicting
+	// embeddings rows + a single vec0 row per message_id.
+	//
+	// Under the buggy migration (embedding_id := message_id), the
+	// gen=2/msg=10 row collided on the UNIQUE(gen,msg,ci) constraint
+	// because eid=10 was already taken by gen=1/msg=10. The fixed
+	// migration lets AUTOINCREMENT allocate distinct eids.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO index_generations (id, model, dimension, fingerprint, started_at, state, message_count) VALUES
+		  (1, 'm', 768, 'm:768', 100, 'active',   1),
+		  (2, 'm', 768, 'm:768', 200, 'building', 1)`); err != nil {
+		t.Fatalf("seed generations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO embeddings (generation_id, message_id, embedded_at, source_char_len, truncated) VALUES
+		  (1, 10, 100, 50, 0),
+		  (2, 10, 200, 50, 0)`); err != nil {
+		t.Fatalf("seed embeddings: %v", err)
+	}
+	v := make([]float32, 768)
+	for i := range v {
+		v[i] = 0.1
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO vectors_vec_d768 (generation_id, message_id, embedding) VALUES (1, 10, ?)`,
+		float32SliceBlob(v)); err != nil {
+		t.Fatalf("seed vec gen=1 msg=10: %v", err)
+	}
+
+	if err := Migrate(ctx, db, 768); err != nil {
+		t.Fatalf("Migrate (this is what the old migration could not survive): %v", err)
+	}
+
+	// Both legacy embeddings rows preserved with distinct
+	// embedding_ids — the AUTOINCREMENT allocation steps around the
+	// (gen=1, msg=10) / (gen=2, msg=10) collision that broke the old
+	// hard-coded eid=msg shortcut.
+	var n int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM embeddings`).Scan(&n); err != nil {
+		t.Fatalf("count embeddings: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("embeddings rows = %d, want 2", n)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT embedding_id) FROM embeddings`).Scan(&n); err != nil {
+		t.Fatalf("count distinct eid: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("distinct embedding_ids = %d, want 2 (one per (gen, msg))", n)
+	}
+
+	// vec0 join still resolves cleanly for the row that was actually
+	// embedded (gen=1, msg=10). The mapping looked up the new eid via
+	// the embeddings table rather than the now-invalid eid=msg
+	// shortcut.
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM vectors_vec_d768 v
+		  JOIN embeddings e ON e.embedding_id = v.embedding_id
+		 WHERE v.generation_id = 1 AND e.message_id = 10`).Scan(&n); err != nil {
+		t.Fatalf("join: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("join returned %d rows, want 1", n)
+	}
+}
+
 func TestMigrate_CreatesDimensionSpecificVecTable(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t, filepath.Join(t.TempDir(), "v.db"))

--- a/internal/vector/sqlitevec/schema.sql
+++ b/internal/vector/sqlitevec/schema.sql
@@ -28,15 +28,32 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_generations_active
 CREATE UNIQUE INDEX IF NOT EXISTS idx_generations_building
     ON index_generations(state) WHERE state = 'building';
 
+-- embeddings.embedding_id is the synthetic rowid that joins to the
+-- dimension-specific vec0 virtual table (vectors_vec_dN). One row per
+-- chunk: long messages produce multiple rows distinguished by
+-- chunk_index (0-based, dense), short messages keep a single row with
+-- chunk_index = 0. The UNIQUE constraint on (generation_id, message_id,
+-- chunk_index) preserves idempotent re-upsert.
+--
+-- chunk_char_start / chunk_char_end record the rune-space offsets into
+-- the preprocessed text for that chunk. They are debugging metadata
+-- today (search returns one Hit per message; "which chunk matched" is
+-- not yet plumbed to the UI) but ship with the schema so retro-fitting
+-- chunk highlighting later does not require another migration.
 CREATE TABLE IF NOT EXISTS embeddings (
+    embedding_id     INTEGER PRIMARY KEY AUTOINCREMENT,
     generation_id    INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
     message_id       INTEGER NOT NULL,
+    chunk_index      INTEGER NOT NULL DEFAULT 0,
     embedded_at      INTEGER NOT NULL,
     source_char_len  INTEGER NOT NULL,
+    chunk_char_start INTEGER NOT NULL DEFAULT 0,
+    chunk_char_end   INTEGER NOT NULL DEFAULT 0,
     truncated        INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (generation_id, message_id)
+    UNIQUE (generation_id, message_id, chunk_index)
 );
 CREATE INDEX IF NOT EXISTS idx_embeddings_msg ON embeddings(message_id);
+CREATE INDEX IF NOT EXISTS idx_embeddings_gen_msg ON embeddings(generation_id, message_id);
 
 CREATE TABLE IF NOT EXISTS pending_embeddings (
     generation_id INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Replaces "one embedding per message" with "one embedding per chunk", keyed by `(generation_id, message_id, chunk_index)`. Long emails are split via a sliding window (overlap ≈ 3% of window, soft breaks at paragraph → sentence → word → hard cut); each window is embedded independently; the search path joins back through `embedding_id`, groups by `message_id`, and keeps the best chunk score per message.

## Motivation

While building embeddings against a 2.2M-message corpus on `nomic-embed-text` (8,192-token window) with `max_input_chars = 6000`, ~1.7% of messages still tripped Ollama's context-length check. Most were polluted (inline base64, leaked HTML/CSS — addressed by #322), but the residual long-tail (CJK threads, legitimate 50K-char prose) can never fit in a single 8K window. Truncation lost the tail; the worker's downshift recovery flattened throughput from 42 msg/s → ~11.

With chunking every embedder input fits by construction (the failure mode disappears), and long messages get their entire content into the index instead of losing tail prose.

## Schema changes (single transactional migration)

```
embeddings:
  + embedding_id     INTEGER PRIMARY KEY AUTOINCREMENT  -- synthetic rowid joined to vec0
  + chunk_index      INTEGER NOT NULL DEFAULT 0
  + chunk_char_start INTEGER NOT NULL DEFAULT 0          -- debug-only metadata
  + chunk_char_end   INTEGER NOT NULL DEFAULT 0
  PRIMARY KEY → UNIQUE (generation_id, message_id, chunk_index)

vectors_vec_dN (vec0):
  generation_id INTEGER PARTITION KEY
  embedding_id  INTEGER PRIMARY KEY                     -- was message_id
  embedding     FLOAT[N]
```

Migration preserves `embedding_id = message_id` for legacy rows so existing vec0 rowids stay valid; the vec0 table is rebuilt in-place (drop + recreate + re-insert) inside a single transaction. The AUTOINCREMENT counter is bumped past every legacy rowid so new chunk inserts cannot collide.

## Read / write path

- **Worker**: `Preprocess` now runs with `maxChars=0` (no truncation); `ChunkText` slices the full preprocessed text into windows; each window becomes one embedder input. `pending_embeddings` stays per-message — a multi-chunk message completes when all its chunks are upserted in the same batch.
- **Search**: both filtered and empty-filter paths `JOIN vec0 ON v.embedding_id = e.embedding_id`, `GROUP BY e.message_id`, `MIN(distance)`. A new `chunkOverfetchFactor` (4×) is applied to the requested `k` so the GROUP BY has enough chunks to recover `k` distinct messages even when several messages contribute multiple top-k chunks.
- **FusedSearch**: the `ann` CTE becomes `ann_chunks → ann (GROUP BY message_id, MIN(distance), ROW_NUMBER)` under the same factor.
- **Stats**: `EmbeddingCount` is `COUNT(DISTINCT message_id)` so the progress-bar invariant (Done/Total in messages) survives the layout change.
- **LoadVector**: returns `chunk_index = 0` — the only consumer (`find_similar`) wants a representative vector, not the full chunk fan-out.

## Tests

- **ChunkText**: empty, single-span, paragraph/sentence/word/hard cuts, overlap-clamp infinite-loop guard, UTF-8 mixed-script integrity, end-to-end coverage check.
- **Upsert**: multi-chunk fan-out lays down N rows with distinct `chunk_index`, joins back to vec0 through `embedding_id`, and `message_count` stays a per-message count.
- **Upsert idempotency**: `TestBackend_Upsert_ReplaceFewerChunks` pins the contract that re-upserting with fewer chunks vacates the stale rows — critical because chunk fan-out can change between upserts when preprocessing rules evolve.
- **Migration**: `TestMigrate_LegacyToChunked` hand-builds the pre-chunking schema, runs `Migrate`, and asserts every legacy row survives as `chunk_index=0` with `embedding_id == legacy message_id`; the vec0 join is verifiable; `sqlite_sequence` is bumped past every legacy rowid; a second `Migrate` is a no-op.
- **Worker**: `TestWorker_FansOutLongMessageIntoMultipleChunks` drives a single long message through the worker, asserts ≥2 chunk rows with consecutive `chunk_index`, `message_count = 1`, and that the queue drains in one Complete.

## Notes

- `chunk_char_start`/`chunk_char_end` are stored but not yet surfaced in search results. Cheap (8 bytes/chunk extra) and enable future per-paragraph highlighting without another migration.
- Overlap is hardcoded at `maxRunes/30` (≈ 3%), floored to 0 for `maxRunes < 200`. Not currently exposed as config; rationale is documented inline.
- Builds on #322 (sanitize) but doesn't depend on it mechanically — these can land in either order.

Co-Authored-By: Claude Opus 4.7 (1M context)