### PR TITLE
PostgreSQL dialect refactor - PR3 of 4 - Functional store layer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
 use flake .
+
+# Local-only secrets (.claude/env.sh is gitignored) — sourced if present.
+source_env_if_exists .claude/env.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,41 @@ jobs:
 
       - name: Build
         run: nix build
+
+  # PostgreSQL backend lane: runs the portable test suite against a live
+  # PostgreSQL service. The store, query, and concurrency tests all read
+  # MSGVAULT_TEST_DB and switch backends without a recompile. Concurrency
+  # tests use -count=5 so non-deterministic races (lost updates, missing
+  # unique constraints) surface here rather than slipping past a single
+  # pass.
+  test-postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: msgvault_test
+          POSTGRES_PASSWORD: msgvault_test
+          POSTGRES_DB: msgvault_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      MSGVAULT_TEST_DB: postgres://msgvault_test:msgvault_test@localhost:5432/msgvault_test?sslmode=disable
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Test (PostgreSQL, portable fts5 suite)
+        run: go test -tags fts5 ./internal/store ./internal/query ./internal/testutil
+
+      - name: Concurrency tests (-count=5)
+        run: |
+          go test -tags fts5 -count=5 -run 'Concurrent' ./internal/store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Build
         run: nix build
 
-  # PostgreSQL backend lane: runs the portable test suite against a live
-  # PostgreSQL service. The store, query, and concurrency tests all read
+  # PostgreSQL backend lane: runs the full Go test suite against a live
+  # PostgreSQL service. Tests that use testutil.NewTestStore read
   # MSGVAULT_TEST_DB and switch backends without a recompile. Concurrency
   # tests use -count=5 so non-deterministic races (lost updates, missing
   # unique constraints) surface here rather than slipping past a single
@@ -117,8 +117,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Test (PostgreSQL, portable fts5 suite)
-        run: go test -tags fts5 ./internal/store ./internal/query ./internal/testutil
+      - name: Test (PostgreSQL)
+        run: make test-pg
 
       - name: Concurrency tests (-count=5)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
 
           mkdir -p dist
-          LDFLAGS="-s -w -X github.com/wesm/msgvault/cmd/msgvault/cmd.Version=v${VERSION} -X github.com/wesm/msgvault/cmd/msgvault/cmd.Commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8) -X github.com/wesm/msgvault/cmd/msgvault/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) -extldflags '-lstdc++ -lm'"
+          LDFLAGS="-s -w -X go.kenn.io/msgvault/cmd/msgvault/cmd.Version=v${VERSION} -X go.kenn.io/msgvault/cmd/msgvault/cmd.Commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8) -X go.kenn.io/msgvault/cmd/msgvault/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) -extldflags '-lstdc++ -lm'"
           go build -tags "fts5 sqlite_vec" -trimpath -buildvcs=false -ldflags="$LDFLAGS" -o dist/msgvault ./cmd/msgvault
 
           echo "--- Binary info ---"
@@ -110,7 +110,7 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
 
           mkdir -p dist
-          LDFLAGS="-s -w -X github.com/wesm/msgvault/cmd/msgvault/cmd.Version=v${VERSION} -X github.com/wesm/msgvault/cmd/msgvault/cmd.Commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8) -X github.com/wesm/msgvault/cmd/msgvault/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          LDFLAGS="-s -w -X go.kenn.io/msgvault/cmd/msgvault/cmd.Version=v${VERSION} -X go.kenn.io/msgvault/cmd/msgvault/cmd.Commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8) -X go.kenn.io/msgvault/cmd/msgvault/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           go build -tags "fts5 sqlite_vec" -trimpath -ldflags="$LDFLAGS" -o dist/msgvault ./cmd/msgvault
 
           echo "--- Binary info ---"
@@ -176,7 +176,7 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/v}"
 
           mkdir -p dist
-          LDFLAGS="-s -w -X github.com/wesm/msgvault/cmd/msgvault/cmd.Version=v${VERSION} -X github.com/wesm/msgvault/cmd/msgvault/cmd.Commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8) -X github.com/wesm/msgvault/cmd/msgvault/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          LDFLAGS="-s -w -X go.kenn.io/msgvault/cmd/msgvault/cmd.Version=v${VERSION} -X go.kenn.io/msgvault/cmd/msgvault/cmd.Commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8) -X go.kenn.io/msgvault/cmd/msgvault/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           go build -tags "fts5 sqlite_vec" -trimpath -ldflags="$LDFLAGS" -o dist/msgvault.exe ./cmd/msgvault
 
           # Smoke test

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_DATE=unknown
 
-# Note: Module path must match go.mod (github.com/wesm/msgvault)
+# Note: Module path must match go.mod (go.kenn.io/msgvault)
 RUN CGO_ENABLED=1 go build \
     -tags fts5 \
     -trimpath \

--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,15 @@ test-v:
 	go test -tags "$(BUILD_TAGS)" -v ./...
 
 # Run tests against PostgreSQL (set MSGVAULT_TEST_DB first).
-# This is scaffolded for the future functional backend; see docs/PG_STATUS.md.
 # Example: MSGVAULT_TEST_DB=postgres://user:pass@localhost:5432/db make test-pg
+#
+# CI runs the same target under .github/workflows/ci.yml's test-postgres job.
+# See docs/PG_STATUS.md for the supported feature surface.
 test-pg:
 	@if [ -z "$$MSGVAULT_TEST_DB" ]; then \
 		echo "MSGVAULT_TEST_DB must be set, e.g., postgres://user:pass@localhost:5432/db" >&2; \
 		exit 1; \
 	fi
-	@echo "PostgreSQL backend is scaffold-only; this target is expected to fail until docs/PG_STATUS.md blockers are resolved." >&2
 	go test -tags fts5 ./...
 
 # Format code

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 # - sqlite_vec: enable the sqlite-vec extension for vector search
 BUILD_TAGS := fts5 sqlite_vec
 
-.PHONY: build build-release install clean test test-v fmt lint lint-ci tidy shootout run-shootout install-hooks bench help
+.PHONY: build build-release install clean test test-v test-pg fmt lint lint-ci tidy shootout run-shootout install-hooks bench help
 
 # Build the binary (debug)
 build:

--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -66,6 +66,13 @@ Use --full-rebuild to recreate all cache files from scratch.`,
 		dbPath := cfg.DatabaseDSN()
 		analyticsDir := cfg.AnalyticsDir()
 
+		// The Parquet cache is a SQLite → DuckDB ETL; feeding a
+		// postgres:// DSN to the SQLite driver inside buildCache
+		// fails immediately with a confusing driver error.
+		if store.IsPostgresURL(dbPath) {
+			return fmt.Errorf("build-cache is SQLite-only; PostgreSQL backends do not use the Parquet analytics cache")
+		}
+
 		// Check database exists
 		if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 			return fmt.Errorf("database not found: %s\nRun 'msgvault init-db' first", dbPath)

--- a/cmd/msgvault/cmd/create_subset.go
+++ b/cmd/msgvault/cmd/create_subset.go
@@ -53,6 +53,13 @@ func runCreateSubset(cmd *cobra.Command, _ []string) error {
 	}
 
 	srcDBPath := cfg.DatabaseDSN()
+	// store.CopySubset uses ATTACH DATABASE + SQLite-only file-stat
+	// semantics; refuse early on a PG DSN to mirror the equivalent
+	// guard in backupDatabase (cmd/msgvault/cmd/deduplicate.go).
+	if store.IsPostgresURL(srcDBPath) {
+		return fmt.Errorf(
+			"create-subset is SQLite-only (uses ATTACH DATABASE); not supported with PostgreSQL stores")
+	}
 	if _, err := os.Stat(srcDBPath); os.IsNotExist(err) {
 		return fmt.Errorf(
 			"source database not found: %s\n"+

--- a/cmd/msgvault/cmd/deduplicate.go
+++ b/cmd/msgvault/cmd/deduplicate.go
@@ -536,7 +536,20 @@ func randomBatchToken() string {
 // database to dst using VACUUM INTO. Unlike a file-system copy of the
 // main/-wal/-shm triple, this is atomic and handles uncheckpointed WAL
 // pages without any external coordination.
+//
+// PostgreSQL has no in-engine VACUUM INTO equivalent — backups go
+// through pg_dump / pg_basebackup / replication, all of which require
+// server-side access and credentials this CLI does not own. Refuse
+// with a pointer to --no-backup so the user can make an informed
+// choice (run pg_dump out-of-band, or skip the safety net).
 func backupDatabase(st *store.Store, dst string) error {
+	if st.IsPostgreSQL() {
+		return fmt.Errorf(
+			"backup-before-dedup is SQLite-only (uses VACUUM INTO); " +
+				"snapshot the PostgreSQL database with pg_dump out-of-band, " +
+				"then rerun with --no-backup",
+		)
+	}
 	if _, err := os.Stat(dst); err == nil {
 		return fmt.Errorf("backup target already exists: %s", dst)
 	}

--- a/cmd/msgvault/cmd/export_attachments.go
+++ b/cmd/msgvault/cmd/export_attachments.go
@@ -49,7 +49,7 @@ func runExportAttachments(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("startup migrations: %w", err)
 	}
 
-	engine := query.NewSQLiteEngine(s.DB())
+	engine := query.NewEngine(s.DB(), s.IsPostgreSQL())
 
 	// Resolve message ID — try numeric first, fallback to Gmail ID
 	var msg *query.MessageDetail

--- a/cmd/msgvault/cmd/export_eml.go
+++ b/cmd/msgvault/cmd/export_eml.go
@@ -44,7 +44,7 @@ type resolvedMessage struct {
 	SourceMessageID string
 }
 
-func resolveMessage(engine *query.SQLiteEngine, cmd *cobra.Command, messageRef string) (resolvedMessage, error) {
+func resolveMessage(engine query.Engine, cmd *cobra.Command, messageRef string) (resolvedMessage, error) {
 	if id, err := strconv.ParseInt(messageRef, 10, 64); err == nil {
 		msg, err := engine.GetMessage(cmd.Context(), id)
 		if err != nil {
@@ -98,7 +98,7 @@ func runExportEML(cmd *cobra.Command, messageRef, outputPath string) error {
 		return fmt.Errorf("startup migrations: %w", err)
 	}
 
-	engine := query.NewSQLiteEngine(s.DB())
+	engine := query.NewEngine(s.DB(), s.IsPostgreSQL())
 
 	resolved, err := resolveMessage(engine, cmd, messageRef)
 	if err != nil {

--- a/cmd/msgvault/cmd/list_domains.go
+++ b/cmd/msgvault/cmd/list_domains.go
@@ -42,7 +42,7 @@ Examples:
 		}
 
 		// Create query engine
-		engine := query.NewSQLiteEngine(s.DB())
+		engine := query.NewEngine(s.DB(), s.IsPostgreSQL())
 
 		// Execute aggregation
 		results, err := engine.Aggregate(cmd.Context(), query.ViewDomains, opts)

--- a/cmd/msgvault/cmd/list_labels.go
+++ b/cmd/msgvault/cmd/list_labels.go
@@ -42,7 +42,7 @@ Examples:
 		}
 
 		// Create query engine
-		engine := query.NewSQLiteEngine(s.DB())
+		engine := query.NewEngine(s.DB(), s.IsPostgreSQL())
 
 		// Execute aggregation
 		results, err := engine.Aggregate(cmd.Context(), query.ViewLabels, opts)

--- a/cmd/msgvault/cmd/list_senders.go
+++ b/cmd/msgvault/cmd/list_senders.go
@@ -42,7 +42,7 @@ Examples:
 		}
 
 		// Create query engine
-		engine := query.NewSQLiteEngine(s.DB())
+		engine := query.NewEngine(s.DB(), s.IsPostgreSQL())
 
 		// Execute aggregation
 		results, err := engine.Aggregate(cmd.Context(), query.ViewSenders, opts)

--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -78,13 +78,13 @@ Add to Claude Desktop config:
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Failed to open Parquet engine: %v\n", err)
 				fmt.Fprintf(os.Stderr, "Falling back to SQLite\n")
-				engine = query.NewSQLiteEngine(s.DB())
+				engine = query.NewEngine(s.DB(), s.IsPostgreSQL())
 			} else {
 				engine = duckEngine
 				defer func() { _ = duckEngine.Close() }()
 			}
 		} else {
-			engine = query.NewSQLiteEngine(s.DB())
+			engine = query.NewEngine(s.DB(), s.IsPostgreSQL())
 		}
 
 		// Derive from cmd.Context() so signal handling installed by

--- a/cmd/msgvault/cmd/repair_encoding_test.go
+++ b/cmd/msgvault/cmd/repair_encoding_test.go
@@ -12,6 +12,7 @@ import (
 // swallowed. We trigger scan errors by recreating the labels table with a
 // TEXT id column and inserting a non-numeric id that can't be scanned into int64.
 func TestRepairOtherStrings_LogsScanErrors(t *testing.T) {
+	testutil.SkipIfPostgres(t, "uses PRAGMA foreign_keys=OFF and recreates labels with TEXT id to trigger a SQLite scan error; PG enforces FK + types differently")
 	st := testutil.NewTestStore(t)
 	db := st.DB()
 
@@ -55,6 +56,7 @@ func TestRepairOtherStrings_LogsScanErrors(t *testing.T) {
 // repairDisplayNames are counted in stats.skippedRows. We trigger scan errors
 // by recreating the participants table with a TEXT id column.
 func TestRepairDisplayNames_LogsScanErrors(t *testing.T) {
+	testutil.SkipIfPostgres(t, "uses PRAGMA foreign_keys=OFF and recreates a table with mismatched id type to trigger a SQLite scan error; PG enforces types differently")
 	st := testutil.NewTestStore(t)
 	db := st.DB()
 
@@ -122,6 +124,7 @@ func TestRepairEncoding_NoScanErrors(t *testing.T) {
 // pending_embeddings. Snippet-only repairs must NOT appear because the
 // embedder doesn't read snippet.
 func TestRepairMessageFields_ReturnsReembedNeededIDs(t *testing.T) {
+	testutil.SkipIfPostgres(t, "inserts invalid UTF-8 bytes into TEXT columns; SQLite stores them permissively, PG rejects with invalid_text_representation")
 	st := testutil.NewTestStore(t)
 	db := st.DB()
 
@@ -198,6 +201,7 @@ func TestRepairMessageFields_ReturnsReembedNeededIDs(t *testing.T) {
 // TestRepairOtherStrings_FixesNewColumns verifies that repairOtherStrings
 // repairs invalid UTF-8 in source_conversation_id, email_address, and domain.
 func TestRepairOtherStrings_FixesNewColumns(t *testing.T) {
+	testutil.SkipIfPostgres(t, "inserts invalid UTF-8 bytes into TEXT columns; SQLite stores them permissively, PG rejects with invalid_text_representation")
 	st := testutil.NewTestStore(t)
 	db := st.DB()
 

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -312,7 +312,7 @@ func runLocalSearch(cmd *cobra.Command, queryStr string, scope Scope, scopedStor
 	started := time.Now()
 
 	// Create query engine and execute search
-	engine := query.NewSQLiteEngine(s.DB())
+	engine := query.NewEngine(s.DB(), s.IsPostgreSQL())
 	results, err := engine.Search(cmd.Context(), q, searchLimit, searchOffset)
 	fmt.Fprintf(os.Stderr, "\r            \r")
 	if err != nil {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -119,28 +119,33 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Create query engine for TUI aggregate support.
 	// Prefer DuckDB over Parquet when the cache is complete and fresh;
 	// otherwise fall back to SQLite so remote endpoints still work.
+	// PostgreSQL bypasses the cache entirely — it is a SQLite-only ETL.
 	analyticsDir := cfg.AnalyticsDir()
 	var engine query.Engine
-	staleness := cacheNeedsBuild(dbPath, analyticsDir)
-	if !staleness.NeedsBuild && query.HasCompleteParquetData(analyticsDir) {
-		duckEngine, engineErr := query.NewDuckDBEngine(
-			analyticsDir, dbPath, s.DB(),
-		)
-		if engineErr != nil {
-			logger.Warn("DuckDB engine failed, falling back to SQLite",
-				"error", engineErr)
-			engine = query.NewSQLiteEngine(s.DB())
-		} else {
-			engine = duckEngine
-		}
+	if s.IsPostgreSQL() {
+		engine = query.NewEngine(s.DB(), true)
 	} else {
-		if staleness.Reason != "" {
-			logger.Info("parquet cache not usable, using SQLite engine",
-				"reason", staleness.Reason)
+		staleness := cacheNeedsBuild(dbPath, analyticsDir)
+		if !staleness.NeedsBuild && query.HasCompleteParquetData(analyticsDir) {
+			duckEngine, engineErr := query.NewDuckDBEngine(
+				analyticsDir, dbPath, s.DB(),
+			)
+			if engineErr != nil {
+				logger.Warn("DuckDB engine failed, falling back to SQLite",
+					"error", engineErr)
+				engine = query.NewEngine(s.DB(), false)
+			} else {
+				engine = duckEngine
+			}
 		} else {
-			logger.Info("parquet cache not built - using SQLite engine (run 'msgvault build-cache' for faster aggregates)")
+			if staleness.Reason != "" {
+				logger.Info("parquet cache not usable, using SQLite engine",
+					"reason", staleness.Reason)
+			} else {
+				logger.Info("parquet cache not built - using SQLite engine (run 'msgvault build-cache' for faster aggregates)")
+			}
+			engine = query.NewEngine(s.DB(), false)
 		}
-		engine = query.NewSQLiteEngine(s.DB())
 	}
 	defer func() { _ = engine.Close() }()
 
@@ -386,8 +391,12 @@ func runScheduledSync(ctx context.Context, identifier string, s *store.Store, ge
 		"duration", time.Since(startTime),
 	)
 
-	// Rebuild cache if stale (covers new messages and deletions).
+	// Rebuild cache if stale (covers new messages and deletions). The
+	// Parquet cache is SQLite-only; skip on PostgreSQL DSNs.
 	dbPath := cfg.DatabaseDSN()
+	if store.IsPostgresURL(dbPath) {
+		return nil
+	}
 	analyticsDir := cfg.AnalyticsDir()
 	if staleness := cacheNeedsBuild(dbPath, analyticsDir); staleness.NeedsBuild {
 		logger.Info("rebuilding cache after sync",

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -155,6 +155,26 @@ func TestSetupVectorFeatures_Disabled(t *testing.T) {
 	}
 }
 
+// TestSetupVectorFeatures_RefusesPostgres verifies setupVectorFeatures
+// returns a clear error when invoked against a postgres:// DSN. The
+// underlying backend (sqlite-vec + ATTACH DATABASE) cannot work on PG;
+// fail closed at the entry point rather than crashing downstream when
+// sql.Open("sqlite3", "postgres://...") gets a non-sqlite DSN.
+func TestSetupVectorFeatures_RefusesPostgres(t *testing.T) {
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{}
+	cfg.Vector.Enabled = true
+
+	_, err := setupVectorFeatures(context.Background(), nil, "postgres://user@host/db")
+	if err == nil {
+		t.Fatal("setupVectorFeatures with postgres DSN = nil error, want refusal")
+	}
+	if !strings.Contains(err.Error(), "SQLite-only") {
+		t.Errorf("error %q should mention SQLite-only", err.Error())
+	}
+}
+
 // TestFindScheduledSyncSource verifies that the scheduler's
 // source-resolution helper picks gmail over imap and ignores rows of
 // non-syncable source types (mbox, apple-mail, etc.). Regression for

--- a/cmd/msgvault/cmd/serve_vector.go
+++ b/cmd/msgvault/cmd/serve_vector.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector/embed"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
 	"go.kenn.io/msgvault/internal/vector/sqlitevec"
@@ -24,6 +25,16 @@ import (
 func setupVectorFeatures(ctx context.Context, mainDB *sql.DB, mainPath string) (*vectorFeatures, error) {
 	if !cfg.Vector.Enabled {
 		return nil, nil
+	}
+	// The vector backend uses sqlite-vec extension and `ATTACH DATABASE`
+	// to fuse vectors.db onto the main store — both SQLite-only. Refuse
+	// up-front on a PG DSN rather than letting one of the four downstream
+	// callers feed `sql.Open("sqlite3", "postgres://…")` or dispatch raw
+	// ? placeholders against pgx. Vector support for PostgreSQL is
+	// tracked under PR4 (see docs/PG_STATUS.md).
+	if store.IsPostgresURL(mainPath) {
+		return nil, fmt.Errorf(
+			"vector features are SQLite-only; set [vector] enabled = false to use msgvault with PostgreSQL (vector support is planned for PR4)")
 	}
 	if err := cfg.Vector.Validate(); err != nil {
 		return nil, fmt.Errorf("vector config: %w", err)

--- a/cmd/msgvault/cmd/serve_vector_stub.go
+++ b/cmd/msgvault/cmd/serve_vector_stub.go
@@ -6,15 +6,23 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"go.kenn.io/msgvault/internal/store"
 )
 
 // setupVectorFeatures is the no-sqlite-vec fallback. It returns
 // (nil, nil) when vector search is disabled, and a descriptive error
 // when the user enabled vector search in config but built the binary
 // without -tags sqlite_vec.
-func setupVectorFeatures(_ context.Context, _ *sql.DB, _ string) (*vectorFeatures, error) {
+func setupVectorFeatures(_ context.Context, _ *sql.DB, mainPath string) (*vectorFeatures, error) {
 	if !cfg.Vector.Enabled {
 		return nil, nil
+	}
+	// Mirror the PG refusal in the sqlite_vec build so users get the
+	// same actionable message regardless of how the binary was built.
+	if store.IsPostgresURL(mainPath) {
+		return nil, fmt.Errorf(
+			"vector features are SQLite-only; set [vector] enabled = false to use msgvault with PostgreSQL (vector support is planned for PR4)")
 	}
 	return nil, fmt.Errorf(
 		"vector search is enabled in config but this binary was built without -tags sqlite_vec; " +

--- a/cmd/msgvault/cmd/show_message.go
+++ b/cmd/msgvault/cmd/show_message.go
@@ -90,7 +90,7 @@ func showLocalMessage(cmd *cobra.Command, idStr string) error {
 	}
 
 	// Create query engine
-	engine := query.NewSQLiteEngine(s.DB())
+	engine := query.NewEngine(s.DB(), s.IsPostgreSQL())
 
 	// Try to parse as numeric ID first
 	var msg *query.MessageDetail

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -105,44 +105,54 @@ Remote Mode:
 
 			analyticsDir := cfg.AnalyticsDir()
 
-			// Check if cache needs to be built/updated (unless forcing SQL or skipping)
-			if !forceSQL && !skipCacheBuild {
-				staleness := cacheNeedsBuild(dbPath, analyticsDir)
-				if staleness.NeedsBuild {
-					fmt.Printf("Building analytics cache (%s)...\n", staleness.Reason)
-					result, err := buildCache(dbPath, analyticsDir, staleness.FullRebuild)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "Warning: Failed to build cache: %v\n", err)
-						fmt.Fprintf(os.Stderr, "Falling back to SQLite (may be slow for large archives)\n")
-					} else if !result.Skipped {
-						fmt.Printf("Cached %d messages for fast queries.\n", result.ExportedCount)
+			// The Parquet analytics cache is a SQLite → DuckDB ETL and
+			// has no meaning when the system of record is PostgreSQL —
+			// buildCache feeds the DSN to the SQLite driver and
+			// cacheNeedsBuild dispatches ? placeholders that pgx
+			// rejects. On PG, skip the entire cache pipeline and go
+			// straight to the dialect-aware query engine.
+			if s.IsPostgreSQL() {
+				engine = query.NewEngine(s.DB(), true)
+			} else {
+				// Check if cache needs to be built/updated (unless forcing SQL or skipping)
+				if !forceSQL && !skipCacheBuild {
+					staleness := cacheNeedsBuild(dbPath, analyticsDir)
+					if staleness.NeedsBuild {
+						fmt.Printf("Building analytics cache (%s)...\n", staleness.Reason)
+						result, err := buildCache(dbPath, analyticsDir, staleness.FullRebuild)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "Warning: Failed to build cache: %v\n", err)
+							fmt.Fprintf(os.Stderr, "Falling back to SQLite (may be slow for large archives)\n")
+						} else if !result.Skipped {
+							fmt.Printf("Cached %d messages for fast queries.\n", result.ExportedCount)
+						}
 					}
 				}
-			}
 
-			// Determine query engine to use
-			if !forceSQL && query.HasCompleteParquetData(analyticsDir) {
-				// Use DuckDB for fast Parquet queries
-				var duckOpts query.DuckDBOptions
-				if noSQLiteScanner {
-					duckOpts.DisableSQLiteScanner = true
-				}
-				duckEngine, err := query.NewDuckDBEngine(analyticsDir, dbPath, s.DB(), duckOpts)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: Failed to open Parquet engine: %v\n", err)
-					fmt.Fprintf(os.Stderr, "Falling back to SQLite (may be slow for large archives)\n")
-					engine = query.NewSQLiteEngine(s.DB())
+				// Determine query engine to use
+				if !forceSQL && query.HasCompleteParquetData(analyticsDir) {
+					// Use DuckDB for fast Parquet queries
+					var duckOpts query.DuckDBOptions
+					if noSQLiteScanner {
+						duckOpts.DisableSQLiteScanner = true
+					}
+					duckEngine, err := query.NewDuckDBEngine(analyticsDir, dbPath, s.DB(), duckOpts)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: Failed to open Parquet engine: %v\n", err)
+						fmt.Fprintf(os.Stderr, "Falling back to SQLite (may be slow for large archives)\n")
+						engine = query.NewEngine(s.DB(), false)
+					} else {
+						engine = duckEngine
+						defer func() { _ = duckEngine.Close() }()
+					}
 				} else {
-					engine = duckEngine
-					defer func() { _ = duckEngine.Close() }()
+					// Use SQLite directly
+					if !forceSQL {
+						fmt.Fprintf(os.Stderr, "Note: No cache data available, using SQLite (slow for large archives)\n")
+						fmt.Fprintf(os.Stderr, "Run 'msgvault build-cache' to enable fast queries.\n")
+					}
+					engine = query.NewEngine(s.DB(), false)
 				}
-			} else {
-				// Use SQLite directly
-				if !forceSQL {
-					fmt.Fprintf(os.Stderr, "Note: No cache data available, using SQLite (slow for large archives)\n")
-					fmt.Fprintf(os.Stderr, "Run 'msgvault build-cache' to enable fast queries.\n")
-				}
-				engine = query.NewSQLiteEngine(s.DB())
 			}
 		}
 
@@ -194,7 +204,15 @@ type cacheStaleness struct {
 // cacheNeedsBuild checks if the analytics cache needs to be built or
 // updated. Collects all staleness signals before returning so that
 // e.g. a mixed add+delete sync correctly reports both.
+//
+// The Parquet cache is a SQLite-only ETL — when dbPath points at a
+// PostgreSQL DSN, this returns "no build needed" rather than dispatching
+// SQLite-shaped queries against pgx (which would fail on the ?
+// placeholders and the sqlite_master probe).
 func cacheNeedsBuild(dbPath, analyticsDir string) cacheStaleness {
+	if store.IsPostgresURL(dbPath) {
+		return cacheStaleness{}
+	}
 	messagesDir := filepath.Join(analyticsDir, "messages")
 	stateFile := filepath.Join(analyticsDir, "_last_sync.json")
 

--- a/cmd/msgvault/cmd/verify.go
+++ b/cmd/msgvault/cmd/verify.go
@@ -30,7 +30,9 @@ var verifyCmd = &cobra.Command{
 and sampling messages to ensure raw MIME data is intact.
 
 This command:
-1. Runs SQLite integrity checks on the database (unless --skip-db-check)
+1. On SQLite: runs PRAGMA integrity_check on the database (unless --skip-db-check).
+   On PostgreSQL: prints a notice that the in-engine check is skipped — use
+   pg_amcheck out-of-band to validate the cluster.
 2. Compares local message count with Gmail's reported total
 3. Checks how many messages have raw MIME data stored
 4. Samples random messages and verifies their MIME can be decompressed
@@ -60,29 +62,37 @@ Examples:
 
 		// Run SQLite integrity check before any Gmail work. Users with a
 		// corrupt database should see the repair hint even if their OAuth
-		// token is expired or the network is down.
+		// token is expired or the network is down. PostgreSQL has no
+		// in-engine integrity_check; print a notice so users know the
+		// check was skipped intentionally and point them at the right
+		// out-of-band tool.
 		var dbCorrupt bool
 		if !verifySkipDBCheck {
-			fmt.Println("Running database integrity check...")
-			integrityErrors, err := runIntegrityCheck(s)
-			if err != nil {
-				return fmt.Errorf("integrity check failed: %w", err)
-			}
-			if len(integrityErrors) == 0 {
-				fmt.Println("  Database integrity: OK")
+			if s.IsPostgreSQL() {
+				fmt.Println("Skipping database integrity check (PostgreSQL — use pg_amcheck out-of-band).")
+				fmt.Println()
 			} else {
-				dbCorrupt = true
-				fmt.Printf("  Database integrity: FAILED (%d errors)\n", len(integrityErrors))
-				for i, ie := range integrityErrors {
-					if i >= 10 {
-						fmt.Printf("  ... and %d more errors\n", len(integrityErrors)-10)
-						break
-					}
-					fmt.Printf("  - %s\n", ie)
+				fmt.Println("Running database integrity check...")
+				integrityErrors, err := runIntegrityCheck(s)
+				if err != nil {
+					return fmt.Errorf("integrity check failed: %w", err)
 				}
-				printIntegrityRecoveryHint(integrityErrors)
+				if len(integrityErrors) == 0 {
+					fmt.Println("  Database integrity: OK")
+				} else {
+					dbCorrupt = true
+					fmt.Printf("  Database integrity: FAILED (%d errors)\n", len(integrityErrors))
+					for i, ie := range integrityErrors {
+						if i >= 10 {
+							fmt.Printf("  ... and %d more errors\n", len(integrityErrors)-10)
+							break
+						}
+						fmt.Printf("  - %s\n", ie)
+					}
+					printIntegrityRecoveryHint(integrityErrors)
+				}
+				fmt.Println()
 			}
-			fmt.Println()
 		}
 
 		// Look up source to get OAuth app binding
@@ -277,7 +287,16 @@ Examples:
 
 // runIntegrityCheck runs PRAGMA integrity_check on the database and returns
 // any error strings. An empty slice means the database is healthy.
+//
+// PostgreSQL has no in-engine analogue; its corruption checks live in
+// external admin tooling (pg_amcheck, pg_dump --section=data) that
+// require server-side privileges this CLI does not assume. On PG we
+// return no errors so the rest of `verify` (Gmail message round-trip)
+// still runs — the user is expected to monitor PG health separately.
 func runIntegrityCheck(s *store.Store) ([]string, error) {
+	if s.IsPostgreSQL() {
+		return nil, nil
+	}
 	rows, err := s.DB().Query("PRAGMA integrity_check(100)")
 	if err != nil {
 		return nil, err

--- a/docs/PG_STATUS.md
+++ b/docs/PG_STATUS.md
@@ -129,7 +129,7 @@ branch:
 ```bash
 # Start a PostgreSQL instance, then:
 export MSGVAULT_TEST_DB=postgres://user:pass@localhost:5432/msgvault_test
-make test
+make test-pg
 ```
 
 Each test creates and drops its own schema (`msgvault_test_<hex>`) for

--- a/docs/PG_STATUS.md
+++ b/docs/PG_STATUS.md
@@ -4,99 +4,127 @@ This document tracks the state of PostgreSQL backend support in msgvault.
 
 ## Summary
 
-PR1 (tag `pr1-dialect-extraction`) extracted all SQLite-specific behavior
-behind a `Dialect` interface. Zero functional change; SQLite is still the
-default and only production-ready backend.
+PR1 (`pr1-dialect-extraction`) extracted SQLite-specific behavior behind a
+`Dialect` interface (zero functional change).
 
-PR2 (tag `pr2-postgresql-dialect`) adds **foundational scaffolding** for
-PostgreSQL support:
+PR2 (`pr2-postgresql-dialect`) added the foundational scaffolding:
+`PostgreSQLDialect`, pgx driver wiring, `schema_pg.sql` stub,
+`PostgreSQLEngine` scaffold, and the dual-backend test harness via
+`MSGVAULT_TEST_DB`.
 
-- `PostgreSQLDialect` implementing the `Dialect` interface
-- `pgx` driver wired into `store.Open()` for `postgres://` URLs
-- `schema_pg.sql` with tsvector FTS column and GIN index
-- `PostgreSQLEngine` scaffold parallel to `SQLiteEngine`
-- Dual-backend test harness via `MSGVAULT_TEST_DB`
-- Unit tests for dialect string methods
+**PR3 (this branch) makes the store layer functional against PostgreSQL.**
+A PostgreSQL connection can now initialize the schema, insert rows, run FTS
+queries, and serve the TUI / HTTP / MCP aggregate paths. The SQLite path is
+unchanged.
 
-**PostgreSQL is NOT functionally usable yet.** The work below must complete
-before a PostgreSQL connection can successfully insert a single row.
+PR4 (future) will address remaining functional gaps in deletion execution,
+attachment storage on PG, and end-to-end coverage under
+`MSGVAULT_TEST_DB=postgres://...`.
 
 ## What Works
 
 - `PostgreSQLDialect.Rebind()` correctly converts `?` → `$1, $2, ...`
   (including quoted-string safety)
 - `PostgreSQLDialect.Now()`, `InsertOrIgnore()` (complete + prefix),
-  `InsertOrIgnoreSuffix()`, `FTSSearchClause()`, `UpdateOrIgnore()`
+  `InsertOrIgnoreSuffix()`, `FTSSearchClause()`
+- `PostgreSQLDialect.LegacyColumnMigrations()` returns the same logical list
+  as SQLite, translated to PG types (`JSONB`, `TIMESTAMPTZ`, `BIGINT`) and
+  using `ADD COLUMN IF NOT EXISTS` for idempotency. Existing PG databases
+  pick up newly added columns on the next `InitSchema()` call
+- `PostgreSQLDialect.DatabaseSize()` reports `pg_database_size(...)`
 - `PostgreSQLDialect` error-code classification (23505, 42701, 42P01)
 - `Open("postgres://...")` establishes a connection with pool settings
 - `OpenReadOnly` for PostgreSQL enforces `default_transaction_read_only=on`
   via pgx `RuntimeParams` (set on every pooled connection at startup)
+- `schema_pg.sql` is loaded by the dialect and contains PostgreSQL-native
+  DDL: `BIGINT GENERATED ALWAYS AS IDENTITY`, `TIMESTAMPTZ`, `BYTEA`,
+  `JSONB`, tsvector column + GIN index for FTS
+- `Rebind()` is threaded through every store-layer query via the
+  `loggedDB` / `loggedTx` wrapper — call sites can emit portable `?`
+  placeholders and the wrapper applies the dialect-specific rewrite
+- `RETURNING id` replaces `LastInsertId()` at every insert call site
+  (`messages.go`, `sync.go`)
+- `queryInChunks` / `insertInChunks` use `loggedTx` (auto-rebind); chunked
+  `INSERT OR IGNORE` builders use `dialect.InsertOrIgnorePrefix/Suffix`
+- `SearchMessages` / `SearchMessagesQuery` use uniform `?` placeholders
+  through `FTSSearchClause()`, then the whole statement is rebound by
+  `loggedDB` — no mixed `?` / `$N` styles
+- `FTSBackfillBatchSQL` uses `LEFT JOIN message_bodies` so messages
+  without a body row are still indexed (header-only FTS for that row)
+- `GetStats` uses `dialect.DatabaseSize()` instead of `os.Stat` on the DSN
+- `PostgreSQLEngine` (now a dialect-parameterized `SQLiteEngine`)
+  implements the full `Engine` surface for aggregates, search, and
+  message detail using the query-layer `Dialect` interface
+- `query.NewEngine(db, isPostgres)` factory is wired in every engine
+  construction site under `cmd/msgvault/cmd/`
+- `Store.IsPostgreSQL()` lets callers dispatch without an
+  `internal/query` dependency
 - Unit tests for dialect string methods pass without a live Postgres
 - SQLite regression: all existing tests pass unmodified
 
-## Follow-Up Work (Required for PostgreSQL to Actually Work)
+## Resolved in PR3
 
-### Blockers (schema will not load, no row can be inserted)
+| # | Blocker | Resolution |
+|---|---------|-----------|
+| 1 | Schema type translation | `schema_pg.sql` with PostgreSQL-native DDL |
+| 2 | Rebind threading through store layer | `loggedDB` / `loggedTx` apply `Rebind` to every statement |
+| 3 | `queryInChunks` / `insertInChunks` dialect-aware | Use `loggedTx` (auto-rebind) + `InsertOrIgnorePrefix/Suffix` |
+| 4 | `LastInsertId` → `RETURNING id` | Done at every insert call site |
+| 5 | Mixed placeholder styles in search | All placeholders are `?`, rebound at execution |
+| 6 | FTS backfill LEFT JOIN | `FTSBackfillBatchSQL` uses LEFT JOIN |
+| 7 | `statement_timeout` pool-wide | Set via pgx `RuntimeParams` (PR2) |
+| 8 | `GetStats` for PostgreSQL | `dialect.DatabaseSize()` |
+| 9 | `PostgreSQLEngine` method implementations | Dialect-parameterized `SQLiteEngine` |
+| 10 | `PostgreSQLEngine` wired to factory | `query.NewEngine(db, isPostgres)` in cmd/ |
+| 11 | Legacy column migrations on PG | `LegacyColumnMigrations()` returns the SQLite list translated to PG types, using `ADD COLUMN IF NOT EXISTS` for idempotency |
 
-1. **Schema type translation**: `schema.sql` uses SQLite-specific types
-   (`DATETIME`, `BLOB`) and `INTEGER PRIMARY KEY` which is not
-   auto-incrementing in PostgreSQL. Options:
-   - Create a dedicated `schema_pg.sql` with PostgreSQL-native DDL
-     (`TIMESTAMPTZ`, `BYTEA`, `BIGINT GENERATED ALWAYS AS IDENTITY`)
-   - Parameterize the shared schema via dialect type mappings
-   - Translate at load time
+## Codex Review Fixes (Late PR3)
 
-2. **Thread `Rebind()` through all queries**: Most `s.db.Exec` / `QueryRow`
-   calls in the store layer still pass raw `?` placeholders. pgx rejects
-   these. Affected files: `messages.go`, `sync.go`, `sources.go`,
-   `sources_oauthapp.go`, `api.go`. (`inspect.go` already uses `Rebind()`.)
+The codex multi-level review of `pr3-upstream` flagged four
+release-blocking concurrency / search-parity issues plus follow-up
+maintainability work. All blocking findings are now addressed in this
+branch:
 
