### PR TITLE
serve: dispatch scheduled sync by source type (IMAP support)

### DIFF
--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -331,95 +331,56 @@ func (a *schedulerAdapter) Status() []api.AccountStatus {
 	return a.scheduler.Status()
 }
 
-// runScheduledSync performs an incremental sync for a scheduled
-// account. When vf is non-nil (vector search enabled), the Syncer is
-// configured to enqueue newly-ingested message IDs into the embedding
-// pipeline so subsequent embed runs pick them up.
-func runScheduledSync(ctx context.Context, email string, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), vf *vectorFeatures) error {
-	logger.Info("starting scheduled sync", "email", email)
+// runScheduledSync performs a sync for a scheduled account. The
+// dispatch is by source_type: Gmail accounts run an incremental sync
+// using the Gmail History API; IMAP accounts run a full sync (already
+// deduplicated by message-id at the store layer, since IMAP has no
+// equivalent history API). When vf is non-nil (vector search enabled),
+// the Syncer is configured to enqueue newly-ingested message IDs into
+// the embedding pipeline so subsequent embed runs pick them up.
+//
+// The identifier passed in is whatever the scheduler holds — for
+// Gmail this is the email address, for IMAP it's the full
+// `imaps://user@host:port` URL recorded by `add-imap`.
+func runScheduledSync(ctx context.Context, identifier string, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), vf *vectorFeatures) error {
+	logger.Info("starting scheduled sync", "identifier", identifier)
 	startTime := time.Now()
 
-	// Look up source to get OAuth app binding. Fall back to default
-	// if no source row exists (token-first workflow).
-	appName := ""
-	src, srcErr := findGmailSource(s, email)
+	src, srcErr := findScheduledSyncSource(s, identifier)
 	if srcErr != nil {
-		return fmt.Errorf("look up source for %s: %w", email, srcErr)
+		return fmt.Errorf("look up source for %s: %w", identifier, srcErr)
 	}
+
+	// Source type drives dispatch. A nil source falls back to Gmail to
+	// preserve the token-first workflow (tokens uploaded via API before
+	// the source row exists).
+	sourceType := "gmail"
 	if src != nil {
-		appName = sourceOAuthApp(src)
-	}
-
-	var tokenSource oauth2.TokenSource
-	var tsErr error
-
-	// Check for service account configuration
-	if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(appName); saKeyPath != "" {
-		saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
-		if saErr != nil {
-			return fmt.Errorf("service account for %s: %w", email, saErr)
-		}
-		tokenSource, tsErr = saMgr.TokenSource(ctx, email)
-		if tsErr != nil {
-			return fmt.Errorf("service account token for %s: %w", email, tsErr)
-		}
-	} else {
-		oauthMgr, oaErr := getOAuthMgr(appName)
-		if oaErr != nil {
-			return fmt.Errorf("resolve OAuth credentials for %s: %w", email, oaErr)
-		}
-
-		// Get token source — intentionally not using getTokenSourceWithReauth here
-		// because serve runs as a daemon and cannot open a browser for OAuth.
-		tokenSource, tsErr = oauthMgr.TokenSource(ctx, email)
-		if tsErr != nil {
-			if oauthMgr.HasToken(email) {
-				return fmt.Errorf("get token source: %w (token may be expired; run 'sync %s' or 'verify %s' from an interactive terminal to re-authorize)", tsErr, email, email)
-			}
-			return fmt.Errorf("get token source: %w (run 'add-account %s' first)", tsErr, email)
+		sourceType = src.SourceType
+		if sourceType == "" {
+			sourceType = "gmail"
 		}
 	}
 
-	// Create Gmail client
-	rateLimiter := gmail.NewRateLimiter(float64(cfg.Sync.RateLimitQPS))
-	client := gmail.NewClient(tokenSource,
-		gmail.WithLogger(logger),
-		gmail.WithRateLimiter(rateLimiter),
+	var (
+		summary *gmail.SyncSummary
+		err     error
 	)
-	defer func() { _ = client.Close() }()
-
-	// Set up sync options
-	opts := sync.DefaultOptions()
-	opts.AttachmentsDir = cfg.AttachmentsDir()
-
-	// Create syncer (no CLI progress for daemon mode)
-	syncer := sync.New(client, s, opts).WithLogger(logger)
-	if vf != nil {
-		syncer.SetEmbedEnqueuer(vf.Enqueuer)
+	switch sourceType {
+	case "gmail":
+		summary, err = runScheduledGmailSync(ctx, identifier, src, s, getOAuthMgr, vf)
+	case "imap":
+		summary, err = runScheduledIMAPSync(ctx, src, s, vf)
+	default:
+		return fmt.Errorf("source %q has type %q which is not supported by the daemon scheduler (only gmail and imap)", identifier, sourceType)
 	}
-
-	// Resolve source — scheduled sync is Gmail-only.
-	source, err := s.GetOrCreateSource("gmail", email)
 	if err != nil {
-		return fmt.Errorf("get source: %w", err)
-	}
-	// Auto-default-identity must run BEFORE the legacy migration retry
-	// — see comment in account_identity.go. serve is a daemon, so the
-	// confirmation message has no terminal; discard it. Helper logs any
-	// failure path through its own logger.Warn.
-	confirmDefaultIdentity(io.Discard, s, source.ID, email, email, "account-identifier")
-	if err := runPostSourceCreateMigrations(s); err != nil {
-		return fmt.Errorf("post-source-create migrations: %w", err)
-	}
-
-	// Run incremental sync
-	summary, err := syncer.Incremental(ctx, source)
-	if err != nil {
-		return fmt.Errorf("incremental sync failed: %w", err)
+		return err
 	}
 
 	logger.Info("sync completed",
-		"email", email,
+		"identifier", identifier,
+		"source_type", sourceType,
 		"messages_added", summary.MessagesAdded,
 		"duration", time.Since(startTime),
 	)
@@ -429,7 +390,7 @@ func runScheduledSync(ctx context.Context, email string, s *store.Store, getOAut
 	analyticsDir := cfg.AnalyticsDir()
 	if staleness := cacheNeedsBuild(dbPath, analyticsDir); staleness.NeedsBuild {
 		logger.Info("rebuilding cache after sync",
-			"email", email, "reason", staleness.Reason,
+			"identifier", identifier, "reason", staleness.Reason,
 			"full_rebuild", staleness.FullRebuild)
 		result, err := buildCache(
 			dbPath, analyticsDir, staleness.FullRebuild)
@@ -444,4 +405,154 @@ func runScheduledSync(ctx context.Context, email string, s *store.Store, getOAut
 	}
 
 	return nil
+}
+
+// findScheduledSyncSource resolves the source row for a scheduler
+// identifier. Returns (nil, nil) when no syncable source matches —
+// callers fall back to the Gmail token-first workflow.
+//
+// Matches against both sources.identifier and sources.display_name so
+// an IMAP account listed in config.toml as a plain email
+// (`email = "user@example.com"`) resolves to the row whose identifier
+// is the `imaps://...` URL but whose display_name is that email.
+//
+// When multiple rows match (rare; e.g. an mbox import plus a Gmail
+// account with the same name), the first syncable row (gmail/imap)
+// wins, with gmail taking precedence over imap.
+func findScheduledSyncSource(s *store.Store, identifier string) (*store.Source, error) {
+	sources, err := s.GetSourcesByIdentifierOrDisplayName(identifier)
+	if err != nil {
+		return nil, err
+	}
+	var imapSrc *store.Source
+	for _, src := range sources {
+		switch src.SourceType {
+		case "gmail":
+			return src, nil
+		case "imap":
+			if imapSrc == nil {
+				imapSrc = src
+			}
+		}
+	}
+	return imapSrc, nil
+}
+
+// runScheduledGmailSync runs an incremental Gmail sync for the daemon.
+// Token-source lookup uses oauthMgr.TokenSource directly (not
+// getTokenSourceWithReauth) because serve runs as a daemon and cannot
+// open a browser for OAuth — the error path tells the user how to
+// re-authorize from a terminal.
+func runScheduledGmailSync(ctx context.Context, email string, src *store.Source, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), vf *vectorFeatures) (*gmail.SyncSummary, error) {
+	appName := ""
+	if src != nil {
+		appName = sourceOAuthApp(src)
+	}
+
+	var tokenSource oauth2.TokenSource
+	var tsErr error
+
+	if saKeyPath := cfg.OAuth.ServiceAccountKeyFor(appName); saKeyPath != "" {
+		saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
+		if saErr != nil {
+			return nil, fmt.Errorf("service account for %s: %w", email, saErr)
+		}
+		tokenSource, tsErr = saMgr.TokenSource(ctx, email)
+		if tsErr != nil {
+			return nil, fmt.Errorf("service account token for %s: %w", email, tsErr)
+		}
+	} else {
+		oauthMgr, oaErr := getOAuthMgr(appName)
+		if oaErr != nil {
+			return nil, fmt.Errorf("resolve OAuth credentials for %s: %w", email, oaErr)
+		}
+		tokenSource, tsErr = oauthMgr.TokenSource(ctx, email)
+		if tsErr != nil {
+			if oauthMgr.HasToken(email) {
+				return nil, fmt.Errorf("get token source: %w (token may be expired; run 'sync %s' or 'verify %s' from an interactive terminal to re-authorize)", tsErr, email, email)
+			}
+			return nil, fmt.Errorf("get token source: %w (run 'add-account %s' first)", tsErr, email)
+		}
+	}
+
+	rateLimiter := gmail.NewRateLimiter(float64(cfg.Sync.RateLimitQPS))
+	client := gmail.NewClient(tokenSource,
+		gmail.WithLogger(logger),
+		gmail.WithRateLimiter(rateLimiter),
+	)
+	defer func() { _ = client.Close() }()
+
+	opts := sync.DefaultOptions()
+	opts.AttachmentsDir = cfg.AttachmentsDir()
+
+	syncer := sync.New(client, s, opts).WithLogger(logger)
+	if vf != nil {
+		syncer.SetEmbedEnqueuer(vf.Enqueuer)
+	}
+
+	source, err := s.GetOrCreateSource("gmail", email)
+	if err != nil {
+		return nil, fmt.Errorf("get source: %w", err)
+	}
+	// Auto-default-identity must run BEFORE the legacy migration retry
+	// — see comment in account_identity.go. serve is a daemon, so the
+	// confirmation message has no terminal; discard it. Helper logs any
+	// failure path through its own logger.Warn.
+	confirmDefaultIdentity(io.Discard, s, source.ID, email, email, "account-identifier")
+	if err := runPostSourceCreateMigrations(s); err != nil {
+		return nil, fmt.Errorf("post-source-create migrations: %w", err)
+	}
+
+	summary, err := syncer.Incremental(ctx, source)
+	if err != nil {
+		return nil, fmt.Errorf("incremental sync failed: %w", err)
+	}
+	return summary, nil
+}
+
+// runScheduledIMAPSync runs a full IMAP sync for the daemon. IMAP has
+// no incremental/history API, so we always do a full pass and rely on
+// the store to dedupe by message-id. NoResume is forced on because
+// IMAP page tokens are numeric offsets that don't survive across
+// processes (see syncfull.go).
+func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store, vf *vectorFeatures) (*gmail.SyncSummary, error) {
+	apiClient, err := buildAPIClient(ctx, src, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build IMAP client: %w", err)
+	}
+	defer func() { _ = apiClient.Close() }()
+
+	opts := sync.DefaultOptions()
+	opts.SourceType = "imap"
+	opts.AttachmentsDir = cfg.AttachmentsDir()
+	opts.NoResume = true
+
+	syncer := sync.New(apiClient, s, opts).WithLogger(logger)
+	if vf != nil {
+		syncer.SetEmbedEnqueuer(vf.Enqueuer)
+	}
+
+	// runPostSourceCreateMigrations is keyed off Gmail-only legacy
+	// state, so it's a no-op for fresh IMAP installs; we still call it
+	// for parity with the Gmail path so the daemon converges legacy
+	// DBs that happen to mix sources.
+	//
+	// Pass display_name (the IMAP username/email recorded by `add-imap`),
+	// not Identifier (the `imaps://...` URL), so the auto-default-identity
+	// matches what add-imap wrote and won't pollute account_identities
+	// with a URL if the user has cleared identities. confirmDefaultIdentity
+	// silently no-ops when the identifier arg is empty, so a legacy IMAP
+	// row with NULL display_name skips the write rather than re-injecting
+	// the URL.
+	displayName := src.DisplayName.String
+	confirmDefaultIdentity(io.Discard, s, src.ID, displayName, displayName, "account-identifier")
+	if err := runPostSourceCreateMigrations(s); err != nil {
+		return nil, fmt.Errorf("post-source-create migrations: %w", err)
+	}
+
+	summary, err := syncer.Full(ctx, src.Identifier)
+	if err != nil {
+		return nil, fmt.Errorf("IMAP sync failed: %w", err)
+	}
+	return summary, nil
 }

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.kenn.io/msgvault/internal/config"
+	imaplib "go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/oauth"
 	"go.kenn.io/msgvault/internal/scheduler"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 func TestServeConfigParsing(t *testing.T) {
@@ -148,6 +152,273 @@ func TestSetupVectorFeatures_Disabled(t *testing.T) {
 	}
 	if vf != nil {
 		t.Errorf("setupVectorFeatures = %v, want nil when disabled", vf)
+	}
+}
+
+// TestFindScheduledSyncSource verifies that the scheduler's
+// source-resolution helper picks gmail over imap and ignores rows of
+// non-syncable source types (mbox, apple-mail, etc.). Regression for
+// the daemon-mode IMAP dispatch (#329).
+func TestFindScheduledSyncSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	// No rows: returns nil, allowing the Gmail token-first fallback.
+	got, err := findScheduledSyncSource(s, "missing@example.com")
+	if err != nil {
+		t.Fatalf("findScheduledSyncSource(missing) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("findScheduledSyncSource(missing) = %v, want nil", got)
+	}
+
+	// IMAP source created by add-imap: identifier is the imaps:// URL,
+	// display_name is the user-facing email. Both lookups must resolve
+	// to the same row.
+	const imapID = "imaps://user@example.com@imap.example.com:993"
+	const imapEmail = "user@example.com"
+	imapSrc, err := s.GetOrCreateSource("imap", imapID)
+	if err != nil {
+		t.Fatalf("create imap source: %v", err)
+	}
+	if err := s.UpdateSourceDisplayName(imapSrc.ID, imapEmail); err != nil {
+		t.Fatalf("set imap display_name: %v", err)
+	}
+
+	got, err = findScheduledSyncSource(s, imapID)
+	if err != nil {
+		t.Fatalf("findScheduledSyncSource(imap by identifier) error: %v", err)
+	}
+	if got == nil || got.SourceType != "imap" {
+		t.Fatalf("findScheduledSyncSource(imap by identifier) = %v, want imap source", got)
+	}
+
+	// Lookup by display_name (the typical config.toml `email = "..."`
+	// shape) must also resolve the IMAP source — otherwise the daemon
+	// falls back to Gmail and produces a misleading token error.
+	got, err = findScheduledSyncSource(s, imapEmail)
+	if err != nil {
+		t.Fatalf("findScheduledSyncSource(imap by display_name) error: %v", err)
+	}
+	if got == nil || got.SourceType != "imap" {
+		t.Fatalf("findScheduledSyncSource(imap by display_name) = %v, want imap source", got)
+	}
+
+	// Identifier shared by an unsyncable mbox row + a gmail row:
+	// gmail wins, the unsyncable row is ignored.
+	const sharedID = "shared@example.com"
+	if _, err := s.GetOrCreateSource("mbox", sharedID); err != nil {
+		t.Fatalf("create mbox source: %v", err)
+	}
+	if _, err := s.GetOrCreateSource("gmail", sharedID); err != nil {
+		t.Fatalf("create gmail source: %v", err)
+	}
+	got, err = findScheduledSyncSource(s, sharedID)
+	if err != nil {
+		t.Fatalf("findScheduledSyncSource(shared) error: %v", err)
+	}
+	if got == nil || got.SourceType != "gmail" {
+		t.Fatalf("findScheduledSyncSource(shared) = %v, want gmail source", got)
+	}
+
+	// Identifier with only an unsyncable row: returns nil so the
+	// dispatcher's Gmail fallback fires and produces a Gmail-shaped
+	// error (rather than misclassifying as imap).
+	const mboxID = "mbox-only@example.com"
+	if _, err := s.GetOrCreateSource("mbox", mboxID); err != nil {
+		t.Fatalf("create mbox source: %v", err)
+	}
+	got, err = findScheduledSyncSource(s, mboxID)
+	if err != nil {
+		t.Fatalf("findScheduledSyncSource(mbox-only) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("findScheduledSyncSource(mbox-only) = %v, want nil", got)
+	}
+}
+
+// TestRunScheduledIMAPSync_NoCredentials verifies that the IMAP path
+// in runScheduledSync is reachable — i.e. an IMAP source row makes the
+// dispatcher build an IMAP client and surface a credentials error,
+// rather than the misleading "oauth2: token expired and refresh token
+// is not set" message reported in #329.
+func TestRunScheduledIMAPSync_NoCredentials(t *testing.T) {
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{}
+	cfg.Data.DataDir = t.TempDir()
+
+	s, err := store.Open(filepath.Join(cfg.Data.DataDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	const imapID = "imaps://user@example.com@imap.example.com:993"
+	if _, err := s.GetOrCreateSource("imap", imapID); err != nil {
+		t.Fatalf("create imap source: %v", err)
+	}
+
+	// getOAuthMgr is only invoked on the Gmail path; fail loudly so
+	// any wrong-path dispatch is obvious.
+	getOAuthMgr := func(app string) (*oauth.Manager, error) {
+		t.Fatalf("Gmail OAuth manager unexpectedly requested for IMAP source (app=%q)", app)
+		return nil, nil
+	}
+
+	err = runScheduledSync(context.Background(), imapID, s, getOAuthMgr, nil)
+	if err == nil {
+		t.Fatal("runScheduledSync(imap, no creds) = nil error, want credentials error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "refresh token") || strings.Contains(msg, "token may be expired") {
+		t.Errorf("IMAP path produced Gmail-flavoured error %q — dispatch is still Gmail-only", msg)
+	}
+	if !strings.Contains(msg, "no credentials") && !strings.Contains(msg, "IMAP") {
+		t.Errorf("error %q does not mention IMAP credentials", msg)
+	}
+}
+
+// TestRunScheduledIMAPSync_DispatchByDisplayName verifies the daemon
+// resolves IMAP sources when config.toml lists the account as a plain
+// email — i.e. the lookup key matches the source's display_name rather
+// than its imaps:// identifier. Regression: a previous version only
+// matched against identifier, so config-driven scheduled syncs fell
+// through to the Gmail OAuth path (#329).
+func TestRunScheduledIMAPSync_DispatchByDisplayName(t *testing.T) {
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{}
+	cfg.Data.DataDir = t.TempDir()
+
+	s, err := store.Open(filepath.Join(cfg.Data.DataDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	const (
+		imapID    = "imaps://user@example.com@imap.example.com:993"
+		imapEmail = "user@example.com"
+	)
+	src, err := s.GetOrCreateSource("imap", imapID)
+	if err != nil {
+		t.Fatalf("create imap source: %v", err)
+	}
+	if err := s.UpdateSourceDisplayName(src.ID, imapEmail); err != nil {
+		t.Fatalf("set display_name: %v", err)
+	}
+
+	getOAuthMgr := func(app string) (*oauth.Manager, error) {
+		t.Fatalf("Gmail OAuth manager unexpectedly requested for IMAP source (app=%q)", app)
+		return nil, nil
+	}
+
+	// Pass the email (as config.toml `email = "..."` would supply it),
+	// not the imaps:// identifier. Dispatch must still land on the
+	// IMAP path; absence of credentials produces an IMAP-shaped error.
+	err = runScheduledSync(context.Background(), imapEmail, s, getOAuthMgr, nil)
+	if err == nil {
+		t.Fatal("runScheduledSync(email, no creds) = nil error, want IMAP credentials error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "refresh token") || strings.Contains(msg, "token may be expired") {
+		t.Errorf("dispatch fell through to Gmail path: %q", msg)
+	}
+	if !strings.Contains(msg, "IMAP") {
+		t.Errorf("error %q does not mention IMAP — dispatch likely missed the source", msg)
+	}
+}
+
+// TestRunScheduledIMAPSync_DefaultIdentityIsDisplayName verifies the
+// IMAP dispatch path writes the source's display_name (the email) as
+// the default account identity — never the raw imaps:// identifier
+// URL. Regression: a previous version passed src.Identifier, which
+// would inject e.g. "imaps://user@host:993" into account_identities
+// when the user had cleared their identities.
+func TestRunScheduledIMAPSync_DefaultIdentityIsDisplayName(t *testing.T) {
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{}
+	cfg.Data.DataDir = t.TempDir()
+
+	s, err := store.Open(filepath.Join(cfg.Data.DataDir, "msgvault.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := s.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	// Use a closed port on loopback so buildAPIClient succeeds (the
+	// client doesn't dial in its constructor) and confirmDefaultIdentity
+	// fires before syncer.Full hits ECONNREFUSED.
+	const (
+		imapID    = "imaps://user@example.com@127.0.0.1:1"
+		imapEmail = "user@example.com"
+	)
+	src, err := s.GetOrCreateSource("imap", imapID)
+	if err != nil {
+		t.Fatalf("create imap source: %v", err)
+	}
+	if err := s.UpdateSourceDisplayName(src.ID, imapEmail); err != nil {
+		t.Fatalf("set display_name: %v", err)
+	}
+	if err := s.UpdateSourceSyncConfig(src.ID,
+		`{"host":"127.0.0.1","port":1,"username":"user@example.com","tls":true}`,
+	); err != nil {
+		t.Fatalf("set sync_config: %v", err)
+	}
+	if err := imaplib.SaveCredentials(cfg.TokensDir(), imapID, "unused"); err != nil {
+		t.Fatalf("save credentials: %v", err)
+	}
+
+	getOAuthMgr := func(app string) (*oauth.Manager, error) {
+		t.Fatalf("Gmail OAuth manager unexpectedly requested (app=%q)", app)
+		return nil, nil
+	}
+
+	// Expected to fail at the IMAP connection; what matters is that
+	// confirmDefaultIdentity ran first with the display_name.
+	_ = runScheduledSync(context.Background(), imapID, s, getOAuthMgr, nil)
+
+	identities, err := s.ListAccountIdentities(src.ID)
+	if err != nil {
+		t.Fatalf("ListAccountIdentities: %v", err)
+	}
+	if len(identities) == 0 {
+		t.Fatal("no identities written — confirmDefaultIdentity did not fire on the IMAP path")
+	}
+	for _, id := range identities {
+		if strings.HasPrefix(id.Address, "imaps://") ||
+			strings.HasPrefix(id.Address, "imap://") ||
+			strings.HasPrefix(id.Address, "imap+starttls://") {
+			t.Errorf("identity %q is an IMAP URL — daemon polluted account_identities", id.Address)
+		}
+	}
+	var foundEmail bool
+	for _, id := range identities {
+		if id.Address == imapEmail {
+			foundEmail = true
+			break
+		}
+	}
+	if !foundEmail {
+		t.Errorf("identities = %+v, want one with Address=%q", identities, imapEmail)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes #329: `runScheduledSync` was hardcoded to the Gmail OAuth path, so every scheduled tick for an IMAP account configured in `config.toml` failed with the misleading `oauth2: token expired and refresh token is not set` error and no IMAP sync ever ran from the daemon.
- Look up the source by identifier and dispatch on `source_type`: Gmail keeps the existing incremental flow (and its daemon-specific token error messages); IMAP runs a full sync via the shared `buildAPIClient` helper (`NoResume=true`, matching the CLI's IMAP behaviour).
- A `nil` source still falls back to Gmail to preserve the token-first workflow where tokens are uploaded via the API before any source row exists.

## Notes

- The shared `buildAPIClient` helper handles both password-IMAP (via `imap.LoadCredentials`) and OAuth-IMAP (Microsoft) — both work from the daemon.
- Unsupported source types (mbox, apple-mail, imessage, etc.) now return an explicit error instead of being misclassified as Gmail.

## Test plan

- [x] `go vet ./...` clean
- [x] `make test` — full suite green
- [x] New `TestFindScheduledSyncSource` — covers nil / imap-only / mixed gmail+mbox / mbox-only identifier rows.
- [x] New `TestRunScheduledIMAPSync_NoCredentials` — verifies the dispatcher actually reaches the IMAP path (no Gmail-flavoured error) and fails with a useful credentials error.