### PR TITLE
test: inline pointer-wrapper helpers as new(expr)

### DIFF
--- a/cmd/msgvault/cmd/export_token_test.go
+++ b/cmd/msgvault/cmd/export_token_test.go
@@ -289,7 +289,7 @@ func TestExport_AccountPostSuccess(t *testing.T) {
 		case strings.HasPrefix(r.URL.Path, "/api/v1/auth/token/"):
 			w.WriteHeader(http.StatusCreated)
 		case r.URL.Path == "/api/v1/accounts":
-			var body map[string]interface{}
+			var body map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			if email, ok := body["email"].(string); ok {
 				accountEmail = email

--- a/cmd/msgvault/cmd/import_mbox_test.go
+++ b/cmd/msgvault/cmd/import_mbox_test.go
@@ -81,10 +81,7 @@ func zeroZipCentralDirUncompressedSize(t *testing.T, zipPath string, entryName s
 		maxCommentLen        = 1<<16 - 1
 		eocdSig       uint32 = 0x06054b50
 	)
-	start := len(b) - (eocdLen + maxCommentLen)
-	if start < 0 {
-		start = 0
-	}
+	start := max(len(b)-(eocdLen+maxCommentLen), 0)
 	eocd := -1
 	for i := len(b) - eocdLen; i >= start; i-- {
 		if binary.LittleEndian.Uint32(b[i:]) == eocdSig {
@@ -115,7 +112,7 @@ func zeroZipCentralDirUncompressedSize(t *testing.T, zipPath string, entryName s
 
 		name := cd[off+46 : off+46+nameLen]
 		if bytes.Equal(name, []byte(entryName)) {
-			for i := 0; i < 4; i++ {
+			for i := range 4 {
 				cd[off+24+i] = 0
 			}
 			found = true

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -123,15 +123,15 @@ func TestHandleListMessages(t *testing.T) {
 
 	assert.Equal(http.StatusOK, w.Code, "status")
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
 
-	messages, ok := resp["messages"].([]interface{})
+	messages, ok := resp["messages"].([]any)
 	require.True(ok, "expected messages array in response")
 	assert.NotEmpty(messages, "expected at least 1 message")
 
 	// Check first message structure
-	msg := messages[0].(map[string]interface{})
+	msg := messages[0].(map[string]any)
 	assert.Equal("Test Subject", msg["subject"], "subject")
 
 	// Verify RFC3339 time format
@@ -151,7 +151,7 @@ func TestHandleListMessagesPagination(t *testing.T) {
 
 	assert.Equal(http.StatusOK, w.Code, "status")
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	requirepkg.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
 
 	assert.Equal(float64(1), resp["page"], "page")
@@ -224,7 +224,7 @@ func TestHandleGetMessage_EngineBodyHTML(t *testing.T) {
 
 	require.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "failed to decode")
 	assert.Equal("plain fallback", resp["body"], "body")
 	assert.Equal("<p>Hello</p>", resp["body_html"], "body_html")
@@ -258,7 +258,7 @@ func TestHandleGetMessage_EngineDeletedAt(t *testing.T) {
 
 	requirepkg.Equal(t, http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	requirepkg.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "failed to decode")
 	want := deletedAt.Format(time.RFC3339)
 	assertpkg.Equal(t, want, resp["deleted_at"], "deleted_at")
@@ -392,18 +392,18 @@ func TestMessageSummaryNilSlices(t *testing.T) {
 	srv.Router().ServeHTTP(w, req)
 
 	// Verify nil slices become empty arrays, not null
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
 
-	messages := resp["messages"].([]interface{})
-	msg := messages[0].(map[string]interface{})
+	messages := resp["messages"].([]any)
+	msg := messages[0].(map[string]any)
 
 	// "to" should be an empty array, not null
-	to, ok := msg["to"].([]interface{})
+	to, ok := msg["to"].([]any)
 	require.True(ok, "expected 'to' to be an array, got %T", msg["to"])
 	assert.Empty(to, "expected empty 'to' array")
 
-	labels, ok := msg["labels"].([]interface{})
+	labels, ok := msg["labels"].([]any)
 	require.True(ok, "expected 'labels' to be an array, got %T", msg["labels"])
 	assert.Empty(labels, "expected empty 'labels' array")
 }
@@ -421,12 +421,12 @@ func TestMessageSummaryCcBccInResponse(t *testing.T) {
 
 	require.Equal(http.StatusOK, w.Code, "status")
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode")
 
-	msg := resp["messages"].([]interface{})[0].(map[string]interface{})
+	msg := resp["messages"].([]any)[0].(map[string]any)
 
-	ccRaw, ok := msg["cc"].([]interface{})
+	ccRaw, ok := msg["cc"].([]any)
 	require.True(ok, "expected 'cc' array, got %T", msg["cc"])
 	var gotCc []string
 	for _, v := range ccRaw {
@@ -436,7 +436,7 @@ func TestMessageSummaryCcBccInResponse(t *testing.T) {
 	wantCc := []string{"cc1@example.com", "cc2@example.com"}
 	assert.Equal(wantCc, gotCc, "cc")
 
-	bcc, ok := msg["bcc"].([]interface{})
+	bcc, ok := msg["bcc"].([]any)
 	require.True(ok, "expected 'bcc' array, got %T", msg["bcc"])
 	require.Len(bcc, 1, "bcc")
 	assert.Equal("bcc@example.com", bcc[0], "bcc[0]")
@@ -993,10 +993,10 @@ func TestHandleFilteredMessages(t *testing.T) {
 
 	assert.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
 
-	messages, ok := resp["messages"].([]interface{})
+	messages, ok := resp["messages"].([]any)
 	require.True(ok, "expected messages array in response")
 	assert.Len(messages, 1, "messages count")
 	require.Equal("sms", gotFilter.MessageType, "message_type filter")
@@ -1249,7 +1249,7 @@ func TestHandleDeepSearch(t *testing.T) {
 
 	assertpkg.Equal(t, http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	requirepkg.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
 
 	assertpkg.Equal(t, "agenda", resp["query"], "query")
@@ -1576,8 +1576,8 @@ func TestHandleSearch_HybridResponseItemShape(t *testing.T) {
 	// Decode into a raw map so we can verify field names (snake-case
 	// keys) and that no unexpected wrapper is present.
 	var resp struct {
-		Mode    string                   `json:"mode"`
-		Results []map[string]interface{} `json:"results"`
+		Mode    string           `json:"mode"`
+		Results []map[string]any `json:"results"`
 	}
 	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode")
 	assert.Equal("vector", resp.Mode, "mode")
@@ -1694,7 +1694,7 @@ func TestHandleSearch_HybridPoolSaturatedAlwaysEmitted(t *testing.T) {
 
 // mapKeys returns the keys of a map[string]interface{} for use in
 // assertion error messages.
-func mapKeys(m map[string]interface{}) []string {
+func mapKeys(m map[string]any) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)
@@ -1868,16 +1868,16 @@ func TestHandleStats_VectorEnabledWithActive(t *testing.T) {
 
 	require.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode")
 
-	vs, ok := resp["vector_search"].(map[string]interface{})
+	vs, ok := resp["vector_search"].(map[string]any)
 	require.True(ok, "expected 'vector_search' object, got %T: %v", resp["vector_search"], resp["vector_search"])
 
 	assert.Equal(true, vs["enabled"], "enabled")
 	assert.Equal(float64(7), vs["pending_embeddings_total"], "pending_embeddings_total")
 
-	active, ok := vs["active_generation"].(map[string]interface{})
+	active, ok := vs["active_generation"].(map[string]any)
 	require.True(ok, "expected 'vector_search.active_generation' object, got %T", vs["active_generation"])
 
 	assert.Equal(float64(100), active["message_count"], "message_count")
@@ -2118,7 +2118,7 @@ func TestHandleGetMessage_EngineUnsupportedFallsBackToStore(t *testing.T) {
 	srv.Router().ServeHTTP(w, req)
 
 	requirepkg.Equal(t, http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
-	var resp map[string]interface{}
+	var resp map[string]any
 	requirepkg.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "decode")
 	assertpkg.Equal(t, "Test Subject", resp["subject"], "subject (store path response)")
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -112,7 +112,7 @@ func TestRateLimiterCloseConcurrent(t *testing.T) {
 	const n = 50
 	start := make(chan struct{})
 	done := make(chan struct{}, n)
-	for i := 0; i < n; i++ {
+	for range n {
 		go func() {
 			<-start
 			rl.Close()
@@ -120,7 +120,7 @@ func TestRateLimiterCloseConcurrent(t *testing.T) {
 		}()
 	}
 	close(start) // release all at once
-	for i := 0; i < n; i++ {
+	for range n {
 		<-done
 	}
 	// If we get here without a panic, the test passes.

--- a/internal/applemail/accounts_test.go
+++ b/internal/applemail/accounts_test.go
@@ -52,9 +52,6 @@ type testAccount struct {
 	parentAccount *int
 }
 
-func strPtr(s string) *string { return &s }
-func intPtr(i int) *int       { return &i }
-
 func mustMkdirAll(t *testing.T, path string) {
 	t.Helper()
 	requirepkg.NoError(t, os.MkdirAll(path, 0o755), "mkdir %q", path)
@@ -71,14 +68,14 @@ func TestResolveAccounts(t *testing.T) {
 	// - PK 7: iCloud parent (has email, description "iCloud")
 	// - PK 8: IMAP child of iCloud with empty-string fields (not NULL)
 	accounts := []testAccount{
-		{pk: 1, identifier: "google-parent-id", username: strPtr("user@gmail.com"), description: strPtr("Google"), parentAccount: nil},
-		{pk: 2, identifier: "13C9A646-1234-5678-9ABC-E07FFBDDEED3", username: nil, description: nil, parentAccount: intPtr(1)},
-		{pk: 3, identifier: "yahoo-parent-id", username: strPtr("user@yahoo.com"), description: strPtr("Yahoo!"), parentAccount: nil},
-		{pk: 4, identifier: "AABBCCDD-1111-2222-3333-445566778899", username: nil, description: nil, parentAccount: intPtr(3)},
-		{pk: 5, identifier: "EXCHANGE1-AAAA-BBBB-CCCC-DDDDEEEEEEEE", username: strPtr("user@exchange.com"), description: strPtr("Exchange"), parentAccount: nil},
-		{pk: 6, identifier: "LOCALONLY-0000-0000-0000-000000000000", username: nil, description: strPtr("On My Mac"), parentAccount: nil},
-		{pk: 7, identifier: "icloud-parent-id", username: strPtr("user@icloud.com"), description: strPtr("iCloud"), parentAccount: nil},
-		{pk: 8, identifier: "ICLOUDCH-1111-2222-3333-444455556666", username: strPtr(""), description: strPtr(""), parentAccount: intPtr(7)},
+		{pk: 1, identifier: "google-parent-id", username: new("user@gmail.com"), description: new("Google"), parentAccount: nil},
+		{pk: 2, identifier: "13C9A646-1234-5678-9ABC-E07FFBDDEED3", username: nil, description: nil, parentAccount: new(1)},
+		{pk: 3, identifier: "yahoo-parent-id", username: new("user@yahoo.com"), description: new("Yahoo!"), parentAccount: nil},
+		{pk: 4, identifier: "AABBCCDD-1111-2222-3333-445566778899", username: nil, description: nil, parentAccount: new(3)},
+		{pk: 5, identifier: "EXCHANGE1-AAAA-BBBB-CCCC-DDDDEEEEEEEE", username: new("user@exchange.com"), description: new("Exchange"), parentAccount: nil},
+		{pk: 6, identifier: "LOCALONLY-0000-0000-0000-000000000000", username: nil, description: new("On My Mac"), parentAccount: nil},
+		{pk: 7, identifier: "icloud-parent-id", username: new("user@icloud.com"), description: new("iCloud"), parentAccount: nil},
+		{pk: 8, identifier: "ICLOUDCH-1111-2222-3333-444455556666", username: new(""), description: new(""), parentAccount: new(7)},
 	}
 
 	dbPath := createTestAccountsDB(t, accounts)
@@ -247,10 +244,10 @@ func TestDiscoverV10Accounts(t *testing.T) {
 
 	// Create accounts DB with these GUIDs.
 	accounts := []testAccount{
-		{pk: 1, identifier: "google-parent", username: strPtr("user@gmail.com"), description: strPtr("Google"), parentAccount: nil},
-		{pk: 2, identifier: guid1, username: nil, description: nil, parentAccount: intPtr(1)},
-		{pk: 3, identifier: "yahoo-parent", username: strPtr("user@yahoo.com"), description: strPtr("Yahoo!"), parentAccount: nil},
-		{pk: 4, identifier: guid2, username: nil, description: nil, parentAccount: intPtr(3)},
+		{pk: 1, identifier: "google-parent", username: new("user@gmail.com"), description: new("Google"), parentAccount: nil},
+		{pk: 2, identifier: guid1, username: nil, description: nil, parentAccount: new(1)},
+		{pk: 3, identifier: "yahoo-parent", username: new("user@yahoo.com"), description: new("Yahoo!"), parentAccount: nil},
+		{pk: 4, identifier: guid2, username: nil, description: nil, parentAccount: new(3)},
 	}
 	dbPath := createTestAccountsDB(t, accounts)
 

--- a/internal/deletion/manifest_test.go
+++ b/internal/deletion/manifest_test.go
@@ -330,7 +330,7 @@ func TestManifest_FormatSummary(t *testing.T) {
 			name: "many top senders truncated to 10",
 			setupManifest: func(t *testing.T) *Manifest {
 				topSenders := make([]SenderCount, 15)
-				for i := 0; i < 15; i++ {
+				for i := range 15 {
 					topSenders[i] = SenderCount{
 						Sender: "sender" + string(rune('a'+i)) + "@example.com",
 						Count:  100 - i,

--- a/internal/export/store_attachment_test.go
+++ b/internal/export/store_attachment_test.go
@@ -107,7 +107,7 @@ func TestStoreAttachmentFile_ConcurrentWriters_SameHash_NoError(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(n)
-	for i := 0; i < n; i++ {
+	for range n {
 		go func() {
 			defer wg.Done()
 			<-start
@@ -130,12 +130,12 @@ func TestStoreAttachmentFile_ConcurrentWriters_SameHash_NoError(t *testing.T) {
 	close(start)
 	wg.Wait()
 
-	for i := 0; i < n; i++ {
+	for range n {
 		require.NoError(<-errCh, "store")
 	}
 
 	wantStoragePath := path.Join(hash[:2], hash)
-	for i := 0; i < n; i++ {
+	for range n {
 		require.Equal(wantStoragePath, <-pathCh, "storage path mismatch")
 	}
 

--- a/internal/fbmessenger/importer_test.go
+++ b/internal/fbmessenger/importer_test.go
@@ -597,7 +597,7 @@ func writeLargeFixture(t *testing.T) string {
 		Participants: []rawPart{{Name: "Test User"}, {Name: "Big Friend"}},
 		Title:        "Big Friend",
 	}
-	for i := 0; i < largeFixtureSize; i++ {
+	for i := range largeFixtureSize {
 		sender := "Test User"
 		if i%2 == 1 {
 			sender = "Big Friend"
@@ -621,7 +621,7 @@ func writeLargeFixture(t *testing.T) string {
 func writeMultiThreadFixture(t *testing.T, n int) string {
 	t.Helper()
 	tmp := t.TempDir()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		name := fmt.Sprintf("thread_%02d_OK", i)
 		threadPath := filepath.Join(tmp, "your_activity_across_facebook", "messages", "inbox", name)
 		requirepkg.NoError(t, os.MkdirAll(threadPath, 0755))

--- a/internal/gmail/ratelimit_test.go
+++ b/internal/gmail/ratelimit_test.go
@@ -314,14 +314,12 @@ func TestRateLimiter_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	errors := make(chan error, 100)
 
-	for i := 0; i < 20; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 20 {
+		wg.Go(func() {
 			if err := rl.Acquire(ctx, OpProfile); err != nil {
 				errors <- err
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/imessage/parser_test.go
+++ b/internal/imessage/parser_test.go
@@ -153,19 +153,19 @@ func makeAttributedBodyBlob(text string) []byte {
 		Archiver string               `plist:"$archiver"`
 		Version  uint64               `plist:"$version"`
 		Top      map[string]plist.UID `plist:"$top"`
-		Objects  []interface{}        `plist:"$objects"`
+		Objects  []any                `plist:"$objects"`
 	}{
 		Archiver: "NSKeyedArchiver",
 		Version:  100000,
 		Top:      map[string]plist.UID{"root": 1},
-		Objects: []interface{}{
+		Objects: []any{
 			"$null",
-			map[string]interface{}{
+			map[string]any{
 				"$class":    plist.UID(3),
 				"NS.string": plist.UID(2),
 			},
 			text,
-			map[string]interface{}{
+			map[string]any{
 				"$classname": "NSAttributedString",
 				"$classes":   []string{"NSAttributedString", "NSObject"},
 			},

--- a/internal/microsoft/oauth_test.go
+++ b/internal/microsoft/oauth_test.go
@@ -574,12 +574,10 @@ func TestTokenSource_ConcurrentAccess(t *testing.T) {
 	requirepkg.NoError(t, err)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			_, _ = fn(t.Context())
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -1040,7 +1040,7 @@ func TestDuckDBEngine_ThreadCount(t *testing.T) {
 	assert.Equal(expected, threads, "expected threads to match GOMAXPROCS")
 
 	// Verify the setting persists across multiple queries (single connection pool)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		var check int
 		err = engine.db.QueryRow("SELECT current_setting('threads')::INT").Scan(&check)
 		require.NoError(err, "query threads setting (iteration %d)", i)
@@ -2772,65 +2772,65 @@ func TestSearchCacheKeyFor(t *testing.T) {
 	tests := []struct {
 		name      string
 		conds1    []string
-		args1     []interface{}
+		args1     []any
 		conds2    []string
-		args2     []interface{}
+		args2     []any
 		wantEqual bool
 	}{
 		{
 			name:      "identical inputs produce same key",
 			conds1:    []string{"a = ?", "b = ?"},
-			args1:     []interface{}{"foo", 42},
+			args1:     []any{"foo", 42},
 			conds2:    []string{"a = ?", "b = ?"},
-			args2:     []interface{}{"foo", 42},
+			args2:     []any{"foo", 42},
 			wantEqual: true,
 		},
 		{
 			name:      "different conditions produce different keys",
 			conds1:    []string{"a = ?"},
-			args1:     []interface{}{"foo"},
+			args1:     []any{"foo"},
 			conds2:    []string{"b = ?"},
-			args2:     []interface{}{"foo"},
+			args2:     []any{"foo"},
 			wantEqual: false,
 		},
 		{
 			name:      "args with commas are not ambiguous",
 			conds1:    []string{"x = ?"},
-			args1:     []interface{}{"foo,bar"},
+			args1:     []any{"foo,bar"},
 			conds2:    []string{"x = ?"},
-			args2:     []interface{}{"foo", "bar"},
+			args2:     []any{"foo", "bar"},
 			wantEqual: false,
 		},
 		{
 			name:      "args with pipes are not ambiguous",
 			conds1:    []string{"a|b"},
-			args1:     []interface{}{"x"},
+			args1:     []any{"x"},
 			conds2:    []string{"a", "b"},
-			args2:     []interface{}{"x"},
+			args2:     []any{"x"},
 			wantEqual: false,
 		},
 		{
 			name:      "different arg types produce different keys",
 			conds1:    []string{"x = ?"},
-			args1:     []interface{}{"42"},
+			args1:     []any{"42"},
 			conds2:    []string{"x = ?"},
-			args2:     []interface{}{42},
+			args2:     []any{42},
 			wantEqual: false,
 		},
 		{
 			name:      "empty inputs produce same key",
 			conds1:    []string{},
-			args1:     []interface{}{},
+			args1:     []any{},
 			conds2:    []string{},
-			args2:     []interface{}{},
+			args2:     []any{},
 			wantEqual: true,
 		},
 		{
 			name:      "condition containing JSON special chars",
 			conds1:    []string{`msg.subject ILIKE ? ESCAPE '\'`},
-			args1:     []interface{}{`%"quoted"%`},
+			args1:     []any{`%"quoted"%`},
 			conds2:    []string{`msg.subject ILIKE ? ESCAPE '\'`},
-			args2:     []interface{}{`%"quoted"%`},
+			args2:     []any{`%"quoted"%`},
 			wantEqual: true,
 		},
 	}

--- a/internal/query/pg_compat_test.go
+++ b/internal/query/pg_compat_test.go
@@ -47,7 +47,7 @@ func TestQueryEngine_PostgresPortability(t *testing.T) {
 	require.NoError(err, "EnsureLabel")
 
 	base := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		mid, err := st.UpsertMessage(&store.Message{
 			ConversationID:  convID,
 			SourceID:        src.ID,

--- a/internal/query/sqlite_aggregate_test.go
+++ b/internal/query/sqlite_aggregate_test.go
@@ -70,7 +70,7 @@ func TestAggregations(t *testing.T) {
 func TestAggregateBySenderName_FallbackToEmail(t *testing.T) {
 	env := newTestEnv(t)
 
-	noNameID := env.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("noname@test.com"), DisplayName: nil, Domain: "test.com"})
+	noNameID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("noname@test.com"), DisplayName: nil, Domain: "test.com"})
 	env.AddMessage(dbtest.MessageOpts{Subject: "No Name Test", SentAt: "2024-05-01 10:00:00", FromID: noNameID})
 
 	rows, err := env.Engine.Aggregate(env.Ctx, ViewSenderNames, DefaultAggregateOptions())
@@ -89,8 +89,8 @@ func TestAggregateBySenderName_FallbackToPhone(t *testing.T) {
 	env := newTestEnv(t)
 
 	phoneOnlyID := env.AddParticipant(dbtest.ParticipantOpts{
-		Phone:       dbtest.StrPtr("+15551234567"),
-		DisplayName: dbtest.StrPtr(""),
+		Phone:       new("+15551234567"),
+		DisplayName: new(""),
 	})
 	env.AddMessage(dbtest.MessageOpts{Subject: "SMS", SentAt: "2024-05-01 10:00:00", FromID: phoneOnlyID})
 
@@ -109,8 +109,8 @@ func TestAggregateByRecipientName_FallbackToPhone(t *testing.T) {
 	env := newTestEnv(t)
 
 	phoneOnlyID := env.AddParticipant(dbtest.ParticipantOpts{
-		Phone:       dbtest.StrPtr("+15557654321"),
-		DisplayName: dbtest.StrPtr(""),
+		Phone:       new("+15557654321"),
+		DisplayName: new(""),
 	})
 	senderID := env.MustLookupParticipant("alice@example.com")
 	env.AddMessage(dbtest.MessageOpts{
@@ -131,8 +131,8 @@ func TestAggregateBySenderName_EmptyStringFallback(t *testing.T) {
 	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 
-	emptyID := env.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("empty@test.com"), DisplayName: dbtest.StrPtr(""), Domain: "test.com"})
-	spacesID := env.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("spaces@test.com"), DisplayName: dbtest.StrPtr("   "), Domain: "test.com"})
+	emptyID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("empty@test.com"), DisplayName: new(""), Domain: "test.com"})
+	spacesID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("spaces@test.com"), DisplayName: new("   "), Domain: "test.com"})
 	env.AddMessage(dbtest.MessageOpts{Subject: "Empty Name", SentAt: "2024-05-01 10:00:00", FromID: emptyID})
 	env.AddMessage(dbtest.MessageOpts{Subject: "Spaces Name", SentAt: "2024-05-02 10:00:00", FromID: spacesID})
 
@@ -413,7 +413,7 @@ func TestAggregateByRecipientName_FallbackToEmail(t *testing.T) {
 	// Resolve participant IDs dynamically to avoid coupling to seed order.
 	aliceID := env.MustLookupParticipant("alice@example.com")
 
-	noNameID := env.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("noname@test.com"), DisplayName: nil, Domain: "test.com"})
+	noNameID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("noname@test.com"), DisplayName: nil, Domain: "test.com"})
 	env.AddMessage(dbtest.MessageOpts{Subject: "No Name Recipient", SentAt: "2024-05-01 10:00:00", FromID: aliceID, ToIDs: []int64{noNameID}})
 
 	rows, err := env.Engine.Aggregate(env.Ctx, ViewRecipientNames, DefaultAggregateOptions())
@@ -428,8 +428,8 @@ func TestAggregateByRecipientName_EmptyStringFallback(t *testing.T) {
 	// Resolve participant IDs dynamically to avoid coupling to seed order.
 	aliceID := env.MustLookupParticipant("alice@example.com")
 
-	emptyID := env.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("empty@test.com"), DisplayName: dbtest.StrPtr(""), Domain: "test.com"})
-	spacesID := env.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("spaces@test.com"), DisplayName: dbtest.StrPtr("   "), Domain: "test.com"})
+	emptyID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("empty@test.com"), DisplayName: new(""), Domain: "test.com"})
+	spacesID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("spaces@test.com"), DisplayName: new("   "), Domain: "test.com"})
 	env.AddMessage(dbtest.MessageOpts{Subject: "Empty Rcpt Name", SentAt: "2024-05-01 10:00:00", FromID: aliceID, ToIDs: []int64{emptyID}})
 	env.AddMessage(dbtest.MessageOpts{Subject: "Spaces Rcpt Name", SentAt: "2024-05-02 10:00:00", FromID: aliceID, CcIDs: []int64{spacesID}})
 
@@ -478,8 +478,8 @@ func TestAggregateDeterministicOrderOnTies(t *testing.T) {
 	// implicit coupling to helper defaults or auto-increment assumptions.
 	sourceID := tdb.AddSource(dbtest.SourceOpts{Identifier: "test@gmail.com", DisplayName: "Test Account"})
 	convID := tdb.AddConversation(dbtest.ConversationOpts{SourceID: sourceID, Title: "Test Thread"})
-	aliceID := tdb.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("alice@example.com"), DisplayName: dbtest.StrPtr("Alice"), Domain: "example.com"})
-	bobID := tdb.AddParticipant(dbtest.ParticipantOpts{Email: dbtest.StrPtr("bob@example.com"), DisplayName: dbtest.StrPtr("Bob"), Domain: "example.com"})
+	aliceID := tdb.AddParticipant(dbtest.ParticipantOpts{Email: new("alice@example.com"), DisplayName: new("Alice"), Domain: "example.com"})
+	bobID := tdb.AddParticipant(dbtest.ParticipantOpts{Email: new("bob@example.com"), DisplayName: new("Bob"), Domain: "example.com"})
 
 	// Create labels with names that would sort differently than insertion order
 	// "Zebra" inserted first, "Apple" inserted second - both will have count=1

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -717,9 +717,8 @@ func TestRecipientAndRecipientNameAndMatchEmptyRecipient(t *testing.T) {
 func TestRecipientNameFilter_IncludesBCC(t *testing.T) {
 	env := newTestEnv(t)
 
-	sp := dbtest.StrPtr
-	aliceID := env.AddParticipant(dbtest.ParticipantOpts{Email: sp("alice-bcc@example.com"), DisplayName: sp("Alice Sender"), Domain: "example.com"})
-	secretID := env.AddParticipant(dbtest.ParticipantOpts{Email: sp("secret@example.com"), DisplayName: sp("Secret Bob"), Domain: "example.com"})
+	aliceID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("alice-bcc@example.com"), DisplayName: new("Alice Sender"), Domain: "example.com"})
+	secretID := env.AddParticipant(dbtest.ParticipantOpts{Email: new("secret@example.com"), DisplayName: new("Secret Bob"), Domain: "example.com"})
 	bobID := env.MustLookupParticipant("bob@company.org")
 
 	env.AddMessage(dbtest.MessageOpts{

--- a/internal/query/sqlite_search_test.go
+++ b/internal/query/sqlite_search_test.go
@@ -59,7 +59,7 @@ func TestSearch_Filters(t *testing.T) {
 		},
 		{
 			name:      "HasAttachment",
-			query:     &search.Query{HasAttachment: ptr.Bool(true)},
+			query:     &search.Query{HasAttachment: new(true)},
 			wantCount: 2,
 			validator: func(m MessageSummary) bool { return m.HasAttachments },
 			validDesc: "HasAttachments=true",
@@ -71,7 +71,7 @@ func TestSearch_Filters(t *testing.T) {
 		},
 		{
 			name:      "SizeFilter",
-			query:     &search.Query{LargerThan: ptr.Int64(largerThan)},
+			query:     &search.Query{LargerThan: new(largerThan)},
 			wantCount: 1,
 			validator: func(m MessageSummary) bool { return m.SizeEstimate > largerThan },
 			validDesc: "SizeEstimate>2500",
@@ -269,7 +269,6 @@ func TestSearchFastCountMatchesSearch(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			results, err := env.Engine.Search(env.Ctx, tc.query, 1000, 0)
 			requirepkg.NoError(t, err, "Search")
@@ -338,7 +337,7 @@ func TestMergeFilterIntoQuery(t *testing.T) {
 			name:     "Attachments",
 			initial:  &search.Query{},
 			filter:   MessageFilter{WithAttachmentsOnly: true},
-			expected: &search.Query{HasAttachment: ptr.Bool(true)},
+			expected: &search.Query{HasAttachment: new(true)},
 		},
 		{
 			name:     "Domain",
@@ -365,7 +364,7 @@ func TestMergeFilterIntoQuery(t *testing.T) {
 				FromAddrs:     []string{"alice@example.com", "bob@example.com", "@domain.com"},
 				ToAddrs:       []string{"carol@example.com"},
 				Labels:        []string{"starred"},
-				HasAttachment: ptr.Bool(true),
+				HasAttachment: new(true),
 				AccountIDs:    []int64{sourceID1},
 			},
 		},

--- a/internal/query/sqlite_testhelpers_test.go
+++ b/internal/query/sqlite_testhelpers_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,10 +141,8 @@ func assertAllResults(t *testing.T, results []MessageSummary, desc string, pred 
 // assertAnyResult verifies that at least one result satisfies the given predicate.
 func assertAnyResult(t *testing.T, results []MessageSummary, desc string, pred func(MessageSummary) bool) {
 	t.Helper()
-	for _, r := range results {
-		if pred(r) {
-			return
-		}
+	if slices.ContainsFunc(results, pred) {
+		return
 	}
 	assert.Fail(t, "no result satisfied "+desc)
 }
@@ -161,8 +160,8 @@ func newTestEnvWithEmptyBuckets(t *testing.T) *testEnv {
 
 	// Participant with empty domain
 	emptyDomainID := env.AddParticipant(dbtest.ParticipantOpts{
-		Email:       dbtest.StrPtr("nodomain@"),
-		DisplayName: dbtest.StrPtr("No Domain User"),
+		Email:       new("nodomain@"),
+		DisplayName: new("No Domain User"),
 		Domain:      "",
 	})
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -299,7 +299,7 @@ func TestSyncPreventsDoubleRun(t *testing.T) {
 	requirepkg.NoError(t, s.AddAccount("test@gmail.com", "0 0 1 1 *"), "AddAccount")
 
 	// Try to trigger multiple times concurrently
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_ = s.TriggerSync("test@gmail.com")
 	}
 

--- a/internal/search/parser_test.go
+++ b/internal/search/parser_test.go
@@ -173,7 +173,7 @@ func TestParse(t *testing.T) {
 				{
 					name:  "has attachment",
 					query: "has:attachment",
-					want:  Query{HasAttachment: ptr.Bool(true)},
+					want:  Query{HasAttachment: new(true)},
 				},
 			},
 		},
@@ -184,8 +184,8 @@ func TestParse(t *testing.T) {
 					name:  "after and before dates",
 					query: "after:2024-01-15 before:2024-06-30",
 					want: Query{
-						AfterDate:  ptr.Time(ptr.Date(2024, 1, 15)),
-						BeforeDate: ptr.Time(ptr.Date(2024, 6, 30)),
+						AfterDate:  new(ptr.Date(2024, 1, 15)),
+						BeforeDate: new(ptr.Date(2024, 6, 30)),
 					},
 				},
 			},
@@ -196,17 +196,17 @@ func TestParse(t *testing.T) {
 				{
 					name:  "larger than 5M",
 					query: "larger:5M",
-					want:  Query{LargerThan: ptr.Int64(5 * 1024 * 1024)},
+					want:  Query{LargerThan: new(int64(5 * 1024 * 1024))},
 				},
 				{
 					name:  "smaller than 100K",
 					query: "smaller:100K",
-					want:  Query{SmallerThan: ptr.Int64(100 * 1024)},
+					want:  Query{SmallerThan: new(int64(100 * 1024))},
 				},
 				{
 					name:  "larger than 1G",
 					query: "larger:1G",
-					want:  Query{LargerThan: ptr.Int64(1024 * 1024 * 1024)},
+					want:  Query{LargerThan: new(int64(1024 * 1024 * 1024))},
 				},
 			},
 		},
@@ -281,8 +281,8 @@ func TestParse(t *testing.T) {
 						ToAddrs:       []string{"bob@example.com"},
 						SubjectTerms:  []string{"meeting"},
 						TextTerms:     []string{"project report"},
-						HasAttachment: ptr.Bool(true),
-						AfterDate:     ptr.Time(ptr.Date(2024, 1, 1)),
+						HasAttachment: new(true),
+						AfterDate:     new(ptr.Date(2024, 1, 1)),
 					},
 				},
 			},
@@ -313,22 +313,22 @@ func TestParse_RelativeDates(t *testing.T) {
 		{
 			name:  "newer_than days",
 			query: "newer_than:7d",
-			want:  Query{AfterDate: ptr.Time(ptr.Date(2025, 6, 8))},
+			want:  Query{AfterDate: new(ptr.Date(2025, 6, 8))},
 		},
 		{
 			name:  "older_than weeks",
 			query: "older_than:2w",
-			want:  Query{BeforeDate: ptr.Time(ptr.Date(2025, 6, 1))},
+			want:  Query{BeforeDate: new(ptr.Date(2025, 6, 1))},
 		},
 		{
 			name:  "newer_than months",
 			query: "newer_than:1m",
-			want:  Query{AfterDate: ptr.Time(ptr.Date(2025, 5, 15))},
+			want:  Query{AfterDate: new(ptr.Date(2025, 5, 15))},
 		},
 		{
 			name:  "older_than years",
 			query: "older_than:1y",
-			want:  Query{BeforeDate: ptr.Time(ptr.Date(2024, 6, 15))},
+			want:  Query{BeforeDate: new(ptr.Date(2024, 6, 15))},
 		},
 	}
 

--- a/internal/store/pg_compat_test.go
+++ b/internal/store/pg_compat_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"database/sql"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -170,7 +171,7 @@ func TestEnsureParticipant_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	ids := make([]int64, N)
 	errs := make([]error, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -209,7 +210,7 @@ func TestEnsureParticipantByPhone_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	ids := make([]int64, N)
 	errs := make([]error, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -250,7 +251,7 @@ func TestAddAccountIdentity_Concurrent(t *testing.T) {
 	signals := []string{"manual", "account-identifier", "header"}
 	var wg sync.WaitGroup
 	errs := make([]error, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -275,12 +276,7 @@ func TestAddAccountIdentity_Concurrent(t *testing.T) {
 }
 
 func containsSignal(set, signal string) bool {
-	for _, s := range splitComma(set) {
-		if s == signal {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(splitComma(set), signal)
 }
 
 func splitComma(s string) []string {
@@ -308,7 +304,7 @@ func TestUpsertAttachment_Concurrent(t *testing.T) {
 	const N = 20
 	var wg sync.WaitGroup
 	errs := make([]error, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -921,7 +921,7 @@ func TestStore_CountMessagesWithRaw(t *testing.T) {
 	assert.Equal(int64(0), count, "count")
 
 	// Add messages, some with raw data
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		msgID := f.CreateMessage(fmt.Sprintf("raw-count-msg-%d", i))
 
 		// Only store raw for first 2 messages
@@ -1004,7 +1004,7 @@ func TestStore_ReplaceMessageRecipients_LargeBatch(t *testing.T) {
 	const numRecipients = 300
 	participantIDs := make([]int64, numRecipients)
 	displayNames := make([]string, numRecipients)
-	for i := 0; i < numRecipients; i++ {
+	for i := range numRecipients {
 		email := fmt.Sprintf("user%d@example.com", i)
 		pid := f.EnsureParticipant(email, fmt.Sprintf("User %d", i), "example.com")
 		participantIDs[i] = pid
@@ -1207,7 +1207,7 @@ func TestStore_ReplaceMessageLabels_LargeBatch(t *testing.T) {
 	// Create 600 labels (exceeds SQLite limit of ~499 rows with 2 params each)
 	const numLabels = 600
 	labelIDs := make([]int64, numLabels)
-	for i := 0; i < numLabels; i++ {
+	for i := range numLabels {
 		sourceLabelID := fmt.Sprintf("Label_%d", i)
 		lid, err := f.Store.EnsureLabel(f.Source.ID, sourceLabelID, fmt.Sprintf("Label %d", i), "user")
 		requirepkg.NoError(t, err, "EnsureLabel")
@@ -1528,7 +1528,7 @@ func makeSecondSource(t *testing.T, f *storetest.Fixture, identifier string) (*s
 func createMessagesForSource(t *testing.T, st *store.Store, srcID, convID int64, prefix string, count int) []int64 {
 	t.Helper()
 	ids := make([]int64, 0, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		id, err := st.UpsertMessage(&store.Message{
 			ConversationID:  convID,
 			SourceID:        srcID,

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -76,7 +76,7 @@ func TestFullSync(t *testing.T) {
 	env.Mock.Messages["msg3"].LabelIDs = []string{"SENT"}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(3), Errors: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(3)), Errors: new(int64(0))})
 	assertpkg.Equal(t, uint64(12345), summary.FinalHistoryID, "history ID")
 
 	assertMockCalls(t, env, 1, 1, 3)
@@ -91,7 +91,7 @@ func TestFullSyncResume(t *testing.T) {
 	seedPagedMessages(env, 4, 2, "msg")
 
 	summary1 := runFullSync(t, env)
-	assertSummary(t, summary1, WantSummary{Added: intPtr(4)})
+	assertSummary(t, summary1, WantSummary{Added: new(int64(4))})
 
 	// Second sync should skip already-synced messages
 	env.Mock.Reset()
@@ -106,7 +106,7 @@ func TestFullSyncResume(t *testing.T) {
 	env.Mock.AddMessage("msg4", testMIME(), []string{"INBOX"})
 
 	summary2 := runFullSync(t, env)
-	assertSummary(t, summary2, WantSummary{Added: intPtr(0)})
+	assertSummary(t, summary2, WantSummary{Added: new(int64(0))})
 }
 
 func TestFullSyncWithErrors(t *testing.T) {
@@ -117,7 +117,7 @@ func TestFullSyncWithErrors(t *testing.T) {
 	env.Mock.GetMessageError["msg2"] = &gmail.NotFoundError{Path: "/messages/msg2"}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(2), Errors: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(2)), Errors: new(int64(1))})
 }
 
 func TestMIMEParsing(t *testing.T) {
@@ -145,7 +145,7 @@ func TestMIMEParsing(t *testing.T) {
 	})
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
 	assertAttachmentCount(t, env.Store, 1)
 }
 
@@ -237,7 +237,7 @@ func TestFullSyncEmptyInbox(t *testing.T) {
 	env.Mock.Profile.HistoryID = 12345
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(0), Found: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(0)), Found: new(int64(0))})
 }
 
 func TestFullSyncProfileError(t *testing.T) {
@@ -257,7 +257,7 @@ func TestFullSyncAllDuplicates(t *testing.T) {
 
 	// Second sync with same messages - all should be skipped
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(0), Skipped: intPtr(3)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(0)), Skipped: new(int64(3))})
 }
 
 func TestFullSyncNoResume(t *testing.T) {
@@ -270,7 +270,7 @@ func TestFullSyncNoResume(t *testing.T) {
 
 	summary := runFullSync(t, env)
 	assertpkg.False(t, summary.WasResumed, "expected WasResumed to be false with NoResume option")
-	assertSummary(t, summary, WantSummary{Added: intPtr(2)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
 }
 
 func TestFullSyncAllErrors(t *testing.T) {
@@ -282,7 +282,7 @@ func TestFullSyncAllErrors(t *testing.T) {
 	env.Mock.GetMessageError["msg3"] = &gmail.NotFoundError{Path: "/messages/msg3"}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(0), Errors: intPtr(3)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(0)), Errors: new(int64(3))})
 }
 
 func TestFullSyncWithQuery(t *testing.T) {
@@ -296,7 +296,7 @@ func TestFullSyncWithQuery(t *testing.T) {
 	summary := runFullSync(t, env)
 
 	assertpkg.Equal(t, "before:2024/06/01", env.Mock.LastQuery, "query")
-	assertSummary(t, summary, WantSummary{Added: intPtr(2)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
 }
 
 func TestFullSyncPagination(t *testing.T) {
@@ -305,7 +305,7 @@ func TestFullSyncPagination(t *testing.T) {
 	seedPagedMessages(env, 6, 2, "msg")
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(6)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(6))})
 	assertListMessagesCalls(t, env, 3)
 }
 
@@ -347,7 +347,7 @@ func TestIncrementalSyncAlreadyUpToDate(t *testing.T) {
 	env.Mock.Profile.HistoryID = 12345 // Same as cursor
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
 }
 
 func TestIncrementalSyncWithChanges(t *testing.T) {
@@ -365,7 +365,7 @@ func TestIncrementalSyncWithChanges(t *testing.T) {
 	)
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(2)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
 }
 
 func TestIncrementalSyncWithDeletions(t *testing.T) {
@@ -378,7 +378,7 @@ func TestIncrementalSyncWithDeletions(t *testing.T) {
 	env.SetHistory(12350, historyDeleted("msg1"))
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Found: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Found: new(int64(1))})
 
 	// Verify deletion was persisted
 	assertDeletedFromSource(t, env.Store, "msg1", true)
@@ -421,7 +421,7 @@ func TestIncrementalSyncWithLabelAdded(t *testing.T) {
 	env.SetHistory(12350, historyLabelAdded("msg1", "STARRED"))
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Found: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Found: new(int64(1))})
 
 	// No additional GetMessageRaw calls should have been made for the existing message
 	callsAfterIncr := len(env.Mock.GetMessageCalls)
@@ -450,7 +450,7 @@ func TestIncrementalSyncWithLabelRemoved(t *testing.T) {
 	env.SetHistory(12350, historyLabelRemoved("msg1", "STARRED"))
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Found: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Found: new(int64(1))})
 
 	// No additional GetMessageRaw calls should have been made
 	callsAfterIncr := len(env.Mock.GetMessageCalls)
@@ -493,7 +493,7 @@ func TestIncrementalSyncLabelRemovedFromMissingMessage(t *testing.T) {
 	env.SetHistory(12350, historyLabelRemoved("unknown-msg", "STARRED"))
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
 }
 
 func TestFullSyncWithAttachment(t *testing.T) {
@@ -505,7 +505,7 @@ func TestFullSyncWithAttachment(t *testing.T) {
 	attachDir := withAttachmentsDir(t, env)
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
 
 	_, statErr := os.Stat(attachDir)
 	assertpkg.False(t, os.IsNotExist(statErr), "attachments directory should have been created")
@@ -594,7 +594,7 @@ func TestFullSync_MessageVariations(t *testing.T) {
 			env.Mock.Messages["msg"].SizeEstimate = int64(len(raw))
 
 			summary := runFullSync(t, env)
-			assertSummary(t, summary, WantSummary{Added: intPtr(1), Errors: intPtr(0)})
+			assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(0))})
 			assertMessageCount(t, env.Store, 1)
 
 			if tt.check != nil {
@@ -626,7 +626,7 @@ func TestFullSync_Latin1InFromName(t *testing.T) {
 	env.Mock.Messages["msg"].SizeEstimate = int64(len(raw))
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1), Errors: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(0))})
 
 	// Verify the participant display_name in the participants table is valid UTF-8.
 	// Before the fix, raw Latin-1 bytes would be stored as-is, causing DuckDB errors
@@ -666,7 +666,7 @@ func TestFullSync_InvalidUTF8InAllAddressFields(t *testing.T) {
 	env.Mock.Messages["msg"].SizeEstimate = int64(len(raw))
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1), Errors: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(0))})
 
 	// EnsureUTF8 should detect Windows-1252 and convert smart quotes to their
 	// proper Unicode equivalents: \x93 → U+201C ("), \x94 → U+201D (")
@@ -724,7 +724,7 @@ func TestFullSync_InvalidUTF8InAttachmentFilename(t *testing.T) {
 	withAttachmentsDir(t, env)
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
 	assertAttachmentCount(t, env.Store, 1)
 
 	filename, mimeType, err := env.Store.InspectAttachment("msg-attach")
@@ -761,7 +761,7 @@ func TestFullSync_MultipleEncodingIssuesSameMessage(t *testing.T) {
 	env.Mock.Messages["msg"].SizeEstimate = int64(len(raw))
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1), Errors: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(0))})
 
 	// From name: Latin-1 \xC9 → UTF-8 É
 	fromName, err := env.Store.InspectParticipantDisplayName("from@example.com")
@@ -794,7 +794,7 @@ func TestFullSyncWithMIMEParseError(t *testing.T) {
 	}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(2), Errors: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(2)), Errors: new(int64(0))})
 
 	// Verify the bad message was stored with placeholder content
 	assertBodyContains(t, env.Store, "msg-bad", "MIME parsing failed")
@@ -810,7 +810,7 @@ func TestFullSyncMessageFetchError(t *testing.T) {
 	env.Mock.MessagePages = [][]string{{"msg-good", "msg-missing"}}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
 }
 
 func TestIncrementalSyncLabelsError(t *testing.T) {
@@ -860,7 +860,7 @@ func TestFullSyncResumeWithCursor(t *testing.T) {
 
 	assert.True(summary.WasResumed, "expected WasResumed = true")
 	assert.Equal("page_1", summary.ResumedFromToken, "ResumedFromToken")
-	assertSummary(t, summary, WantSummary{Added: intPtr(4)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(4))})
 
 	assertListMessagesCalls(t, env, 1)
 	assertMessageCount(t, env.Store, 4)
@@ -906,7 +906,7 @@ func TestFullSyncEmptyRawMIME(t *testing.T) {
 	}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1), Errors: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(1))})
 }
 
 func TestFullSyncEmptyThreadID(t *testing.T) {
@@ -926,7 +926,7 @@ func TestFullSyncEmptyThreadID(t *testing.T) {
 	env.Mock.MessagePages = [][]string{{"msg-no-thread"}}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1), Errors: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(0))})
 
 	assertThreadSourceID(t, env.Store, "msg-no-thread", "msg-no-thread")
 }
@@ -950,7 +950,7 @@ func TestFullSyncListEmptyThreadIDRawPresent(t *testing.T) {
 	env.Mock.MessagePages = [][]string{{"msg-list-empty"}}
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1), Errors: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(0))})
 
 	assertThreadSourceID(t, env.Store, "msg-list-empty", "actual-thread-from-raw")
 }
@@ -1271,7 +1271,7 @@ func TestIncrementalSyncLabelAddAndRemoveOnExisting(t *testing.T) {
 	)
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Found: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Found: new(int64(1))})
 
 	// Zero additional API calls
 	callsAfterIncr := len(env.Mock.GetMessageCalls)
@@ -1300,7 +1300,7 @@ func TestIncrementalSyncBatchDeletions(t *testing.T) {
 	)
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Found: intPtr(3)})
+	assertSummary(t, summary, WantSummary{Found: new(int64(3))})
 
 	assertDeletedFromSource(t, env.Store, "msg1", true)
 	assertDeletedFromSource(t, env.Store, "msg2", true)
@@ -1330,7 +1330,7 @@ func TestIncrementalSyncBatchNewMessages(t *testing.T) {
 	)
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(5)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(5))})
 	assertMessageCount(t, env.Store, 5)
 }
 
@@ -1356,7 +1356,7 @@ func TestIncrementalSyncMixedOperations(t *testing.T) {
 	)
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Found: intPtr(3), Added: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Found: new(int64(3)), Added: new(int64(1))})
 
 	// 1 new message fetched (batch), 0 for label change on existing
 	callsAfterIncr := len(env.Mock.GetMessageCalls)
@@ -1480,7 +1480,7 @@ func TestIMAPThreading(t *testing.T) {
 	env.Mock.AddMessage("INBOX|4", standaloneMIME, []string{"INBOX"})
 
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(4)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(4))})
 
 	// All three thread messages should share the same conversation
 	// (thread key = References[0] = root@example.com, brackets stripped)
@@ -1521,7 +1521,7 @@ func TestIMAPCrossSyncDedup(t *testing.T) {
 	env.Mock.Profile.HistoryID = 100
 	env.Mock.AddMessage("INBOX|42", msg, []string{"INBOX"})
 	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
 	assertMessageHasLabel(t, env.Store, "INBOX|42", "INBOX")
 
 	// Second sync: message moved to Trash (different composite ID)
@@ -1529,7 +1529,7 @@ func TestIMAPCrossSyncDedup(t *testing.T) {
 	env.Mock.AddMessage("TRASH|99", msg, []string{"TRASH"})
 	summary = runFullSync(t, env)
 	// Should be skipped via RFC822 Message-ID dedup, not re-imported
-	assertSummary(t, summary, WantSummary{Added: intPtr(0)})
+	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
 
 	// Only one message should exist in the database
 	var count int
@@ -1581,7 +1581,7 @@ func TestIncrementalSyncLabelRemovedWithMissingRaw(t *testing.T) {
 	env.SetHistory(12350, historyLabelRemoved("msg1", "STARRED"))
 
 	summary := runIncrementalSync(t, env)
-	assertSummary(t, summary, WantSummary{Found: intPtr(1)})
+	assertSummary(t, summary, WantSummary{Found: new(int64(1))})
 
 	// No raw fetches should occur for label-only changes
 	callsAfterIncr := len(env.Mock.GetMessageCalls)

--- a/internal/sync/testenv_test.go
+++ b/internal/sync/testenv_test.go
@@ -131,9 +131,6 @@ type WantSummary struct {
 	Found   *int64
 }
 
-// intPtr returns a pointer to an int64 value for use in WantSummary.
-func intPtr(v int64) *int64 { return &v }
-
 // assertSummary checks SyncSummary fields against expected values.
 // Only non-nil fields in want are checked.
 func assertSummary(t *testing.T, s *gmail.SyncSummary, want WantSummary) {

--- a/internal/testutil/dbtest/dbtest.go
+++ b/internal/testutil/dbtest/dbtest.go
@@ -14,11 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// StrPtr returns a pointer to a string (useful for optional fields in test opts).
-//
-//go:fix inline
-func StrPtr(s string) *string { return new(s) }
-
 // TestDB wraps a *sql.DB with auto-increment counters and builder helpers
 // for seeding test data.
 type TestDB struct {
@@ -245,7 +240,7 @@ func (tdb *TestDB) AddMessageLabel(messageID, labelID int64) {
 
 // ParticipantOpts configures a participant to insert.
 type ParticipantOpts struct {
-	Email       *string // nil = NULL; use StrPtr("x") for a value
+	Email       *string // nil = NULL; use new("x") for a value
 	DisplayName *string // nil = NULL
 	Phone       *string // nil = NULL; E.164 format when set
 	Domain      string

--- a/internal/testutil/dbtest/dbtest_test.go
+++ b/internal/testutil/dbtest/dbtest_test.go
@@ -18,11 +18,11 @@ type fakeT struct {
 	fatalMsg string
 }
 
-func (f *fakeT) Errorf(format string, args ...interface{}) {
+func (f *fakeT) Errorf(format string, args ...any) {
 	f.fatalMsg = fmt.Sprintf(format, args...)
 }
 
-func (f *fakeT) Fatalf(format string, args ...interface{}) {
+func (f *fakeT) Fatalf(format string, args ...any) {
 	f.fatalMsg = fmt.Sprintf(format, args...)
 	panic("fatalf") // stop execution in the caller
 }

--- a/internal/testutil/email/builder_test.go
+++ b/internal/testutil/email/builder_test.go
@@ -100,7 +100,7 @@ func TestHeaderCaseInsensitiveOverwrite(t *testing.T) {
 
 	// Case-insensitive dedup should produce exactly one header line.
 	count := 0
-	for _, line := range strings.Split(got, "\n") {
+	for line := range strings.SplitSeq(got, "\n") {
 		lower := strings.ToLower(line)
 		if strings.HasPrefix(lower, "x-custom:") {
 			count++

--- a/internal/testutil/ptr/ptr.go
+++ b/internal/testutil/ptr/ptr.go
@@ -1,27 +1,7 @@
-// Package ptr provides generic pointer helpers for tests.
+// Package ptr provides small value constructors for tests.
 package ptr
 
 import "time"
-
-// Bool returns a pointer to the given bool value.
-//
-//go:fix inline
-func Bool(v bool) *bool { return new(v) }
-
-// Int64 returns a pointer to the given int64 value.
-//
-//go:fix inline
-func Int64(v int64) *int64 { return new(v) }
-
-// String returns a pointer to the given string value.
-//
-//go:fix inline
-func String(v string) *string { return new(v) }
-
-// Time returns a pointer to the given time.Time value.
-//
-//go:fix inline
-func Time(v time.Time) *time.Time { return new(v) }
 
 // Date returns a UTC time for the given year, month, and day.
 func Date(year int, month time.Month, day int) time.Time {

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -125,7 +125,7 @@ func TestStageForDeletion_MultipleAggregates_DeterministicFilter(t *testing.T) {
 
 	agg := testutil.MakeSet("charlie@example.com", "alice@example.com", "bob@example.com")
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		manifest := env.StageForDeletion(stageArgs{aggregates: agg, view: query.ViewSenders})
 		assertpkg.Equal(t, []string{"alice@example.com", "bob@example.com", "charlie@example.com"}, manifest.Filters.Senders)
 	}

--- a/internal/tui/nav_detail_test.go
+++ b/internal/tui/nav_detail_test.go
@@ -89,10 +89,7 @@ func TestResizeRecalculatesDetailLineCount(t *testing.T) {
 	// Scroll should be clamped if it exceeds new bounds
 	m.detailScroll = 1000
 	m.clampDetailScroll()
-	maxScroll := m.detailLineCount - m.pageSize
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
+	maxScroll := max(m.detailLineCount-m.pageSize, 0)
 	assertpkg.LessOrEqual(t, m.detailScroll, maxScroll, "expected detailScroll clamped")
 }
 
@@ -156,10 +153,7 @@ func TestScrollClampingAfterResize(t *testing.T) {
 	m, _ := sendKey(t, model, keyDown())
 
 	// detailScroll should be clamped to max (50 - 27 = 23 for detailPageSize)
-	maxScroll := model.detailLineCount - m.detailPageSize()
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
+	maxScroll := max(model.detailLineCount-m.detailPageSize(), 0)
 	assertpkg.LessOrEqual(t, m.detailScroll, maxScroll, "detailScroll exceeds maxScroll after resize")
 }
 

--- a/internal/tui/selection_test.go
+++ b/internal/tui/selection_test.go
@@ -331,7 +331,7 @@ func TestToggleAggregateSelection(t *testing.T) {
 
 func TestSelectVisibleAggregates(t *testing.T) {
 	rows := make([]query.AggregateRow, 0, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		rows = append(rows, query.AggregateRow{Key: fmt.Sprintf("user%d", i)})
 	}
 	m := NewBuilder().WithRows(rows...).Build()

--- a/internal/tui/view_render_test.go
+++ b/internal/tui/view_render_test.go
@@ -612,7 +612,7 @@ func TestViewDuringSpinnerAnimation(t *testing.T) {
 	model = resizeModel(t, model, terminalWidth, terminalHeight)
 
 	// Simulate multiple spinner frames
-	for frame := 0; frame < 10; frame++ {
+	for frame := range 10 {
 		model.spinnerFrame = frame
 
 		view := model.View()

--- a/internal/vector/config_test.go
+++ b/internal/vector/config_test.go
@@ -11,9 +11,6 @@ import (
 	requirepkg "github.com/stretchr/testify/require"
 )
 
-func boolPtr(v bool) *bool { return &v }
-func intPtr(v int) *int    { return &v }
-
 func TestConfig_DefaultsAndParse(t *testing.T) {
 	assert := assertpkg.New(t)
 	input := `
@@ -108,7 +105,7 @@ func validConfig() Config {
 			RRFK:              60,
 			KPerSignal:        100,
 			SubjectBoost:      2.0,
-			MaxPageSizeHybrid: intPtr(50),
+			MaxPageSizeHybrid: new(50),
 		},
 	}
 }
@@ -233,7 +230,7 @@ func TestApplyDefaults_OverridesZeroValues(t *testing.T) {
 		// Preprocess intentionally left with nil pointers to confirm
 		// ApplyDefaults doesn't clobber them.
 		Preprocess: PreprocessConfig{
-			StripQuotes: boolPtr(false), // explicit user intent
+			StripQuotes: new(false), // explicit user intent
 		},
 	}
 	c.ApplyDefaults()
@@ -262,7 +259,7 @@ func TestApplyDefaults_OverridesZeroValues(t *testing.T) {
 // clobber the explicit zero either.
 func TestApplyDefaults_PreservesExplicitMaxPageSizeHybridZero(t *testing.T) {
 	c := Config{
-		Search: SearchConfig{MaxPageSizeHybrid: intPtr(0)},
+		Search: SearchConfig{MaxPageSizeHybrid: new(0)},
 	}
 	c.ApplyDefaults()
 	c.ApplyDefaults() // idempotent: second call must not clobber

--- a/internal/vector/embed/chunk_test.go
+++ b/internal/vector/embed/chunk_test.go
@@ -103,7 +103,7 @@ func TestChunkText(t *testing.T) {
 		assert := assertpkg.New(t)
 		// Mixed-script input with multi-byte runes scattered through.
 		var b strings.Builder
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			b.WriteString("Hello world. ")
 			b.WriteString("こんにちは世界。")
 		}
@@ -169,7 +169,7 @@ func TestChunkText(t *testing.T) {
 		// findSoftBreak returns a sentence boundary near windowEnd
 		// and Trunc stays false on every chunk. With maxSpans=2 we
 		// emit 2 chunks and drop the rest — tailDropped must be true.
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			b.WriteString(strings.Repeat("a", 85))
 			b.WriteString(". ")
 		}

--- a/internal/vector/hybrid/filter_test.go
+++ b/internal/vector/hybrid/filter_test.go
@@ -3,7 +3,7 @@ package hybrid
 import (
 	"context"
 	"database/sql"
-	"sort"
+	"slices"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -50,7 +50,7 @@ CREATE TABLE labels (
 
 func sortedIDs(ids []int64) []int64 {
 	out := append([]int64(nil), ids...)
-	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	slices.Sort(out)
 	return out
 }
 
@@ -330,7 +330,6 @@ func TestBuildFilter_LabelsMatchCaseInsensitiveSubstring(t *testing.T) {
 		{"no match", `label:nowhere`, 1, 1},      // sentinel (no real matches)
 	}
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			q := search.Parse(c.query)
 			f, err := BuildFilter(ctx, db, q)

--- a/internal/vector/hybrid/rrf_test.go
+++ b/internal/vector/hybrid/rrf_test.go
@@ -114,7 +114,7 @@ func TestFuse_TiedRRFScoresStableByMessageID(t *testing.T) {
 	// rank 1 have identical RRF scores (1/61 + 1/62).
 	bm25 := []vector.Hit{{MessageID: 7, Rank: 1}, {MessageID: 3, Rank: 2}}
 	vec := []vector.Hit{{MessageID: 3, Rank: 1}, {MessageID: 7, Rank: 2}}
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		out := Fuse(bm25, vec, 60, 1.0, nil, nil)
 		require.Lenf(out, 2, "iter %d", i)
 		require.Equalf(out[0].RRFScore, out[1].RRFScore, "iter %d: scores differ, not a tie scenario: %+v", i, out)

--- a/internal/whatsapp/mapping_test.go
+++ b/internal/whatsapp/mapping_test.go
@@ -2,6 +2,7 @@ package whatsapp
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 
 	assertpkg "github.com/stretchr/testify/assert"
@@ -169,16 +170,16 @@ func TestMapMessage(t *testing.T) {
 
 func TestMapMessageSnippetTruncation(t *testing.T) {
 	// Create a message with text longer than 100 characters.
-	longText := ""
-	for i := 0; i < 150; i++ {
-		longText += "x"
+	var longText strings.Builder
+	for range 150 {
+		longText.WriteString("x")
 	}
 
 	msg := waMessage{
 		KeyID:       "LONG1",
 		Timestamp:   1700000000000,
 		MessageType: 0,
-		TextData:    sql.NullString{String: longText, Valid: true},
+		TextData:    sql.NullString{String: longText.String(), Valid: true},
 	}
 
 	result := mapMessage(msg, 1, 1, sql.NullInt64{})


### PR DESCRIPTION
Follow-up to #347. Removes the test-only pointer-wrapper helpers and inlines them as Go 1.26 `new(expr)`.

## What changed

- Deletes `ptr.{Bool,Int64,String,Time}`, `dbtest.StrPtr`, and the per-file `boolPtr`/`intPtr`/`strPtr` wrappers.
- Every call site becomes `new(expr)` — e.g. `ptr.String("x")` → `new("x")`, `intPtr(int64(3))` → `new(int64(3))`.
- Applied mechanically via `go fix` (the helpers carried `//go:fix inline`), then the dead helpers were removed.

## Why

These wrappers only existed because `&"literal"` isn't addressable. `new(expr)` (Go 1.26) returns a pointer to a copy of the argument, so behavior is identical and the indirection goes away. `ptr.Date` stays — it returns a value, not a pointer.

Net −54 lines across 36 files; `go vet`, `golangci-lint`, and the suite stay green.
