### PR TITLE
lint: enable wrapcheck and nilnil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,9 +54,6 @@ linters:
     - wrapcheck        # %w wrapping at every external-package boundary (~29)
     - noctx            # ~130 DB calls (mostly tests + ctx-less constructors)
                        # need *Context variants; a dedicated sweep, not standup
-    - nilnil           # (nil, nil) is the idiomatic not-found / empty-input /
-                       # mock-stub signal across store getters, query mocks, and
-                       # the updater; a sentinel-error sweep is its own pass
     - sqlclosecheck    # batch loops close rows explicitly per-iteration (defer
                        # would leak across chunks); satisfying it cleanly needs
                        # per-query helper extraction — a dedicated refactor
@@ -163,12 +160,6 @@ linters:
       - linters: [staticcheck]
         path: _test\.go
         text: "SA5011"
-
-      # store getters use the idiomatic (nil, nil) signal for not-found rows
-      # (sql.ErrNoRows) and for empty-input batch helpers; callers branch on
-      # the nil result. A sentinel error here would only add caller noise.
-      - linters: [nilnil]
-        path: internal/store/(api|sync)\.go
 
       # Test suites are exempted from the linter sweep in this standup. The
       # codebase just migrated to testify (#345); holding the freshly-rewritten

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
     # Follow-up work — these surface real refactors that don't belong in the
     # standup PR. Re-enable in dedicated passes.
     - contextcheck     # ctx threading through call chains (~50 findings)