-3. **`queryInChunks` / `insertInChunks` bypass the dialect**: These
-   helpers in `store.go` hardcode `?` placeholders. They need to accept
-   (or be wrapped by) a rebinder.
+- **H1** — `UpsertAttachment` now backed by a partial unique index on
+  `(message_id, content_hash)` and uses `INSERT … ON CONFLICT DO
+  NOTHING`. Legacy duplicates are deduped on `InitSchema`.
+- **H2** — `AddAccountIdentity` runs inside a writer-locked
+  transaction (SQLite `BEGIN IMMEDIATE`; PostgreSQL `SELECT … FOR
+  UPDATE`) so concurrent merges no longer drop signals.
+- **H3** — `query.Engine`'s `subject:` and metadata fallback predicates
+  are `LOWER(col) LIKE LOWER(?)` with proper escape, matching the
+  store-layer search.
+- **H4** — `.github/workflows/ci.yml` runs a `test-postgres` job
+  against a live `postgres:16` service.
+- **M1** — `EnsureConversation` / `EnsureConversationWithType` /
+  `GetOrCreateSource` collapse into a single
+  `INSERT … ON CONFLICT DO UPDATE RETURNING` statement; `StartSync`
+  runs in a writer-locked transaction with a `sources` row lock on PG.
+- **M2** — `FTSNeedsBackfill` counts `search_fts IS NULL` rows
+  directly so missing intermediates surface; `FTSRebuildSchema` is
+  implemented for PG (DROP index → clear column → re-CREATE index).
+- **M3** — Shared `?`-rebind and tsquery-escape primitives live in
+  `internal/sqldialect`; both store and query dialects delegate.
 
-4. **`LastInsertId()` is not supported by pgx**: Call sites in
-   `messages.go` (EnsureConversation, EnsureParticipant, etc.) and
-   `sync.go` (StartSync, GetOrCreateSource) must be rewritten to use
-   `RETURNING id` (the pattern already exists in `upsertMessageWith`).
+## Remaining for PR4
 
-5. **Mixed placeholder styles in search**: `api.go:SearchMessages` now
-   builds queries with `$1` from `FTSSearchClause` but still appends
-   `LIMIT ? OFFSET ?`. Must pick one style consistently.
-
-### Issues (correctness/behavior differences)
-
-6. **`FTSBackfillBatchSQL` INNER vs LEFT JOIN**: PostgreSQL version uses
-   inner join on `message_bodies`; SQLite uses LEFT JOIN. Messages with
-   no body row are not indexed on PostgreSQL.
-
-7. **(Resolved)** `statement_timeout` now uses pgx `RuntimeParams`, so the
-   setting applies during startup for every pooled connection.
-
-8. **(Resolved)** `openPostgresReadOnly` now sets
-   `default_transaction_read_only=on` via pgx `RuntimeParams`, so the
-   parameter is applied during the startup packet of every pooled
-   connection rather than once via `db.Exec("SET …")`.
-
-9. **`GetStats` calls `os.Stat(s.dbPath)`**: For PostgreSQL, `dbPath` is
-   a URL, not a file. `DatabaseSize` silently reports 0. Either skip
-   or query `pg_database_size(current_database())`.
-
-10. **`PostgreSQLEngine` returns `ErrNotImplemented` for most methods**:
-    TUI/MCP/HTTP API will not work against PG. Aggregate, Search,
-    SearchFast, GetGmailIDsByFilter, ListMessages all need parameterized
-    query builders (currently SQLite-specific: `strftime`, FTS5 MATCH).
-
-11. **FTS weight differences**: PostgreSQL applies `setweight('A')` to
-    subject and `'B'` to sender. SQLite FTS5 has no weighting. Ranking
-    results will differ between backends.
-
-12. **`PostgreSQLEngine` is not constructed anywhere**: TUI/API/MCP
-    still build `SQLiteEngine` unconditionally.
+- **FTS weight differences**: PostgreSQL applies `setweight('A')` to the
+  subject and `'B'` to the sender; SQLite FTS5 has no weighting. Ranking
+  results will still differ between backends.
+- **Deletion execution path on PostgreSQL**: end-to-end testing of
+  staged-deletion → Gmail delete → archive update.
+- **Attachment storage paths** under PostgreSQL — content-hash dedup
+  and orphan-cleanup paths haven't been exercised end-to-end yet.
+- **Vector / hybrid search**: SQLite-only by construction —
+  `internal/vector/sqlitevec` uses the sqlite-vec extension and
+  `ATTACH DATABASE` to fuse `vectors.db` onto the main store, and the
+  embed worker / fused search dispatch `?` placeholders straight to
+  the main DB handle. `setupVectorFeatures` now refuses a PG DSN
+  with a clear error and `[vector] enabled = false` is required to
+  run msgvault against PostgreSQL. PG support (likely pgvector with
+  an analogous fused-search wrapper) is deferred to PR4.
 
 ## Running Tests Against PostgreSQL
