### PR TITLE
cmd: decouple over-coupled constants by external contract

### DIFF
--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -8,9 +8,11 @@ const (
 	sourceTypeMbox  = "mbox"
 )
 
-// Analytics dataset / SQLite table names. These double as the Parquet
-// subdirectory under analytics/ and the source table in build-cache and
-// repair-encoding queries, and as stats/JSON field keys for the same entities.
+// Analytics dataset / SQLite table names: the Parquet subdirectory under
+// analytics/, the source table in build-cache and repair-encoding queries,
+// and the entity label in stats output. JSON response fields and CLI flag
+// names that happen to share these strings use their own literals/constants,
+// so renaming a storage entity cannot silently change an external contract.
 const (
 	tableMessages      = "messages"
 	tableLabels        = "labels"
@@ -19,8 +21,12 @@ const (
 	tableConversations = "conversations"
 )
 
-// outputFormatJSON is the JSON output mode: both the --json flag name and the
-// "json" value accepted by --format.
+// flagJSON is the name of the boolean --json output flag. It is kept distinct
+// from outputFormatJSON (the value accepted by --format) so the flag name and
+// the format value can change independently.
+const flagJSON = "json"
+
+// outputFormatJSON is the "json" value accepted by the --format flag.
 const outputFormatJSON = "json"
 
 // keyEmail is the map/log field key carrying an account or address email.

--- a/cmd/msgvault/cmd/export_attachment.go
+++ b/cmd/msgvault/cmd/export_attachment.go
@@ -180,6 +180,6 @@ func readAttachmentFile(storagePath, contentHash string) ([]byte, error) {
 func init() {
 	rootCmd.AddCommand(exportAttachmentCmd)
 	exportAttachmentCmd.Flags().StringVarP(&exportAttachmentOutput, "output", "o", "", "Output file path (default: stdout, use - for stdout)")
-	exportAttachmentCmd.Flags().BoolVar(&exportAttachmentJSON, outputFormatJSON, false, "Output as JSON with base64-encoded data")
+	exportAttachmentCmd.Flags().BoolVar(&exportAttachmentJSON, flagJSON, false, "Output as JSON with base64-encoded data")
 	exportAttachmentCmd.Flags().BoolVar(&exportAttachmentBase64, "base64", false, "Output raw base64 to stdout")
 }

--- a/cmd/msgvault/cmd/identity.go
+++ b/cmd/msgvault/cmd/identity.go
@@ -417,9 +417,9 @@ func init() {
 		"collection", "", "Restrict to all member accounts of one collection")
 	identityListCmd.MarkFlagsMutuallyExclusive("account", "collection")
 	identityListCmd.Flags().BoolVar(&identityListJSON,
-		outputFormatJSON, false, "Output as JSON")
+		flagJSON, false, "Output as JSON")
 	identityShowCmd.Flags().BoolVar(&identityShowJSON,
-		outputFormatJSON, false, "Output as JSON")
+		flagJSON, false, "Output as JSON")
 	identityAddCmd.Flags().StringVar(&identityAddSignal,
 		"signal", "manual",
 		"Evidence signal name (e.g. manual, account-identifier, phone-e164). "+

--- a/cmd/msgvault/cmd/import_synctech_sms.go
+++ b/cmd/msgvault/cmd/import_synctech_sms.go
@@ -44,7 +44,7 @@ SMS Backup & Restore by SyncTech Pty Ltd.`,
 	cmd.Flags().BoolVar(&opts.IncludeSMS, "sms", true, "Import SMS records")
 	cmd.Flags().BoolVar(&opts.IncludeMMS, "mms", true, "Import MMS records")
 	cmd.Flags().BoolVar(&opts.IncludeCalls, "calls", true, "Import call log records")
-	cmd.Flags().BoolVar(&opts.IncludeAttachments, tableAttachments, true, "Import MMS attachments")
+	cmd.Flags().BoolVar(&opts.IncludeAttachments, "attachments", true, "Import MMS attachments")
 	return cmd
 }
 

--- a/cmd/msgvault/cmd/list_accounts.go
+++ b/cmd/msgvault/cmd/list_accounts.go
@@ -232,5 +232,5 @@ func outputRemoteAccountsJSON(accounts []remote.AccountInfo) error {
 
 func init() {
 	rootCmd.AddCommand(listAccountsCmd)
-	listAccountsCmd.Flags().BoolVar(&listAccountsJSON, outputFormatJSON, false, "Output as JSON")
+	listAccountsCmd.Flags().BoolVar(&listAccountsJSON, flagJSON, false, "Output as JSON")
 }

--- a/cmd/msgvault/cmd/output.go
+++ b/cmd/msgvault/cmd/output.go
@@ -61,7 +61,7 @@ func addCommonAggregateFlags(cmd *cobra.Command) {
 		"Filter to messages before date (YYYY-MM-DD)",
 	)
 	cmd.Flags().BoolVar(
-		&aggJSON, outputFormatJSON, false, "Output as JSON",
+		&aggJSON, flagJSON, false, "Output as JSON",
 	)
 }
 

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -416,7 +416,7 @@ func outputSearchResultsJSON(results []query.MessageSummary) error {
 			"size_estimate":          msg.SizeEstimate,
 			"has_attachments":        msg.HasAttachments,
 			"attachment_count":       msg.AttachmentCount,
-			tableLabels:              msg.Labels,
+			"labels":                 msg.Labels,
 		}
 	}
 
@@ -427,7 +427,7 @@ func init() {
 	rootCmd.AddCommand(searchCmd)
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "n", 50, "Maximum number of results")
 	searchCmd.Flags().IntVar(&searchOffset, "offset", 0, "Skip first N results")
-	searchCmd.Flags().BoolVar(&searchJSON, outputFormatJSON, false, "Output as JSON")
+	searchCmd.Flags().BoolVar(&searchJSON, flagJSON, false, "Output as JSON")
 	searchCmd.Flags().StringVar(&searchAccount, "account", "", "Limit results to a specific account (email address)")
 	searchCmd.Flags().StringVar(&searchCollection, "collection", "",
 		"Limit results to all member accounts of one collection")

--- a/cmd/msgvault/cmd/show_message.go
+++ b/cmd/msgvault/cmd/show_message.go
@@ -232,8 +232,8 @@ func outputMessageJSON(msg *query.MessageDetail) error {
 		"to":                     toAddrs,
 		"cc":                     ccAddrs,
 		"bcc":                    bccAddrs,
-		tableLabels:              msg.Labels,
-		tableAttachments:         attachments,
+		"labels":                 msg.Labels,
+		"attachments":            attachments,
 		"body_text":              msg.BodyText,
 		"body_html":              msg.BodyHTML,
 	}
@@ -338,8 +338,8 @@ func outputRemoteMessageJSON(msg *store.APIMessage) error {
 		"sent_at":         msg.SentAt.Format(time.RFC3339),
 		"size_estimate":   msg.SizeEstimate,
 		"has_attachments": msg.HasAttachments,
-		tableLabels:       msg.Labels,
-		tableAttachments:  attachments,
+		"labels":          msg.Labels,
+		"attachments":     attachments,
 		"body":            msg.Body,
 	}
 
@@ -350,5 +350,5 @@ func outputRemoteMessageJSON(msg *store.APIMessage) error {
 
 func init() {
 	rootCmd.AddCommand(showMessageCmd)
-	showMessageCmd.Flags().BoolVar(&showMessageJSON, outputFormatJSON, false, "Output as JSON")
+	showMessageCmd.Flags().BoolVar(&showMessageJSON, flagJSON, false, "Output as JSON")
 }

--- a/internal/fbmessenger/discover.go
+++ b/internal/fbmessenger/discover.go
@@ -23,7 +23,7 @@ type ThreadDir struct {
 	// Name is the thread directory basename (e.g. "testuser_ABC123XYZ").
 	// For E2EE exports, this is the filename without extension.
 	Name string
-	// Format is formatJSON, "html", "both", or "e2ee_json".
+	// Format is "json", "html", "both", or "e2ee_json".
 	Format string
 }
 

--- a/internal/fbmessenger/importer.go
+++ b/internal/fbmessenger/importer.go
@@ -46,7 +46,7 @@ type ImportOptions struct {
 	Me string
 	// RootDir is the DYI export root directory.
 	RootDir string
-	// Format overrides auto-detection. One of "auto", formatJSON, "html",
+	// Format overrides auto-detection. One of "auto", "json", "html",
 	// "both". Empty is treated as "auto".
 	Format string
 	// AttachmentsDir is the content-addressed attachment storage root.


### PR DESCRIPTION
## Summary
Addresses the roborev review on the goconst pass (#351): one set of constants was reused across independent external contracts that merely share a string today.

- JSON response field keys in `show-message`/`search` output and the synctech-sms `--attachments` flag name are string literals again, decoupled from the analytics `table*` constants.
- New `flagJSON` constant for the boolean `--json` flag name, kept distinct from `outputFormatJSON` (the value accepted by `--format`).
- fbmessenger doc comments reference the literal `"json"` instead of the `formatJSON` identifier.

The `table*` constants now cover only the analytics/storage/stats entity name. Lint stays clean.