### PR TITLE
cli: stop dumping help on every error

### DIFF
--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -95,7 +95,7 @@ Examples:
 		saKeyPath := cfg.OAuth.ServiceAccountKeyFor(resolvedApp)
 		if headless {
 			if saKeyPath != "" {
-				return fmt.Errorf("service accounts do not use --headless; run add-account without --headless")
+				return usageErr(cmd, fmt.Errorf("service accounts do not use --headless; run add-account without --headless"))
 			}
 			oauth.PrintHeadlessInstructions(email, cfg.TokensDir(), resolvedApp)
 			return nil
@@ -104,7 +104,7 @@ Examples:
 		// Check for service account configuration first
 		if saKeyPath != "" {
 			if forceReauth {
-				return fmt.Errorf("service accounts do not use --force; tokens are minted on demand from the configured service account key")
+				return usageErr(cmd, fmt.Errorf("service accounts do not use --force; tokens are minted on demand from the configured service account key"))
 			}
 			saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
 			if saErr != nil {

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -43,7 +43,7 @@ Examples:
 		email := args[0]
 
 		if headless && forceReauth {
-			return fmt.Errorf("--headless and --force cannot be used together: --force requires browser-based OAuth which is not available in headless mode")
+			return usageErr(cmd, fmt.Errorf("--headless and --force cannot be used together: --force requires browser-based OAuth which is not available in headless mode"))
 		}
 
 		// Resolve which client secrets to use

--- a/cmd/msgvault/cmd/addimap.go
+++ b/cmd/msgvault/cmd/addimap.go
@@ -82,13 +82,13 @@ Examples:
   msgvault add-imap --host mail.example.com --username user@example.com --no-tls`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if imapHost == "" {
-			return fmt.Errorf("--host is required")
+			return usageErr(cmd, fmt.Errorf("--host is required"))
 		}
 		if imapUsername == "" {
-			return fmt.Errorf("--username is required")
+			return usageErr(cmd, fmt.Errorf("--username is required"))
 		}
 		if imapNoTLS && imapSTARTTLS {
-			return fmt.Errorf("--no-tls and --starttls are mutually exclusive")
+			return usageErr(cmd, fmt.Errorf("--no-tls and --starttls are mutually exclusive"))
 		}
 
 		// Build IMAP config

--- a/cmd/msgvault/cmd/collection.go
+++ b/cmd/msgvault/cmd/collection.go
@@ -69,7 +69,7 @@ var (
 	collectionRemoveAccounts string
 )
 
-func runCollectionCreate(_ *cobra.Command, args []string) error {
+func runCollectionCreate(cmd *cobra.Command, args []string) error {
 	st, err := openStoreAndInit()
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func runCollectionCreate(_ *cobra.Command, args []string) error {
 	defer func() { _ = st.Close() }()
 
 	name := args[0]
-	sourceIDs, err := resolveAccountList(st, collectionCreateAccounts)
+	sourceIDs, err := resolveAccountList(cmd, st, collectionCreateAccounts)
 	if err != nil {
 		return err
 	}
@@ -155,14 +155,14 @@ func runCollectionShow(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runCollectionAdd(_ *cobra.Command, args []string) error {
+func runCollectionAdd(cmd *cobra.Command, args []string) error {
 	st, err := openStoreAndInit()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = st.Close() }()
 
-	sourceIDs, err := resolveAccountList(st, collectionAddAccounts)
+	sourceIDs, err := resolveAccountList(cmd, st, collectionAddAccounts)
 	if err != nil {
 		return err
 	}
@@ -174,14 +174,14 @@ func runCollectionAdd(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runCollectionRemove(_ *cobra.Command, args []string) error {
+func runCollectionRemove(cmd *cobra.Command, args []string) error {
 	st, err := openStoreAndInit()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = st.Close() }()
 
-	sourceIDs, err := resolveAccountList(st, collectionRemoveAccounts)
+	sourceIDs, err := resolveAccountList(cmd, st, collectionRemoveAccounts)
 	if err != nil {
 		return err
 	}
@@ -207,9 +207,9 @@ func runCollectionDelete(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func resolveAccountList(st *store.Store, accounts string) ([]int64, error) {
+func resolveAccountList(cmd *cobra.Command, st *store.Store, accounts string) ([]int64, error) {
 	if accounts == "" {
-		return nil, fmt.Errorf("--accounts is required")
+		return nil, usageErr(cmd, fmt.Errorf("--accounts is required"))
 	}
 	parts := strings.Split(accounts, ",")
 	var ids []int64

--- a/cmd/msgvault/cmd/collection_test.go
+++ b/cmd/msgvault/cmd/collection_test.go
@@ -78,7 +78,7 @@ func TestResolveAccountListRejectsMissingNumericID(t *testing.T) {
 		t.Fatalf("create source: %v", err)
 	}
 
-	ids, err := resolveAccountList(st, fmt.Sprintf("%d", src.ID))
+	ids, err := resolveAccountList(nil, st, fmt.Sprintf("%d", src.ID))
 	if err != nil {
 		t.Fatalf("resolveAccountList(existing id): %v", err)
 	}
@@ -93,7 +93,7 @@ func TestResolveAccountListRejectsMissingNumericID(t *testing.T) {
 	// identifier (e.g. unprefixed phone "15551234567") that wasn't a
 	// source ID would never get a chance to match by identifier. The
 	// test below asserts the fall-through path is reachable.
-	if _, err := resolveAccountList(st, "999999"); err == nil {
+	if _, err := resolveAccountList(nil, st, "999999"); err == nil {
 		t.Fatal("expected error for missing numeric source ID, got nil")
 	}
 }
@@ -128,7 +128,7 @@ func TestResolveAccountListNumericFallthroughResolvesIdentifier(t *testing.T) {
 		t.Fatalf("test assumption broken: source id %d collides with identifier", src.ID)
 	}
 
-	ids, err := resolveAccountList(st, phoneIdentifier)
+	ids, err := resolveAccountList(nil, st, phoneIdentifier)
 	if err != nil {
 		t.Fatalf("resolveAccountList(numeric identifier): %v", err)
 	}

--- a/cmd/msgvault/cmd/create_subset.go
+++ b/cmd/msgvault/cmd/create_subset.go
@@ -49,7 +49,7 @@ func runCreateSubset(cmd *cobra.Command, _ []string) error {
 	}
 
 	if subsetRows <= 0 {
-		return fmt.Errorf("--rows must be a positive integer")
+		return usageErr(cmd, fmt.Errorf("--rows must be a positive integer"))
 	}
 
 	srcDBPath := cfg.DatabaseDSN()

--- a/cmd/msgvault/cmd/delete_deduped.go
+++ b/cmd/msgvault/cmd/delete_deduped.go
@@ -46,7 +46,7 @@ func runDeleteDeduped(cmd *cobra.Command, _ []string) error {
 	}
 
 	if len(deleteDedupedBatchIDs) == 0 && !deleteDedupedAllHidden {
-		return fmt.Errorf("must specify --batch or --all-hidden")
+		return usageErr(cmd, fmt.Errorf("must specify --batch or --all-hidden"))
 	}
 
 	st, err := openStoreAndInit()

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -415,11 +415,11 @@ Examples:
 			}
 
 			if len(accounts) == 0 {
-				return fmt.Errorf("no account in deletion manifest - use --account flag")
+				return usageErr(cmd, fmt.Errorf("no account in deletion manifest - use --account flag"))
 			} else if len(accounts) == 1 {
 				account = accounts[0]
 			} else {
-				return fmt.Errorf("multiple accounts in pending batches (%v) - use --account flag to specify which account", accounts)
+				return usageErr(cmd, fmt.Errorf("multiple accounts in pending batches (%v) - use --account flag to specify which account", accounts))
 			}
 		} else {
 			// Resolve the user-supplied value to a source.

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -126,7 +126,7 @@ Examples:
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if cancelAll && len(args) > 0 {
-			return fmt.Errorf("cannot use --all with a batch ID argument")
+			return usageErr(cmd, fmt.Errorf("cannot use --all with a batch ID argument"))
 		}
 
 		deletionsDir := filepath.Join(cfg.Data.DataDir, "deletions")
@@ -196,7 +196,7 @@ Examples:
 				fmt.Println("  (none)")
 			}
 			fmt.Println()
-			return fmt.Errorf("provide a batch ID or use --all")
+			return usageErr(cmd, fmt.Errorf("provide a batch ID or use --all"))
 		}
 
 		batchID := args[0]

--- a/cmd/msgvault/cmd/export_attachment.go
+++ b/cmd/msgvault/cmd/export_attachment.go
@@ -54,14 +54,14 @@ func runExportAttachment(cmd *cobra.Command, args []string) error {
 
 	// Validate flag combinations
 	if exportAttachmentJSON && exportAttachmentBase64 {
-		return fmt.Errorf("--json and --base64 are mutually exclusive")
+		return usageErr(cmd, fmt.Errorf("--json and --base64 are mutually exclusive"))
 	}
 	if exportAttachmentOutput != "" && exportAttachmentOutput != "-" {
 		if exportAttachmentJSON {
-			return fmt.Errorf("--json and --output are mutually exclusive (--json writes to stdout)")
+			return usageErr(cmd, fmt.Errorf("--json and --output are mutually exclusive (--json writes to stdout)"))
 		}
 		if exportAttachmentBase64 {
-			return fmt.Errorf("--base64 and --output are mutually exclusive (--base64 writes to stdout)")
+			return usageErr(cmd, fmt.Errorf("--base64 and --output are mutually exclusive (--base64 writes to stdout)"))
 		}
 	}
 

--- a/cmd/msgvault/cmd/identity.go
+++ b/cmd/msgvault/cmd/identity.go
@@ -277,10 +277,10 @@ func runIdentityAdd(cmd *cobra.Command, args []string) error {
 	accountArg, identifierArg := args[0], args[1]
 	identifier := strings.TrimSpace(identifierArg)
 	if identifier == "" {
-		return fmt.Errorf("identifier cannot be empty")
+		return usageErr(cmd, fmt.Errorf("identifier cannot be empty"))
 	}
 	if strings.Contains(identityAddSignal, ",") {
-		return fmt.Errorf("signal names cannot contain commas: %q", identityAddSignal)
+		return usageErr(cmd, fmt.Errorf("signal names cannot contain commas: %q", identityAddSignal))
 	}
 
 	scope, err := ResolveAccountFlag(st, accountArg)
@@ -341,7 +341,7 @@ func runIdentityRemove(cmd *cobra.Command, args []string) error {
 
 	identifier := strings.TrimSpace(args[1])
 	if identifier == "" {
-		return fmt.Errorf("identifier must not be empty")
+		return usageErr(cmd, fmt.Errorf("identifier must not be empty"))
 	}
 
 	scope, err := ResolveAccountFlag(st, args[0])

--- a/cmd/msgvault/cmd/import.go
+++ b/cmd/msgvault/cmd/import.go
@@ -50,10 +50,10 @@ func runWhatsAppImport(cmd *cobra.Command, sourcePath string) error {
 
 	// Validate phone number.
 	if importPhone == "" {
-		return fmt.Errorf("--phone is required for WhatsApp import (E.164 format, e.g., +447700900000)")
+		return usageErr(cmd, fmt.Errorf("--phone is required for WhatsApp import (E.164 format, e.g., +447700900000)"))
 	}
 	if !strings.HasPrefix(importPhone, "+") {
-		return fmt.Errorf("phone number must be in E.164 format (starting with +), got %q", importPhone)
+		return usageErr(cmd, fmt.Errorf("phone number must be in E.164 format (starting with +), got %q", importPhone))
 	}
 
 	// Validate media dir if provided.

--- a/cmd/msgvault/cmd/import_emlx.go
+++ b/cmd/msgvault/cmd/import_emlx.go
@@ -59,8 +59,7 @@ Examples:
   # Legacy two-arg form (deprecated, still works)
   msgvault import-emlx me@gmail.com ~/Library/Mail/V10/SOME-GUID
 `,
-	Args:         cobra.MaximumNArgs(2),
-	SilenceUsage: true,
+	Args: cobra.MaximumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Use a local copy so we don't mutate the package-global
 		// flag variable (which persists across Execute() calls).

--- a/cmd/msgvault/cmd/import_mbox.go
+++ b/cmd/msgvault/cmd/import_mbox.go
@@ -49,8 +49,7 @@ Examples:
   # HEY.com export (still MBOX)
   msgvault import-mbox you@hey.com hey-export.zip --source-type hey --label hey
 `,
-	Args:         cobra.ExactArgs(2),
-	SilenceUsage: true,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		identifier := args[0]
 		exportPath := args[1]

--- a/cmd/msgvault/cmd/import_messenger.go
+++ b/cmd/msgvault/cmd/import_messenger.go
@@ -49,8 +49,7 @@ Examples:
   msgvault import-messenger --me test.user@facebook.messenger --format both ./dyi
   msgvault import-messenger --me test.user@facebook.messenger --limit 100 ./dyi
 `,
-	Args:         cobra.ExactArgs(1),
-	SilenceUsage: true,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := MustBeLocal("import-messenger"); err != nil {
 			return err

--- a/cmd/msgvault/cmd/import_pst.go
+++ b/cmd/msgvault/cmd/import_pst.go
@@ -38,8 +38,7 @@ Examples:
   msgvault import-pst you@outlook.com backup.pst --skip-folder "Deleted Items"
   msgvault import-pst you@outlook.com backup.pst --no-resume
 `,
-	Args:         cobra.ExactArgs(2),
-	SilenceUsage: true,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		identifier := args[0]
 		pstPath := args[1]

--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -124,7 +124,7 @@ Add to Claude Desktop config:
 		if mcpHTTPAddr != "" {
 			normalized, err := normalizeMCPHTTPAddr(mcpHTTPAddr, mcpHTTPAllowInsecure)
 			if err != nil {
-				return err
+				return usageErr(cmd, err)
 			}
 			return mcpserver.ServeHTTPWithOptions(ctx, opts, normalized)
 		}

--- a/cmd/msgvault/cmd/root.go
+++ b/cmd/msgvault/cmd/root.go
@@ -49,12 +49,32 @@ email data locally with full-text search capabilities.
 This is the Go implementation providing sync, search, and TUI functionality
 in a single binary.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Cobra's command lifecycle (v1.10.x) is:
+		//   1. ParseFlags + ValidateArgs (Args:)
+		//   2. PersistentPreRunE  ← we are here
+		//   3. PreRunE
+		//   4. ValidateRequiredFlags  ← MarkFlagRequired
+		//   5. ValidateFlagGroups     ← MarkFlagsMutuallyExclusive
+		//   6. RunE
+		//
+		// Errors from (2) (config load, logger setup) are runtime
+		// failures: hide the usage block. Errors from (4)/(5) are
+		// invocation-contract failures: keep the usage block. To get
+		// both, silence usage on entry and clear it before a successful
+		// return so the subsequent built-in validators see the default
+		// (usage on). Each command's RunE is wrapped separately (see
+		// silenceUsageInRunE) to re-silence usage once those validators
+		// have run; usageErr() flips it back on for RunE-internal
+		// invocation-contract violations.
+		cmd.SilenceUsage = true
+
 		// Skip config loading (and therefore logging setup) for
 		// commands that must run without touching disk or config.
 		if cmd.Name() == "version" || cmd.Name() == "update" ||
 			cmd.Name() == "quickstart" || cmd.Name() == "completion" ||
 			cmd.Name() == cobra.ShellCompRequestCmd ||
 			cmd.Name() == cobra.ShellCompNoDescRequestCmd {
+			cmd.SilenceUsage = false
 			return nil
 		}
 
@@ -142,6 +162,10 @@ in a single binary.`,
 		logger.Debug("msgvault startup args",
 			"args", sanitizeArgs(args),
 		)
+		// Restore the default so cobra's required-flag and
+		// mutually-exclusive-flag validators (steps 4/5 above) print
+		// usage if they fail.
+		cmd.SilenceUsage = false
 		return nil
 	},
 	// Note: log file closing is handled by ExecuteContext's deferred
@@ -225,6 +249,8 @@ func Execute() error {
 // Installs a panic recovery and closes the log file handler on
 // return so every run ends cleanly in the log.
 func ExecuteContext(ctx context.Context) error {
+	silenceUsageOnce.Do(func() { silenceUsageInRunE(rootCmd) })
+
 	// Defer ordering is load-bearing. LIFO means recoverAndLogPanic
 	// runs before the log-file close. Because recoverAndLogPanic calls
 	// os.Exit (which skips remaining defers), it closes logResult
@@ -250,6 +276,47 @@ func ExecuteContext(ctx context.Context) error {
 		}
 	}
 	return err
+}
+
+// usageErr re-enables the usage block for cmd and returns err. Use inside
+// RunE for validation that's semantically part of the invocation contract
+// (mutually exclusive flags, missing required values, bad enum values).
+// silenceUsageInRunE silences usage at RunE entry; this flips it back for
+// the specific case of "the user invoked me wrong."
+// A nil cmd is tolerated so tests can call RunE-internal helpers without
+// constructing a cobra.Command.
+func usageErr(cmd *cobra.Command, err error) error {
+	if cmd != nil {
+		cmd.SilenceUsage = false
+	}
+	return err
+}
+
+// silenceUsageOnce guards silenceUsageInRunE so each command's RunE is
+// only wrapped once, even if Execute is called more than once (e.g. in
+// tests that drive rootCmd repeatedly).
+var silenceUsageOnce sync.Once
+
+// silenceUsageInRunE walks cmd's subtree and replaces each RunE with a
+// wrapper that sets SilenceUsage = true on entry, then delegates to the
+// original handler. Cobra's required-flag and mutually-exclusive-flag
+// validators run after PersistentPreRunE but before RunE, so wrapping
+// here suppresses usage only for the runtime errors RunE actually
+// returns — leaving the built-in invocation-contract validators free
+// to print the usage block on failure. RunE handlers that detect their
+// own invocation-contract violations flip SilenceUsage back on via
+// usageErr.
+func silenceUsageInRunE(cmd *cobra.Command) {
+	if cmd.RunE != nil {
+		orig := cmd.RunE
+		cmd.RunE = func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return orig(cmd, args)
+		}
+	}
+	for _, sub := range cmd.Commands() {
+		silenceUsageInRunE(sub)
+	}
 }
 
 // oauthSetupHint returns help text for OAuth configuration issues,

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -59,31 +59,31 @@ Examples:
 		queryStr := strings.Join(args, " ")
 
 		if queryStr == "" && searchAccount == "" && searchCollection == "" {
-			return fmt.Errorf("provide a search query or --account/--collection flag")
+			return usageErr(cmd, fmt.Errorf("provide a search query or --account/--collection flag"))
 		}
 
 		// Use remote search if configured
 		if IsRemoteMode() {
 			if searchAccount != "" {
-				return fmt.Errorf(
+				return usageErr(cmd, fmt.Errorf(
 					"--account is not supported in remote mode",
-				)
+				))
 			}
 			if searchCollection != "" {
-				return fmt.Errorf("--collection is not supported in remote mode")
+				return usageErr(cmd, fmt.Errorf("--collection is not supported in remote mode"))
 			}
 			if searchMode != "fts" {
-				return fmt.Errorf("--mode is not supported in remote mode")
+				return usageErr(cmd, fmt.Errorf("--mode is not supported in remote mode"))
 			}
 			return runRemoteSearch(queryStr)
 		}
 
 		// Validate mode before any scope work so we fail fast on a typo.
 		if searchMode != "fts" && searchMode != "vector" && searchMode != "hybrid" {
-			return fmt.Errorf("invalid --mode: %q (want fts|vector|hybrid)", searchMode)
+			return usageErr(cmd, fmt.Errorf("invalid --mode: %q (want fts|vector|hybrid)", searchMode))
 		}
 		if searchMode != "fts" && searchOffset > 0 {
-			return fmt.Errorf("--offset is not supported with --mode=%s (pagination is single-page)", searchMode)
+			return usageErr(cmd, fmt.Errorf("--offset is not supported with --mode=%s (pagination is single-page)", searchMode))
 		}
 		// Vector and hybrid modes need free-text terms to embed; both
 		// an empty raw query and a filter-only query (e.g. `from:alice`)
@@ -92,10 +92,10 @@ Examples:
 		// allows scoped queryless searches.
 		if searchMode != "fts" {
 			if queryStr == "" {
-				return fmt.Errorf("--mode=%s requires query text to embed; pass a query or use --mode=fts", searchMode)
+				return usageErr(cmd, fmt.Errorf("--mode=%s requires query text to embed; pass a query or use --mode=fts", searchMode))
 			}
 			if len(search.Parse(queryStr).TextTerms) == 0 {
-				return fmt.Errorf("--mode=%s requires free-text terms to embed; %q parsed to filters only — add a search phrase or use --mode=fts", searchMode, queryStr)
+				return usageErr(cmd, fmt.Errorf("--mode=%s requires free-text terms to embed; %q parsed to filters only — add a search phrase or use --mode=fts", searchMode, queryStr))
 			}
 		}
 

--- a/cmd/msgvault/cmd/show_message.go
+++ b/cmd/msgvault/cmd/show_message.go
@@ -37,7 +37,7 @@ Examples:
 
 		// Use remote if configured
 		if IsRemoteMode() {
-			return showRemoteMessage(idStr)
+			return showRemoteMessage(cmd, idStr)
 		}
 
 		return showLocalMessage(cmd, idStr)
@@ -45,11 +45,11 @@ Examples:
 }
 
 // showRemoteMessage fetches and displays a message from the remote server.
-func showRemoteMessage(idStr string) error {
+func showRemoteMessage(cmd *cobra.Command, idStr string) error {
 	// Parse as numeric ID (remote API only supports numeric IDs)
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("remote mode requires numeric message ID (got: %s)", idStr)
+		return usageErr(cmd, fmt.Errorf("remote mode requires numeric message ID (got: %s)", idStr))
 	}
 
 	s, err := OpenRemoteStore()

--- a/cmd/msgvault/cmd/stats.go
+++ b/cmd/msgvault/cmd/stats.go
@@ -24,10 +24,10 @@ Use --local to force local database.`,
 
 		if IsRemoteMode() {
 			if statsAccount != "" {
-				return fmt.Errorf("--account is not supported in remote mode")
+				return usageErr(cmd, fmt.Errorf("--account is not supported in remote mode"))
 			}
 			if statsCollection != "" {
-				return fmt.Errorf("--collection is not supported in remote mode")
+				return usageErr(cmd, fmt.Errorf("--collection is not supported in remote mode"))
 			}
 		}
 

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -51,16 +51,16 @@ Examples:
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if syncLimit < 0 {
-			return fmt.Errorf("--limit must be a non-negative number")
+			return usageErr(cmd, fmt.Errorf("--limit must be a non-negative number"))
 		}
 		if syncAfter != "" {
 			if _, err := time.Parse("2006-01-02", syncAfter); err != nil {
-				return fmt.Errorf("invalid --after date %q (expected YYYY-MM-DD): %w", syncAfter, err)
+				return usageErr(cmd, fmt.Errorf("invalid --after date %q (expected YYYY-MM-DD): %w", syncAfter, err))
 			}
 		}
 		if syncBefore != "" {
 			if _, err := time.Parse("2006-01-02", syncBefore); err != nil {
-				return fmt.Errorf("invalid --before date %q (expected YYYY-MM-DD): %w", syncBefore, err)
+				return usageErr(cmd, fmt.Errorf("invalid --before date %q (expected YYYY-MM-DD): %w", syncBefore, err))
 			}
 		}
 

--- a/cmd/msgvault/cmd/update_account.go
+++ b/cmd/msgvault/cmd/update_account.go
@@ -24,7 +24,7 @@ Examples:
 		email := args[0]
 
 		if updateDisplayName == "" {
-			return fmt.Errorf("nothing to update: use --display-name to set a display name")
+			return usageErr(cmd, fmt.Errorf("nothing to update: use --display-name to set a display name"))
 		}
 
 		dbPath := cfg.DatabaseDSN()


### PR DESCRIPTION
## Summary

Cobra's default behavior dumps the full usage block on every `RunE` error, which buries actual error messages under a wall of help text. Four import commands worked around this by scattering `SilenceUsage: true` on their `cobra.Command` structs, but every other RunE handler still printed the help wall on, e.g., a failed sync or a missing OAuth token.

Mirrors the cleanup done in roborev (`roborev-dev/roborev#727`).

## What changed

- Root `PersistentPreRunE` sets `cmd.SilenceUsage = true` at the top. Cobra runs flag parsing and `Args` validators before `PersistentPreRunE`, so unknown flags / bad arg counts still get usage. Anything reached via `RunE` runs with usage silenced.
- `usageErr(cmd, err)` flips `SilenceUsage` back to `false` for RunE-internal invocation-contract errors (mutex flags, bad enums, missing required values, bad date/phone formats). Applied across `syncfull`, `stats`, `search`, `import` (whatsapp), `export-attachment`, `deletions`, `delete-deduped`, `create-subset`, `add-imap`, `add-account`.
- Drop the now-redundant `SilenceUsage` assignments from the four `import_*` commands.

## Resulting behavior

| invocation | output |
|---|---|
| `msgvault sync-full --bogus` | `Error: unknown flag: --bogus` + usage (cobra default) |
| `msgvault sync-full --limit=-1 ...` | `Error: --limit must be a non-negative number` + usage |
| `msgvault sync-incremental missing@...` | `Error: ...no source found...` only (no usage) |