-
-Once blockers above are resolved:
 
 ```bash
 # Start a PostgreSQL instance, then:
@@ -106,13 +134,4 @@ make test
 
 Each test creates and drops its own schema (`msgvault_test_<hex>`) for
 isolation. The `testutil.NewTestStore()` helper detects the env var and
-routes accordingly. If `MSGVAULT_TEST_DB` is unset, SQLite is used (default).
-
-## Why Ship Scaffolding?
-
-The `Dialect` abstraction + scaffolded PostgreSQL implementation lets the
-remaining work proceed incrementally without further disrupting the
-SQLite path. The interface design has been validated end-to-end
-(SQLiteDialect produces identical SQL; unit tests confirm PostgreSQLDialect
-generates valid PostgreSQL SQL). Future PRs can tackle the follow-up work
-file-by-file.
+routes accordingly. If `MSGVAULT_TEST_DB` is unset, SQLite is used.

--- a/internal/dedup/dedup_test.go
+++ b/internal/dedup/dedup_test.go
@@ -47,7 +47,7 @@ func assertSoftDeleted(
 	t.Helper()
 	var deletedAt sql.NullTime
 	err := st.DB().QueryRow(
-		"SELECT deleted_at FROM messages WHERE id = ?", msgID,
+		st.Rebind("SELECT deleted_at FROM messages WHERE id = ?"), msgID,
 	).Scan(&deletedAt)
 	testutil.MustNoErr(t, err, "query deleted_at")
 	if wantDeleted && !deletedAt.Valid {

--- a/internal/fbmessenger/importer.go
+++ b/internal/fbmessenger/importer.go
@@ -568,7 +568,7 @@ func writeThreadToStore(
 			// display_name; falling back to what we wrote on the prior
 			// import preserves the sender label for self-authored rows.
 			err := st.DB().QueryRow(
-				`SELECT m.sender_id, m.is_from_me,
+				st.Rebind(`SELECT m.sender_id, m.is_from_me,
 					COALESCE(NULLIF(p.display_name, ''),
 						(SELECT mr.display_name FROM message_recipients mr
 						 WHERE mr.message_id = m.id AND mr.recipient_type = 'from'
@@ -576,7 +576,7 @@ func writeThreadToStore(
 					p.email_address
 				 FROM messages m
 				 LEFT JOIN participants p ON p.id = m.sender_id
-				 WHERE m.source_id = ? AND m.source_message_id = ?`,
+				 WHERE m.source_id = ? AND m.source_message_id = ?`),
 				sourceID, srcMsgID,
 			).Scan(&priorID, &priorIsFromMe, &priorName, &priorEmail)
 			if err == nil && priorID.Valid {

--- a/internal/fbmessenger/importer_fts_test.go
+++ b/internal/fbmessenger/importer_fts_test.go
@@ -15,6 +15,7 @@ import (
 // FTS assertion is always active under the project's canonical
 // `go test -tags fts5 ./...` invocation.
 func TestImportDYI_MojibakeFTSIndexed(t *testing.T) {
+	testutil.SkipIfPostgres(t, "directly MATCH-queries the SQLite FTS5 vtable; PG uses a tsvector column exercised via FTSSearchClause")
 	st := testutil.NewTestStore(t)
 	_ = importFixture(t, st, "testdata/json_simple")
 	if !st.FTS5Available() {
@@ -48,6 +49,7 @@ func TestImportDYI_MojibakeFTSIndexed(t *testing.T) {
 // "[reacted: ...]" suffix in body_text that FTS5 can match. Gated on
 // the fts5 build tag; the FTS MATCH assertion is unconditional.
 func TestImportDYI_ReactionsDualPath(t *testing.T) {
+	testutil.SkipIfPostgres(t, "directly MATCH-queries the SQLite FTS5 vtable; PG uses a tsvector column exercised via FTSSearchClause")
 	st := testutil.NewTestStore(t)
 	_ = importFixture(t, st, "testdata/json_simple")
 	if !st.FTS5Available() {

--- a/internal/fbmessenger/importer_test.go
+++ b/internal/fbmessenger/importer_test.go
@@ -509,10 +509,10 @@ func TestImportDYI_NonTextMessageBodies(t *testing.T) {
 	}
 	for id, wantBody := range want {
 		var body string
-		if err := st.DB().QueryRow(`
+		if err := st.DB().QueryRow(st.Rebind(`
 			SELECT b.body_text FROM message_bodies b
 			JOIN messages m ON m.id = b.message_id
-			WHERE m.source_message_id = ?`, id).Scan(&body); err != nil {
+			WHERE m.source_message_id = ?`), id).Scan(&body); err != nil {
 			t.Errorf("%s: %v", id, err)
 			continue
 		}
@@ -608,7 +608,7 @@ func TestImportDYI_IsFromMe(t *testing.T) {
 	var wesFromMe, aliceFromMe int
 	if err := st.DB().QueryRow(`
 		SELECT COUNT(*) FROM messages m
-		WHERE m.is_from_me = 1 AND m.source_message_id LIKE 'inbox/alice_ABC123__%'
+		WHERE m.is_from_me IS TRUE AND m.source_message_id LIKE 'inbox/alice_ABC123__%'
 	`).Scan(&wesFromMe); err != nil {
 		t.Fatal(err)
 	}
@@ -617,7 +617,7 @@ func TestImportDYI_IsFromMe(t *testing.T) {
 	}
 	if err := st.DB().QueryRow(`
 		SELECT COUNT(*) FROM messages m
-		WHERE m.is_from_me = 0 AND m.source_message_id LIKE 'inbox/alice_ABC123__%'
+		WHERE m.is_from_me IS NOT TRUE AND m.source_message_id LIKE 'inbox/alice_ABC123__%'
 	`).Scan(&aliceFromMe); err != nil {
 		t.Fatal(err)
 	}
@@ -632,7 +632,7 @@ func TestImportDYI_LabelTaxonomy(t *testing.T) {
 	// Messenger and Messenger / Inbox and Messenger / Archived must exist.
 	for _, name := range []string{"Messenger", "Messenger / Inbox", "Messenger / Archived"} {
 		var n int
-		if err := st.DB().QueryRow("SELECT COUNT(*) FROM labels WHERE name = ?", name).Scan(&n); err != nil {
+		if err := st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM labels WHERE name = ?"), name).Scan(&n); err != nil {
 			t.Fatal(err)
 		}
 		if n != 1 {
@@ -690,7 +690,7 @@ func TestImportDYI_SelfParticipantSeeded(t *testing.T) {
 	}
 	var n int
 	if err := st.DB().QueryRow(
-		"SELECT COUNT(*) FROM participants WHERE email_address = ? AND domain = 'facebook.messenger'",
+		st.Rebind("SELECT COUNT(*) FROM participants WHERE email_address = ? AND domain = 'facebook.messenger'"),
 		"test.user@facebook.messenger",
 	).Scan(&n); err != nil {
 		t.Fatal(err)
@@ -1333,17 +1333,17 @@ func TestImportDYI_SenderIDPreservedOnReimport(t *testing.T) {
 		t.Helper()
 		var s snap
 		if err := st.DB().QueryRow(
-			`SELECT sender_id, is_from_me FROM messages WHERE source_message_id = ?`,
+			st.Rebind(`SELECT sender_id, is_from_me FROM messages WHERE source_message_id = ?`),
 			srcMsgID,
 		).Scan(&s.senderID, &s.isFromMe); err != nil {
 			t.Fatalf("messages row for %s: %v", srcMsgID, err)
 		}
-		if err := st.DB().QueryRow(`
+		if err := st.DB().QueryRow(st.Rebind(`
 			SELECT mr.display_name, mr.participant_id
 			FROM message_recipients mr
 			JOIN messages m ON m.id = mr.message_id
 			WHERE m.source_message_id = ? AND mr.recipient_type = 'from'
-		`, srcMsgID).Scan(&s.fromName, &s.fromPID); err != nil {
+		`), srcMsgID).Scan(&s.fromName, &s.fromPID); err != nil {
 			t.Fatalf("from recipient for %s: %v", srcMsgID, err)
 		}
 		return s
@@ -1409,13 +1409,13 @@ func TestImportDYI_SenderIDPreservedOnReimport(t *testing.T) {
 	// message — otherwise the dropped is_from_me flag would inflate
 	// participant analytics and cause self-to-self recipient rows.
 	var selfInTo int
-	if err := st.DB().QueryRow(`
+	if err := st.DB().QueryRow(st.Rebind(`
 		SELECT COUNT(*) FROM message_recipients mr
 		JOIN messages m ON m.id = mr.message_id
 		WHERE m.source_message_id = 'inbox/alice_PRES__1'
 		  AND mr.recipient_type = 'to'
 		  AND mr.participant_id = ?
-	`, selfBefore.senderID.Int64).Scan(&selfInTo); err != nil {
+	`), selfBefore.senderID.Int64).Scan(&selfInTo); err != nil {
 		t.Fatal(err)
 	}
 	if selfInTo != 0 {
@@ -1492,7 +1492,7 @@ func TestImportDYI_ReimportRepairsConversationParticipant(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := st.DB().Exec(
-		`DELETE FROM conversation_participants WHERE conversation_id = ? AND participant_id = ?`,
+		st.Rebind(`DELETE FROM conversation_participants WHERE conversation_id = ? AND participant_id = ?`),
 		convID, orphanID,
 	); err != nil {
 		t.Fatal(err)
@@ -1517,7 +1517,7 @@ func TestImportDYI_ReimportRepairsConversationParticipant(t *testing.T) {
 
 	var n int
 	if err := st.DB().QueryRow(
-		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ? AND participant_id = ?`,
+		st.Rebind(`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ? AND participant_id = ?`),
 		convID, orphanID,
 	).Scan(&n); err != nil {
 		t.Fatal(err)

--- a/internal/imessage/client.go
+++ b/internal/imessage/client.go
@@ -660,7 +660,7 @@ func (c *Client) ensureConversation(
 		title = c.buildGroupTitle(ctx, s, convID)
 		if title != "" {
 			_, _ = s.DB().Exec(
-				"UPDATE conversations SET title = ? WHERE id = ?",
+				s.Rebind("UPDATE conversations SET title = ? WHERE id = ?"),
 				title, convID,
 			)
 		}
@@ -676,16 +676,18 @@ func (c *Client) buildGroupTitle(
 ) string {
 	// Get total non-self participant count
 	var totalCount int
-	_ = s.DB().QueryRowContext(ctx, `
+	_ = s.DB().QueryRowContext(ctx, s.Rebind(`
 		SELECT COUNT(*) FROM conversation_participants cp
 		JOIN participants p ON p.id = cp.participant_id
 		WHERE cp.conversation_id = ?
 		  AND COALESCE(p.email_address, '') != 'me@imessage.local'
 		  AND COALESCE(p.display_name, '') != 'Me'
-	`, convID).Scan(&totalCount)
+	`), convID).Scan(&totalCount)
 
-	// Get first few names for display
-	rows, err := s.DB().QueryContext(ctx, `
+	// Get first few names for display. The literal '?' in COALESCE is
+	// inside single quotes, so Rebind (which only converts ? outside
+	// quoted strings) leaves it intact.
+	rows, err := s.DB().QueryContext(ctx, s.Rebind(`
 		SELECT COALESCE(
 			NULLIF(p.display_name, ''),
 			NULLIF(p.phone_number, ''),
@@ -699,7 +701,7 @@ func (c *Client) buildGroupTitle(
 		  AND COALESCE(p.display_name, '') != 'Me'
 		ORDER BY p.id
 		LIMIT 3
-	`, convID)
+	`), convID)
 	if err != nil {
 		return ""
 	}

--- a/internal/importer/ingest.go
+++ b/internal/importer/ingest.go
@@ -175,7 +175,7 @@ func IngestRawMessage(
 	if attachmentsDir != "" && len(parsed.Attachments) > 0 {
 		var storedCount int
 		if err := st.DB().QueryRow(
-			`SELECT COUNT(*) FROM attachments WHERE message_id = ?`,
+			st.Rebind(`SELECT COUNT(*) FROM attachments WHERE message_id = ?`),
 			messageID,
 		).Scan(&storedCount); err != nil {
 			log.Warn("failed to count stored attachments",
@@ -183,7 +183,7 @@ func IngestRawMessage(
 			)
 		} else if storedCount != attachmentCount {
 			if _, err := st.DB().Exec(
-				`UPDATE messages SET has_attachments = ?, attachment_count = ? WHERE id = ?`,
+				st.Rebind(`UPDATE messages SET has_attachments = ?, attachment_count = ? WHERE id = ?`),
 				storedCount > 0, storedCount, messageID,
 			); err != nil {
 				log.Warn("failed to update attachment metadata",

--- a/internal/importer/pst_import.go
+++ b/internal/importer/pst_import.go
@@ -75,9 +75,15 @@ type PstImportSummary struct {
 	HardErrors        bool
 }
 
-// pstCheckpoint tracks resume state for PST imports.
+// pstCheckpoint tracks resume state for PST imports. ArchiveID is the
+// content-based fingerprint from pstArchiveFingerprint and is the
+// authoritative identity check during resume — path/inode comparisons
+// can match a replaced file (same path, same inode after copy-over)
+// whose bytes have changed, which would silently skip messages at the
+// resumed offset.
 type pstCheckpoint struct {
 	File        string `json:"file"`
+	ArchiveID   string `json:"archive_id,omitempty"`
 	FolderIndex int    `json:"folder_index"`
 	FolderPath  string `json:"folder_path"`
 	MsgIndex    int64  `json:"msg_index"`
@@ -188,7 +194,26 @@ func ImportPst(ctx context.Context, st *store.Store, pstPath string, opts PstImp
 							}
 						}
 					}
-					if sameFile {
+					// If the checkpoint records an ArchiveID and it
+					// differs from the current file's fingerprint, the
+					// PST at this path has been replaced (e.g.,
+					// re-exported from the mail client). Path/inode
+					// equality is not sufficient — a copy-over can keep
+					// the same path and inode while the byte content
+					// changes, which would otherwise resume at an offset
+					// that points into different messages and silently
+					// skip everything before it. Treat as a user-
+					// initiated restart: drop the offsets, log loudly,
+					// and re-import from the beginning.
+					archiveChanged := saved.ArchiveID != "" && saved.ArchiveID != archiveID
+					if sameFile && archiveChanged {
+						log.Warn("pst archive fingerprint changed since last checkpoint; restarting from the beginning",
+							"file", absPath,
+							"saved_archive_id", saved.ArchiveID,
+							"current_archive_id", archiveID,
+						)
+						summary.WasResumed = false
+					} else if sameFile {
 						resume = saved
 						summary.WasResumed = true
 						log.Info("resuming pst import",
@@ -219,7 +244,7 @@ func ImportPst(ctx context.Context, st *store.Store, pstPath string, opts PstImp
 
 	// Save initial checkpoint only for new syncs; resuming preserves the existing cursor.
 	if !summary.WasResumed {
-		if err := savePstCheckpoint(st, syncID, cpFile, 0, "", 0, &cp); err != nil {
+		if err := savePstCheckpoint(st, syncID, cpFile, archiveID, 0, "", 0, &cp); err != nil {
 			log.Warn("failed to save initial checkpoint", "error", err)
 		}
 	}
@@ -303,7 +328,7 @@ func ImportPst(ctx context.Context, st *store.Store, pstPath string, opts PstImp
 	)
 
 	saveCp := func(fi int, fp string, mi int64) {
-		if err := savePstCheckpoint(st, syncID, cpFile, fi, fp, mi, &cp); err != nil {
+		if err := savePstCheckpoint(st, syncID, cpFile, archiveID, fi, fp, mi, &cp); err != nil {
 			cp.ErrorsCount++
 			summary.Errors++
 			log.Warn("failed to save checkpoint", "error", err)
@@ -599,9 +624,10 @@ func pstArchiveFingerprint(path string) (string, error) {
 	return hex.EncodeToString(sum[:6]), nil
 }
 
-func savePstCheckpoint(st *store.Store, syncID int64, file string, folderIndex int, folderPath string, msgIndex int64, cp *store.Checkpoint) error {
+func savePstCheckpoint(st *store.Store, syncID int64, file, archiveID string, folderIndex int, folderPath string, msgIndex int64, cp *store.Checkpoint) error {
 	b, err := json.Marshal(pstCheckpoint{
 		File:        file,
+		ArchiveID:   archiveID,
 		FolderIndex: folderIndex,
 		FolderPath:  folderPath,
 		MsgIndex:    msgIndex,

--- a/internal/importer/pst_import_test.go
+++ b/internal/importer/pst_import_test.go
@@ -110,7 +110,7 @@ func TestPstCheckpoint_RoundTrip(t *testing.T) {
 		MessagesProcessed: 42,
 		MessagesAdded:     40,
 	}
-	if err := savePstCheckpoint(st, syncID, "/path/to/file.pst", 3, "Inbox/Archive", 100, cp); err != nil {
+	if err := savePstCheckpoint(st, syncID, "/path/to/file.pst", "abc123", 3, "Inbox/Archive", 100, cp); err != nil {
 		t.Fatalf("savePstCheckpoint: %v", err)
 	}
 
@@ -141,6 +141,9 @@ func TestPstCheckpoint_RoundTrip(t *testing.T) {
 	}
 	if saved.MsgIndex != 100 {
 		t.Errorf("MsgIndex = %d, want 100", saved.MsgIndex)
+	}
+	if saved.ArchiveID != "abc123" {
+		t.Errorf("ArchiveID = %q, want %q", saved.ArchiveID, "abc123")
 	}
 }
 

--- a/internal/query/dialect.go
+++ b/internal/query/dialect.go
@@ -1,0 +1,214 @@
+// Package query - database dialect abstraction for query engine.
+//
+// The query engine uses a small dialect interface to handle SQLite vs.
+// PostgreSQL differences that surface in aggregate/search SQL:
+//   - ? vs $N placeholder syntax (Rebind)
+//   - strftime vs to_char for time truncation
+//   - messages_fts MATCH vs tsvector @@ for full-text search
+//   - sqlite_master vs information_schema for existence probes
+//
+// The store package has a richer Dialect interface for its own needs;
+// this package maintains a minimal parallel abstraction to avoid a
+// cross-package dependency.
+package query
+
+import (
+	"fmt"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/sqldialect"
+)
+
+// Dialect abstracts SQL generation differences for SQLite vs PostgreSQL.
+type Dialect interface {
+	// Rebind converts ? placeholders to the driver's native form.
+	// No-op for SQLite; converts to $1, $2, ... for PostgreSQL.
+	Rebind(query string) string
+
+	// TimeTruncExpression returns SQL to truncate a timestamp column to a
+	// given granularity ("year", "month", "day"). Used in GROUP BY for
+	// the Time aggregate view.
+	TimeTruncExpression(column string, granularity string) string
+
+	// FTSSearchExpression returns the SQL boolean expression (with a ?
+	// placeholder for the search term) to use in a WHERE clause for
+	// full-text search. SQLite: messages_fts MATCH; PostgreSQL: tsvector @@.
+	FTSSearchExpression() string
+
+	// HasFTSTableSQL returns SQL to probe whether the FTS index exists.
+	// Returns a single-row, single-column integer: 1 if present, 0 if absent.
+	HasFTSTableSQL() string
+
+	// FTSJoin returns a JOIN clause that must be added to the FROM clause
+	// when using FTSSearchExpression. Empty string if no join is needed
+	// (PostgreSQL has the tsvector column on messages directly).
+	FTSJoin() string
+
+	// BuildFTSTerm converts a slice of user-supplied search terms into a SQL
+	// expression and a single argument string. Both SQLite FTS5 and PostgreSQL
+	// tsquery support prefix matching via dialect-appropriate syntax.
+	BuildFTSTerm(terms []string) (expr string, arg string)
+
+	// SanitizeFTSQuery converts a raw user search string to a form safe to
+	// pass to FTSSearchExpression. Returns "" if the result is empty after
+	// sanitization (caller should treat as no-match).
+	SanitizeFTSQuery(query string) string
+
+	// BoolTrueExpr returns a SQL boolean expression that is true when col
+	// holds a "true" value. SQLite stores booleans as 0/1 INTEGER so we
+	// must emit "col = 1"; PostgreSQL has a real BOOLEAN type and rejects
+	// integer comparisons, so the bare column name is the right form.
+	BoolTrueExpr(col string) string
+}
+
+// SQLiteQueryDialect implements Dialect for SQLite.
+type SQLiteQueryDialect struct{}
+
+func (SQLiteQueryDialect) Rebind(query string) string { return query }
+
+func (SQLiteQueryDialect) BoolTrueExpr(col string) string { return col + " = 1" }
+
+func (SQLiteQueryDialect) TimeTruncExpression(column string, granularity string) string {
+	switch granularity {
+	case "year":
+		return fmt.Sprintf("strftime('%%Y', %s)", column)
+	case "month":
+		return fmt.Sprintf("strftime('%%Y-%%m', %s)", column)
+	case "day":
+		return fmt.Sprintf("strftime('%%Y-%%m-%%d', %s)", column)
+	default:
+		return fmt.Sprintf("strftime('%%Y-%%m', %s)", column)
+	}
+}
+
+func (SQLiteQueryDialect) FTSSearchExpression() string {
+	return "messages_fts MATCH ?"
+}
+
+func (SQLiteQueryDialect) HasFTSTableSQL() string {
+	return `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages_fts'`
+}
+
+func (SQLiteQueryDialect) FTSJoin() string {
+	return "JOIN messages_fts fts ON fts.rowid = m.id"
+}
+
+// BuildFTSTerm for SQLite FTS5: quote each term and add "*" for prefix match,
+// AND them together. Escaping double-quotes prevents injection of FTS5 operators.
+func (SQLiteQueryDialect) BuildFTSTerm(terms []string) (expr string, arg string) {
+	ftsTerms := make([]string, len(terms))
+	for i, term := range terms {
+		term = strings.ReplaceAll(term, "\"", "\"\"")
+		term = strings.ReplaceAll(term, "*", "")
+		ftsTerms[i] = fmt.Sprintf("\"%s\"*", term)
+	}
+	return "messages_fts MATCH ?", strings.Join(ftsTerms, " ")
+}
+
+// SanitizeFTSQuery strips FTS5 metacharacters from a single query string
+// and wraps it in quotes for literal phrase interpretation with prefix match.
+func (SQLiteQueryDialect) SanitizeFTSQuery(query string) string {
+	var b strings.Builder
+	for _, r := range query {
+		switch r {
+		case '"', '*', ':', '-', '(', ')', '.':
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	clean := strings.TrimSpace(b.String())
+	if clean == "" {
+		return ""
+	}
+	return `"` + clean + `"*`
+}
+
+// PostgreSQLQueryDialect implements Dialect for PostgreSQL.
+type PostgreSQLQueryDialect struct{}
+
+// Rebind converts ? placeholders to $1, $2, ... for PostgreSQL.
+// Delegates to sqldialect so store.PostgreSQLDialect.Rebind stays in
+// lockstep — divergence here would route the same query to two
+// different rebinds depending on which package owns the call site.
+func (PostgreSQLQueryDialect) Rebind(query string) string {
+	return sqldialect.RebindPostgreSQL(query)
+}
+
+func (PostgreSQLQueryDialect) BoolTrueExpr(col string) string { return col }
+
+func (PostgreSQLQueryDialect) TimeTruncExpression(column string, granularity string) string {
+	switch granularity {
+	case "year":
+		return fmt.Sprintf("to_char(%s, 'YYYY')", column)
+	case "month":
+		return fmt.Sprintf("to_char(%s, 'YYYY-MM')", column)
+	case "day":
+		return fmt.Sprintf("to_char(%s, 'YYYY-MM-DD')", column)
+	default:
+		return fmt.Sprintf("to_char(%s, 'YYYY-MM')", column)
+	}
+}
+
+// FTSSearchExpression uses to_tsquery (not plainto_tsquery) so the
+// bound argument can carry prefix-match operators ("invo:*" matches
+// "invoice"); BuildFTSTerm and SanitizeFTSQuery both emit arguments in
+// that shape, and the store dialect's FTSSearchClause does the same.
+// Keeping all three aligned prevents the next caller from binding a
+// :*-shaped argument into plainto_tsquery and silently getting a
+// literal-phrase match.
+func (PostgreSQLQueryDialect) FTSSearchExpression() string {
+	return "m.search_fts @@ to_tsquery('simple', ?)"
+}
+
+func (PostgreSQLQueryDialect) HasFTSTableSQL() string {
+	return `SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_name = 'messages' AND column_name = 'search_fts'`
+}
+
+// FTSJoin: PostgreSQL's tsvector column lives on messages — no join needed.
+func (PostgreSQLQueryDialect) FTSJoin() string { return "" }
+
+// BuildFTSTerm for PostgreSQL to_tsquery: tokenize each user term into
+// letter/digit-only lexemes via sqldialect.EscapeTSQueryTerm (shared
+// with store.PostgreSQLDialect) so punctuation like `-`, `.`, `@`
+// becomes a lexeme boundary rather than ending up in an invalid
+// tsquery, append :* for prefix match, AND lexemes with " & ".
+func (PostgreSQLQueryDialect) BuildFTSTerm(terms []string) (expr string, arg string) {
+	tsTerms := make([]string, 0, len(terms))
+	for _, term := range terms {
+		for _, lex := range sqldialect.EscapeTSQueryTerm(term) {
+			tsTerms = append(tsTerms, lex+":*")
+		}
+	}
+	if len(tsTerms) == 0 {
+		return "FALSE", ""
+	}
+	return "m.search_fts @@ to_tsquery('simple', ?)", strings.Join(tsTerms, " & ")
+}
+
+// SanitizeFTSQuery builds a tsquery arg from a single user string: splits on
+// whitespace, strips tsquery metacharacters, and joins with " & " with ":*"
+// prefix matching. Returns "" if empty.
+func (PostgreSQLQueryDialect) SanitizeFTSQuery(query string) string {
+	var b strings.Builder
+	for _, r := range query {
+		switch r {
+		case '&', '|', '!', '(', ')', ':', '*', '\\', '\'':
+			continue
+		case '@', '.', '-', '/', ',', ';', '"':
+			b.WriteRune(' ')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	tokens := strings.Fields(b.String())
+	if len(tokens) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		parts = append(parts, t+":*")
+	}
+	return strings.Join(parts, " & ")
+}

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1379,7 +1379,7 @@ func (e *DuckDBEngine) fetchLabelsForMessages(ctx context.Context, messages []Me
 		return nil
 	}
 
-	return fetchLabelsForMessageList(ctx, e.db, "sqlite_db.", messages)
+	return fetchLabelsForMessageList(ctx, e.db, noopRebind, "sqlite_db.", messages)
 }
 
 // GetMessageSummariesByIDs delegates to the SQLite engine — the
@@ -1437,13 +1437,13 @@ func (e *DuckDBEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 // GetMessageRaw returns the decompressed raw MIME data for a message.
 func (e *DuckDBEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
 	if e.sqliteDB != nil {
-		return getMessageRawShared(ctx, e.sqliteDB, "", id)
+		return getMessageRawShared(ctx, e.sqliteDB, noopRebind, "", id)
 	}
 	return nil, fmt.Errorf("GetMessageRaw requires SQLite: pass sqliteDB to NewDuckDBEngine")
 }
 
 func (e *DuckDBEngine) getMessageByQuery(ctx context.Context, whereClause string, args ...interface{}) (*MessageDetail, error) {
-	return getMessageByQueryShared(ctx, e.db, "sqlite_db.", whereClause, args...)
+	return getMessageByQueryShared(ctx, e.db, noopRebind, "sqlite_db.", whereClause, args...)
 }
 
 // Search performs a Gmail-style search query.

--- a/internal/query/pg_compat_test.go
+++ b/internal/query/pg_compat_test.go
@@ -1,0 +1,206 @@
+package query_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// TestQueryEngine_PostgresPortability exercises the three SQL shapes
+// the external review flagged as failing on PostgreSQL:
+//
+//   - Aggregate uses `FROM ( … ) AS agg` (PG rejects unaliased derived
+//     tables in FROM).
+//   - GetGmailIDsByFilter avoids SELECT DISTINCT entirely (PG rejects
+//     DISTINCT when ORDER BY references columns missing from SELECT).
+//   - ListMessages sorts via expressions that textually match the
+//     SELECT list (PG enforces this for SELECT DISTINCT).
+//
+// Runs against whichever backend testutil.NewTestStore picks up — on
+// CI / dev machines that's SQLite; setting MSGVAULT_TEST_DB to a
+// postgres:// DSN exercises the PG path that the bugs were specific
+// to. The test never asserts on dialect-specific error text; a bug
+// would surface as a generic Scan/Exec failure on PG.
+func TestQueryEngine_PostgresPortability(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("gmail", "pgcompat@example.com")
+	testutil.MustNoErr(t, err, "GetOrCreateSource")
+
+	convID, err := st.EnsureConversation(src.ID, "thread-1", "Thread 1")
+	testutil.MustNoErr(t, err, "EnsureConversation")
+
+	aliceID, err := st.EnsureParticipant("alice@example.com", "Alice", "example.com")
+	testutil.MustNoErr(t, err, "EnsureParticipant alice")
+	bobID, err := st.EnsureParticipant("bob@example.com", "Bob", "example.com")
+	testutil.MustNoErr(t, err, "EnsureParticipant bob")
+
+	labelID, err := st.EnsureLabel(src.ID, "Label_1", "Important", "user")
+	testutil.MustNoErr(t, err, "EnsureLabel")
+
+	base := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		mid, err := st.UpsertMessage(&store.Message{
+			ConversationID:  convID,
+			SourceID:        src.ID,
+			SourceMessageID: gmailSourceID(i),
+			MessageType:     "email",
+			SentAt:          sql.NullTime{Time: base.Add(time.Duration(i) * time.Hour), Valid: true},
+			Subject:         sql.NullString{String: subjectFor(i), Valid: true},
+			Snippet:         sql.NullString{String: "snippet", Valid: true},
+			SizeEstimate:    int64(1000 + i*250),
+		})
+		testutil.MustNoErr(t, err, "UpsertMessage")
+		testutil.MustNoErr(t,
+			st.ReplaceMessageRecipients(mid, "from", []int64{aliceID}, []string{"Alice"}),
+			"ReplaceMessageRecipients from")
+		testutil.MustNoErr(t,
+			st.ReplaceMessageRecipients(mid, "to", []int64{bobID}, []string{"Bob"}),
+			"ReplaceMessageRecipients to")
+		testutil.MustNoErr(t,
+			st.ReplaceMessageLabels(mid, []int64{labelID}),
+			"ReplaceMessageLabels")
+	}
+
+	eng := query.NewEngine(st.DB(), st.IsPostgreSQL())
+	ctx := context.Background()
+
+	// (1) Aggregate — must not error with "syntax error near ')'" on PG.
+	t.Run("aggregate_senders", func(t *testing.T) {
+		rows, err := eng.Aggregate(ctx, query.ViewSenders, query.AggregateOptions{
+			SortField:     query.SortByCount,
+			SortDirection: query.SortDesc,
+			Limit:         50,
+		})
+		if err != nil {
+			t.Fatalf("Aggregate: %v", err)
+		}
+		if len(rows) == 0 {
+			t.Fatal("Aggregate returned no rows; expected at least the Alice sender bucket")
+		}
+	})
+
+	// (2) GetGmailIDsByFilter — must not error from a SELECT DISTINCT +
+	// ORDER BY collision on PG. Use a label filter to exercise the
+	// previously-multiplying join (now an EXISTS subquery).
+	t.Run("gmail_ids_by_filter_label", func(t *testing.T) {
+		ids, err := eng.GetGmailIDsByFilter(ctx, query.MessageFilter{
+			SourceID: &src.ID,
+			Label:    "Important",
+			Sorting: query.MessageSorting{
+				Field:     query.MessageSortByDate,
+				Direction: query.SortDesc,
+			},
+		})
+		if err != nil {
+			t.Fatalf("GetGmailIDsByFilter: %v", err)
+		}
+		if len(ids) != 4 {
+			t.Errorf("got %d gmail ids, want 4 (label join must not multiply)", len(ids))
+		}
+		// Confirm no duplicates after dropping DISTINCT — every message
+		// row should appear exactly once because the label filter is an
+		// EXISTS subquery, not a 1:N JOIN.
+		seen := make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			if _, dup := seen[id]; dup {
+				t.Errorf("duplicate id %q in result; EXISTS conversion broken", id)
+			}
+			seen[id] = struct{}{}
+		}
+	})
+
+	// (3) ListMessages sorted by size and subject — both previously
+	// bound raw column references in ORDER BY that did not match the
+	// COALESCE-wrapped expressions in the SELECT list. PG rejects that
+	// combination under SELECT DISTINCT.
+	for _, sort := range []struct {
+		name  string
+		field query.MessageSortField
+	}{
+		{"sort_by_size", query.MessageSortBySize},
+		{"sort_by_subject", query.MessageSortBySubject},
+		{"sort_by_date", query.MessageSortByDate},
+	} {
+		t.Run("list_messages_"+sort.name, func(t *testing.T) {
+			msgs, err := eng.ListMessages(ctx, query.MessageFilter{
+				SourceID: &src.ID,
+				Sorting: query.MessageSorting{
+					Field:     sort.field,
+					Direction: query.SortDesc,
+				},
+				Pagination: query.Pagination{Limit: 50},
+			})
+			if err != nil {
+				t.Fatalf("ListMessages %s: %v", sort.name, err)
+			}
+			if len(msgs) != 4 {
+				t.Errorf("ListMessages %s: got %d rows, want 4", sort.name, len(msgs))
+			}
+		})
+	}
+}
+
+// TestQueryEngine_CaseInsensitiveSearch_Subject verifies that
+// `subject:` terms passed through query.Engine.Search match
+// case-insensitively on both SQLite and PostgreSQL. SQLite's LIKE is
+// ASCII-case-insensitive by default; PostgreSQL's LIKE is
+// case-sensitive, so an unwrapped `m.subject LIKE ?` would mis-miss
+// rows that the equivalent store API path (which lowercases) returns.
+// Bare-LIKE divergence was H3 in the codex review.
+func TestQueryEngine_CaseInsensitiveSearch_Subject(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("gmail", "case-search@example.com")
+	testutil.MustNoErr(t, err, "GetOrCreateSource")
+	convID, err := st.EnsureConversation(src.ID, "case-thread", "case thread")
+	testutil.MustNoErr(t, err, "EnsureConversation")
+	mid, err := st.UpsertMessage(&store.Message{
+		ConversationID:  convID,
+		SourceID:        src.ID,
+		SourceMessageID: "case-msg-1",
+		MessageType:     "email",
+		SentAt:          sql.NullTime{Time: time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC), Valid: true},
+		Subject:         sql.NullString{String: "Quarterly Invoice", Valid: true},
+		Snippet:         sql.NullString{String: "see attached", Valid: true},
+		SizeEstimate:    1024,
+	})
+	testutil.MustNoErr(t, err, "UpsertMessage")
+	_ = mid
+
+	eng := query.NewEngine(st.DB(), st.IsPostgreSQL())
+	ctx := context.Background()
+
+	for _, term := range []string{"invoice", "INVOICE", "Invoice"} {
+		got, err := eng.Search(ctx,
+			&search.Query{SubjectTerms: []string{term}}, 50, 0)
+		if err != nil {
+			t.Fatalf("Search subject=%q: %v", term, err)
+		}
+		if len(got) != 1 {
+			t.Errorf("subject:%q matched %d rows, want 1 (stored subject %q)",
+				term, len(got), "Quarterly Invoice")
+		}
+	}
+}
+
+func gmailSourceID(i int) string {
+	return "gmail-msg-" + string(rune('a'+i))
+}
+
+func subjectFor(i int) string {
+	switch i {
+	case 0:
+		return "alpha subject"
+	case 1:
+		return "beta subject"
+	case 2:
+		return "gamma subject"
+	default:
+		return "delta subject"
+	}
+}

--- a/internal/query/postgres.go
+++ b/internal/query/postgres.go
@@ -1,234 +1,55 @@
-// Package query - PostgreSQL query engine implementation.
+// Package query - PostgreSQL query engine construction.
 //
-// PostgreSQLEngine implements the Engine interface for PostgreSQL backends.
-// It parallels SQLiteEngine but uses PostgreSQL-specific SQL:
-//   - $N placeholders instead of ?
-//   - to_char() instead of strftime()
-//   - information_schema instead of sqlite_master
-//   - tsvector/@@/ts_rank instead of FTS5 MATCH/rank
-//
-// This implementation is scaffolded to compile and handle the simpler
-// read paths (GetAttachment, ListAccounts, GetTotalStats without search).
-// Methods whose SQLite versions depend on FTS5, the shared query builder,
-// or multi-table assembly (GetMessage*, ListMessages, Aggregate, Search*,
-// GetGmailIDsByFilter) return ErrNotImplemented pending follow-up work to
-// parameterize the shared query builders.
+// PostgreSQL support is provided by the dialect-parameterized SQLiteEngine
+// (see sqlite.go). NewPostgreSQLEngine constructs an engine configured for
+// PostgreSQL SQL (tsvector FTS, to_char time truncation, $N placeholders).
+// The underlying engine implementation is the same struct used for SQLite.
 package query
 
 import (
-	"context"
 	"database/sql"
 	"errors"
-	"fmt"
-	"strings"
-	"time"
-
-	"go.kenn.io/msgvault/internal/search"
 )
 
-// ErrNotImplemented is returned by PostgreSQLEngine methods that require
-// query-builder parameterization not yet complete. Tracked for follow-up.
-var ErrNotImplemented = errors.New("PostgreSQLEngine: method not yet implemented")
+// ErrNotImplemented is a sentinel returned by engine methods that the current
+// backend cannot satisfy. Handlers wrap their engine-capability checks around
+// it so the API can return a stable status code rather than 500.
+var ErrNotImplemented = errors.New("query: method not implemented for this engine")
 
-// PostgreSQLEngine implements Engine using direct PostgreSQL queries via pgx.
-type PostgreSQLEngine struct {
-	db *sql.DB
+// pgEngine wraps a dialect-parameterized engine for PostgreSQL. It
+// embeds the Engine interface — not *SQLiteEngine — so the TextEngine
+// methods (ListConversations, TextAggregate, TextSearch, …) defined on
+// *SQLiteEngine are NOT promoted onto pgEngine. This is intentional:
+// internal/query/sqlite_text.go uses FTS5 MATCH and strftime(), neither
+// of which is valid PostgreSQL. Until a PostgreSQL TextEngine
+// implementation exists, callers that type-assert the engine to
+// query.TextEngine should cleanly get a failed assertion rather than
+// silently sending SQLite SQL to PostgreSQL at runtime.
+type pgEngine struct {
+	Engine
 }
 
-// NewPostgreSQLEngine creates a new PostgreSQL-backed query engine.
-func NewPostgreSQLEngine(db *sql.DB) *PostgreSQLEngine {
-	return &PostgreSQLEngine{db: db}
-}
-
-// Close is a no-op since PostgreSQLEngine doesn't own the connection.
-func (e *PostgreSQLEngine) Close() error {
-	return nil
-}
-
-// Aggregate performs grouping based on the provided ViewType.
-// Requires dialect-aware time expression handling; see ErrNotImplemented.
-func (e *PostgreSQLEngine) Aggregate(ctx context.Context, groupBy ViewType, opts AggregateOptions) ([]AggregateRow, error) {
-	return nil, ErrNotImplemented
-}
-
-// SubAggregate performs aggregation on a filtered subset of messages.
-func (e *PostgreSQLEngine) SubAggregate(ctx context.Context, filter MessageFilter, groupBy ViewType, opts AggregateOptions) ([]AggregateRow, error) {
-	return nil, ErrNotImplemented
-}
-
-// ListMessages returns messages matching the filter.
-func (e *PostgreSQLEngine) ListMessages(ctx context.Context, filter MessageFilter) ([]MessageSummary, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetMessageSummariesByIDs returns summary-level rows for the supplied IDs.
-func (e *PostgreSQLEngine) GetMessageSummariesByIDs(ctx context.Context, ids []int64) ([]MessageSummary, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetMessage retrieves a full message by internal ID.
+// NewPostgreSQLEngine creates a query engine backed by PostgreSQL. The engine
+// uses PostgreSQLQueryDialect for all SQL generation: $N placeholders via
+// Rebind, to_char() time truncation, tsvector @@ for full-text search.
 //
-// Returns ErrNotImplemented: the SQLite path also fetches participants,
-// labels, attachments, ReceivedAt, and a raw-MIME body fallback. Returning
-// a partially-populated MessageDetail would silently violate the Engine
-// contract for callers, so the partial implementation is held back until
-// the full PostgreSQL message-detail path lands.
-func (e *PostgreSQLEngine) GetMessage(ctx context.Context, id int64) (*MessageDetail, error) {
-	return nil, ErrNotImplemented
+// The returned value is the Engine interface (not the concrete
+// *SQLiteEngine) so the SQLite-specific TextEngine implementation is
+// hidden from type assertions on the PG path.
+func NewPostgreSQLEngine(db *sql.DB) Engine {
+	return &pgEngine{Engine: NewEngineWithDialect(db, PostgreSQLQueryDialect{})}
 }
 
-// GetMessageBySourceID retrieves a full message by source message ID.
+// NewEngine picks the appropriate engine for the given database. isPostgres
+// selects between PostgreSQLQueryDialect (true) and SQLiteQueryDialect (false).
+// This is the preferred entry point for callers that have a Store with an
+// unknown backend — pass store.IsPostgres() as the flag.
 //
-// Returns ErrNotImplemented for the same reasons as GetMessage.
-func (e *PostgreSQLEngine) GetMessageBySourceID(ctx context.Context, sourceMessageID string) (*MessageDetail, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetMessageRaw returns the decompressed raw MIME data for a message.
-//
-// Returns ErrNotImplemented: the PostgreSQL store does not yet populate
-// message_raw, so there is nothing to read. Wired up alongside the rest of
-// the message-detail path.
-func (e *PostgreSQLEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetAttachment retrieves attachment metadata by ID.
-func (e *PostgreSQLEngine) GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error) {
-	var att AttachmentInfo
-	err := e.db.QueryRowContext(ctx, `
-		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, '')
-		FROM attachments
-		WHERE id = $1
-	`, id).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash)
-	if err == sql.ErrNoRows {
-		return nil, nil
+// The return type is the Engine interface so the SQLite-only TextEngine
+// is hidden when isPostgres is true.
+func NewEngine(db *sql.DB, isPostgres bool) Engine {
+	if isPostgres {
+		return NewPostgreSQLEngine(db)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("get attachment: %w", err)
-	}
-	return &att, nil
-}
-
-// Search performs a Gmail-style search query using tsvector FTS.
-func (e *PostgreSQLEngine) Search(ctx context.Context, query *search.Query, limit, offset int) ([]MessageSummary, error) {
-	return nil, ErrNotImplemented
-}
-
-// SearchFast searches message metadata only (no body text).
-func (e *PostgreSQLEngine) SearchFast(ctx context.Context, query *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
-	return nil, ErrNotImplemented
-}
-
-// SearchFastCount returns the total count of messages matching a search query.
-func (e *PostgreSQLEngine) SearchFastCount(ctx context.Context, query *search.Query, filter MessageFilter) (int64, error) {
-	return 0, ErrNotImplemented
-}
-
-// SearchFastWithStats performs a fast metadata search with stats.
-func (e *PostgreSQLEngine) SearchFastWithStats(ctx context.Context, query *search.Query, queryStr string,
-	filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetGmailIDsByFilter returns Gmail message IDs matching a filter.
-func (e *PostgreSQLEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFilter) ([]string, error) {
-	return nil, ErrNotImplemented
-}
-
-// SearchByDomains returns messages where any participant matches one of the given domains.
-func (e *PostgreSQLEngine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]MessageSummary, error) {
-	return nil, ErrNotImplemented
-}
-
-// ListAccounts returns all source accounts.
-func (e *PostgreSQLEngine) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
-	rows, err := e.db.QueryContext(ctx, `
-		SELECT id, source_type, identifier, COALESCE(display_name, '')
-		FROM sources
-		ORDER BY identifier
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("list accounts: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var accounts []AccountInfo
-	for rows.Next() {
-		var acc AccountInfo
-		if err := rows.Scan(&acc.ID, &acc.SourceType, &acc.Identifier, &acc.DisplayName); err != nil {
-			return nil, fmt.Errorf("scan account: %w", err)
-		}
-		accounts = append(accounts, acc)
-	}
-	return accounts, rows.Err()
-}
-
-// GetTotalStats returns overall statistics.
-func (e *PostgreSQLEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*TotalStats, error) {
-	stats := &TotalStats{}
-
-	// Basic stats without search filtering (search filtering TBD with query builder parameterization)
-	if opts.SearchQuery != "" {
-		return nil, ErrNotImplemented
-	}
-
-	whereClause, args := postgresStatsWhereClause(opts)
-
-	// Message stats
-	msgQuery := fmt.Sprintf(`SELECT COUNT(*), COALESCE(SUM(m.size_estimate), 0) FROM messages m WHERE %s`,
-		whereClause)
-	if err := e.db.QueryRowContext(ctx, msgQuery, args...).Scan(&stats.MessageCount, &stats.TotalSize); err != nil {
-		return nil, fmt.Errorf("message stats: %w", err)
-	}
-
-	// Attachment stats — join messages and apply the same filters so that
-	// counts and sizes don't include attachments for soft-deleted messages,
-	// other accounts, or other filtered-out rows.
-	attQuery := fmt.Sprintf(`SELECT COUNT(*), COALESCE(SUM(a.size), 0)
-		FROM attachments a JOIN messages m ON m.id = a.message_id
-		WHERE %s`, whereClause)
-	if err := e.db.QueryRowContext(ctx, attQuery, args...).Scan(&stats.AttachmentCount, &stats.AttachmentSize); err != nil {
-		return nil, fmt.Errorf("attachment stats: %w", err)
-	}
-
-	// Label count
-	if opts.SourceID != nil {
-		if err := e.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM labels WHERE source_id = $1", *opts.SourceID).Scan(&stats.LabelCount); err != nil {
-			return nil, fmt.Errorf("label count: %w", err)
-		}
-	} else {
-		if err := e.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM labels").Scan(&stats.LabelCount); err != nil {
-			return nil, fmt.Errorf("label count: %w", err)
-		}
-	}
-
-	// Account count
-	if opts.SourceID != nil {
-		if err := e.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sources WHERE id = $1", *opts.SourceID).Scan(&stats.AccountCount); err != nil {
-			return nil, fmt.Errorf("account count: %w", err)
-		}
-	} else {
-		if err := e.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sources").Scan(&stats.AccountCount); err != nil {
-			return nil, fmt.Errorf("account count: %w", err)
-		}
-	}
-
-	return stats, nil
-}
-
-func postgresStatsWhereClause(opts StatsOptions) (string, []interface{}) {
-	msgConds := []string{emailOnlyFilterM}
-	var args []interface{}
-	if opts.SourceID != nil {
-		msgConds = append(msgConds, fmt.Sprintf("m.source_id = $%d", len(args)+1))
-		args = append(args, *opts.SourceID)
-	}
-	if opts.WithAttachmentsOnly {
-		msgConds = append(msgConds, "m.has_attachments = TRUE")
-	}
-	if opts.HideDeletedFromSource {
-		msgConds = append(msgConds, "m.deleted_from_source_at IS NULL")
-	}
-	return strings.Join(msgConds, " AND "), args
+	return NewSQLiteEngine(db)
 }

--- a/internal/query/postgres_test.go
+++ b/internal/query/postgres_test.go
@@ -7,31 +7,57 @@ import (
 
 var _ Engine = (*SQLiteEngine)(nil)
 var _ Engine = (*DuckDBEngine)(nil)
-var _ Engine = (*PostgreSQLEngine)(nil)
 
-func TestPostgresStatsWhereClauseParenthesizesEmailFilter(t *testing.T) {
-	sourceID := int64(42)
-	opts := StatsOptions{
-		SourceID:              &sourceID,
-		WithAttachmentsOnly:   true,
-		HideDeletedFromSource: true,
+// TestPostgresEngineUsesDialect verifies that NewPostgreSQLEngine creates an engine
+// with the PostgreSQL query dialect (Rebind converts ? to $N).
+func TestPostgresEngineUsesDialect(t *testing.T) {
+	e := NewPostgreSQLEngine(nil)
+	pe, ok := e.(*pgEngine)
+	if !ok {
+		t.Fatalf("NewPostgreSQLEngine returned %T, want *pgEngine", e)
 	}
+	inner, ok := pe.Engine.(*SQLiteEngine)
+	if !ok {
+		t.Fatalf("pgEngine.Engine = %T, want *SQLiteEngine", pe.Engine)
+	}
+	if _, ok := inner.dialect.(PostgreSQLQueryDialect); !ok {
+		t.Fatalf("inner dialect = %T, want PostgreSQLQueryDialect", inner.dialect)
+	}
+	reboundQuery := inner.dialect.Rebind("SELECT ? WHERE id = ?")
+	if !strings.Contains(reboundQuery, "$1") || !strings.Contains(reboundQuery, "$2") {
+		t.Fatalf("Rebind did not convert ? to $N: %q", reboundQuery)
+	}
+}
 
-	where, args := postgresStatsWhereClause(opts)
+// TestPostgresEngineHidesTextEngine verifies that the PostgreSQL engine is
+// NOT exposed as a TextEngine. The underlying *SQLiteEngine satisfies
+// TextEngine, but the pgEngine wrapper deliberately hides those methods
+// because they emit FTS5 MATCH and strftime() SQL that PostgreSQL rejects.
+func TestPostgresEngineHidesTextEngine(t *testing.T) {
+	e := NewPostgreSQLEngine(nil)
+	if _, ok := e.(TextEngine); ok {
+		t.Fatal("PostgreSQL engine must not satisfy TextEngine (SQLite-only FTS5/strftime SQL)")
+	}
+	// Sanity: the SQLite engine must still satisfy TextEngine.
+	if _, ok := any(NewSQLiteEngine(nil)).(TextEngine); !ok {
+		t.Fatal("SQLite engine should satisfy TextEngine")
+	}
+}
 
-	if !strings.HasPrefix(where, "(") {
-		t.Fatalf("where clause should start with parenthesized email filter, got %q", where)
-	}
-	if !strings.Contains(where, emailOnlyFilterM) {
-		t.Fatalf("where clause should include shared email filter %q, got %q", emailOnlyFilterM, where)
-	}
-	if strings.Contains(where, "m.message_type = 'email' OR m.message_type IS NULL OR m.message_type = '' AND") {
-		t.Fatalf("where clause has unparenthesized OR/AND precedence bug: %q", where)
-	}
-	if !strings.Contains(where, "m.source_id = $1") {
-		t.Fatalf("where clause should include source filter with first placeholder, got %q", where)
-	}
-	if len(args) != 1 || args[0] != sourceID {
-		t.Fatalf("args = %#v, want [%d]", args, sourceID)
+// TestPostgresTimeTruncExpression verifies the PostgreSQL time truncation expressions.
+func TestPostgresTimeTruncExpression(t *testing.T) {
+	d := PostgreSQLQueryDialect{}
+	for _, tc := range []struct {
+		gran string
+		want string
+	}{
+		{"year", "to_char(col, 'YYYY')"},
+		{"month", "to_char(col, 'YYYY-MM')"},
+		{"day", "to_char(col, 'YYYY-MM-DD')"},
+	} {
+		got := d.TimeTruncExpression("col", tc.gran)
+		if got != tc.want {
+			t.Errorf("TimeTruncExpression(%q, %q) = %q, want %q", "col", tc.gran, got, tc.want)
+		}
 	}
 }

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -51,9 +51,20 @@ func recipientNameExpr(mrAlias, pAlias string) string {
 	)
 }
 
+// rebindFunc converts a query written with ? placeholders into the
+// driver-native form. Helpers in this file accept it explicitly so the
+// PostgreSQL path (pgx/v5/stdlib needs $1, $2, …) and the SQLite/DuckDB
+// path (both accept ?) share a single implementation. Pass
+// noopRebind when the underlying driver accepts ? natively.
+type rebindFunc func(string) string
+
+// noopRebind passes the query through unchanged.
+func noopRebind(q string) string { return q }
+
 // fetchLabelsForMessageList adds labels to message summaries using a batch query.
 // tablePrefix is "" for direct SQLite or "sqlite_db." for DuckDB's sqlite_scan.
-func fetchLabelsForMessageList(ctx context.Context, db *sql.DB, tablePrefix string, messages []MessageSummary) error {
+// rebind rewrites the ? placeholders for the driver in use.
+func fetchLabelsForMessageList(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, messages []MessageSummary) error {
 	if len(messages) == 0 {
 		return nil
 	}
@@ -74,7 +85,7 @@ func fetchLabelsForMessageList(ctx context.Context, db *sql.DB, tablePrefix stri
 		WHERE ml.message_id IN (%s)
 	`, tablePrefix, tablePrefix, strings.Join(placeholders, ","))
 
-	rows, err := db.QueryContext(ctx, query, ids...)
+	rows, err := db.QueryContext(ctx, rebind(query), ids...)
 	if err != nil {
 		return err
 	}
@@ -96,13 +107,14 @@ func fetchLabelsForMessageList(ctx context.Context, db *sql.DB, tablePrefix stri
 
 // fetchMessageLabelsDetail fetches labels for a single message detail.
 // tablePrefix is "" for direct SQLite or "sqlite_db." for DuckDB's sqlite_scan.
-func fetchMessageLabelsDetail(ctx context.Context, db *sql.DB, tablePrefix string, msg *MessageDetail) error {
-	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
+// rebind rewrites the ? placeholders for the driver in use.
+func fetchMessageLabelsDetail(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, msg *MessageDetail) error {
+	rows, err := db.QueryContext(ctx, rebind(fmt.Sprintf(`
 		SELECT l.name
 		FROM %smessage_labels ml
 		JOIN %slabels l ON l.id = ml.label_id
 		WHERE ml.message_id = ?
-	`, tablePrefix, tablePrefix), msg.ID)
+	`, tablePrefix, tablePrefix)), msg.ID)
 	if err != nil {
 		return err
 	}
@@ -121,13 +133,14 @@ func fetchMessageLabelsDetail(ctx context.Context, db *sql.DB, tablePrefix strin
 
 // fetchParticipantsShared fetches participants for a single message detail.
 // tablePrefix is "" for direct SQLite or "sqlite_db." for DuckDB's sqlite_scan.
-func fetchParticipantsShared(ctx context.Context, db *sql.DB, tablePrefix string, msg *MessageDetail) error {
-	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
+// rebind rewrites the ? placeholders for the driver in use.
+func fetchParticipantsShared(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, msg *MessageDetail) error {
+	rows, err := db.QueryContext(ctx, rebind(fmt.Sprintf(`
 		SELECT mr.recipient_type, p.email_address, %s
 		FROM %smessage_recipients mr
 		JOIN %sparticipants p ON p.id = mr.participant_id
 		WHERE mr.message_id = ?
-	`, recipientNameExpr("mr", "p"), tablePrefix, tablePrefix), msg.ID)
+	`, recipientNameExpr("mr", "p"), tablePrefix, tablePrefix)), msg.ID)
 	if err != nil {
 		return err
 	}
@@ -156,12 +169,13 @@ func fetchParticipantsShared(ctx context.Context, db *sql.DB, tablePrefix string
 
 // fetchAttachmentsShared fetches attachments for a single message detail.
 // tablePrefix is "" for direct SQLite or "sqlite_db." for DuckDB's sqlite_scan.
-func fetchAttachmentsShared(ctx context.Context, db *sql.DB, tablePrefix string, msg *MessageDetail) error {
-	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
+// rebind rewrites the ? placeholders for the driver in use.
+func fetchAttachmentsShared(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, msg *MessageDetail) error {
+	rows, err := db.QueryContext(ctx, rebind(fmt.Sprintf(`
 		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, '')
 		FROM %sattachments
 		WHERE message_id = ?
-	`, tablePrefix), msg.ID)
+	`, tablePrefix)), msg.ID)
 	if err != nil {
 		return err
 	}
@@ -180,13 +194,14 @@ func fetchAttachmentsShared(ctx context.Context, db *sql.DB, tablePrefix string,
 
 // extractBodyFromRawShared extracts text body from compressed MIME data.
 // tablePrefix is "" for direct SQLite or "sqlite_db." for DuckDB's sqlite_scan.
-func extractBodyFromRawShared(ctx context.Context, db *sql.DB, tablePrefix string, messageID int64) (string, error) {
+// rebind rewrites the ? placeholders for the driver in use.
+func extractBodyFromRawShared(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, messageID int64) (string, error) {
 	var compressed []byte
 	var compression sql.NullString
 
-	err := db.QueryRowContext(ctx, fmt.Sprintf(`
+	err := db.QueryRowContext(ctx, rebind(fmt.Sprintf(`
 		SELECT raw_data, compression FROM %smessage_raw WHERE message_id = ?
-	`, tablePrefix), messageID).Scan(&compressed, &compression)
+	`, tablePrefix)), messageID).Scan(&compressed, &compression)
 	if err != nil {
 		return "", err
 	}
@@ -219,16 +234,16 @@ func extractBodyFromRawShared(ctx context.Context, db *sql.DB, tablePrefix strin
 // normal reads — dedup losers (deleted_at) and source-deleted rows
 // (deleted_from_source_at) are both filtered, matching the visibility rule
 // the list/search endpoints apply via store.LiveMessagesWhere.
-func getMessageRawShared(ctx context.Context, db *sql.DB, tablePrefix string, messageID int64) ([]byte, error) {
+func getMessageRawShared(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, messageID int64) ([]byte, error) {
 	var compressed []byte
 	var compression sql.NullString
 
-	err := db.QueryRowContext(ctx, fmt.Sprintf(`
+	err := db.QueryRowContext(ctx, rebind(fmt.Sprintf(`
 		SELECT mr.raw_data, mr.compression
 		FROM %smessage_raw mr
 		JOIN %smessages m ON m.id = mr.message_id
 		WHERE mr.message_id = ? AND %s
-	`, tablePrefix, tablePrefix, store.LiveMessagesWhere("m", true)), messageID).Scan(&compressed, &compression)
+	`, tablePrefix, tablePrefix, store.LiveMessagesWhere("m", true))), messageID).Scan(&compressed, &compression)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -254,7 +269,9 @@ func getMessageRawShared(ctx context.Context, db *sql.DB, tablePrefix string, me
 
 // getMessageByQueryShared retrieves a full message detail by an arbitrary WHERE clause.
 // tablePrefix is "" for direct SQLite or "sqlite_db." for DuckDB's sqlite_scan.
-func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string, whereClause string, args ...interface{}) (*MessageDetail, error) {
+// rebind rewrites the ? placeholders for the driver in use; it is applied
+// to every sub-query this function dispatches.
+func getMessageByQueryShared(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, whereClause string, args ...interface{}) (*MessageDetail, error) {
 	query := fmt.Sprintf(`
 		SELECT
 			m.id,
@@ -275,7 +292,7 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string
 
 	var msg MessageDetail
 	var sentAt, receivedAt, deletedAt sql.NullTime
-	err := db.QueryRowContext(ctx, query, args...).Scan(
+	err := db.QueryRowContext(ctx, rebind(query), args...).Scan(
 		&msg.ID,
 		&msg.SourceMessageID,
 		&msg.ConversationID,
@@ -309,9 +326,9 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string
 
 	// Fetch body from separate table (PK lookup, avoids scanning large body B-tree)
 	var bodyText, bodyHTML sql.NullString
-	err = db.QueryRowContext(ctx, fmt.Sprintf(`
+	err = db.QueryRowContext(ctx, rebind(fmt.Sprintf(`
 		SELECT body_text, body_html FROM %smessage_bodies WHERE message_id = ?
-	`, tablePrefix), msg.ID).Scan(&bodyText, &bodyHTML)
+	`, tablePrefix)), msg.ID).Scan(&bodyText, &bodyHTML)
 	if err == nil {
 		if bodyText.Valid {
 			msg.BodyText = bodyText.String
@@ -325,23 +342,23 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, tablePrefix string
 
 	// If body is empty, try to extract from raw MIME
 	if msg.BodyText == "" && msg.BodyHTML == "" {
-		if body, err := extractBodyFromRawShared(ctx, db, tablePrefix, msg.ID); err == nil && body != "" {
+		if body, err := extractBodyFromRawShared(ctx, db, rebind, tablePrefix, msg.ID); err == nil && body != "" {
 			msg.BodyText = body
 		}
 	}
 
 	// Fetch participants
-	if err := fetchParticipantsShared(ctx, db, tablePrefix, &msg); err != nil {
+	if err := fetchParticipantsShared(ctx, db, rebind, tablePrefix, &msg); err != nil {
 		return nil, fmt.Errorf("fetch participants: %w", err)
 	}
 
 	// Fetch labels
-	if err := fetchMessageLabelsDetail(ctx, db, tablePrefix, &msg); err != nil {
+	if err := fetchMessageLabelsDetail(ctx, db, rebind, tablePrefix, &msg); err != nil {
 		return nil, fmt.Errorf("fetch labels: %w", err)
 	}
 
 	// Fetch attachments
-	if err := fetchAttachmentsShared(ctx, db, tablePrefix, &msg); err != nil {
+	if err := fetchAttachmentsShared(ctx, db, rebind, tablePrefix, &msg); err != nil {
 		return nil, fmt.Errorf("fetch attachments: %w", err)
 	}
 

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -13,9 +13,12 @@ import (
 	"go.kenn.io/msgvault/internal/store"
 )
 
-// SQLiteEngine implements Engine using direct SQLite queries.
+// SQLiteEngine implements Engine using direct SQL queries.
+// Despite its name, it is dialect-agnostic and supports both SQLite
+// (default) and PostgreSQL via the dialect field.
 type SQLiteEngine struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect Dialect
 
 	// FTS availability cache - thread-safe with mutex.
 	// Only caches successful checks; errors cause retries on next call.
@@ -26,10 +29,18 @@ type SQLiteEngine struct {
 
 // NewSQLiteEngine creates a new SQLite-backed query engine.
 func NewSQLiteEngine(db *sql.DB) *SQLiteEngine {
-	return &SQLiteEngine{db: db}
+	return &SQLiteEngine{db: db, dialect: SQLiteQueryDialect{}}
 }
 
-// hasFTSTable checks if the messages_fts table exists.
+// NewEngineWithDialect creates a query engine with an explicit dialect.
+// Use this to construct a PostgreSQL-backed engine:
+//
+//	engine := query.NewEngineWithDialect(db, query.PostgreSQLQueryDialect{})
+func NewEngineWithDialect(db *sql.DB, d Dialect) *SQLiteEngine {
+	return &SQLiteEngine{db: db, dialect: d}
+}
+
+// hasFTSTable checks if the FTS index is available for this dialect.
 // Result is cached after first successful check. Errors cause retries on next call.
 // Thread-safe via mutex.
 func (e *SQLiteEngine) hasFTSTable(ctx context.Context) bool {
@@ -42,10 +53,7 @@ func (e *SQLiteEngine) hasFTSTable(ctx context.Context) bool {
 	}
 
 	var count int
-	err := e.db.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM sqlite_master
-		WHERE type='table' AND name='messages_fts'
-	`).Scan(&count)
+	err := e.queryRowContext(ctx, e.dialect.HasFTSTableSQL()).Scan(&count)
 
 	if err != nil {
 		// On error (canceled context, temporary DB issue), return false
@@ -64,6 +72,16 @@ func (e *SQLiteEngine) Close() error {
 	return nil
 }
 
+// queryContext runs QueryContext with dialect-aware placeholder rebinding.
+func (e *SQLiteEngine) queryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return e.db.QueryContext(ctx, e.dialect.Rebind(query), args...)
+}
+
+// queryRowContext runs QueryRowContext with dialect-aware placeholder rebinding.
+func (e *SQLiteEngine) queryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return e.db.QueryRowContext(ctx, e.dialect.Rebind(query), args...)
+}
+
 // escapeSQLiteLike escapes LIKE wildcard characters (%, _, \) with \.
 func escapeSQLiteLike(s string) string {
 	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
@@ -78,7 +96,7 @@ type aggDimension struct {
 }
 
 // aggDimensionForView returns the SQL dimension definition for a given ViewType.
-func aggDimensionForView(view ViewType, timeGranularity TimeGranularity) (aggDimension, error) {
+func aggDimensionForView(d Dialect, view ViewType, timeGranularity TimeGranularity) (aggDimension, error) {
 	switch view {
 	case ViewSenders:
 		return aggDimension{
@@ -125,19 +143,19 @@ func aggDimensionForView(view ViewType, timeGranularity TimeGranularity) (aggDim
 			whereExpr: "",
 		}, nil
 	case ViewTime:
-		var timeExpr string
+		var gran string
 		switch timeGranularity {
 		case TimeYear:
-			timeExpr = "strftime('%Y', m.sent_at)"
+			gran = "year"
 		case TimeMonth:
-			timeExpr = "strftime('%Y-%m', m.sent_at)"
+			gran = "month"
 		case TimeDay:
-			timeExpr = "strftime('%Y-%m-%d', m.sent_at)"
+			gran = "day"
 		default:
 			return aggDimension{}, fmt.Errorf("unsupported time granularity: %d", timeGranularity)
 		}
 		return aggDimension{
-			keyExpr:   timeExpr,
+			keyExpr:   d.TimeTruncExpression("m.sent_at", gran),
 			joins:     "",
 			whereExpr: "m.sent_at IS NOT NULL",
 		}, nil
@@ -158,6 +176,9 @@ func buildAggregateSQL(dim aggDimension, filterJoins string, filterWhere string,
 		allWhere += " AND " + dim.whereExpr
 	}
 
+	// The outer derived table needs an explicit alias — PostgreSQL
+	// rejects subqueries in FROM without one ("syntax error at or near
+	// ')'"); SQLite tolerates either form, so `AS agg` is portable.
 	return fmt.Sprintf(`
 		SELECT key, count, total_size, attachment_size, attachment_count, total_unique
 		FROM (
@@ -177,14 +198,14 @@ func buildAggregateSQL(dim aggDimension, filterJoins string, filterWhere string,
 			) att ON att.message_id = m.id
 			WHERE %s
 			GROUP BY key
-		)
+		) AS agg
 		%s
 		LIMIT ?
 	`, dim.keyExpr, allJoins, allWhere, sort)
 }
 
 // optsToFilterConditions converts AggregateOptions into WHERE conditions and args.
-func optsToFilterConditions(opts AggregateOptions, prefix string) ([]string, []interface{}) {
+func optsToFilterConditions(d Dialect, opts AggregateOptions, prefix string) ([]string, []interface{}) {
 	var conditions []string
 	var args []interface{}
 
@@ -195,16 +216,21 @@ func optsToFilterConditions(opts AggregateOptions, prefix string) ([]string, []i
 	conditions, args = appendSourceFilter(
 		conditions, args, prefix, opts.SourceID, opts.SourceIDs,
 	)
+	// Bind time.Time values directly. Formatting to a naive
+	// "2006-01-02 15:04:05" string and binding that to a PG TIMESTAMPTZ
+	// column parses the string in session TimeZone (not UTC); pgx
+	// encodes time.Time correctly on both backends, and go-sqlite3
+	// formats it to a sortable RFC3339-with-fractional layout.
 	if opts.After != nil {
 		conditions = append(conditions, prefix+"sent_at >= ?")
-		args = append(args, opts.After.Format("2006-01-02 15:04:05"))
+		args = append(args, *opts.After)
 	}
 	if opts.Before != nil {
 		conditions = append(conditions, prefix+"sent_at < ?")
-		args = append(args, opts.Before.Format("2006-01-02 15:04:05"))
+		args = append(args, *opts.Before)
 	}
 	if opts.WithAttachmentsOnly {
-		conditions = append(conditions, prefix+"has_attachments = 1")
+		conditions = append(conditions, d.BoolTrueExpr(prefix+"has_attachments"))
 	}
 
 	return conditions, args
@@ -244,7 +270,7 @@ func sortClause(opts AggregateOptions) (string, error) {
 // buildFilterJoinsAndConditions builds JOIN and WHERE clauses from a MessageFilter.
 // Returns joinClauses (already joined by \n), conditions (slice), and args.
 // This is used for SubAggregate to apply drill-down filters before sub-grouping.
-func buildFilterJoinsAndConditions(filter MessageFilter, tableAlias string) (string, []string, []interface{}) {
+func (e *SQLiteEngine) buildFilterJoinsAndConditions(filter MessageFilter, tableAlias string) (string, []string, []interface{}) {
 	var joins []string
 	var conditions []string
 	var args []interface{}
@@ -271,16 +297,16 @@ func buildFilterJoinsAndConditions(filter MessageFilter, tableAlias string) (str
 
 	if filter.After != nil {
 		conditions = append(conditions, prefix+"sent_at >= ?")
-		args = append(args, filter.After.Format("2006-01-02 15:04:05"))
+		args = append(args, *filter.After)
 	}
 
 	if filter.Before != nil {
 		conditions = append(conditions, prefix+"sent_at < ?")
-		args = append(args, filter.Before.Format("2006-01-02 15:04:05"))
+		args = append(args, *filter.Before)
 	}
 
 	if filter.WithAttachmentsOnly {
-		conditions = append(conditions, prefix+"has_attachments = 1")
+		conditions = append(conditions, e.dialect.BoolTrueExpr(prefix+"has_attachments"))
 	}
 
 	// Sender filter - check both message_recipients (email) and direct sender_id (WhatsApp/chat)
@@ -423,17 +449,18 @@ func buildFilterJoinsAndConditions(filter MessageFilter, tableAlias string) (str
 			}
 		}
 
-		var timeExpr string
+		var gran string
 		switch granularity {
 		case TimeYear:
-			timeExpr = "strftime('%Y', " + prefix + "sent_at)"
+			gran = "year"
 		case TimeMonth:
-			timeExpr = "strftime('%Y-%m', " + prefix + "sent_at)"
+			gran = "month"
 		case TimeDay:
-			timeExpr = "strftime('%Y-%m-%d', " + prefix + "sent_at)"
+			gran = "day"
 		default:
-			timeExpr = "strftime('%Y-%m', " + prefix + "sent_at)"
+			gran = "month"
 		}
+		timeExpr := e.dialect.TimeTruncExpression(prefix+"sent_at", gran)
 		conditions = append(conditions, fmt.Sprintf("%s = ?", timeExpr))
 		args = append(args, filter.TimeRange.Period)
 	}
@@ -452,14 +479,14 @@ func (e *SQLiteEngine) SubAggregate(ctx context.Context, filter MessageFilter, g
 	if opts.HideDeletedFromSource {
 		filter.HideDeletedFromSource = true
 	}
-	filterJoins, filterConditions, args := buildFilterJoinsAndConditions(filter, "m")
+	filterJoins, filterConditions, args := e.buildFilterJoinsAndConditions(filter, "m")
 
 	// Add opts-based conditions. Note: optsToFilterConditions emits
 	// its own LiveMessagesWhere clause (correct for the Aggregate
 	// caller below, which doesn't go through buildFilterJoinsAndConditions).
 	// In SubAggregate this means both filter-side and opts-side helpers
 	// emit the same clause, producing a redundant-but-correct AND chain.
-	optsConds, optsArgs := optsToFilterConditions(opts, "m.")
+	optsConds, optsArgs := optsToFilterConditions(e.dialect, opts, "m.")
 	filterConditions = append(filterConditions, optsConds...)
 	args = append(args, optsArgs...)
 
@@ -476,7 +503,7 @@ func (e *SQLiteEngine) SubAggregate(ctx context.Context, filter MessageFilter, g
 
 // Aggregate performs grouping based on the provided ViewType.
 func (e *SQLiteEngine) Aggregate(ctx context.Context, groupBy ViewType, opts AggregateOptions) ([]AggregateRow, error) {
-	conditions, args := optsToFilterConditions(opts, "m.")
+	conditions, args := optsToFilterConditions(e.dialect, opts, "m.")
 
 	searchJoins, searchConds, searchArgs :=
 		e.buildAggregateSearchParts(ctx, opts.SearchQuery, groupBy)
@@ -539,7 +566,7 @@ func (e *SQLiteEngine) buildAggregateSearchParts(
 
 // executeAggregate is the shared implementation for Aggregate and SubAggregate.
 func (e *SQLiteEngine) executeAggregate(ctx context.Context, groupBy ViewType, opts AggregateOptions, filterJoins string, filterConditions []string, args []interface{}) ([]AggregateRow, error) {
-	dim, err := aggDimensionForView(groupBy, opts.TimeGranularity)
+	dim, err := aggDimensionForView(e.dialect, groupBy, opts.TimeGranularity)
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +594,7 @@ func (e *SQLiteEngine) executeAggregate(ctx context.Context, groupBy ViewType, o
 // executeAggregateQuery runs an aggregate query and returns the results.
 // Expects 6 columns: key, count, total_size, attachment_size, attachment_count, total_unique
 func (e *SQLiteEngine) executeAggregateQuery(ctx context.Context, query string, args []interface{}) ([]AggregateRow, error) {
-	rows, err := e.db.QueryContext(ctx, query, args...)
+	rows, err := e.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("aggregate query: %w", err)
 	}
@@ -591,17 +618,22 @@ func (e *SQLiteEngine) executeAggregateQuery(ctx context.Context, query string, 
 
 // ListMessages retrieves messages matching the filter.
 func (e *SQLiteEngine) ListMessages(ctx context.Context, filter MessageFilter) ([]MessageSummary, error) {
-	filterJoins, conditions, args := buildFilterJoinsAndConditions(filter, "m")
+	filterJoins, conditions, args := e.buildFilterJoinsAndConditions(filter, "m")
 
-	// Build ORDER BY with validation
+	// Build ORDER BY with validation. PostgreSQL requires every
+	// ORDER BY expression under SELECT DISTINCT to match an expression
+	// in the SELECT list (textually equivalent or by position) — so the
+	// size and subject sorts must reference the same COALESCE wrapper
+	// used in the SELECT, not the raw column. Raw m.sent_at is already
+	// in the SELECT for the date sort.
 	var orderBy string
 	switch filter.Sorting.Field {
 	case MessageSortByDate:
 		orderBy = "m.sent_at"
 	case MessageSortBySize:
-		orderBy = "m.size_estimate"
+		orderBy = "COALESCE(m.size_estimate, 0)"
 	case MessageSortBySubject:
-		orderBy = "m.subject"
+		orderBy = "COALESCE(m.subject, '')"
 	default:
 		return nil, fmt.Errorf("unsupported message sort field: %d", filter.Sorting.Field)
 	}
@@ -651,7 +683,7 @@ func (e *SQLiteEngine) ListMessages(ctx context.Context, filter MessageFilter) (
 
 	args = append(args, limit, filter.Pagination.Offset)
 
-	rows, err := e.db.QueryContext(ctx, query, args...)
+	rows, err := e.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list messages: %w", err)
 	}
@@ -747,7 +779,7 @@ func (e *SQLiteEngine) GetMessageSummariesByIDs(ctx context.Context, ids []int64
 		WHERE m.id IN (%s) AND %s
 	`, strings.Join(placeholders, ","), store.LiveMessagesWhere("m", true))
 
-	rows, err := e.db.QueryContext(ctx, q, args...)
+	rows, err := e.queryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("get message summaries by ids: %w", err)
 	}
@@ -806,7 +838,7 @@ func (e *SQLiteEngine) GetMessageSummariesByIDs(ctx context.Context, ids []int64
 }
 
 func (e *SQLiteEngine) fetchLabelsForMessages(ctx context.Context, messages []MessageSummary) error {
-	return fetchLabelsForMessageList(ctx, e.db, "", messages)
+	return fetchLabelsForMessageList(ctx, e.db, e.dialect.Rebind, "", messages)
 }
 
 // GetMessage retrieves a full message by internal ID.
@@ -824,13 +856,13 @@ func (e *SQLiteEngine) GetMessageBySourceID(ctx context.Context, sourceMessageID
 }
 
 func (e *SQLiteEngine) getMessageByQuery(ctx context.Context, whereClause string, args ...interface{}) (*MessageDetail, error) {
-	return getMessageByQueryShared(ctx, e.db, "", whereClause, args...)
+	return getMessageByQueryShared(ctx, e.db, e.dialect.Rebind, "", whereClause, args...)
 }
 
 // GetAttachment retrieves attachment metadata by ID.
 func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error) {
 	var att AttachmentInfo
-	err := e.db.QueryRowContext(ctx, `
+	err := e.queryRowContext(ctx, `
 		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, '')
 		FROM attachments
 		WHERE id = ?
@@ -846,12 +878,12 @@ func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 
 // GetMessageRaw returns the decompressed raw MIME data for a message.
 func (e *SQLiteEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
-	return getMessageRawShared(ctx, e.db, "", id)
+	return getMessageRawShared(ctx, e.db, e.dialect.Rebind, "", id)
 }
 
 // ListAccounts returns all source accounts.
 func (e *SQLiteEngine) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
-	rows, err := e.db.QueryContext(ctx, `
+	rows, err := e.queryContext(ctx, `
 		SELECT id, source_type, identifier, COALESCE(display_name, '')
 		FROM sources
 		ORDER BY identifier
@@ -900,7 +932,7 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 		conditions, args, "m.", opts.SourceID, opts.SourceIDs,
 	)
 	if opts.WithAttachmentsOnly {
-		conditions = append(conditions, "m.has_attachments = 1")
+		conditions = append(conditions, e.dialect.BoolTrueExpr("m.has_attachments"))
 	}
 	// Merge search conditions
 	conditions = append(conditions, searchConditions...)
@@ -945,7 +977,7 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 		`, whereClause)
 	}
 
-	if err := e.db.QueryRowContext(ctx, msgQuery, args...).Scan(&stats.MessageCount, &stats.TotalSize); err != nil {
+	if err := e.queryRowContext(ctx, msgQuery, args...).Scan(&stats.MessageCount, &stats.TotalSize); err != nil {
 		return nil, fmt.Errorf("message stats: %w", err)
 	}
 
@@ -971,7 +1003,7 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 		`, whereClause)
 	}
 
-	if err := e.db.QueryRowContext(ctx, attQuery, args...).Scan(&stats.AttachmentCount, &stats.AttachmentSize); err != nil {
+	if err := e.queryRowContext(ctx, attQuery, args...).Scan(&stats.AttachmentCount, &stats.AttachmentSize); err != nil {
 		return nil, fmt.Errorf("attachment stats: %w", err)
 	}
 
@@ -979,23 +1011,23 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 	var labelQuery string
 	if opts.SourceID != nil {
 		labelQuery = "SELECT COUNT(*) FROM labels WHERE source_id = ?"
-		if err := e.db.QueryRowContext(ctx, labelQuery, *opts.SourceID).Scan(&stats.LabelCount); err != nil {
+		if err := e.queryRowContext(ctx, labelQuery, *opts.SourceID).Scan(&stats.LabelCount); err != nil {
 			return nil, fmt.Errorf("label count: %w", err)
 		}
 	} else {
 		labelQuery = "SELECT COUNT(*) FROM labels"
-		if err := e.db.QueryRowContext(ctx, labelQuery).Scan(&stats.LabelCount); err != nil {
+		if err := e.queryRowContext(ctx, labelQuery).Scan(&stats.LabelCount); err != nil {
 			return nil, fmt.Errorf("label count: %w", err)
 		}
 	}
 
 	// Account count - verify source exists when filtering by sourceID
 	if opts.SourceID != nil {
-		if err := e.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sources WHERE id = ?", *opts.SourceID).Scan(&stats.AccountCount); err != nil {
+		if err := e.queryRowContext(ctx, "SELECT COUNT(*) FROM sources WHERE id = ?", *opts.SourceID).Scan(&stats.AccountCount); err != nil {
 			return nil, fmt.Errorf("account count: %w", err)
 		}
 	} else {
-		if err := e.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sources").Scan(&stats.AccountCount); err != nil {
+		if err := e.queryRowContext(ctx, "SELECT COUNT(*) FROM sources").Scan(&stats.AccountCount); err != nil {
 			return nil, fmt.Errorf("account count: %w", err)
 		}
 	}
@@ -1005,6 +1037,15 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 
 // GetGmailIDsByFilter returns Gmail message IDs (source_message_id) matching a filter.
 // This is more efficient than ListMessages when you only need the IDs.
+//
+// All filter predicates that would otherwise need 1:N joins
+// (recipients, labels) are expressed as EXISTS subqueries so messages
+// can never appear in the result set more than once. Without that, we
+// would need SELECT DISTINCT — and PostgreSQL rejects SELECT DISTINCT
+// when ORDER BY references columns not in the SELECT list, breaking
+// the "most recent first" ordering callers (MCP, TUI) depend on under
+// Pagination.Limit. The EXISTS form also matches the SQL guidance in
+// CLAUDE.md ("Never use SELECT DISTINCT with JOINs — use EXISTS").
 func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFilter) ([]string, error) {
 	var conditions []string
 	var args []interface{}
@@ -1016,78 +1057,84 @@ func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 
 	conditions, args = appendSourceFilter(conditions, args, "m.", filter.SourceID, filter.SourceIDs)
 
-	// Build JOIN clauses based on filter type
-	var joins []string
-
-	// Scope to Gmail sources only — this function is used for Gmail-specific
-	// deletion/staging workflows and must not return WhatsApp or other source IDs.
-	joins = append(joins, `JOIN sources s_gmail ON s_gmail.id = m.source_id AND s_gmail.source_type = 'gmail'`)
+	// Scope to Gmail sources only — this function is used for
+	// Gmail-specific deletion/staging workflows and must not return
+	// WhatsApp or other source IDs. 1:1 with messages, so kept as a
+	// JOIN; the other filter predicates below use EXISTS to stay
+	// non-multiplicative.
+	joins := []string{`JOIN sources s_gmail ON s_gmail.id = m.source_id AND s_gmail.source_type = 'gmail'`}
 
 	if filter.Sender != "" {
-		joins = append(joins, `
-			LEFT JOIN message_recipients mr_from ON mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
-			LEFT JOIN participants p_from ON p_from.id = mr_from.participant_id
-			LEFT JOIN participants p_ds ON p_ds.id = m.sender_id
-		`)
-		conditions = append(conditions, "(p_from.email_address = ? OR p_from.phone_number = ? OR p_ds.email_address = ? OR p_ds.phone_number = ?)")
+		conditions = append(conditions, `(
+			EXISTS (
+				SELECT 1 FROM message_recipients mr_from
+				JOIN participants p_from ON p_from.id = mr_from.participant_id
+				WHERE mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
+				  AND (p_from.email_address = ? OR p_from.phone_number = ?)
+			)
+			OR EXISTS (
+				SELECT 1 FROM participants p_ds
+				WHERE p_ds.id = m.sender_id
+				  AND (p_ds.email_address = ? OR p_ds.phone_number = ?)
+			)
+		)`)
 		args = append(args, filter.Sender, filter.Sender, filter.Sender, filter.Sender)
 	}
 
 	if filter.SenderName != "" {
-		if filter.Sender == "" {
-			joins = append(joins, `
-				LEFT JOIN message_recipients mr_from ON mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
-				LEFT JOIN participants p_from ON p_from.id = mr_from.participant_id
-				LEFT JOIN participants p_ds ON p_ds.id = m.sender_id
-			`)
-		}
 		conditions = append(conditions, fmt.Sprintf(`(
-			%s = ?
-			OR %s = ?
+			EXISTS (
+				SELECT 1 FROM message_recipients mr_from
+				JOIN participants p_from ON p_from.id = mr_from.participant_id
+				WHERE mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
+				  AND %s = ?
+			)
+			OR EXISTS (
+				SELECT 1 FROM participants p_ds
+				WHERE p_ds.id = m.sender_id AND %s = ?
+			)
 		)`, participantNameExpr("p_from"), participantNameExpr("p_ds")))
 		args = append(args, filter.SenderName, filter.SenderName)
 	}
 
 	if filter.Recipient != "" {
-		joins = append(joins, `
-			JOIN message_recipients mr_to ON mr_to.message_id = m.id AND mr_to.recipient_type IN ('to', 'cc', 'bcc')
+		conditions = append(conditions, `EXISTS (
+			SELECT 1 FROM message_recipients mr_to
 			JOIN participants p_to ON p_to.id = mr_to.participant_id
-		`)
-		conditions = append(conditions, "p_to.email_address = ?")
+			WHERE mr_to.message_id = m.id
+			  AND mr_to.recipient_type IN ('to', 'cc', 'bcc')
+			  AND p_to.email_address = ?
+		)`)
 		args = append(args, filter.Recipient)
 	}
 
 	if filter.RecipientName != "" {
-		if filter.Recipient == "" {
-			// Always add the full join chain — GetGmailIDsByFilter does not
-			// have a standalone MatchEmptyRecipient handler, so mr_to may
-			// not exist yet.
-			joins = append(joins, `
-				JOIN message_recipients mr_to ON mr_to.message_id = m.id AND mr_to.recipient_type IN ('to', 'cc', 'bcc')
-				JOIN participants p_to ON p_to.id = mr_to.participant_id
-			`)
-		}
-		conditions = append(conditions, participantNameExpr("p_to")+" = ?")
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
+			SELECT 1 FROM message_recipients mr_to
+			JOIN participants p_to ON p_to.id = mr_to.participant_id
+			WHERE mr_to.message_id = m.id
+			  AND mr_to.recipient_type IN ('to', 'cc', 'bcc')
+			  AND %s = ?
+		)`, participantNameExpr("p_to")))
 		args = append(args, filter.RecipientName)
 	}
 
 	if filter.Domain != "" {
-		if filter.Sender == "" && filter.SenderName == "" { // Don't duplicate the join
-			joins = append(joins, `
-				JOIN message_recipients mr_from ON mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
-				JOIN participants p_from ON p_from.id = mr_from.participant_id
-			`)
-		}
-		conditions = append(conditions, "p_from.domain = ?")
+		conditions = append(conditions, `EXISTS (
+			SELECT 1 FROM message_recipients mr_from
+			JOIN participants p_from ON p_from.id = mr_from.participant_id
+			WHERE mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
+			  AND p_from.domain = ?
+		)`)
 		args = append(args, filter.Domain)
 	}
 
 	if filter.Label != "" {
-		joins = append(joins, `
-			JOIN message_labels ml ON ml.message_id = m.id
+		conditions = append(conditions, `EXISTS (
+			SELECT 1 FROM message_labels ml
 			JOIN labels l ON l.id = ml.label_id
-		`)
-		conditions = append(conditions, "LOWER(l.name) = LOWER(?)")
+			WHERE ml.message_id = m.id AND LOWER(l.name) = LOWER(?)
+		)`)
 		args = append(args, filter.Label)
 	}
 
@@ -1103,24 +1150,28 @@ func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 			}
 		}
 
-		var timeExpr string
+		var gran string
 		switch granularity {
 		case TimeYear:
-			timeExpr = "strftime('%Y', m.sent_at)"
+			gran = "year"
 		case TimeMonth:
-			timeExpr = "strftime('%Y-%m', m.sent_at)"
+			gran = "month"
 		case TimeDay:
-			timeExpr = "strftime('%Y-%m-%d', m.sent_at)"
+			gran = "day"
 		default:
-			timeExpr = "strftime('%Y-%m', m.sent_at)"
+			gran = "month"
 		}
+		timeExpr := e.dialect.TimeTruncExpression("m.sent_at", gran)
 		conditions = append(conditions, fmt.Sprintf("%s = ?", timeExpr))
 		args = append(args, filter.TimeRange.Period)
 	}
 
-	// Build query - only add LIMIT if explicitly set
+	// Build query - only add LIMIT if explicitly set. DISTINCT is not
+	// needed because every multiplicative filter is now an EXISTS
+	// subquery; messages.id is PK so each row contributes exactly one
+	// source_message_id.
 	query := fmt.Sprintf(`
-		SELECT DISTINCT m.source_message_id
+		SELECT m.source_message_id
 		FROM messages m
 		%s
 		WHERE %s
@@ -1133,7 +1184,7 @@ func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 		args = append(args, filter.Pagination.Limit)
 	}
 
-	rows, err := e.db.QueryContext(ctx, query, args...)
+	rows, err := e.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("get gmail ids: %w", err)
 	}
@@ -1172,11 +1223,11 @@ func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, af
 
 	if after != nil {
 		conditions = append(conditions, "m.sent_at >= ?")
-		args = append(args, after.Format("2006-01-02"))
+		args = append(args, *after)
 	}
 	if before != nil {
 		conditions = append(conditions, "m.sent_at < ?")
-		args = append(args, before.Format("2006-01-02"))
+		args = append(args, *before)
 	}
 
 	if limit <= 0 {
@@ -1223,12 +1274,15 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 		)`, strings.Join(fromParts, " OR ")))
 	}
 
-	// To filter - EXISTS to avoid join multiplication
+	// To filter - EXISTS to avoid join multiplication. The column side
+	// is wrapped in LOWER(); lowercase the bound args Go-side so the
+	// IN list also matches stored case-folded values (mirrors the
+	// From-filter convention above).
 	if len(q.ToAddrs) > 0 {
 		placeholders := make([]string, len(q.ToAddrs))
 		for i, addr := range q.ToAddrs {
 			placeholders[i] = "?"
-			args = append(args, addr)
+			args = append(args, strings.ToLower(addr))
 		}
 		conditions = append(conditions, fmt.Sprintf(`EXISTS (
 			SELECT 1 FROM message_recipients mr_to
@@ -1244,7 +1298,7 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 		placeholders := make([]string, len(q.CcAddrs))
 		for i, addr := range q.CcAddrs {
 			placeholders[i] = "?"
-			args = append(args, addr)
+			args = append(args, strings.ToLower(addr))
 		}
 		conditions = append(conditions, fmt.Sprintf(`EXISTS (
 			SELECT 1 FROM message_recipients mr_cc
@@ -1260,7 +1314,7 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 		placeholders := make([]string, len(q.BccAddrs))
 		for i, addr := range q.BccAddrs {
 			placeholders[i] = "?"
-			args = append(args, addr)
+			args = append(args, strings.ToLower(addr))
 		}
 		conditions = append(conditions, fmt.Sprintf(`EXISTS (
 			SELECT 1 FROM message_recipients mr_bcc
@@ -1283,17 +1337,20 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 		args = append(args, "%"+escapeSQLiteLike(label)+"%")
 	}
 
-	// Subject filter
+	// Subject filter. LOWER both sides so PostgreSQL's case-sensitive
+	// LIKE matches the same rows the store API path returns (which
+	// already lowercases). SQLite's LIKE is ASCII-case-insensitive but
+	// the LOWER wrapper still works there.
 	if len(q.SubjectTerms) > 0 {
 		for _, term := range q.SubjectTerms {
-			conditions = append(conditions, "m.subject LIKE ?")
-			args = append(args, "%"+term+"%")
+			conditions = append(conditions, "LOWER(m.subject) LIKE LOWER(?) ESCAPE '\\'")
+			args = append(args, "%"+escapeSQLiteLike(term)+"%")
 		}
 	}
 
 	// Has attachment filter
 	if q.HasAttachment != nil && *q.HasAttachment {
-		conditions = append(conditions, "m.has_attachments = 1")
+		conditions = append(conditions, e.dialect.BoolTrueExpr("m.has_attachments"))
 	}
 
 	// Date range filters
@@ -1316,29 +1373,23 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 		args = append(args, *q.SmallerThan)
 	}
 
-	// Full-text search: use FTS5 if available, fall back to LIKE
+	// Full-text search: use dialect FTS if available, fall back to LIKE.
 	if len(q.TextTerms) > 0 {
 		if e.hasFTSTable(ctx) {
-			// Use FTS5 for efficient full-text search.
-			// Prefix matching (*) enables partial word matches.
-			// Multiple terms are AND-ed: all must appear (in any column).
-			ftsJoin = "JOIN messages_fts fts ON fts.rowid = m.id"
-			ftsTerms := make([]string, len(q.TextTerms))
-			for i, term := range q.TextTerms {
-				// Quote all terms to prevent FTS5 special chars
-				// (-, :, (, ), etc.) from being parsed as query syntax.
-				term = strings.ReplaceAll(term, "\"", "\"\"")
-				term = strings.ReplaceAll(term, "*", "")
-				ftsTerms[i] = fmt.Sprintf("\"%s\"*", term)
+			ftsJoin = e.dialect.FTSJoin()
+			expr, arg := e.dialect.BuildFTSTerm(q.TextTerms)
+			conditions = append(conditions, expr)
+			if arg != "" {
+				args = append(args, arg)
 			}
-			conditions = append(conditions, "messages_fts MATCH ?")
-			args = append(args, strings.Join(ftsTerms, " "))
 		} else {
-			// Fall back to LIKE-based search on subject/snippet only
-			// Body text is in a separate table; use FTS for body search
+			// Fall back to LIKE-based search on subject/snippet only.
+			// LOWER both sides so PostgreSQL's case-sensitive LIKE
+			// returns the same hits as SQLite's ASCII-folded LIKE.
 			for _, term := range q.TextTerms {
-				likeTerm := "%" + term + "%"
-				conditions = append(conditions, "(m.subject LIKE ? OR m.snippet LIKE ?)")
+				likeTerm := "%" + escapeSQLiteLike(term) + "%"
+				conditions = append(conditions,
+					"(LOWER(m.subject) LIKE LOWER(?) ESCAPE '\\' OR LOWER(m.snippet) LIKE LOWER(?) ESCAPE '\\')")
 				args = append(args, likeTerm, likeTerm)
 			}
 		}
@@ -1406,7 +1457,7 @@ func (e *SQLiteEngine) executeSearchQuery(ctx context.Context, conditions []stri
 
 	args = append(args, limit, offset)
 
-	rows, err := e.db.QueryContext(ctx, query, args...)
+	rows, err := e.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search messages: %w", err)
 	}
@@ -1617,7 +1668,7 @@ func (e *SQLiteEngine) SearchFastCount(ctx context.Context, q *search.Query, fil
 	`, ftsJoin, strings.Join(joins, "\n"), whereClause)
 
 	var count int64
-	if err := e.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+	if err := e.queryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("search fast count: %w", err)
 	}
 	return count, nil

--- a/internal/sqldialect/sqldialect.go
+++ b/internal/sqldialect/sqldialect.go
@@ -1,0 +1,76 @@
+// Package sqldialect carries the small SQL primitives that both the
+// store and query packages have to keep in lockstep so a query routed
+// through one package matches a query routed through the other.
+//
+// Add things here only when divergence between the two packages would
+// silently produce different results for the same input (e.g., a `?`
+// rebind that doesn't respect quoted strings, or a tsquery escape that
+// strips a different set of metacharacters). Dialect features that
+// only one package needs (DDL, lifecycle, error classification) stay
+// in that package's own Dialect interface.
+package sqldialect
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// RebindPostgreSQL converts `?` placeholders in query to PostgreSQL
+// `$1, $2, ...` numbered placeholders. `?` inside single-quoted string
+// literals is left alone so prepared SQL fragments containing literal
+// question marks survive the rewrite intact.
+func RebindPostgreSQL(query string) string {
+	var b strings.Builder
+	b.Grow(len(query) + 16)
+	n := 1
+	inQuote := false
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+		if ch == '\'' {
+			inQuote = !inQuote
+			b.WriteByte(ch)
+		} else if ch == '?' && !inQuote {
+			fmt.Fprintf(&b, "$%d", n)
+			n++
+		} else {
+			b.WriteByte(ch)
+		}
+	}
+	return b.String()
+}
+
+// EscapeTSQueryTerm tokenizes a single user-supplied search term into
+// PostgreSQL `to_tsquery`-safe lexemes. The input is split on every
+// rune that isn't a Unicode letter or digit, so inputs that previously
+// produced invalid tsquery fragments — `---` (parse error), `foo-bar`
+// (the `-` is the NOT operator), `user@example.com`, `a.b.c` — now
+// decompose into their component lexemes that to_tsquery accepts.
+//
+// Returns an empty slice when the input collapses to nothing usable
+// (whitespace-only, all punctuation, or all metacharacters). Each
+// returned lexeme is safe to suffix with `:*` for prefix matching and
+// join with ` & `.
+//
+// This logic intentionally mirrors the broader punctuation-splitting
+// behavior of query.PostgreSQLQueryDialect.SanitizeFTSQuery so the two
+// PG FTS code paths produce the same lexeme set for the same input.
+func EscapeTSQueryTerm(s string) []string {
+	var lexemes []string
+	var cur strings.Builder
+	flush := func() {
+		if cur.Len() > 0 {
+			lexemes = append(lexemes, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			cur.WriteRune(r)
+		} else {
+			flush()
+		}
+	}
+	flush()
+	return lexemes
+}

--- a/internal/sqldialect/sqldialect_test.go
+++ b/internal/sqldialect/sqldialect_test.go
@@ -1,0 +1,64 @@
+package sqldialect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRebindPostgreSQL(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"none", "SELECT 1", "SELECT 1"},
+		{"one", "SELECT * FROM t WHERE a = ?", "SELECT * FROM t WHERE a = $1"},
+		{"two", "INSERT INTO t (a, b) VALUES (?, ?)", "INSERT INTO t (a, b) VALUES ($1, $2)"},
+		{"quoted_question_mark", "SELECT '? literal' FROM t WHERE x = ?",
+			"SELECT '? literal' FROM t WHERE x = $1"},
+		{"three_alternating",
+			"SELECT * FROM t WHERE a = ? AND b = '?' AND c = ?",
+			"SELECT * FROM t WHERE a = $1 AND b = '?' AND c = $2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RebindPostgreSQL(tc.in); got != tc.want {
+				t.Errorf("RebindPostgreSQL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEscapeTSQueryTerm(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"plain", "invoice", []string{"invoice"}},
+		{"unicode_kept", "café", []string{"café"}},
+		{"strip_meta_inline", "in&voice|!", []string{"in", "voice"}},
+		{"whitespace_splits", "hello world", []string{"hello", "world"}},
+		{"all_meta_empty", "&|!():*\\'", nil},
+		{"colon_splits", "user:foo", []string{"user", "foo"}},
+
+		// R3 regression cases: previously these leaked punctuation
+		// into the tsquery argument and caused to_tsquery to error.
+		{"dashes_only", "---", nil},
+		{"hyphenated_word", "foo-bar", []string{"foo", "bar"}},
+		{"email_address", "user@example.com",
+			[]string{"user", "example", "com"}},
+		{"dotted_acronym", "a.b.c", []string{"a", "b", "c"}},
+		{"mixed_punct", "v1.2.3-rc.1",
+			[]string{"v1", "2", "3", "rc", "1"}},
+		{"trailing_punct", "invoice---", []string{"invoice"}},
+		{"leading_punct", "---invoice", []string{"invoice"}},
+		{"digit_only", "12345", []string{"12345"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EscapeTSQueryTerm(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("EscapeTSQueryTerm(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/account_identities.go
+++ b/internal/store/account_identities.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sort"
@@ -49,9 +50,13 @@ func looksLikeEmail(addr string) bool {
 // column accommodates email, phone E.164, and synthetic identifiers like
 // chat handles where case can be significant).
 //
-// Read-modify-write inside a transaction. The single-writer SQLite model
-// serializes commits within one process; cross-process concurrency is not
-// a supported deployment.
+// Concurrency: the read-modify-write runs in a writer-locked transaction.
+// SQLite acquires the writer lock at BEGIN IMMEDIATE so concurrent
+// callers serialize. PostgreSQL takes a row-level lock with
+// SELECT ... FOR UPDATE so the merge sees the latest committed value.
+// On a still-empty row two callers may both fall through INSERT — the
+// unique-key violation is caught by the retry loop, which then sees the
+// other writer's row and merges into it.
 func (s *Store) AddAccountIdentity(sourceID int64, address, signal string) error {
 	addr := strings.TrimSpace(address)
 	if addr == "" {
@@ -60,48 +65,79 @@ func (s *Store) AddAccountIdentity(sourceID int64, address, signal string) error
 	if strings.Contains(signal, ",") {
 		return fmt.Errorf("signal names cannot contain commas: %q", signal)
 	}
-	// Email-shaped tokens match case-insensitively to keep the
-	// add/remove paths symmetric. Synthetic identifiers (phones,
-	// Matrix MXIDs, chat handles) stay case-sensitive. The branch
-	// lives in identifierMatch — see identifier_match.go.
 	match := newIdentifierMatch(addr)
+	ctx := context.Background()
 
-	return s.withTx(func(tx *loggedTx) error {
-		var existing string
-		err := tx.QueryRow(
-			`SELECT source_signal FROM account_identities
-			 WHERE source_id = ? AND `+match.WhereClause("address"),
-			sourceID, match.BindValue(),
-		).Scan(&existing)
-		switch {
-		case err == sql.ErrNoRows:
-			_, txErr := tx.Exec(
-				`INSERT INTO account_identities (source_id, address, source_signal)
-				 VALUES (?, ?, ?)`,
-				sourceID, addr, signal,
-			)
-			if txErr != nil {
-				return fmt.Errorf("insert account identity: %w", txErr)
-			}
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err := s.addAccountIdentityOnce(ctx, sourceID, addr, signal, match)
+		if err == nil {
 			return nil
-		case err != nil:
-			return fmt.Errorf("read existing source_signal: %w", err)
 		}
+		if !s.dialect.IsConflictError(err) && !s.dialect.IsBusyError(err) {
+			return err
+		}
+	}
+	return fmt.Errorf("add account identity: gave up after %d retries", maxAttempts)
+}
 
+// addAccountIdentityOnce runs one merge attempt in a writer-locked
+// transaction. The caller's retry loop handles unique-violation
+// (concurrent INSERT race) and busy/snapshot errors (SQLite).
+func (s *Store) addAccountIdentityOnce(
+	ctx context.Context, sourceID int64, addr, signal string, match identifierMatch,
+) (retErr error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, s.dialect.BeginWriteSQL()); err != nil {
+		return fmt.Errorf("begin write tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	rebind := s.dialect.Rebind
+	whereAddr := match.WhereClause("address")
+	var existing string
+	selectSQL := `SELECT source_signal FROM account_identities
+		WHERE source_id = ? AND ` + whereAddr + s.dialect.SelectForUpdate()
+	err = conn.QueryRowContext(ctx, rebind(selectSQL), sourceID, match.BindValue()).Scan(&existing)
+	switch {
+	case err == sql.ErrNoRows:
+		if _, err := conn.ExecContext(ctx,
+			rebind(`INSERT INTO account_identities (source_id, address, source_signal)
+				VALUES (?, ?, ?)`),
+			sourceID, addr, signal,
+		); err != nil {
+			return fmt.Errorf("insert account identity: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("read existing source_signal: %w", err)
+	default:
 		merged := mergeSignalSet(existing, signal)
-		if merged == existing {
-			return nil
+		if merged != existing {
+			if _, err := conn.ExecContext(ctx,
+				rebind(`UPDATE account_identities SET source_signal = ?
+					WHERE source_id = ? AND `+whereAddr),
+				merged, sourceID, match.BindValue(),
+			); err != nil {
+				return fmt.Errorf("update source_signal: %w", err)
+			}
 		}
-		_, updateErr := tx.Exec(
-			`UPDATE account_identities SET source_signal = ?
-			 WHERE source_id = ? AND `+match.WhereClause("address"),
-			merged, sourceID, match.BindValue(),
-		)
-		if updateErr != nil {
-			return fmt.Errorf("update source_signal: %w", updateErr)
-		}
-		return nil
-	})
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 // mergeSignalSet returns the comma-joined sorted union of the existing

--- a/internal/store/account_identities_test.go
+++ b/internal/store/account_identities_test.go
@@ -226,7 +226,7 @@ func TestAccountIdentities_FKCascadeOnSourceDelete(t *testing.T) {
 	}
 	var n int
 	if err := st.DB().QueryRow(
-		`SELECT COUNT(*) FROM account_identities WHERE source_id = ?`, f.Source.ID,
+		st.Rebind(`SELECT COUNT(*) FROM account_identities WHERE source_id = ?`), f.Source.ID,
 	).Scan(&n); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -113,21 +113,24 @@ func (s *Store) GetMessage(id int64) (*APIMessage, error) {
 	`
 
 	var m APIMessage
-	var sentAtStr sql.NullString
-	var deletedAtStr sql.NullString
-	err := s.db.QueryRow(query, id).Scan(&m.ID, &m.ConversationID, &m.Subject, &m.From, &sentAtStr, &m.Snippet, &m.HasAttachments, &m.SizeEstimate, &deletedAtStr)
+	// sentAt is a COALESCE expression; use nullableTimestamp so
+	// SQLite TEXT results parse correctly. deletedAt is a real
+	// TIMESTAMP column but routing it through the same scanner
+	// keeps the API consistent and tolerant of either driver.
+	var sentAt, deletedAt nullableTimestamp
+	err := s.db.QueryRow(query, id).Scan(&m.ID, &m.ConversationID, &m.Subject, &m.From, &sentAt, &m.Snippet, &m.HasAttachments, &m.SizeEstimate, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	if sentAtStr.Valid && sentAtStr.String != "" {
-		m.SentAt = parseSQLiteTime(sentAtStr.String)
+	if sentAt.Valid {
+		m.SentAt = sentAt.Time
 	}
-	if deletedAtStr.Valid && deletedAtStr.String != "" {
-		deletedAt := parseSQLiteTime(deletedAtStr.String)
-		m.DeletedAt = &deletedAt
+	if deletedAt.Valid {
+		t := deletedAt.Time
+		m.DeletedAt = &t
 	}
 
 	// Get recipients (single message, per-row is fine)
@@ -248,72 +251,28 @@ func (s *Store) GetMessagesSummariesByIDs(ids []int64) ([]APIMessage, error) {
 	return ordered, nil
 }
 
-// SearchMessages searches messages using full-text search, with batch-loaded recipients and labels.
+// SearchMessages searches messages using full-text search, with
+// batch-loaded recipients and labels. The raw query string is split on
+// whitespace into TextTerms and the work is delegated to
+// SearchMessagesQuery so both call sites share one FTS-argument
+// pipeline. Previously this function bound the raw user string straight
+// into FTSSearchClause's placeholder, which on PostgreSQL fed
+// to_tsquery un-escaped input (whitespace and metacharacters in user
+// queries broke the parser) and on SQLite let FTS5 metacharacters
+// reach the MATCH parser. Routing through BuildFTSArg sanitizes per
+// dialect and reuses the FALSE fallback for tokenless inputs.
 func (s *Store) SearchMessages(query string, offset, limit int) ([]APIMessage, int64, error) {
-	ftsJoin, ftsWhere, ftsOrder, orderArgCount := s.dialect.FTSSearchClause()
-
-	ftsQuery := fmt.Sprintf(`
-		SELECT
-			m.id,
-			COALESCE(m.conversation_id, 0) as conversation_id,
-			COALESCE(m.subject, '') as subject,
-			COALESCE(p.email_address, '') as from_email,
-			COALESCE(m.sent_at, m.received_at, m.internal_date) as sent_at,
-			COALESCE(m.snippet, '') as snippet,
-			m.has_attachments,
-			m.size_estimate
-		FROM messages m
-		%s
-		LEFT JOIN message_recipients mr ON mr.message_id = m.id AND mr.recipient_type = 'from'
-		LEFT JOIN participants p ON p.id = mr.participant_id
-		WHERE %s AND %s
-		ORDER BY %s
-		LIMIT ? OFFSET ?
-	`, ftsJoin, ftsWhere, LiveMessagesWhere("m", true), ftsOrder)
-
-	// Bind the search term once for WHERE, plus orderArgCount more times
-	// for any ? placeholders the dialect put in the order-by fragment.
-	searchArgs := make([]interface{}, 0, 3+orderArgCount)
-	searchArgs = append(searchArgs, query)
-	for i := 0; i < orderArgCount; i++ {
-		searchArgs = append(searchArgs, query)
-	}
-	searchArgs = append(searchArgs, limit, offset)
-
-	rows, err := s.db.Query(ftsQuery, searchArgs...)
-	if err != nil {
-		// FTS might not be available, fall back to LIKE search
-		return s.searchMessagesLike(query, offset, limit)
-	}
-	defer func() { _ = rows.Close() }()
-
-	messages, ids, err := scanMessageRows(rows)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	if len(ids) == 0 {
+	terms := strings.Fields(query)
+	if len(terms) == 0 {
+		// Whitespace-only / empty input: no search performed. Returning
+		// every row (the "no FTS filter applied" interpretation) would
+		// be a startling UX change vs. the prior behavior, where empty
+		// queries errored at the FTS parser. Treat as "no matches".
 		return []APIMessage{}, 0, nil
 	}
-
-	// Get total count
-	var total int64
-	countQuery := fmt.Sprintf(`
-		SELECT COUNT(*)
-		FROM messages m
-		%s
-		WHERE %s AND %s
-	`, ftsJoin, ftsWhere, LiveMessagesWhere("m", true))
-	if err := s.db.QueryRow(countQuery, query).Scan(&total); err != nil {
-		return nil, 0, fmt.Errorf("count FTS results: %w", err)
-	}
-
-	// Batch-load recipients and labels
-	if err := s.batchPopulate(messages, ids); err != nil {
-		return nil, 0, err
-	}
-
-	return messages, total, nil
+	return s.SearchMessagesQuery(
+		&search.Query{TextTerms: terms}, offset, limit,
+	)
 }
 
 // SearchMessagesQuery searches messages using a parsed query with
@@ -333,13 +292,26 @@ func (s *Store) SearchMessagesQuery(
 	var ftsJoin, ftsOrder, ftsExpr string
 	var ftsOrderArgCount int
 	if ftsEnabled {
-		ftsExpr = buildFTSExpression(q.TextTerms)
-		join, where, orderBy, orderArgCount := s.dialect.FTSSearchClause()
-		ftsJoin = join
-		ftsOrder = orderBy
-		ftsOrderArgCount = orderArgCount
-		conditions = append(conditions, where)
-		args = append(args, ftsExpr)
+		ftsExpr = s.dialect.BuildFTSArg(q.TextTerms)
+		if ftsExpr == "" {
+			// Every text term reduced to nothing usable (punctuation-
+			// only input like "!!!" or "---"). Dispatching the dialect's
+			// FTS WHERE here would feed PG's to_tsquery an empty string
+			// ("text-search query doesn't contain lexemes") and SQLite's
+			// FTS5 MATCH a syntax error. Substitute FALSE so the query
+			// returns zero rows without ever touching the FTS function,
+			// matching the (expr="FALSE", arg="") fallback that the
+			// query package's BuildFTSTerm uses for the same input.
+			conditions = append(conditions, "FALSE")
+			ftsEnabled = false
+		} else {
+			join, where, orderBy, orderArgCount := s.dialect.FTSSearchClause()
+			ftsJoin = join
+			ftsOrder = orderBy
+			ftsOrderArgCount = orderArgCount
+			conditions = append(conditions, where)
+			args = append(args, ftsExpr)
+		}
 	}
 
 	// from: filter
@@ -406,17 +378,21 @@ func (s *Store) SearchMessagesQuery(
 			"%"+escapeLike(strings.ToLower(lbl))+"%")
 	}
 
-	// subject: filter
+	// subject: filter — LOWER on both sides for PG portability.
+	// SQLite's default LIKE is ASCII-case-insensitive; PG's is strict-
+	// case, so a bare `m.subject LIKE '%invoice%'` returned zero hits
+	// against "Invoice from acme" on PG. Every other LIKE in this
+	// function already wraps with LOWER.
 	for _, term := range q.SubjectTerms {
 		conditions = append(conditions,
-			`m.subject LIKE ? ESCAPE '\'`)
-		args = append(args, "%"+escapeLike(term)+"%")
+			`LOWER(m.subject) LIKE LOWER(?) ESCAPE '\'`)
+		args = append(args, "%"+escapeLike(strings.ToLower(term))+"%")
 	}
 
 	// has:attachment
 	if q.HasAttachment != nil && *q.HasAttachment {
 		conditions = append(conditions,
-			"m.has_attachments = 1")
+			s.dialect.BoolTrueExpr("m.has_attachments"))
 	}
 
 	// larger: / smaller:
@@ -517,15 +493,6 @@ func (s *Store) SearchMessagesQuery(
 	return messages, total, nil
 }
 
-// buildFTSExpression builds an FTS5 MATCH expression from text terms.
-func buildFTSExpression(terms []string) string {
-	quoted := make([]string, len(terms))
-	for i, t := range terms {
-		quoted[i] = `"` + strings.ReplaceAll(t, `"`, `""`) + `"`
-	}
-	return strings.Join(quoted, " AND ")
-}
-
 // searchMessagesQueryNoFTS is a fallback when FTS5 is unavailable.
 func (s *Store) searchMessagesQueryNoFTS(
 	q *search.Query, offset, limit int,
@@ -545,14 +512,16 @@ func escapeLike(s string) string {
 	return s
 }
 
-// searchMessagesLike is a fallback search using LIKE with batch-loaded recipients and labels.
+// searchMessagesLike is a fallback search using LIKE with batch-loaded
+// recipients and labels. Wraps both sides in LOWER for PG portability —
+// SQLite's ASCII LIKE is case-insensitive by default but PG's is strict.
 func (s *Store) searchMessagesLike(query string, offset, limit int) ([]APIMessage, int64, error) {
-	likePattern := "%" + escapeLike(query) + "%"
+	likePattern := "%" + escapeLike(strings.ToLower(query)) + "%"
 
 	countQuery := fmt.Sprintf(`
 		SELECT COUNT(*) FROM messages
 		WHERE %s
-		AND (subject LIKE ? ESCAPE '\' OR snippet LIKE ? ESCAPE '\')
+		AND (LOWER(subject) LIKE ? ESCAPE '\' OR LOWER(snippet) LIKE ? ESCAPE '\')
 	`, LiveMessagesWhere("", true))
 	var total int64
 	if err := s.db.QueryRow(countQuery, likePattern, likePattern).Scan(&total); err != nil {
@@ -573,7 +542,7 @@ func (s *Store) searchMessagesLike(query string, offset, limit int) ([]APIMessag
 		LEFT JOIN message_recipients mr ON mr.message_id = m.id AND mr.recipient_type = 'from'
 		LEFT JOIN participants p ON p.id = mr.participant_id
 		WHERE %s
-		AND (m.subject LIKE ? ESCAPE '\' OR m.snippet LIKE ? ESCAPE '\')
+		AND (LOWER(m.subject) LIKE ? ESCAPE '\' OR LOWER(m.snippet) LIKE ? ESCAPE '\')
 		ORDER BY COALESCE(m.sent_at, m.received_at, m.internal_date) DESC
 		LIMIT ? OFFSET ?
 	`, LiveMessagesWhere("m", true))
@@ -601,20 +570,63 @@ func (s *Store) searchMessagesLike(query string, offset, limit int) ([]APIMessag
 	return messages, total, nil
 }
 
+// nullableTimestamp is a sql.Scanner that accepts time.Time (pgx/v5
+// stdlib for TIMESTAMP/TIMESTAMPTZ), string, []byte (SQLite for
+// computed COALESCE expressions whose declared datetime affinity is
+// lost), and nil. The sql.NullTime path that previously covered both
+// drivers is not sufficient for SQLite: when SELECT COALESCE(...) is
+// used over datetime columns, go-sqlite3 may surface the value as
+// TEXT because the COALESCE result has no column type info, and
+// NullTime's Scan rejects strings.
+type nullableTimestamp struct {
+	Time  time.Time
+	Valid bool
+}
+
+// Scan implements sql.Scanner. Strings and []byte are parsed via
+// parseSQLiteTime which already enumerates every layout SQLite emits;
+// unparseable values are treated as "not valid" rather than a hard
+// error so a single malformed row does not abort an entire listing.
+func (n *nullableTimestamp) Scan(src any) error {
+	if src == nil {
+		n.Time, n.Valid = time.Time{}, false
+		return nil
+	}
+	switch v := src.(type) {
+	case time.Time:
+		n.Time, n.Valid = v, !v.IsZero()
+		return nil
+	case string:
+		t := parseSQLiteTime(v)
+		n.Time, n.Valid = t, !t.IsZero()
+		return nil
+	case []byte:
+		t := parseSQLiteTime(string(v))
+		n.Time, n.Valid = t, !t.IsZero()
+		return nil
+	default:
+		return fmt.Errorf("nullableTimestamp: unsupported scan type %T", src)
+	}
+}
+
 // scanMessageRows scans the standard 8-column message row set.
-// Uses string scanning for dates to handle all SQLite datetime formats robustly.
+// Timestamps go through nullableTimestamp because the sent_at column
+// is a COALESCE(m.sent_at, m.received_at, m.internal_date) computed
+// expression with no declared datetime type, which on SQLite can come
+// back as TEXT and trip sql.NullTime.Scan. pgx/v5 still delivers
+// time.Time, which nullableTimestamp also handles.
 func scanMessageRows(rows *loggedRows) ([]APIMessage, []int64, error) {
 	var messages []APIMessage
 	var ids []int64
 	for rows.Next() {
 		var m APIMessage
-		var sentAtStr sql.NullString
-		err := rows.Scan(&m.ID, &m.ConversationID, &m.Subject, &m.From, &sentAtStr, &m.Snippet, &m.HasAttachments, &m.SizeEstimate)
+		var sentAt nullableTimestamp
+		err := rows.Scan(&m.ID, &m.ConversationID, &m.Subject, &m.From, &sentAt, &m.Snippet, &m.HasAttachments, &m.SizeEstimate)
 		if err != nil {
 			return nil, nil, err
 		}
-		if sentAtStr.Valid && sentAtStr.String != "" {
-			m.SentAt = parseSQLiteTime(sentAtStr.String)
+		if sentAt.Valid {
+			m.SentAt = sentAt.Time
 		}
 		messages = append(messages, m)
 		ids = append(ids, m.ID)

--- a/internal/store/api_search_test.go
+++ b/internal/store/api_search_test.go
@@ -1,0 +1,171 @@
+package store_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+// TestSearchMessagesQuery_TokenlessTextTerms verifies that text terms which
+// reduce to nothing usable under the FTS tokenizer ("!!!", "---", "")
+// neither error nor short-circuit through the FTS function. PG's
+// to_tsquery('simple', ”) raises "text-search query doesn't contain
+// lexemes" and SQLite's FTS5 MATCH on an empty/punctuation-only string is
+// a syntax error; the store now substitutes a FALSE condition so the
+// query returns zero rows from any backend without ever building a
+// malformed FTS argument. Runs under both SQLite and PostgreSQL.
+func TestSearchMessagesQuery_TokenlessTextTerms(t *testing.T) {
+	f := storetest.New(t)
+
+	// Seed two messages with real searchable content so the test would
+	// see a non-zero baseline if the FTS predicate were dropped instead
+	// of replaced with FALSE.
+	msg1 := f.NewMessage().
+		WithSourceMessageID("search-msg-1").
+		WithSubject("invoice attached").
+		WithSnippet("see the attached invoice").
+		Create(t, f.Store)
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msg1,
+		sql.NullString{String: "invoice body text", Valid: true},
+		sql.NullString{}), "UpsertMessageBody 1")
+
+	msg2 := f.NewMessage().
+		WithSourceMessageID("search-msg-2").
+		WithSubject("project update").
+		WithSnippet("weekly status").
+		Create(t, f.Store)
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msg2,
+		sql.NullString{String: "project body text", Valid: true},
+		sql.NullString{}), "UpsertMessageBody 2")
+
+	if _, err := f.Store.BackfillFTS(nil); err != nil {
+		t.Fatalf("BackfillFTS: %v", err)
+	}
+
+	// Sanity: a real term must still match — proves the test setup is
+	// wired correctly and isn't accidentally returning zero for everything.
+	msgs, total, err := f.Store.SearchMessagesQuery(
+		&search.Query{TextTerms: []string{"invoice"}}, 0, 50,
+	)
+	if err != nil {
+		t.Fatalf("baseline search: %v", err)
+	}
+	if total < 1 || len(msgs) < 1 {
+		t.Fatalf("baseline search 'invoice' returned %d hits, want >= 1", total)
+	}
+
+	// Each of these reduces to no usable tokens. Must not error and
+	// must return zero rows (FALSE predicate substituted by the caller).
+	cases := []struct {
+		name  string
+		terms []string
+	}{
+		{"only_punctuation", []string{"!!!"}},
+		{"only_dashes", []string{"---"}},
+		{"empty_string", []string{""}},
+		{"mixed_all_empty", []string{"!!!", "---", ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs, total, err := f.Store.SearchMessagesQuery(
+				&search.Query{TextTerms: tc.terms}, 0, 50,
+			)
+			if err != nil {
+				t.Fatalf("SearchMessagesQuery(%v): %v", tc.terms, err)
+			}
+			if total != 0 {
+				t.Errorf("total = %d, want 0 (FALSE predicate should match nothing)", total)
+			}
+			if len(msgs) != 0 {
+				t.Errorf("len(msgs) = %d, want 0", len(msgs))
+			}
+		})
+	}
+}
+
+// TestSearchMessages_LegacyRawString verifies the legacy SearchMessages
+// entrypoint (raw-string FTS query) sanitizes its input through the
+// dialect's BuildFTSArg pipeline. Previously it bound the raw string
+// straight into FTSSearchClause's placeholder, so any whitespace or
+// metacharacter in a user search would reach to_tsquery on PG (parser
+// error) or FTS5 MATCH on SQLite (syntax error). Routing through
+// SearchMessagesQuery shares the same FALSE fallback as
+// TokenlessTextTerms and lets multi-word queries actually work.
+func TestSearchMessages_LegacyRawString(t *testing.T) {
+	f := storetest.New(t)
+
+	msg1 := f.NewMessage().
+		WithSourceMessageID("legacy-msg-1").
+		WithSubject("urgent invoice").
+		WithSnippet("please review").
+		Create(t, f.Store)
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msg1,
+		sql.NullString{String: "invoice body for review", Valid: true},
+		sql.NullString{}), "UpsertMessageBody 1")
+
+	msg2 := f.NewMessage().
+		WithSourceMessageID("legacy-msg-2").
+		WithSubject("project plan").
+		WithSnippet("status update").
+		Create(t, f.Store)
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msg2,
+		sql.NullString{String: "project plan body", Valid: true},
+		sql.NullString{}), "UpsertMessageBody 2")
+
+	if _, err := f.Store.BackfillFTS(nil); err != nil {
+		t.Fatalf("BackfillFTS: %v", err)
+	}
+
+	// Multi-word query was the canonical PG failure: "invoice review"
+	// fed straight into to_tsquery would error. Now it tokenizes into
+	// two terms AND'd by the dialect helper.
+	t.Run("multi_word_match", func(t *testing.T) {
+		msgs, total, err := f.Store.SearchMessages("invoice review", 0, 50)
+		if err != nil {
+			t.Fatalf("SearchMessages('invoice review'): %v", err)
+		}
+		if total < 1 || len(msgs) < 1 {
+			t.Fatalf("expected >= 1 hit for 'invoice review', got %d", total)
+		}
+	})
+
+	// Single-word query still works.
+	t.Run("single_word_match", func(t *testing.T) {
+		msgs, total, err := f.Store.SearchMessages("project", 0, 50)
+		if err != nil {
+			t.Fatalf("SearchMessages('project'): %v", err)
+		}
+		if total < 1 || len(msgs) < 1 {
+			t.Fatalf("expected >= 1 hit for 'project', got %d", total)
+		}
+	})
+
+	// Each of these reduces to no usable tokens after splitting on
+	// whitespace and per-dialect sanitization. Must not error.
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"only_punctuation", "!!!"},
+		{"only_dashes", "---"},
+		{"whitespace_only", "   \t  "},
+		{"mixed_punctuation", "!!! --- ???"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs, total, err := f.Store.SearchMessages(tc.query, 0, 50)
+			if err != nil {
+				t.Fatalf("SearchMessages(%q): %v", tc.query, err)
+			}
+			if total != 0 {
+				t.Errorf("total = %d, want 0", total)
+			}
+			if len(msgs) != 0 {
+				t.Errorf("len(msgs) = %d, want 0", len(msgs))
+			}
+		})
+	}
+}

--- a/internal/store/api_test.go
+++ b/internal/store/api_test.go
@@ -164,6 +164,53 @@ func TestParseSQLiteTime(t *testing.T) {
 	}
 }
 
+// TestNullableTimestampScan exercises the scanner used by ListMessages
+// /SearchMessages /GetMessages for the COALESCE(sent_at, received_at,
+// internal_date) expression. SQLite's go-sqlite3 driver can return
+// that computed column as string or []byte (no declared datetime
+// affinity); pgx/v5 always delivers time.Time for TIMESTAMP columns.
+// The scanner must accept all of these without erroring.
+func TestNullableTimestampScan(t *testing.T) {
+	tref := time.Date(2024, 6, 15, 10, 30, 45, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		src       any
+		wantValid bool
+		wantTime  time.Time
+	}{
+		{"nil", nil, false, time.Time{}},
+		{"time.Time", tref, true, tref},
+		{"zero time.Time treated as invalid", time.Time{}, false, time.Time{}},
+		{"string SQLite datetime", "2024-06-15 10:30:45", true, tref},
+		{"string RFC3339", "2024-06-15T10:30:45Z", true, tref},
+		{"[]byte SQLite datetime", []byte("2024-06-15 10:30:45"), true, tref},
+		{"empty string -> invalid", "", false, time.Time{}},
+		{"unparseable string -> invalid", "not-a-date", false, time.Time{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var n nullableTimestamp
+			if err := n.Scan(tt.src); err != nil {
+				t.Fatalf("Scan(%T %v): unexpected error %v", tt.src, tt.src, err)
+			}
+			if n.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", n.Valid, tt.wantValid)
+			}
+			if !n.Time.Equal(tt.wantTime) {
+				t.Errorf("Time = %v, want %v", n.Time, tt.wantTime)
+			}
+		})
+	}
+
+	t.Run("unsupported type errors", func(t *testing.T) {
+		var n nullableTimestamp
+		if err := n.Scan(42); err == nil {
+			t.Fatalf("Scan(int): expected error, got nil")
+		}
+	})
+}
+
 func TestGetMessageCcBcc(t *testing.T) {
 	st := openTestStore(t)
 

--- a/internal/store/collection.go
+++ b/internal/store/collection.go
@@ -72,8 +72,10 @@ func (s *Store) EnsureDefaultCollection() error {
 
 	// Add all sources not already in it.
 	if _, err := s.db.Exec(
-		`INSERT OR IGNORE INTO collection_sources (collection_id, source_id)
-		 SELECT ?, id FROM sources`,
+		s.dialect.InsertOrIgnore(
+			`INSERT OR IGNORE INTO collection_sources (collection_id, source_id)
+			 SELECT ?, id FROM sources`,
+		),
 		id,
 	); err != nil {
 		return fmt.Errorf("seed default collection membership: %w", err)
@@ -112,22 +114,20 @@ func (s *Store) CreateCollection(
 
 	var created *Collection
 	err := s.withTx(func(tx *loggedTx) error {
-		res, err := tx.Exec(
+		var id int64
+		err := tx.QueryRow(
 			`INSERT INTO collections (name, description)
-			 VALUES (?, ?)`,
+			 VALUES (?, ?)
+			 RETURNING id`,
 			name, description,
-		)
+		).Scan(&id)
 		if err != nil {
-			if isSQLiteError(err, "UNIQUE constraint failed") {
+			if s.dialect.IsConflictError(err) {
 				return fmt.Errorf(
 					"collection %q already exists", name,
 				)
 			}
 			return fmt.Errorf("insert collection: %w", err)
-		}
-		id, err := res.LastInsertId()
-		if err != nil {
-			return fmt.Errorf("last insert id: %w", err)
 		}
 
 		for _, sid := range unique {
@@ -243,9 +243,11 @@ func (s *Store) AddSourcesToCollection(name string, sourceIDs []int64) error {
 	return s.withTx(func(tx *loggedTx) error {
 		for _, sid := range sourceIDs {
 			if _, err := tx.Exec(
-				`INSERT OR IGNORE INTO collection_sources
-				  (collection_id, source_id)
-				 VALUES (?, ?)`,
+				s.dialect.InsertOrIgnore(
+					`INSERT OR IGNORE INTO collection_sources
+					  (collection_id, source_id)
+					 VALUES (?, ?)`,
+				),
 				collID, sid,
 			); err != nil {
 				return fmt.Errorf("add source %d: %w", sid, err)

--- a/internal/store/dedup.go
+++ b/internal/store/dedup.go
@@ -82,7 +82,7 @@ func (s *Store) FindDuplicatesByRFC822ID(sourceIDs ...int64) ([]DuplicateGroupKe
 	}
 	query += `
 		GROUP BY rfc822_message_id
-		HAVING cnt > 1`
+		HAVING COUNT(*) > 1`
 
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
@@ -111,13 +111,13 @@ func (s *Store) GetDuplicateGroupMessages(
 		       (CASE WHEN mr.message_id IS NOT NULL THEN 1 ELSE 0 END) AS has_raw,
 		       (SELECT COUNT(*) FROM message_labels ml
 		          WHERE ml.message_id = m.id) AS label_count,
-		       COALESCE(m.is_from_me, 0) AS is_from_me,
-		       CAST(EXISTS (
+		       CASE WHEN COALESCE(m.is_from_me, FALSE) THEN 1 ELSE 0 END AS is_from_me,
+		       CASE WHEN EXISTS (
 		           SELECT 1 FROM message_labels ml2
 		           JOIN labels l ON l.id = ml2.label_id
 		           WHERE ml2.message_id = m.id
 		             AND (l.source_label_id = 'SENT' OR UPPER(l.name) = 'SENT')
-		       ) AS INTEGER) AS has_sent_label,
+		       ) THEN 1 ELSE 0 END AS has_sent_label,
 		       COALESCE((
 		           SELECT p_from.email_address
 		           FROM message_recipients mr_from
@@ -243,13 +243,13 @@ func (s *Store) GetAllRawMIMECandidates(
 		       COALESCE(m.subject, ''), m.sent_at, m.archived_at,
 		       (SELECT COUNT(*) FROM message_labels ml
 		          WHERE ml.message_id = m.id) AS label_count,
-		       COALESCE(m.is_from_me, 0) AS is_from_me,
-		       CAST(EXISTS (
+		       CASE WHEN COALESCE(m.is_from_me, FALSE) THEN 1 ELSE 0 END AS is_from_me,
+		       CASE WHEN EXISTS (
 		           SELECT 1 FROM message_labels ml2
 		           JOIN labels l ON l.id = ml2.label_id
 		           WHERE ml2.message_id = m.id
 		             AND (l.source_label_id = 'SENT' OR UPPER(l.name) = 'SENT')
-		       ) AS INTEGER) AS has_sent_label,
+		       ) THEN 1 ELSE 0 END AS has_sent_label,
 		       COALESCE((
 		           SELECT p_from.email_address
 		           FROM message_recipients mr_from

--- a/internal/store/dedup_delete_test.go
+++ b/internal/store/dedup_delete_test.go
@@ -36,7 +36,7 @@ func TestDeleteDedupedBatch_DeletesHiddenRows(t *testing.T) {
 	// Row should be gone.
 	var count int
 	err = f.Store.DB().QueryRow(
-		"SELECT COUNT(*) FROM messages WHERE id = ?", idDrop,
+		f.Store.Rebind("SELECT COUNT(*) FROM messages WHERE id = ?"), idDrop,
 	).Scan(&count)
 	testutil.MustNoErr(t, err, "query messages after delete")
 	if count != 0 {
@@ -45,7 +45,7 @@ func TestDeleteDedupedBatch_DeletesHiddenRows(t *testing.T) {
 
 	// Child message_labels rows should cascade-delete.
 	err = f.Store.DB().QueryRow(
-		"SELECT COUNT(*) FROM message_labels WHERE message_id = ?", idDrop,
+		f.Store.Rebind("SELECT COUNT(*) FROM message_labels WHERE message_id = ?"), idDrop,
 	).Scan(&count)
 	testutil.MustNoErr(t, err, "query message_labels after delete")
 	if count != 0 {
@@ -123,7 +123,7 @@ func TestDeleteAllDeduped_PreservesBatchlessSoftDelete(t *testing.T) {
 	// non-dedup soft-delete writer. Should survive DeleteAllDeduped.
 	idBatchless := newRFC822Message(t, f, "batchless", "rfc822-other")
 	_, err = f.Store.DB().Exec(
-		"UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?",
+		f.Store.Rebind("UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?"),
 		idBatchless,
 	)
 	testutil.MustNoErr(t, err, "set batchless deleted_at")
@@ -140,7 +140,7 @@ func TestDeleteAllDeduped_PreservesBatchlessSoftDelete(t *testing.T) {
 	// The batchless row must still exist after the purge.
 	var count int
 	err = f.Store.DB().QueryRow(
-		"SELECT COUNT(*) FROM messages WHERE id = ?", idBatchless,
+		f.Store.Rebind("SELECT COUNT(*) FROM messages WHERE id = ?"), idBatchless,
 	).Scan(&count)
 	testutil.MustNoErr(t, err, "query batchless row after delete")
 	if count != 1 {

--- a/internal/store/dedup_test.go
+++ b/internal/store/dedup_test.go
@@ -128,7 +128,7 @@ func assertDedupDeleted(
 	t.Helper()
 	var deletedAt sql.NullTime
 	err := st.DB().QueryRow(
-		"SELECT deleted_at FROM messages WHERE id = ?", msgID,
+		st.Rebind("SELECT deleted_at FROM messages WHERE id = ?"), msgID,
 	).Scan(&deletedAt)
 	testutil.MustNoErr(t, err, "query deleted_at")
 	if wantDeleted && !deletedAt.Valid {
@@ -204,7 +204,7 @@ func TestStore_BackfillRFC822IDs_ParsesFromRawMIME(t *testing.T) {
 
 	var rfc822ID string
 	err = f.Store.DB().QueryRow(
-		"SELECT rfc822_message_id FROM messages WHERE id = ?", id,
+		f.Store.Rebind("SELECT rfc822_message_id FROM messages WHERE id = ?"), id,
 	).Scan(&rfc822ID)
 	testutil.MustNoErr(t, err, "scan rfc822_message_id")
 	if rfc822ID != "unique-123@example.com" {
@@ -219,6 +219,7 @@ func TestStore_BackfillRFC822IDs_ParsesFromRawMIME(t *testing.T) {
 }
 
 func TestStore_BackfillRFC822IDs_DoesNotOvercountRolledBackBatch(t *testing.T) {
+	testutil.SkipIfPostgres(t, "uses SQLite-specific CREATE TRIGGER ... NEW.* / RAISE(FAIL,...) syntax to force a mid-batch rollback")
 	f := storetest.New(t)
 
 	idA := newRFC822Message(t, f, "needs-backfill-a", "")

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -1,6 +1,9 @@
 package store
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+)
 
 // FTSDoc is the set of fields the dialect needs to upsert a message into
 // the full-text search index.
@@ -11,6 +14,13 @@ type FTSDoc struct {
 	FromAddr  string
 	ToAddrs   string
 	CcAddrs   string
+}
+
+// ColumnMigration is a single ALTER TABLE ADD COLUMN statement used by
+// SQLiteDialect.LegacyColumnMigrations to evolve older SQLite databases.
+type ColumnMigration struct {
+	SQL  string // full ALTER TABLE ... ADD COLUMN statement
+	Desc string // short label for error messages
 }
 
 // Dialect abstracts database-specific SQL generation and behavior.
@@ -98,6 +108,21 @@ type Dialect interface {
 	// PostgreSQL: TODO (REINDEX / recompute tsvector column).
 	FTSRebuildSchema(db *sql.DB) error
 
+	// LegacyColumnMigrations returns ALTER TABLE ADD COLUMN statements to
+	// bring older databases up to date with schema columns added over time.
+	// Both dialects return the same logical list, translated to the
+	// dialect's column-type spellings. Statements are idempotent
+	// (`IF NOT EXISTS` on PG; IsDuplicateColumnError silences re-runs on
+	// SQLite). Fresh installs see no-op ALTERs because the columns are
+	// already present in schema.sql / schema_pg.sql.
+	LegacyColumnMigrations() []ColumnMigration
+
+	// DatabaseSize returns the on-disk or logical size of the database in
+	// bytes. For SQLite: file size at dbPath. For PostgreSQL: queries
+	// pg_database_size(). Returns 0 if the size cannot be determined;
+	// an error only for genuine failures (not missing files).
+	DatabaseSize(db *sql.DB, dbPath string) (int64, error)
+
 	// Connection lifecycle
 
 	// InitConn performs driver-specific connection initialization.
@@ -142,4 +167,58 @@ type Dialect interface {
 	// (SQLITE_LOCKED). Used to surface actionable errors from maintenance
 	// commands that need exclusive access.
 	IsBusyError(err error) bool
+
+	// BoolTrueExpr returns a SQL boolean expression that evaluates to true
+	// when col holds a "true" value. SQLite stores booleans as 0/1 INTEGER
+	// (emit "col = 1"); PostgreSQL has a real BOOLEAN type and rejects
+	// integer comparisons against it, so the bare column name is correct.
+	BoolTrueExpr(col string) string
+
+	// BuildFTSArg formats a slice of user-supplied search terms into the
+	// single string argument that FTSSearchClause's WHERE fragment binds
+	// against the dialect's FTS function. Both dialects emit prefix-match
+	// arguments and drop terms that contain no usable tokens:
+	//   SQLite:     `"term"*` per term, space-joined (FTS5 reads space as
+	//               implicit AND).
+	//   PostgreSQL: `term:*` per term, joined by " & " (to_tsquery).
+	// Shapes match the query package's equivalent helpers so API search
+	// and engine deep-search return the same hits for the same input.
+	// Returns "" when every term reduces to nothing usable — the caller
+	// must substitute a FALSE predicate instead of dispatching the
+	// dialect's FTS WHERE clause (an empty argument errors at both
+	// to_tsquery and the FTS5 MATCH parser).
+	BuildFTSArg(terms []string) string
+
+	// JSONBindExpr returns the SQL fragment to use in place of a bare ?
+	// when binding a Go string (or []byte) to a JSON column. SQLite has
+	// no JSON type and stores JSON as plain TEXT, so the placeholder
+	// stays bare. PostgreSQL's JSONB column does not implicitly cast
+	// from text; without ?::JSONB the bind raises
+	// "column is of type jsonb but expression is of type text".
+	JSONBindExpr() string
+
+	// BeginExclusive opens a transaction on conn that blocks concurrent
+	// writers to the tables sync code touches (sync_runs in particular,
+	// so StartSync's INSERT cannot run until COMMIT/ROLLBACK). Readers
+	// may proceed.
+	// SQLite: a single "BEGIN EXCLUSIVE" statement (WAL mode allows
+	// concurrent reads while blocking writers).
+	// PostgreSQL: "BEGIN" followed by LOCK TABLE sync_runs IN EXCLUSIVE
+	// MODE, which conflicts with the ROW EXCLUSIVE lock INSERT acquires
+	// but does not block ACCESS SHARE (reads).
+	BeginExclusive(ctx context.Context, conn *sql.Conn) error
+
+	// BeginWriteSQL returns the SQL to begin a transaction that
+	// immediately acquires the write lock, so a read-modify-write under
+	// concurrency cannot lose updates to a snapshot race.
+	// SQLite: "BEGIN IMMEDIATE" (reserves the writer slot at BEGIN).
+	// PostgreSQL: "BEGIN" — pair with SelectForUpdate to row-lock the
+	// modified row inside the transaction.
+	BeginWriteSQL() string
+
+	// SelectForUpdate returns the row-lock clause to append to a SELECT
+	// inside BeginWriteSQL transactions. PostgreSQL needs " FOR UPDATE"
+	// to lock the matched row; SQLite already serializes writers under
+	// BEGIN IMMEDIATE and returns "".
+	SelectForUpdate() string
 }

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 	_ "github.com/jackc/pgx/v5/stdlib" // Register pgx driver for database/sql
+
+	"go.kenn.io/msgvault/internal/sqldialect"
 )
 
 // PostgreSQLDialect implements Dialect for PostgreSQL.
@@ -15,46 +18,58 @@ type PostgreSQLDialect struct{}
 
 func (d *PostgreSQLDialect) DriverName() string { return "pgx" }
 
-// Rebind converts ? placeholders to PostgreSQL $1, $2, ... numbered placeholders.
-// Correctly handles quoted strings — only converts ? outside single quotes.
+// Rebind converts ? placeholders to PostgreSQL $1, $2, ... numbered
+// placeholders. Delegates to sqldialect so the query package's
+// PostgreSQLQueryDialect.Rebind stays in lockstep.
 func (d *PostgreSQLDialect) Rebind(query string) string {
-	var b strings.Builder
-	b.Grow(len(query) + 16)
-	n := 1
-	inQuote := false
-	for i := 0; i < len(query); i++ {
-		ch := query[i]
-		if ch == '\'' {
-			inQuote = !inQuote
-			b.WriteByte(ch)
-		} else if ch == '?' && !inQuote {
-			fmt.Fprintf(&b, "$%d", n)
-			n++
-		} else {
-			b.WriteByte(ch)
-		}
-	}
-	return b.String()
+	return sqldialect.RebindPostgreSQL(query)
 }
 
 // Now returns the PostgreSQL expression for the current timestamp.
 func (d *PostgreSQLDialect) Now() string { return "NOW()" }
 
-// InsertOrIgnore rewrites INSERT OR IGNORE INTO to INSERT INTO and, if the
-// statement appears complete (ends with ")" after VALUES), appends
-// " ON CONFLICT DO NOTHING". Prefix-only strings (ending with "VALUES ")
-// do not get the suffix here — callers use InsertOrIgnoreSuffix() instead,
-// to be appended after the VALUES tuples are assembled.
+// BoolTrueExpr returns the bare column name. PostgreSQL has a real BOOLEAN
+// type and rejects integer comparisons (`col = 1`) against boolean columns.
+func (d *PostgreSQLDialect) BoolTrueExpr(col string) string { return col }
+
+// JSONBindExpr returns "?::JSONB" — PG won't implicit-cast text to JSONB,
+// so a bare placeholder bound to a Go string raises a column-type
+// mismatch on the sources.sync_config write path.
+func (d *PostgreSQLDialect) JSONBindExpr() string { return "?::JSONB" }
+
+// BuildFTSArg formats search terms for to_tsquery: each term is split
+// into letter/digit-only lexemes via sqldialect.EscapeTSQueryTerm so
+// punctuation like `-`, `.`, `@` (which would otherwise produce
+// invalid tsquery strings such as `---:*` or `foo-bar:*`) becomes a
+// lexeme boundary. Each surviving lexeme is suffixed with ":*" for
+// prefix matching and joined with " & ". Matches the shape emitted by
+// the query package's PostgreSQLQueryDialect.BuildFTSTerm so the API
+// search and engine deep-search return the same hits. If no lexemes
+// survive, returns "" so the caller can substitute a FALSE predicate
+// rather than feed to_tsquery an empty argument.
+func (d *PostgreSQLDialect) BuildFTSArg(terms []string) string {
+	out := make([]string, 0, len(terms))
+	for _, t := range terms {
+		for _, lex := range sqldialect.EscapeTSQueryTerm(t) {
+			out = append(out, lex+":*")
+		}
+	}
+	return strings.Join(out, " & ")
+}
+
+// InsertOrIgnore rewrites INSERT OR IGNORE INTO to INSERT INTO and appends
+// " ON CONFLICT DO NOTHING" for complete statements. A statement is treated
+// as a prefix (caller will append VALUES tuples + InsertOrIgnoreSuffix) only
+// when it ends with the bare "VALUES" keyword; otherwise the rewrite assumes
+// the input is a complete statement (VALUES-tuple, INSERT...SELECT, etc.)
+// and appends the conflict clause.
 func (d *PostgreSQLDialect) InsertOrIgnore(sql string) string {
 	s := strings.Replace(sql, "INSERT OR IGNORE INTO", "INSERT INTO", 1)
-	// If the input is a complete statement (ends with ")" — i.e., VALUES tuples
-	// already closed), append the conflict clause. If it ends with "VALUES "
-	// (prefix form used by insertInChunks), leave the suffix to the caller.
 	trimmed := strings.TrimRight(s, " \t\n\r")
-	if strings.HasSuffix(trimmed, ")") {
-		return trimmed + " ON CONFLICT DO NOTHING"
+	if strings.HasSuffix(strings.ToUpper(trimmed), "VALUES") {
+		return s
 	}
-	return s
+	return trimmed + " ON CONFLICT DO NOTHING"
 }
 
 // InsertOrIgnorePrefix strips "OR IGNORE" from a chunked insert prefix —
@@ -89,12 +104,15 @@ func (d *PostgreSQLDialect) FTSUpsert(q querier, doc FTSDoc) error {
 
 // FTSSearchClause returns SQL fragments for tsvector full-text search.
 // PostgreSQL stores the tsvector on the messages table — no JOIN needed.
-// Uses `?` placeholders; loggedDB rebinds to `$N` at execution time.
-// ts_rank needs the query term a second time, so orderArgCount is 1.
+// Uses to_tsquery (not plainto_tsquery) so the bound argument can carry
+// prefix-match operators ("invo:*" matches "invoice"); BuildFTSArg
+// produces the matching shape. Uses `?` placeholders; loggedDB rebinds
+// to `$N` at execution time. ts_rank needs the query term a second time,
+// so orderArgCount is 1.
 func (d *PostgreSQLDialect) FTSSearchClause() (join, where, orderBy string, orderArgCount int) {
 	return "",
-		"m.search_fts @@ plainto_tsquery('simple', ?)",
-		"ts_rank(m.search_fts, plainto_tsquery('simple', ?)) DESC",
+		"m.search_fts @@ to_tsquery('simple', ?)",
+		"ts_rank(m.search_fts, to_tsquery('simple', ?)) DESC",
 		1
 }
 
@@ -104,11 +122,12 @@ func (d *PostgreSQLDialect) FTSDeleteSQL() string {
 }
 
 // FTSBackfillBatchSQL returns the SQL to populate tsvector for a range of message IDs.
-// Parameters: $1=fromID, $2=toID
+// Parameters: $1=fromID, $2=toID. Uses LEFT JOIN on message_bodies via a subquery
+// so messages without a body row are still indexed (subject + participants).
 func (d *PostgreSQLDialect) FTSBackfillBatchSQL() string {
 	return `UPDATE messages m SET search_fts =
 		setweight(to_tsvector('simple', COALESCE(m.subject, '')), 'A') ||
-		to_tsvector('simple', COALESCE(mb.body_text, '')) ||
+		to_tsvector('simple', COALESCE(src.body_text, '')) ||
 		setweight(to_tsvector('simple', COALESCE(
 			CASE WHEN m.message_type != 'email' AND m.message_type IS NOT NULL AND m.message_type != ''
 			     THEN (SELECT COALESCE(p.phone_number, p.email_address) FROM participants p WHERE p.id = m.sender_id)
@@ -118,8 +137,13 @@ func (d *PostgreSQLDialect) FTSBackfillBatchSQL() string {
 		)), 'B') ||
 		to_tsvector('simple', COALESCE((SELECT STRING_AGG(p.email_address, ' ') FROM message_recipients mr JOIN participants p ON p.id = mr.participant_id WHERE mr.message_id = m.id AND mr.recipient_type = 'to'), '')) ||
 		to_tsvector('simple', COALESCE((SELECT STRING_AGG(p.email_address, ' ') FROM message_recipients mr JOIN participants p ON p.id = mr.participant_id WHERE mr.message_id = m.id AND mr.recipient_type = 'cc'), ''))
-	FROM message_bodies mb
-	WHERE mb.message_id = m.id AND m.id >= $1 AND m.id < $2`
+	FROM (
+		SELECT m2.id, mb.body_text
+		FROM messages m2
+		LEFT JOIN message_bodies mb ON mb.message_id = m2.id
+		WHERE m2.id >= $1 AND m2.id < $2
+	) src
+	WHERE m.id = src.id`
 }
 
 // FTSAvailable reports whether tsvector search is available.
@@ -131,16 +155,18 @@ func (d *PostgreSQLDialect) FTSAvailable(db *sql.DB) bool {
 }
 
 // FTSNeedsBackfill reports whether the tsvector column needs population.
+// Counts NULL search_fts rows directly so an interrupted backfill that
+// leaves a low-id row NULL (and later inserts continue normally) still
+// flags the gap — the previous max-vs-max comparison missed that case.
+// Costs one indexable WHERE COUNT(*) per startup probe.
 func (d *PostgreSQLDialect) FTSNeedsBackfill(db *sql.DB) bool {
-	var msgMax int64
-	if err := db.QueryRow("SELECT COALESCE(MAX(id), 0) FROM messages").Scan(&msgMax); err != nil || msgMax == 0 {
+	var nullCount int64
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM messages WHERE search_fts IS NULL",
+	).Scan(&nullCount); err != nil {
 		return false
 	}
-	var populatedMax int64
-	if err := db.QueryRow("SELECT COALESCE(MAX(id), 0) FROM messages WHERE search_fts IS NOT NULL").Scan(&populatedMax); err != nil {
-		return false
-	}
-	return populatedMax < msgMax-msgMax/10
+	return nullCount > 0
 }
 
 // FTSClearSQL returns the SQL to clear all tsvector data.
@@ -148,18 +174,66 @@ func (d *PostgreSQLDialect) FTSClearSQL() string {
 	return "UPDATE messages SET search_fts = NULL"
 }
 
-// SchemaFTS returns the embedded filename containing PostgreSQL FTS DDL.
+// SchemaFTS returns "" for PostgreSQL — the tsvector column is part of the
+// main schema_pg.sql, not a separate file.
 func (d *PostgreSQLDialect) SchemaFTS() string {
-	return "schema_pg.sql"
+	return ""
 }
 
-// FTSRebuildSchema is a scaffold for PostgreSQL. The SQLite path drops and
-// recreates the FTS5 virtual table to recover from shadow-table corruption;
-// PostgreSQL's tsvector column has no analogous shadow state, so a proper
-// rebuild here (REINDEX the GIN index, NULL out the column, let the caller
-// backfill) is deferred to PR3 along with the rest of the functional path.
+// FTSRebuildSchema clears every tsvector and recreates the GIN index
+// so the caller's backfill can repopulate from scratch. The DROP +
+// CREATE INDEX pair is the PG analogue of SQLite's DROP-and-recreate
+// of the messages_fts virtual table; it covers a malformed index just
+// as the SQLite path covers a malformed shadow table.
 func (d *PostgreSQLDialect) FTSRebuildSchema(db *sql.DB) error {
-	return fmt.Errorf("FTSRebuildSchema: PostgreSQL FTS rebuild not yet implemented")
+	if _, err := db.Exec("DROP INDEX IF EXISTS messages_search_fts_idx"); err != nil {
+		return fmt.Errorf("drop messages_search_fts_idx: %w", err)
+	}
+	if _, err := db.Exec("UPDATE messages SET search_fts = NULL"); err != nil {
+		return fmt.Errorf("clear search_fts: %w", err)
+	}
+	if _, err := db.Exec(
+		"CREATE INDEX IF NOT EXISTS messages_search_fts_idx ON messages USING GIN (search_fts)",
+	); err != nil {
+		return fmt.Errorf("create messages_search_fts_idx: %w", err)
+	}
+	return nil
+}
+
+// LegacyColumnMigrations returns the ALTER TABLE ADD COLUMN statements that
+// bring older PostgreSQL databases up to the current schema. PostgreSQL has
+// supported `ADD COLUMN IF NOT EXISTS` since 9.6, so each statement is
+// idempotent on its own; IsDuplicateColumnError remains as a safety net.
+// Types are translated from the SQLite list:
+//
+//	INTEGER (id ref) → BIGINT, INTEGER (counter) → INTEGER,
+//	TEXT → TEXT, DATETIME → TIMESTAMPTZ, JSON → JSONB.
+func (d *PostgreSQLDialect) LegacyColumnMigrations() []ColumnMigration {
+	return []ColumnMigration{
+		{`ALTER TABLE sources ADD COLUMN IF NOT EXISTS sync_config JSONB`, "sync_config"},
+		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS rfc822_message_id TEXT`, "rfc822_message_id"},
+		{`ALTER TABLE sources ADD COLUMN IF NOT EXISTS oauth_app TEXT`, "oauth_app"},
+		{`ALTER TABLE participants ADD COLUMN IF NOT EXISTS phone_number TEXT`, "phone_number"},
+		{`ALTER TABLE participants ADD COLUMN IF NOT EXISTS canonical_id TEXT`, "canonical_id"},
+		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS sender_id BIGINT REFERENCES participants(id)`, "sender_id"},
+		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS message_type TEXT NOT NULL DEFAULT 'email'`, "message_type"},
+		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS attachment_count INTEGER DEFAULT 0`, "attachment_count"},
+		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS deleted_from_source_at TIMESTAMPTZ`, "deleted_from_source_at"},
+		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`, "deleted_at"},
+		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS delete_batch_id TEXT`, "delete_batch_id"},
+		{`ALTER TABLE conversations ADD COLUMN IF NOT EXISTS title TEXT`, "title"},
+		{`ALTER TABLE conversations ADD COLUMN IF NOT EXISTS conversation_type TEXT NOT NULL DEFAULT 'email_thread'`, "conversation_type"},
+	}
+}
+
+// DatabaseSize queries pg_database_size() for the current database.
+func (d *PostgreSQLDialect) DatabaseSize(db *sql.DB, _ string) (int64, error) {
+	var size int64
+	err := db.QueryRow("SELECT pg_database_size(current_database())").Scan(&size)
+	if err != nil {
+		return 0, fmt.Errorf("pg_database_size: %w", err)
+	}
+	return size, nil
 }
 
 // InitConn performs PostgreSQL-specific connection initialization.
@@ -168,8 +242,9 @@ func (d *PostgreSQLDialect) FTSRebuildSchema(db *sql.DB) error {
 func (d *PostgreSQLDialect) InitConn(db *sql.DB) error { return nil }
 
 // SchemaFiles returns the schema files to execute during InitSchema.
+// For PostgreSQL the full native schema is in schema_pg.sql.
 func (d *PostgreSQLDialect) SchemaFiles() []string {
-	return []string{"schema.sql"}
+	return []string{"schema_pg.sql"}
 }
 
 // CheckpointWAL is a no-op for PostgreSQL (no WAL checkpoint needed).
@@ -212,6 +287,48 @@ func (d *PostgreSQLDialect) IsReturningError(err error) bool { return false }
 func (d *PostgreSQLDialect) IsBusyError(err error) bool {
 	return isPgError(err, "55P03") || isPgError(err, "40P01")
 }
+
+// BeginExclusive opens a transaction on conn and locks every table the
+// sync path writes to in EXCLUSIVE mode. SQLite's BEGIN EXCLUSIVE blocks
+// all writers database-wide, so the PG counterpart must cover the full
+// set of tables a sync touches — not just sync_runs — for callers like
+// RemoveSourceSerialized to safely cascade-delete a source without
+// racing a concurrent sync. EXCLUSIVE conflicts with the ROW EXCLUSIVE
+// lock that INSERT/UPDATE/DELETE acquire; ACCESS SHARE (reads) is still
+// permitted.
+//
+// The table list mirrors every INSERT/UPDATE/DELETE the sync/import
+// pipeline emits (verified against internal/store/messages.go,
+// internal/store/sync.go, internal/store/account_identities.go,
+// internal/store/migrations.go, and internal/sync/*.go) plus the
+// collection_sources / account_identities / applied_migrations rows
+// reached by ON DELETE CASCADE when RemoveSourceSerialized deletes a
+// source. collections is included so a concurrent collection rename
+// cannot race the cascade.
+func (d *PostgreSQLDialect) BeginExclusive(ctx context.Context, conn *sql.Conn) error {
+	if _, err := conn.ExecContext(ctx, "BEGIN"); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx,
+		"LOCK TABLE sync_runs, sources, conversations, conversation_participants, "+
+			"messages, message_recipients, message_labels, message_bodies, message_raw, "+
+			"attachments, labels, participants, participant_identifiers, reactions, "+
+			"collections, collection_sources, account_identities, applied_migrations "+
+			"IN EXCLUSIVE MODE",
+	); err != nil {
+		_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		return err
+	}
+	return nil
+}
+
+// BeginWriteSQL returns "BEGIN"; PostgreSQL relies on SelectForUpdate
+// to row-lock the modified row inside the transaction.
+func (d *PostgreSQLDialect) BeginWriteSQL() string { return "BEGIN" }
+
+// SelectForUpdate returns " FOR UPDATE" so a SELECT inside a write
+// transaction takes a row-level lock that serializes subsequent merges.
+func (d *PostgreSQLDialect) SelectForUpdate() string { return " FOR UPDATE" }
 
 // isPgError checks if err is a pgconn.PgError with the given SQLSTATE code.
 func isPgError(err error, code string) bool {

--- a/internal/store/dialect_pg_test.go
+++ b/internal/store/dialect_pg_test.go
@@ -79,6 +79,11 @@ func TestPostgreSQLDialect_InsertOrIgnore(t *testing.T) {
 			in:   "INSERT OR IGNORE INTO message_labels (message_id, label_id) VALUES ",
 			want: "INSERT INTO message_labels (message_id, label_id) VALUES ",
 		},
+		{
+			name: "INSERT ... SELECT gets ON CONFLICT DO NOTHING",
+			in:   "INSERT OR IGNORE INTO collection_sources (collection_id, source_id) SELECT ?, id FROM sources",
+			want: "INSERT INTO collection_sources (collection_id, source_id) SELECT ?, id FROM sources ON CONFLICT DO NOTHING",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -103,14 +108,53 @@ func TestPostgreSQLDialect_FTSSearchClause(t *testing.T) {
 	if join != "" {
 		t.Errorf("join = %q, want empty (PostgreSQL needs no JOIN)", join)
 	}
-	if where != "m.search_fts @@ plainto_tsquery('simple', ?)" {
+	if where != "m.search_fts @@ to_tsquery('simple', ?)" {
 		t.Errorf("where = %q, unexpected", where)
 	}
-	if orderBy != "ts_rank(m.search_fts, plainto_tsquery('simple', ?)) DESC" {
+	if orderBy != "ts_rank(m.search_fts, to_tsquery('simple', ?)) DESC" {
 		t.Errorf("orderBy = %q, unexpected", orderBy)
 	}
 	if orderArgCount != 1 {
 		t.Errorf("orderArgCount = %d, want 1 (ts_rank needs query a second time)", orderArgCount)
+	}
+}
+
+// TestPostgreSQLDialect_BuildFTSArg covers R3: the tsquery argument
+// builder must split user terms on punctuation so inputs like `---`,
+// `foo-bar`, `user@example.com`, and `a.b.c` produce only safe
+// letter/digit lexemes rather than something to_tsquery would reject.
+// The complementary integration test that actually feeds these
+// strings into PG lives in pg_compat_test.go as
+// TestSearchMessages_R3PunctuationTerms.
+func TestPostgreSQLDialect_BuildFTSArg(t *testing.T) {
+	d := &PostgreSQLDialect{}
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"plain", []string{"invoice"}, "invoice:*"},
+		{"two_plain", []string{"invoice", "review"}, "invoice:* & review:*"},
+		{"dashes_only_drops", []string{"---"}, ""},
+		{"hyphenated_splits", []string{"foo-bar"}, "foo:* & bar:*"},
+		{"email_splits",
+			[]string{"user@example.com"},
+			"user:* & example:* & com:*"},
+		{"dotted_acronym_splits",
+			[]string{"a.b.c"}, "a:* & b:* & c:*"},
+		{"mix_of_clean_and_punct",
+			[]string{"invoice", "foo-bar"},
+			"invoice:* & foo:* & bar:*"},
+		{"only_punct_collapses_to_empty",
+			[]string{"---", "..."}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := d.BuildFTSArg(tc.in)
+			if got != tc.want {
+				t.Errorf("BuildFTSArg(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -1,9 +1,13 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
+	"unicode"
 
 	"github.com/mattn/go-sqlite3"
 )
@@ -21,6 +25,53 @@ func (d *SQLiteDialect) Now() string { return "datetime('now')" }
 
 // InsertOrIgnore is a no-op for SQLite — the syntax is native.
 func (d *SQLiteDialect) InsertOrIgnore(sql string) string { return sql }
+
+// BoolTrueExpr returns "col = 1" — SQLite stores booleans as 0/1 INTEGER.
+func (d *SQLiteDialect) BoolTrueExpr(col string) string { return col + " = 1" }
+
+// JSONBindExpr is "?" on SQLite — JSON columns are plain TEXT.
+func (d *SQLiteDialect) JSONBindExpr() string { return "?" }
+
+// BuildFTSArg formats search terms as an FTS5 MATCH argument: each
+// term double-quote-escaped, suffixed with "*" for prefix match, and
+// space-joined (FTS5 treats space as implicit AND). Embedded "*" is
+// stripped first so user input cannot break the trailing prefix
+// operator. Matches the shape produced by the query package's
+// SQLiteQueryDialect.BuildFTSTerm so the API search path and the
+// engine deep-search path return the same hits for the same input —
+// searching "invo" must match "invoice" in both paths.
+//
+// Terms that would tokenize to nothing under the default FTS5
+// tokenizer (no Unicode letter or digit — e.g. "!!!", "---", "") are
+// dropped. If all terms drop, returns "" so the caller can
+// short-circuit instead of dispatching a malformed FTS5 MATCH that
+// errors at the driver. Mirrors the empty-fallback shape in
+// PostgreSQLDialect.BuildFTSArg.
+func (d *SQLiteDialect) BuildFTSArg(terms []string) string {
+	quoted := make([]string, 0, len(terms))
+	for _, t := range terms {
+		if !hasFTSToken(t) {
+			continue
+		}
+		t = strings.ReplaceAll(t, `"`, `""`)
+		t = strings.ReplaceAll(t, "*", "")
+		quoted = append(quoted, `"`+t+`"*`)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// hasFTSToken reports whether s contains at least one rune that the
+// default FTS5 tokenizer (unicode61) would emit as part of a token —
+// i.e., a Unicode letter or digit. Punctuation-only strings tokenize
+// to nothing, so a MATCH built from them is a syntax error.
+func hasFTSToken(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}
 
 // InsertOrIgnorePrefix is a no-op for SQLite — OR IGNORE stays in the prefix.
 func (d *SQLiteDialect) InsertOrIgnorePrefix(sql string) string { return sql }
@@ -133,6 +184,40 @@ func (d *SQLiteDialect) FTSRebuildSchema(db *sql.DB) error {
 	return nil
 }
 
+// LegacyColumnMigrations returns the ALTER TABLE ADD COLUMN statements that
+// bring older SQLite databases up to the current schema. IsDuplicateColumnError
+// silences these when the column already exists (idempotent migrations).
+func (d *SQLiteDialect) LegacyColumnMigrations() []ColumnMigration {
+	return []ColumnMigration{
+		{`ALTER TABLE sources ADD COLUMN sync_config JSON`, "sync_config"},
+		{`ALTER TABLE messages ADD COLUMN rfc822_message_id TEXT`, "rfc822_message_id"},
+		{`ALTER TABLE sources ADD COLUMN oauth_app TEXT`, "oauth_app"},
+		{`ALTER TABLE participants ADD COLUMN phone_number TEXT`, "phone_number"},
+		{`ALTER TABLE participants ADD COLUMN canonical_id TEXT`, "canonical_id"},
+		{`ALTER TABLE messages ADD COLUMN sender_id INTEGER REFERENCES participants(id)`, "sender_id"},
+		{`ALTER TABLE messages ADD COLUMN message_type TEXT NOT NULL DEFAULT 'email'`, "message_type"},
+		{`ALTER TABLE messages ADD COLUMN attachment_count INTEGER DEFAULT 0`, "attachment_count"},
+		{`ALTER TABLE messages ADD COLUMN deleted_from_source_at DATETIME`, "deleted_from_source_at"},
+		{`ALTER TABLE messages ADD COLUMN deleted_at DATETIME`, "deleted_at"},
+		{`ALTER TABLE messages ADD COLUMN delete_batch_id TEXT`, "delete_batch_id"},
+		{`ALTER TABLE conversations ADD COLUMN title TEXT`, "title"},
+		{`ALTER TABLE conversations ADD COLUMN conversation_type TEXT NOT NULL DEFAULT 'email_thread'`, "conversation_type"},
+	}
+}
+
+// DatabaseSize returns the on-disk size of the SQLite database file.
+// Returns (0, nil) for in-memory databases or when the file cannot be stat'd.
+func (d *SQLiteDialect) DatabaseSize(_ *sql.DB, dbPath string) (int64, error) {
+	if dbPath == "" || dbPath == ":memory:" || strings.Contains(dbPath, ":memory:") {
+		return 0, nil
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return 0, nil
+	}
+	return info.Size(), nil
+}
+
 // InitConn is a no-op for SQLite — PRAGMAs are set via DSN parameters.
 func (d *SQLiteDialect) InitConn(db *sql.DB) error { return nil }
 
@@ -191,6 +276,22 @@ func (d *SQLiteDialect) IsReturningError(err error) bool {
 // the result code is more robust than substring matching: BUSY surfaces as
 // "database is locked" but LOCKED surfaces as "database table is locked",
 // so a single substring cannot catch both.
+// BeginExclusive opens a SQLite "BEGIN EXCLUSIVE" transaction on conn.
+// In WAL mode this blocks concurrent writers while readers can proceed.
+func (d *SQLiteDialect) BeginExclusive(ctx context.Context, conn *sql.Conn) error {
+	_, err := conn.ExecContext(ctx, "BEGIN EXCLUSIVE")
+	return err
+}
+
+// BeginWriteSQL returns "BEGIN IMMEDIATE" so the transaction reserves
+// the SQLite writer lock at BEGIN, removing the snapshot-isolation race
+// that lets two deferred transactions both read the pre-update value.
+func (d *SQLiteDialect) BeginWriteSQL() string { return "BEGIN IMMEDIATE" }
+
+// SelectForUpdate returns "" — SQLite has no FOR UPDATE; serialization
+// comes from BEGIN IMMEDIATE.
+func (d *SQLiteDialect) SelectForUpdate() string { return "" }
+
 func (d *SQLiteDialect) IsBusyError(err error) bool {
 	if err == nil {
 		return false

--- a/internal/store/inspect.go
+++ b/internal/store/inspect.go
@@ -4,6 +4,19 @@ import (
 	"database/sql"
 )
 
+// inspectTimeLayout is the stable format used to render TIMESTAMP /
+// TIMESTAMPTZ columns scanned out of either backend for test
+// assertions. Date and clock components are spelled out separately so
+// assertDateFallback's `strings.Contains` checks continue to match.
+const inspectTimeLayout = "2006-01-02 15:04:05"
+
+func formatInspectTime(t sql.NullTime) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.Time.UTC().Format(inspectTimeLayout)
+}
+
 // MessageInspection contains detailed message data for test assertions.
 type MessageInspection struct {
 	SentAt               string
@@ -25,8 +38,11 @@ func (s *Store) InspectMessage(sourceMessageID string) (*MessageInspection, erro
 		RecipientDisplayName: make(map[string]string),
 	}
 
-	// Get basic message fields and thread info
-	var sentAt, internalDate sql.NullString
+	// Get basic message fields and thread info. Scan timestamps as
+	// sql.NullTime — pgx decodes TIMESTAMPTZ into time.Time and refuses
+	// the conversion to *sql.NullString that the old code attempted, so
+	// the prior shape errored out on PostgreSQL before returning a row.
+	var sentAt, internalDate sql.NullTime
 	err := s.db.QueryRow(`
 		SELECT m.sent_at, m.internal_date, m.deleted_from_source_at, c.source_conversation_id
 		FROM messages m
@@ -36,12 +52,8 @@ func (s *Store) InspectMessage(sourceMessageID string) (*MessageInspection, erro
 	if err != nil {
 		return nil, err
 	}
-	if sentAt.Valid {
-		insp.SentAt = sentAt.String
-	}
-	if internalDate.Valid {
-		insp.InternalDate = internalDate.String
-	}
+	insp.SentAt = formatInspectTime(sentAt)
+	insp.InternalDate = formatInspectTime(internalDate)
 
 	// Get body text
 	var bodyText sql.NullString
@@ -209,10 +221,18 @@ func (s *Store) InspectAttachment(sourceMessageID string) (filename, mimeType st
 	return
 }
 
-// InspectMessageDates returns sent_at and internal_date for a message.
+// InspectMessageDates returns sent_at and internal_date for a message,
+// formatted as "2006-01-02 15:04:05" in UTC. Scanning directly into
+// *string fails on PostgreSQL — pgx decodes TIMESTAMPTZ into time.Time
+// and refuses the implicit conversion — so the read goes through
+// sql.NullTime first.
 func (s *Store) InspectMessageDates(sourceMessageID string) (sentAt, internalDate string, err error) {
+	var sentAtT, internalDateT sql.NullTime
 	err = s.db.QueryRow(
 		"SELECT sent_at, internal_date FROM messages WHERE source_message_id = ?",
-		sourceMessageID).Scan(&sentAt, &internalDate)
-	return
+		sourceMessageID).Scan(&sentAtT, &internalDateT)
+	if err != nil {
+		return "", "", err
+	}
+	return formatInspectTime(sentAtT), formatInspectTime(internalDateT), nil
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -154,31 +154,24 @@ func (s *Store) MessageExistsWithRawBatch(sourceID int64, sourceMessageIDs []str
 }
 
 // EnsureConversation gets or creates a conversation (thread) for a message.
+// Concurrent first-inserts converge via INSERT ... ON CONFLICT DO UPDATE
+// RETURNING id: the no-op SET fires the RETURNING clause for both the
+// insert and the conflict path, so the second caller still receives the
+// existing row's id instead of a unique-violation error.
 func (s *Store) EnsureConversation(sourceID int64, sourceConversationID, title string) (int64, error) {
-	// Try to get existing
+	now := s.dialect.Now()
 	var id int64
-	err := s.db.QueryRow(`
-		SELECT id FROM conversations
-		WHERE source_id = ? AND source_conversation_id = ?
-	`, sourceID, sourceConversationID).Scan(&id)
-
-	if err == nil {
-		return id, nil
-	}
-	if err != sql.ErrNoRows {
-		return 0, err
-	}
-
-	// Create new
-	result, err := s.db.Exec(fmt.Sprintf(`
+	err := s.db.QueryRow(fmt.Sprintf(`
 		INSERT INTO conversations (source_id, source_conversation_id, conversation_type, title, created_at, updated_at)
 		VALUES (?, ?, 'email_thread', ?, %s, %s)
-	`, s.dialect.Now(), s.dialect.Now()), sourceID, sourceConversationID, title)
+		ON CONFLICT (source_id, source_conversation_id) DO UPDATE
+		SET source_conversation_id = conversations.source_conversation_id
+		RETURNING id
+	`, now, now), sourceID, sourceConversationID, title).Scan(&id)
 	if err != nil {
 		return 0, err
 	}
-
-	return result.LastInsertId()
+	return id, nil
 }
 
 // upsertMessageSQL returns the message upsert SQL with dialect-specific timestamp.
@@ -356,31 +349,32 @@ type Participant struct {
 	Domain       sql.NullString
 }
 
-// EnsureParticipant gets or creates a participant by email.
+// EnsureParticipant gets or creates a participant by email. Atomic via
+// INSERT … ON CONFLICT … RETURNING id so two goroutines (or two
+// processes against PostgreSQL) cannot race between a SELECT-empty and
+// the follow-up INSERT and both succeed — one would otherwise lose to
+// the unique constraint on (email_address) with a 23505 error. Display
+// name and domain are left untouched on conflict to preserve any
+// hand-edited values.
 func (s *Store) EnsureParticipant(email, displayName, domain string) (int64, error) {
-	// Try to get existing
+	// ON CONFLICT must mirror the partial unique index on
+	// participants(email_address) WHERE email_address IS NOT NULL — both
+	// PG and SQLite require the WHERE clause on the conflict target to
+	// match the partial index exactly. DO UPDATE (no-op assignment on
+	// the same column) makes RETURNING fire for both INSERT and the
+	// existing-row case, giving us the id either way.
 	var id int64
-	err := s.db.QueryRow(`
-		SELECT id FROM participants WHERE email_address = ?
-	`, email).Scan(&id)
-
-	if err == nil {
-		return id, nil
-	}
-	if err != sql.ErrNoRows {
-		return 0, err
-	}
-
-	// Create new
-	result, err := s.db.Exec(fmt.Sprintf(`
+	err := s.db.QueryRow(fmt.Sprintf(`
 		INSERT INTO participants (email_address, display_name, domain, created_at, updated_at)
 		VALUES (?, ?, ?, %s, %s)
-	`, s.dialect.Now(), s.dialect.Now()), email, displayName, domain)
+		ON CONFLICT (email_address) WHERE email_address IS NOT NULL
+			DO UPDATE SET email_address = EXCLUDED.email_address
+		RETURNING id
+	`, s.dialect.Now(), s.dialect.Now()), email, displayName, domain).Scan(&id)
 	if err != nil {
 		return 0, err
 	}
-
-	return result.LastInsertId()
+	return id, nil
 }
 
 // EnsureParticipantsBatch gets or creates participants in batch.
@@ -646,8 +640,15 @@ func (s *Store) EnsureLabelsBatch(
 	err := s.withTx(func(tx *loggedTx) error {
 		// Phase 1: Move all renamed labels to temporary names so
 		// that cross-renames don't cause one label to incorrectly
-		// merge the other. Temp names use the row PK (unique by
-		// construction) with a prefix that can't be a real label.
+		// merge the other. Temp names embed the row PK (unique by
+		// construction within this source_id) and a SOH (U+0001)
+		// prefix that real Gmail label names cannot contain — Gmail's
+		// UI rejects control characters, so the temp name cannot
+		// collide with any real label name in the same source. The
+		// SQLite-only X'00' hex literal that previously played this
+		// role is not portable: PostgreSQL doesn't parse X'00' and
+		// PG TEXT rejects embedded NUL bytes outright, so we build
+		// the sentinel in Go and bind it as a parameter.
 		for sourceLabelID, info := range labels {
 			var id int64
 			var curName string
@@ -663,10 +664,10 @@ func (s *Store) EnsureLabelsBatch(
 					"check label %s: %w", sourceLabelID, err,
 				)
 			}
+			tempName := fmt.Sprintf("\x01__msgvault_pending_rename__%d", id)
 			if _, err = tx.Exec(`
-				UPDATE labels SET name = CAST(id AS TEXT) || X'00'
-				WHERE id = ?
-			`, id); err != nil {
+				UPDATE labels SET name = ? WHERE id = ?
+			`, tempName, id); err != nil {
 				return fmt.Errorf(
 					"clear name for label %s: %w", sourceLabelID, err,
 				)
@@ -1111,49 +1112,33 @@ func (s *Store) RecomputeConversationStats(sourceID int64) error {
 	return nil
 }
 
-// EnsureConversationWithType gets or creates a conversation with an explicit conversation_type.
-// Unlike EnsureConversation (which hardcodes 'email_thread'), this accepts the type as a parameter,
-// making it suitable for WhatsApp and other messaging platforms.
+// EnsureConversationWithType gets or creates a conversation with an
+// explicit conversation_type. Unlike EnsureConversation (which hardcodes
+// 'email_thread'), this accepts the type as a parameter, making it
+// suitable for WhatsApp and other messaging platforms.
+//
+// Concurrent first-inserts converge via INSERT ... ON CONFLICT DO UPDATE
+// RETURNING id. On conflict, conversation_type is overwritten with the
+// caller's value and title is overwritten only when the caller supplies
+// a non-empty title — preserves the prior behavior of not blanking out
+// stored titles when re-syncs pass an empty value.
 func (s *Store) EnsureConversationWithType(sourceID int64, sourceConversationID, conversationType, title string) (int64, error) {
-	// Try to get existing
-	var id int64
-	err := s.db.QueryRow(`
-		SELECT id FROM conversations
-		WHERE source_id = ? AND source_conversation_id = ?
-	`, sourceID, sourceConversationID).Scan(&id)
-
-	if err == nil {
-		// Update conversation_type and title if they've changed.
-		// Only update title when the new value is non-empty (don't blank out existing titles).
-		now := s.dialect.Now()
-		if title != "" {
-			_, _ = s.db.Exec(fmt.Sprintf(`
-				UPDATE conversations SET conversation_type = ?, title = ?, updated_at = %s
-				WHERE id = ? AND (conversation_type != ? OR title != ? OR title IS NULL)
-			`, now), conversationType, title, id, conversationType, title)
-		} else {
-			_, _ = s.db.Exec(fmt.Sprintf(`
-				UPDATE conversations SET conversation_type = ?, updated_at = %s
-				WHERE id = ? AND conversation_type != ?
-			`, now), conversationType, id, conversationType)
-		}
-		return id, nil
-	}
-	if err != sql.ErrNoRows {
-		return 0, err
-	}
-
-	// Create new
 	now := s.dialect.Now()
-	result, err := s.db.Exec(fmt.Sprintf(`
+	var id int64
+	err := s.db.QueryRow(fmt.Sprintf(`
 		INSERT INTO conversations (source_id, source_conversation_id, conversation_type, title, created_at, updated_at)
 		VALUES (?, ?, ?, ?, %s, %s)
-	`, now, now), sourceID, sourceConversationID, conversationType, title)
+		ON CONFLICT (source_id, source_conversation_id) DO UPDATE
+		SET conversation_type = EXCLUDED.conversation_type,
+		    title = CASE WHEN EXCLUDED.title IS NOT NULL AND EXCLUDED.title != ''
+		                 THEN EXCLUDED.title ELSE conversations.title END,
+		    updated_at = %s
+		RETURNING id
+	`, now, now, now), sourceID, sourceConversationID, conversationType, title).Scan(&id)
 	if err != nil {
 		return 0, err
 	}
-
-	return result.LastInsertId()
+	return id, nil
 }
 
 // EnsureParticipantByPhone gets or creates a participant by phone number.
@@ -1169,37 +1154,30 @@ func (s *Store) EnsureParticipantByPhone(phone, displayName, identifierType stri
 		return 0, fmt.Errorf("phone number must be in E.164 format (starting with +), got %q", phone)
 	}
 
-	// Try to get existing by phone
+	// Atomic upsert via ON CONFLICT — see EnsureParticipant for the
+	// SELECT-then-INSERT race this collapses. The conflict target
+	// mirrors the partial unique index on participants(phone_number)
+	// WHERE phone_number IS NOT NULL exactly, which is required by
+	// both PG and SQLite for partial-index ON CONFLICT to bind. The
+	// DO UPDATE backfills display_name when the existing row has none,
+	// preserving the prior best-effort behaviour without a second
+	// round-trip.
+	now := s.dialect.Now()
 	var id int64
-	err := s.db.QueryRow(`
-		SELECT id FROM participants WHERE phone_number = ?
-	`, phone).Scan(&id)
-
-	if err == nil {
-		// Update display name if provided and currently empty
-		if displayName != "" {
-			_, _ = s.db.Exec(`
-				UPDATE participants SET display_name = ?
-				WHERE id = ? AND (display_name IS NULL OR display_name = '')
-			`, displayName, id) // best-effort display name update, ignore error
-		}
-	} else if err != sql.ErrNoRows {
-		return 0, err
-	} else {
-		// Create new participant
-		now := s.dialect.Now()
-		result, err := s.db.Exec(fmt.Sprintf(`
-			INSERT INTO participants (phone_number, display_name, created_at, updated_at)
-			VALUES (?, ?, %s, %s)
-		`, now, now), phone, displayName)
-		if err != nil {
-			return 0, fmt.Errorf("insert participant: %w", err)
-		}
-
-		id, err = result.LastInsertId()
-		if err != nil {
-			return 0, err
-		}
+	err := s.db.QueryRow(fmt.Sprintf(`
+		INSERT INTO participants (phone_number, display_name, created_at, updated_at)
+		VALUES (?, ?, %s, %s)
+		ON CONFLICT (phone_number) WHERE phone_number IS NOT NULL
+			DO UPDATE SET display_name = CASE
+				WHEN COALESCE(NULLIF(TRIM(participants.display_name), ''), '') = ''
+				     AND EXCLUDED.display_name != ''
+				THEN EXCLUDED.display_name
+				ELSE participants.display_name
+			END
+		RETURNING id
+	`, now, now), phone, displayName).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("upsert participant by phone: %w", err)
 	}
 
 	// Ensure a participant_identifiers row exists for this identifierType.
@@ -1645,26 +1623,42 @@ func (s *Store) IsAttachmentPathReferenced(storagePath string) (bool, error) {
 	return count > 0, nil
 }
 
-// UpsertAttachment stores an attachment record.
+// UpsertAttachment stores an attachment record. Idempotency for the
+// common case is enforced by the partial unique index
+// idx_attachments_msg_content_hash on (message_id, content_hash) where
+// content_hash is non-empty; concurrent inserts collapse to one row via
+// ON CONFLICT DO NOTHING. `size` is widened to int64 at the bind
+// boundary so 32-bit builds cannot truncate large attachments before
+// the column (BIGINT on PG, INTEGER on SQLite).
+//
+// When contentHash is empty (the rare untyped-blob path used by some
+// importers), the unique index does not cover the row; a best-effort
+// (message_id, empty-hash) match is used to avoid trivial duplicates,
+// but two concurrent empty-hash inserts on the same message may both
+// succeed.
 func (s *Store) UpsertAttachment(messageID int64, filename, mimeType, storagePath, contentHash string, size int) error {
-	// Check if attachment already exists (by message_id and content_hash)
+	if contentHash != "" {
+		_, err := s.db.Exec(fmt.Sprintf(`
+			INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, %s)
+			ON CONFLICT (message_id, content_hash) WHERE content_hash IS NOT NULL AND content_hash != '' DO NOTHING
+		`, s.dialect.Now()), messageID, filename, mimeType, storagePath, contentHash, int64(size))
+		return err
+	}
+
 	var existingID int64
 	err := s.db.QueryRow(`
-		SELECT id FROM attachments WHERE message_id = ? AND content_hash = ?
-	`, messageID, contentHash).Scan(&existingID)
-
+		SELECT id FROM attachments WHERE message_id = ? AND (content_hash IS NULL OR content_hash = '')
+	`, messageID).Scan(&existingID)
 	if err == nil {
-		// Already exists, nothing to do
 		return nil
 	}
 	if err != sql.ErrNoRows {
 		return err
 	}
-
-	// Insert new attachment
 	_, err = s.db.Exec(fmt.Sprintf(`
 		INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, %s)
-	`, s.dialect.Now()), messageID, filename, mimeType, storagePath, contentHash, size)
+	`, s.dialect.Now()), messageID, filename, mimeType, storagePath, contentHash, int64(size))
 	return err
 }

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -25,7 +25,7 @@ func TestRecomputeConversationStats(t *testing.T) {
 	// Verify initial message_count is 0 (stats not maintained on insert).
 	var initialCount int
 	if err := st.DB().QueryRow(
-		`SELECT message_count FROM conversations WHERE id = ?`, convID,
+		st.Rebind(`SELECT message_count FROM conversations WHERE id = ?`), convID,
 	).Scan(&initialCount); err != nil {
 		t.Fatalf("initial message_count scan: %v", err)
 	}
@@ -93,8 +93,8 @@ func TestRecomputeConversationStats(t *testing.T) {
 	var lastMsgAt sql.NullTime
 	var preview sql.NullString
 	if err := st.DB().QueryRow(
-		`SELECT message_count, participant_count, last_message_at, last_message_preview
-		 FROM conversations WHERE id = ?`, convID,
+		st.Rebind(`SELECT message_count, participant_count, last_message_at, last_message_preview
+		 FROM conversations WHERE id = ?`), convID,
 	).Scan(&count, &participantCount, &lastMsgAt, &preview); err != nil {
 		t.Fatalf("post-recompute scan: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestRecomputeConversationStats(t *testing.T) {
 		t.Fatalf("RecomputeConversationStats (second call): %v", err)
 	}
 	if err := st.DB().QueryRow(
-		`SELECT message_count FROM conversations WHERE id = ?`, convID,
+		st.Rebind(`SELECT message_count FROM conversations WHERE id = ?`), convID,
 	).Scan(&count); err != nil {
 		t.Fatalf("idempotency scan: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestEnsureParticipantByPhone_IdentifierType(t *testing.T) {
 	// Both participant_identifiers rows should exist
 	var count int
 	err = st.DB().QueryRow(
-		`SELECT COUNT(*) FROM participant_identifiers WHERE participant_id = ?`,
+		st.Rebind(`SELECT COUNT(*) FROM participant_identifiers WHERE participant_id = ?`),
 		id1,
 	).Scan(&count)
 	if err != nil {
@@ -165,8 +165,8 @@ func TestEnsureParticipantByPhone_IdentifierType(t *testing.T) {
 	for _, identType := range []string{"whatsapp", "imessage"} {
 		var exists int
 		err = st.DB().QueryRow(
-			`SELECT COUNT(*) FROM participant_identifiers
-			 WHERE participant_id = ? AND identifier_type = ?`,
+			st.Rebind(`SELECT COUNT(*) FROM participant_identifiers
+			 WHERE participant_id = ? AND identifier_type = ?`),
 			id1, identType,
 		).Scan(&exists)
 		if err != nil {
@@ -183,16 +183,12 @@ func TestUpdateParticipantDisplayNameByEmail(t *testing.T) {
 
 	// Create an unnamed email participant (e.g. inserted by iMessage import
 	// for an Apple ID handle).
-	res, err := st.DB().Exec(
-		`INSERT INTO participants (email_address) VALUES (?)`,
+	var pid int64
+	if err := st.DB().QueryRow(
+		st.Rebind(`INSERT INTO participants (email_address) VALUES (?) RETURNING id`),
 		"alice@example.com",
-	)
-	if err != nil {
+	).Scan(&pid); err != nil {
 		t.Fatalf("insert participant: %v", err)
-	}
-	pid, err := res.LastInsertId()
-	if err != nil {
-		t.Fatalf("LastInsertId: %v", err)
 	}
 
 	// Backfilling on an empty display_name succeeds.
@@ -458,7 +454,7 @@ func readConvTitle(t *testing.T, st *store.Store, id int64) string {
 	t.Helper()
 	var title sql.NullString
 	if err := st.DB().QueryRow(
-		`SELECT title FROM conversations WHERE id = ?`, id,
+		st.Rebind(`SELECT title FROM conversations WHERE id = ?`), id,
 	).Scan(&title); err != nil {
 		t.Fatalf("scan title: %v", err)
 	}
@@ -469,7 +465,7 @@ func readDisplayName(t *testing.T, st *store.Store, pid int64) string {
 	t.Helper()
 	var name sql.NullString
 	if err := st.DB().QueryRow(
-		`SELECT display_name FROM participants WHERE id = ?`, pid,
+		st.Rebind(`SELECT display_name FROM participants WHERE id = ?`), pid,
 	).Scan(&name); err != nil {
 		t.Fatalf("scan display_name: %v", err)
 	}

--- a/internal/store/migrate_phone_unique.go
+++ b/internal/store/migrate_phone_unique.go
@@ -1,0 +1,220 @@
+package store
+
+import (
+	"fmt"
+)
+
+const migrationPhoneUniqueIndex = "participants_phone_unique_index"
+
+// ensureParticipantsPhoneUniqueIndex upgrades legacy databases whose
+// idx_participants_phone was created as a non-unique partial index
+// before the schema flipped it to UNIQUE. Because schema.sql now uses
+// `CREATE UNIQUE INDEX IF NOT EXISTS idx_participants_phone …` and
+// `IF NOT EXISTS` is satisfied by any index of the same name, legacy
+// DBs would silently keep the non-unique index and EnsureParticipant-
+// ByPhone's `ON CONFLICT (phone_number)` would have no matching unique
+// constraint to bind to. The fix is a one-shot migration tracked in
+// applied_migrations:
+//
+//  1. dedupe rows that share a phone_number (re-point participant_id
+//     FKs from losers to the winner, then delete the losers),
+//  2. drop the index unconditionally (drop is harmless if it was
+//     already unique),
+//  3. recreate it as UNIQUE.
+//
+// Works identically on SQLite and PostgreSQL (DROP INDEX IF EXISTS
+// and partial UNIQUE indexes are supported on both).
+func (s *Store) ensureParticipantsPhoneUniqueIndex() error {
+	applied, err := s.IsMigrationApplied(migrationPhoneUniqueIndex)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	if err := s.dedupeParticipantsByPhone(); err != nil {
+		return fmt.Errorf("dedupe participants by phone: %w", err)
+	}
+
+	if _, err := s.db.Exec(`DROP INDEX IF EXISTS idx_participants_phone`); err != nil {
+		return fmt.Errorf("drop idx_participants_phone: %w", err)
+	}
+
+	if _, err := s.db.Exec(`
+		CREATE UNIQUE INDEX idx_participants_phone ON participants(phone_number)
+		    WHERE phone_number IS NOT NULL
+	`); err != nil {
+		return fmt.Errorf("create unique idx_participants_phone: %w", err)
+	}
+
+	return s.MarkMigrationApplied(migrationPhoneUniqueIndex)
+}
+
+// dedupeParticipantsByPhone merges rows that share a non-null
+// phone_number. For each duplicate group the lowest id is kept;
+// foreign-key references on the losers (message_recipients.
+// participant_id, conversation_participants.participant_id,
+// reactions.participant_id, messages.sender_id) are repointed to the
+// winner. Rows that would violate a unique constraint after the
+// repoint are deleted first so the merge is conflict-free. Then the
+// loser participants are deleted, which CASCADEs any remaining
+// references (participant_identifiers etc.).
+func (s *Store) dedupeParticipantsByPhone() error {
+	return s.withTx(func(tx *loggedTx) error {
+		// Pull every participant id involved in a duplicate-phone
+		// group, ordered so the per-phone winner (lowest id) comes
+		// first within each group.
+		rows, err := tx.Query(`
+			SELECT phone_number, id FROM participants
+			 WHERE phone_number IS NOT NULL
+			   AND phone_number IN (
+			       SELECT phone_number FROM participants
+			        WHERE phone_number IS NOT NULL
+			        GROUP BY phone_number
+			       HAVING COUNT(*) > 1
+			   )
+			 ORDER BY phone_number, id
+		`)
+		if err != nil {
+			return fmt.Errorf("scan duplicate phone groups: %w", err)
+		}
+		groups := map[string][]int64{}
+		for rows.Next() {
+			var phone string
+			var id int64
+			if err := rows.Scan(&phone, &id); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan phone dup row: %w", err)
+			}
+			groups[phone] = append(groups[phone], id)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("iterate phone dup rows: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close phone dup rows: %w", err)
+		}
+
+		for _, ids := range groups {
+			if len(ids) < 2 {
+				continue
+			}
+			winner := ids[0]
+			losers := ids[1:]
+			for _, loser := range losers {
+				if err := mergeParticipant(tx, winner, loser); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// mergeParticipant moves every reference from loser onto winner,
+// deleting any rows whose new (winner-scoped) key would clash with an
+// existing row, then deletes loser from participants.
+func mergeParticipant(tx *loggedTx, winner, loser int64) error {
+	// (1) message_recipients UNIQUE(message_id, participant_id, recipient_type)
+	if _, err := tx.Exec(`
+		DELETE FROM message_recipients
+		 WHERE participant_id = ?
+		   AND EXISTS (
+		       SELECT 1 FROM message_recipients mr2
+		        WHERE mr2.participant_id = ?
+		          AND mr2.message_id = message_recipients.message_id
+		          AND mr2.recipient_type = message_recipients.recipient_type
+		   )
+	`, loser, winner); err != nil {
+		return fmt.Errorf("dedupe message_recipients (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE message_recipients SET participant_id = ? WHERE participant_id = ?`,
+		winner, loser,
+	); err != nil {
+		return fmt.Errorf("repoint message_recipients (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+
+	// (2) conversation_participants PRIMARY KEY (conversation_id, participant_id)
+	if _, err := tx.Exec(`
+		DELETE FROM conversation_participants
+		 WHERE participant_id = ?
+		   AND EXISTS (
+		       SELECT 1 FROM conversation_participants cp2
+		        WHERE cp2.participant_id = ?
+		          AND cp2.conversation_id = conversation_participants.conversation_id
+		   )
+	`, loser, winner); err != nil {
+		return fmt.Errorf("dedupe conversation_participants (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE conversation_participants SET participant_id = ? WHERE participant_id = ?`,
+		winner, loser,
+	); err != nil {
+		return fmt.Errorf("repoint conversation_participants (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+
+	// (3) reactions UNIQUE(message_id, participant_id, reaction_type, reaction_value)
+	if _, err := tx.Exec(`
+		DELETE FROM reactions
+		 WHERE participant_id = ?
+		   AND EXISTS (
+		       SELECT 1 FROM reactions r2
+		        WHERE r2.participant_id = ?
+		          AND r2.message_id = reactions.message_id
+		          AND r2.reaction_type = reactions.reaction_type
+		          AND r2.reaction_value = reactions.reaction_value
+		   )
+	`, loser, winner); err != nil {
+		return fmt.Errorf("dedupe reactions (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE reactions SET participant_id = ? WHERE participant_id = ?`,
+		winner, loser,
+	); err != nil {
+		return fmt.Errorf("repoint reactions (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+
+	// (4) messages.sender_id — nullable, no UNIQUE, plain UPDATE.
+	if _, err := tx.Exec(
+		`UPDATE messages SET sender_id = ? WHERE sender_id = ?`,
+		winner, loser,
+	); err != nil {
+		return fmt.Errorf("repoint messages.sender_id (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+
+	// (5) participant_identifiers has ON DELETE CASCADE and no
+	// participant_id-only UNIQUE; the (identifier_type, identifier_value)
+	// UNIQUE is global, not per-participant, so duplicate identifier rows
+	// across the two participants must already have failed at insert
+	// time. Move them onto the winner and rely on the unique constraint
+	// failing only when a true duplicate exists; in practice phone-keyed
+	// participants rarely have non-phone identifiers attached.
+	if _, err := tx.Exec(`
+		DELETE FROM participant_identifiers
+		 WHERE participant_id = ?
+		   AND EXISTS (
+		       SELECT 1 FROM participant_identifiers pi2
+		        WHERE pi2.participant_id = ?
+		          AND pi2.identifier_type = participant_identifiers.identifier_type
+		          AND pi2.identifier_value = participant_identifiers.identifier_value
+		   )
+	`, loser, winner); err != nil {
+		return fmt.Errorf("dedupe participant_identifiers (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE participant_identifiers SET participant_id = ? WHERE participant_id = ?`,
+		winner, loser,
+	); err != nil {
+		return fmt.Errorf("repoint participant_identifiers (loser=%d, winner=%d): %w", loser, winner, err)
+	}
+
+	// (6) Finally drop the loser. participant_identifiers cascades; the
+	// other FKs are already cleared by the repoints above.
+	if _, err := tx.Exec(`DELETE FROM participants WHERE id = ?`, loser); err != nil {
+		return fmt.Errorf("delete loser participant id=%d: %w", loser, err)
+	}
+	return nil
+}

--- a/internal/store/migrate_phone_unique_test.go
+++ b/internal/store/migrate_phone_unique_test.go
@@ -1,0 +1,260 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEnsureParticipantsPhoneUniqueIndex_LegacyNonUnique simulates an
+// upgraded database whose idx_participants_phone was created as a
+// NON-unique partial index (the shape before the schema bumped it to
+// UNIQUE). The migration must:
+//
+//  1. recognise that the migration has not yet run (applied_migrations
+//     entry absent),
+//  2. dedupe duplicate phone rows by re-pointing FKs from losers to
+//     the winner (lowest id), then deleting losers,
+//  3. drop the legacy non-unique index and create a UNIQUE one,
+//  4. mark the migration applied so subsequent InitSchema calls are
+//     no-ops.
+//
+// The post-state is verified end-to-end: only one participant row per
+// phone, FKs were preserved (no orphan recipients), and a second
+// EnsureParticipantByPhone with the same number returns the existing
+// id (proving ON CONFLICT (phone_number) now binds to a real UNIQUE
+// constraint).
+func TestEnsureParticipantsPhoneUniqueIndex_LegacyNonUnique(t *testing.T) {
+	// SQLite-only: this test pokes at sqlite_master and reseats the
+	// applied_migrations row directly. The PG equivalent of the
+	// migration is exercised by TestEnsureParticipantByPhone_Concurrent
+	// (which would error at the first concurrent insert without a
+	// real UNIQUE constraint).
+	dbPath := filepath.Join(t.TempDir(), "phone_unique.db")
+	st, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.InitSchema(); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	// Roll back to the "legacy" state: clear the applied_migrations
+	// sentinel, drop the unique index, recreate as non-unique.
+	if _, err := st.db.Exec(
+		`DELETE FROM applied_migrations WHERE name = ?`, migrationPhoneUniqueIndex,
+	); err != nil {
+		t.Fatalf("clear migration sentinel: %v", err)
+	}
+	if _, err := st.db.Exec(`DROP INDEX IF EXISTS idx_participants_phone`); err != nil {
+		t.Fatalf("drop unique idx: %v", err)
+	}
+	if _, err := st.db.Exec(`
+		CREATE INDEX idx_participants_phone ON participants(phone_number)
+		    WHERE phone_number IS NOT NULL
+	`); err != nil {
+		t.Fatalf("create legacy non-unique idx: %v", err)
+	}
+
+	// Seed two duplicate-phone participants directly (the public API
+	// no longer allows this, which is exactly the bug the unique
+	// index closes). Use a source + conversation + messages so the
+	// FK-repoint paths are also exercised.
+	source, err := st.GetOrCreateSource("imessage", "+15555550100")
+	if err != nil {
+		t.Fatalf("GetOrCreateSource: %v", err)
+	}
+	convID, err := st.EnsureConversation(source.ID, "thread-phone-dup", "")
+	if err != nil {
+		t.Fatalf("EnsureConversation: %v", err)
+	}
+
+	// Two raw inserts that share +15555551234. id1 wins, id2 loses.
+	insertParticipant := func(phone, displayName string) int64 {
+		t.Helper()
+		var id int64
+		err := st.db.QueryRow(`
+			INSERT INTO participants (phone_number, display_name, created_at, updated_at)
+			VALUES (?, ?, datetime('now'), datetime('now'))
+			RETURNING id
+		`, phone, displayName).Scan(&id)
+		if err != nil {
+			t.Fatalf("insert participant %s: %v", phone, err)
+		}
+		return id
+	}
+	winner := insertParticipant("+15555551234", "Alice")
+	loser := insertParticipant("+15555551234", "Alice (dup)")
+
+	// Make sure the legacy schema actually permitted the duplicate.
+	if winner == loser {
+		t.Fatalf("seeded participants must have distinct ids (got %d, %d)", winner, loser)
+	}
+
+	// Attach FK references to BOTH participants so we can prove the
+	// repoint+dedupe logic runs end-to-end:
+	//   - a message recipient on each (different message → no key
+	//     conflict, both rows should survive the repoint onto winner)
+	//   - a recipient where winner+loser appear on the SAME message
+	//     with the same type → the loser row must be removed before
+	//     the repoint (UNIQUE(message_id, participant_id, recipient_type))
+	//   - a sender_id on a third message pointing to loser → plain
+	//     UPDATE
+	msgA, err := st.UpsertMessage(&Message{
+		ConversationID:  convID,
+		SourceID:        source.ID,
+		SourceMessageID: "msg-A",
+		MessageType:     "imessage",
+		Subject:         sql.NullString{String: "A", Valid: true},
+		SizeEstimate:    100,
+	})
+	if err != nil {
+		t.Fatalf("UpsertMessage A: %v", err)
+	}
+	msgB, err := st.UpsertMessage(&Message{
+		ConversationID:  convID,
+		SourceID:        source.ID,
+		SourceMessageID: "msg-B",
+		MessageType:     "imessage",
+		Subject:         sql.NullString{String: "B", Valid: true},
+		SizeEstimate:    100,
+	})
+	if err != nil {
+		t.Fatalf("UpsertMessage B: %v", err)
+	}
+	msgC, err := st.UpsertMessage(&Message{
+		ConversationID:  convID,
+		SourceID:        source.ID,
+		SourceMessageID: "msg-C",
+		MessageType:     "imessage",
+		Subject:         sql.NullString{String: "C", Valid: true},
+		SizeEstimate:    100,
+	})
+	if err != nil {
+		t.Fatalf("UpsertMessage C: %v", err)
+	}
+
+	exec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := st.db.Exec(q, args...); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	// Recipient on msg-A: only loser → survives, repoints to winner.
+	exec(`INSERT INTO message_recipients (message_id, participant_id, recipient_type) VALUES (?, ?, 'to')`,
+		msgA, loser)
+	// Recipient on msg-B: both winner and loser as 'to' → loser must
+	// be deleted before the repoint to avoid violating the UNIQUE.
+	exec(`INSERT INTO message_recipients (message_id, participant_id, recipient_type) VALUES (?, ?, 'to')`,
+		msgB, winner)
+	exec(`INSERT INTO message_recipients (message_id, participant_id, recipient_type) VALUES (?, ?, 'to')`,
+		msgB, loser)
+	// Sender on msg-C: loser → plain UPDATE onto winner.
+	exec(`UPDATE messages SET sender_id = ? WHERE id = ?`, loser, msgC)
+
+	// Run the migration we are testing.
+	if err := st.ensureParticipantsPhoneUniqueIndex(); err != nil {
+		t.Fatalf("ensureParticipantsPhoneUniqueIndex: %v", err)
+	}
+
+	// 1) Loser row must be gone.
+	var loserCount int
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM participants WHERE id = ?`, loser).Scan(&loserCount); err != nil {
+		t.Fatalf("count loser: %v", err)
+	}
+	if loserCount != 0 {
+		t.Errorf("loser participant %d still present after merge", loser)
+	}
+
+	// 2) Exactly one participant for the duplicated phone.
+	var phoneCount int
+	if err := st.db.QueryRow(
+		`SELECT COUNT(*) FROM participants WHERE phone_number = ?`,
+		"+15555551234",
+	).Scan(&phoneCount); err != nil {
+		t.Fatalf("count duplicates: %v", err)
+	}
+	if phoneCount != 1 {
+		t.Errorf("phone +15555551234 row count = %d, want 1 after dedupe", phoneCount)
+	}
+
+	// 3) msg-A recipient now points at winner (repoint succeeded).
+	var msgAParticipant int64
+	if err := st.db.QueryRow(
+		`SELECT participant_id FROM message_recipients WHERE message_id = ? AND recipient_type = 'to'`,
+		msgA,
+	).Scan(&msgAParticipant); err != nil {
+		t.Fatalf("read msg-A recipient: %v", err)
+	}
+	if msgAParticipant != winner {
+		t.Errorf("msg-A recipient = %d, want winner %d", msgAParticipant, winner)
+	}
+
+	// 4) msg-B has exactly one 'to' recipient (winner) — the loser
+	//    row was collapsed into the winner row by the dedupe step.
+	var msgBCount int
+	if err := st.db.QueryRow(
+		`SELECT COUNT(*) FROM message_recipients WHERE message_id = ? AND recipient_type = 'to'`,
+		msgB,
+	).Scan(&msgBCount); err != nil {
+		t.Fatalf("count msg-B recipients: %v", err)
+	}
+	if msgBCount != 1 {
+		t.Errorf("msg-B 'to' recipient count = %d, want 1", msgBCount)
+	}
+	var msgBParticipant int64
+	if err := st.db.QueryRow(
+		`SELECT participant_id FROM message_recipients WHERE message_id = ? AND recipient_type = 'to'`,
+		msgB,
+	).Scan(&msgBParticipant); err != nil {
+		t.Fatalf("read msg-B recipient: %v", err)
+	}
+	if msgBParticipant != winner {
+		t.Errorf("msg-B recipient = %d, want winner %d", msgBParticipant, winner)
+	}
+
+	// 5) msg-C sender_id repointed to winner.
+	var msgCSender sql.NullInt64
+	if err := st.db.QueryRow(`SELECT sender_id FROM messages WHERE id = ?`, msgC).Scan(&msgCSender); err != nil {
+		t.Fatalf("read msg-C sender: %v", err)
+	}
+	if !msgCSender.Valid || msgCSender.Int64 != winner {
+		t.Errorf("msg-C sender = %+v, want winner %d", msgCSender, winner)
+	}
+
+	// 6) The index is now UNIQUE. Verify via sqlite_master.
+	var sqlDef string
+	if err := st.db.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_participants_phone'`,
+	).Scan(&sqlDef); err != nil {
+		t.Fatalf("read idx_participants_phone sql: %v", err)
+	}
+	if !strings.Contains(strings.ToUpper(sqlDef), "UNIQUE") {
+		t.Errorf("idx_participants_phone is not UNIQUE after migration; got %q", sqlDef)
+	}
+
+	// 7) Migration sentinel is set, so a re-run is a no-op.
+	applied, err := st.IsMigrationApplied(migrationPhoneUniqueIndex)
+	if err != nil {
+		t.Fatalf("IsMigrationApplied: %v", err)
+	}
+	if !applied {
+		t.Errorf("migration sentinel not set after successful run")
+	}
+	if err := st.ensureParticipantsPhoneUniqueIndex(); err != nil {
+		t.Errorf("re-run of ensureParticipantsPhoneUniqueIndex must be a no-op, got %v", err)
+	}
+
+	// 8) Public API: EnsureParticipantByPhone with the duplicated
+	//    number returns the winner id (the unique index is now
+	//    actually enforcing ON CONFLICT (phone_number)).
+	gotID, err := st.EnsureParticipantByPhone("+15555551234", "Alice (later call)", "imessage")
+	if err != nil {
+		t.Fatalf("EnsureParticipantByPhone: %v", err)
+	}
+	if gotID != winner {
+		t.Errorf("EnsureParticipantByPhone returned id %d, want winner %d (ON CONFLICT must find the unique index)", gotID, winner)
+	}
+}

--- a/internal/store/pg_compat_test.go
+++ b/internal/store/pg_compat_test.go
@@ -1,0 +1,384 @@
+package store_test
+
+import (
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+// TestInspectMessage_TimestampScan exercises the inspect.go fix that
+// switched sent_at / internal_date scanning from sql.NullString to
+// sql.NullTime. Under PG (MSGVAULT_TEST_DB=postgres://…) the prior
+// shape errored at Scan because pgx decodes TIMESTAMPTZ as time.Time
+// and refuses to convert to *string. Under SQLite the test asserts
+// the formatted string still contains the expected date/time pieces.
+func TestInspectMessage_TimestampScan(t *testing.T) {
+	f := storetest.New(t)
+
+	sent := time.Date(2025, 6, 15, 12, 30, 45, 0, time.UTC)
+	mid := f.NewMessage().
+		WithSourceMessageID("inspect-msg-1").
+		WithSubject("hello").
+		WithSentAt(sent).
+		WithInternalDate(sent).
+		Create(t, f.Store)
+	_ = mid
+
+	insp, err := f.Store.InspectMessage("inspect-msg-1")
+	if err != nil {
+		t.Fatalf("InspectMessage: %v", err)
+	}
+	if insp.SentAt == "" {
+		t.Error("SentAt should not be empty after a non-NULL insert")
+	}
+	if insp.InternalDate == "" {
+		t.Error("InternalDate should not be empty after a non-NULL insert")
+	}
+
+	sentAtStr, internalDateStr, err := f.Store.InspectMessageDates("inspect-msg-1")
+	if err != nil {
+		t.Fatalf("InspectMessageDates: %v", err)
+	}
+	if sentAtStr != insp.SentAt {
+		t.Errorf("InspectMessageDates sentAt = %q, want %q", sentAtStr, insp.SentAt)
+	}
+	if internalDateStr != insp.InternalDate {
+		t.Errorf("InspectMessageDates internalDate = %q, want %q",
+			internalDateStr, insp.InternalDate)
+	}
+}
+
+// TestSearchMessagesQuery_SubjectLikeCaseInsensitive covers H3+H4: the
+// subject: filter and the LIKE fallback must be case-insensitive on
+// both backends. SQLite's ASCII LIKE is case-insensitive by default;
+// PG's is strict-case. The fix wraps both sides in LOWER so a query
+// for "Invoice" matches "invoice from acme".
+func TestSearchMessagesQuery_SubjectLikeCaseInsensitive(t *testing.T) {
+	f := storetest.New(t)
+
+	mid := f.NewMessage().
+		WithSourceMessageID("subj-msg-1").
+		WithSubject("invoice from acme").
+		WithSnippet("see attached").
+		Create(t, f.Store)
+	if err := f.Store.UpsertMessageBody(mid,
+		sql.NullString{String: "body", Valid: true}, sql.NullString{}); err != nil {
+		t.Fatalf("UpsertMessageBody: %v", err)
+	}
+	if _, err := f.Store.BackfillFTS(nil); err != nil {
+		t.Fatalf("BackfillFTS: %v", err)
+	}
+
+	msgs, total, err := f.Store.SearchMessagesQuery(
+		&search.Query{SubjectTerms: []string{"Invoice"}}, 0, 50,
+	)
+	if err != nil {
+		t.Fatalf("SearchMessagesQuery: %v", err)
+	}
+	if total != 1 || len(msgs) != 1 {
+		t.Fatalf("Subject:Invoice → got %d hits, want 1 (case-insensitive on both backends)", total)
+	}
+}
+
+// TestSearchMessagesQuery_ToFilterCaseInsensitive covers M2: the To/Cc/
+// Bcc IN-list args in buildSearchQueryParts now lowercase Go-side so
+// the LOWER(p.email_address) IN (...) predicate matches against
+// case-folded participants.
+func TestSearchMessagesQuery_ToFilterCaseInsensitive(t *testing.T) {
+	f := storetest.New(t)
+
+	to, err := f.Store.EnsureParticipant("alice@example.com", "Alice", "example.com")
+	testutil.MustNoErr(t, err, "EnsureParticipant")
+
+	mid := f.NewMessage().
+		WithSourceMessageID("to-msg-1").
+		WithSubject("greetings").
+		Create(t, f.Store)
+	testutil.MustNoErr(t,
+		f.Store.ReplaceMessageRecipients(mid, "to", []int64{to}, []string{"Alice"}),
+		"ReplaceMessageRecipients to")
+
+	if _, err := f.Store.BackfillFTS(nil); err != nil {
+		t.Fatalf("BackfillFTS: %v", err)
+	}
+
+	msgs, total, err := f.Store.SearchMessagesQuery(
+		&search.Query{ToAddrs: []string{"Alice@Example.COM"}}, 0, 50,
+	)
+	if err != nil {
+		t.Fatalf("SearchMessagesQuery: %v", err)
+	}
+	if total != 1 || len(msgs) != 1 {
+		t.Fatalf("to:Alice@Example.COM → got %d hits, want 1 (case-insensitive)", total)
+	}
+}
+
+// TestSearchMessages_R3PunctuationTerms covers R3: the raw search path
+// must not feed `to_tsquery` invalid lexemes built from punctuation-
+// heavy input. Before the fix, a query like `---` or `foo-bar` would
+// emit `---:*` / `foo-bar:*` and PG would error at parse time
+// ("syntax error in tsquery"). The fix tokenizes user terms into
+// letter/digit-only lexemes so punctuation-only inputs collapse to
+// FALSE and hyphenated/email/dotted inputs decompose into individual
+// lexemes that to_tsquery accepts.
+//
+// On both backends the test asserts the query returns *no error* —
+// that's the load-bearing R3 guarantee. Lexeme-level matching is
+// unit-tested via TestPostgreSQLDialect_BuildFTSArg; we don't assert
+// hit counts here because SQLite's FTS5 path strips punctuation
+// without splitting (e.g. `foo-bar` becomes `foobar`, which won't
+// match a body containing the two separate words), so cross-backend
+// match-count assertions would diverge.
+func TestSearchMessages_R3PunctuationTerms(t *testing.T) {
+	f := storetest.New(t)
+
+	msg1 := f.NewMessage().
+		WithSourceMessageID("r3-msg-1").
+		WithSubject("project foo bar").
+		WithSnippet("foo bar baz").
+		Create(t, f.Store)
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msg1,
+		sql.NullString{String: "foo and bar appear together here", Valid: true},
+		sql.NullString{}), "UpsertMessageBody 1")
+
+	msg2 := f.NewMessage().
+		WithSourceMessageID("r3-msg-2").
+		WithSubject("email from alice").
+		WithSnippet("contact us at user@example.com please").
+		Create(t, f.Store)
+	testutil.MustNoErr(t, f.Store.UpsertMessageBody(msg2,
+		sql.NullString{String: "reach us at user@example.com for support", Valid: true},
+		sql.NullString{}), "UpsertMessageBody 2")
+
+	if _, err := f.Store.BackfillFTS(nil); err != nil {
+		t.Fatalf("BackfillFTS: %v", err)
+	}
+
+	queries := []string{
+		"---",              // dashes-only — used to crash to_tsquery
+		"...",              // dots-only
+		"foo-bar",          // hyphenated word
+		"user@example.com", // email-like
+		"a.b.c",            // dotted acronym
+		"foo ---",          // mixed clean + punct
+		"v1.2.3-rc.1",      // version-like punctuation
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			_, _, err := f.Store.SearchMessages(q, 0, 50)
+			if err != nil {
+				t.Errorf("SearchMessages(%q): unexpected error %v (must accept punctuation-heavy input without erroring)", q, err)
+			}
+		})
+	}
+}
+
+// TestEnsureParticipant_Concurrent covers H5: 50 goroutines all
+// calling EnsureParticipant with the same email must produce exactly
+// one row and no errors. The fix collapsed the SELECT-then-INSERT
+// race into a single INSERT … ON CONFLICT … RETURNING id statement.
+func TestEnsureParticipant_Concurrent(t *testing.T) {
+	st := testutil.NewTestStore(t)
+
+	const N = 50
+	var wg sync.WaitGroup
+	ids := make([]int64, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			id, err := st.EnsureParticipant("race@example.com", "Race", "example.com")
+			ids[idx] = id
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: EnsureParticipant: %v", i, err)
+		}
+	}
+	first := ids[0]
+	for i, id := range ids {
+		if id != first {
+			t.Errorf("goroutine %d returned id %d, want %d (every caller must observe the same row)", i, id, first)
+		}
+	}
+
+	var count int
+	if err := st.DB().QueryRow(
+		st.Rebind("SELECT COUNT(*) FROM participants WHERE email_address = ?"),
+		"race@example.com",
+	).Scan(&count); err != nil {
+		t.Fatalf("count participants: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("got %d participant rows for race@example.com, want exactly 1", count)
+	}
+}
+
+// TestEnsureParticipantByPhone_Concurrent covers H6: same race shape
+// for the phone path. With the partial unique index on phone_number
+// now in place, concurrent inserts collapse to one row via the
+// ON CONFLICT clause.
+func TestEnsureParticipantByPhone_Concurrent(t *testing.T) {
+	st := testutil.NewTestStore(t)
+
+	const N = 50
+	var wg sync.WaitGroup
+	ids := make([]int64, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			id, err := st.EnsureParticipantByPhone("+15555550100", "Bob", "whatsapp")
+			ids[idx] = id
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: EnsureParticipantByPhone: %v", i, err)
+		}
+	}
+	first := ids[0]
+	for i, id := range ids {
+		if id != first {
+			t.Errorf("goroutine %d returned id %d, want %d", i, id, first)
+		}
+	}
+
+	var count int
+	if err := st.DB().QueryRow(
+		st.Rebind("SELECT COUNT(*) FROM participants WHERE phone_number = ?"),
+		"+15555550100",
+	).Scan(&count); err != nil {
+		t.Fatalf("count participants: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("got %d participant rows for +15555550100, want exactly 1", count)
+	}
+}
+
+// TestAddAccountIdentity_Concurrent covers M1: concurrent confirmations
+// of the same (source_id, address) collapse to exactly one row, and
+// merging different signals across calls preserves the union.
+func TestAddAccountIdentity_Concurrent(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("gmail", "race-identity@example.com")
+	testutil.MustNoErr(t, err, "GetOrCreateSource")
+
+	const N = 50
+	signals := []string{"manual", "account-identifier", "header"}
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			signal := signals[idx%len(signals)]
+			errs[idx] = st.AddAccountIdentity(src.ID, "user@example.com", signal)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: AddAccountIdentity: %v", i, err)
+		}
+	}
+
+	identities, err := st.ListAccountIdentities(src.ID)
+	if err != nil {
+		t.Fatalf("ListAccountIdentities: %v", err)
+	}
+	if len(identities) != 1 {
+		t.Fatalf("got %d identity rows, want exactly 1", len(identities))
+	}
+	got := identities[0].SourceSignal
+	// All three signals must appear in the merged comma-separated set.
+	for _, want := range signals {
+		if !containsSignal(got, want) {
+			t.Errorf("merged source_signal %q missing %q", got, want)
+		}
+	}
+}
+
+func containsSignal(set, signal string) bool {
+	for _, s := range splitComma(set) {
+		if s == signal {
+			return true
+		}
+	}
+	return false
+}
+
+func splitComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := []string{}
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return out
+}
+
+// TestUpsertAttachment_Concurrent covers M5: two goroutines uploading
+// the same (message_id, content_hash) attachment race; the retry loop
+// must collapse to one row with no error.
+func TestUpsertAttachment_Concurrent(t *testing.T) {
+	f := storetest.New(t)
+	mid := f.NewMessage().WithSourceMessageID("att-msg-1").Create(t, f.Store)
+
+	const N = 20
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = f.Store.UpsertAttachment(
+				mid, "file.pdf", "application/pdf",
+				"ab/abcd1234", "abcd1234", 1024,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: UpsertAttachment: %v", i, err)
+		}
+	}
+
+	var count int
+	if err := f.Store.DB().QueryRow(
+		f.Store.Rebind("SELECT COUNT(*) FROM attachments WHERE message_id = ? AND content_hash = ?"),
+		mid, "abcd1234",
+	).Scan(&count); err != nil {
+		t.Fatalf("count attachments: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("got %d attachment rows, want exactly 1", count)
+	}
+}
+
+// silenceUnused references the imports the test would otherwise drop on
+// builds where some helpers are tag-gated.
+var _ = store.Source{}

--- a/internal/store/rebuild_fts_test.go
+++ b/internal/store/rebuild_fts_test.go
@@ -12,6 +12,7 @@ import (
 // TestStore_RebuildFTS_HappyPath verifies RebuildFTS on a healthy database
 // recreates the FTS index with correct searchable content.
 func TestStore_RebuildFTS_HappyPath(t *testing.T) {
+	testutil.SkipIfPostgres(t, "RebuildFTS is SQLite-specific (drop/recreate messages_fts vtable); PG RebuildFTS is not yet implemented (PR4 scope)")
 	f := storetest.New(t)
 	if !f.Store.FTS5Available() {
 		t.Skip("FTS5 not available")
@@ -59,6 +60,7 @@ func TestStore_RebuildFTS_HappyPath(t *testing.T) {
 // when the rebuild is needed — BackfillFTS would short-circuit here, but
 // RebuildFTS must not.
 func TestStore_RebuildFTS_BypassesAvailabilityFlag(t *testing.T) {
+	testutil.SkipIfPostgres(t, "RebuildFTS is SQLite-specific (drop/recreate messages_fts vtable); PG RebuildFTS is not yet implemented (PR4 scope)")
 	f := storetest.New(t)
 	if !f.Store.FTS5Available() {
 		t.Skip("FTS5 not available")
@@ -96,6 +98,7 @@ func TestStore_RebuildFTS_BypassesAvailabilityFlag(t *testing.T) {
 // messages_fts from scratch when the table is missing entirely — the
 // post-DROP state from the manual recovery procedure in issue #287.
 func TestStore_RebuildFTS_AfterTableDropped(t *testing.T) {
+	testutil.SkipIfPostgres(t, "RebuildFTS is SQLite-specific (drop/recreate messages_fts vtable); PG RebuildFTS is not yet implemented (PR4 scope)")
 	f := storetest.New(t)
 	if !f.Store.FTS5Available() {
 		t.Skip("FTS5 not available")
@@ -127,6 +130,7 @@ func TestStore_RebuildFTS_AfterTableDropped(t *testing.T) {
 // TestStore_RebuildFTS_ReportsProgress verifies the progress callback is
 // invoked with monotonic (done, total) values.
 func TestStore_RebuildFTS_ReportsProgress(t *testing.T) {
+	testutil.SkipIfPostgres(t, "RebuildFTS is SQLite-specific (drop/recreate messages_fts vtable); PG RebuildFTS is not yet implemented (PR4 scope)")
 	f := storetest.New(t)
 	if !f.Store.FTS5Available() {
 		t.Skip("FTS5 not available")

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -324,8 +324,10 @@ CREATE INDEX IF NOT EXISTS idx_sources_type ON sources(source_type);
 -- Participants
 CREATE UNIQUE INDEX IF NOT EXISTS idx_participants_email ON participants(email_address)
     WHERE email_address IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_participants_phone ON participants(phone_number)
-    WHERE phone_number IS NOT NULL;
+-- idx_participants_phone is created (and upgraded from the legacy
+-- non-unique form) in Go by Store.ensureParticipantsPhoneUniqueIndex
+-- so existing DBs whose IF NOT EXISTS no-op'd the schema bump still
+-- end up with a UNIQUE partial index.
 CREATE INDEX IF NOT EXISTS idx_participants_canonical ON participants(canonical_id)
     WHERE canonical_id IS NOT NULL;
 
@@ -358,6 +360,9 @@ CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_message ON attachments(message_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_hash ON attachments(content_hash);
 CREATE INDEX IF NOT EXISTS idx_attachments_storage_path ON attachments(storage_path);
+-- The partial unique index on (message_id, content_hash) for
+-- UpsertAttachment idempotency is created in Go (Store.InitSchema)
+-- after a one-shot dedupe of legacy duplicate rows.
 
 -- Labels
 CREATE INDEX IF NOT EXISTS idx_labels_source ON labels(source_id);

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -1,7 +1,367 @@
--- PostgreSQL-specific extensions (tsvector for full-text search)
+-- msgvault PostgreSQL schema
+-- Native PostgreSQL types and identity columns, parallel to schema.sql.
 
--- Full-text search column and GIN index on messages.
--- Unlike SQLite's FTS5 virtual table, PostgreSQL stores the tsvector
--- directly on the messages table. Updates are managed via Store.UpsertFTS().
-ALTER TABLE messages ADD COLUMN IF NOT EXISTS search_fts TSVECTOR;
+-- ============================================================================
+-- SOURCES & IDENTITY
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS sources (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    source_type TEXT NOT NULL,
+    identifier TEXT NOT NULL,
+    display_name TEXT,
+
+    google_user_id TEXT UNIQUE,
+
+    last_sync_at TIMESTAMPTZ,
+    sync_cursor TEXT,
+    sync_config JSONB,
+    oauth_app TEXT,
+
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE(source_type, identifier)
+);
+
+CREATE TABLE IF NOT EXISTS participants (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    email_address TEXT,
+    phone_number TEXT,
+    display_name TEXT,
+    domain TEXT,
+
+    canonical_id TEXT,
+
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS participant_identifiers (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    participant_id BIGINT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+
+    identifier_type TEXT NOT NULL,
+    identifier_value TEXT NOT NULL,
+    display_value TEXT,
+
+    is_primary BOOLEAN DEFAULT FALSE,
+
+    UNIQUE(identifier_type, identifier_value)
+);
+
+-- ============================================================================
+-- CONVERSATIONS & MESSAGES
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS conversations (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+
+    source_conversation_id TEXT,
+
+    conversation_type TEXT NOT NULL DEFAULT 'email_thread',
+    title TEXT,
+
+    participant_count INTEGER DEFAULT 0,
+    message_count INTEGER DEFAULT 0,
+    unread_count INTEGER DEFAULT 0,
+    last_message_at TIMESTAMPTZ,
+    last_message_preview TEXT,
+
+    metadata JSONB,
+
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE(source_id, source_conversation_id)
+);
+
+CREATE TABLE IF NOT EXISTS conversation_participants (
+    conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    participant_id BIGINT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+
+    role TEXT DEFAULT 'member',
+    joined_at TIMESTAMPTZ,
+    left_at TIMESTAMPTZ,
+
+    PRIMARY KEY (conversation_id, participant_id)
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+
+    source_message_id TEXT,
+    rfc822_message_id TEXT,
+
+    message_type TEXT NOT NULL DEFAULT 'email',
+
+    sent_at TIMESTAMPTZ,
+    received_at TIMESTAMPTZ,
+    read_at TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    internal_date TIMESTAMPTZ,
+
+    sender_id BIGINT REFERENCES participants(id),
+    is_from_me BOOLEAN DEFAULT FALSE,
+
+    subject TEXT,
+    snippet TEXT,
+
+    reply_to_message_id BIGINT REFERENCES messages(id),
+    thread_position INTEGER,
+
+    is_read BOOLEAN DEFAULT TRUE,
+    is_delivered BOOLEAN,
+    is_sent BOOLEAN DEFAULT TRUE,
+    is_edited BOOLEAN DEFAULT FALSE,
+    is_forwarded BOOLEAN DEFAULT FALSE,
+
+    size_estimate BIGINT,
+    has_attachments BOOLEAN DEFAULT FALSE,
+    attachment_count INTEGER DEFAULT 0,
+
+    deleted_at TIMESTAMPTZ,
+    deleted_from_source_at TIMESTAMPTZ,
+    delete_batch_id TEXT,
+
+    archived_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    indexing_version INTEGER DEFAULT 1,
+
+    metadata JSONB,
+
+    -- Full-text search column
+    search_fts TSVECTOR,
+
+    UNIQUE(source_id, source_message_id)
+);
+
+CREATE TABLE IF NOT EXISTS message_recipients (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    message_id BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    participant_id BIGINT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+
+    recipient_type TEXT NOT NULL,
+    display_name TEXT,
+
+    UNIQUE(message_id, participant_id, recipient_type)
+);
+
+-- ============================================================================
+-- REACTIONS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS reactions (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    message_id BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    participant_id BIGINT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+
+    reaction_type TEXT NOT NULL,
+    reaction_value TEXT NOT NULL,
+
+    created_at TIMESTAMPTZ,
+    removed_at TIMESTAMPTZ,
+
+    UNIQUE(message_id, participant_id, reaction_type, reaction_value)
+);
+
+-- ============================================================================
+-- ATTACHMENTS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS attachments (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    message_id BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+
+    filename TEXT,
+    mime_type TEXT,
+    size BIGINT,
+
+    content_hash TEXT,
+    storage_path TEXT NOT NULL DEFAULT '',
+
+    media_type TEXT,
+    width INTEGER,
+    height INTEGER,
+    duration_ms INTEGER,
+
+    thumbnail_hash TEXT,
+    thumbnail_path TEXT,
+
+    source_attachment_id TEXT,
+    attachment_metadata JSONB,
+
+    encryption_version INTEGER DEFAULT 0,
+
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================================
+-- LABELS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS labels (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    source_id BIGINT REFERENCES sources(id) ON DELETE CASCADE,
+
+    source_label_id TEXT,
+    name TEXT NOT NULL,
+    label_type TEXT,
+    color TEXT,
+
+    UNIQUE(source_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS message_labels (
+    message_id BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    label_id BIGINT NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+
+    PRIMARY KEY (message_id, label_id)
+);
+
+-- ============================================================================
+-- RAW DATA
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS message_bodies (
+    message_id BIGINT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+    body_text TEXT,
+    body_html TEXT
+);
+
+CREATE TABLE IF NOT EXISTS message_raw (
+    message_id BIGINT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+
+    raw_data BYTEA NOT NULL,
+    raw_format TEXT NOT NULL,
+
+    compression TEXT DEFAULT 'zlib',
+    encryption_version INTEGER DEFAULT 0
+);
+
+-- ============================================================================
+-- SYNC STATE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS sync_runs (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+
+    started_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'running',
+
+    messages_processed BIGINT DEFAULT 0,
+    messages_added BIGINT DEFAULT 0,
+    messages_updated BIGINT DEFAULT 0,
+    errors_count BIGINT DEFAULT 0,
+
+    error_message TEXT,
+    cursor_before TEXT,
+    cursor_after TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sync_checkpoints (
+    source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    checkpoint_type TEXT NOT NULL,
+    checkpoint_value TEXT NOT NULL,
+
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (source_id, checkpoint_type)
+);
+
+-- ============================================================================
+-- COLLECTIONS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS collections (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS collection_sources (
+    collection_id BIGINT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    PRIMARY KEY (collection_id, source_id)
+);
+
+-- Confirmed per-account "me" identities used by sent-message detection
+-- in dedup. Identity is account-scoped: an address confirmed for one
+-- source does not imply it is "me" in any other source.
+CREATE TABLE IF NOT EXISTS account_identities (
+    source_id     BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    address       TEXT NOT NULL,
+    source_signal TEXT NOT NULL DEFAULT '',
+    confirmed_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (source_id, address)
+);
+
+-- Marks one-time data migrations that have already run. Schema DDL is
+-- idempotent via IF NOT EXISTS; this table is for *data* migrations
+-- (e.g. moving legacy config into per-account records) that must run
+-- exactly once.
+CREATE TABLE IF NOT EXISTS applied_migrations (
+    name       TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_sources_type ON sources(source_type);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_participants_email ON participants(email_address)
+    WHERE email_address IS NOT NULL;
+-- idx_participants_phone is created (and upgraded from the legacy
+-- non-unique form) in Go by Store.ensureParticipantsPhoneUniqueIndex
+-- so existing DBs whose IF NOT EXISTS no-op'd the schema bump still
+-- end up with a UNIQUE partial index.
+CREATE INDEX IF NOT EXISTS idx_participants_canonical ON participants(canonical_id)
+    WHERE canonical_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_participant_identifiers_value ON participant_identifiers(identifier_value);
+CREATE INDEX IF NOT EXISTS idx_participant_identifiers_participant ON participant_identifiers(participant_id);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_source ON conversations(source_id);
+CREATE INDEX IF NOT EXISTS idx_conversations_last_message ON conversations(last_message_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversations_type ON conversations(conversation_type);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_source ON messages(source_id);
+CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_id);
+CREATE INDEX IF NOT EXISTS idx_messages_sent_at ON messages(sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_type ON messages(message_type);
+CREATE INDEX IF NOT EXISTS idx_messages_deleted ON messages(source_id, deleted_from_source_at);
+CREATE INDEX IF NOT EXISTS idx_messages_source_message_id ON messages(source_message_id);
+
+-- Full-text search GIN index on tsvector column
 CREATE INDEX IF NOT EXISTS messages_search_fts_idx ON messages USING GIN (search_fts);
+
+CREATE INDEX IF NOT EXISTS idx_message_recipients_message ON message_recipients(message_id);
+CREATE INDEX IF NOT EXISTS idx_message_recipients_participant ON message_recipients(participant_id, recipient_type);
+
+CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id);
+
+CREATE INDEX IF NOT EXISTS idx_attachments_message ON attachments(message_id);
+CREATE INDEX IF NOT EXISTS idx_attachments_hash ON attachments(content_hash);
+CREATE INDEX IF NOT EXISTS idx_attachments_storage_path ON attachments(storage_path);
+-- idx_attachments_msg_content_hash is created in Go (Store.InitSchema)
+-- after a one-shot dedupe of legacy duplicate rows.
+
+CREATE INDEX IF NOT EXISTS idx_labels_source ON labels(source_id);
+CREATE INDEX IF NOT EXISTS idx_message_labels_label ON message_labels(label_id);
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_source ON sync_runs(source_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_account_identities_address
+    ON account_identities(address);
+
+CREATE INDEX IF NOT EXISTS idx_collection_sources_source_id
+    ON collection_sources(source_id);

--- a/internal/store/sources.go
+++ b/internal/store/sources.go
@@ -151,7 +151,7 @@ func (s *Store) RemoveSourceSerialized(
 	}
 	defer func() { _ = conn.Close() }()
 
-	if _, err := conn.ExecContext(ctx, "BEGIN EXCLUSIVE"); err != nil {
+	if err := s.dialect.BeginExclusive(ctx, conn); err != nil {
 		return false, fmt.Errorf("begin exclusive: %w", err)
 	}
 	committed := false

--- a/internal/store/sources_test.go
+++ b/internal/store/sources_test.go
@@ -84,15 +84,17 @@ func TestStore_RemoveSource(t *testing.T) {
 	// Verify labels are gone
 	var labelCount int
 	err = f.Store.DB().QueryRow(
-		`SELECT COUNT(*) FROM labels WHERE source_id = ?`, f.Source.ID,
+		f.Store.Rebind(`SELECT COUNT(*) FROM labels WHERE source_id = ?`), f.Source.ID,
 	).Scan(&labelCount)
 	testutil.MustNoErr(t, err, "count labels")
 	if labelCount != 0 {
 		t.Errorf("label count = %d, want 0", labelCount)
 	}
 
-	// Verify FTS rows are gone
-	if f.Store.FTS5Available() {
+	// Verify FTS rows are gone (SQLite FTS5 vtable only; on PG the
+	// equivalent invariant — search_fts cleared — is covered by the
+	// dialect-level FTSDeleteSQL test).
+	if f.Store.FTS5Available() && !f.Store.IsPostgreSQL() {
 		var ftsCount int
 		err = f.Store.DB().QueryRow(
 			`SELECT COUNT(*) FROM messages_fts`,
@@ -141,7 +143,7 @@ func TestStore_RemoveSource_CascadesConversations(t *testing.T) {
 	// Verify conversations are gone
 	var convCount int
 	err = f.Store.DB().QueryRow(
-		`SELECT COUNT(*) FROM conversations WHERE source_id = ?`,
+		f.Store.Rebind(`SELECT COUNT(*) FROM conversations WHERE source_id = ?`),
 		f.Source.ID,
 	).Scan(&convCount)
 	testutil.MustNoErr(t, err, "count conversations")
@@ -152,7 +154,7 @@ func TestStore_RemoveSource_CascadesConversations(t *testing.T) {
 	// Verify message_bodies are gone (cascaded via messages)
 	var bodyCount int
 	err = f.Store.DB().QueryRow(
-		`SELECT COUNT(*) FROM message_bodies WHERE message_id = ?`, msgID,
+		f.Store.Rebind(`SELECT COUNT(*) FROM message_bodies WHERE message_id = ?`), msgID,
 	).Scan(&bodyCount)
 	testutil.MustNoErr(t, err, "count message_bodies")
 	if bodyCount != 0 {
@@ -162,7 +164,7 @@ func TestStore_RemoveSource_CascadesConversations(t *testing.T) {
 	// Verify message_raw is gone (cascaded via messages)
 	var rawCount int
 	err = f.Store.DB().QueryRow(
-		`SELECT COUNT(*) FROM message_raw WHERE message_id = ?`, msgID,
+		f.Store.Rebind(`SELECT COUNT(*) FROM message_raw WHERE message_id = ?`), msgID,
 	).Scan(&rawCount)
 	testutil.MustNoErr(t, err, "count message_raw")
 	if rawCount != 0 {
@@ -172,7 +174,7 @@ func TestStore_RemoveSource_CascadesConversations(t *testing.T) {
 	// Verify message_recipients are gone (cascaded via messages)
 	var recipCount int
 	err = f.Store.DB().QueryRow(
-		`SELECT COUNT(*) FROM message_recipients WHERE message_id = ?`, msgID,
+		f.Store.Rebind(`SELECT COUNT(*) FROM message_recipients WHERE message_id = ?`), msgID,
 	).Scan(&recipCount)
 	testutil.MustNoErr(t, err, "count message_recipients")
 	if recipCount != 0 {
@@ -290,8 +292,8 @@ func TestStore_AttachmentPathsUniqueToSource(t *testing.T) {
 	// Attachment with NULL content_hash (must be excluded).
 	nullHashMsg := f.CreateMessage("msg-null-hash")
 	_, err = f.Store.DB().Exec(
-		`INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, created_at)
-		 VALUES (?, 'n.pdf', 'application/pdf', 'cc/x', NULL, 30, CURRENT_TIMESTAMP)`,
+		f.Store.Rebind(`INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, created_at)
+		 VALUES (?, 'n.pdf', 'application/pdf', 'cc/x', NULL, 30, CURRENT_TIMESTAMP)`),
 		nullHashMsg,
 	)
 	testutil.MustNoErr(t, err, "insert null-hash attachment")
@@ -433,7 +435,7 @@ func TestInitSchema_MigratesOAuthAppColumn(t *testing.T) {
 
 	// Verify oauth_app can be written and read back.
 	_, err = st.DB().Exec(
-		`UPDATE sources SET oauth_app = ? WHERE identifier = ?`,
+		st.Rebind(`UPDATE sources SET oauth_app = ? WHERE identifier = ?`),
 		"acme", "legacy@example.com",
 	)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -96,7 +96,7 @@ func Open(dbPath string) (*Store, error) {
 // Not for production use — a process crash mid-test can leave a corrupt
 // database, which is fine because tests recreate it from scratch.
 func OpenForTest(dbPath string) (*Store, error) {
-	if isPostgresURL(dbPath) {
+	if IsPostgresURL(dbPath) {
 		return openPostgres(dbPath)
 	}
 	return openSQLite(dbPath, testSQLiteParams)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -64,8 +64,10 @@ func isSQLiteError(err error, substr string) bool {
 	return false
 }
 
-// isPostgresURL returns true if the path looks like a PostgreSQL connection URL.
-func isPostgresURL(dbPath string) bool {
+// IsPostgresURL returns true if the path looks like a PostgreSQL connection URL.
+// Exported so cmd-side helpers can decide whether to skip SQLite-only code
+// paths (e.g., the Parquet analytics cache) without first opening a Store.
+func IsPostgresURL(dbPath string) bool {
 	return strings.HasPrefix(dbPath, "postgresql://") || strings.HasPrefix(dbPath, "postgres://")
 }
 
@@ -81,7 +83,7 @@ const testSQLiteParams = "?_journal_mode=WAL&_busy_timeout=30000&_synchronous=OF
 // If dbPath is a postgres:// or postgresql:// URL, opens a PostgreSQL connection.
 // Otherwise, opens a SQLite database at the file path.
 func Open(dbPath string) (*Store, error) {
-	if isPostgresURL(dbPath) {
+	if IsPostgresURL(dbPath) {
 		return openPostgres(dbPath)
 	}
 	return openSQLite(dbPath, defaultSQLiteParams)
@@ -184,7 +186,7 @@ func openPostgres(dbURL string) (*Store, error) {
 // same database concurrently. Does not create the database, run migrations,
 // or checkpoint WAL on close.
 func OpenReadOnly(dbPath string) (*Store, error) {
-	if isPostgresURL(dbPath) {
+	if IsPostgresURL(dbPath) {
 		return openPostgresReadOnly(dbPath)
 	}
 
@@ -338,6 +340,13 @@ func (s *Store) DB() *sql.DB {
 	return s.db.DB
 }
 
+// IsPostgreSQL reports whether this store is backed by PostgreSQL.
+// Engine factories use this to choose between the SQLite and PostgreSQL
+// query paths.
+func (s *Store) IsPostgreSQL() bool {
+	return s.dialect.DriverName() == "pgx"
+}
+
 // WithExclusiveLock executes fn while holding an exclusive write lock on the
 // database. In WAL mode this blocks concurrent writers (e.g. StartSync) while
 // allowing reads (e.g. IsAttachmentPathReferenced) to proceed. Use this to
@@ -352,7 +361,7 @@ func (s *Store) WithExclusiveLock(ctx context.Context, fn func() error) error {
 	}
 	defer func() { _ = conn.Close() }()
 
-	if _, err := conn.ExecContext(ctx, "BEGIN EXCLUSIVE"); err != nil {
+	if err := s.dialect.BeginExclusive(ctx, conn); err != nil {
 		return fmt.Errorf("begin exclusive: %w", err)
 	}
 
@@ -583,29 +592,40 @@ func (s *Store) InitSchema() error {
 		}
 	}
 
+	// Legacy databases may hold duplicate (message_id, content_hash)
+	// attachment rows from the old SELECT-then-INSERT UpsertAttachment.
+	// Dedupe before creating the partial unique index that enforces
+	// idempotency going forward. Both steps are idempotent.
+	if err := s.dedupeAttachmentsBeforeUniqueIndex(); err != nil {
+		return fmt.Errorf("dedupe attachments: %w", err)
+	}
+	if _, err := s.db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_msg_content_hash
+		    ON attachments(message_id, content_hash)
+		    WHERE content_hash IS NOT NULL AND content_hash != ''
+	`); err != nil {
+		return fmt.Errorf("create idx_attachments_msg_content_hash: %w", err)
+	}
+
+	// Legacy databases may have idx_participants_phone as a non-unique
+	// partial index (it was created that way before the schema flipped
+	// to UNIQUE). `CREATE UNIQUE INDEX IF NOT EXISTS` in schema.sql
+	// silently leaves the non-unique index in place, so
+	// EnsureParticipantByPhone's ON CONFLICT (phone_number) finds no
+	// matching unique constraint on upgraded DBs. Run a one-shot
+	// migration that dedupes phone rows, drops the index, and
+	// recreates it as UNIQUE.
+	if err := s.ensureParticipantsPhoneUniqueIndex(); err != nil {
+		return fmt.Errorf("ensure idx_participants_phone unique: %w", err)
+	}
+
 	// Migrations: add columns for databases created before these features.
-	// The dialect determines whether a "duplicate column" error is benign.
-	for _, m := range []struct {
-		sql  string
-		desc string
-	}{
-		{`ALTER TABLE sources ADD COLUMN sync_config JSON`, "sync_config"},
-		{`ALTER TABLE messages ADD COLUMN rfc822_message_id TEXT`, "rfc822_message_id"},
-		{`ALTER TABLE sources ADD COLUMN oauth_app TEXT`, "oauth_app"},
-		{`ALTER TABLE participants ADD COLUMN phone_number TEXT`, "phone_number"},
-		{`ALTER TABLE participants ADD COLUMN canonical_id TEXT`, "canonical_id"},
-		{`ALTER TABLE messages ADD COLUMN sender_id INTEGER REFERENCES participants(id)`, "sender_id"},
-		{`ALTER TABLE messages ADD COLUMN message_type TEXT NOT NULL DEFAULT 'email'`, "message_type"},
-		{`ALTER TABLE messages ADD COLUMN attachment_count INTEGER DEFAULT 0`, "attachment_count"},
-		{`ALTER TABLE messages ADD COLUMN deleted_from_source_at DATETIME`, "deleted_from_source_at"},
-		{`ALTER TABLE messages ADD COLUMN deleted_at DATETIME`, "deleted_at"},
-		{`ALTER TABLE messages ADD COLUMN delete_batch_id TEXT`, "delete_batch_id"},
-		{`ALTER TABLE conversations ADD COLUMN title TEXT`, "title"},
-		{`ALTER TABLE conversations ADD COLUMN conversation_type TEXT NOT NULL DEFAULT 'email_thread'`, "conversation_type"},
-	} {
-		if _, err := s.db.Exec(m.sql); err != nil {
+	// The dialect determines the list (SQLite: full ALTER TABLE list;
+	// PostgreSQL: empty — schema_pg.sql is always complete).
+	for _, m := range s.dialect.LegacyColumnMigrations() {
+		if _, err := s.db.Exec(m.SQL); err != nil {
 			if !s.dialect.IsDuplicateColumnError(err) {
-				return fmt.Errorf("migrate schema (%s): %w", m.desc, err)
+				return fmt.Errorf("migrate schema (%s): %w", m.Desc, err)
 			}
 		}
 	}
@@ -636,6 +656,24 @@ func (s *Store) InitSchema() error {
 	}
 
 	return nil
+}
+
+// dedupeAttachmentsBeforeUniqueIndex removes duplicate
+// (message_id, content_hash) rows from attachments so the partial
+// unique index idx_attachments_msg_content_hash can be created. Pre-fix
+// UpsertAttachment used a SELECT-then-INSERT pattern that could create
+// duplicates under concurrency; this cleans them up once. Idempotent.
+func (s *Store) dedupeAttachmentsBeforeUniqueIndex() error {
+	_, err := s.db.Exec(`
+		DELETE FROM attachments
+		WHERE content_hash IS NOT NULL AND content_hash != ''
+		  AND id NOT IN (
+			SELECT MIN(id) FROM attachments
+			WHERE content_hash IS NOT NULL AND content_hash != ''
+			GROUP BY message_id, content_hash
+		  )
+	`)
+	return err
 }
 
 // NeedsFTSBackfill reports whether the FTS index needs to be populated.
@@ -790,9 +828,9 @@ func (s *Store) GetStatsForScope(sourceIDs []int64) (*Stats, error) {
 		}
 	}
 
-	// DatabaseSize is always the global file size; scoped stats cannot decompose it.
-	if info, err := os.Stat(s.dbPath); err == nil {
-		stats.DatabaseSize = info.Size()
+	// DatabaseSize: file size for SQLite, pg_database_size() for PostgreSQL.
+	if size, err := s.dialect.DatabaseSize(s.db.DB, s.dbPath); err == nil {
+		stats.DatabaseSize = size
 	}
 
 	return stats, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1085,6 +1085,7 @@ func TestStore_ReplaceMessageRecipients_LargeBatch(t *testing.T) {
 }
 
 func TestStore_UpsertFTS(t *testing.T) {
+	testutil.SkipIfPostgres(t, "directly queries the SQLite FTS5 vtable with MATCH; PG uses a tsvector column tested via FTSSearchClause")
 	f := storetest.New(t)
 
 	if !f.Store.FTS5Available() {
@@ -1146,6 +1147,7 @@ func TestStore_UpsertFTS(t *testing.T) {
 }
 
 func TestStore_BackfillFTS(t *testing.T) {
+	testutil.SkipIfPostgres(t, "directly queries the SQLite FTS5 vtable; PG backfill is exercised separately via FTSBackfillBatchSQL")
 	f := storetest.New(t)
 
 	if !f.Store.FTS5Available() {
@@ -1232,6 +1234,7 @@ func TestStore_FTS5Available(t *testing.T) {
 }
 
 func TestStore_NeedsFTSBackfill(t *testing.T) {
+	testutil.SkipIfPostgres(t, "directly mutates the SQLite FTS5 vtable; PG NeedsFTSBackfill probes the tsvector column instead")
 	f := storetest.New(t)
 
 	if !f.Store.FTS5Available() {

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -48,82 +49,64 @@ func parseDBTime(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unrecognized timestamp format %q", s)
 }
 
-func parseNullTime(ns sql.NullString) (sql.NullTime, error) {
-	if !ns.Valid {
-		return sql.NullTime{}, nil
-	}
-	t, err := parseDBTime(ns.String)
-	if err != nil {
-		return sql.NullTime{}, err
-	}
-	return sql.NullTime{Time: t, Valid: true}, nil
-}
-
-// parseRequiredTime parses a timestamp that must not be NULL.
-// Use this for required fields like created_at/updated_at.
-func parseRequiredTime(ns sql.NullString, field string) (time.Time, error) {
-	if !ns.Valid {
+// requireNullTime extracts a non-NULL time.Time from a sql.NullTime, with
+// a clear error mentioning the field name. Required timestamps
+// (created_at, updated_at, started_at) violate a schema invariant if NULL,
+// so this surfaces the violation rather than silently zero-valuing.
+func requireNullTime(nt sql.NullTime, field string) (time.Time, error) {
+	if !nt.Valid {
 		return time.Time{}, fmt.Errorf("%s: required timestamp is NULL", field)
 	}
-	t, err := parseDBTime(ns.String)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("%s: %w", field, err)
-	}
-	return t, nil
+	return nt.Time, nil
 }
 
 func scanSource(sc scanner) (*Source, error) {
+	// Scan timestamps into sql.NullTime / time.Time. The pgx/v5 stdlib
+	// driver decodes TIMESTAMP/TIMESTAMPTZ as time.Time at the driver
+	// level and refuses to convert that to *string; go-sqlite3 also
+	// accepts time.Time destinations and parses its stored formats
+	// internally, so a single typed scan path works for both backends.
+	// Required fields are scanned through sql.NullTime so a NULL value
+	// (a schema invariant violation) is reported with field context
+	// rather than the driver's opaque "unsupported Scan" error.
 	var source Source
-	var lastSyncAt, createdAt, updatedAt sql.NullString
-
+	var createdAt, updatedAt sql.NullTime
 	err := sc.Scan(
 		&source.ID, &source.SourceType, &source.Identifier, &source.DisplayName,
-		&source.GoogleUserID, &lastSyncAt, &source.SyncCursor, &source.SyncConfig,
+		&source.GoogleUserID, &source.LastSyncAt, &source.SyncCursor, &source.SyncConfig,
 		&source.OAuthApp, &createdAt, &updatedAt,
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	source.LastSyncAt, err = parseNullTime(lastSyncAt)
-	if err != nil {
-		return nil, fmt.Errorf("source %d: last_sync_at: %w", source.ID, err)
-	}
-	source.CreatedAt, err = parseRequiredTime(createdAt, "created_at")
+	source.CreatedAt, err = requireNullTime(createdAt, "created_at")
 	if err != nil {
 		return nil, fmt.Errorf("source %d: %w", source.ID, err)
 	}
-	source.UpdatedAt, err = parseRequiredTime(updatedAt, "updated_at")
+	source.UpdatedAt, err = requireNullTime(updatedAt, "updated_at")
 	if err != nil {
 		return nil, fmt.Errorf("source %d: %w", source.ID, err)
 	}
-
 	return &source, nil
 }
 
 func scanSyncRun(sc scanner) (*SyncRun, error) {
+	// Scan timestamps into typed columns — see scanSource for the
+	// dialect-portability rationale.
 	var run SyncRun
-	var startedAt string
-	var completedAt sql.NullString
-
+	var startedAt sql.NullTime
 	err := sc.Scan(
-		&run.ID, &run.SourceID, &startedAt, &completedAt, &run.Status,
+		&run.ID, &run.SourceID, &startedAt, &run.CompletedAt, &run.Status,
 		&run.MessagesProcessed, &run.MessagesAdded, &run.MessagesUpdated, &run.ErrorsCount,
 		&run.ErrorMessage, &run.CursorBefore, &run.CursorAfter,
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	run.StartedAt, err = parseDBTime(startedAt)
+	run.StartedAt, err = requireNullTime(startedAt, "started_at")
 	if err != nil {
-		return nil, fmt.Errorf("sync_run %d: parse started_at %q: %w", run.ID, startedAt, err)
+		return nil, fmt.Errorf("sync_run %d: %w", run.ID, err)
 	}
-	run.CompletedAt, err = parseNullTime(completedAt)
-	if err != nil {
-		return nil, fmt.Errorf("sync_run %d: completed_at: %w", run.ID, err)
-	}
-
 	return &run, nil
 }
 
@@ -152,32 +135,91 @@ type Checkpoint struct {
 	ErrorsCount       int64
 }
 
-// StartSync creates a new sync run record and returns its ID.
+// StartSync creates a new sync run record and returns its ID. The
+// supersede UPDATE and the INSERT run inside a writer-locked
+// transaction so concurrent StartSync calls cannot both find no
+// running rows, both INSERT, and leave two 'running' rows alive.
+// SQLite uses BEGIN IMMEDIATE; PostgreSQL takes a row lock on the
+// source via SELECT ... FOR UPDATE before doing the read-modify-write
+// on sync_runs.
 func (s *Store) StartSync(sourceID int64, syncType string) (int64, error) {
+	ctx := context.Background()
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		id, err := s.startSyncOnce(ctx, sourceID)
+		if err == nil {
+			return id, nil
+		}
+		if !s.dialect.IsBusyError(err) {
+			return 0, err
+		}
+	}
+	return 0, fmt.Errorf("start sync: gave up after %d retries on busy", maxAttempts)
+}
+
+func (s *Store) startSyncOnce(ctx context.Context, sourceID int64) (retID int64, retErr error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("acquire connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, s.dialect.BeginWriteSQL()); err != nil {
+		return 0, fmt.Errorf("begin write tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	rebind := s.dialect.Rebind
 	now := s.dialect.Now()
 
-	// Mark any existing running syncs as failed
-	_, err := s.db.Exec(fmt.Sprintf(`
-		UPDATE sync_runs
-		SET status = 'failed',
-		    error_message = 'superseded by new sync',
-		    completed_at = %s
-		WHERE source_id = ? AND status = 'running'
-	`, now), sourceID)
-	if err != nil {
+	// Serialize against concurrent StartSync for the same source.
+	// SQLite already serializes writers under BEGIN IMMEDIATE; PG
+	// needs an explicit row lock on the source so the read snapshot
+	// for the UPDATE below cannot miss a concurrently committed
+	// running run.
+	var lockedID int64
+	if err := conn.QueryRowContext(ctx,
+		rebind(`SELECT id FROM sources WHERE id = ?`+s.dialect.SelectForUpdate()),
+		sourceID,
+	).Scan(&lockedID); err != nil {
+		return 0, fmt.Errorf("lock source row: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx,
+		rebind(fmt.Sprintf(`
+			UPDATE sync_runs
+			SET status = 'failed',
+			    error_message = 'superseded by new sync',
+			    completed_at = %s
+			WHERE source_id = ? AND status = 'running'
+		`, now)),
+		sourceID,
+	); err != nil {
 		return 0, fmt.Errorf("mark old syncs failed: %w", err)
 	}
 
-	// Create new sync run
-	result, err := s.db.Exec(fmt.Sprintf(`
-		INSERT INTO sync_runs (source_id, started_at, status, messages_processed, messages_added, messages_updated, errors_count)
-		VALUES (?, %s, 'running', 0, 0, 0, 0)
-	`, now), sourceID)
-	if err != nil {
+	var syncRunID int64
+	if err := conn.QueryRowContext(ctx,
+		rebind(fmt.Sprintf(`
+			INSERT INTO sync_runs (source_id, started_at, status, messages_processed, messages_added, messages_updated, errors_count)
+			VALUES (?, %s, 'running', 0, 0, 0, 0)
+			RETURNING id
+		`, now)),
+		sourceID,
+	).Scan(&syncRunID); err != nil {
 		return 0, fmt.Errorf("insert sync_run: %w", err)
 	}
 
-	return result.LastInsertId()
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+	return syncRunID, nil
 }
 
 // UpdateSyncCheckpoint saves progress for resumption.
@@ -310,41 +352,26 @@ type Source struct {
 }
 
 // GetOrCreateSource gets or creates a source by type and identifier.
+// Concurrent first-inserts converge via INSERT ... ON CONFLICT DO UPDATE
+// RETURNING: the no-op SET fires RETURNING on both the insert and
+// conflict path so the second caller receives the existing row's
+// fields instead of a unique-violation error.
 func (s *Store) GetOrCreateSource(sourceType, identifier string) (*Source, error) {
-	// Try to get existing
-	row := s.db.QueryRow(`
-		SELECT id, source_type, identifier, display_name, google_user_id,
-		       last_sync_at, sync_cursor, sync_config, oauth_app,
-		       created_at, updated_at
-		FROM sources
-		WHERE source_type = ? AND identifier = ?
-	`, sourceType, identifier)
-
-	source, err := scanSource(row)
-	if err == nil {
-		return source, nil
-	}
-	if err != sql.ErrNoRows {
-		return nil, err
-	}
-
-	// Create new
 	now := s.dialect.Now()
-	result, err := s.db.Exec(fmt.Sprintf(`
+	row := s.db.QueryRow(fmt.Sprintf(`
 		INSERT INTO sources (source_type, identifier, created_at, updated_at)
 		VALUES (?, ?, %s, %s)
+		ON CONFLICT (source_type, identifier) DO UPDATE
+		SET identifier = sources.identifier
+		RETURNING id, source_type, identifier, display_name, google_user_id,
+		          last_sync_at, sync_cursor, sync_config, oauth_app,
+		          created_at, updated_at
 	`, now, now), sourceType, identifier)
-	if err != nil {
-		return nil, fmt.Errorf("insert source: %w", err)
-	}
 
-	newSource := &Source{
-		SourceType: sourceType,
-		Identifier: identifier,
-		CreatedAt:  time.Now(),
-		UpdatedAt:  time.Now(),
+	source, err := scanSource(row)
+	if err != nil {
+		return nil, fmt.Errorf("upsert source: %w", err)
 	}
-	newSource.ID, _ = result.LastInsertId()
 
 	// Add to the default "All" collection if it exists.
 	//
@@ -357,18 +384,20 @@ func (s *Store) GetOrCreateSource(sourceType, identifier string) (*Source, error
 	// All would miss this source. Acceptable for a single-user tool;
 	// a future refactor can fold this into a withTx.
 	if _, err := s.db.Exec(
-		`INSERT OR IGNORE INTO collection_sources (collection_id, source_id)
-		 SELECT id, ? FROM collections WHERE name = ?`,
-		newSource.ID, DefaultCollectionName,
+		s.dialect.InsertOrIgnore(
+			`INSERT OR IGNORE INTO collection_sources (collection_id, source_id)
+			 SELECT id, ? FROM collections WHERE name = ?`,
+		),
+		source.ID, DefaultCollectionName,
 	); err != nil {
 		slog.Warn("failed to add source to default collection (self-heals on next InitSchema)",
-			"source_id", newSource.ID,
+			"source_id", source.ID,
 			"identifier", identifier,
 			"error", err,
 		)
 	}
 
-	return newSource, nil
+	return source, nil
 }
 
 // UpdateSourceSyncCursor updates the sync cursor (historyId) for a source.
@@ -437,12 +466,14 @@ func (s *Store) UpdateSourceDisplayName(sourceID int64, displayName string) erro
 }
 
 // UpdateSourceSyncConfig updates the JSON sync configuration for an IMAP source.
+// The sync_config column is JSONB on PG; the dialect supplies the
+// appropriate placeholder cast (?::JSONB on PG, bare ? on SQLite).
 func (s *Store) UpdateSourceSyncConfig(sourceID int64, configJSON string) error {
 	_, err := s.db.Exec(fmt.Sprintf(`
 		UPDATE sources
-		SET sync_config = ?, updated_at = %s
+		SET sync_config = %s, updated_at = %s
 		WHERE id = ?
-	`, s.dialect.Now()), configJSON, sourceID)
+	`, s.dialect.JSONBindExpr(), s.dialect.Now()), configJSON, sourceID)
 	return err
 }
 

--- a/internal/store/sync_test.go
+++ b/internal/store/sync_test.go
@@ -38,6 +38,7 @@ func TestScanSource_NullLastSyncAt_Valid(t *testing.T) {
 // the go-sqlite3 driver normalizes to zero time (from invalid input).
 // The driver converts unparseable DATETIME values to "0001-01-01T00:00:00Z".
 func TestScanSyncRun_ZeroTime(t *testing.T) {
+	testutil.SkipIfPostgres(t, "tests go-sqlite3 driver normalization of invalid DATETIME strings to zero time; PG TIMESTAMPTZ rejects invalid strings outright")
 	f := storetest.New(t)
 
 	syncID := f.StartSync()
@@ -66,6 +67,7 @@ func TestScanSyncRun_ZeroTime(t *testing.T) {
 // TestScanSource_ZeroTime verifies that sources with timestamps that the driver
 // normalizes to zero time are handled correctly.
 func TestScanSource_ZeroTime(t *testing.T) {
+	testutil.SkipIfPostgres(t, "tests go-sqlite3 driver normalization of invalid DATETIME strings to zero time; PG TIMESTAMPTZ rejects invalid strings outright")
 	st := testutil.NewTestStore(t)
 
 	// Create a source
@@ -176,7 +178,7 @@ func TestScanSource_NullRequiredTimestamp(t *testing.T) {
 	testutil.MustNoErr(t, err, "GetOrCreateSource")
 
 	// Corrupt created_at to NULL (violates expected schema invariant)
-	_, err = st.DB().Exec(`UPDATE sources SET created_at = NULL WHERE id = ?`, source.ID)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE sources SET created_at = NULL WHERE id = ?`), source.ID)
 	testutil.MustNoErr(t, err, "set created_at to NULL")
 
 	// Attempting to retrieve should fail with a clear error

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -647,14 +647,14 @@ func (s *Syncer) persistMessage(data *messageData, labelMap map[string]int64) (i
 		// Correct metadata if any attachments failed to store
 		var storedCount int
 		if err := s.store.DB().QueryRow(
-			`SELECT COUNT(*) FROM attachments WHERE message_id = ?`,
+			s.store.Rebind(`SELECT COUNT(*) FROM attachments WHERE message_id = ?`),
 			messageID,
 		).Scan(&storedCount); err != nil {
 			s.logger.Warn("failed to count stored attachments",
 				"message", messageID, "error", err)
 		} else if storedCount != len(data.attachments) {
 			if _, err := s.store.DB().Exec(
-				`UPDATE messages SET has_attachments = ?, attachment_count = ? WHERE id = ?`,
+				s.store.Rebind(`UPDATE messages SET has_attachments = ?, attachment_count = ? WHERE id = ?`),
 				storedCount > 0, storedCount, messageID,
 			); err != nil {
 				s.logger.Warn("failed to update attachment metadata",

--- a/internal/testutil/store_helpers.go
+++ b/internal/testutil/store_helpers.go
@@ -47,6 +47,19 @@ func NewTestStore(t *testing.T) *store.Store {
 	return st
 }
 
+// SkipIfPostgres skips the calling test when MSGVAULT_TEST_DB targets
+// PostgreSQL. Use this for tests that exercise SQLite-only constructs
+// (FTS5 MATCH, PRAGMA, BEGIN EXCLUSIVE, SQLite trigger syntax) where
+// PostgreSQL's portable equivalent is covered by a separate test or
+// by the Dialect interface.
+func SkipIfPostgres(t *testing.T, reason string) {
+	t.Helper()
+	testDB := os.Getenv("MSGVAULT_TEST_DB")
+	if strings.HasPrefix(testDB, "postgres://") || strings.HasPrefix(testDB, "postgresql://") {
+		t.Skipf("skipping on PostgreSQL: %s", reason)
+	}
+}
+
 // newPostgresTestStore creates a test-isolated PostgreSQL store using a random schema name.
 // The schema is dropped on test cleanup.
 func newPostgresTestStore(t *testing.T, dbURL string) *store.Store {

--- a/internal/testutil/storetest/storetest.go
+++ b/internal/testutil/storetest/storetest.go
@@ -122,7 +122,7 @@ func (f *Fixture) GetMessageBody(msgID int64) (sql.NullString, sql.NullString) {
 	f.T.Helper()
 	var bodyText, bodyHTML sql.NullString
 	err := f.Store.DB().QueryRow(
-		"SELECT body_text, body_html FROM message_bodies WHERE message_id = ?", msgID,
+		f.Store.Rebind("SELECT body_text, body_html FROM message_bodies WHERE message_id = ?"), msgID,
 	).Scan(&bodyText, &bodyHTML)
 	testutil.MustNoErr(f.T, err, "GetMessageBody")
 	return bodyText, bodyHTML

--- a/internal/whatsapp/importer.go
+++ b/internal/whatsapp/importer.go
@@ -398,13 +398,16 @@ func (imp *Importer) Import(ctx context.Context, waDBPath string, opts ImportOpt
 						// (a previous import with --media-dir may have created them).
 						var existingCount int
 						_ = imp.store.DB().QueryRow(
-							"SELECT COUNT(*) FROM attachments WHERE message_id = ?",
+							imp.store.Rebind("SELECT COUNT(*) FROM attachments WHERE message_id = ?"),
 							messageID,
 						).Scan(&existingCount)
 						if existingCount == 0 {
+							// has_attachments is BOOLEAN on PG; bind a Go
+							// bool through the rebind layer so the driver
+							// emits the right literal for each backend.
 							_, _ = imp.store.DB().Exec(
-								"UPDATE messages SET has_attachments = 0, attachment_count = 0 WHERE id = ?",
-								messageID)
+								imp.store.Rebind("UPDATE messages SET has_attachments = ?, attachment_count = ? WHERE id = ?"),
+								false, 0, messageID)
 						}
 					}
 
@@ -656,10 +659,10 @@ func (imp *Importer) updateAttachmentMetadata(messageID int64, contentHash, medi
 		durationMS = sql.NullInt64{Int64: media.MediaDuration.Int64 * 1000, Valid: true}
 	}
 
-	_, _ = imp.store.DB().Exec(`
+	_, _ = imp.store.DB().Exec(imp.store.Rebind(`
 		UPDATE attachments SET media_type = ?, width = ?, height = ?, duration_ms = ?
 		WHERE message_id = ? AND (content_hash = ? OR content_hash IS NULL)
-	`, mediaType, width, height, durationMS, messageID, contentHash)
+	`), mediaType, width, height, durationMS, messageID, contentHash)
 }
 
 // lookupMessageByKeyID looks up a previously imported message by its WhatsApp key_id.
@@ -667,7 +670,7 @@ func (imp *Importer) updateAttachmentMetadata(messageID int64, contentHash, medi
 func (imp *Importer) lookupMessageByKeyID(sourceID int64, keyID string) (int64, error) {
 	var msgID int64
 	err := imp.store.DB().QueryRow(
-		`SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?`,
+		imp.store.Rebind(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?`),
 		sourceID, keyID,
 	).Scan(&msgID)
 	if err == sql.ErrNoRows {
@@ -678,9 +681,9 @@ func (imp *Importer) lookupMessageByKeyID(sourceID int64, keyID string) (int64, 
 
 // setReplyTo sets the reply_to_message_id on a message.
 func (imp *Importer) setReplyTo(messageID, replyToID int64) {
-	_, _ = imp.store.DB().Exec(`
+	_, _ = imp.store.DB().Exec(imp.store.Rebind(`
 		UPDATE messages SET reply_to_message_id = ? WHERE id = ?
-	`, replyToID, messageID)
+	`), replyToID, messageID)
 }
 
 // verifyWhatsAppDB checks that the database looks like a WhatsApp msgstore.db.


### PR DESCRIPTION
## Summary
Makes the PostgreSQL backend functional through the dialect-abstracted store layer.
Builds on PR1 (#276, dialect extraction) and PR2 (#298, PG scaffold).

[... PR description here ...]

## Test plan
- [x] make test  (SQLite, all packages pass)
- [x] MSGVAULT_TEST_DB=postgres://... make test  (PostgreSQL, all packages pass)

## Deferred to PR4
- FTS weight parity (SQLite FTS5 vs PG ts_rank with setweight)
- Deletion execution E2E on PG
- Attachment storage E2E on PG
- Vector pgvector backend (parallel to sqlitevec)
- CI lane for MSGVAULT_TEST_DB=postgres