### PR TITLE
lint: enable goconst and unparam

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,6 @@ linters:
     # standup PR. Re-enable in dedicated passes.
     - contextcheck     # ctx threading through call chains (~50 findings)
     - unparam          # unused params; needs caller-wide refactor (~38)
-    - goconst          # repeated literals; judgement on which to lift (~33)
     - wrapcheck        # %w wrapping at every external-package boundary (~29)
     - noctx            # ~130 DB calls (mostly tests + ctx-less constructors)
                        # need *Context variants; a dedicated sweep, not standup

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,6 @@ linters:
     # Follow-up work — these surface real refactors that don't belong in the
     # standup PR. Re-enable in dedicated passes.
     - contextcheck     # ctx threading through call chains (~50 findings)
-    - unparam          # unused params; needs caller-wide refactor (~38)
     - wrapcheck        # %w wrapping at every external-package boundary (~29)
     - noctx            # ~130 DB calls (mostly tests + ctx-less constructors)
                        # need *Context variants; a dedicated sweep, not standup

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -18,8 +18,11 @@ var (
 	noDefaultIdentityAddAccount bool
 )
 
+// addAccountUse is the usage string for the add-account command.
+const addAccountUse = "add-account <email>"
+
 var addAccountCmd = &cobra.Command{
-	Use:   "add-account <email>",
+	Use:   addAccountUse,
 	Short: "Add a Gmail account via OAuth",
 	Long: `Add a Gmail account by completing the OAuth2 authorization flow.
 
@@ -135,7 +138,7 @@ Examples:
 			}
 
 			// Register source
-			source, saErr := s.GetOrCreateSource("gmail", email)
+			source, saErr := s.GetOrCreateSource(sourceTypeGmail, email)
 			if saErr != nil {
 				return fmt.Errorf("create source: %w", saErr)
 			}
@@ -202,7 +205,7 @@ Examples:
 		tokenReusable := !forceReauth && oauthMgr.HasToken(email) &&
 			(!needsClientCheck || oauthMgr.TokenMatchesClient(email))
 		if tokenReusable {
-			source, err := s.GetOrCreateSource("gmail", email)
+			source, err := s.GetOrCreateSource(sourceTypeGmail, email)
 			if err != nil {
 				return fmt.Errorf("create source: %w", err)
 			}
@@ -265,7 +268,7 @@ Examples:
 		}
 
 		// Authorization succeeded — now persist the binding and source.
-		source, err := s.GetOrCreateSource("gmail", email)
+		source, err := s.GetOrCreateSource(sourceTypeGmail, email)
 		if err != nil {
 			return fmt.Errorf("create source: %w", err)
 		}
@@ -312,7 +315,7 @@ func findGmailSource(
 		return nil, fmt.Errorf("look up sources for %s: %w", email, err)
 	}
 	for _, src := range sources {
-		if src.SourceType == "gmail" {
+		if src.SourceType == sourceTypeGmail {
 			return src, nil
 		}
 	}

--- a/cmd/msgvault/cmd/addimap.go
+++ b/cmd/msgvault/cmd/addimap.go
@@ -162,7 +162,7 @@ Examples:
 		}
 
 		// Create source record
-		source, err := s.GetOrCreateSource("imap", identifier)
+		source, err := s.GetOrCreateSource(sourceTypeIMAP, identifier)
 		if err != nil {
 			return fmt.Errorf("create source: %w", err)
 		}

--- a/cmd/msgvault/cmd/addo365.go
+++ b/cmd/msgvault/cmd/addo365.go
@@ -104,7 +104,7 @@ Examples:
 			return fmt.Errorf("look up existing source: %w", err)
 		}
 		for _, src := range existing {
-			if src.SourceType == "imap" && isMicrosoftIMAPSource(src, email) {
+			if src.SourceType == sourceTypeIMAP && isMicrosoftIMAPSource(src, email) {
 				source = src
 				break
 			}
@@ -115,7 +115,7 @@ Examples:
 				return fmt.Errorf("update source identifier: %w", err)
 			}
 		} else {
-			source, err = s.GetOrCreateSource("imap", identifier)
+			source, err = s.GetOrCreateSource(sourceTypeIMAP, identifier)
 			if err != nil {
 				return fmt.Errorf("create source: %w", err)
 			}

--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -286,7 +286,7 @@ func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, er
 	// because DuckDB can use SQLite indexes efficiently for simple queries
 
 	// 1. Export messages (partitioned by year)
-	messagesDir := filepath.Join(analyticsDir, "messages")
+	messagesDir := filepath.Join(analyticsDir, tableMessages)
 	escapedMessagesDir := strings.ReplaceAll(messagesDir, "'", "''")
 
 	writeMode := "OVERWRITE_OR_IGNORE"
@@ -294,7 +294,7 @@ func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, er
 		writeMode = "APPEND"
 	}
 
-	if err := runExport("messages", fmt.Sprintf(`
+	if err := runExport(tableMessages, fmt.Sprintf(`
 	COPY (
 		SELECT
 			m.id,
@@ -369,13 +369,13 @@ func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, er
 	}
 
 	// 4. Export attachments
-	attachmentsDir := filepath.Join(analyticsDir, "attachments")
+	attachmentsDir := filepath.Join(analyticsDir, tableAttachments)
 	escapedAttachmentsDir := strings.ReplaceAll(attachmentsDir, "'", "''")
 	attachmentsFilter := ""
 	if !fullRebuild && lastMessageID > 0 {
 		attachmentsFilter = fmt.Sprintf(" WHERE message_id > %d", lastMessageID)
 	}
-	if err := runExport("attachments", fmt.Sprintf(`
+	if err := runExport(tableAttachments, fmt.Sprintf(`
 	COPY (
 		SELECT
 			message_id,
@@ -391,9 +391,9 @@ func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, er
 	}
 
 	// 5. Export participants
-	participantsDir := filepath.Join(analyticsDir, "participants")
+	participantsDir := filepath.Join(analyticsDir, tableParticipants)
 	escapedParticipantsDir := strings.ReplaceAll(participantsDir, "'", "''")
-	if err := runExport("participants", fmt.Sprintf(`
+	if err := runExport(tableParticipants, fmt.Sprintf(`
 	COPY (
 		SELECT
 			id,
@@ -411,9 +411,9 @@ func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, er
 	}
 
 	// 6. Export labels
-	labelsDir := filepath.Join(analyticsDir, "labels")
+	labelsDir := filepath.Join(analyticsDir, tableLabels)
 	escapedLabelsDir := strings.ReplaceAll(labelsDir, "'", "''")
-	if err := runExport("labels", fmt.Sprintf(`
+	if err := runExport(tableLabels, fmt.Sprintf(`
 	COPY (
 		SELECT
 			id,
@@ -446,9 +446,9 @@ func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, er
 	}
 
 	// 8. Export conversations (for Gmail thread IDs)
-	conversationsDir := filepath.Join(analyticsDir, "conversations")
+	conversationsDir := filepath.Join(analyticsDir, tableConversations)
 	escapedConversationsDir := strings.ReplaceAll(conversationsDir, "'", "''")
-	if err := runExport("conversations", fmt.Sprintf(`
+	if err := runExport(tableConversations, fmt.Sprintf(`
 	COPY (
 		SELECT
 			id,
@@ -520,7 +520,7 @@ func missingRequiredParquet(analyticsDir string) bool {
 			return true
 		}
 		// For messages, also check hive-partitioned layout (messages/year=*/*.parquet)
-		if dir == "messages" {
+		if dir == tableMessages {
 			if deep, _ := filepath.Glob(filepath.Join(analyticsDir, dir, "*", "*.parquet")); len(deep) > 0 {
 				return true
 			}
@@ -536,7 +536,7 @@ var cacheStatsCmd = &cobra.Command{
 	Long:    `Display statistics about the analytics cache, including row counts and file sizes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		analyticsDir := cfg.AnalyticsDir()
-		messagesDir := filepath.Join(analyticsDir, "messages")
+		messagesDir := filepath.Join(analyticsDir, tableMessages)
 
 		// Check if directory exists and contains parquet files
 		if _, err := os.Stat(messagesDir); os.IsNotExist(err) {
@@ -614,7 +614,7 @@ var cacheStatsCmd = &cobra.Command{
 		}
 
 		// Get attachment stats separately
-		attachmentsDir := filepath.Join(analyticsDir, "attachments")
+		attachmentsDir := filepath.Join(analyticsDir, tableAttachments)
 		var attachmentSize int64
 		if _, err := os.Stat(attachmentsDir); err == nil {
 			attachSQL := fmt.Sprintf(`
@@ -696,15 +696,15 @@ func setupSQLiteSource(duckDB *sql.DB, dbPath string) (cleanup func(), err error
 		// `deleted_at IS NULL` filter on this path the same way it does
 		// on the sqlite_scanner path; otherwise DuckDB binds against a
 		// CSV view that lacks the column and the export fails on Windows.
-		{"messages", "SELECT id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, deleted_from_source_at, deleted_at, sender_id, message_type FROM messages WHERE sent_at IS NOT NULL",
+		{tableMessages, "SELECT id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, deleted_from_source_at, deleted_at, sender_id, message_type FROM messages WHERE sent_at IS NOT NULL",
 			"types={'sent_at': 'TIMESTAMP', 'deleted_from_source_at': 'TIMESTAMP', 'deleted_at': 'TIMESTAMP'}"},
 		{"message_recipients", "SELECT message_id, participant_id, recipient_type, display_name FROM message_recipients", ""},
 		{"message_labels", "SELECT message_id, label_id FROM message_labels", ""},
-		{"attachments", "SELECT message_id, size, filename FROM attachments", ""},
-		{"participants", "SELECT id, email_address, domain, display_name, phone_number FROM participants", ""},
-		{"labels", "SELECT id, name FROM labels", ""},
+		{tableAttachments, "SELECT message_id, size, filename FROM attachments", ""},
+		{tableParticipants, "SELECT id, email_address, domain, display_name, phone_number FROM participants", ""},
+		{tableLabels, "SELECT id, name FROM labels", ""},
 		{"sources", "SELECT id, identifier, source_type FROM sources", ""},
-		{"conversations", "SELECT id, source_conversation_id, title, COALESCE(conversation_type, 'email_thread') AS conversation_type FROM conversations", ""},
+		{tableConversations, "SELECT id, source_conversation_id, title, COALESCE(conversation_type, 'email_thread') AS conversation_type FROM conversations", ""},
 	}
 
 	for _, t := range tables {

--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -1,0 +1,27 @@
+package cmd
+
+// Source-type identifiers stored in sources.source_type and matched against
+// when dispatching sync/import logic per account kind.
+const (
+	sourceTypeGmail = "gmail"
+	sourceTypeIMAP  = "imap"
+	sourceTypeMbox  = "mbox"
+)
+
+// Analytics dataset / SQLite table names. These double as the Parquet
+// subdirectory under analytics/ and the source table in build-cache and
+// repair-encoding queries, and as stats/JSON field keys for the same entities.
+const (
+	tableMessages      = "messages"
+	tableLabels        = "labels"
+	tableAttachments   = "attachments"
+	tableParticipants  = "participants"
+	tableConversations = "conversations"
+)
+
+// outputFormatJSON is the JSON output mode: both the --json flag name and the
+// "json" value accepted by --format.
+const outputFormatJSON = "json"
+
+// keyEmail is the map/log field key carrying an account or address email.
+const keyEmail = "email"

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -431,7 +431,7 @@ Examples:
 			}
 			var syncable []*store.Source
 			for _, c := range resolved {
-				if c.SourceType == "gmail" || c.SourceType == "imap" {
+				if c.SourceType == sourceTypeGmail || c.SourceType == sourceTypeIMAP {
 					syncable = append(syncable, c)
 				}
 			}
@@ -478,7 +478,7 @@ Examples:
 		}
 		var src *store.Source
 		for _, candidate := range sources {
-			if candidate.SourceType == "gmail" || candidate.SourceType == "imap" {
+			if candidate.SourceType == sourceTypeGmail || candidate.SourceType == sourceTypeIMAP {
 				src = candidate
 				break
 			}
@@ -492,7 +492,7 @@ Examples:
 		// Service-account flows get scopes via the JWT assertion (no stored
 		// token), so the scope-escalation prompt only applies to browser OAuth.
 		var clientSecretsPath string
-		if src.SourceType == "gmail" {
+		if src.SourceType == sourceTypeGmail {
 			if !cfg.OAuth.HasAnyConfig() {
 				return errOAuthNotConfigured()
 			}
@@ -589,7 +589,7 @@ Examples:
 				}
 
 				// Check if this is a scope error - offer to re-authorize (Gmail only)
-				if src.SourceType == "gmail" && isInsufficientScopeError(execErr) {
+				if src.SourceType == sourceTypeGmail && isInsufficientScopeError(execErr) {
 					if cfg.OAuth.ServiceAccountKeyFor(sourceOAuthApp(src)) != "" {
 						return fmt.Errorf(
 							"service account lacks required Gmail deletion scope for %s: "+

--- a/cmd/msgvault/cmd/export_attachment.go
+++ b/cmd/msgvault/cmd/export_attachment.go
@@ -85,7 +85,7 @@ func runExportAttachment(cmd *cobra.Command, args []string) error {
 	if exportAttachmentBase64 {
 		return exportAttachmentAsBase64(storagePath)
 	}
-	return exportAttachmentBinary(storagePath, contentHash)
+	return exportAttachmentBinary(storagePath)
 }
 
 func exportAttachmentAsJSON(storagePath, contentHash string) error {
@@ -122,7 +122,7 @@ func exportAttachmentAsBase64(storagePath string) error {
 	return nil
 }
 
-func exportAttachmentBinary(storagePath, contentHash string) error {
+func exportAttachmentBinary(storagePath string) error {
 	f, err := openAttachmentFile(storagePath)
 	if err != nil {
 		return err

--- a/cmd/msgvault/cmd/export_attachment.go
+++ b/cmd/msgvault/cmd/export_attachment.go
@@ -180,6 +180,6 @@ func readAttachmentFile(storagePath, contentHash string) ([]byte, error) {
 func init() {
 	rootCmd.AddCommand(exportAttachmentCmd)
 	exportAttachmentCmd.Flags().StringVarP(&exportAttachmentOutput, "output", "o", "", "Output file path (default: stdout, use - for stdout)")
-	exportAttachmentCmd.Flags().BoolVar(&exportAttachmentJSON, "json", false, "Output as JSON with base64-encoded data")
+	exportAttachmentCmd.Flags().BoolVar(&exportAttachmentJSON, outputFormatJSON, false, "Output as JSON with base64-encoded data")
 	exportAttachmentCmd.Flags().BoolVar(&exportAttachmentBase64, "base64", false, "Output raw base64 to stdout")
 }

--- a/cmd/msgvault/cmd/export_attachment_test.go
+++ b/cmd/msgvault/cmd/export_attachment_test.go
@@ -53,7 +53,7 @@ func TestExportAttachment_BinaryToFile(t *testing.T) {
 	exportAttachmentBase64 = false
 	defer func() { exportAttachmentOutput = "" }()
 
-	require.NoError(exportAttachmentBinary(storagePath, contentHash), "exportAttachmentBinary")
+	require.NoError(exportAttachmentBinary(storagePath), "exportAttachmentBinary")
 
 	got, err := os.ReadFile(outFile)
 	require.NoError(err, "read output")

--- a/cmd/msgvault/cmd/export_attachments_test.go
+++ b/cmd/msgvault/cmd/export_attachments_test.go
@@ -31,8 +31,8 @@ func TestExportAttachmentsCmd_Registration(t *testing.T) {
 
 // setupExportAttachmentsTest creates a temp directory with a SQLite database
 // containing a message with attachments and corresponding content-addressed
-// files on disk. Returns the data dir and the message ID.
-func setupExportAttachmentsTest(t *testing.T) (dataDir string, msgID int64) {
+// files on disk. Returns the data dir.
+func setupExportAttachmentsTest(t *testing.T) (dataDir string) {
 	t.Helper()
 	dataDir = t.TempDir()
 
@@ -58,7 +58,7 @@ func setupExportAttachmentsTest(t *testing.T) (dataDir string, msgID int64) {
 	createTestAttachment(t, db, attDir, 2, 1, "photo.jpg", []byte("JPEG image data"))
 
 	_ = s.Close()
-	return dataDir, 1
+	return dataDir
 }
 
 // createTestAttachment creates a content-addressed file and inserts the
@@ -85,7 +85,7 @@ func createTestAttachment(t *testing.T, db *sql.DB, attDir string, attID, msgID 
 func TestExportAttachments_FullFlow(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
-	dataDir, _ := setupExportAttachmentsTest(t)
+	dataDir := setupExportAttachmentsTest(t)
 
 	// Set global cfg to point to our test data
 	oldCfg := cfg
@@ -116,7 +116,7 @@ func TestExportAttachments_FullFlow(t *testing.T) {
 }
 
 func TestExportAttachments_GmailIDFallback(t *testing.T) {
-	dataDir, _ := setupExportAttachmentsTest(t)
+	dataDir := setupExportAttachmentsTest(t)
 
 	oldCfg := cfg
 	cfg = &config.Config{
@@ -139,7 +139,7 @@ func TestExportAttachments_GmailIDFallback(t *testing.T) {
 }
 
 func TestExportAttachments_MessageNotFound(t *testing.T) {
-	dataDir, _ := setupExportAttachmentsTest(t)
+	dataDir := setupExportAttachmentsTest(t)
 
 	oldCfg := cfg
 	cfg = &config.Config{
@@ -156,7 +156,7 @@ func TestExportAttachments_MessageNotFound(t *testing.T) {
 }
 
 func TestExportAttachments_OutputDirValidation(t *testing.T) {
-	dataDir, _ := setupExportAttachmentsTest(t)
+	dataDir := setupExportAttachmentsTest(t)
 
 	oldCfg := cfg
 	cfg = &config.Config{
@@ -177,7 +177,7 @@ func TestExportAttachments_OutputDirValidation(t *testing.T) {
 }
 
 func TestExportAttachments_NotADirectory(t *testing.T) {
-	dataDir, _ := setupExportAttachmentsTest(t)
+	dataDir := setupExportAttachmentsTest(t)
 
 	oldCfg := cfg
 	cfg = &config.Config{

--- a/cmd/msgvault/cmd/export_token_test.go
+++ b/cmd/msgvault/cmd/export_token_test.go
@@ -124,11 +124,11 @@ func newTestExporter(srv *httptest.Server, tokensDir string) *tokenExporter {
 	}
 }
 
-// writeTestToken writes a fake token file and returns the email used.
-func writeTestToken(t *testing.T, tokensDir, email, content string) {
+// writeTestToken writes a fake token file for the test account.
+func writeTestToken(t *testing.T, tokensDir, content string) {
 	t.Helper()
 	requirepkg.NoError(t, os.MkdirAll(tokensDir, 0700), "mkdir tokens")
-	path := filepath.Join(tokensDir, email+".json")
+	path := filepath.Join(tokensDir, "user@gmail.com.json")
 	requirepkg.NoError(t, os.WriteFile(path, []byte(content), 0600), "write token")
 }
 
@@ -154,7 +154,7 @@ func TestExport_UploadSuccess(t *testing.T) {
 	defer srv.Close()
 
 	tokensDir := t.TempDir()
-	writeTestToken(t, tokensDir, "user@gmail.com", `{"token":"secret"}`)
+	writeTestToken(t, tokensDir, `{"token":"secret"}`)
 
 	e := newTestExporter(srv, tokensDir)
 	result, err := e.export("user@gmail.com", srv.URL, "my-key", false)
@@ -183,7 +183,7 @@ func TestExport_UploadFailure(t *testing.T) {
 	defer srv.Close()
 
 	tokensDir := t.TempDir()
-	writeTestToken(t, tokensDir, "user@gmail.com", `{"token":"secret"}`)
+	writeTestToken(t, tokensDir, `{"token":"secret"}`)
 
 	e := newTestExporter(srv, tokensDir)
 	_, err := e.export("user@gmail.com", srv.URL, "key", false)
@@ -229,7 +229,7 @@ func TestExport_HTTPAllowedWithInsecure(t *testing.T) {
 	defer srv.Close()
 
 	tokensDir := t.TempDir()
-	writeTestToken(t, tokensDir, "user@gmail.com", `{"token":"data"}`)
+	writeTestToken(t, tokensDir, `{"token":"data"}`)
 
 	e := &tokenExporter{
 		httpClient: srv.Client(),
@@ -254,7 +254,7 @@ func TestExport_HTTPWarning(t *testing.T) {
 	defer srv.Close()
 
 	tokensDir := t.TempDir()
-	writeTestToken(t, tokensDir, "user@gmail.com", `{"token":"data"}`)
+	writeTestToken(t, tokensDir, `{"token":"data"}`)
 
 	var stderr bytes.Buffer
 	e := &tokenExporter{
@@ -300,7 +300,7 @@ func TestExport_AccountPostSuccess(t *testing.T) {
 	defer srv.Close()
 
 	tokensDir := t.TempDir()
-	writeTestToken(t, tokensDir, "user@gmail.com", `{}`)
+	writeTestToken(t, tokensDir, `{}`)
 
 	e := newTestExporter(srv, tokensDir)
 	_, err := e.export("user@gmail.com", srv.URL, "key", false)
@@ -322,7 +322,7 @@ func TestExport_AccountPostFailureIsNonFatal(t *testing.T) {
 	defer srv.Close()
 
 	tokensDir := t.TempDir()
-	writeTestToken(t, tokensDir, "user@gmail.com", `{}`)
+	writeTestToken(t, tokensDir, `{}`)
 
 	var stderr bytes.Buffer
 	e := &tokenExporter{
@@ -354,7 +354,7 @@ func TestExport_AllowInsecureFromConfig(t *testing.T) {
 	defer srv.Close()
 
 	tokensDir := t.TempDir()
-	writeTestToken(t, tokensDir, "user@gmail.com", `{"token":"data"}`)
+	writeTestToken(t, tokensDir, `{"token":"data"}`)
 
 	e := &tokenExporter{
 		httpClient: srv.Client(),

--- a/cmd/msgvault/cmd/identity.go
+++ b/cmd/msgvault/cmd/identity.go
@@ -23,8 +23,11 @@ var (
 	identityAddSignal      string
 )
 
+// identityCmdUse is the usage/name of the identity command.
+const identityCmdUse = "identity"
+
 var identityCmd = &cobra.Command{
-	Use:   "identity",
+	Use:   identityCmdUse,
 	Short: "Manage the confirmed \"me\" identifiers for each account",
 	Long: `Each account has one identity: the set of identifiers (email
 addresses, phone numbers, chat handles, synthetic identifiers) that mean
@@ -410,9 +413,9 @@ func init() {
 		"collection", "", "Restrict to all member accounts of one collection")
 	identityListCmd.MarkFlagsMutuallyExclusive("account", "collection")
 	identityListCmd.Flags().BoolVar(&identityListJSON,
-		"json", false, "Output as JSON")
+		outputFormatJSON, false, "Output as JSON")
 	identityShowCmd.Flags().BoolVar(&identityShowJSON,
-		"json", false, "Output as JSON")
+		outputFormatJSON, false, "Output as JSON")
 	identityAddCmd.Flags().StringVar(&identityAddSignal,
 		"signal", "manual",
 		"Evidence signal name (e.g. manual, account-identifier, phone-e164). "+

--- a/cmd/msgvault/cmd/identity.go
+++ b/cmd/msgvault/cmd/identity.go
@@ -163,6 +163,10 @@ func splitSignalSet(s string) []string {
 	return out
 }
 
+// nil error return mirrors writeIdentityJSON so callers can return either
+// uniformly; tabwriter output never fails.
+//
+//nolint:unparam // symmetry with error-returning writeIdentityJSON sibling
 func writeIdentityTable(w io.Writer, rows []identityRow) error {
 	if len(rows) == 0 {
 		_, _ = fmt.Fprintln(w, "No accounts in scope.")

--- a/cmd/msgvault/cmd/import_synctech_sms.go
+++ b/cmd/msgvault/cmd/import_synctech_sms.go
@@ -44,7 +44,7 @@ SMS Backup & Restore by SyncTech Pty Ltd.`,
 	cmd.Flags().BoolVar(&opts.IncludeSMS, "sms", true, "Import SMS records")
 	cmd.Flags().BoolVar(&opts.IncludeMMS, "mms", true, "Import MMS records")
 	cmd.Flags().BoolVar(&opts.IncludeCalls, "calls", true, "Import call log records")
-	cmd.Flags().BoolVar(&opts.IncludeAttachments, "attachments", true, "Import MMS attachments")
+	cmd.Flags().BoolVar(&opts.IncludeAttachments, tableAttachments, true, "Import MMS attachments")
 	return cmd
 }
 

--- a/cmd/msgvault/cmd/list_accounts.go
+++ b/cmd/msgvault/cmd/list_accounts.go
@@ -152,7 +152,7 @@ func outputAccountsJSON(stats []accountStats) error {
 	for i, s := range stats {
 		entry := map[string]any{
 			"id":            s.ID,
-			"email":         s.Email,
+			keyEmail:        s.Email,
 			"type":          s.Type,
 			"display_name":  s.DisplayName,
 			"message_count": s.MessageCount,
@@ -232,5 +232,5 @@ func outputRemoteAccountsJSON(accounts []remote.AccountInfo) error {
 
 func init() {
 	rootCmd.AddCommand(listAccountsCmd)
-	listAccountsCmd.Flags().BoolVar(&listAccountsJSON, "json", false, "Output as JSON")
+	listAccountsCmd.Flags().BoolVar(&listAccountsJSON, outputFormatJSON, false, "Output as JSON")
 }

--- a/cmd/msgvault/cmd/output.go
+++ b/cmd/msgvault/cmd/output.go
@@ -61,7 +61,7 @@ func addCommonAggregateFlags(cmd *cobra.Command) {
 		"Filter to messages before date (YYYY-MM-DD)",
 	)
 	cmd.Flags().BoolVar(
-		&aggJSON, "json", false, "Output as JSON",
+		&aggJSON, outputFormatJSON, false, "Output as JSON",
 	)
 }
 

--- a/cmd/msgvault/cmd/query.go
+++ b/cmd/msgvault/cmd/query.go
@@ -126,7 +126,7 @@ func executeQuery(
 	}
 
 	switch format {
-	case "json":
+	case outputFormatJSON:
 		return writeJSON(w, cols, allRows)
 	case "csv":
 		return writeCSV(w, cols, allRows)
@@ -265,7 +265,7 @@ func writeTable(
 func init() {
 	rootCmd.AddCommand(queryCmd)
 	queryCmd.Flags().StringVar(
-		&queryFormat, "format", "json",
+		&queryFormat, "format", outputFormatJSON,
 		"Output format: json, csv, or table",
 	)
 }

--- a/cmd/msgvault/cmd/query.go
+++ b/cmd/msgvault/cmd/query.go
@@ -203,6 +203,10 @@ func writeCSV(
 	return cw.Error()
 }
 
+// nil error return mirrors writeJSON/writeCSV so the format switch can
+// `return writeTable(...)` uniformly; text printing never fails.
+//
+//nolint:unparam // symmetry with error-returning writeJSON/writeCSV siblings
 func writeTable(
 	w io.Writer, cols []string, rows [][]any,
 ) error {

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -153,7 +153,7 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 
 	// Remove credentials for the source type.
 	switch source.SourceType {
-	case "gmail":
+	case sourceTypeGmail:
 		tokenPath := oauth.TokenFilePath(
 			cfg.TokensDir(), source.Identifier,
 		)
@@ -163,7 +163,7 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 				tokenPath, err,
 			)
 		}
-	case "imap":
+	case sourceTypeIMAP:
 		if source.SyncConfig.Valid && source.SyncConfig.String != "" {
 			imapCfg, parseErr := imaplib.ConfigFromJSON(source.SyncConfig.String)
 			if parseErr == nil {

--- a/cmd/msgvault/cmd/repair_encoding.go
+++ b/cmd/msgvault/cmd/repair_encoding.go
@@ -406,7 +406,7 @@ func repairDisplayNames(s *store.Store, stats *repairStats) error {
 			updateStmt: "UPDATE message_recipients SET display_name = ? WHERE id = ?",
 		},
 		{
-			name:       "participants",
+			name:       tableParticipants,
 			query:      "SELECT id, display_name FROM participants WHERE display_name IS NOT NULL",
 			updateStmt: "UPDATE participants SET display_name = ? WHERE id = ?",
 		},
@@ -528,42 +528,42 @@ func repairOtherStrings(s *store.Store, stats *repairStats) error {
 		counter    *int
 	}{
 		{
-			name:       "labels",
+			name:       tableLabels,
 			column:     "name",
 			query:      "SELECT id, name FROM labels WHERE name IS NOT NULL",
 			updateStmt: "UPDATE labels SET name = ? WHERE id = ?",
 			counter:    &stats.labels,
 		},
 		{
-			name:       "attachments",
+			name:       tableAttachments,
 			column:     "filename",
 			query:      "SELECT id, filename FROM attachments WHERE filename IS NOT NULL",
 			updateStmt: "UPDATE attachments SET filename = ? WHERE id = ?",
 			counter:    &stats.filenames,
 		},
 		{
-			name:       "conversations",
+			name:       tableConversations,
 			column:     "title",
 			query:      "SELECT id, title FROM conversations WHERE title IS NOT NULL",
 			updateStmt: "UPDATE conversations SET title = ? WHERE id = ?",
 			counter:    &stats.convTitles,
 		},
 		{
-			name:       "conversations",
+			name:       tableConversations,
 			column:     "source_conversation_id",
 			query:      "SELECT id, source_conversation_id FROM conversations WHERE source_conversation_id IS NOT NULL",
 			updateStmt: "UPDATE conversations SET source_conversation_id = ? WHERE id = ?",
 			counter:    &stats.convSourceIDs,
 		},
 		{
-			name:       "participants",
+			name:       tableParticipants,
 			column:     "email_address",
 			query:      "SELECT id, email_address FROM participants WHERE email_address IS NOT NULL",
 			updateStmt: "UPDATE participants SET email_address = ? WHERE id = ?",
 			counter:    &stats.emailAddrs,
 		},
 		{
-			name:       "participants",
+			name:       tableParticipants,
 			column:     "domain",
 			query:      "SELECT id, domain FROM participants WHERE domain IS NOT NULL",
 			updateStmt: "UPDATE participants SET domain = ? WHERE id = ?",

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -408,7 +408,7 @@ func outputSearchResultsJSON(results []query.MessageSummary) error {
 			"size_estimate":          msg.SizeEstimate,
 			"has_attachments":        msg.HasAttachments,
 			"attachment_count":       msg.AttachmentCount,
-			"labels":                 msg.Labels,
+			tableLabels:              msg.Labels,
 		}
 	}
 
@@ -419,7 +419,7 @@ func init() {
 	rootCmd.AddCommand(searchCmd)
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 50, "Maximum number of results")
 	searchCmd.Flags().IntVar(&searchOffset, "offset", 0, "Skip first N results")
-	searchCmd.Flags().BoolVar(&searchJSON, "json", false, "Output as JSON")
+	searchCmd.Flags().BoolVar(&searchJSON, outputFormatJSON, false, "Output as JSON")
 	searchCmd.Flags().StringVar(&searchAccount, "account", "", "Limit results to a specific account (email address)")
 	searchCmd.Flags().StringVar(&searchCollection, "collection", "",
 		"Limit results to all member accounts of one collection")

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -340,6 +340,10 @@ func runLocalSearch(cmd *cobra.Command, queryStr string, scope Scope, scopedStor
 	return outputSearchResultsTable(results)
 }
 
+// nil error return mirrors outputSearchResultsJSON so callers can return
+// either uniformly; tabwriter output never fails.
+//
+//nolint:unparam // symmetry with error-returning outputSearchResultsJSON sibling
 func outputSearchResultsTable(results []query.MessageSummary) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "ID\tDATE\tFROM\tSUBJECT\tSIZE")
@@ -367,6 +371,10 @@ func summaryFromDisplay(msg query.MessageSummary) string {
 	return ""
 }
 
+// nil error return mirrors outputRemoteSearchResultsJSON so callers can
+// return either uniformly; tabwriter output never fails.
+//
+//nolint:unparam // symmetry with error-returning outputRemoteSearchResultsJSON sibling
 func outputRemoteSearchResultsTable(results []store.APIMessage, total int64) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "ID\tDATE\tFROM\tSUBJECT\tSIZE")

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -376,11 +376,11 @@ func runScheduledSync(ctx context.Context, identifier string, s *store.Store, ge
 	// Source type drives dispatch. A nil source falls back to Gmail to
 	// preserve the token-first workflow (tokens uploaded via API before
 	// the source row exists).
-	sourceType := "gmail"
+	sourceType := sourceTypeGmail
 	if src != nil {
 		sourceType = src.SourceType
 		if sourceType == "" {
-			sourceType = "gmail"
+			sourceType = sourceTypeGmail
 		}
 	}
 
@@ -389,9 +389,9 @@ func runScheduledSync(ctx context.Context, identifier string, s *store.Store, ge
 		err     error
 	)
 	switch sourceType {
-	case "gmail":
+	case sourceTypeGmail:
 		summary, err = runScheduledGmailSync(ctx, identifier, src, s, getOAuthMgr, vf)
-	case "imap":
+	case sourceTypeIMAP:
 		summary, err = runScheduledIMAPSync(ctx, src, s, vf)
 	default:
 		return fmt.Errorf("source %q has type %q which is not supported by the daemon scheduler (only gmail and imap)", identifier, sourceType)
@@ -453,9 +453,9 @@ func findScheduledSyncSource(s *store.Store, identifier string) (*store.Source, 
 	var imapSrc *store.Source
 	for _, src := range sources {
 		switch src.SourceType {
-		case "gmail":
+		case sourceTypeGmail:
 			return src, nil
-		case "imap":
+		case sourceTypeIMAP:
 			if imapSrc == nil {
 				imapSrc = src
 			}
@@ -523,7 +523,7 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 		syncer.SetEmbedEnqueuer(vf.Enqueuer)
 	}
 
-	source, err := s.GetOrCreateSource("gmail", email)
+	source, err := s.GetOrCreateSource(sourceTypeGmail, email)
 	if err != nil {
 		return nil, fmt.Errorf("get source: %w", err)
 	}
@@ -556,7 +556,7 @@ func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store
 	defer func() { _ = apiClient.Close() }()
 
 	opts := sync.DefaultOptions()
-	opts.SourceType = "imap"
+	opts.SourceType = sourceTypeIMAP
 	opts.AttachmentsDir = cfg.AttachmentsDir()
 	opts.NoResume = true
 

--- a/cmd/msgvault/cmd/show_message.go
+++ b/cmd/msgvault/cmd/show_message.go
@@ -186,19 +186,19 @@ func outputMessageJSON(msg *query.MessageDetail) error {
 	// Build address arrays
 	fromAddrs := make([]map[string]string, len(msg.From))
 	for i, addr := range msg.From {
-		fromAddrs[i] = map[string]string{"email": addr.Email, "name": addr.Name}
+		fromAddrs[i] = map[string]string{keyEmail: addr.Email, "name": addr.Name}
 	}
 	toAddrs := make([]map[string]string, len(msg.To))
 	for i, addr := range msg.To {
-		toAddrs[i] = map[string]string{"email": addr.Email, "name": addr.Name}
+		toAddrs[i] = map[string]string{keyEmail: addr.Email, "name": addr.Name}
 	}
 	ccAddrs := make([]map[string]string, len(msg.Cc))
 	for i, addr := range msg.Cc {
-		ccAddrs[i] = map[string]string{"email": addr.Email, "name": addr.Name}
+		ccAddrs[i] = map[string]string{keyEmail: addr.Email, "name": addr.Name}
 	}
 	bccAddrs := make([]map[string]string, len(msg.Bcc))
 	for i, addr := range msg.Bcc {
-		bccAddrs[i] = map[string]string{"email": addr.Email, "name": addr.Name}
+		bccAddrs[i] = map[string]string{keyEmail: addr.Email, "name": addr.Name}
 	}
 
 	// Build attachment array
@@ -227,8 +227,8 @@ func outputMessageJSON(msg *query.MessageDetail) error {
 		"to":                     toAddrs,
 		"cc":                     ccAddrs,
 		"bcc":                    bccAddrs,
-		"labels":                 msg.Labels,
-		"attachments":            attachments,
+		tableLabels:              msg.Labels,
+		tableAttachments:         attachments,
 		"body_text":              msg.BodyText,
 		"body_html":              msg.BodyHTML,
 	}
@@ -329,8 +329,8 @@ func outputRemoteMessageJSON(msg *store.APIMessage) error {
 		"sent_at":         msg.SentAt.Format(time.RFC3339),
 		"size_estimate":   msg.SizeEstimate,
 		"has_attachments": msg.HasAttachments,
-		"labels":          msg.Labels,
-		"attachments":     attachments,
+		tableLabels:       msg.Labels,
+		tableAttachments:  attachments,
 		"body":            msg.Body,
 	}
 
@@ -341,5 +341,5 @@ func outputRemoteMessageJSON(msg *store.APIMessage) error {
 
 func init() {
 	rootCmd.AddCommand(showMessageCmd)
-	showMessageCmd.Flags().BoolVar(&showMessageJSON, "json", false, "Output as JSON")
+	showMessageCmd.Flags().BoolVar(&showMessageJSON, outputFormatJSON, false, "Output as JSON")
 }

--- a/cmd/msgvault/cmd/show_message.go
+++ b/cmd/msgvault/cmd/show_message.go
@@ -120,6 +120,10 @@ func showLocalMessage(cmd *cobra.Command, idStr string) error {
 	return outputMessageText(msg)
 }
 
+// nil error return mirrors outputMessageJSON so callers can return either
+// uniformly; text printing never fails.
+//
+//nolint:unparam // symmetry with error-returning outputMessageJSON sibling
 func outputMessageText(msg *query.MessageDetail) error {
 	// Header section
 	fmt.Println("═══════════════════════════════════════════════════════════════════════════════")
@@ -255,6 +259,10 @@ func formatAddresses(addrs []query.Address) string {
 }
 
 // outputRemoteMessageText displays a message from the remote API.
+// nil error return mirrors outputRemoteMessageJSON so callers can return
+// either uniformly; text printing never fails.
+//
+//nolint:unparam // symmetry with error-returning outputRemoteMessageJSON sibling
 func outputRemoteMessageText(msg *store.APIMessage) error {
 	fmt.Println("═══════════════════════════════════════════════════════════════════════════════")
 	fmt.Printf("Message ID: %d\n", msg.ID)

--- a/cmd/msgvault/cmd/stats.go
+++ b/cmd/msgvault/cmd/stats.go
@@ -75,10 +75,10 @@ Use --local to force local database.`,
 				return fmt.Errorf("get stats: %w", err)
 			}
 			logger.Info("stats",
-				"messages", dbStats.MessageCount,
+				tableMessages, dbStats.MessageCount,
 				"threads", dbStats.ThreadCount,
-				"attachments", dbStats.AttachmentCount,
-				"labels", dbStats.LabelCount,
+				tableAttachments, dbStats.AttachmentCount,
+				tableLabels, dbStats.LabelCount,
 				"accounts", dbStats.SourceCount,
 				"db_bytes", dbStats.DatabaseSize,
 			)
@@ -123,10 +123,10 @@ Use --local to force local database.`,
 			return fmt.Errorf("get stats: %w", err)
 		}
 		logger.Info("stats",
-			"messages", dbStats.MessageCount,
+			tableMessages, dbStats.MessageCount,
 			"threads", dbStats.ThreadCount,
-			"attachments", dbStats.AttachmentCount,
-			"labels", dbStats.LabelCount,
+			tableAttachments, dbStats.AttachmentCount,
+			tableLabels, dbStats.LabelCount,
 			"accounts", dbStats.SourceCount,
 			"db_bytes", dbStats.DatabaseSize,
 		)

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -103,9 +103,9 @@ Examples:
 			}
 			for _, src := range allMatches {
 				switch src.SourceType {
-				case "gmail":
+				case sourceTypeGmail:
 					gmailTargets = append(gmailTargets, syncTarget{source: src, email: src.Identifier})
-				case "imap":
+				case sourceTypeIMAP:
 					imapTargets = append(imapTargets, src)
 				}
 			}
@@ -127,7 +127,7 @@ Examples:
 			}
 			for _, src := range allSources {
 				switch src.SourceType {
-				case "gmail":
+				case sourceTypeGmail:
 					if !cfg.OAuth.HasAnyConfig() {
 						fmt.Printf("Skipping %s (OAuth not configured)\n", src.Identifier)
 						continue
@@ -150,7 +150,7 @@ Examples:
 						}
 					}
 					gmailTargets = append(gmailTargets, syncTarget{source: src, email: src.Identifier})
-				case "imap":
+				case sourceTypeIMAP:
 					skipMsg, parseErr := imapSkipReason(src)
 					if parseErr != nil {
 						syncErrors = append(syncErrors, fmt.Sprintf("%s: malformed sync_config: %v", src.Identifier, parseErr))
@@ -302,7 +302,7 @@ func runIncrementalSync(ctx context.Context, s *store.Store, getOAuthMgr func(st
 
 	elapsed := time.Since(startTime)
 	logger.Info("incremental sync completed",
-		"email", email,
+		keyEmail, email,
 		"messages_added", summary.MessagesAdded,
 		"elapsed", elapsed,
 	)

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -95,7 +95,7 @@ Examples:
 				return fmt.Errorf("look up source: %w", err)
 			}
 			for _, src := range allMatches {
-				if src.SourceType == "gmail" || src.SourceType == "imap" {
+				if src.SourceType == sourceTypeGmail || src.SourceType == sourceTypeIMAP {
 					sources = append(sources, src)
 				}
 			}
@@ -105,7 +105,7 @@ Examples:
 					return fmt.Errorf("account %q exists but its source type cannot be synced (only gmail and imap are supported)", args[0])
 				}
 				// Not in DB yet - assume Gmail (legacy behaviour)
-				sources = []*store.Source{{SourceType: "gmail", Identifier: args[0]}}
+				sources = []*store.Source{{SourceType: sourceTypeGmail, Identifier: args[0]}}
 			}
 		} else {
 			// Sync all configured sources
@@ -118,7 +118,7 @@ Examples:
 			}
 			for _, src := range allSources {
 				switch src.SourceType {
-				case "gmail":
+				case sourceTypeGmail:
 					if !cfg.OAuth.HasAnyConfig() {
 						fmt.Printf("Skipping %s (OAuth not configured)\n", src.Identifier)
 						continue
@@ -136,7 +136,7 @@ Examples:
 							continue
 						}
 					}
-				case "imap":
+				case sourceTypeIMAP:
 					skipMsg, parseErr := imapSkipReason(src)
 					if parseErr != nil {
 						syncErrors = append(syncErrors, fmt.Sprintf("%s: malformed sync_config: %v", src.Identifier, parseErr))
@@ -193,7 +193,7 @@ Examples:
 			}
 
 			// Ensure credentials are available before syncing Gmail sources.
-			if src.SourceType == "gmail" || src.SourceType == "" {
+			if src.SourceType == sourceTypeGmail || src.SourceType == "" {
 				appName := sourceOAuthApp(src)
 				if cfg.OAuth.ServiceAccountKeyFor(appName) == "" {
 					if _, err := getOAuthMgr(appName); err != nil {
@@ -234,7 +234,7 @@ Examples:
 // access.
 func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(string) (*oauth.Manager, error), saScopes []string) (gmail.API, error) {
 	switch src.SourceType {
-	case "gmail", "":
+	case sourceTypeGmail, "":
 		appName := sourceOAuthApp(src)
 		var tokenSource oauth2.TokenSource
 
@@ -270,7 +270,7 @@ func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(str
 			gmail.WithRateLimiter(rateLimiter),
 		), nil
 
-	case "imap":
+	case sourceTypeIMAP:
 		if !src.SyncConfig.Valid || src.SyncConfig.String == "" {
 			return nil, fmt.Errorf("IMAP source %s has no config (run 'add-imap' first)", src.Identifier)
 		}
@@ -341,7 +341,7 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	// Build query from flags (Gmail only; IMAP date filters are
 	// handled via WithDateFilter on the client).
 	query := buildSyncQuery()
-	if query != "" && src.SourceType == "imap" {
+	if query != "" && src.SourceType == sourceTypeIMAP {
 		// --after/--before are handled natively by IMAP SEARCH;
 		// only warn about --query which has no IMAP equivalent.
 		if syncQuery != "" {
@@ -363,7 +363,7 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	// resume is unreliable because additions or deletions shift
 	// the offsets. Already-imported messages are efficiently
 	// skipped via MessageExistsWithRawBatch.
-	if src.SourceType == "imap" {
+	if src.SourceType == sourceTypeIMAP {
 		opts.NoResume = true
 	}
 
@@ -382,7 +382,7 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 		displayID = src.DisplayName.String
 	}
 	fmt.Printf("Starting full sync for %s\n", displayID)
-	if query != "" && src.SourceType != "imap" {
+	if query != "" && src.SourceType != sourceTypeIMAP {
 		fmt.Printf("Query: %s\n", query)
 	}
 	fmt.Println()

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -213,7 +213,7 @@ func cacheNeedsBuild(dbPath, analyticsDir string) cacheStaleness {
 	if store.IsPostgresURL(dbPath) {
 		return cacheStaleness{}
 	}
-	messagesDir := filepath.Join(analyticsDir, "messages")
+	messagesDir := filepath.Join(analyticsDir, tableMessages)
 	stateFile := filepath.Join(analyticsDir, "_last_sync.json")
 
 	hasParquetData := query.HasParquetData(analyticsDir)

--- a/internal/emlx/discover_test.go
+++ b/internal/emlx/discover_test.go
@@ -9,6 +9,9 @@ import (
 	requirepkg "github.com/stretchr/testify/require"
 )
 
+// testMailboxGUID is the synthetic mailbox GUID used by the V10 fixtures.
+const testMailboxGUID = "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
+
 // mkMailbox creates a mock legacy Apple Mail mailbox structure
 // with a direct Messages/ subdirectory.
 func mkMailbox(t *testing.T, base string, emlxFiles ...string) {
@@ -25,10 +28,10 @@ func mkMailbox(t *testing.T, base string, emlxFiles ...string) {
 // mkV10Mailbox creates a modern V10-style mailbox structure
 // with <GUID>/Data/Messages/ layout.
 func mkV10Mailbox(
-	t *testing.T, base, guid string, emlxFiles ...string,
+	t *testing.T, base string, emlxFiles ...string,
 ) {
 	t.Helper()
-	msgDir := filepath.Join(base, guid, "Data", "Messages")
+	msgDir := filepath.Join(base, testMailboxGUID, "Data", "Messages")
 	requirepkg.NoError(t, os.MkdirAll(msgDir, 0700), "mkdir %q", msgDir)
 	for _, name := range emlxFiles {
 		data := "10\nFrom: x\r\n\r\n"
@@ -218,20 +221,19 @@ func TestDiscoverMailboxes_V10Layout(t *testing.T) {
 	root := t.TempDir()
 	v10 := filepath.Join(root, "V10")
 	acctGUID := "13C9A646-EE0A-4698-B5A2-E07FFBDDEED3"
-	mboxGUID := "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
 	acctDir := filepath.Join(v10, acctGUID)
 
 	mkV10Mailbox(t,
 		filepath.Join(acctDir, "INBOX.mbox"),
-		mboxGUID, "1.emlx", "2.emlx", "3.emlx",
+		"1.emlx", "2.emlx", "3.emlx",
 	)
 	mkV10Mailbox(t,
 		filepath.Join(acctDir, "Sent Messages.mbox"),
-		mboxGUID, "10.emlx",
+		"10.emlx",
 	)
 	mkV10Mailbox(t,
 		filepath.Join(acctDir, "Junk.mbox"),
-		mboxGUID, "27.emlx", "28.emlx",
+		"27.emlx", "28.emlx",
 	)
 
 	mailboxes, err := DiscoverMailboxes(v10)
@@ -272,7 +274,7 @@ func TestDiscoverMailboxes_V10SingleMailbox(t *testing.T) {
 	root := t.TempDir()
 	guid := "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
 	mboxDir := filepath.Join(root, "INBOX.mbox")
-	mkV10Mailbox(t, mboxDir, guid, "1.emlx", "2.emlx")
+	mkV10Mailbox(t, mboxDir, "1.emlx", "2.emlx")
 
 	// Point directly at the .mbox directory.
 	mailboxes, err := DiscoverMailboxes(mboxDir)
@@ -291,9 +293,8 @@ func TestDiscoverMailboxes_V10SingleMailbox(t *testing.T) {
 func TestDiscoverMailboxes_V10PartialSkipped(t *testing.T) {
 	require := requirepkg.New(t)
 	root := t.TempDir()
-	guid := "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
 	mboxDir := filepath.Join(root, "Test.mbox")
-	mkV10Mailbox(t, mboxDir, guid,
+	mkV10Mailbox(t, mboxDir,
 		"1.emlx", "2.partial.emlx",
 	)
 
@@ -312,7 +313,7 @@ func TestDiscoverMailboxes_MixedLegacyAndV10(t *testing.T) {
 
 	// Create empty legacy Messages/ alongside populated V10 path.
 	require.NoError(os.MkdirAll(filepath.Join(mboxDir, "Messages"), 0700), "mkdir")
-	mkV10Mailbox(t, mboxDir, guid, "1.emlx", "2.emlx")
+	mkV10Mailbox(t, mboxDir, "1.emlx", "2.emlx")
 
 	mailboxes, err := DiscoverMailboxes(mboxDir)
 	require.NoError(err, "DiscoverMailboxes")

--- a/internal/fbmessenger/convergence_test.go
+++ b/internal/fbmessenger/convergence_test.go
@@ -22,9 +22,9 @@ func TestJSONHTMLConvergence_Simple(t *testing.T) {
 	assert := assertpkg.New(t)
 	jsonRoot := "testdata/json_simple"
 	htmlRoot := "testdata/html_simple"
-	jsonTh, err := ParseJSONThread(jsonRoot, threadDir(t, jsonRoot, "inbox", "alice_ABC123"))
+	jsonTh, err := ParseJSONThread(jsonRoot, threadDir(t, jsonRoot, "alice_ABC123"))
 	require.NoError(err, "json")
-	htmlTh, err := ParseHTMLThread(htmlRoot, threadDir(t, htmlRoot, "inbox", "alice_ABC123"))
+	htmlTh, err := ParseHTMLThread(htmlRoot, threadDir(t, htmlRoot, "alice_ABC123"))
 	require.NoError(err, "html")
 	require.Equal(len(htmlTh.Messages), len(jsonTh.Messages), "message count")
 	// Participants equal by slug.

--- a/internal/fbmessenger/discover.go
+++ b/internal/fbmessenger/discover.go
@@ -23,7 +23,7 @@ type ThreadDir struct {
 	// Name is the thread directory basename (e.g. "testuser_ABC123XYZ").
 	// For E2EE exports, this is the filename without extension.
 	Name string
-	// Format is "json", "html", "both", or "e2ee_json".
+	// Format is formatJSON, "html", "both", or "e2ee_json".
 	Format string
 }
 
@@ -294,7 +294,7 @@ func detectFormat(threadPath string) (string, bool) {
 	case hasJSON && hasHTML:
 		return "both", true
 	case hasJSON:
-		return "json", true
+		return formatJSON, true
 	case hasHTML:
 		return "html", true
 	}

--- a/internal/fbmessenger/html_parser_test.go
+++ b/internal/fbmessenger/html_parser_test.go
@@ -15,7 +15,7 @@ func TestParseHTMLThread_Simple(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	root := "testdata/html_simple"
-	th, err := ParseHTMLThread(root, threadDir(t, root, "inbox", "alice_ABC123"))
+	th, err := ParseHTMLThread(root, threadDir(t, root, "alice_ABC123"))
 	require.NoError(err, "parse")
 	assert.Len(th.Participants, 2)
 	assert.Equal("direct_chat", th.ConvType)
@@ -37,7 +37,7 @@ func TestParseHTMLThread_Simple(t *testing.T) {
 func TestParseHTMLThread_WithMedia(t *testing.T) {
 	require := requirepkg.New(t)
 	root := "testdata/html_with_media"
-	th, err := ParseHTMLThread(root, threadDir(t, root, "inbox", "bob_XYZ789"))
+	th, err := ParseHTMLThread(root, threadDir(t, root, "bob_XYZ789"))
 	require.NoError(err, "parse")
 	require.Len(th.Messages, 1, "messages: %+v", th.Messages)
 	m := th.Messages[0]
@@ -74,7 +74,7 @@ func TestParseHTMLThread_ImagePositioning(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	root := "testdata/html_multi_media"
-	th, err := ParseHTMLThread(root, threadDir(t, root, "inbox", "carol_IMG456"))
+	th, err := ParseHTMLThread(root, threadDir(t, root, "carol_IMG456"))
 	require.NoError(err, "parse")
 	require.Len(th.Messages, 3)
 	// Message 0: "Hello Carol" — no image, no attachments.

--- a/internal/fbmessenger/importer.go
+++ b/internal/fbmessenger/importer.go
@@ -46,7 +46,7 @@ type ImportOptions struct {
 	Me string
 	// RootDir is the DYI export root directory.
 	RootDir string
-	// Format overrides auto-detection. One of "auto", "json", "html",
+	// Format overrides auto-detection. One of "auto", formatJSON, "html",
 	// "both". Empty is treated as "auto".
 	Format string
 	// AttachmentsDir is the content-addressed attachment storage root.
@@ -105,7 +105,7 @@ func ImportDYI(ctx context.Context, st *store.Store, opts ImportOptions) (*Impor
 		format = "auto"
 	}
 	switch format {
-	case "auto", "json", "html", "both":
+	case "auto", formatJSON, "html", "both":
 		// valid
 	default:
 		return nil, fmt.Errorf("fbmessenger: unknown --format %q (valid: auto, json, html, both)", format)
@@ -263,13 +263,13 @@ func ImportDYI(ctx context.Context, st *store.Store, opts ImportOptions) (*Impor
 		// E2EE threads bypass the format filter entirely.
 		if effective != "e2ee_json" {
 			switch format {
-			case "json":
+			case formatJSON:
 				if effective == "html" {
 					continue
 				}
-				effective = "json"
+				effective = formatJSON
 			case "html":
-				if effective == "json" {
+				if effective == formatJSON {
 					continue
 				}
 				effective = "html"
@@ -277,7 +277,7 @@ func ImportDYI(ctx context.Context, st *store.Store, opts ImportOptions) (*Impor
 				// Keep as-is; "both" threads get both parsed.
 			case "auto":
 				if effective == "both" {
-					effective = "json"
+					effective = formatJSON
 				}
 			}
 		}
@@ -430,7 +430,7 @@ func importThread(
 		if err := runHTML("html_"); err != nil {
 			return err
 		}
-	case effective == "json":
+	case effective == formatJSON:
 		if err := runJSON(""); err != nil {
 			return err
 		}

--- a/internal/fbmessenger/importer_test.go
+++ b/internal/fbmessenger/importer_test.go
@@ -17,7 +17,7 @@ import (
 	"go.kenn.io/msgvault/internal/testutil"
 )
 
-func importFixture(t *testing.T, st *store.Store, rootDir string, extra ...func(*ImportOptions)) *ImportSummary {
+func importFixture(t *testing.T, st *store.Store, rootDir string) *ImportSummary {
 	t.Helper()
 	opts := ImportOptions{
 		Me:             "test.user@facebook.messenger",
@@ -25,22 +25,19 @@ func importFixture(t *testing.T, st *store.Store, rootDir string, extra ...func(
 		Format:         "auto",
 		AttachmentsDir: t.TempDir(),
 	}
-	for _, f := range extra {
-		f(&opts)
-	}
 	summary, err := ImportDYI(context.Background(), st, opts)
 	requirepkg.NoError(t, err, "ImportDYI(%s)", rootDir)
 	return summary
 }
 
-func countMessages(t *testing.T, st *store.Store, where string, args ...any) int {
+func countMessages(t *testing.T, st *store.Store, where string) int {
 	t.Helper()
 	var n int
 	q := "SELECT COUNT(*) FROM messages"
 	if where != "" {
 		q += " WHERE " + where
 	}
-	err := st.DB().QueryRow(q, args...).Scan(&n)
+	err := st.DB().QueryRow(q).Scan(&n)
 	requirepkg.NoError(t, err, "count query")
 	return n
 }

--- a/internal/fbmessenger/json_parser.go
+++ b/internal/fbmessenger/json_parser.go
@@ -112,7 +112,7 @@ func ParseJSONThread(rootDir, threadDir string) (*Thread, error) {
 	// object with `participants` and `messages`. We take participants
 	// from the lowest-numbered file, and concatenate all messages.
 	var thread Thread
-	thread.Format = "json"
+	thread.Format = formatJSON
 	thread.DirName = filepath.Base(threadDir)
 	thread.BadSiblings = badSiblings
 	var rawConcat []rawJSONMessage

--- a/internal/fbmessenger/json_parser_test.go
+++ b/internal/fbmessenger/json_parser_test.go
@@ -9,18 +9,18 @@ import (
 	requirepkg "github.com/stretchr/testify/require"
 )
 
-func threadDir(t *testing.T, root, section, name string) string {
+func threadDir(t *testing.T, root, name string) string {
 	t.Helper()
 	abs, err := filepath.Abs(root)
 	requirepkg.NoError(t, err)
-	return filepath.Join(abs, "your_activity_across_facebook", "messages", section, name)
+	return filepath.Join(abs, "your_activity_across_facebook", "messages", "inbox", name)
 }
 
 func TestParseJSONThread_Simple(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	root := "testdata/json_simple"
-	th, err := ParseJSONThread(root, threadDir(t, root, "inbox", "alice_ABC123"))
+	th, err := ParseJSONThread(root, threadDir(t, root, "alice_ABC123"))
 	require.NoError(err, "parse")
 	assert.Equal("direct_chat", th.ConvType)
 	assert.Len(th.Participants, 2)
@@ -43,7 +43,7 @@ func TestParseJSONThread_Simple(t *testing.T) {
 
 func TestParseJSONThread_Group(t *testing.T) {
 	root := "testdata/json_group"
-	th, err := ParseJSONThread(root, threadDir(t, root, "inbox", "crew_GRP123"))
+	th, err := ParseJSONThread(root, threadDir(t, root, "crew_GRP123"))
 	requirepkg.NoError(t, err, "parse")
 	assertpkg.Equal(t, "group_chat", th.ConvType)
 	assertpkg.Len(t, th.Participants, 3)
@@ -51,7 +51,7 @@ func TestParseJSONThread_Group(t *testing.T) {
 
 func TestParseJSONThread_Multifile_NumericSort(t *testing.T) {
 	root := "testdata/json_multifile"
-	th, err := ParseJSONThread(root, threadDir(t, root, "inbox", "dave_MULTI"))
+	th, err := ParseJSONThread(root, threadDir(t, root, "dave_MULTI"))
 	requirepkg.NoError(t, err, "parse")
 	requirepkg.Len(t, th.Messages, 4)
 	// Bodies, in chronological order, must be A,B,C,D.
@@ -68,7 +68,7 @@ func TestParseJSONThread_Multifile_NumericSort(t *testing.T) {
 
 func TestParseJSONThread_Corrupt(t *testing.T) {
 	root := "testdata/corrupt"
-	_, err := ParseJSONThread(root, threadDir(t, root, "inbox", "broken_BAD"))
+	_, err := ParseJSONThread(root, threadDir(t, root, "broken_BAD"))
 	requirepkg.Error(t, err)
 	assertpkg.ErrorIs(t, err, ErrCorruptJSON)
 }
@@ -77,7 +77,7 @@ func TestParseJSONThread_Attachments(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	root := "testdata/json_with_media"
-	th, err := ParseJSONThread(root, threadDir(t, root, "inbox", "bob_XYZ789"))
+	th, err := ParseJSONThread(root, threadDir(t, root, "bob_XYZ789"))
 	require.NoError(err, "parse")
 	require.Len(th.Messages, 1)
 	m := th.Messages[0]
@@ -107,7 +107,7 @@ func TestParseJSONThread_Attachments_AltLayout(t *testing.T) {
 
 func TestParseJSONThread_NonTextBodies(t *testing.T) {
 	root := "testdata/json_nontext"
-	th, err := ParseJSONThread(root, threadDir(t, root, "inbox", "sam_NONTXT"))
+	th, err := ParseJSONThread(root, threadDir(t, root, "sam_NONTXT"))
 	requirepkg.NoError(t, err, "parse")
 	// Ordered chronologically ascending: unsubscribe, share, missed call, call, photo, sticker.
 	wantBodies := []string{

--- a/internal/fbmessenger/types.go
+++ b/internal/fbmessenger/types.go
@@ -5,6 +5,9 @@ import (
 	"time"
 )
 
+// formatJSON is the Thread.Format value for JSON-sourced threads.
+const formatJSON = "json"
+
 // ErrCorruptJSON is returned by the JSON parser when a message_*.json file
 // cannot be parsed as valid JSON. Callers should log and skip the thread.
 var ErrCorruptJSON = errors.New("fbmessenger: corrupt json")

--- a/internal/gmail/ratelimit_test.go
+++ b/internal/gmail/ratelimit_test.go
@@ -130,11 +130,12 @@ func (f *rlFixture) drain() {
 	f.rl.tokens = 0
 }
 
-// state returns a snapshot of the limiter's internal fields under the mutex.
-func (f *rlFixture) state() (tokens, refillRate float64, throttledUntil time.Time) {
+// state returns a snapshot of the limiter's refill rate and throttle deadline
+// under the mutex.
+func (f *rlFixture) state() (refillRate float64, throttledUntil time.Time) {
 	f.rl.mu.Lock()
 	defer f.rl.mu.Unlock()
-	return f.rl.tokens, f.rl.refillRate, f.rl.throttledUntil
+	return f.rl.refillRate, f.rl.throttledUntil
 }
 
 // assertAvailable checks the current available tokens.
@@ -362,12 +363,12 @@ func TestRateLimiter_Throttle(t *testing.T) {
 
 		f.rl.Throttle(10 * time.Millisecond)
 
-		_, rate, _ := f.state()
+		rate, _ := f.state()
 		assert.Equal(t, DefaultRefillRate*0.5, rate, "refillRate after Throttle")
 
 		f.rl.RecoverRate()
 
-		_, rate, _ = f.state()
+		rate, _ = f.state()
 		assert.Equal(t, DefaultRefillRate, rate, "refillRate after RecoverRate")
 	})
 
@@ -375,10 +376,10 @@ func TestRateLimiter_Throttle(t *testing.T) {
 		f := newRLFixture()
 
 		f.rl.Throttle(200 * time.Millisecond)
-		_, _, first := f.state()
+		_, first := f.state()
 
 		f.rl.Throttle(50 * time.Millisecond)
-		_, _, second := f.state()
+		_, second := f.state()
 
 		assert.False(t, second.Before(first), "Throttle shortened existing backoff: first=%v, second=%v", first, second)
 	})
@@ -387,11 +388,11 @@ func TestRateLimiter_Throttle(t *testing.T) {
 		f := newRLFixture()
 
 		f.rl.Throttle(50 * time.Millisecond)
-		_, _, first := f.state()
+		_, first := f.state()
 
 		f.clk.Advance(30 * time.Millisecond)
 		f.rl.Throttle(50 * time.Millisecond)
-		_, _, second := f.state()
+		_, second := f.state()
 
 		assert.True(t, second.After(first), "Throttle did not extend backoff: first=%v, second=%v", first, second)
 	})
@@ -401,13 +402,13 @@ func TestRateLimiter_Throttle(t *testing.T) {
 
 		f.rl.Throttle(50 * time.Millisecond)
 
-		_, rate, _ := f.state()
+		rate, _ := f.state()
 		assert.Equal(t, DefaultRefillRate*0.5, rate, "refillRate after Throttle")
 
 		f.clk.Advance(100 * time.Millisecond)
 		f.rl.Available() // triggers refill and auto-recovery
 
-		_, rate, _ = f.state()
+		rate, _ = f.state()
 		assert.Equal(t, DefaultRefillRate, rate, "refillRate after throttle expiry")
 	})
 }

--- a/internal/gvoice/client.go
+++ b/internal/gvoice/client.go
@@ -163,7 +163,7 @@ func (c *Client) Import(
 		switch entry.FileType {
 		case fileTypeText, fileTypeGroup:
 			n, err := c.importTextEntry(
-				ctx, s, sourceID, &entry, ownerID,
+				s, sourceID, &entry, ownerID,
 				labelIDs, phoneCache, convCache, summary,
 			)
 			if err != nil {
@@ -179,7 +179,7 @@ func (c *Client) Import(
 
 		default:
 			if err := c.importCallEntry(
-				ctx, s, sourceID, &entry, ownerID,
+				s, sourceID, &entry, ownerID,
 				labelIDs, phoneCache, convCache, summary,
 			); err != nil {
 				c.logger.Warn(
@@ -219,7 +219,6 @@ func (c *Client) ensureLabels(
 }
 
 func (c *Client) importTextEntry(
-	ctx context.Context,
 	s *store.Store,
 	sourceID int64,
 	entry *indexEntry,
@@ -327,7 +326,7 @@ func (c *Client) importTextEntry(
 		SourceID:        sourceID,
 		SourceMessageID: entry.ID,
 		ConversationID:  convID,
-		Snippet:         nullStr(snippet(msg.Body, 100)),
+		Snippet:         nullStr(snippet(msg.Body)),
 		SentAt:          sentAt,
 		MessageType:     msgType,
 		SenderID:        senderIDNull,
@@ -382,7 +381,6 @@ func (c *Client) importTextEntry(
 }
 
 func (c *Client) importCallEntry(
-	ctx context.Context,
 	s *store.Store,
 	sourceID int64,
 	entry *indexEntry,
@@ -483,7 +481,7 @@ func (c *Client) importCallEntry(
 		SourceID:        sourceID,
 		SourceMessageID: entry.ID,
 		ConversationID:  convID,
-		Snippet:         nullStr(snippet(bodyStr, 100)),
+		Snippet:         nullStr(snippet(bodyStr)),
 		SentAt:          sentAt,
 		MessageType:     msgType,
 		SenderID:        senderIDNull,
@@ -744,7 +742,7 @@ func (c *Client) buildIndex() error {
 			continue
 		}
 
-		name, ft, err := classifyFile(entry.Name())
+		_, ft, err := classifyFile(entry.Name())
 		if err != nil {
 			skipped++
 			continue
@@ -754,7 +752,7 @@ func (c *Client) buildIndex() error {
 
 		switch ft {
 		case fileTypeText, fileTypeGroup:
-			ents, err := c.indexTextFile(filePath, name, ft)
+			ents, err := c.indexTextFile(filePath, ft)
 			if err != nil {
 				c.logger.Warn(
 					"failed to index text file",
@@ -766,7 +764,7 @@ func (c *Client) buildIndex() error {
 			index = append(index, ents...)
 
 		default:
-			ent, err := c.indexCallFile(filePath, name, ft)
+			ent, err := c.indexCallFile(filePath, ft)
 			if err != nil {
 				c.logger.Warn(
 					"failed to index call file",
@@ -809,7 +807,7 @@ func (c *Client) buildIndex() error {
 }
 
 func (c *Client) indexTextFile(
-	filePath, contactName string, ft fileType,
+	filePath string, ft fileType,
 ) ([]indexEntry, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -837,7 +835,7 @@ func (c *Client) indexTextFile(
 		var threadID string
 		if ft == fileTypeGroup {
 			threadID = computeThreadID(
-				c.owner.Cell, fileTypeGroup,
+				fileTypeGroup,
 				"", groupParticipants,
 			)
 		} else {
@@ -851,7 +849,7 @@ func (c *Client) indexTextFile(
 				}
 			}
 			threadID = computeThreadID(
-				c.owner.Cell, fileTypeText,
+				fileTypeText,
 				otherPhone, nil,
 			)
 		}
@@ -872,7 +870,7 @@ func (c *Client) indexTextFile(
 }
 
 func (c *Client) indexCallFile(
-	filePath, contactName string, ft fileType,
+	filePath string, ft fileType,
 ) (*indexEntry, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -894,7 +892,7 @@ func (c *Client) indexCallFile(
 		record.Timestamp.Format(time.RFC3339Nano),
 	)
 	threadID := computeThreadID(
-		c.owner.Cell, ft, record.Phone, nil,
+		ft, record.Phone, nil,
 	)
 	label := labelForFileType(ft)
 

--- a/internal/gvoice/parser.go
+++ b/internal/gvoice/parser.go
@@ -376,12 +376,16 @@ func parseCallHTML(r io.Reader) (*callRecord, error) {
 	return record, nil
 }
 
-// snippet returns the first n characters of s, suitable for message preview.
-func snippet(s string, maxLen int) string {
+// snippetMaxLen bounds the message-preview length produced by snippet.
+const snippetMaxLen = 100
+
+// snippet returns the first snippetMaxLen characters of s, suitable for
+// message preview.
+func snippet(s string) string {
 	s = strings.Join(strings.Fields(s), " ")
 	runes := []rune(s)
-	if len(runes) > maxLen {
-		return string(runes[:maxLen])
+	if len(runes) > snippetMaxLen {
+		return string(runes[:snippetMaxLen])
 	}
 	return s
 }
@@ -396,7 +400,7 @@ func computeMessageID(parts ...string) string {
 // For 1:1 texts, uses the other party's normalized phone.
 // For group texts, uses "group:" + sorted(all participant phones).
 // For calls, uses "calls:" + normalizedPhone.
-func computeThreadID(ownerCell string, ft fileType, contactPhone string, groupParticipants []string) string {
+func computeThreadID(ft fileType, contactPhone string, groupParticipants []string) string {
 	switch ft {
 	case fileTypeGroup:
 		phones := make([]string, len(groupParticipants))

--- a/internal/gvoice/parser_test.go
+++ b/internal/gvoice/parser_test.go
@@ -300,27 +300,27 @@ func TestFormatDuration(t *testing.T) {
 
 func TestComputeThreadID(t *testing.T) {
 	// 1:1 text uses other party's phone
-	tid := computeThreadID("+15553334444", fileTypeText, "+12023065386", nil)
+	tid := computeThreadID(fileTypeText, "+12023065386", nil)
 	assertpkg.Equal(t, "+12023065386", tid, "1:1 threadID")
 
 	// Group uses sorted participants
-	tid = computeThreadID("+15553334444", fileTypeGroup, "", []string{"+12023065386", "+12022712272"})
+	tid = computeThreadID(fileTypeGroup, "", []string{"+12023065386", "+12022712272"})
 	assertpkg.Equal(t, "group:+12022712272,+12023065386", tid, "group threadID")
 
 	// Call uses calls: prefix
-	tid = computeThreadID("+15553334444", fileTypeReceived, "+12023065386", nil)
+	tid = computeThreadID(fileTypeReceived, "+12023065386", nil)
 	assertpkg.Equal(t, "calls:+12023065386", tid, "call threadID")
 }
 
 func TestSnippet(t *testing.T) {
 	long := strings.Repeat("a", 200)
-	s := snippet(long, 100)
+	s := snippet(long)
 	assertpkg.Len(t, s, 100)
 
-	s = snippet("short", 100)
+	s = snippet("short")
 	assertpkg.Equal(t, "short", s)
 
 	// Whitespace normalization
-	s = snippet("  hello   world  ", 100)
+	s = snippet("  hello   world  ")
 	assertpkg.Equal(t, "hello world", s)
 }

--- a/internal/imap/labels.go
+++ b/internal/imap/labels.go
@@ -37,6 +37,9 @@ var systemNames = map[string]bool{
 	"[gmail]/all mail": true,
 }
 
+// labelTypeSystem is the label_type value for standard IMAP folders.
+const labelTypeSystem = "system"
+
 // classifyLabelType returns "system" for standard IMAP folders
 // (detected via RFC 6154 attributes or well-known folder names)
 // and "user" for everything else.
@@ -46,11 +49,11 @@ func classifyLabelType(
 ) string {
 	for _, a := range attrs {
 		if systemAttrs[a] {
-			return "system"
+			return labelTypeSystem
 		}
 	}
 	if systemNames[strings.ToLower(mailbox)] {
-		return "system"
+		return labelTypeSystem
 	}
 	return "user"
 }

--- a/internal/importer/emlx_import.go
+++ b/internal/importer/emlx_import.go
@@ -258,9 +258,12 @@ func ImportEmlxDir(
 		log.Warn("failed to save initial checkpoint", "error", err)
 	}
 
-	flushPending := func() (bool, error) {
+	// flushPending writes the buffered batch and returns true when the
+	// context was cancelled mid-flush so the caller can stop. Per-batch
+	// errors are recorded on the summary and logged, never propagated.
+	flushPending := func() bool {
 		if len(pending) == 0 {
-			return false, nil
+			return false
 		}
 
 		ids := make([]string, len(pending))
@@ -293,7 +296,7 @@ func ImportEmlxDir(
 				); err != nil {
 					log.Warn("checkpoint save failed", "error", err)
 				}
-				return true, nil
+				return true
 			}
 
 			cp.MessagesProcessed++
@@ -399,7 +402,7 @@ func ImportEmlxDir(
 		pending = pending[:0]
 		pendingBytes = 0
 		clear(pendingIdx)
-		return false, nil
+		return false
 	}
 
 	for mboxIdx := startMbox; mboxIdx < len(mailboxes); mboxIdx++ {
@@ -504,20 +507,14 @@ func ImportEmlxDir(
 			}
 
 			if len(pending) >= batchSize || pendingBytes >= batchBytes {
-				stop, err := flushPending()
-				if err != nil {
-					return summary, err
-				}
-				if stop {
+				if flushPending() {
 					return summary, nil
 				}
 			}
 		}
 
 		// Flush remaining for this mailbox.
-		if stop, err := flushPending(); err != nil {
-			return summary, err
-		} else if stop {
+		if flushPending() {
 			return summary, nil
 		}
 

--- a/internal/importer/mbox_import.go
+++ b/internal/importer/mbox_import.go
@@ -77,6 +77,9 @@ type mboxCheckpoint struct {
 
 const defaultMaxMboxMessageBytes int64 = 128 << 20 // 128 MiB
 
+// sourceTypeMbox is the default sources.source_type for MBOX imports.
+const sourceTypeMbox = "mbox"
+
 // ImportMbox imports a single MBOX file into the msgvault database.
 //
 // This is intended for services like HEY.com that provide an export in MBOX
@@ -84,7 +87,7 @@ const defaultMaxMboxMessageBytes int64 = 128 << 20 // 128 MiB
 // parsed bodies, participants, recipients, and (optionally) attachments.
 func ImportMbox(ctx context.Context, st *store.Store, mboxPath string, opts MboxImportOptions) (*MboxImportSummary, error) {
 	if opts.SourceType == "" {
-		opts.SourceType = "mbox"
+		opts.SourceType = sourceTypeMbox
 	}
 	if opts.Identifier == "" {
 		return nil, errors.New("identifier is required")

--- a/internal/importer/mbox_import.go
+++ b/internal/importer/mbox_import.go
@@ -278,9 +278,12 @@ func ImportMbox(ctx context.Context, st *store.Store, mboxPath string, opts Mbox
 
 	msgSeq := seq
 
-	flushPending := func() (bool, error) {
+	// flushPending writes the buffered batch and returns true when the
+	// context was cancelled mid-flush so the caller can stop. Per-batch
+	// errors are recorded on the summary and logged, never propagated.
+	flushPending := func() bool {
 		if len(pending) == 0 {
-			return false, nil
+			return false
 		}
 
 		ids := make([]string, len(pending))
@@ -313,7 +316,7 @@ func ImportMbox(ctx context.Context, st *store.Store, mboxPath string, opts Mbox
 					summary.Errors++
 					log.Warn("failed to save checkpoint", "error", err)
 				}
-				return true, nil
+				return true
 			}
 
 			cp.MessagesProcessed++
@@ -416,7 +419,7 @@ func ImportMbox(ctx context.Context, st *store.Store, mboxPath string, opts Mbox
 		clear(pending)
 		pending = pending[:0]
 		pendingBytes = 0
-		return false, nil
+		return false
 	}
 
 	for {
@@ -467,19 +470,13 @@ func ImportMbox(ctx context.Context, st *store.Store, mboxPath string, opts Mbox
 		pendingBytes += int64(len(msg.Raw))
 
 		if len(pending) >= existsCheckBatchSize || pendingBytes >= existsCheckBatchBytes {
-			stop, err := flushPending()
-			if err != nil {
-				return summary, err
-			}
-			if stop {
+			if flushPending() {
 				return summary, nil
 			}
 		}
 	}
 
-	if stop, err := flushPending(); err != nil {
-		return summary, err
-	} else if stop {
+	if flushPending() {
 		return summary, nil
 	}
 

--- a/internal/microsoft/oauth.go
+++ b/internal/microsoft/oauth.go
@@ -40,6 +40,13 @@ const (
 
 	redirectPort = "8089"
 	callbackPath = "/callback/microsoft"
+
+	// scopeOfflineAccess is the OAuth scope requesting a refresh token.
+	scopeOfflineAccess = "offline_access"
+	// scopeEmail is the OpenID "email" scope requested alongside the IMAP scope.
+	scopeEmail = "email"
+	// logKeyEmail is the structured-log field key carrying the account email.
+	logKeyEmail = "email"
 )
 
 // scopesForEmail returns the OAuth scopes appropriate for the given email.
@@ -49,7 +56,7 @@ func scopesForEmail(email string) []string {
 	if isPersonalMicrosoftAccount(email) {
 		imapScope = ScopeIMAPPersonal
 	}
-	return []string{imapScope, "offline_access", "openid", "email"}
+	return []string{imapScope, scopeOfflineAccess, "openid", scopeEmail}
 }
 
 // isPersonalMicrosoftAccount returns true for common consumer Microsoft domains.
@@ -160,12 +167,12 @@ func (m *Manager) Authorize(ctx context.Context, email string) error {
 		correctIMAPScope := imapScopeForTenant(claims.TenantID)
 		if scopes[0] != correctIMAPScope {
 			m.logger.Info("correcting IMAP scope based on tenant ID, re-authorizing",
-				"email", email,
+				logKeyEmail, email,
 				"tid", claims.TenantID,
 				"from", scopes[0],
 				"to", correctIMAPScope,
 			)
-			scopes = []string{correctIMAPScope, "offline_access", "openid", "email"}
+			scopes = []string{correctIMAPScope, scopeOfflineAccess, "openid", scopeEmail}
 			token, nonce, err = flow(ctx, email, scopes)
 			if err != nil {
 				return fmt.Errorf("re-authorize with correct IMAP scope: %w", err)
@@ -224,7 +231,7 @@ func (m *Manager) TokenSource(ctx context.Context, email string) (func(context.C
 	if tf.TenantID == "" && m.tenantID != "" && m.tenantID != DefaultTenant {
 		tf.TenantID = m.tenantID
 		m.logger.Info("migrating pre-scope-correction token: binding tenant ID",
-			"email", email, "tenant", m.tenantID)
+			logKeyEmail, email, "tenant", m.tenantID)
 	}
 
 	// Validate persisted scopes against tenant ID to detect stale tokens
@@ -234,7 +241,7 @@ func (m *Manager) TokenSource(ctx context.Context, email string) (func(context.C
 		correctScope := imapScopeForTenant(tf.TenantID)
 		if tf.Scopes[0] != correctScope {
 			m.logger.Debug("stale IMAP scope detected",
-				"email", email,
+				logKeyEmail, email,
 				"current_scope", tf.Scopes[0],
 				"expected_scope", correctScope,
 				"tenant_id", tf.TenantID,
@@ -662,9 +669,9 @@ func (m *Manager) DeleteToken(email string) error {
 	if loadErr == nil && tf.RefreshToken != "" {
 		if revokeErr := m.revokeToken(tf.RefreshToken, tf.TenantID); revokeErr != nil {
 			m.logger.Warn("failed to revoke Microsoft token (will expire naturally)",
-				"email", email, "error", revokeErr)
+				logKeyEmail, email, "error", revokeErr)
 		} else {
-			m.logger.Info("revoked Microsoft refresh token", "email", email)
+			m.logger.Info("revoked Microsoft refresh token", logKeyEmail, email)
 		}
 	}
 

--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -66,7 +66,7 @@ func Parse(raw []byte) (*Message, error) {
 
 	// Parse date
 	if dateStr := env.GetHeader("Date"); dateStr != "" {
-		if t, err := parseDate(dateStr); err == nil {
+		if t := parseDate(dateStr); !t.IsZero() {
 			msg.Date = t
 		}
 	}
@@ -250,7 +250,9 @@ func toUTC(t time.Time, numericOffset bool) time.Time {
 // Returns the time in UTC for consistent storage.
 // Named timezones (like "MST") are treated as UTC since their offsets
 // can't be reliably determined across platforms.
-func parseDate(s string) (time.Time, error) {
+// parseDate returns the zero time when no known format matches; callers
+// detect failure via the zero value rather than an error.
+func parseDate(s string) time.Time {
 	// Normalize whitespace efficiently: split on whitespace runs and rejoin
 	s = strings.Join(strings.Fields(s), " ")
 
@@ -270,7 +272,7 @@ func parseDate(s string) (time.Time, error) {
 	// like -0700 are absolute and unaffected by the reference location.
 	for _, format := range dateFormats {
 		if t, err := time.ParseInLocation(format, baseStr, time.UTC); err == nil {
-			return toUTC(t, numericOffset), nil
+			return toUTC(t, numericOffset)
 		}
 	}
 
@@ -280,12 +282,12 @@ func parseDate(s string) (time.Time, error) {
 			if t, err := time.ParseInLocation(format, s, time.UTC); err == nil {
 				// Recompute numericOffset for the original string since it may
 				// have a different offset than baseStr (e.g., "+0700 (UTC)")
-				return toUTC(t, hasNumericOffset(s)), nil
+				return toUTC(t, hasNumericOffset(s))
 			}
 		}
 	}
 
-	return time.Time{}, nil
+	return time.Time{}
 }
 
 // Block tags that should create line breaks when stripped.

--- a/internal/mime/parse_test.go
+++ b/internal/mime/parse_test.go
@@ -219,8 +219,7 @@ func TestParseDate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assertpkg.New(t)
-			got, err := parseDate(tc.input)
-			requirepkg.NoError(t, err, "parseDate(%q)", tc.input)
+			got := parseDate(tc.input)
 			if tc.want.IsZero() {
 				assert.True(got.IsZero(), "parseDate(%q) = %v, want zero time", tc.input, got)
 				return

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -142,19 +142,19 @@ func NewDuckDBEngine(analyticsDir string, sqlitePath string, sqliteDB *sql.DB, o
 	// Probe Parquet schemas for optional columns added in PR #160 (WhatsApp import).
 	// Old cache files may lack these columns; we'll supply defaults in parquetCTEs().
 	engine.optionalCols = map[string]map[string]bool{
-		"participants":  engine.probeParquetColumns(engine.parquetPath("participants"), false),
-		"messages":      engine.probeParquetColumns(engine.parquetGlob(), true),
-		"conversations": engine.probeParquetColumns(engine.parquetPath("conversations"), false),
-		"sources":       engine.probeParquetColumns(engine.parquetPath("sources"), false),
+		datasetParticipants:  engine.probeParquetColumns(engine.parquetPath(datasetParticipants), false),
+		datasetMessages:      engine.probeParquetColumns(engine.parquetGlob(), true),
+		datasetConversations: engine.probeParquetColumns(engine.parquetPath(datasetConversations), false),
+		"sources":            engine.probeParquetColumns(engine.parquetPath("sources"), false),
 	}
 	var missing []string
 	for _, col := range []struct{ table, col string }{
-		{"participants", "phone_number"},
-		{"messages", "attachment_count"},
-		{"messages", "sender_id"},
-		{"messages", "message_type"},
-		{"conversations", "title"},
-		{"conversations", "conversation_type"},
+		{datasetParticipants, "phone_number"},
+		{datasetMessages, "attachment_count"},
+		{datasetMessages, "sender_id"},
+		{datasetMessages, "message_type"},
+		{datasetConversations, "title"},
+		{datasetConversations, "conversation_type"},
 		{"sources", "source_type"},
 	} {
 		if !engine.optionalCols[col.table][col.col] {
@@ -232,7 +232,7 @@ func (e *DuckDBEngine) hasSQLite() bool {
 
 // parquetGlob returns the glob pattern for reading message Parquet files.
 func (e *DuckDBEngine) parquetGlob() string {
-	return filepath.Join(e.analyticsDir, "messages", "**", "*.parquet")
+	return filepath.Join(e.analyticsDir, datasetMessages, "**", "*.parquet")
 }
 
 // parquetPath returns the path pattern for a specific Parquet table.
@@ -284,22 +284,22 @@ func (e *DuckDBEngine) parquetCTEs() string {
 		"COALESCE(TRY_CAST(has_attachments AS BOOLEAN), false) AS has_attachments",
 	}
 	var msgExtra []string
-	if e.hasCol("messages", "attachment_count") {
+	if e.hasCol(datasetMessages, "attachment_count") {
 		msgReplace = append(msgReplace, "COALESCE(TRY_CAST(attachment_count AS INTEGER), 0) AS attachment_count")
 	} else {
 		msgExtra = append(msgExtra, "0 AS attachment_count")
 	}
-	if e.hasCol("messages", "sender_id") {
+	if e.hasCol(datasetMessages, "sender_id") {
 		msgReplace = append(msgReplace, "TRY_CAST(sender_id AS BIGINT) AS sender_id")
 	} else {
 		msgExtra = append(msgExtra, "NULL::BIGINT AS sender_id")
 	}
-	if e.hasCol("messages", "message_type") {
+	if e.hasCol(datasetMessages, "message_type") {
 		msgReplace = append(msgReplace, "COALESCE(CAST(message_type AS VARCHAR), '') AS message_type")
 	} else {
 		msgExtra = append(msgExtra, "'' AS message_type")
 	}
-	if e.hasCol("messages", "deleted_at") {
+	if e.hasCol(datasetMessages, "deleted_at") {
 		msgReplace = append(msgReplace, "TRY_CAST(deleted_at AS TIMESTAMP) AS deleted_at")
 	} else {
 		msgExtra = append(msgExtra, "NULL::TIMESTAMP AS deleted_at")
@@ -318,7 +318,7 @@ func (e *DuckDBEngine) parquetCTEs() string {
 		"CAST(display_name AS VARCHAR) AS display_name",
 	}
 	var pExtra []string
-	if e.hasCol("participants", "phone_number") {
+	if e.hasCol(datasetParticipants, "phone_number") {
 		pReplace = append(pReplace, "COALESCE(CAST(phone_number AS VARCHAR), '') AS phone_number")
 	} else {
 		pExtra = append(pExtra, "'' AS phone_number")
@@ -327,7 +327,7 @@ func (e *DuckDBEngine) parquetCTEs() string {
 	if len(pExtra) > 0 {
 		pCTE += ", " + strings.Join(pExtra, ", ")
 	}
-	pCTE += fmt.Sprintf(" FROM read_parquet('%s')", e.parquetPath("participants"))
+	pCTE += fmt.Sprintf(" FROM read_parquet('%s')", e.parquetPath(datasetParticipants))
 
 	// --- conversations CTE ---
 	convReplace := []string{
@@ -335,12 +335,12 @@ func (e *DuckDBEngine) parquetCTEs() string {
 		"CAST(source_conversation_id AS VARCHAR) AS source_conversation_id",
 	}
 	var convExtra []string
-	if e.hasCol("conversations", "title") {
+	if e.hasCol(datasetConversations, "title") {
 		convReplace = append(convReplace, "COALESCE(CAST(title AS VARCHAR), '') AS title")
 	} else {
 		convExtra = append(convExtra, "'' AS title")
 	}
-	if e.hasCol("conversations", "conversation_type") {
+	if e.hasCol(datasetConversations, "conversation_type") {
 		convReplace = append(convReplace, "COALESCE(CAST(conversation_type AS VARCHAR), 'email') AS conversation_type")
 	} else {
 		convExtra = append(convExtra, "'email' AS conversation_type")
@@ -349,7 +349,7 @@ func (e *DuckDBEngine) parquetCTEs() string {
 	if len(convExtra) > 0 {
 		convCTE += ", " + strings.Join(convExtra, ", ")
 	}
-	convCTE += fmt.Sprintf(" FROM read_parquet('%s')", e.parquetPath("conversations"))
+	convCTE += fmt.Sprintf(" FROM read_parquet('%s')", e.parquetPath(datasetConversations))
 
 	// --- sources CTE ---
 	srcReplace := []string{
@@ -1855,8 +1855,8 @@ func (e *DuckDBEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 
 // HasParquetData checks if Parquet files exist and are usable.
 func HasParquetData(analyticsDir string) bool {
-	pattern := filepath.Join(analyticsDir, "messages", "**", "*.parquet")
-	matches, err := filepath.Glob(filepath.Join(analyticsDir, "messages", "*", "*.parquet"))
+	pattern := filepath.Join(analyticsDir, datasetMessages, "**", "*.parquet")
+	matches, err := filepath.Glob(filepath.Join(analyticsDir, datasetMessages, "*", "*.parquet"))
 	if err != nil {
 		return false
 	}
@@ -1868,14 +1868,14 @@ func HasParquetData(analyticsDir string) bool {
 // contain at least one .parquet file for the cache to be considered complete.
 // Shared between the cache builder, TUI, and MCP startup paths.
 var RequiredParquetDirs = []string{
-	"messages",
+	datasetMessages,
 	"sources",
-	"participants",
+	datasetParticipants,
 	"message_recipients",
 	"labels",
 	"message_labels",
 	"attachments",
-	"conversations",
+	datasetConversations,
 }
 
 // HasCompleteParquetData checks that all required parquet tables exist.
@@ -1890,7 +1890,7 @@ func HasCompleteParquetData(analyticsDir string) bool {
 			continue
 		}
 		// For messages, also check hive-partitioned layout (messages/year=*/*.parquet)
-		if dir == "messages" {
+		if dir == datasetMessages {
 			deepMatches, _ := filepath.Glob(filepath.Join(analyticsDir, dir, "*", "*.parquet"))
 			if len(deepMatches) > 0 {
 				continue

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -120,11 +120,11 @@ func buildStandardTestData(t *testing.T) *TestDataBuilder {
 
 	// Messages
 	convAB := int64(101) // shared conversation for msg1+msg2
-	msg1 := b.AddMessage(MessageOpt{Subject: "Hello World", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000, ConversationID: convAB})
-	msg2 := b.AddMessage(MessageOpt{Subject: "Re: Hello", SentAt: makeDate(2024, 1, 16), SizeEstimate: 2000, HasAttachments: true, ConversationID: convAB})
-	msg3 := b.AddMessage(MessageOpt{Subject: "Follow up", SentAt: makeDate(2024, 2, 1), SizeEstimate: 1500, ConversationID: 102})
-	msg4 := b.AddMessage(MessageOpt{Subject: "Question", SentAt: makeDate(2024, 2, 15), SizeEstimate: 3000, HasAttachments: true, ConversationID: 103})
-	msg5 := b.AddMessage(MessageOpt{Subject: "Final", SentAt: makeDate(2024, 3, 1), SizeEstimate: 500, ConversationID: 104})
+	msg1 := b.AddMessage(MessageOpt{Subject: "Hello World", SentAt: makeDate(1, 15), SizeEstimate: 1000, ConversationID: convAB})
+	msg2 := b.AddMessage(MessageOpt{Subject: "Re: Hello", SentAt: makeDate(1, 16), SizeEstimate: 2000, HasAttachments: true, ConversationID: convAB})
+	msg3 := b.AddMessage(MessageOpt{Subject: "Follow up", SentAt: makeDate(2, 1), SizeEstimate: 1500, ConversationID: 102})
+	msg4 := b.AddMessage(MessageOpt{Subject: "Question", SentAt: makeDate(2, 15), SizeEstimate: 3000, HasAttachments: true, ConversationID: 103})
+	msg5 := b.AddMessage(MessageOpt{Subject: "Final", SentAt: makeDate(3, 1), SizeEstimate: 500, ConversationID: 104})
 
 	// Recipients
 	b.AddFrom(msg1, 1, "Alice")
@@ -590,8 +590,8 @@ func TestDuckDBEngine_AggregateBySenderName_EmptyStringFallback(t *testing.T) {
 	b.AddSource("test@gmail.com")
 	empty := b.AddParticipant("empty@test.com", "test.com", "")
 	spaces := b.AddParticipant("spaces@test.com", "test.com", "   ")
-	msg1 := b.AddMessage(MessageOpt{Subject: "Hello", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000})
-	msg2 := b.AddMessage(MessageOpt{Subject: "World", SentAt: makeDate(2024, 1, 16), SizeEstimate: 1000})
+	msg1 := b.AddMessage(MessageOpt{Subject: "Hello", SentAt: makeDate(1, 15), SizeEstimate: 1000})
+	msg2 := b.AddMessage(MessageOpt{Subject: "World", SentAt: makeDate(1, 16), SizeEstimate: 1000})
 	b.AddFrom(msg1, empty, "Empty")
 	b.AddFrom(msg2, spaces, "Spaces")
 	b.SetEmptyAttachments()
@@ -624,7 +624,7 @@ func TestDuckDBEngine_AggregateBySenderName_PhoneFallback(t *testing.T) {
 	b := NewTestDataBuilder(t)
 	b.AddSource("test@gmail.com")
 	phoneOnly := b.AddPhoneParticipant("+15551234567", "")
-	msg := b.AddMessage(MessageOpt{Subject: "SMS", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000})
+	msg := b.AddMessage(MessageOpt{Subject: "SMS", SentAt: makeDate(1, 15), SizeEstimate: 1000})
 	b.AddFrom(msg, phoneOnly, "")
 	b.SetEmptyAttachments()
 	engine := b.BuildEngine()
@@ -648,9 +648,9 @@ func TestDuckDBEngine_AggregateBySenderName_SearchByPhone(t *testing.T) {
 	b.AddSource("test@gmail.com")
 	phoneOnly := b.AddPhoneParticipant("+15551234567", "")
 	other := b.AddParticipant("alice@test.com", "test.com", "Alice")
-	smsMsg := b.AddMessage(MessageOpt{Subject: "SMS", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000})
+	smsMsg := b.AddMessage(MessageOpt{Subject: "SMS", SentAt: makeDate(1, 15), SizeEstimate: 1000})
 	b.AddFrom(smsMsg, phoneOnly, "")
-	emailMsg := b.AddMessage(MessageOpt{Subject: "Hello", SentAt: makeDate(2024, 1, 16), SizeEstimate: 1000})
+	emailMsg := b.AddMessage(MessageOpt{Subject: "Hello", SentAt: makeDate(1, 16), SizeEstimate: 1000})
 	b.AddFrom(emailMsg, other, "Alice")
 	b.SetEmptyAttachments()
 	engine := b.BuildEngine()
@@ -669,8 +669,8 @@ func TestDuckDBEngine_ListMessages_MatchEmptySenderName(t *testing.T) {
 	b := NewTestDataBuilder(t)
 	b.AddSource("test@gmail.com")
 	alice := b.AddParticipant("alice@test.com", "test.com", "Alice")
-	msg1 := b.AddMessage(MessageOpt{Subject: "Has Sender", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000})
-	_ = b.AddMessage(MessageOpt{Subject: "No Sender", SentAt: makeDate(2024, 1, 16), SizeEstimate: 1000})
+	msg1 := b.AddMessage(MessageOpt{Subject: "Has Sender", SentAt: makeDate(1, 15), SizeEstimate: 1000})
+	_ = b.AddMessage(MessageOpt{Subject: "No Sender", SentAt: makeDate(1, 16), SizeEstimate: 1000})
 	b.AddFrom(msg1, alice, "Alice")
 	b.SetEmptyAttachments()
 	engine := b.BuildEngine()
@@ -697,7 +697,7 @@ func TestDuckDBEngine_ListMessages_RecipientNameEmptyFallsBackToParticipant(t *t
 	b.AddSource("test@gmail.com")
 	// Phone-only participant with a vCard-backfilled display name.
 	alice := b.AddPhoneParticipant("+15551234567", "Alice Backfilled")
-	msg := b.AddMessage(MessageOpt{Subject: "SMS", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000})
+	msg := b.AddMessage(MessageOpt{Subject: "SMS", SentAt: makeDate(1, 15), SizeEstimate: 1000})
 	// Empty recipient display_name — what import-imessage writes.
 	b.AddFrom(msg, alice, "")
 	b.SetEmptyAttachments()
@@ -718,7 +718,7 @@ func TestDuckDBEngine_ListMessages_PhoneBackedSMSParticipants(t *testing.T) {
 	b.AddSourceWithType("sms-backup", "synctech-sms")
 	sender := b.AddPhoneParticipant("+15551234567", "SMS Sender")
 	recipient := b.AddPhoneParticipant("+15557654321", "Me")
-	msg := b.AddMessage(MessageOpt{Subject: "", Snippet: "known sms snippet", SentAt: makeDate(2024, 4, 1), SizeEstimate: 17})
+	msg := b.AddMessage(MessageOpt{Subject: "", Snippet: "known sms snippet", SentAt: makeDate(4, 1), SizeEstimate: 17})
 	b.AddFrom(msg, sender, "")
 	b.AddTo(msg, recipient, "")
 	b.SetEmptyAttachments()
@@ -920,8 +920,8 @@ func TestDuckDBEngine_ListMessages_DateFilter(t *testing.T) {
 	ctx := context.Background()
 
 	// Test data: msg1-3 Jan 2024, msg4 Feb 2024, msg5 Mar 2024
-	feb1 := makeDate(2024, 2, 1)
-	mar1 := makeDate(2024, 3, 1)
+	feb1 := makeDate(2, 1)
+	mar1 := makeDate(3, 1)
 
 	// After Feb 1 (>=): msg3 (Feb 1 09:00), msg4 (Feb 15), msg5 (Mar 1) = 3
 	results, err := engine.ListMessages(ctx, MessageFilter{After: &feb1})
@@ -963,7 +963,7 @@ func TestDuckDBEngine_AggregateBySender_DateFilter(t *testing.T) {
 	ctx := context.Background()
 
 	// After Feb 1 (>=): msg3 from alice, msg4 from bob, msg5 from bob
-	feb1 := makeDate(2024, 2, 1)
+	feb1 := makeDate(2, 1)
 	opts := DefaultAggregateOptions()
 	opts.After = &feb1
 
@@ -981,7 +981,7 @@ func TestDuckDBEngine_SubAggregate_DateFilter(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
-	feb1 := makeDate(2024, 2, 1)
+	feb1 := makeDate(2, 1)
 	filter := MessageFilter{Sender: "alice@example.com"}
 	opts := DefaultAggregateOptions()
 	opts.After = &feb1
@@ -1012,7 +1012,7 @@ func TestDuckDBEngine_AggregateByDomain_DateFilter(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
-	feb1 := makeDate(2024, 2, 1)
+	feb1 := makeDate(2, 1)
 	opts := DefaultAggregateOptions()
 	opts.After = &feb1
 
@@ -1262,12 +1262,12 @@ func buildEmptyBucketsTestData(t *testing.T) *TestDataBuilder {
 	nodomain := b.AddParticipant("nodomain", "", "No Domain")
 
 	// Messages
-	msg1 := b.AddMessage(MessageOpt{Subject: "Normal 1", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000})
-	msg2 := b.AddMessage(MessageOpt{Subject: "Normal 2", SentAt: makeDate(2024, 1, 16), SizeEstimate: 2000})
-	msg3 := b.AddMessage(MessageOpt{Subject: "No Sender", SentAt: makeDate(2024, 1, 17), SizeEstimate: 1500})
-	msg4 := b.AddMessage(MessageOpt{Subject: "No Recipients", SentAt: makeDate(2024, 1, 18), SizeEstimate: 3000})
-	msg5 := b.AddMessage(MessageOpt{Subject: "No Labels", SentAt: makeDate(2024, 1, 19), SizeEstimate: 500})
-	msg6 := b.AddMessage(MessageOpt{Subject: "Empty Domain", SentAt: makeDate(2024, 1, 20), SizeEstimate: 600})
+	msg1 := b.AddMessage(MessageOpt{Subject: "Normal 1", SentAt: makeDate(1, 15), SizeEstimate: 1000})
+	msg2 := b.AddMessage(MessageOpt{Subject: "Normal 2", SentAt: makeDate(1, 16), SizeEstimate: 2000})
+	msg3 := b.AddMessage(MessageOpt{Subject: "No Sender", SentAt: makeDate(1, 17), SizeEstimate: 1500})
+	msg4 := b.AddMessage(MessageOpt{Subject: "No Recipients", SentAt: makeDate(1, 18), SizeEstimate: 3000})
+	msg5 := b.AddMessage(MessageOpt{Subject: "No Labels", SentAt: makeDate(1, 19), SizeEstimate: 500})
+	msg6 := b.AddMessage(MessageOpt{Subject: "Empty Domain", SentAt: makeDate(1, 20), SizeEstimate: 600})
 
 	// Recipients
 	b.AddFrom(msg1, alice, "Alice")
@@ -2504,8 +2504,8 @@ func TestDuckDBEngine_Aggregate_DomainExcludesEmpty(t *testing.T) {
 	nodom := b.AddParticipant("nodom@", "", "No Domain") // empty domain
 
 	// Messages
-	msg1 := b.AddMessage(MessageOpt{Subject: "From Alice", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000})
-	msg2 := b.AddMessage(MessageOpt{Subject: "From NoDomain", SentAt: makeDate(2024, 1, 16), SizeEstimate: 1000})
+	msg1 := b.AddMessage(MessageOpt{Subject: "From Alice", SentAt: makeDate(1, 15), SizeEstimate: 1000})
+	msg2 := b.AddMessage(MessageOpt{Subject: "From NoDomain", SentAt: makeDate(1, 16), SizeEstimate: 1000})
 
 	// Senders
 	b.AddFrom(msg1, alice, "Alice")
@@ -2928,9 +2928,9 @@ func TestDuckDBEngine_HideDeletedFromSource(t *testing.T) {
 	b.AddParticipant("bob@company.org", "company.org", "Bob")
 
 	// msg1: deleted, msg2+msg3: not deleted
-	msg1 := b.AddMessage(MessageOpt{Subject: "Deleted msg", SentAt: makeDate(2024, 1, 15), SizeEstimate: 1000, DeletedAt: &now})
-	msg2 := b.AddMessage(MessageOpt{Subject: "Active msg", SentAt: makeDate(2024, 1, 16), SizeEstimate: 2000})
-	msg3 := b.AddMessage(MessageOpt{Subject: "Another active", SentAt: makeDate(2024, 2, 1), SizeEstimate: 1500})
+	msg1 := b.AddMessage(MessageOpt{Subject: "Deleted msg", SentAt: makeDate(1, 15), SizeEstimate: 1000, DeletedAt: &now})
+	msg2 := b.AddMessage(MessageOpt{Subject: "Active msg", SentAt: makeDate(1, 16), SizeEstimate: 2000})
+	msg3 := b.AddMessage(MessageOpt{Subject: "Another active", SentAt: makeDate(2, 1), SizeEstimate: 1500})
 
 	b.AddFrom(msg1, 1, "Alice")
 	b.AddTo(msg1, 2, "Bob")

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -13,6 +13,14 @@ import (
 	"go.kenn.io/msgvault/internal/store"
 )
 
+// Analytics dataset names. Each is both the Parquet subdirectory under
+// analyticsDir and the view/probe key for that dataset's optional columns.
+const (
+	datasetMessages      = "messages"
+	datasetParticipants  = "participants"
+	datasetConversations = "conversations"
+)
+
 // emailOnlyFilterMsg is the SQL condition restricting to email messages with "msg." alias (DuckDB).
 // NULL and empty string handle old data where message_type was not yet populated.
 const emailOnlyFilterMsg = "(msg.message_type = 'email' OR msg.message_type IS NULL OR msg.message_type = '')"

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1266,6 +1266,11 @@ func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, af
 // Search performs a Gmail-style search query.
 // buildSearchQueryParts builds the WHERE conditions, args, joins, and FTS join
 // for a search query. This is shared between Search and SearchFastCount.
+// joins is a reserved slot in the returned tuple that executeSearchQuery's
+// shared SELECT template interpolates; current filters emit none, but the shape
+// stays uniform with executeSearchQuery's signature.
+//
+//nolint:unparam // joins slot kept for uniformity with executeSearchQuery
 func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Query) (conditions []string, args []any, joins []string, ftsJoin string) {
 	// Exclude rows soft-deleted by deduplicate; gate source-deleted on
 	// q.HideDeleted via the helper.

--- a/internal/query/sqlite_aggregate_test.go
+++ b/internal/query/sqlite_aggregate_test.go
@@ -78,7 +78,7 @@ func TestAggregateBySenderName_FallbackToEmail(t *testing.T) {
 
 	assertpkg.Len(t, rows, 3, "expected 3 sender names")
 
-	assertRow(t, rows, "noname@test.com", 1)
+	assertRow(t, rows, "noname@test.com")
 }
 
 // TestAggregateBySenderName_FallbackToPhone covers phone-only iMessage/SMS
@@ -97,7 +97,7 @@ func TestAggregateBySenderName_FallbackToPhone(t *testing.T) {
 	rows, err := env.Engine.Aggregate(env.Ctx, ViewSenderNames, DefaultAggregateOptions())
 	requirepkg.NoError(t, err, "AggregateBySenderName")
 
-	assertRow(t, rows, "+15551234567", 1)
+	assertRow(t, rows, "+15551234567")
 
 	// Same fallback drives the SenderName filter.
 	listed := env.MustListMessages(MessageFilter{SenderName: "+15551234567"})
@@ -121,7 +121,7 @@ func TestAggregateByRecipientName_FallbackToPhone(t *testing.T) {
 	rows, err := env.Engine.Aggregate(env.Ctx, ViewRecipientNames, DefaultAggregateOptions())
 	requirepkg.NoError(t, err, "AggregateByRecipientName")
 
-	assertRow(t, rows, "+15557654321", 1)
+	assertRow(t, rows, "+15557654321")
 
 	listed := env.MustListMessages(MessageFilter{RecipientName: "+15557654321"})
 	assertpkg.Len(t, listed, 1, "ListMessages by phone-fallback recipient name")
@@ -419,7 +419,7 @@ func TestAggregateByRecipientName_FallbackToEmail(t *testing.T) {
 	rows, err := env.Engine.Aggregate(env.Ctx, ViewRecipientNames, DefaultAggregateOptions())
 	requirepkg.NoError(t, err, "AggregateByRecipientName")
 
-	assertRow(t, rows, "noname@test.com", 1)
+	assertRow(t, rows, "noname@test.com")
 }
 
 func TestAggregateByRecipientName_EmptyStringFallback(t *testing.T) {

--- a/internal/query/sqlite_testhelpers_test.go
+++ b/internal/query/sqlite_testhelpers_test.go
@@ -95,15 +95,15 @@ func assertRowsContain(t *testing.T, rows []AggregateRow, want []aggExpectation)
 	}
 }
 
-// assertRow finds a single key in the aggregate rows and asserts its count.
-func assertRow(t *testing.T, rows []AggregateRow, key string, count int64) {
+// assertRow finds a single key in the aggregate rows and asserts its count is 1.
+func assertRow(t *testing.T, rows []AggregateRow, key string) {
 	t.Helper()
 	m := aggRowMap(t, rows)
 	got, ok := m[key]
 	if !assert.True(t, ok, "key %q not found in results", key) {
 		return
 	}
-	assert.Equal(t, count, got, "key %q count", key)
+	assert.Equal(t, int64(1), got, "key %q count", key)
 }
 
 // assertAggRows verifies that aggregate rows contain the expected key/count pairs

--- a/internal/query/testfixtures_test.go
+++ b/internal/query/testfixtures_test.go
@@ -637,7 +637,7 @@ func assertDescendingOrder(t testing.TB, got []AggregateRow) {
 	}
 }
 
-// makeDate creates a time.Time for the given year, month, day in UTC with zero time.
-func makeDate(year, month, day int) time.Time {
-	return time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+// makeDate creates a time.Time for the given month, day in 2024, UTC, zero time.
+func makeDate(month, day int) time.Time {
+	return time.Date(2024, time.Month(month), day, 0, 0, 0, 0, time.UTC)
 }

--- a/internal/query/views.go
+++ b/internal/query/views.go
@@ -117,15 +117,15 @@ func buildViewSQL(def viewDef, probedCols map[string]bool) string {
 // have optional columns, returning a map of table name -> column set.
 // Used by both RegisterViews and RegisterViewsWithColumns.
 func probeAllOptionalColumns(db *sql.DB, analyticsDir string) map[string]map[string]bool {
-	msgGlob := filepath.Join(analyticsDir, "messages", "**", "*.parquet")
+	msgGlob := filepath.Join(analyticsDir, datasetMessages, "**", "*.parquet")
 	tablePath := func(name string) string {
 		return filepath.Join(analyticsDir, name, "*.parquet")
 	}
 	return map[string]map[string]bool{
-		"messages":      probeColumns(db, msgGlob, true),
-		"participants":  probeColumns(db, tablePath("participants"), false),
-		"conversations": probeColumns(db, tablePath("conversations"), false),
-		"sources":       probeColumns(db, tablePath("sources"), false),
+		datasetMessages:      probeColumns(db, msgGlob, true),
+		datasetParticipants:  probeColumns(db, tablePath(datasetParticipants), false),
+		datasetConversations: probeColumns(db, tablePath(datasetConversations), false),
+		"sources":            probeColumns(db, tablePath("sources"), false),
 	}
 }
 
@@ -151,7 +151,7 @@ func RegisterViewsWithColumns(db *sql.DB, analyticsDir string, optCols map[strin
 // pre-computed optional column map so no additional Parquet probes occur.
 func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[string]bool) error {
 	msgGlob := filepath.Join(
-		analyticsDir, "messages", "**", "*.parquet",
+		analyticsDir, datasetMessages, "**", "*.parquet",
 	)
 	tablePath := func(name string) string {
 		return filepath.Join(analyticsDir, name, "*.parquet")
@@ -170,7 +170,7 @@ func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[str
 	}{
 		{
 			def: viewDef{
-				name:             "messages",
+				name:             datasetMessages,
 				pathPattern:      msgGlob,
 				hivePartitioning: true,
 				replaceCols: []string{
@@ -201,12 +201,12 @@ func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[str
 					},
 				},
 			},
-			probe: colsFor("messages"),
+			probe: colsFor(datasetMessages),
 		},
 		{
 			def: viewDef{
-				name:        "participants",
-				pathPattern: tablePath("participants"),
+				name:        datasetParticipants,
+				pathPattern: tablePath(datasetParticipants),
 				replaceCols: []string{
 					"CAST(id AS BIGINT) AS id",
 					"CAST(email_address AS VARCHAR) AS email_address",
@@ -221,7 +221,7 @@ func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[str
 					},
 				},
 			},
-			probe: colsFor("participants"),
+			probe: colsFor(datasetParticipants),
 		},
 		{
 			def: viewDef{
@@ -268,8 +268,8 @@ func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[str
 		},
 		{
 			def: viewDef{
-				name:        "conversations",
-				pathPattern: tablePath("conversations"),
+				name:        datasetConversations,
+				pathPattern: tablePath(datasetConversations),
 				replaceCols: []string{
 					"CAST(id AS BIGINT) AS id",
 					"CAST(source_conversation_id AS VARCHAR) AS source_conversation_id",
@@ -287,7 +287,7 @@ func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[str
 					},
 				},
 			},
-			probe: colsFor("conversations"),
+			probe: colsFor(datasetConversations),
 		},
 		{
 			def: viewDef{

--- a/internal/remote/engine.go
+++ b/internal/remote/engine.go
@@ -398,7 +398,7 @@ func (e *Engine) Aggregate(ctx context.Context, groupBy query.ViewType, opts que
 	params := buildAggregateQuery(groupBy, opts)
 	path := "/api/v1/aggregates?" + params.Encode()
 
-	resp, err := e.store.doRequestWithContext(ctx, "GET", path, nil)
+	resp, err := e.store.doRequestWithContext(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (e *Engine) SubAggregate(ctx context.Context, filter query.MessageFilter, g
 
 	path := "/api/v1/aggregates/sub?" + params.Encode()
 
-	resp, err := e.store.doRequestWithContext(ctx, "GET", path, nil)
+	resp, err := e.store.doRequestWithContext(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +458,7 @@ func (e *Engine) ListMessages(ctx context.Context, filter query.MessageFilter) (
 	params := buildFilterQuery(filter)
 	path := "/api/v1/messages/filter?" + params.Encode()
 
-	resp, err := e.store.doRequestWithContext(ctx, "GET", path, nil)
+	resp, err := e.store.doRequestWithContext(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +618,7 @@ func (e *Engine) Search(ctx context.Context, q *search.Query, limit, offset int)
 
 	path := "/api/v1/search/deep?" + params.Encode()
 
-	resp, err := e.store.doRequestWithContext(ctx, "GET", path, nil)
+	resp, err := e.store.doRequestWithContext(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -667,7 +667,7 @@ func (e *Engine) SearchFastWithStats(ctx context.Context, q *search.Query, query
 
 	path := "/api/v1/search/fast?" + params.Encode()
 
-	resp, err := e.store.doRequestWithContext(ctx, "GET", path, nil)
+	resp, err := e.store.doRequestWithContext(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +734,7 @@ func (e *Engine) GetTotalStats(ctx context.Context, opts query.StatsOptions) (*q
 	params := buildStatsQuery(opts)
 	path := "/api/v1/stats/total?" + params.Encode()
 
-	resp, err := e.store.doRequestWithContext(ctx, "GET", path, nil)
+	resp, err := e.store.doRequestWithContext(ctx, path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/remote/store.go
+++ b/internal/remote/store.go
@@ -76,16 +76,18 @@ func (s *Store) Close() error {
 	return nil
 }
 
-// doRequest performs an authenticated HTTP request.
-func (s *Store) doRequest(method, path string, body io.Reader) (*http.Response, error) {
-	return s.doRequestWithContext(context.Background(), method, path, body)
+// doRequest performs an authenticated HTTP GET request against the background
+// context. The remote API is read-only, so every request is a body-less GET.
+func (s *Store) doRequest(path string) (*http.Response, error) {
+	return s.doRequestWithContext(context.Background(), path)
 }
 
-// doRequestWithContext performs an authenticated HTTP request with context support.
-func (s *Store) doRequestWithContext(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+// doRequestWithContext performs an authenticated, body-less HTTP GET request
+// with context support.
+func (s *Store) doRequestWithContext(ctx context.Context, path string) (*http.Response, error) {
 	reqURL := s.baseURL + path
 
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -136,7 +138,7 @@ type statsResponse struct {
 
 // GetStats fetches stats from the remote server.
 func (s *Store) GetStats() (*store.Stats, error) {
-	resp, err := s.doRequest("GET", "/api/v1/stats", nil)
+	resp, err := s.doRequest("/api/v1/stats")
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +248,7 @@ func (s *Store) ListMessages(offset, limit int) ([]store.APIMessage, int64, erro
 	page := (offset / limit) + 1
 
 	path := fmt.Sprintf("/api/v1/messages?page=%d&page_size=%d", page, limit)
-	resp, err := s.doRequest("GET", path, nil)
+	resp, err := s.doRequest(path)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -272,7 +274,7 @@ func (s *Store) ListMessages(offset, limit int) ([]store.APIMessage, int64, erro
 // GetMessage fetches a single message by ID.
 func (s *Store) GetMessage(id int64) (*store.APIMessage, error) {
 	path := "/api/v1/messages/" + strconv.FormatInt(id, 10)
-	resp, err := s.doRequest("GET", path, nil)
+	resp, err := s.doRequest(path)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +329,7 @@ func (s *Store) SearchMessages(query string, offset, limit int) ([]store.APIMess
 	path := fmt.Sprintf("/api/v1/search?q=%s&page=%d&page_size=%d",
 		url.QueryEscape(query), page, limit)
 
-	resp, err := s.doRequest("GET", path, nil)
+	resp, err := s.doRequest(path)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -368,7 +370,7 @@ type accountsResponse struct {
 
 // ListAccounts fetches configured accounts from the remote server.
 func (s *Store) ListAccounts() ([]AccountInfo, error) {
-	resp, err := s.doRequest("GET", "/api/v1/accounts", nil)
+	resp, err := s.doRequest("/api/v1/accounts")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/remote/store_test.go
+++ b/internal/remote/store_test.go
@@ -99,7 +99,7 @@ func TestDoRequest_SetsAuthHeader(t *testing.T) {
 	defer srv.Close()
 
 	s := newTestStore(srv, "secret-key")
-	resp, err := s.doRequest("GET", "/test", nil)
+	resp, err := s.doRequest("/test")
 	requirepkg.NoError(t, err, "doRequest error")
 	_ = resp.Body.Close()
 }
@@ -112,7 +112,7 @@ func TestDoRequest_OmitsAuthHeaderWhenEmpty(t *testing.T) {
 	defer srv.Close()
 
 	s := newTestStore(srv, "")
-	resp, err := s.doRequest("GET", "/test", nil)
+	resp, err := s.doRequest("/test")
 	requirepkg.NoError(t, err, "doRequest error")
 	_ = resp.Body.Close()
 }

--- a/internal/store/db_logger_test.go
+++ b/internal/store/db_logger_test.go
@@ -18,15 +18,15 @@ import (
 	requirepkg "github.com/stretchr/testify/require"
 )
 
-// captureSlog installs a JSON handler over buf as the default
-// slog logger for the duration of a test. Returns a cleanup
-// closure that restores the previous default.
-func captureSlog(t *testing.T, level slog.Level) *bytes.Buffer {
+// captureSlog installs a JSON handler over buf as the default slog logger at
+// debug level for the duration of a test. Returns a cleanup closure that
+// restores the previous default.
+func captureSlog(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(
-		&buf, &slog.HandlerOptions{Level: level},
+		&buf, &slog.HandlerOptions{Level: slog.LevelDebug},
 	)))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 	return &buf
@@ -51,7 +51,7 @@ func TestLoggedDB_ExecLogsStatement(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 
 	res, err := db.Exec(
@@ -62,7 +62,7 @@ func TestLoggedDB_ExecLogsStatement(t *testing.T) {
 	assert.Equal(int64(1), n, "rows_affected")
 
 	// Find the sql line in the captured output.
-	rec := findLogLine(t, buf, "sql")
+	rec := findLogLine(t, buf)
 	assert.Equal("exec", rec["kind"], "kind")
 	assert.Contains(rec["stmt"].(string), "INSERT INTO t", "stmt")
 	assert.Equal(float64(1), rec["rows_affected"].(float64), "rows_affected")
@@ -75,7 +75,7 @@ func TestLogStmt_SlowQueryPromotedToWarn(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{SlowMs: 50})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	logStmtWith(
 		"exec", "INSERT INTO t VALUES (?)", []any{"v"},
 		nil, 100*time.Millisecond,
@@ -91,7 +91,7 @@ func TestLoggedDB_ErrorAlwaysLogged(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	ConfigureSQLLogging(SQLLogOptions{})
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 
 	_, err := db.ExecContext(
@@ -113,7 +113,7 @@ func TestLoggedDB_QueryRowLogsButNoError(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 
 	_, err := db.Exec(
@@ -145,7 +145,7 @@ func TestLoggedRows_LogsAtClose(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 	_, err := db.Exec(
 		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
@@ -166,7 +166,7 @@ func TestLoggedRows_LogsAtClose(t *testing.T) {
 	require.NoError(rows.Err(), "rows.Err")
 	require.NoError(rows.Close(), "close")
 
-	rec := findLogLine(t, buf, "sql")
+	rec := findLogLine(t, buf)
 	assertpkg.Equal(t, "query", rec["kind"], "kind")
 }
 
@@ -177,7 +177,7 @@ func TestLoggedRows_CloseIdempotent(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 	rows, err := db.Query("SELECT 1")
 	requirepkg.NoError(t, err, "query")
@@ -204,7 +204,7 @@ func TestLoggedRows_CloseIdempotent(t *testing.T) {
 // is returned.
 func TestLoggedRows_QueryErrorLogsImmediately(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{})
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 
 	_, err := db.Query("SELECT * FROM no_such_table")
@@ -226,7 +226,7 @@ func TestLoggedRows_FinalizesAtEndOfScan(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 	_, err := db.Exec(
 		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
@@ -242,7 +242,7 @@ func TestLoggedRows_FinalizesAtEndOfScan(t *testing.T) {
 	}
 	// The log line must be emitted by the time Next returns
 	// false, before any deferred Close fires.
-	rec := findLogLine(t, buf, "sql")
+	rec := findLogLine(t, buf)
 	assert.Equal("query", rec["kind"], "kind")
 	durAtEndOfScan := rec["duration_ms"].(float64)
 
@@ -278,7 +278,7 @@ func TestLoggedRows_EarlyExitFinalizesOnClose(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 	_, err := db.Exec(
 		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
@@ -295,7 +295,7 @@ func TestLoggedRows_EarlyExitFinalizesOnClose(t *testing.T) {
 	require.Nil(findLogLineByMsg(t, buf, "sql"),
 		"log line emitted before Close on early-exit path")
 	require.NoError(rows.Close(), "close")
-	rec := findLogLine(t, buf, "sql")
+	rec := findLogLine(t, buf)
 	assertpkg.Equal(t, "query", rec["kind"], "kind")
 }
 
@@ -307,7 +307,7 @@ func TestLoggedRows_EarlyExitFinalizesOnClose(t *testing.T) {
 func TestLoggedRows_IterationErrorSurfacedOnClose(t *testing.T) {
 	require := requirepkg.New(t)
 	ConfigureSQLLogging(SQLLogOptions{})
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	db := openLoggedMem(t)
 	_, err := db.Exec(
 		"INSERT INTO t (val) VALUES ('a'), ('b'), ('c')",
@@ -342,7 +342,7 @@ func TestLogStmt_SlowQueryIncludesArgsShape(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{SlowMs: 50})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	logStmtWith(
 		"query", "SELECT * FROM t WHERE id = ? AND src = ?",
 		[]any{int64(42), "gmail"},
@@ -371,14 +371,14 @@ func TestLogStmt_FullTraceOmitsArgs(t *testing.T) {
 	ConfigureSQLLogging(SQLLogOptions{FullTrace: true})
 	t.Cleanup(func() { ConfigureSQLLogging(SQLLogOptions{}) })
 
-	buf := captureSlog(t, slog.LevelDebug)
+	buf := captureSlog(t)
 	logStmtWith(
 		"query", "SELECT * FROM t WHERE id = ?",
 		[]any{int64(42)},
 		nil, 1*time.Millisecond,
 	)
 
-	rec := findLogLine(t, buf, "sql")
+	rec := findLogLine(t, buf)
 	_, present := rec["args"]
 	assertpkg.False(t, present, "args should not be present on info/full-trace lines: %v", rec)
 	_, present = rec["args_shape"]
@@ -473,11 +473,12 @@ func TestNormalizeStmt_UTF8Safe(t *testing.T) {
 
 // ---- test helpers ----
 
-// findLogLine returns the first record whose msg matches exactly.
+// findLogLine returns the first record whose msg is exactly "sql".
 func findLogLine(
-	t *testing.T, buf *bytes.Buffer, msg string,
+	t *testing.T, buf *bytes.Buffer,
 ) map[string]any {
 	t.Helper()
+	const msg = "sql"
 	for _, rec := range decodeAll(t, buf) {
 		if rec["msg"] == msg {
 			return rec

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -165,7 +165,7 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 						continue
 					}
 					threadID := newMsgThreads[newMsgIDs[i]]
-					insertedID, err := s.ingestMessage(ctx, source.ID, raw, threadID, labelMap)
+					insertedID, err := s.ingestMessage(source.ID, raw, threadID, labelMap)
 					if err != nil {
 						s.logger.Warn("failed to ingest added message", "id", newMsgIDs[i], "error", err)
 						checkpoint.ErrorsCount++
@@ -281,7 +281,7 @@ func (s *Syncer) handleLabelChange(ctx context.Context, sourceID int64, messageI
 			if err != nil {
 				return false, err
 			}
-			insertedID, err := s.ingestMessage(ctx, sourceID, raw, threadID, labelMap)
+			insertedID, err := s.ingestMessage(sourceID, raw, threadID, labelMap)
 			if err != nil {
 				return false, err
 			}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -223,7 +223,7 @@ func (s *Syncer) processBatch(ctx context.Context, sourceID int64, listResp *gma
 			}
 
 			threadID := threadIDs[newIDs[i]]
-			insertedID, err := s.ingestMessage(ctx, sourceID, raw, threadID, labelMap)
+			insertedID, err := s.ingestMessage(sourceID, raw, threadID, labelMap)
 			if err != nil {
 				if errors.Is(err, errDuplicateRFC822) {
 					result.skipped++
@@ -689,7 +689,7 @@ var errDuplicateRFC822 = errors.New("duplicate RFC822 Message-ID")
 // ingestMessage parses and stores a single message, returning the
 // internal message ID on success. Returns (0, errDuplicateRFC822) for
 // IMAP deduplication skips.
-func (s *Syncer) ingestMessage(ctx context.Context, sourceID int64, raw *gmail.RawMessage, threadID string, labelMap map[string]int64) (int64, error) {
+func (s *Syncer) ingestMessage(sourceID int64, raw *gmail.RawMessage, threadID string, labelMap map[string]int64) (int64, error) {
 	data, err := s.parseToModel(sourceID, raw, threadID)
 	if err != nil {
 		return 0, err

--- a/internal/sync/testenv_test.go
+++ b/internal/sync/testenv_test.go
@@ -24,10 +24,8 @@ type TestEnv struct {
 	Context context.Context
 }
 
-func newTestEnv(t *testing.T, opt ...*Options) *TestEnv {
+func newTestEnv(t *testing.T) *TestEnv {
 	t.Helper()
-
-	require.LessOrEqual(t, len(opt), 1, "newTestEnv: at most one *Options allowed")
 
 	tmpDir, err := os.MkdirTemp("", "msgvault-test-*")
 	require.NoError(t, err, "create temp dir")
@@ -47,15 +45,10 @@ func newTestEnv(t *testing.T, opt ...*Options) *TestEnv {
 		HistoryID:     1000,
 	}
 
-	var o *Options
-	if len(opt) > 0 {
-		o = opt[0]
-	}
-
 	return &TestEnv{
 		Store:   st,
 		Mock:    mock,
-		Syncer:  New(mock, st, o),
+		Syncer:  New(mock, st, nil),
 		TmpDir:  tmpDir,
 		Context: context.Background(),
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -8,13 +8,19 @@ import (
 	"go.kenn.io/msgvault/internal/query"
 )
 
+// Key names matched against tea.KeyMsg.String() in the key-handling switches.
+const (
+	keyNameEnter = "enter"
+	keyNameEsc   = "esc"
+)
+
 // handleInlineSearchKeys handles keys when inline search bar is active.
 func (m Model) handleInlineSearchKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "enter":
+	case keyNameEnter:
 		return m.commitInlineSearch()
 
-	case "esc":
+	case keyNameEsc:
 		return m.cancelInlineSearch()
 
 	case "ctrl+c":
@@ -130,7 +136,7 @@ func (m Model) handleAggregateKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	// Esc: sub-agg tries goBack() first; top-level clears search
-	case "esc":
+	case keyNameEsc:
 		if isSub {
 			if len(m.breadcrumbs) > 0 {
 				return m.goBack()
@@ -219,7 +225,7 @@ func (m Model) handleAggregateKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.stageForDeletion()
 
 	// Drill down - go to message list for selected aggregate
-	case "enter":
+	case keyNameEnter:
 		if len(m.rows) > 0 && m.cursor < len(m.rows) {
 			return m.enterDrillDown(m.rows[m.cursor])
 		}
@@ -352,7 +358,7 @@ func (m Model) handleMessageListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	// Back - clear inner search first, then navigate back
-	case "esc":
+	case keyNameEsc:
 		// Clear search only if it was initiated at this level (snapshot exists).
 		// Inherited search (from aggregate drill-down) has no snapshot —
 		// goBack restores the parent view with its search intact.
@@ -426,7 +432,7 @@ func (m Model) handleMessageListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	// Drill down to message detail
-	case "enter":
+	case keyNameEnter:
 		if len(m.messages) > 0 && m.cursor < len(m.messages) {
 			m.transitionBuffer = m.renderView() // Freeze screen until data loads
 
@@ -648,7 +654,7 @@ func (m Model) handleMessageDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// When detail search input is active, route keys there first
 	if m.detailSearchActive {
 		switch msg.String() {
-		case "enter":
+		case keyNameEnter:
 			m.detailSearchActive = false
 			m.detailSearchQuery = m.detailSearchInput.Value()
 			m.findDetailMatches()
@@ -657,7 +663,7 @@ func (m Model) handleMessageDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.scrollToDetailMatch()
 			}
 			return m, nil
-		case "esc":
+		case keyNameEsc:
 			m.detailSearchActive = false
 			m.detailSearchInput.SetValue("")
 			return m, nil
@@ -677,7 +683,7 @@ func (m Model) handleMessageDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	// Back to message list or clear detail search
-	case "esc":
+	case keyNameEsc:
 		if m.detailSearchQuery != "" {
 			m.detailSearchQuery = ""
 			m.detailSearchMatches = nil
@@ -818,7 +824,7 @@ func (m Model) handleThreadViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	// Back to previous view
-	case "esc":
+	case keyNameEsc:
 		return m.goBack()
 
 	// Navigation
@@ -859,7 +865,7 @@ func (m Model) handleThreadViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	// View message detail
-	case "enter":
+	case keyNameEnter:
 		if len(m.threadMessages) > 0 && m.threadCursor < len(m.threadMessages) {
 			m.transitionBuffer = m.renderView() // Freeze screen until data loads
 
@@ -914,7 +920,7 @@ func (m Model) handleDeleteConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y":
 		return m.confirmDeletion()
-	case "n", "N", "esc":
+	case "n", "N", keyNameEsc:
 		m.modal = modalNone
 		m.pendingManifest = nil
 	}
@@ -930,10 +936,10 @@ func (m Model) handleDeleteResultKeys() (tea.Model, tea.Cmd) {
 
 func (m Model) handleQuitConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "y", "Y", "enter":
+	case "y", "Y", keyNameEnter:
 		m.quitting = true
 		return m, tea.Quit
-	case "n", "N", "esc", "q":
+	case "n", "N", keyNameEsc, "q":
 		m.modal = modalNone
 	}
 	return m, nil
@@ -950,7 +956,7 @@ func (m Model) handleAccountSelectorKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.modalCursor < maxIdx {
 			m.modalCursor++
 		}
-	case "enter":
+	case keyNameEnter:
 		// Apply selection with bounds check
 		if m.modalCursor == 0 || m.modalCursor > len(m.accounts) {
 			m.accountFilter = nil // All accounts (or fallback if out of bounds)
@@ -966,7 +972,7 @@ func (m Model) handleAccountSelectorKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.aggregateRequestID++
 		return m, tea.Batch(m.loadData(), m.loadStats())
-	case "esc":
+	case keyNameEsc:
 		m.modal = modalNone
 	}
 	return m, nil
@@ -993,7 +999,7 @@ func (m Model) handleFilterToggleKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case 1:
 			m.filters.hideDeletedFromSource = !m.filters.hideDeletedFromSource
 		}
-	case "enter", "esc":
+	case keyNameEnter, keyNameEsc:
 		// Apply filters: close modal and reload data
 		m.modal = modalNone
 		m.loading = true
@@ -1040,9 +1046,9 @@ func (m Model) handleExportAttachmentsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		for i := range m.messageDetail.Attachments {
 			m.exportSelection[i] = false
 		}
-	case "enter":
+	case keyNameEnter:
 		return m.exportAttachments()
-	case "esc":
+	case keyNameEsc:
 		m.modal = modalNone
 		m.exportSelection = nil
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1295,7 +1295,8 @@ func (m Model) commitInlineSearch() (tea.Model, tea.Cmd) {
 		// Empty search clears filter - restore from snapshot if available
 		m.clearSearchState()
 		if m.level == levelMessageList && m.preSearchMessages != nil {
-			return m, m.restorePreSearchSnapshot()
+			m.restorePreSearchSnapshot()
+			return m, nil
 		}
 		return m.reloadCurrentView()
 	}
@@ -1323,7 +1324,8 @@ func (m Model) cancelInlineSearch() (tea.Model, tea.Cmd) {
 	m.clearSearchState()
 
 	if m.level == levelMessageList && m.preSearchMessages != nil {
-		return m, m.restorePreSearchSnapshot()
+		m.restorePreSearchSnapshot()
+		return m, nil
 	}
 	return m.reloadCurrentView()
 }
@@ -1336,7 +1338,8 @@ func (m Model) clearMessageListSearch() (tea.Model, tea.Cmd) {
 	m.searchRequestID++
 
 	if m.preSearchMessages != nil {
-		return m, m.restorePreSearchSnapshot()
+		m.restorePreSearchSnapshot()
+		return m, nil
 	}
 	m.contextStats = nil
 	m.loadRequestID++
@@ -1344,8 +1347,9 @@ func (m Model) clearMessageListSearch() (tea.Model, tea.Cmd) {
 }
 
 // restorePreSearchSnapshot restores the cached message list state from before
-// the search began, avoiding a re-query. Returns nil cmd since no async work needed.
-func (m *Model) restorePreSearchSnapshot() tea.Cmd {
+// the search began, avoiding a re-query. No async work is needed, so callers
+// pair it with a nil command.
+func (m *Model) restorePreSearchSnapshot() {
 	m.messages = m.preSearchMessages
 	m.cursor = m.preSearchCursor
 	m.scrollOffset = m.preSearchScrollOffset
@@ -1358,7 +1362,6 @@ func (m *Model) restorePreSearchSnapshot() tea.Cmd {
 	// Clear the snapshot
 	m.preSearchMessages = nil
 	m.preSearchContextStats = nil
-	return nil
 }
 
 func (m *Model) activateInlineSearch(placeholder string) tea.Cmd {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -78,7 +78,7 @@ func TestModel_Update_DataLoaded_TransitionsFromLoading(t *testing.T) {
 
 func TestModel_Update_DataLoaded_ResetsCursor(t *testing.T) {
 	model := NewBuilder().
-		WithRows(makeRows(10)...).
+		WithRows(makeRows()...).
 		WithLoading(true).
 		Build()
 	model.cursor = 5
@@ -95,14 +95,14 @@ func TestModel_Update_DataLoaded_ResetsCursor(t *testing.T) {
 
 func TestModel_Update_DataLoaded_PreservesPositionWhenRestoring(t *testing.T) {
 	model := NewBuilder().
-		WithRows(makeRows(10)...).
+		WithRows(makeRows()...).
 		WithLoading(true).
 		Build()
 	model.cursor = 5
 	model.scrollOffset = 3
 	model.restorePosition = true
 
-	newRows := makeRows(10)
+	newRows := makeRows()
 	msg := dataLoadedMsg{rows: newRows, requestID: model.aggregateRequestID}
 	updatedModel, _ := model.Update(msg)
 	m := updatedModel.(Model)

--- a/internal/tui/nav_detail_test.go
+++ b/internal/tui/nav_detail_test.go
@@ -78,7 +78,7 @@ func TestResizeRecalculatesDetailLineCount(t *testing.T) {
 	initialLineCount := model.detailLineCount
 
 	// Simulate window resize to narrower width (should wrap more)
-	m, _ := sendMsg(t, model, tea.WindowSizeMsg{Width: 40, Height: 20})
+	m := sendMsg(t, model, tea.WindowSizeMsg{Width: 40, Height: 20})
 
 	// Line count should be recalculated (narrower width = more wrapping = more lines)
 	if m.detailLineCount == initialLineCount && m.width != 80 {

--- a/internal/tui/nav_drill_test.go
+++ b/internal/tui/nav_drill_test.go
@@ -307,7 +307,7 @@ func TestViewTypeRestoredAfterEscFromSubAggregate(t *testing.T) {
 // without requiring a reload.
 func TestCursorScrollPreservedAfterGoBack(t *testing.T) {
 	assert := assertpkg.New(t)
-	rows := makeRows(10)
+	rows := makeRows()
 	model := NewBuilder().WithRows(rows...).WithViewType(query.ViewSenders).Build()
 	model.cursor = 5
 	model.scrollOffset = 3

--- a/internal/tui/nav_test.go
+++ b/internal/tui/nav_test.go
@@ -25,7 +25,7 @@ func TestStaleAsyncResponsesIgnored(t *testing.T) {
 		requestID: 3, // Old request ID
 	}
 
-	m, _ := sendMsg(t, model, staleMsg)
+	m := sendMsg(t, model, staleMsg)
 
 	// Stale response should be ignored - messages should be unchanged (empty)
 	assert.Empty(t, m.messages, "stale response should be ignored")
@@ -36,7 +36,7 @@ func TestStaleAsyncResponsesIgnored(t *testing.T) {
 		requestID: 5, // Current request ID
 	}
 
-	m, _ = sendMsg(t, m, validMsg)
+	m = sendMsg(t, m, validMsg)
 
 	// Valid response should be processed
 	require.Len(t, m.messages, 1, "valid response should be processed")
@@ -57,7 +57,7 @@ func TestStaleDetailResponsesIgnored(t *testing.T) {
 		requestID: 8, // Old request ID
 	}
 
-	m, _ := sendMsg(t, model, staleMsg)
+	m := sendMsg(t, model, staleMsg)
 
 	// Stale response should be ignored
 	assert.Nil(t, m.messageDetail, "stale detail response should be ignored")
@@ -68,7 +68,7 @@ func TestStaleDetailResponsesIgnored(t *testing.T) {
 		requestID: 10, // Current request ID
 	}
 
-	m, _ = sendMsg(t, m, validMsg)
+	m = sendMsg(t, m, validMsg)
 
 	// Valid response should be processed
 	require.NotNil(t, m.messageDetail, "valid detail response should be processed")

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -470,7 +470,7 @@ func TestMessageListPaginationTriggersOnNavigation(t *testing.T) {
 			requestID: 5,
 			append:    true,
 		}
-		m, _ := sendMsg(t, model, loadMsg)
+		m := sendMsg(t, model, loadMsg)
 
 		assert.Len(m.messages, messageListPageSize+100, "after append")
 		assert.Equal(400, m.cursor, "expected cursor preserved")
@@ -494,7 +494,7 @@ func TestMessageListPaginationTriggersOnNavigation(t *testing.T) {
 			requestID: 5,
 			append:    true,
 		}
-		m, _ := sendMsg(t, model, loadMsg)
+		m := sendMsg(t, model, loadMsg)
 
 		assertpkg.True(t, m.msgListComplete, "after empty append")
 		assertpkg.Len(t, m.messages, messageListPageSize, "expected messages unchanged")
@@ -521,7 +521,7 @@ func TestMessageListPaginationTriggersOnNavigation(t *testing.T) {
 			requestID: 5,
 			append:    false,
 		}
-		m, _ := sendMsg(t, model, loadMsg)
+		m := sendMsg(t, model, loadMsg)
 
 		assertpkg.False(t, m.msgListComplete, "after fresh load")
 	})
@@ -759,7 +759,7 @@ func TestAggregateSearchFilterSetsContextStats(t *testing.T) {
 	assert := assertpkg.New(t)
 	model := newTestModelAtLevel(levelAggregates).
 		withSearchQuery("test query").
-		withAggregateRequestID(1)
+		withAggregateRequestID()
 
 	msg := dataLoadedMsg{
 		rows:      testAggregateRows,
@@ -783,7 +783,7 @@ func TestAggregateSearchFilterSetsContextStats(t *testing.T) {
 func TestAggregateSearchFilterUsesFilteredStats(t *testing.T) {
 	model := newTestModelAtLevel(levelAggregates).
 		withSearchQuery("test query").
-		withAggregateRequestID(1)
+		withAggregateRequestID()
 
 	// Simulate recipient view: rows sum to 175 (inflated) but actual distinct is 100
 	filteredStats := &query.TotalStats{MessageCount: 100, TotalSize: 5000, AttachmentCount: 10}
@@ -810,7 +810,7 @@ func TestAggregateSearchFilterUsesFilteredStats(t *testing.T) {
 // when no search filter is active at aggregate level.
 func TestAggregateNoSearchFilterClearsContextStats(t *testing.T) {
 	model := newTestModelAtLevel(levelAggregates).
-		withAggregateRequestID(1).
+		withAggregateRequestID().
 		withContextStats(&query.TotalStats{MessageCount: 500}) // Stale stats
 
 	msg := dataLoadedMsg{
@@ -829,7 +829,7 @@ func TestAggregateNoSearchFilterClearsContextStats(t *testing.T) {
 func TestSubAggregateSearchFilterSetsContextStats(t *testing.T) {
 	model := newTestModelAtLevel(levelDrillDown).
 		withSearchQuery("important").
-		withAggregateRequestID(1)
+		withAggregateRequestID()
 
 	rows := []query.AggregateRow{
 		{Key: "work", Count: 30, TotalSize: 3000, AttachmentCount: 10},
@@ -1356,7 +1356,7 @@ func TestStaleLoadMessagesDoesNotOverwriteSearch(t *testing.T) {
 		messages:  allMessages,
 		requestID: staleLoadRequestID,
 	}
-	model, _ = sendMsg(t, model, staleMsg)
+	model = sendMsg(t, model, staleMsg)
 
 	// The stale response must be ignored — search results should remain.
 	requirepkg.Len(t, model.messages, 2, "stale loadMessages overwrote search results")
@@ -1383,7 +1383,7 @@ func TestSearchClearsStaleMessages(t *testing.T) {
 		debounceID: model.inlineSearchDebounce,
 	}
 	model.inlineSearchActive = true
-	model, _ = sendMsg(t, model, debounceMsg)
+	model = sendMsg(t, model, debounceMsg)
 
 	// Messages should be nil immediately — not showing stale results while
 	// waiting for the async search to complete.

--- a/internal/tui/selection_test.go
+++ b/internal/tui/selection_test.go
@@ -75,7 +75,7 @@ func TestSelectionClearedOnViewSwitch(t *testing.T) {
 		WithRows(makeRow("alice@example.com", 10)).
 		Build()
 
-	model = selectRow(t, model, 0)
+	model = selectRow(t, model)
 	assertSelectionCount(t, model, 1)
 
 	// Switch view with Tab
@@ -90,7 +90,7 @@ func TestSelectionClearedOnShiftTab(t *testing.T) {
 		WithRows(makeRow("alice@example.com", 10)).
 		Build()
 
-	model = selectRow(t, model, 0)
+	model = selectRow(t, model)
 
 	// Switch view with Shift+Tab
 	model = applyAggregateKey(t, model, keyShiftTab())
@@ -103,7 +103,7 @@ func TestClearSelection(t *testing.T) {
 		WithRows(makeRow("alice@example.com", 10)).
 		Build()
 
-	model = selectRow(t, model, 0)
+	model = selectRow(t, model)
 	assertSelectionCount(t, model, 1)
 
 	// Clear with 'x'
@@ -118,7 +118,7 @@ func TestStageForDeletionWithAggregateSelection(t *testing.T) {
 		WithGmailIDs("msg1", "msg2").
 		Build()
 
-	model = selectRow(t, model, 0)
+	model = selectRow(t, model)
 	model, _ = sendKey(t, model, key('D'))
 
 	assertModal(t, model, modalDeleteConfirm)
@@ -175,7 +175,7 @@ func TestStageForDeletion(t *testing.T) {
 			}
 
 			model := b.Build()
-			model = selectRow(t, model, 0)
+			model = selectRow(t, model)
 
 			newModel, _ := model.stageForDeletion()
 			model = newModel.(Model)

--- a/internal/tui/setup_test.go
+++ b/internal/tui/setup_test.go
@@ -342,10 +342,10 @@ func sendKey(t *testing.T, m Model, k tea.KeyMsg) (Model, tea.Cmd) {
 }
 
 // sendMsg sends any tea.Msg through Update and returns the concrete Model.
-func sendMsg(t *testing.T, m Model, msg tea.Msg) (Model, tea.Cmd) {
+func sendMsg(t *testing.T, m Model, msg tea.Msg) Model {
 	t.Helper()
-	newM, cmd := m.Update(msg)
-	return newM.(Model), cmd
+	newM, _ := m.Update(msg)
+	return newM.(Model)
 }
 
 // assertModal checks that the model is in the expected modal state
@@ -464,8 +464,8 @@ func (m Model) withSearchQuery(q string) Model {
 }
 
 // withRequestID sets the aggregate request ID for testing stale response handling.
-func (m Model) withAggregateRequestID(id uint64) Model {
-	m.aggregateRequestID = id
+func (m Model) withAggregateRequestID() Model {
+	m.aggregateRequestID = 1
 	return m
 }
 
@@ -549,8 +549,9 @@ func makeRow(key string, count int) query.AggregateRow {
 	return query.AggregateRow{Key: key, Count: int64(count)}
 }
 
-// makeRows creates n AggregateRows with sequential keys ("row-0", "row-1", ...).
-func makeRows(n int) []query.AggregateRow {
+// makeRows creates 10 AggregateRows with sequential keys ("row-0", "row-1", ...).
+func makeRows() []query.AggregateRow {
+	const n = 10
 	rows := make([]query.AggregateRow, n)
 	for i := range rows {
 		rows[i] = query.AggregateRow{
@@ -595,10 +596,10 @@ func assertSelectionCount(t *testing.T, m Model, expected int) {
 // Key Application Helpers - remove handleXKeys casting boilerplate
 // -----------------------------------------------------------------------------
 
-// selectRow moves the cursor to the given index and toggles selection with space.
-func selectRow(t *testing.T, m Model, index int) Model {
+// selectRow moves the cursor to the first row and toggles selection with space.
+func selectRow(t *testing.T, m Model) Model {
 	t.Helper()
-	m.cursor = index
+	m.cursor = 0
 	return applyAggregateKey(t, m, key(' '))
 }
 

--- a/internal/tui/text_keys.go
+++ b/internal/tui/text_keys.go
@@ -62,10 +62,10 @@ func (m Model) handleTextListKeys(
 		m.loading = true
 		return m, m.loadTextData()
 
-	case "enter":
+	case keyNameEnter:
 		return m.textDrillDown()
 
-	case "esc", "backspace":
+	case keyNameEsc, "backspace":
 		return m.textGoBack()
 
 	case "s":
@@ -132,7 +132,7 @@ func (m Model) handleTextTimelineKeys(
 		m.searchInput.Focus()
 		return m, nil
 
-	case "esc", "backspace":
+	case keyNameEsc, "backspace":
 		return m.textGoBack()
 
 	case "j", "down":
@@ -191,7 +191,7 @@ func (m Model) handleTextInlineSearchKeys(
 	msg tea.KeyMsg,
 ) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "enter":
+	case keyNameEnter:
 		m.exitInlineSearchMode()
 		queryStr := m.searchInput.Value()
 		if queryStr == "" {
@@ -253,7 +253,7 @@ func (m Model) handleTextInlineSearchKeys(
 		m.loading = true
 		return m, m.loadTextSearch(queryStr)
 
-	case "esc":
+	case keyNameEsc:
 		m.exitInlineSearchMode()
 		m.searchInput.SetValue("")
 		return m, nil

--- a/internal/tui/view_render_test.go
+++ b/internal/tui/view_render_test.go
@@ -477,8 +477,8 @@ func TestViewFitsTerminalHeightStartupSequence(t *testing.T) {
 	lines2 := strings.Split(view2, "\n")
 	actualLines2 := countViewLines(view2)
 	t.Logf("Stage 2 (after resize, loading=true, no data): lines=%d, pageSize=%d", actualLines2, model.pageSize)
-	t.Logf("  First line: %q", truncateTestString(lines2[0], 60))
-	t.Logf("  Last line: %q", truncateTestString(lines2[actualLines2-1], 60))
+	t.Logf("  First line: %q", truncateTestString(lines2[0]))
+	t.Logf("  Last line: %q", truncateTestString(lines2[actualLines2-1]))
 
 	assert.Equal(terminalHeight, actualLines2, "Stage 2: loading, no data")
 
@@ -502,7 +502,7 @@ func TestViewFitsTerminalHeightStartupSequence(t *testing.T) {
 	lines4 := strings.Split(view4, "\n")
 	actualLines4 := countViewLines(view4)
 	t.Logf("Stage 4 (data loaded): lines=%d", actualLines4)
-	t.Logf("  First line: %q", truncateTestString(lines4[0], 60))
+	t.Logf("  First line: %q", truncateTestString(lines4[0]))
 
 	assert.Equal(terminalHeight, actualLines4, "Stage 4: data loaded")
 
@@ -512,8 +512,9 @@ func TestViewFitsTerminalHeightStartupSequence(t *testing.T) {
 	}
 }
 
-// truncateTestString truncates a string for test output display.
-func truncateTestString(s string, max int) string {
+// truncateTestString truncates a string to 60 characters for test output display.
+func truncateTestString(s string) string {
+	const max = 60
 	if len(s) <= max {
 		return s
 	}
@@ -550,7 +551,7 @@ func TestViewFitsTerminalHeightWithBadData(t *testing.T) {
 		// Log the problematic lines for debugging
 		for i, line := range lines {
 			if i >= terminalHeight {
-				t.Logf("  Extra line %d: %q", i, truncateTestString(line, 60))
+				t.Logf("  Extra line %d: %q", i, truncateTestString(line))
 			}
 		}
 	}
@@ -657,7 +658,7 @@ func TestHeaderLineFitsWidth(t *testing.T) {
 	// Check that no line exceeds terminal width
 	for i, line := range lines[:min(5, len(lines))] {
 		lineWidth := lipgloss.Width(line)
-		assertpkg.LessOrEqual(t, lineWidth, terminalWidth, "Line %d: %q", i, truncateTestString(line, 60))
+		assertpkg.LessOrEqual(t, lineWidth, terminalWidth, "Line %d: %q", i, truncateTestString(line))
 	}
 }
 

--- a/internal/whatsapp/importer.go
+++ b/internal/whatsapp/importer.go
@@ -434,7 +434,7 @@ func (imp *Importer) Import(ctx context.Context, waDBPath string, opts ImportOpt
 				// Handle reactions.
 				if reactions, ok := reactionMap[waMsg.RowID]; ok {
 					for _, r := range reactions {
-						reactionType, reactionValue := mapReaction(r)
+						reactionValue := mapReaction(r)
 						if reactionValue == "" {
 							continue
 						}
@@ -469,7 +469,7 @@ func (imp *Importer) Import(ctx context.Context, waDBPath string, opts ImportOpt
 						}
 
 						createdAt := time.Unix(r.Timestamp/1000, 0)
-						if err := imp.store.UpsertReaction(messageID, reactorID, reactionType, reactionValue, createdAt); err != nil {
+						if err := imp.store.UpsertReaction(messageID, reactorID, reactionTypeEmoji, reactionValue, createdAt); err != nil {
 							summary.Errors++
 							imp.progress.OnError(fmt.Errorf("upsert reaction: %w", err))
 						} else {

--- a/internal/whatsapp/mapping.go
+++ b/internal/whatsapp/mapping.go
@@ -176,12 +176,17 @@ func resolveLidSender(jidRowID sql.NullInt64, server string, lidMap map[int64]wa
 	return normalizePhone(mapping.PhoneUser, mapping.PhoneServer)
 }
 
-// mapReaction maps a WhatsApp reaction to reaction_type and reaction_value.
-func mapReaction(r waReaction) (reactionType, reactionValue string) {
+// reactionTypeEmoji is the only reaction_type WhatsApp exports; every
+// reaction is an emoji.
+const reactionTypeEmoji = "emoji"
+
+// mapReaction returns the reaction_value for a WhatsApp reaction. The
+// reaction_type is always reactionTypeEmoji, so callers supply it directly.
+func mapReaction(r waReaction) (reactionValue string) {
 	if r.ReactionValue.Valid && r.ReactionValue.String != "" {
-		return "emoji", r.ReactionValue.String
+		return r.ReactionValue.String
 	}
-	return "emoji", ""
+	return ""
 }
 
 // mapGroupRole maps a WhatsApp admin level to a conversation participant role.

--- a/internal/whatsapp/mapping_test.go
+++ b/internal/whatsapp/mapping_test.go
@@ -208,15 +208,15 @@ func TestMapReaction(t *testing.T) {
 	r := waReaction{
 		ReactionValue: sql.NullString{String: "❤️", Valid: true},
 	}
-	typ, val := mapReaction(r)
-	assertpkg.Equal(t, "emoji", typ, "reaction type")
+	val := mapReaction(r)
+	assertpkg.Equal(t, "emoji", reactionTypeEmoji, "reaction type")
 	assertpkg.Equal(t, "❤️", val, "reaction value")
 
 	// Empty reaction.
 	empty := waReaction{
 		ReactionValue: sql.NullString{},
 	}
-	_, val = mapReaction(empty)
+	val = mapReaction(empty)
 	assertpkg.Empty(t, val, "empty reaction value")
 }
 

--- a/tools/testifyhelpercheck/analyzer.go
+++ b/tools/testifyhelpercheck/analyzer.go
@@ -29,7 +29,7 @@ func run(pass *analysis.Pass) (any, error) {
 			if !ok || !isTestFuncDecl(fn, imports.testing) {
 				continue
 			}
-			analyzeBody(pass, fn.Body, fn.Type.Params.List[0].Names[0].Name, imports)
+			analyzeBody(pass, fn.Body, fn.Type.Params.List[0].Names[0].Name)
 		}
 
 		ast.Inspect(file, func(n ast.Node) bool {
@@ -38,7 +38,7 @@ func run(pass *analysis.Pass) (any, error) {
 				return true
 			}
 			paramName := lit.Type.Params.List[0].Names[0].Name
-			analyzeBody(pass, lit.Body, paramName, imports)
+			analyzeBody(pass, lit.Body, paramName)
 			return false
 		})
 	}
@@ -108,7 +108,7 @@ func isTestingT(expr ast.Expr, testingImports map[string]struct{}) bool {
 	return ok
 }
 
-func analyzeBody(pass *analysis.Pass, body *ast.BlockStmt, tName string, imports importSet) {
+func analyzeBody(pass *analysis.Pass, body *ast.BlockStmt, tName string) {
 	if body == nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- Re-enables `goconst` and `unparam` in golangci-lint.
- `goconst`: lifts repeated literals (source-type strings, SQL table names, OAuth scopes, TUI key names) into named constants.
- `unparam`: drops unused and constant-valued parameters and always-nil error returns; a few text-output helpers keep their nil-error return behind a scoped `//nolint:unparam` to stay symmetric with their JSON-emitting siblings.