### PR TITLE
update: use HTML redirect endpoint to avoid GitHub API rate limit

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -23,25 +23,16 @@ import (
 )
 
 const (
-	githubAPIURL     = "https://api.github.com/repos/wesm/msgvault/releases/latest"
-	cacheFileName    = "update_check.json"
-	cacheDuration    = 1 * time.Hour
-	devCacheDuration = 15 * time.Minute
+	// githubLatestReleaseURL is the HTML endpoint that 302-redirects to
+	// /releases/tag/<tag>. Unlike api.github.com it is not rate-limited
+	// at 60 req/hr per IP for unauthenticated callers.
+	githubLatestReleaseURL    = "https://github.com/wesm/msgvault/releases/latest"
+	githubReleaseDownloadBase = "https://github.com/wesm/msgvault/releases/download"
+	updateUserAgent           = "msgvault-update"
+	cacheFileName             = "update_check.json"
+	cacheDuration             = 1 * time.Hour
+	devCacheDuration          = 15 * time.Minute
 )
-
-// Release represents a GitHub release.
-type Release struct {
-	TagName string  `json:"tag_name"`
-	Body    string  `json:"body"`
-	Assets  []Asset `json:"assets"`
-}
-
-// Asset represents a release asset.
-type Asset struct {
-	Name               string `json:"name"`
-	Size               int64  `json:"size"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-}
 
 // UpdateInfo contains information about an available update.
 type UpdateInfo struct {
@@ -52,20 +43,6 @@ type UpdateInfo struct {
 	Size           int64
 	Checksum       string
 	IsDevBuild     bool
-}
-
-// findAssets locates the platform-specific binary and checksums file from release assets.
-func findAssets(assets []Asset, assetName string) (asset *Asset, checksumsAsset *Asset) {
-	for i := range assets {
-		a := &assets[i]
-		if a.Name == assetName {
-			asset = a
-		}
-		if a.Name == "SHA256SUMS" || a.Name == "checksums.txt" {
-			checksumsAsset = a
-		}
-	}
-	return asset, checksumsAsset
 }
 
 // cachedCheck stores the last update check result.
@@ -86,14 +63,14 @@ func CheckForUpdate(currentVersion string, forceCheck bool) (*UpdateInfo, error)
 		}
 	}
 
-	release, err := fetchLatestRelease()
+	tag, err := resolveLatestTag(githubLatestReleaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("check for updates: %w", err)
 	}
 
-	saveCache(release.TagName)
+	saveCache(tag)
 
-	latestVersion := strings.TrimPrefix(release.TagName, "v")
+	latestVersion := strings.TrimPrefix(tag, "v")
 
 	if !isDevBuild && !isNewer(latestVersion, cleanVersion) {
 		return nil, nil
@@ -104,25 +81,25 @@ func CheckForUpdate(currentVersion string, forceCheck bool) (*UpdateInfo, error)
 		ext = ".zip"
 	}
 	assetName := fmt.Sprintf("msgvault_%s_%s_%s%s", latestVersion, runtime.GOOS, runtime.GOARCH, ext)
-	asset, checksumsAsset := findAssets(release.Assets, assetName)
-	if asset == nil {
-		return nil, fmt.Errorf("no release asset found for %s/%s", runtime.GOOS, runtime.GOARCH)
+	downloadURL := fmt.Sprintf("%s/%s/%s", githubReleaseDownloadBase, tag, assetName)
+	checksumsURL := fmt.Sprintf("%s/%s/SHA256SUMS", githubReleaseDownloadBase, tag)
+
+	// HEAD the asset to confirm it exists for this platform. The previous
+	// API-based code returned "no release asset" up front; now that we
+	// construct the URL ourselves, we have to verify it resolves.
+	size, err := fetchContentLength(downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("no release asset for %s/%s: %w", runtime.GOOS, runtime.GOARCH, err)
 	}
 
-	var checksum string
-	if checksumsAsset != nil {
-		checksum, _ = fetchChecksumFromFile(checksumsAsset.BrowserDownloadURL, assetName)
-	}
-	if checksum == "" {
-		checksum = extractChecksum(release.Body, assetName)
-	}
+	checksum, _ := fetchChecksumFromFile(checksumsURL, assetName)
 
 	return &UpdateInfo{
 		CurrentVersion: currentVersion,
-		LatestVersion:  release.TagName,
-		DownloadURL:    asset.BrowserDownloadURL,
-		AssetName:      asset.Name,
-		Size:           asset.Size,
+		LatestVersion:  tag,
+		DownloadURL:    downloadURL,
+		AssetName:      assetName,
+		Size:           size,
 		Checksum:       checksum,
 		IsDevBuild:     isDevBuild,
 	}, nil
@@ -296,31 +273,73 @@ func getCacheDir() string {
 	return config.DefaultHome()
 }
 
-func fetchLatestRelease() (*Release, error) {
-	req, err := http.NewRequest("GET", githubAPIURL, nil)
-	if err != nil {
-		return nil, err
+// resolveLatestTag follows the /releases/latest 302 redirect to
+// /releases/tag/<tag> and returns the tag. Using the HTML endpoint
+// avoids api.github.com's 60-req/hr unauthenticated rate limit.
+func resolveLatestTag(url string) (string, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("User-Agent", "msgvault-update")
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", updateUserAgent)
 
-	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return "", fmt.Errorf("expected redirect from %s, got %s", url, resp.Status)
+	}
+
+	loc, err := resp.Location()
+	if err != nil {
+		return "", fmt.Errorf("read Location header: %w", err)
+	}
+
+	const marker = "/releases/tag/"
+	idx := strings.Index(loc.Path, marker)
+	if idx < 0 {
+		return "", fmt.Errorf("unexpected redirect target %q", loc.String())
+	}
+	tag := loc.Path[idx+len(marker):]
+	if tag == "" {
+		return "", fmt.Errorf("empty tag in redirect target %q", loc.String())
+	}
+	return tag, nil
+}
+
+// fetchContentLength does a HEAD request and returns the Content-Length
+// of the eventual asset (following redirects to the S3 backend).
+// Returns 0 if the size can't be determined; callers degrade gracefully.
+func fetchContentLength(url string) (int64, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("User-Agent", updateUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned %s", resp.Status)
+		return 0, fmt.Errorf("HEAD %s returned %s", url, resp.Status)
 	}
-
-	var release Release
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, err
+	if resp.ContentLength < 0 {
+		return 0, nil
 	}
-
-	return &release, nil
+	return resp.ContentLength, nil
 }
 
 func downloadFile(url, dest string, totalSize int64, progressFn func(downloaded, total int64)) (string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -346,66 +348,124 @@ func TestIsNewer(t *testing.T) {
 	}
 }
 
-func TestFindAssets(t *testing.T) {
+func TestResolveLatestTag(t *testing.T) {
 	t.Parallel()
-	assets := []Asset{
-		{Name: "msgvault_linux_amd64.tar.gz", Size: 1000, BrowserDownloadURL: "https://example.com/linux_amd64"},
-		{Name: "msgvault_darwin_arm64.tar.gz", Size: 2000, BrowserDownloadURL: "https://example.com/darwin_arm64"},
-		{Name: "SHA256SUMS", Size: 500, BrowserDownloadURL: "https://example.com/checksums"},
-		{Name: "msgvault_darwin_amd64.tar.gz", Size: 3000, BrowserDownloadURL: "https://example.com/darwin_amd64"},
-	}
-
 	tests := []struct {
-		name             string
-		assetName        string
-		wantAssetURL     string
-		wantAssetSize    int64
-		wantChecksumsURL string
-		wantAssetNil     bool
+		name       string
+		status     int
+		location   string
+		wantTag    string
+		wantErrSub string
 	}{
 		{
-			name:             "find darwin_arm64",
-			assetName:        "msgvault_darwin_arm64.tar.gz",
-			wantAssetURL:     "https://example.com/darwin_arm64",
-			wantAssetSize:    2000,
-			wantChecksumsURL: "https://example.com/checksums",
+			name:     "valid 302 redirect",
+			status:   http.StatusFound,
+			location: "https://github.com/wesm/msgvault/releases/tag/v0.30.1",
+			wantTag:  "v0.30.1",
 		},
 		{
-			name:             "find linux_amd64",
-			assetName:        "msgvault_linux_amd64.tar.gz",
-			wantAssetURL:     "https://example.com/linux_amd64",
-			wantAssetSize:    1000,
-			wantChecksumsURL: "https://example.com/checksums",
+			name:     "pre-release tag",
+			status:   http.StatusFound,
+			location: "https://github.com/wesm/msgvault/releases/tag/v0.9.0-rc1",
+			wantTag:  "v0.9.0-rc1",
 		},
 		{
-			name:             "asset not found",
-			assetName:        "msgvault_freebsd_amd64.tar.gz",
-			wantAssetNil:     true,
-			wantChecksumsURL: "https://example.com/checksums",
+			name:       "200 OK is not a redirect",
+			status:     http.StatusOK,
+			wantErrSub: "expected redirect",
+		},
+		{
+			name:       "redirect target without /tag/",
+			status:     http.StatusFound,
+			location:   "https://github.com/wesm/msgvault/releases",
+			wantErrSub: "unexpected redirect target",
+		},
+		{
+			name:       "empty tag after /tag/",
+			status:     http.StatusFound,
+			location:   "https://github.com/wesm/msgvault/releases/tag/",
+			wantErrSub: "empty tag",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			asset, checksums := findAssets(assets, tt.assetName)
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					if tt.location != "" {
+						w.Header().Set("Location", tt.location)
+					}
+					w.WriteHeader(tt.status)
+				},
+			))
+			defer srv.Close()
 
-			if tt.wantAssetNil {
-				if asset != nil {
-					t.Errorf("expected asset to be nil, got %+v", asset)
+			tag, err := resolveLatestTag(srv.URL)
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrSub)
 				}
-			} else {
-				if asset == nil {
-					t.Fatal("expected asset to be non-nil")
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrSub)
 				}
-				testutil.AssertEqual(t, asset.BrowserDownloadURL, tt.wantAssetURL)
-				testutil.AssertEqual(t, asset.Size, tt.wantAssetSize)
+				return
 			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			testutil.AssertEqual(t, tag, tt.wantTag)
+		})
+	}
+}
 
-			if checksums == nil {
-				t.Fatal("expected checksums to be non-nil")
+func TestFetchContentLength(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		status     int
+		bodySize   int
+		wantSize   int64
+		wantErrSub string
+	}{
+		{
+			name:     "200 with body",
+			status:   http.StatusOK,
+			bodySize: 1234,
+			wantSize: 1234,
+		},
+		{
+			name:       "404",
+			status:     http.StatusNotFound,
+			wantErrSub: "404",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					if tt.bodySize > 0 {
+						w.Header().Set("Content-Length", fmt.Sprintf("%d", tt.bodySize))
+					}
+					w.WriteHeader(tt.status)
+				},
+			))
+			defer srv.Close()
+
+			size, err := fetchContentLength(srv.URL)
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrSub)
+				}
+				return
 			}
-			testutil.AssertEqual(t, checksums.BrowserDownloadURL, tt.wantChecksumsURL)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			testutil.AssertEqual(t, size, tt.wantSize)
 		})
 	}
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,13 +65,47 @@ function Invoke-WebRequestCompat {
 }
 
 function Get-LatestVersion {
-    $url = "https://api.github.com/repos/$repo/releases/latest"
-    try {
-        $response = Invoke-WebRequestCompat -Uri $url
-        return $response.tag_name
-    } catch {
-        throw "Failed to fetch latest version: $_"
+    # Use the HTML /releases/latest endpoint, which 302-redirects to
+    # /releases/tag/<version>. Unlike api.github.com it is not rate-limited
+    # at 60 req/hr per IP, so users behind shared NAT / VPN don't get 403.
+    $url = "https://github.com/$repo/releases/latest"
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
+
+    $params = @{
+        Uri = $url
+        MaximumRedirection = 0
+        ErrorAction = 'Stop'
+    }
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $params.UseBasicParsing = $true
+    }
+
+    $location = $null
+    try {
+        # PowerShell 7+ returns the 302 as a normal response.
+        $response = Invoke-WebRequest @params
+        $location = $response.Headers.Location
+    } catch {
+        # PowerShell 5.x throws System.Net.WebException for 3xx when
+        # MaximumRedirection=0. The Location header lives on the response.
+        if ($_.Exception.Response) {
+            $location = $_.Exception.Response.Headers['Location']
+        } else {
+            throw "Failed to fetch latest version: $_"
+        }
+    }
+
+    if ($location -is [array]) { $location = $location[0] }
+    if (-not $location) {
+        throw "Failed to fetch latest version: no Location header from $url"
+    }
+    if ($location -notmatch '/releases/tag/([^/]+)/?$') {
+        throw "Failed to fetch latest version: unexpected redirect target $location"
+    }
+    return $Matches[1]
 }
 
 function Get-InstallDir {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,12 +60,25 @@ download() {
 
 # Get latest release version
 get_latest_version() {
-    local url="https://api.github.com/repos/${REPO}/releases/latest"
+    # Use the HTML /releases/latest endpoint, which 302-redirects to
+    # /releases/tag/<version>. Unlike api.github.com it is not rate-limited
+    # at 60 req/hr per IP, so users behind shared NAT / VPN don't get 403.
+    local url="https://github.com/${REPO}/releases/latest"
+    local final_url=""
     if command -v curl &>/dev/null; then
-        curl -fsSL "$url" | grep '"tag_name"' | head -1 | cut -d'"' -f4
+        final_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$url") || return 1
     elif command -v wget &>/dev/null; then
-        wget -qO- "$url" | grep '"tag_name"' | head -1 | cut -d'"' -f4
+        final_url=$(wget --spider -S "$url" 2>&1 \
+            | awk 'tolower($1)=="location:" {print $2}' \
+            | tail -1 \
+            | tr -d '\r\n') || return 1
+    else
+        return 1
     fi
+    case "$final_url" in
+        */releases/tag/*) echo "${final_url##*/releases/tag/}" ;;
+        *) return 1 ;;
+    esac
 }
 
 # Verify checksum


### PR DESCRIPTION
Both `scripts/install.sh` and the in-binary `msgvault update` command called `api.github.com/repos/.../releases/latest`, which GitHub rate-limits to 60 req/hr per IP for unauthenticated callers. Users behind shared NAT, VPN, or CGNAT exhaust that quota and see HTTP 403 from the installer or `GitHub API returned 403` from the update command.

Both code paths now use the HTML `https://github.com/wesm/msgvault/releases/latest` endpoint, which 302-redirects to `/releases/tag/<tag>` and isn't subject to the same rate limit.

**`scripts/install.sh`** — `get_latest_version` reads the redirect target via `curl -fsSLI -w '%{url_effective}'` (or `wget --server-response`).

**`internal/update/update.go`** — `resolveLatestTag` follows the redirect with `CheckRedirect: ErrUseLastResponse` and parses the Location header. Download and `SHA256SUMS` URLs are constructed from the tag. Asset size comes from a HEAD request (`fetchContentLength`). Drops the now-unused `Release`/`Asset` structs, `findAssets`, and the release-body checksum fallback; every release publishes `SHA256SUMS` as an asset.

Ports agentsview a3b98849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)