-    - wrapcheck        # %w wrapping at every external-package boundary (~29)
     - noctx            # ~130 DB calls (mostly tests + ctx-less constructors)
                        # need *Context variants; a dedicated sweep, not standup
     - sqlclosecheck    # batch loops close rows explicitly per-iteration (defer

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -21,6 +21,12 @@ var (
 // addAccountUse is the usage string for the add-account command.
 const addAccountUse = "add-account <email>"
 
+// errGmailSourceNotFound is returned by findGmailSource when no Gmail
+// source is registered for the given identifier. Wrapped via fmt.Errorf
+// so callers can use errors.Is to tell "no such account" apart from real
+// lookup errors.
+var errGmailSourceNotFound = errors.New("gmail source not found")
+
 var addAccountCmd = &cobra.Command{
 	Use:   addAccountUse,
 	Short: "Add a Gmail account via OAuth",
@@ -71,7 +77,7 @@ Examples:
 
 		// Look up existing source to detect binding changes
 		existingSource, err := findGmailSource(s, email)
-		if err != nil {
+		if err != nil && !errors.Is(err, errGmailSourceNotFound) {
 			return fmt.Errorf("look up existing source: %w", err)
 		}
 
@@ -123,7 +129,7 @@ Examples:
 				var mismatch *oauth.TokenMismatchError
 				if errors.As(saErr, &mismatch) {
 					existing, lookupErr := findGmailSource(s, email)
-					if lookupErr != nil {
+					if lookupErr != nil && !errors.Is(lookupErr, errGmailSourceNotFound) {
 						return fmt.Errorf("service account validation failed: %w (also: %w)", saErr, lookupErr)
 					}
 					if existing == nil {
@@ -253,7 +259,7 @@ Examples:
 			var mismatch *oauth.TokenMismatchError
 			if errors.As(err, &mismatch) {
 				existing, lookupErr := findGmailSource(s, email)
-				if lookupErr != nil {
+				if lookupErr != nil && !errors.Is(lookupErr, errGmailSourceNotFound) {
 					return fmt.Errorf("authorization failed: %w (also: %w)", err, lookupErr)
 				}
 				if existing == nil {
@@ -319,7 +325,7 @@ func findGmailSource(
 			return src, nil
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("identifier %q: %w", email, errGmailSourceNotFound)
 }
 
 func init() {

--- a/cmd/msgvault/cmd/addaccount_test.go
+++ b/cmd/msgvault/cmd/addaccount_test.go
@@ -30,14 +30,14 @@ func TestFindGmailSource(t *testing.T) {
 
 	// No sources at all — should suggest add-account.
 	src, err := findGmailSource(s, email)
-	require.NoError(err, "findGmailSource")
+	require.ErrorIs(err, errGmailSourceNotFound, "findGmailSource")
 	assert.Nil(src, "expected nil with no sources")
 
 	// Non-Gmail source exists — should still suggest add-account.
 	_, err = s.GetOrCreateSource("mbox", email)
 	require.NoError(err, "create mbox source")
 	src, err = findGmailSource(s, email)
-	require.NoError(err, "findGmailSource")
+	require.ErrorIs(err, errGmailSourceNotFound, "findGmailSource")
 	assert.Nil(src, "expected nil with only mbox source")
 
 	// Gmail source exists — should suppress the hint.

--- a/cmd/msgvault/cmd/import_mbox.go
+++ b/cmd/msgvault/cmd/import_mbox.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -130,7 +131,7 @@ Examples:
 				return fmt.Errorf("get/create source: %w", err)
 			}
 			active, err := st.GetActiveSync(src.ID)
-			if err != nil {
+			if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 				return fmt.Errorf("check active sync: %w", err)
 			}
 			if active != nil && active.CursorBefore.Valid && active.CursorBefore.String != "" {
@@ -175,7 +176,7 @@ Examples:
 				// sync run. This avoids rescanning already-finished files when a
 				// multi-file import is interrupted between files.
 				last, err := st.GetLastSuccessfulSync(src.ID)
-				if err != nil {
+				if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 					return fmt.Errorf("check last successful sync: %w", err)
 				}
 				if last != nil && last.CursorBefore.Valid && last.CursorBefore.String != "" {

--- a/cmd/msgvault/cmd/logs.go
+++ b/cmd/msgvault/cmd/logs.go
@@ -280,7 +280,7 @@ func followLogFile(
 			}
 		}
 		if err != nil && err != io.EOF {
-			return err
+			return fmt.Errorf("read log line: %w", err)
 		}
 		select {
 		case <-ctx.Done():

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -83,7 +83,7 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 	}
 
 	activeSync, err := s.GetActiveSync(source.ID)
-	if err != nil {
+	if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 		return fmt.Errorf("check active sync: %w", err)
 	}
 	if activeSync != nil && !yes {

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -154,7 +154,7 @@ func TestRemoveAccountCmd_SkipsDeletionDuringActiveSync(t *testing.T) {
 	defer func() { _ = s2.Close() }()
 	require.NoError(s2.InitSchema(), "reinit schema")
 	src, err := s2.GetSourceByIdentifier("alice@example.com")
-	require.NoError(err, "GetSourceByIdentifier")
+	require.ErrorIs(err, store.ErrSourceNotFound, "GetSourceByIdentifier")
 	assert.Nil(src, "source should have been removed from DB despite skipped file deletion")
 }
 
@@ -311,7 +311,7 @@ func TestRemoveAccountCmd_WithYesFlag(t *testing.T) {
 	require.NoError(s.InitSchema(), "reinit schema")
 
 	src, err := s.GetSourceByIdentifier("test@example.com")
-	require.NoError(err, "GetSourceByIdentifier")
+	require.ErrorIs(err, store.ErrSourceNotFound, "GetSourceByIdentifier")
 	assertpkg.Nil(t, src, "account should be removed after --yes")
 }
 

--- a/cmd/msgvault/cmd/root.go
+++ b/cmd/msgvault/cmd/root.go
@@ -275,7 +275,10 @@ func ExecuteContext(ctx context.Context) error {
 			logger.Info("msgvault exit", "outcome", "ok")
 		}
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("execute command: %w", err)
+	}
+	return nil
 }
 
 // usageErr re-enables the usage block for cmd and returns err. Use inside

--- a/cmd/msgvault/cmd/serve_vector.go
+++ b/cmd/msgvault/cmd/serve_vector.go
@@ -24,7 +24,7 @@ import (
 // connection.
 func setupVectorFeatures(ctx context.Context, mainDB *sql.DB, mainPath string) (*vectorFeatures, error) {
 	if !cfg.Vector.Enabled {
-		return nil, nil
+		return nil, nil //nolint:nilnil // vector disabled: callers nil-check vf; (nil, nil) means "no features, no error"
 	}
 	// The vector backend uses sqlite-vec extension and `ATTACH DATABASE`
 	// to fuse vectors.db onto the main store — both SQLite-only. Refuse

--- a/cmd/msgvault/cmd/serve_vector_stub.go
+++ b/cmd/msgvault/cmd/serve_vector_stub.go
@@ -16,7 +16,7 @@ import (
 // without -tags sqlite_vec.
 func setupVectorFeatures(_ context.Context, _ *sql.DB, mainPath string) (*vectorFeatures, error) {
 	if !cfg.Vector.Enabled {
-		return nil, nil
+		return nil, nil //nolint:nilnil // vector disabled: callers nil-check vf; (nil, nil) means "no features, no error"
 	}
 	// Mirror the PG refusal in the sqlite_vec build so users get the
 	// same actionable message regardless of how the binary was built.

--- a/cmd/msgvault/cmd/setup.go
+++ b/cmd/msgvault/cmd/setup.go
@@ -229,7 +229,7 @@ func setupRemoteServer(reader *bufio.Reader, oauthSecretsPath string) (string, s
 func generateAPIKey() (string, error) {
 	bytes := make([]byte, 32)
 	if _, err := rand.Read(bytes); err != nil {
-		return "", err
+		return "", fmt.Errorf("read random bytes for API key: %w", err)
 	}
 	return hex.EncodeToString(bytes), nil
 }

--- a/cmd/msgvault/cmd/show_message.go
+++ b/cmd/msgvault/cmd/show_message.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -59,11 +60,11 @@ func showRemoteMessage(cmd *cobra.Command, idStr string) error {
 	defer func() { _ = s.Close() }()
 
 	msg, err := s.GetMessage(id)
+	if errors.Is(err, store.ErrMessageNotFound) {
+		return fmt.Errorf("message not found: %s", idStr)
+	}
 	if err != nil {
 		return fmt.Errorf("get message: %w", err)
-	}
-	if msg == nil {
-		return fmt.Errorf("message not found: %s", idStr)
 	}
 
 	if showMessageJSON {

--- a/cmd/msgvault/cmd/update_account.go
+++ b/cmd/msgvault/cmd/update_account.go
@@ -43,11 +43,11 @@ Examples:
 		}
 
 		source, err := s.GetSourceByIdentifier(email)
+		if errors.Is(err, store.ErrSourceNotFound) {
+			return fmt.Errorf("account not found: %s", email)
+		}
 		if err != nil {
 			return fmt.Errorf("get account: %w", err)
-		}
-		if source == nil {
-			return fmt.Errorf("account not found: %s", email)
 		}
 
 		if err := s.UpdateSourceDisplayName(source.ID, updateDisplayName); err != nil {

--- a/cmd/msgvault/cmd/verify.go
+++ b/cmd/msgvault/cmd/verify.go
@@ -99,7 +99,7 @@ Examples:
 		// Look up source to get OAuth app binding
 		appName := ""
 		src, srcErr := findGmailSource(s, email)
-		if srcErr != nil {
+		if srcErr != nil && !errors.Is(srcErr, errGmailSourceNotFound) {
 			return fmt.Errorf("look up source for %s: %w", email, srcErr)
 		}
 		if src != nil {
@@ -171,7 +171,7 @@ Examples:
 		// specifically since the same identifier may exist for
 		// other source types (mbox, imap).
 		source, err := findGmailSource(s, email)
-		if err != nil {
+		if err != nil && !errors.Is(err, errGmailSourceNotFound) {
 			return fmt.Errorf("get source: %w", err)
 		}
 		if source == nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -377,13 +377,13 @@ func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	msg, err := s.store.GetMessage(id)
+	if errors.Is(err, store.ErrMessageNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "Message not found")
+		return
+	}
 	if err != nil {
 		s.logger.Error("failed to get message", "id", id, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to retrieve message")
-		return
-	}
-	if msg == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Message not found")
 		return
 	}
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -14,6 +14,7 @@ import (
 	requirepkg "github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 // testLogger returns a logger for tests that discards output
@@ -94,7 +95,7 @@ func (m *mockStore) GetMessage(id int64) (*APIMessage, error) {
 			return &msg, nil
 		}
 	}
-	return nil, nil
+	return nil, store.ErrMessageNotFound
 }
 
 func (m *mockStore) GetMessagesSummariesByIDs(ids []int64) ([]APIMessage, error) {

--- a/internal/applemail/accounts.go
+++ b/internal/applemail/accounts.go
@@ -51,7 +51,7 @@ func DefaultAccountsDBPath() string {
 // GUID → AccountInfo for each GUID that was found.
 func ResolveAccounts(dbPath string, guids []string) (map[string]AccountInfo, error) {
 	if len(guids) == 0 {
-		return nil, nil
+		return map[string]AccountInfo{}, nil
 	}
 
 	db, err := sql.Open("sqlite3", dbPath+"?mode=ro")

--- a/internal/fbmessenger/importer.go
+++ b/internal/fbmessenger/importer.go
@@ -151,12 +151,12 @@ func ImportDYI(ctx context.Context, st *store.Store, opts ImportOptions) (*Impor
 		// then fall back to the latest checkpointed run (which includes
 		// failed/interrupted runs whose checkpoint is still valid).
 		prev, err := st.GetActiveSync(source.ID)
-		if err != nil {
+		if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 			return nil, fmt.Errorf("fbmessenger: check active sync: %w", err)
 		}
 		if prev == nil || !prev.CursorBefore.Valid || prev.CursorBefore.String == "" {
 			prev, err = st.GetLatestCheckpointedSync(source.ID)
-			if err != nil {
+			if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 				return nil, fmt.Errorf("fbmessenger: check checkpointed sync: %w", err)
 			}
 		}

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -262,10 +262,18 @@ type rawMessageResponse struct {
 func decodeBase64URL(s string) ([]byte, error) {
 	if strings.ContainsRune(s, '=') {
 		// Input has padding - use URLEncoding which validates padding correctness
-		return base64.URLEncoding.DecodeString(s)
+		decoded, err := base64.URLEncoding.DecodeString(s)
+		if err != nil {
+			return nil, fmt.Errorf("decode padded base64url: %w", err)
+		}
+		return decoded, nil
 	}
 	// No padding - use RawURLEncoding for unpadded base64url
-	return base64.RawURLEncoding.DecodeString(s)
+	decoded, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("decode unpadded base64url: %w", err)
+	}
+	return decoded, nil
 }
 
 type historyMessageChange struct {
@@ -462,7 +470,7 @@ func (c *Client) GetMessagesRawBatch(ctx context.Context, messageIDs []string) (
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetch messages concurrently: %w", err)
 	}
 
 	return results, nil

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -308,10 +308,10 @@ func (c *Client) enumerateMailbox(
 				nil,
 			).Wait()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("UID SEARCH after reconnect in mailbox %q: %w", mailbox, err)
 			}
 		} else {
-			return nil, err
+			return nil, fmt.Errorf("UID SEARCH in mailbox %q: %w", mailbox, err)
 		}
 	}
 
@@ -939,5 +939,8 @@ func (c *Client) Close() error {
 	conn := c.conn
 	c.conn = nil
 	c.selectedMailbox = ""
-	return conn.Logout().Wait()
+	if err := conn.Logout().Wait(); err != nil {
+		return fmt.Errorf("IMAP logout: %w", err)
+	}
+	return nil
 }

--- a/internal/importer/emlx_import.go
+++ b/internal/importer/emlx_import.go
@@ -145,7 +145,7 @@ func ImportEmlxDir(
 
 	if !opts.NoResume {
 		active, err := st.GetActiveSync(src.ID)
-		if err != nil {
+		if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 			return nil, fmt.Errorf("check active sync: %w", err)
 		}
 		if active != nil {

--- a/internal/importer/mbox_import.go
+++ b/internal/importer/mbox_import.go
@@ -135,7 +135,7 @@ func ImportMbox(ctx context.Context, st *store.Store, mboxPath string, opts Mbox
 
 	if !opts.NoResume {
 		active, err := st.GetActiveSync(src.ID)
-		if err != nil {
+		if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 			return nil, fmt.Errorf("check active sync: %w", err)
 		}
 		if active != nil {

--- a/internal/importer/mbox_import_test.go
+++ b/internal/importer/mbox_import_test.go
@@ -825,7 +825,10 @@ func (h *cancelOnLogMessageHandler) Handle(ctx context.Context, r slog.Record) e
 	if r.Message == h.msg {
 		h.cancel()
 	}
-	return h.next.Handle(ctx, r)
+	if err := h.next.Handle(ctx, r); err != nil {
+		return fmt.Errorf("delegate slog handler: %w", err)
+	}
+	return nil
 }
 
 func (h *cancelOnLogMessageHandler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/internal/importer/pst_import.go
+++ b/internal/importer/pst_import.go
@@ -174,7 +174,7 @@ func ImportPst(ctx context.Context, st *store.Store, pstPath string, opts PstImp
 
 	if !opts.NoResume {
 		active, err := st.GetActiveSync(src.ID)
-		if err != nil {
+		if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 			return nil, fmt.Errorf("check active sync: %w", err)
 		}
 		if active != nil {

--- a/internal/mbox/reader.go
+++ b/internal/mbox/reader.go
@@ -209,9 +209,9 @@ func (r *Reader) readLineBytes() ([]byte, error) {
 			return out, io.EOF
 		}
 		if len(out) > 0 {
-			return out, err
+			return out, fmt.Errorf("read mbox line: %w", err)
 		}
-		return nil, err
+		return nil, fmt.Errorf("read mbox line: %w", err)
 	}
 }
 
@@ -265,7 +265,7 @@ func Validate(r io.Reader, maxBytes int64) error {
 			if err == io.EOF {
 				return errors.New("no \"From \" separators found (not an mbox file?)")
 			}
-			return err
+			return fmt.Errorf("read mbox line: %w", err)
 		}
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -140,7 +140,10 @@ func Serve(ctx context.Context, engine query.Engine, attachmentsDir, dataDir str
 func ServeWithOptions(ctx context.Context, opts ServeOptions) error {
 	s := newMCPServer(opts)
 	stdio := server.NewStdioServer(s)
-	return stdio.Listen(ctx, os.Stdin, os.Stdout)
+	if err := stdio.Listen(ctx, os.Stdin, os.Stdout); err != nil {
+		return fmt.Errorf("serve MCP over stdio: %w", err)
+	}
+	return nil
 }
 
 // ServeHTTPWithOptions creates an MCP server from opts and serves over

--- a/internal/microsoft/oauth.go
+++ b/internal/microsoft/oauth.go
@@ -460,7 +460,10 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 		token, err := cfg.Exchange(ctx, code,
 			oauth2.SetAuthURLParam("code_verifier", verifier),
 		)
-		return token, nonce, err
+		if err != nil {
+			return nil, "", fmt.Errorf("exchange authorization code: %w", err)
+		}
+		return token, nonce, nil
 	case err := <-errChan:
 		return nil, "", err
 	case <-ctx.Done():
@@ -782,5 +785,8 @@ func openBrowser(ctx context.Context, rawURL string) error {
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start browser command: %w", err)
+	}
+	return nil
 }

--- a/internal/microsoft/oauth_test.go
+++ b/internal/microsoft/oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -177,7 +178,7 @@ func testVerifyFn(_ context.Context, rawIDToken string) (*idTokenClaims, error) 
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode JWT payload: %w", err)
 	}
 	var raw struct {
 		Email             string `json:"email"`

--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"html"
 	"regexp"
 	"strings"
@@ -53,7 +54,7 @@ type Attachment struct {
 func Parse(raw []byte) (*Message, error) {
 	env, err := enmime.ReadEnvelope(bytes.NewReader(raw))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read MIME envelope: %w", err)
 	}
 
 	msg := &Message{

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -294,7 +294,11 @@ func (m *Manager) browserFlow(
 	// Wait for callback
 	select {
 	case code := <-codeChan:
-		return m.config.Exchange(ctx, code)
+		token, err := m.config.Exchange(ctx, code)
+		if err != nil {
+			return nil, fmt.Errorf("exchange authorization code: %w", err)
+		}
+		return token, nil
 	case err := <-errChan:
 		return nil, err
 	case <-ctx.Done():
@@ -600,7 +604,10 @@ func openBrowser(ctx context.Context, rawURL string) error {
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
 
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start browser command: %w", err)
+	}
+	return nil
 }
 
 // NewManagerWithScopes creates an OAuth manager with custom scopes.
@@ -648,7 +655,7 @@ func parseClientSecrets(data []byte, scopes []string) (*oauth2.Config, error) {
 				return nil, errors.New("OAuth client is missing redirect_uris (TV/device clients are not supported - Gmail doesn't work with device flow). Please create a 'Desktop application' or 'Web application' OAuth client in Google Cloud Console")
 			}
 		}
-		return nil, err
+		return nil, fmt.Errorf("parse OAuth client secrets: %w", err)
 	}
 	return config, nil
 }

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -112,9 +112,9 @@ func (m *MockEngine) GetMessageBySourceID(ctx context.Context, sourceID string) 
 		if msg, ok := m.MessagesBySourceID[sourceID]; ok {
 			return msg, nil
 		}
-		return nil, nil
+		return nil, nil //nolint:nilnil // mirrors Engine.GetMessageBySourceID (nil, nil) not-found contract
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // mirrors Engine.GetMessageBySourceID (nil, nil) not-found contract
 }
 
 func (m *MockEngine) GetAttachment(_ context.Context, id int64) (*query.AttachmentInfo, error) {
@@ -123,7 +123,7 @@ func (m *MockEngine) GetAttachment(_ context.Context, id int64) (*query.Attachme
 			return a, nil
 		}
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // mirrors Engine.GetAttachment (nil, nil) not-found contract
 }
 
 func (m *MockEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
@@ -196,7 +196,7 @@ func (m *MockEngine) GetTotalStats(ctx context.Context, opts query.StatsOptions)
 	if m.Stats != nil {
 		return m.Stats, nil
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // mock stub: no stats configured, no error
 }
 
 func (m *MockEngine) Close() error { return nil }

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -278,7 +278,7 @@ func extractBodyFromRawShared(ctx context.Context, db *sql.DB, rebind rebindFunc
 	if compression.Valid && compression.String == "zlib" {
 		r, err := zlib.NewReader(bytes.NewReader(compressed))
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("open zlib reader for raw message: %w", err)
 		}
 		defer func() { _ = r.Close() }()
 		rawData, err = io.ReadAll(r)
@@ -376,7 +376,7 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, rebind rebindFunc,
 		&deletedAt,
 	)
 	if err == sql.ErrNoRows {
-		return nil, nil
+		return nil, nil //nolint:nilnil // Engine.GetMessage/GetMessageBySourceID use (nil, nil) for not-found; callers chain fallback lookups on the nil result
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get message: %w", err)

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -888,7 +888,7 @@ func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 		WHERE id = ?
 	`, id).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash)
 	if err == sql.ErrNoRows {
-		return nil, nil
+		return nil, nil //nolint:nilnil // Engine.GetAttachment uses (nil, nil) for not-found; callers branch on the nil result
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get attachment: %w", err)

--- a/internal/remote/engine.go
+++ b/internal/remote/engine.go
@@ -15,6 +15,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 // ErrNotSupported is returned for operations not available in remote mode.
@@ -479,11 +480,11 @@ func (e *Engine) ListMessages(ctx context.Context, filter query.MessageFilter) (
 // GetMessage returns a single message by ID.
 func (e *Engine) GetMessage(ctx context.Context, id int64) (*query.MessageDetail, error) {
 	msg, err := e.store.GetMessage(id)
+	if errors.Is(err, store.ErrMessageNotFound) {
+		return nil, nil //nolint:nilnil // engine API uses (nil, nil) for not-found
+	}
 	if err != nil {
 		return nil, err
-	}
-	if msg == nil {
-		return nil, nil //nolint:nilnil // engine API uses (nil, nil) for not-found
 	}
 
 	// Convert store.APIMessage to query.MessageDetail

--- a/internal/remote/store.go
+++ b/internal/remote/store.go
@@ -281,7 +281,7 @@ func (s *Store) GetMessage(id int64) (*store.APIMessage, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, nil //nolint:nilnil // store API uses (nil, nil) for not-found; mirrors local Store
+		return nil, fmt.Errorf("message %d: %w", id, store.ErrMessageNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, handleErrorResponse(resp)

--- a/internal/remote/store_test.go
+++ b/internal/remote/store_test.go
@@ -9,6 +9,8 @@ import (
 
 	assertpkg "github.com/stretchr/testify/assert"
 	requirepkg "github.com/stretchr/testify/require"
+
+	"go.kenn.io/msgvault/internal/store"
 )
 
 func TestNew_RejectsHTTPWithoutAllowInsecure(t *testing.T) {
@@ -189,7 +191,7 @@ func TestGetMessage_NotFound(t *testing.T) {
 
 	s := newTestStore(srv, "key")
 	msg, err := s.GetMessage(999)
-	requirepkg.NoError(t, err, "GetMessage error")
+	requirepkg.ErrorIs(t, err, store.ErrMessageNotFound, "GetMessage(999) should report not found")
 	assertpkg.Nil(t, msg, "GetMessage(999) should return nil for not found")
 }
 
@@ -358,17 +360,14 @@ func TestListAccounts_Success(t *testing.T) {
 	assertpkg.Equal(t, "user@gmail.com", accounts[0].Email, "Email")
 }
 
-// readCloser wraps a string in an io.ReadCloser.
+// readCloser wraps a string in an io.ReadCloser. The embedded *strings.Reader
+// promotes Read so io.EOF propagates verbatim to callers.
 func readCloser(s string) *readCloserImpl {
-	return &readCloserImpl{r: strings.NewReader(s)}
+	return &readCloserImpl{Reader: strings.NewReader(s)}
 }
 
 type readCloserImpl struct {
-	r *strings.Reader
-}
-
-func (rc *readCloserImpl) Read(p []byte) (int, error) {
-	return rc.r.Read(p)
+	*strings.Reader
 }
 
 func (rc *readCloserImpl) Close() error {

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -121,6 +121,11 @@ func (s *Store) ListMessages(offset, limit int) ([]APIMessage, int64, error) {
 	return messages, total, nil
 }
 
+// ErrMessageNotFound is returned by GetMessage when no message row
+// matches the given ID. Wrapped via fmt.Errorf("...: %w", ...) so
+// callers can use errors.Is to distinguish absence from real DB errors.
+var ErrMessageNotFound = errors.New("message not found")
+
 // GetMessage returns a single message with full details.
 // Only this method accesses message_bodies (single PK lookup).
 func (s *Store) GetMessage(id int64) (*APIMessage, error) {
@@ -150,7 +155,7 @@ func (s *Store) GetMessage(id int64) (*APIMessage, error) {
 	var sentAt, deletedAt nullableTimestamp
 	err := s.db.QueryRow(query, id).Scan(&m.ID, &m.ConversationID, &m.Subject, &m.MessageType, &m.From, &sentAt, &m.Snippet, &m.HasAttachments, &m.SizeEstimate, &deletedAt)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return nil, fmt.Errorf("message %d: %w", id, ErrMessageNotFound)
 	}
 	if err != nil {
 		return nil, err
@@ -749,7 +754,7 @@ func (s *Store) batchPopulate(messages []APIMessage, ids []int64) error {
 // batchGetRecipients loads recipients for multiple messages in a single query.
 func (s *Store) batchGetRecipients(messageIDs []int64, recipientType string) (map[int64][]string, error) {
 	if len(messageIDs) == 0 {
-		return nil, nil
+		return map[int64][]string{}, nil
 	}
 
 	placeholders := make([]string, len(messageIDs))
@@ -793,7 +798,7 @@ func (s *Store) batchGetRecipients(messageIDs []int64, recipientType string) (ma
 // batchGetLabels loads labels for multiple messages in a single query.
 func (s *Store) batchGetLabels(messageIDs []int64) (map[int64][]string, error) {
 	if len(messageIDs) == 0 {
-		return nil, nil
+		return map[int64][]string{}, nil
 	}
 
 	placeholders := make([]string, len(messageIDs))

--- a/internal/store/sources.go
+++ b/internal/store/sources.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 )
 
-// ErrSourceNotFound is returned by GetSourceByID when no source row
-// matches the given ID. Wrapped via fmt.Errorf("...: %w", ...) so
+// ErrSourceNotFound is returned by GetSourceByID and GetSourceByIdentifier
+// when no source row matches. Wrapped via fmt.Errorf("...: %w", ...) so
 // callers can use errors.Is to distinguish absence from real DB
 // errors.
 var ErrSourceNotFound = errors.New("source not found")

--- a/internal/store/sources_test.go
+++ b/internal/store/sources_test.go
@@ -67,7 +67,7 @@ func TestStore_RemoveSource(t *testing.T) {
 
 	// Verify source is gone
 	src, err := f.Store.GetSourceByIdentifier("test@example.com")
-	require.NoError(err, "GetSourceByIdentifier")
+	require.ErrorIs(err, store.ErrSourceNotFound, "GetSourceByIdentifier")
 	assert.Nil(src, "source should be nil after removal")
 
 	// Verify messages are gone
@@ -175,7 +175,7 @@ func TestStore_RemoveSourceSerialized_NoActiveSync(t *testing.T) {
 	assert.False(had, "hadActiveSync")
 
 	src, err := f.Store.GetSourceByIdentifier("test@example.com")
-	require.NoError(err, "GetSourceByIdentifier")
+	require.ErrorIs(err, store.ErrSourceNotFound, "GetSourceByIdentifier")
 	assert.Nil(src, "source should be removed")
 }
 
@@ -193,7 +193,7 @@ func TestStore_RemoveSourceSerialized_ActiveSyncSameSource(t *testing.T) {
 	assert.True(had, "hadActiveSync should be true for sync on removed source")
 
 	src, err := f.Store.GetSourceByIdentifier("test@example.com")
-	require.NoError(err, "GetSourceByIdentifier")
+	require.ErrorIs(err, store.ErrSourceNotFound, "GetSourceByIdentifier")
 	assert.Nil(src, "source should still be removed even when sync was active")
 }
 
@@ -214,7 +214,7 @@ func TestStore_RemoveSourceSerialized_ActiveSyncOtherSource(t *testing.T) {
 
 	// Original source is gone.
 	src, err := f.Store.GetSourceByIdentifier("test@example.com")
-	require.NoError(err, "GetSourceByIdentifier")
+	require.ErrorIs(err, store.ErrSourceNotFound, "GetSourceByIdentifier")
 	assert.Nil(src, "test source should be removed")
 
 	// Other source (with the active sync) is untouched.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -804,7 +804,7 @@ func TestStore_GetLastSuccessfulSync_None(t *testing.T) {
 
 	// No successful sync yet
 	lastSync, err := f.Store.GetLastSuccessfulSync(f.Source.ID)
-	requirepkg.NoError(t, err, "GetLastSuccessfulSync()")
+	requirepkg.ErrorIs(t, err, store.ErrSyncRunNotFound, "GetLastSuccessfulSync()")
 	assertpkg.Nil(t, lastSync, "expected nil last sync")
 }
 
@@ -812,7 +812,7 @@ func TestStore_GetSourceByIdentifier_NotFound(t *testing.T) {
 	f := storetest.New(t)
 
 	source, err := f.Store.GetSourceByIdentifier("nonexistent@example.com")
-	requirepkg.NoError(t, err, "GetSourceByIdentifier()")
+	requirepkg.ErrorIs(t, err, store.ErrSourceNotFound, "GetSourceByIdentifier()")
 	assertpkg.Nil(t, source, "expected nil source")
 }
 

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -15,6 +15,16 @@ const (
 	SyncStatusFailed    = "failed"
 )
 
+// ErrSyncRunNotFound is returned by the sync-run getters (GetActiveSync,
+// GetLatestCheckpointedSync, GetLastSuccessfulSync) when no matching run
+// exists. Wrapped via fmt.Errorf so callers can use errors.Is to tell
+// absence apart from real DB errors.
+var ErrSyncRunNotFound = errors.New("sync run not found")
+
+// ErrSourceImportItemNotFound is returned by GetSourceImportItem when no
+// import-item row matches. Wrapped via fmt.Errorf for errors.Is checks.
+var ErrSourceImportItemNotFound = errors.New("source import item not found")
+
 // dbTimeLayouts lists formats used by SQLite/go-sqlite3 for timestamp storage.
 // This matches the full set from SQLiteTimestampFormats in mattn/go-sqlite3,
 // plus RFC3339/RFC3339Nano as fallbacks for maximum compatibility.
@@ -290,7 +300,7 @@ func (s *Store) GetActiveSync(sourceID int64) (*SyncRun, error) {
 
 	run, err := scanSyncRun(row)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return nil, fmt.Errorf("active sync for source %d: %w", sourceID, ErrSyncRunNotFound)
 	}
 	return run, err
 }
@@ -314,7 +324,7 @@ func (s *Store) GetLatestCheckpointedSync(sourceID int64) (*SyncRun, error) {
 
 	run, err := scanSyncRun(row)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return nil, fmt.Errorf("latest checkpointed sync for source %d: %w", sourceID, ErrSyncRunNotFound)
 	}
 	return run, err
 }
@@ -358,7 +368,7 @@ func (s *Store) GetSourceImportItem(sourceID int64, provider, providerID string)
 		&item.Status, &item.RecordsImported, &item.ErrorMessage,
 	)
 	if err == sql.ErrNoRows {
-		return nil, nil
+		return nil, fmt.Errorf("source import item %s/%s for source %d: %w", provider, providerID, sourceID, ErrSourceImportItemNotFound)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get source import item: %w", err)
@@ -418,7 +428,7 @@ func (s *Store) GetLastSuccessfulSync(sourceID int64) (*SyncRun, error) {
 
 	run, err := scanSyncRun(row)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return nil, fmt.Errorf("last successful sync for source %d: %w", sourceID, ErrSyncRunNotFound)
 	}
 	return run, err
 }
@@ -588,7 +598,7 @@ func (s *Store) GetSourceByIdentifier(identifier string) (*Source, error) {
 
 	source, err := scanSource(row)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return nil, fmt.Errorf("source %q: %w", identifier, ErrSourceNotFound)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -120,7 +120,7 @@ func (s *Syncer) initSyncState(sourceID int64) (*syncState, error) {
 
 	if !s.opts.NoResume {
 		activeSync, err := s.store.GetActiveSync(sourceID)
-		if err != nil {
+		if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 			return nil, fmt.Errorf("check active sync: %w", err)
 		}
 		if activeSync != nil {

--- a/internal/synctechsms/files.go
+++ b/internal/synctechsms/files.go
@@ -113,14 +113,14 @@ func discoverZip(path string) ([]BackupFile, error) {
 			Opener: func() (io.ReadCloser, error) {
 				zr, err := zip.OpenReader(path)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("open zip archive: %w", err)
 				}
 				for _, entry := range zr.File {
 					if entry.Name == name {
 						rc, err := entry.Open()
 						if err != nil {
 							_ = zr.Close()
-							return nil, err
+							return nil, fmt.Errorf("open zip entry %s: %w", name, err)
 						}
 						return zipEntryReadCloser{ReadCloser: rc, closeZip: zr.Close}, nil
 					}

--- a/internal/testutil/storetest/storetest.go
+++ b/internal/testutil/storetest/storetest.go
@@ -220,7 +220,7 @@ func (f *Fixture) AssertActiveSync(wantID int64, wantStatus string) {
 func (f *Fixture) AssertNoActiveSync() {
 	f.T.Helper()
 	active, err := f.Store.GetActiveSync(f.Source.ID)
-	require.NoError(f.T, err, "GetActiveSync")
+	require.ErrorIs(f.T, err, store.ErrSyncRunNotFound, "GetActiveSync")
 	assert.Nilf(f.T, active, "expected no active sync, got %+v", active)
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -74,7 +74,7 @@ func CheckForUpdate(currentVersion string, forceCheck bool) (*UpdateInfo, error)
 	latestVersion := strings.TrimPrefix(tag, "v")
 
 	if !isDevBuild && !isNewer(latestVersion, cleanVersion) {
-		return nil, nil
+		return nil, nil //nolint:nilnil // (nil, nil) signals "already up to date"; callers treat a nil UpdateInfo as success, not an error
 	}
 
 	ext := ".tar.gz"
@@ -406,7 +406,7 @@ func extractTarGz(archivePath, destDir string) error {
 
 	gzr, err := gzip.NewReader(file)
 	if err != nil {
-		return err
+		return fmt.Errorf("open gzip reader: %w", err)
 	}
 	defer func() { _ = gzr.Close() }()
 
@@ -417,7 +417,7 @@ func extractTarGz(archivePath, destDir string) error {
 			break
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("read tar header: %w", err)
 		}
 
 		target, err := sanitizeTarPath(absDestDir, header.Name)
@@ -502,7 +502,7 @@ func extractZip(archivePath, destDir string) error {
 
 	r, err := zip.OpenReader(archivePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("open zip archive: %w", err)
 	}
 	defer func() { _ = r.Close() }()
 
@@ -525,7 +525,7 @@ func extractZip(archivePath, destDir string) error {
 
 		rc, err := f.Open()
 		if err != nil {
-			return err
+			return fmt.Errorf("open zip entry %q: %w", f.Name, err)
 		}
 
 		outFile, err := os.Create(target)

--- a/tools/testifyhelpercheck/analyzer.go
+++ b/tools/testifyhelpercheck/analyzer.go
@@ -43,7 +43,7 @@ func run(pass *analysis.Pass) (any, error) {
 		})
 	}
 
-	return nil, nil
+	return nil, nil //nolint:nilnil // go/analysis Run returns (nil result, nil error): this analyzer produces no result fact
 }
 
 type importSet struct {


### PR DESCRIPTION
## Summary
- Re-enables `wrapcheck` and `nilnil`, and drops the `internal/store/(api|sync).go` nilnil exclusion.
- `wrapcheck`: wraps errors crossing third-party boundaries the config doesn't already ignore (gmail, IMAP, oauth2, cobra, enmime, `crypto/rand`, the zlib/gzip/tar/zip readers, the MCP stdio listener, etc.) with `fmt.Errorf("...: %w", err)`.
- `nilnil`: replaces `(nil, nil)` not-found returns with sentinel errors (`ErrMessageNotFound`, `ErrSyncRunNotFound`, `ErrSourceImportItemNotFound`, reuses `ErrSourceNotFound`); callers now branch on `errors.Is`. Empty-input batch helpers return empty non-nil values; the query Engine's intentional `(nil,nil)` not-found control-flow contract is kept behind scoped `//nolint:nilnil`.