### PR TITLE
cmd: manage embedding generations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          determinate: false
 
       - name: Build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,18 @@ jobs:
 
   nix-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Build
+        env:
+          NIX_CONFIG: |
+            access-tokens = github.com=${{ github.token }}
         run: nix build
 
   # PostgreSQL backend lane: runs the full Go test suite against a live

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-        with:
-          determinate: false
 
       - name: Build
         run: nix build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,6 @@ jobs:
 
   nix-build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,6 @@ jobs:
           determinate: false
 
       - name: Build
-        env:
-          NIX_CONFIG: |
-            access-tokens = github.com=${{ github.token }}
         run: nix build
 
   # PostgreSQL backend lane: runs the full Go test suite against a live

--- a/cmd/msgvault/cmd/collection.go
+++ b/cmd/msgvault/cmd/collection.go
@@ -30,7 +30,7 @@ var collectionCreateCmd = &cobra.Command{
 }
 
 var collectionListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   cmdUseList,
 	Short: "List all collections",
 	RunE:  runCollectionList,
 }

--- a/cmd/msgvault/cmd/confirm.go
+++ b/cmd/msgvault/cmd/confirm.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 // ConfirmMode selects the prompt and validation for confirmDestructive.
@@ -86,10 +87,10 @@ func confirmDestructive(r io.Reader, w io.Writer, mode ConfirmMode) (bool, error
 	}
 }
 
-// confirmEmbed reads a y/N answer from stdin. Default is no.
-func confirmEmbed(prompt string) bool {
-	fmt.Fprint(os.Stderr, prompt+"[y/N]: ")
-	r := bufio.NewReader(os.Stdin)
+// confirmEmbed reads a y/N answer from the command input. Default is no.
+func confirmEmbed(cmd *cobra.Command, prompt string) bool {
+	fmt.Fprint(cmd.ErrOrStderr(), prompt+"[y/N]: ")
+	r := bufio.NewReader(cmd.InOrStdin())
 	line, err := r.ReadString('\n')
 	if err != nil {
 		return false

--- a/cmd/msgvault/cmd/confirm.go
+++ b/cmd/msgvault/cmd/confirm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 )
 
@@ -83,4 +84,16 @@ func confirmDestructive(r io.Reader, w io.Writer, mode ConfirmMode) (bool, error
 	default:
 		return false, fmt.Errorf("unknown ConfirmMode: %d", mode)
 	}
+}
+
+// confirmEmbed reads a y/N answer from stdin. Default is no.
+func confirmEmbed(prompt string) bool {
+	fmt.Fprint(os.Stderr, prompt+"[y/N]: ")
+	r := bufio.NewReader(os.Stdin)
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	line = strings.TrimSpace(strings.ToLower(line))
+	return line == "y" || line == "yes"
 }

--- a/cmd/msgvault/cmd/confirm.go
+++ b/cmd/msgvault/cmd/confirm.go
@@ -89,7 +89,7 @@ func confirmDestructive(r io.Reader, w io.Writer, mode ConfirmMode) (bool, error
 
 // confirmEmbed reads a y/N answer from the command input. Default is no.
 func confirmEmbed(cmd *cobra.Command, prompt string) bool {
-	fmt.Fprint(cmd.ErrOrStderr(), prompt+"[y/N]: ")
+	_, _ = fmt.Fprint(cmd.ErrOrStderr(), prompt+"[y/N]: ")
 	r := bufio.NewReader(cmd.InOrStdin())
 	line, err := r.ReadString('\n')
 	if err != nil {

--- a/cmd/msgvault/cmd/confirm_test.go
+++ b/cmd/msgvault/cmd/confirm_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,4 +75,14 @@ func TestConfirmDestructive_YesNo_StdinClosed(t *testing.T) {
 	ok, err := confirmDestructive(strings.NewReader(""), &out, ConfirmModeYesNo)
 	require.NoError(t, err, "want nil (cancel-on-EOF) on closed stdin")
 	assert.False(t, ok, "want false on closed stdin")
+}
+
+func TestConfirmEmbedUsesCommandIO(t *testing.T) {
+	var errOut bytes.Buffer
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetIn(strings.NewReader("yes\n"))
+	cmd.SetErr(&errOut)
+
+	assert.True(t, confirmEmbed(cmd, "Proceed? "))
+	assert.Equal(t, "Proceed? [y/N]: ", errOut.String())
 }

--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -26,6 +26,9 @@ const (
 // the format value can change independently.
 const flagJSON = "json"
 
+// cmdUseList is the shared Cobra use/name for list subcommands.
+const cmdUseList = "list"
+
 // outputFormatJSON is the "json" value accepted by the --format flag.
 const outputFormatJSON = "json"
 

--- a/cmd/msgvault/cmd/delete_deduped.go
+++ b/cmd/msgvault/cmd/delete_deduped.go
@@ -26,7 +26,7 @@ after a local delete.
 Parquet analytics and the vector index may contain stale entries for
 deleted rows until rebuilt; the rebuild commands are separate. Run
 'msgvault build-cache --full-rebuild' for parquet analytics and
-'msgvault build-embeddings --full-rebuild' for the vector index.`,
+'msgvault embeddings build --full-rebuild' for the vector index.`,
 	RunE: runDeleteDeduped,
 }
 
@@ -150,7 +150,7 @@ func runDeleteDeduped(cmd *cobra.Command, _ []string) error {
 	// Note: parquet analytics and the vector index may contain entries
 	// for deleted rows; the post-run summary recommends rebuilding each
 	// separately ('build-cache --full-rebuild' and
-	// 'build-embeddings --full-rebuild').
+	// 'embeddings build --full-rebuild').
 
 	var deletedTotal int64
 	var batchCount int64
@@ -176,7 +176,7 @@ func runDeleteDeduped(cmd *cobra.Command, _ []string) error {
 	_, _ = fmt.Fprintf(out, "\nDeleted %d message(s) from %d batch(es).\n\n", deletedTotal, batchCount)
 	_, _ = fmt.Fprintln(out, "Caches may have stale entries; rebuild each separately:")
 	_, _ = fmt.Fprintln(out, "  'msgvault build-cache --full-rebuild'        (parquet analytics)")
-	_, _ = fmt.Fprintln(out, "  'msgvault build-embeddings --full-rebuild'   (vector index, if enabled)")
+	_, _ = fmt.Fprintln(out, "  'msgvault embeddings build --full-rebuild'   (vector index, if enabled)")
 
 	return nil
 }

--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -75,7 +75,7 @@ func runEmbeddingsBuild(cmd *cobra.Command, args []string) error {
 	if cfg.Vector.Embeddings.Endpoint == "" || cfg.Vector.Embeddings.Model == "" {
 		return errors.New("[vector.embeddings] endpoint and model are required")
 	}
-	return runEmbed(cmd.Context())
+	return runEmbed(cmd)
 }
 
 func runEmbeddingsResume(cmd *cobra.Command, args []string) error {

--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -31,7 +31,7 @@ active generation.`,
 	RunE: runEmbeddingsResume,
 }
 var embeddingsListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   cmdUseList,
 	Short: "List vector embedding generations",
 	RunE:  runEmbeddingsList,
 }

--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -21,6 +21,15 @@ var embeddingsCmd = &cobra.Command{
 }
 
 var embeddingsBuildCmd = newEmbeddingsBuildCmd("build")
+var embeddingsResumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume or top up the current vector embedding generation",
+	Long: `Resume or top up the current vector embedding generation.
+If a matching generation is building, this drains its pending queue and
+activates it when complete. Otherwise it embeds pending rows for the
+active generation.`,
+	RunE: runEmbeddingsResume,
+}
 var embeddingsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List vector embedding generations",
@@ -69,6 +78,18 @@ func runEmbeddingsBuild(cmd *cobra.Command, args []string) error {
 	return runEmbed(cmd.Context())
 }
 
+func runEmbeddingsResume(cmd *cobra.Command, args []string) error {
+	oldFullRebuild := embedFullRebuild
+	oldYes := embedYes
+	embedFullRebuild = false
+	embedYes = false
+	defer func() {
+		embedFullRebuild = oldFullRebuild
+		embedYes = oldYes
+	}()
+	return runEmbeddingsBuild(cmd, args)
+}
+
 func init() {
 	embedCmd.Deprecated = "use 'msgvault embeddings build' instead"
 	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireYes, "yes", false, "Skip confirmation prompt")
@@ -76,6 +97,7 @@ func init() {
 	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateYes, "yes", false, "Skip confirmation prompt")
 	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateForce, "force", false, "Allow activation with pending rows or a fingerprint mismatch")
 	embeddingsCmd.AddCommand(embeddingsBuildCmd)
+	embeddingsCmd.AddCommand(embeddingsResumeCmd)
 	embeddingsCmd.AddCommand(embeddingsListCmd)
 	embeddingsCmd.AddCommand(embeddingsRetireCmd)
 	embeddingsCmd.AddCommand(embeddingsActivateCmd)

--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -7,8 +7,12 @@ import (
 )
 
 var (
-	embedFullRebuild bool
-	embedYes         bool
+	embedFullRebuild            bool
+	embedYes                    bool
+	embeddingsRetireYes         bool
+	embeddingsRetireForceActive bool
+	embeddingsActivateForce     bool
+	embeddingsActivateYes       bool
 )
 
 var embeddingsCmd = &cobra.Command{
@@ -17,6 +21,23 @@ var embeddingsCmd = &cobra.Command{
 }
 
 var embeddingsBuildCmd = newEmbeddingsBuildCmd("build")
+var embeddingsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List vector embedding generations",
+	RunE:  runEmbeddingsList,
+}
+var embeddingsRetireCmd = &cobra.Command{
+	Use:   "retire <generation-id>",
+	Short: "Retire a vector embedding generation",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEmbeddingsRetire,
+}
+var embeddingsActivateCmd = &cobra.Command{
+	Use:   "activate <generation-id>",
+	Short: "Activate a completed vector embedding generation",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEmbeddingsActivate,
+}
 var embedCmd = newEmbeddingsBuildCmd("build-embeddings")
 
 func newEmbeddingsBuildCmd(use string) *cobra.Command {
@@ -50,7 +71,14 @@ func runEmbeddingsBuild(cmd *cobra.Command, args []string) error {
 
 func init() {
 	embedCmd.Deprecated = "use 'msgvault embeddings build' instead"
+	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireYes, "yes", false, "Skip confirmation prompt")
+	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireForceActive, "force-active", false, "Allow retiring the active generation")
+	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateYes, "yes", false, "Skip confirmation prompt")
+	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateForce, "force", false, "Allow activation with pending rows or a fingerprint mismatch")
 	embeddingsCmd.AddCommand(embeddingsBuildCmd)
+	embeddingsCmd.AddCommand(embeddingsListCmd)
+	embeddingsCmd.AddCommand(embeddingsRetireCmd)
+	embeddingsCmd.AddCommand(embeddingsActivateCmd)
 	rootCmd.AddCommand(embeddingsCmd)
 	rootCmd.AddCommand(embedCmd)
 }

--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -11,10 +11,19 @@ var (
 	embedYes         bool
 )
 
-var embedCmd = &cobra.Command{
-	Use:   "build-embeddings",
-	Short: "Build or update the vector embedding index (incremental by default; --full-rebuild for a new generation)",
-	Long: `Build or update the vector embedding index for hybrid search.
+var embeddingsCmd = &cobra.Command{
+	Use:   "embeddings",
+	Short: "Manage vector embeddings",
+}
+
+var embeddingsBuildCmd = newEmbeddingsBuildCmd("build")
+var embedCmd = newEmbeddingsBuildCmd("build-embeddings")
+
+func newEmbeddingsBuildCmd(use string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Build or update the vector embedding index (incremental by default; --full-rebuild for a new generation)",
+		Long: `Build or update the vector embedding index for hybrid search.
 Writes vectors to the co-located vectors.db. In the default incremental
 mode, the command drains any pending rows in the active generation. With
 --full-rebuild, it creates a new building generation, embeds the entire
@@ -22,19 +31,26 @@ corpus, and (on a clean completion) atomically activates it.
 
 Requires [vector] to be enabled in config.toml and [vector.embeddings]
 to point at a running OpenAI-compatible endpoint.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if !cfg.Vector.Enabled {
-			return errors.New("vector search not enabled; add [vector] enabled=true to config.toml first")
-		}
-		if cfg.Vector.Embeddings.Endpoint == "" || cfg.Vector.Embeddings.Model == "" {
-			return errors.New("[vector.embeddings] endpoint and model are required")
-		}
-		return runEmbed(cmd.Context())
-	},
+		RunE: runEmbeddingsBuild,
+	}
+	cmd.Flags().BoolVar(&embedFullRebuild, "full-rebuild", false, "Create a new generation and rebuild from scratch")
+	cmd.Flags().BoolVar(&embedYes, "yes", false, "Skip confirmation prompts")
+	return cmd
+}
+
+func runEmbeddingsBuild(cmd *cobra.Command, args []string) error {
+	if !cfg.Vector.Enabled {
+		return errors.New("vector search not enabled; add [vector] enabled=true to config.toml first")
+	}
+	if cfg.Vector.Embeddings.Endpoint == "" || cfg.Vector.Embeddings.Model == "" {
+		return errors.New("[vector.embeddings] endpoint and model are required")
+	}
+	return runEmbed(cmd.Context())
 }
 
 func init() {
+	embedCmd.Deprecated = "use 'msgvault embeddings build' instead"
+	embeddingsCmd.AddCommand(embeddingsBuildCmd)
+	rootCmd.AddCommand(embeddingsCmd)
 	rootCmd.AddCommand(embedCmd)
-	embedCmd.Flags().BoolVar(&embedFullRebuild, "full-rebuild", false, "Create a new generation and rebuild from scratch")
-	embedCmd.Flags().BoolVar(&embedYes, "yes", false, "Skip confirmation prompts")
 }

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -20,6 +20,11 @@ func TestEmbeddingsCommandRegistration(t *testing.T) {
 	requirepkg.NotNil(t, buildCmd.Flags().Lookup("full-rebuild"))
 	requirepkg.NotNil(t, buildCmd.Flags().Lookup("yes"))
 
+	resumeCmd, _, err := rootCmd.Find([]string{"embeddings", "resume"})
+	requirepkg.NoError(t, err)
+	requirepkg.Equal(t, "resume", resumeCmd.Name())
+	requirepkg.Nil(t, resumeCmd.Flags().Lookup("full-rebuild"))
+
 	listCmd, _, err := rootCmd.Find([]string{"embeddings", "list"})
 	requirepkg.NoError(t, err)
 	requirepkg.Equal(t, "list", listCmd.Name())

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -79,7 +79,7 @@ func TestActivateEmbeddingGenerationRetiresPreviousActive(t *testing.T) {
 	_, err := db.ExecContext(ctx, `DELETE FROM pending_embeddings WHERE generation_id = 2`)
 	require.NoError(err)
 
-	require.NoError(activateEmbeddingGeneration(ctx, db, 2))
+	require.NoError(activateEmbeddingGeneration(ctx, db, 2, false))
 
 	active := mustGetEmbeddingGeneration(ctx, t, db, 2)
 	assert.Equal(vector.GenerationActive, active.State)
@@ -108,6 +108,24 @@ func TestRunEmbeddingsActivateRefusesPendingWithoutForce(t *testing.T) {
 
 	require.Error(err)
 	assert.Contains(err.Error(), "pending embedding rows")
+}
+
+func TestActivateEmbeddingGenerationProtectsPendingRace(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	db := newEmbeddingMetadataTestDB(t)
+	ctx := t.Context()
+
+	err := activateEmbeddingGeneration(ctx, db, 2, false)
+	require.Error(err)
+	assert.Contains(err.Error(), "pending embedding rows")
+
+	building := mustGetEmbeddingGeneration(ctx, t, db, 2)
+	assert.Equal(vector.GenerationBuilding, building.State)
+
+	require.NoError(activateEmbeddingGeneration(ctx, db, 2, true))
+	active := mustGetEmbeddingGeneration(ctx, t, db, 2)
+	assert.Equal(vector.GenerationActive, active.State)
 }
 
 func TestRetireEmbeddingGenerationRefusesActiveWithoutForce(t *testing.T) {

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -1,17 +1,40 @@
 package cmd
 
 import (
+	"context"
+	"database/sql"
+	"path/filepath"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
+	assertpkg "github.com/stretchr/testify/assert"
 	requirepkg "github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/vector"
 )
 
-func TestEmbeddingsBuildCommandRegistration(t *testing.T) {
+func TestEmbeddingsCommandRegistration(t *testing.T) {
 	buildCmd, _, err := rootCmd.Find([]string{"embeddings", "build"})
 	requirepkg.NoError(t, err)
 	requirepkg.Equal(t, "build", buildCmd.Name())
 	requirepkg.NotNil(t, buildCmd.Flags().Lookup("full-rebuild"))
 	requirepkg.NotNil(t, buildCmd.Flags().Lookup("yes"))
+
+	listCmd, _, err := rootCmd.Find([]string{"embeddings", "list"})
+	requirepkg.NoError(t, err)
+	requirepkg.Equal(t, "list", listCmd.Name())
+
+	retireCmd, _, err := rootCmd.Find([]string{"embeddings", "retire"})
+	requirepkg.NoError(t, err)
+	requirepkg.Equal(t, "retire", retireCmd.Name())
+	requirepkg.NotNil(t, retireCmd.Flags().Lookup("yes"))
+	requirepkg.NotNil(t, retireCmd.Flags().Lookup("force-active"))
+
+	activateCmd, _, err := rootCmd.Find([]string{"embeddings", "activate"})
+	requirepkg.NoError(t, err)
+	requirepkg.Equal(t, "activate", activateCmd.Name())
+	requirepkg.NotNil(t, activateCmd.Flags().Lookup("yes"))
+	requirepkg.NotNil(t, activateCmd.Flags().Lookup("force"))
 
 	legacyCmd, _, err := rootCmd.Find([]string{"build-embeddings"})
 	requirepkg.NoError(t, err)
@@ -19,4 +42,169 @@ func TestEmbeddingsBuildCommandRegistration(t *testing.T) {
 	requirepkg.NotEmpty(t, legacyCmd.Deprecated)
 	requirepkg.NotNil(t, legacyCmd.Flags().Lookup("full-rebuild"))
 	requirepkg.NotNil(t, legacyCmd.Flags().Lookup("yes"))
+}
+
+func TestListEmbeddingGenerationsIncludesActiveAndBuilding(t *testing.T) {
+	db := newEmbeddingMetadataTestDB(t)
+
+	rows, err := listEmbeddingGenerations(t.Context(), db)
+	requirepkg.NoError(t, err)
+	requirepkg.Len(t, rows, 2)
+
+	assertpkg.Equal(t, vector.GenerationID(1), rows[0].ID)
+	assertpkg.Equal(t, vector.GenerationActive, rows[0].State)
+	assertpkg.Equal(t, int64(2), rows[0].MessageCount)
+	assertpkg.Equal(t, int64(0), rows[0].PendingCount)
+
+	assertpkg.Equal(t, vector.GenerationID(2), rows[1].ID)
+	assertpkg.Equal(t, vector.GenerationBuilding, rows[1].State)
+	assertpkg.Equal(t, int64(1), rows[1].PendingCount)
+}
+
+func TestActivateEmbeddingGenerationRetiresPreviousActive(t *testing.T) {
+	db := newEmbeddingMetadataTestDB(t)
+	ctx := t.Context()
+
+	_, err := db.ExecContext(ctx, `DELETE FROM pending_embeddings WHERE generation_id = 2`)
+	requirepkg.NoError(t, err)
+
+	requirepkg.NoError(t, activateEmbeddingGeneration(ctx, db, 2))
+
+	active := mustGetEmbeddingGeneration(t, ctx, db, 2)
+	assertpkg.Equal(t, vector.GenerationActive, active.State)
+	assertpkg.NotNil(t, active.ActivatedAt)
+	assertpkg.NotNil(t, active.CompletedAt)
+
+	retired := mustGetEmbeddingGeneration(t, ctx, db, 1)
+	assertpkg.Equal(t, vector.GenerationRetired, retired.State)
+	assertpkg.NotNil(t, retired.CompletedAt)
+}
+
+func TestRunEmbeddingsActivateRefusesPendingWithoutForce(t *testing.T) {
+	dbPath := newEmbeddingMetadataTestDBFile(t)
+	withEmbeddingCommandConfig(t, dbPath)
+
+	oldYes := embeddingsActivateYes
+	embeddingsActivateYes = true
+	t.Cleanup(func() { embeddingsActivateYes = oldYes })
+	cmd := embeddingsActivateCmd
+	cmd.SetContext(context.Background())
+	t.Cleanup(func() { cmd.SetContext(nil) })
+	err := runEmbeddingsActivate(cmd, []string{"2"})
+
+	requirepkg.Error(t, err)
+	assertpkg.Contains(t, err.Error(), "pending embedding rows")
+}
+
+func TestRetireEmbeddingGenerationRefusesActiveWithoutForce(t *testing.T) {
+	dbPath := newEmbeddingMetadataTestDBFile(t)
+	withEmbeddingCommandConfig(t, dbPath)
+
+	oldYes := embeddingsRetireYes
+	oldForce := embeddingsRetireForceActive
+	embeddingsRetireYes = true
+	embeddingsRetireForceActive = false
+	t.Cleanup(func() {
+		embeddingsRetireYes = oldYes
+		embeddingsRetireForceActive = oldForce
+	})
+
+	cmd := embeddingsRetireCmd
+	cmd.SetContext(context.Background())
+	t.Cleanup(func() { cmd.SetContext(nil) })
+
+	err := runEmbeddingsRetire(cmd, []string{"1"})
+	requirepkg.Error(t, err)
+	assertpkg.Contains(t, err.Error(), "active")
+
+	embeddingsRetireForceActive = true
+	requirepkg.NoError(t, runEmbeddingsRetire(cmd, []string{"1"}))
+
+	db, err := sql.Open("sqlite3", dbPath)
+	requirepkg.NoError(t, err)
+	t.Cleanup(func() { requirepkg.NoError(t, db.Close()) })
+	row := mustGetEmbeddingGeneration(t, t.Context(), db, 1)
+	assertpkg.Equal(t, vector.GenerationRetired, row.State)
+}
+
+func newEmbeddingMetadataTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	path := newEmbeddingMetadataTestDBFile(t)
+
+	db, err := sql.Open("sqlite3", path)
+	requirepkg.NoError(t, err)
+	t.Cleanup(func() { requirepkg.NoError(t, db.Close()) })
+	return db
+}
+
+func newEmbeddingMetadataTestDBFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	db, err := sql.Open("sqlite3", path)
+	requirepkg.NoError(t, err)
+	defer func() { requirepkg.NoError(t, db.Close()) }()
+
+	_, err = db.Exec(`
+CREATE TABLE index_generations (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	model TEXT NOT NULL,
+	dimension INTEGER NOT NULL,
+	fingerprint TEXT NOT NULL,
+	started_at INTEGER NOT NULL,
+	seeded_at INTEGER,
+	completed_at INTEGER,
+	activated_at INTEGER,
+	state TEXT NOT NULL,
+	message_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE pending_embeddings (
+	generation_id INTEGER NOT NULL,
+	message_id INTEGER NOT NULL,
+	enqueued_at INTEGER NOT NULL,
+	claimed_at INTEGER,
+	claim_token TEXT,
+	PRIMARY KEY (generation_id, message_id)
+);
+`)
+	requirepkg.NoError(t, err)
+
+	fp := newTestConfigForFingerprint("").Vector.GenerationFingerprint()
+	_, err = db.Exec(`
+INSERT INTO index_generations
+	(id, model, dimension, fingerprint, started_at, completed_at, activated_at, state, message_count)
+VALUES
+	(1, 'model', 4, ?, 100, 110, 111, 'active', 2),
+	(2, 'model', 4, ?, 120, NULL, NULL, 'building', 1);
+INSERT INTO pending_embeddings (generation_id, message_id, enqueued_at) VALUES (2, 42, 120);
+`, fp, fp)
+	requirepkg.NoError(t, err)
+	return path
+}
+
+func withEmbeddingCommandConfig(t *testing.T, vecPath string) {
+	t.Helper()
+	oldCfg := cfg
+	cfg = newTestConfigForFingerprint(vecPath)
+	t.Cleanup(func() { cfg = oldCfg })
+}
+
+func newTestConfigForFingerprint(vecPath string) *config.Config {
+	return &config.Config{
+		Vector: vector.Config{
+			Enabled: true,
+			DBPath:  vecPath,
+			Embeddings: vector.EmbeddingsConfig{
+				Model:         "model",
+				Dimension:     4,
+				MaxInputChars: 32768,
+			},
+		},
+	}
+}
+
+func mustGetEmbeddingGeneration(t *testing.T, ctx context.Context, db *sql.DB, gen vector.GenerationID) embeddingGenerationRow {
+	t.Helper()
+	row, err := getEmbeddingGeneration(ctx, db, gen)
+	requirepkg.NoError(t, err)
+	return row
 }

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"testing"
+
+	requirepkg "github.com/stretchr/testify/require"
+)
+
+func TestEmbeddingsBuildCommandRegistration(t *testing.T) {
+	buildCmd, _, err := rootCmd.Find([]string{"embeddings", "build"})
+	requirepkg.NoError(t, err)
+	requirepkg.Equal(t, "build", buildCmd.Name())
+	requirepkg.NotNil(t, buildCmd.Flags().Lookup("full-rebuild"))
+	requirepkg.NotNil(t, buildCmd.Flags().Lookup("yes"))
+
+	legacyCmd, _, err := rootCmd.Find([]string{"build-embeddings"})
+	requirepkg.NoError(t, err)
+	requirepkg.Equal(t, "build-embeddings", legacyCmd.Name())
+	requirepkg.NotEmpty(t, legacyCmd.Deprecated)
+	requirepkg.NotNil(t, legacyCmd.Flags().Lookup("full-rebuild"))
+	requirepkg.NotNil(t, legacyCmd.Flags().Lookup("yes"))
+}

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -128,6 +128,30 @@ func TestActivateEmbeddingGenerationProtectsPendingRace(t *testing.T) {
 	assert.Equal(vector.GenerationActive, active.State)
 }
 
+func TestActivateEmbeddingGenerationRefusesUnseededWithoutForce(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	db := newEmbeddingMetadataTestDB(t)
+	ctx := t.Context()
+
+	_, err := db.ExecContext(ctx, `
+DELETE FROM pending_embeddings WHERE generation_id = 2;
+UPDATE index_generations SET seeded_at = NULL WHERE id = 2;
+`)
+	require.NoError(err)
+
+	err = activateEmbeddingGeneration(ctx, db, 2, false)
+	require.Error(err)
+	assert.Contains(err.Error(), "finished seeding")
+
+	building := mustGetEmbeddingGeneration(ctx, t, db, 2)
+	assert.Equal(vector.GenerationBuilding, building.State)
+
+	require.NoError(activateEmbeddingGeneration(ctx, db, 2, true))
+	active := mustGetEmbeddingGeneration(ctx, t, db, 2)
+	assert.Equal(vector.GenerationActive, active.State)
+}
+
 func TestRetireEmbeddingGenerationRefusesActiveWithoutForce(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
@@ -224,10 +248,10 @@ CREATE TABLE pending_embeddings (
 	fp := newTestConfigForFingerprint("").Vector.GenerationFingerprint()
 	_, err = db.Exec(`
 INSERT INTO index_generations
-	(id, model, dimension, fingerprint, started_at, completed_at, activated_at, state, message_count)
+	(id, model, dimension, fingerprint, started_at, seeded_at, completed_at, activated_at, state, message_count)
 VALUES
-	(1, 'model', 4, ?, 100, 110, 111, 'active', 2),
-	(2, 'model', 4, ?, 120, NULL, NULL, 'building', 1);
+	(1, 'model', 4, ?, 100, 101, 110, 111, 'active', 2),
+	(2, 'model', 4, ?, 120, 121, NULL, NULL, 'building', 1);
 INSERT INTO pending_embeddings (generation_id, message_id, enqueued_at) VALUES (2, 42, 120);
 `, fp, fp)
 	requirepkg.NoError(t, err)

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -14,78 +14,86 @@ import (
 )
 
 func TestEmbeddingsCommandRegistration(t *testing.T) {
+	require := requirepkg.New(t)
+
 	buildCmd, _, err := rootCmd.Find([]string{"embeddings", "build"})
-	requirepkg.NoError(t, err)
-	requirepkg.Equal(t, "build", buildCmd.Name())
-	requirepkg.NotNil(t, buildCmd.Flags().Lookup("full-rebuild"))
-	requirepkg.NotNil(t, buildCmd.Flags().Lookup("yes"))
+	require.NoError(err)
+	require.Equal("build", buildCmd.Name())
+	require.NotNil(buildCmd.Flags().Lookup("full-rebuild"))
+	require.NotNil(buildCmd.Flags().Lookup("yes"))
 
 	resumeCmd, _, err := rootCmd.Find([]string{"embeddings", "resume"})
-	requirepkg.NoError(t, err)
-	requirepkg.Equal(t, "resume", resumeCmd.Name())
-	requirepkg.Nil(t, resumeCmd.Flags().Lookup("full-rebuild"))
+	require.NoError(err)
+	require.Equal("resume", resumeCmd.Name())
+	require.Nil(resumeCmd.Flags().Lookup("full-rebuild"))
 
 	listCmd, _, err := rootCmd.Find([]string{"embeddings", "list"})
-	requirepkg.NoError(t, err)
-	requirepkg.Equal(t, "list", listCmd.Name())
+	require.NoError(err)
+	require.Equal("list", listCmd.Name())
 
 	retireCmd, _, err := rootCmd.Find([]string{"embeddings", "retire"})
-	requirepkg.NoError(t, err)
-	requirepkg.Equal(t, "retire", retireCmd.Name())
-	requirepkg.NotNil(t, retireCmd.Flags().Lookup("yes"))
-	requirepkg.NotNil(t, retireCmd.Flags().Lookup("force-active"))
+	require.NoError(err)
+	require.Equal("retire", retireCmd.Name())
+	require.NotNil(retireCmd.Flags().Lookup("yes"))
+	require.NotNil(retireCmd.Flags().Lookup("force-active"))
 
 	activateCmd, _, err := rootCmd.Find([]string{"embeddings", "activate"})
-	requirepkg.NoError(t, err)
-	requirepkg.Equal(t, "activate", activateCmd.Name())
-	requirepkg.NotNil(t, activateCmd.Flags().Lookup("yes"))
-	requirepkg.NotNil(t, activateCmd.Flags().Lookup("force"))
+	require.NoError(err)
+	require.Equal("activate", activateCmd.Name())
+	require.NotNil(activateCmd.Flags().Lookup("yes"))
+	require.NotNil(activateCmd.Flags().Lookup("force"))
 
 	legacyCmd, _, err := rootCmd.Find([]string{"build-embeddings"})
-	requirepkg.NoError(t, err)
-	requirepkg.Equal(t, "build-embeddings", legacyCmd.Name())
-	requirepkg.NotEmpty(t, legacyCmd.Deprecated)
-	requirepkg.NotNil(t, legacyCmd.Flags().Lookup("full-rebuild"))
-	requirepkg.NotNil(t, legacyCmd.Flags().Lookup("yes"))
+	require.NoError(err)
+	require.Equal("build-embeddings", legacyCmd.Name())
+	require.NotEmpty(legacyCmd.Deprecated)
+	require.NotNil(legacyCmd.Flags().Lookup("full-rebuild"))
+	require.NotNil(legacyCmd.Flags().Lookup("yes"))
 }
 
 func TestListEmbeddingGenerationsIncludesActiveAndBuilding(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	db := newEmbeddingMetadataTestDB(t)
 
 	rows, err := listEmbeddingGenerations(t.Context(), db)
-	requirepkg.NoError(t, err)
-	requirepkg.Len(t, rows, 2)
+	require.NoError(err)
+	require.Len(rows, 2)
 
-	assertpkg.Equal(t, vector.GenerationID(1), rows[0].ID)
-	assertpkg.Equal(t, vector.GenerationActive, rows[0].State)
-	assertpkg.Equal(t, int64(2), rows[0].MessageCount)
-	assertpkg.Equal(t, int64(0), rows[0].PendingCount)
+	assert.Equal(vector.GenerationID(1), rows[0].ID)
+	assert.Equal(vector.GenerationActive, rows[0].State)
+	assert.Equal(int64(2), rows[0].MessageCount)
+	assert.Equal(int64(0), rows[0].PendingCount)
 
-	assertpkg.Equal(t, vector.GenerationID(2), rows[1].ID)
-	assertpkg.Equal(t, vector.GenerationBuilding, rows[1].State)
-	assertpkg.Equal(t, int64(1), rows[1].PendingCount)
+	assert.Equal(vector.GenerationID(2), rows[1].ID)
+	assert.Equal(vector.GenerationBuilding, rows[1].State)
+	assert.Equal(int64(1), rows[1].PendingCount)
 }
 
 func TestActivateEmbeddingGenerationRetiresPreviousActive(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	db := newEmbeddingMetadataTestDB(t)
 	ctx := t.Context()
 
 	_, err := db.ExecContext(ctx, `DELETE FROM pending_embeddings WHERE generation_id = 2`)
-	requirepkg.NoError(t, err)
+	require.NoError(err)
 
-	requirepkg.NoError(t, activateEmbeddingGeneration(ctx, db, 2))
+	require.NoError(activateEmbeddingGeneration(ctx, db, 2))
 
-	active := mustGetEmbeddingGeneration(t, ctx, db, 2)
-	assertpkg.Equal(t, vector.GenerationActive, active.State)
-	assertpkg.NotNil(t, active.ActivatedAt)
-	assertpkg.NotNil(t, active.CompletedAt)
+	active := mustGetEmbeddingGeneration(ctx, t, db, 2)
+	assert.Equal(vector.GenerationActive, active.State)
+	assert.NotNil(active.ActivatedAt)
+	assert.NotNil(active.CompletedAt)
 
-	retired := mustGetEmbeddingGeneration(t, ctx, db, 1)
-	assertpkg.Equal(t, vector.GenerationRetired, retired.State)
-	assertpkg.NotNil(t, retired.CompletedAt)
+	retired := mustGetEmbeddingGeneration(ctx, t, db, 1)
+	assert.Equal(vector.GenerationRetired, retired.State)
+	assert.NotNil(retired.CompletedAt)
 }
 
 func TestRunEmbeddingsActivateRefusesPendingWithoutForce(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	dbPath := newEmbeddingMetadataTestDBFile(t)
 	withEmbeddingCommandConfig(t, dbPath)
 
@@ -93,15 +101,18 @@ func TestRunEmbeddingsActivateRefusesPendingWithoutForce(t *testing.T) {
 	embeddingsActivateYes = true
 	t.Cleanup(func() { embeddingsActivateYes = oldYes })
 	cmd := embeddingsActivateCmd
+	oldCtx := cmd.Context()
 	cmd.SetContext(context.Background())
-	t.Cleanup(func() { cmd.SetContext(nil) })
+	t.Cleanup(func() { cmd.SetContext(oldCtx) })
 	err := runEmbeddingsActivate(cmd, []string{"2"})
 
-	requirepkg.Error(t, err)
-	assertpkg.Contains(t, err.Error(), "pending embedding rows")
+	require.Error(err)
+	assert.Contains(err.Error(), "pending embedding rows")
 }
 
 func TestRetireEmbeddingGenerationRefusesActiveWithoutForce(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	dbPath := newEmbeddingMetadataTestDBFile(t)
 	withEmbeddingCommandConfig(t, dbPath)
 
@@ -115,21 +126,22 @@ func TestRetireEmbeddingGenerationRefusesActiveWithoutForce(t *testing.T) {
 	})
 
 	cmd := embeddingsRetireCmd
+	oldCtx := cmd.Context()
 	cmd.SetContext(context.Background())
-	t.Cleanup(func() { cmd.SetContext(nil) })
+	t.Cleanup(func() { cmd.SetContext(oldCtx) })
 
 	err := runEmbeddingsRetire(cmd, []string{"1"})
-	requirepkg.Error(t, err)
-	assertpkg.Contains(t, err.Error(), "active")
+	require.Error(err)
+	assert.Contains(err.Error(), "active")
 
 	embeddingsRetireForceActive = true
-	requirepkg.NoError(t, runEmbeddingsRetire(cmd, []string{"1"}))
+	require.NoError(runEmbeddingsRetire(cmd, []string{"1"}))
 
 	db, err := sql.Open("sqlite3", dbPath)
-	requirepkg.NoError(t, err)
-	t.Cleanup(func() { requirepkg.NoError(t, db.Close()) })
-	row := mustGetEmbeddingGeneration(t, t.Context(), db, 1)
-	assertpkg.Equal(t, vector.GenerationRetired, row.State)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(db.Close()) })
+	row := mustGetEmbeddingGeneration(t.Context(), t, db, 1)
+	assert.Equal(vector.GenerationRetired, row.State)
 }
 
 func newEmbeddingMetadataTestDB(t *testing.T) *sql.DB {
@@ -207,7 +219,7 @@ func newTestConfigForFingerprint(vecPath string) *config.Config {
 	}
 }
 
-func mustGetEmbeddingGeneration(t *testing.T, ctx context.Context, db *sql.DB, gen vector.GenerationID) embeddingGenerationRow {
+func mustGetEmbeddingGeneration(ctx context.Context, t *testing.T, db *sql.DB, gen vector.GenerationID) embeddingGenerationRow {
 	t.Helper()
 	row, err := getEmbeddingGeneration(ctx, db, gen)
 	requirepkg.NoError(t, err)

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -144,6 +144,24 @@ func TestRetireEmbeddingGenerationRefusesActiveWithoutForce(t *testing.T) {
 	assert.Equal(vector.GenerationRetired, row.State)
 }
 
+func TestRetireEmbeddingGenerationProtectsActiveRace(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	db := newEmbeddingMetadataTestDB(t)
+	ctx := t.Context()
+
+	err := retireEmbeddingGeneration(ctx, db, 1, false)
+	require.Error(err)
+	assert.Contains(err.Error(), "force-active")
+
+	active := mustGetEmbeddingGeneration(ctx, t, db, 1)
+	assert.Equal(vector.GenerationActive, active.State)
+
+	require.NoError(retireEmbeddingGeneration(ctx, db, 1, true))
+	retired := mustGetEmbeddingGeneration(ctx, t, db, 1)
+	assert.Equal(vector.GenerationRetired, retired.State)
+}
+
 func newEmbeddingMetadataTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	path := newEmbeddingMetadataTestDBFile(t)

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -21,6 +20,8 @@ import (
 
 func runEmbed(cmd *cobra.Command) error {
 	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
 	s, err := store.Open(cfg.DatabaseDSN())
 	if err != nil {
 		return fmt.Errorf("open main db: %w", err)
@@ -55,7 +56,7 @@ func runEmbed(cmd *cobra.Command) error {
 			return embedYes ||
 				confirmEmbed(cmd, "Start a full rebuild? This builds a new generation and atomically swaps it in when complete. ")
 		},
-		Stderr: cmd.ErrOrStderr(),
+		Stderr: errOut,
 	})
 	if err != nil {
 		return err
@@ -92,20 +93,20 @@ func runEmbed(cmd *cobra.Command) error {
 		EmbedTimeout:    cfg.Vector.Embeddings.Timeout,
 		EmbedMaxRetries: cfg.Vector.Embeddings.MaxRetries,
 		TotalPending:    totalPending,
-		Progress:        newProgressPrinter(os.Stderr, totalPending, cfg.Vector.Embeddings.ETAWindow),
+		Progress:        newProgressPrinter(errOut, totalPending, cfg.Vector.Embeddings.ETAWindow),
 	})
 
 	if n, err := worker.ReclaimStale(ctx); err != nil {
 		return fmt.Errorf("reclaim stale: %w", err)
 	} else if n > 0 {
-		fmt.Fprintf(os.Stderr, "Reclaimed %d stale claims.\n", n)
+		fmt.Fprintf(errOut, "Reclaimed %d stale claims.\n", n)
 	}
 
 	res, err := worker.RunOnce(ctx, gen)
 	if err != nil {
 		return fmt.Errorf("embed run: %w", err)
 	}
-	fmt.Printf("Claimed: %d, succeeded: %d, failed: %d, truncated: %d\n",
+	fmt.Fprintf(out, "Claimed: %d, succeeded: %d, failed: %d, truncated: %d\n",
 		res.Claimed, res.Succeeded, res.Failed, res.Truncated)
 
 	// Activation is a function of the generation's final state, not
@@ -121,9 +122,9 @@ func runEmbed(cmd *cobra.Command) error {
 			if err := backend.ActivateGeneration(ctx, gen); err != nil {
 				return fmt.Errorf("activate generation: %w", err)
 			}
-			fmt.Printf("Generation %d activated.\n", gen)
+			fmt.Fprintf(out, "Generation %d activated.\n", gen)
 		} else {
-			fmt.Fprintf(os.Stderr,
+			fmt.Fprintf(errOut,
 				"Generation %d still has %d pending rows; run `msgvault embeddings resume` again to finish, then it will activate automatically.\n",
 				gen, remaining)
 		}

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -122,7 +122,7 @@ func runEmbed(ctx context.Context) error {
 			fmt.Printf("Generation %d activated.\n", gen)
 		} else {
 			fmt.Fprintf(os.Stderr,
-				"Generation %d still has %d pending rows; run `msgvault embeddings build` again to finish, then it will activate automatically.\n",
+				"Generation %d still has %d pending rows; run `msgvault embeddings resume` again to finish, then it will activate automatically.\n",
 				gen, remaining)
 		}
 	}

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -124,7 +124,7 @@ func runEmbed(ctx context.Context) error {
 			fmt.Printf("Generation %d activated.\n", gen)
 		} else {
 			fmt.Fprintf(os.Stderr,
-				"Generation %d still has %d pending rows; run `msgvault build-embeddings` again to finish, then it will activate automatically.\n",
+				"Generation %d still has %d pending rows; run `msgvault embeddings build` again to finish, then it will activate automatically.\n",
 				gen, remaining)
 		}
 	}
@@ -187,7 +187,7 @@ func pickEmbedGeneration(ctx context.Context, backend vector.Backend, opts embed
 	//
 	//  1. A matching in-flight rebuild gets drained even if an
 	//     (older / stale) active generation also exists — otherwise
-	//     `msgvault build-embeddings` would top up the active index forever and
+	//     `msgvault embeddings build` would top up the active index forever and
 	//     leave the new build stranded in `building`.
 	//
 	//  2. A mismatched in-flight rebuild is rejected immediately,

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"errors"
@@ -11,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"go.kenn.io/msgvault/internal/store"
@@ -334,16 +332,4 @@ func formatETA(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%ds", s)
 	}
-}
-
-// confirmEmbed reads a y/N answer from stdin. Default is no.
-func confirmEmbed(prompt string) bool {
-	fmt.Fprint(os.Stderr, prompt+"[y/N]: ")
-	r := bufio.NewReader(os.Stdin)
-	line, err := r.ReadString('\n')
-	if err != nil {
-		return false
-	}
-	line = strings.TrimSpace(strings.ToLower(line))
-	return line == "y" || line == "yes"
 }

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -12,13 +12,15 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/embed"
 	"go.kenn.io/msgvault/internal/vector/sqlitevec"
 )
 
-func runEmbed(ctx context.Context) error {
+func runEmbed(cmd *cobra.Command) error {
+	ctx := cmd.Context()
 	s, err := store.Open(cfg.DatabaseDSN())
 	if err != nil {
 		return fmt.Errorf("open main db: %w", err)
@@ -51,9 +53,9 @@ func runEmbed(ctx context.Context) error {
 		Fingerprint: cfg.Vector.GenerationFingerprint(),
 		Confirm: func() bool {
 			return embedYes ||
-				confirmEmbed("Start a full rebuild? This builds a new generation and atomically swaps it in when complete. ")
+				confirmEmbed(cmd, "Start a full rebuild? This builds a new generation and atomically swaps it in when complete. ")
 		},
-		Stderr: os.Stderr,
+		Stderr: cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return err
@@ -140,7 +142,7 @@ type embedGenerationOpts struct {
 	// Confirm is only called when FullRebuild is true. Returns
 	// true if the user agreed to proceed.
 	Confirm func() bool
-	Stderr  *os.File
+	Stderr  io.Writer
 }
 
 // pickEmbedGeneration resolves which generation this embed run

--- a/cmd/msgvault/cmd/embed_vector_stub.go
+++ b/cmd/msgvault/cmd/embed_vector_stub.go
@@ -3,14 +3,15 @@
 package cmd
 
 import (
-	"context"
 	"errors"
+
+	"github.com/spf13/cobra"
 )
 
 // runEmbed is a stub for builds that lack the sqlite_vec build tag.
 // The sqlite-vec extension is required for embedding generation; binaries
 // produced by `make build` (which sets `-tags "fts5 sqlite_vec"`) use
 // the real implementation in embed_vector.go.
-func runEmbed(_ context.Context) error {
+func runEmbed(_ *cobra.Command) error {
 	return errors.New("msgvault embeddings build requires sqlite-vec support; rebuild with `go build -tags \"fts5 sqlite_vec\"`")
 }

--- a/cmd/msgvault/cmd/embed_vector_stub.go
+++ b/cmd/msgvault/cmd/embed_vector_stub.go
@@ -12,5 +12,5 @@ import (
 // produced by `make build` (which sets `-tags "fts5 sqlite_vec"`) use
 // the real implementation in embed_vector.go.
 func runEmbed(_ context.Context) error {
-	return errors.New("msgvault build-embeddings requires sqlite-vec support; rebuild with `go build -tags \"fts5 sqlite_vec\"`")
+	return errors.New("msgvault embeddings build requires sqlite-vec support; rebuild with `go build -tags \"fts5 sqlite_vec\"`")
 }

--- a/cmd/msgvault/cmd/embed_vector_test.go
+++ b/cmd/msgvault/cmd/embed_vector_test.go
@@ -137,7 +137,7 @@ func TestPickEmbedGeneration_ResumeFingerprintMismatch(t *testing.T) {
 // regression-guards the precedence bug where pickEmbedGeneration
 // targeted an existing active generation even when a building
 // generation for the configured model was in flight. The user
-// expectation is that `msgvault build-embeddings` drains the in-progress build
+// expectation is that `msgvault embeddings build` drains the in-progress build
 // (so it can be activated) rather than continuing to top up the old
 // active generation.
 func TestPickEmbedGeneration_PrefersBuildingOverActive_MatchingFingerprint(t *testing.T) {
@@ -275,7 +275,7 @@ func TestPickEmbedGeneration_FullRebuildAbortsWhenDeclined(t *testing.T) {
 // TestPickEmbedGeneration_ResumeReseedsUnseededBuilding regression-
 // guards the crash-window bug where a process that died between
 // inserting the building row and committing the initial seed would
-// leave the queue empty; a later `msgvault build-embeddings` would then "drain"
+// leave the queue empty; a later `msgvault embeddings build` would then "drain"
 // zero rows and silently activate an unseeded generation. The resume
 // path must call EnsureSeeded on the matched build before returning,
 // reseeding pending_embeddings so the activation gate sees real work
@@ -352,12 +352,12 @@ func TestPickEmbedGeneration_ResumeRacesActivation(t *testing.T) {
 	b := openTestBackend(t)
 
 	// Create the building generation as if the operator had just run
-	// `msgvault build-embeddings --full-rebuild`. CreateGeneration seeds pending
+	// `msgvault embeddings build --full-rebuild`. CreateGeneration seeds pending
 	// rows for id=1 via openTestBackend's seed message.
 	gen, err := b.CreateGeneration(ctx, "fake", 4, "")
 	require.NoError(err, "CreateGeneration")
 	// Simulate the race: another actor (the daemon, or a concurrent
-	// `msgvault build-embeddings` run that finished first) activated the
+	// `msgvault embeddings build` run that finished first) activated the
 	// generation. From this actor's perspective BuildingGeneration
 	// returned non-nil a moment ago, but the state has since flipped.
 	require.NoError(b.ActivateGeneration(ctx, gen), "ActivateGeneration")

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -152,7 +152,7 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := activateEmbeddingGeneration(cmd.Context(), db, gen); err != nil {
+	if err := activateEmbeddingGeneration(cmd.Context(), db, gen, embeddingsActivateForce); err != nil {
 		return err
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generation %d activated.\n", gen)
@@ -281,7 +281,7 @@ func retireEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.Gener
 	return fmt.Errorf("generation %d could not be retired from %q state", gen, row.State)
 }
 
-func activateEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID) error {
+func activateEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID, force bool) error {
 	now := time.Now().Unix()
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -298,12 +298,24 @@ func activateEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.Gen
 	res, err := tx.ExecContext(ctx,
 		`UPDATE index_generations
 		 SET state = 'active', activated_at = ?, completed_at = COALESCE(completed_at, ?)
-		 WHERE id = ? AND state = 'building'`, now, now, int64(gen))
+		 WHERE id = ? AND state = 'building'
+		   AND (? OR NOT EXISTS (
+		       SELECT 1 FROM pending_embeddings WHERE generation_id = ?
+		   ))`, now, now, int64(gen), force, int64(gen))
 	if err != nil {
 		return fmt.Errorf("activate generation %d: %w", gen, err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
+		var pending int64
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM pending_embeddings WHERE generation_id = ?`, int64(gen)).Scan(&pending); err != nil {
+			return fmt.Errorf("count pending rows for generation %d: %w", gen, err)
+		}
+		if pending > 0 && !force {
+			return fmt.Errorf("generation %d still has %d pending embedding rows; run `msgvault embeddings resume` or pass --force",
+				gen, pending)
+		}
 		return fmt.Errorf("generation %d not in %q state", gen, vector.GenerationBuilding)
 	}
 	if err := tx.Commit(); err != nil {

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -129,7 +129,7 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 			gen, row.Fingerprint, expected)
 	}
 	if row.PendingCount > 0 && !embeddingsActivateForce {
-		return fmt.Errorf("generation %d still has %d pending embedding rows; run `msgvault embeddings build` or pass --force",
+		return fmt.Errorf("generation %d still has %d pending embedding rows; run `msgvault embeddings resume` or pass --force",
 			gen, row.PendingCount)
 	}
 

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -62,7 +62,10 @@ func runEmbeddingsList(cmd *cobra.Command, _ []string) error {
 			formatGenerationTimePtr(row.ActivatedAt),
 		)
 	}
-	return w.Flush()
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("flush embedding generations table: %w", err)
+	}
+	return nil
 }
 
 func runEmbeddingsRetire(cmd *cobra.Command, args []string) error {
@@ -85,6 +88,7 @@ func runEmbeddingsRetire(cmd *cobra.Command, args []string) error {
 	case vector.GenerationRetired:
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generation %d is already retired.\n", gen)
 		return nil
+	case vector.GenerationBuilding:
 	case vector.GenerationActive:
 		if !embeddingsRetireForceActive {
 			return fmt.Errorf("generation %d is active; pass --force-active to retire the serving generation", gen)
@@ -133,13 +137,13 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 			gen, row.PendingCount)
 	}
 
-	active, err := activeEmbeddingGeneration(cmd.Context(), db)
+	active, hasActive, err := activeEmbeddingGeneration(cmd.Context(), db)
 	if err != nil {
 		return err
 	}
 	if !embeddingsActivateYes {
 		prompt := fmt.Sprintf("Activate generation %d (%s)", gen, row.Fingerprint)
-		if active != nil {
+		if hasActive {
 			prompt += fmt.Sprintf(" and retire active generation %d (%s)", active.ID, active.Fingerprint)
 		}
 		prompt += "? "
@@ -228,7 +232,7 @@ func getEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.Generati
 	return g, nil
 }
 
-func activeEmbeddingGeneration(ctx context.Context, db *sql.DB) (*embeddingGenerationRow, error) {
+func activeEmbeddingGeneration(ctx context.Context, db *sql.DB) (embeddingGenerationRow, bool, error) {
 	row := db.QueryRowContext(ctx, `
 		SELECT g.id, g.model, g.dimension, g.fingerprint, g.state,
 		       g.started_at, g.completed_at, g.activated_at, g.message_count,
@@ -239,12 +243,12 @@ func activeEmbeddingGeneration(ctx context.Context, db *sql.DB) (*embeddingGener
 		 GROUP BY g.id`, string(vector.GenerationActive))
 	g, err := scanEmbeddingGeneration(row)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return embeddingGenerationRow{}, false, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("lookup active generation: %w", err)
+		return embeddingGenerationRow{}, false, fmt.Errorf("lookup active generation: %w", err)
 	}
-	return &g, nil
+	return g, true, nil
 }
 
 func retireEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID) error {

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -24,6 +24,7 @@ type embeddingGenerationRow struct {
 	Fingerprint  string
 	State        vector.GenerationState
 	StartedAt    time.Time
+	SeededAt     *time.Time
 	CompletedAt  *time.Time
 	ActivatedAt  *time.Time
 	MessageCount int64
@@ -136,6 +137,10 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("generation %d still has %d pending embedding rows; run `msgvault embeddings resume` or pass --force",
 			gen, row.PendingCount)
 	}
+	if row.SeededAt == nil && !embeddingsActivateForce {
+		return fmt.Errorf("generation %d has not finished seeding; run `msgvault embeddings resume` or pass --force",
+			gen)
+	}
 
 	active, hasActive, err := activeEmbeddingGeneration(cmd.Context(), db)
 	if err != nil {
@@ -170,11 +175,19 @@ func openEmbeddingsMetadataDB() (*sql.DB, func(), error) {
 		}
 		return nil, nil, fmt.Errorf("stat vectors.db: %w", err)
 	}
-	db, err := sql.Open("sqlite3", vecPath)
+	db, err := sql.Open("sqlite3", sqliteDSNWithBusyTimeout(vecPath))
 	if err != nil {
 		return nil, nil, fmt.Errorf("open vectors.db: %w", err)
 	}
 	return db, func() { _ = db.Close() }, nil
+}
+
+func sqliteDSNWithBusyTimeout(path string) string {
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + "_busy_timeout=5000"
 }
 
 func parseGenerationID(s string) (vector.GenerationID, error) {
@@ -189,7 +202,7 @@ func listEmbeddingGenerations(ctx context.Context, db *sql.DB) ([]embeddingGener
 	rows, err := db.QueryContext(ctx, `
 		SELECT g.id, g.model, g.dimension, g.fingerprint, g.state,
 		       g.started_at, g.completed_at, g.activated_at, g.message_count,
-		       COUNT(p.message_id) AS pending_count
+		       g.seeded_at, COUNT(p.message_id) AS pending_count
 		  FROM index_generations g
 		  LEFT JOIN pending_embeddings p ON p.generation_id = g.id
 		 GROUP BY g.id
@@ -217,7 +230,7 @@ func getEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.Generati
 	row := db.QueryRowContext(ctx, `
 		SELECT g.id, g.model, g.dimension, g.fingerprint, g.state,
 		       g.started_at, g.completed_at, g.activated_at, g.message_count,
-		       COUNT(p.message_id) AS pending_count
+		       g.seeded_at, COUNT(p.message_id) AS pending_count
 		  FROM index_generations g
 		  LEFT JOIN pending_embeddings p ON p.generation_id = g.id
 		 WHERE g.id = ?
@@ -236,7 +249,7 @@ func activeEmbeddingGeneration(ctx context.Context, db *sql.DB) (embeddingGenera
 	row := db.QueryRowContext(ctx, `
 		SELECT g.id, g.model, g.dimension, g.fingerprint, g.state,
 		       g.started_at, g.completed_at, g.activated_at, g.message_count,
-		       COUNT(p.message_id) AS pending_count
+		       g.seeded_at, COUNT(p.message_id) AS pending_count
 		  FROM index_generations g
 		  LEFT JOIN pending_embeddings p ON p.generation_id = g.id
 		 WHERE g.state = ?
@@ -299,9 +312,10 @@ func activateEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.Gen
 		`UPDATE index_generations
 		 SET state = 'active', activated_at = ?, completed_at = COALESCE(completed_at, ?)
 		 WHERE id = ? AND state = 'building'
+		   AND (? OR seeded_at IS NOT NULL)
 		   AND (? OR NOT EXISTS (
 		       SELECT 1 FROM pending_embeddings WHERE generation_id = ?
-		   ))`, now, now, int64(gen), force, int64(gen))
+		   ))`, now, now, int64(gen), force, force, int64(gen))
 	if err != nil {
 		return fmt.Errorf("activate generation %d: %w", gen, err)
 	}
@@ -315,6 +329,19 @@ func activateEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.Gen
 		if pending > 0 && !force {
 			return fmt.Errorf("generation %d still has %d pending embedding rows; run `msgvault embeddings resume` or pass --force",
 				gen, pending)
+		}
+		var state vector.GenerationState
+		var seededAt sql.NullInt64
+		if err := tx.QueryRowContext(ctx,
+			`SELECT state, seeded_at FROM index_generations WHERE id = ?`, int64(gen)).Scan(&state, &seededAt); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("%w: %d", vector.ErrUnknownGeneration, gen)
+			}
+			return fmt.Errorf("lookup generation %d: %w", gen, err)
+		}
+		if state == vector.GenerationBuilding && !seededAt.Valid && !force {
+			return fmt.Errorf("generation %d has not finished seeding; run `msgvault embeddings resume` or pass --force",
+				gen)
 		}
 		return fmt.Errorf("generation %d not in %q state", gen, vector.GenerationBuilding)
 	}
@@ -331,7 +358,7 @@ type generationScanner interface {
 func scanEmbeddingGeneration(s generationScanner) (embeddingGenerationRow, error) {
 	var row embeddingGenerationRow
 	var startedAt int64
-	var completedAt, activatedAt sql.NullInt64
+	var seededAt, completedAt, activatedAt sql.NullInt64
 	if err := s.Scan(
 		&row.ID,
 		&row.Model,
@@ -342,11 +369,16 @@ func scanEmbeddingGeneration(s generationScanner) (embeddingGenerationRow, error
 		&completedAt,
 		&activatedAt,
 		&row.MessageCount,
+		&seededAt,
 		&row.PendingCount,
 	); err != nil {
 		return embeddingGenerationRow{}, err
 	}
 	row.StartedAt = time.Unix(startedAt, 0)
+	if seededAt.Valid {
+		t := time.Unix(seededAt.Int64, 0)
+		row.SeededAt = &t
+	}
 	if completedAt.Valid {
 		t := time.Unix(completedAt.Int64, 0)
 		row.CompletedAt = &t

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -101,7 +101,7 @@ func runEmbeddingsRetire(cmd *cobra.Command, args []string) error {
 			return errors.New("aborted")
 		}
 	}
-	if err := retireEmbeddingGeneration(cmd.Context(), db, gen); err != nil {
+	if err := retireEmbeddingGeneration(cmd.Context(), db, gen, embeddingsRetireForceActive); err != nil {
 		return err
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generation %d retired.\n", gen)
@@ -251,17 +251,34 @@ func activeEmbeddingGeneration(ctx context.Context, db *sql.DB) (embeddingGenera
 	return g, true, nil
 }
 
-func retireEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID) error {
+func retireEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID, forceActive bool) error {
+	stateFilter := `state = ?`
+	args := []any{string(vector.GenerationBuilding), int64(gen)}
+	if forceActive {
+		stateFilter = `state IN (?, ?)`
+		args = []any{string(vector.GenerationBuilding), string(vector.GenerationActive), int64(gen)}
+	}
 	res, err := db.ExecContext(ctx,
-		`UPDATE index_generations SET state = 'retired' WHERE id = ?`, int64(gen))
+		`UPDATE index_generations SET state = 'retired' WHERE `+stateFilter+` AND id = ?`, args...)
 	if err != nil {
 		return fmt.Errorf("retire generation %d: %w", gen, err)
 	}
 	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("%w: %d", vector.ErrUnknownGeneration, gen)
+	if n > 0 {
+		return nil
 	}
-	return nil
+
+	row, err := getEmbeddingGeneration(ctx, db, gen)
+	if err != nil {
+		return err
+	}
+	if row.State == vector.GenerationRetired {
+		return nil
+	}
+	if row.State == vector.GenerationActive && !forceActive {
+		return fmt.Errorf("generation %d is active; pass --force-active to retire the serving generation", gen)
+	}
+	return fmt.Errorf("generation %d could not be retired from %q state", gen, row.State)
 }
 
 func activateEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID) error {

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -1,0 +1,340 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver for vectors.db metadata commands.
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+type embeddingGenerationRow struct {
+	ID           vector.GenerationID
+	Model        string
+	Dimension    int
+	Fingerprint  string
+	State        vector.GenerationState
+	StartedAt    time.Time
+	CompletedAt  *time.Time
+	ActivatedAt  *time.Time
+	MessageCount int64
+	PendingCount int64
+}
+
+func runEmbeddingsList(cmd *cobra.Command, _ []string) error {
+	db, closeDB, err := openEmbeddingsMetadataDB()
+	if err != nil {
+		return err
+	}
+	defer closeDB()
+
+	rows, err := listEmbeddingGenerations(cmd.Context(), db)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No embedding generations found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tSTATE\tMODEL\tDIM\tMESSAGES\tPENDING\tFINGERPRINT\tSTARTED\tCOMPLETED\tACTIVATED")
+	for _, row := range rows {
+		_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\n",
+			row.ID,
+			row.State,
+			row.Model,
+			row.Dimension,
+			row.MessageCount,
+			row.PendingCount,
+			row.Fingerprint,
+			formatGenerationTime(row.StartedAt),
+			formatGenerationTimePtr(row.CompletedAt),
+			formatGenerationTimePtr(row.ActivatedAt),
+		)
+	}
+	return w.Flush()
+}
+
+func runEmbeddingsRetire(cmd *cobra.Command, args []string) error {
+	gen, err := parseGenerationID(args[0])
+	if err != nil {
+		return err
+	}
+
+	db, closeDB, err := openEmbeddingsMetadataDB()
+	if err != nil {
+		return err
+	}
+	defer closeDB()
+
+	row, err := getEmbeddingGeneration(cmd.Context(), db, gen)
+	if err != nil {
+		return err
+	}
+	switch row.State {
+	case vector.GenerationRetired:
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generation %d is already retired.\n", gen)
+		return nil
+	case vector.GenerationActive:
+		if !embeddingsRetireForceActive {
+			return fmt.Errorf("generation %d is active; pass --force-active to retire the serving generation", gen)
+		}
+	}
+
+	if !embeddingsRetireYes {
+		prompt := fmt.Sprintf("Retire generation %d (%s)? ", gen, row.Fingerprint)
+		if !confirmEmbed(prompt) {
+			return errors.New("aborted")
+		}
+	}
+	if err := retireEmbeddingGeneration(cmd.Context(), db, gen); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generation %d retired.\n", gen)
+	return nil
+}
+
+func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
+	gen, err := parseGenerationID(args[0])
+	if err != nil {
+		return err
+	}
+
+	db, closeDB, err := openEmbeddingsMetadataDB()
+	if err != nil {
+		return err
+	}
+	defer closeDB()
+
+	row, err := getEmbeddingGeneration(cmd.Context(), db, gen)
+	if err != nil {
+		return err
+	}
+	if row.State != vector.GenerationBuilding {
+		return fmt.Errorf("generation %d is %q, not %q", gen, row.State, vector.GenerationBuilding)
+	}
+	expected := cfg.Vector.GenerationFingerprint()
+	if row.Fingerprint != expected && !embeddingsActivateForce {
+		return fmt.Errorf("generation %d fingerprint=%q does not match config=%q; pass --force to activate anyway",
+			gen, row.Fingerprint, expected)
+	}
+	if row.PendingCount > 0 && !embeddingsActivateForce {
+		return fmt.Errorf("generation %d still has %d pending embedding rows; run `msgvault embeddings build` or pass --force",
+			gen, row.PendingCount)
+	}
+
+	active, err := activeEmbeddingGeneration(cmd.Context(), db)
+	if err != nil {
+		return err
+	}
+	if !embeddingsActivateYes {
+		prompt := fmt.Sprintf("Activate generation %d (%s)", gen, row.Fingerprint)
+		if active != nil {
+			prompt += fmt.Sprintf(" and retire active generation %d (%s)", active.ID, active.Fingerprint)
+		}
+		prompt += "? "
+		if !confirmEmbed(prompt) {
+			return errors.New("aborted")
+		}
+	}
+
+	if err := activateEmbeddingGeneration(cmd.Context(), db, gen); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Generation %d activated.\n", gen)
+	return nil
+}
+
+func openEmbeddingsMetadataDB() (*sql.DB, func(), error) {
+	vecPath := cfg.Vector.DBPath
+	if vecPath == "" {
+		vecPath = filepath.Join(cfg.Data.DataDir, "vectors.db")
+	}
+	if _, err := os.Stat(vecPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("vectors.db not found at %s", vecPath)
+		}
+		return nil, nil, fmt.Errorf("stat vectors.db: %w", err)
+	}
+	db, err := sql.Open("sqlite3", vecPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open vectors.db: %w", err)
+	}
+	return db, func() { _ = db.Close() }, nil
+}
+
+func parseGenerationID(s string) (vector.GenerationID, error) {
+	id, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("invalid generation id %q", s)
+	}
+	return vector.GenerationID(id), nil
+}
+
+func listEmbeddingGenerations(ctx context.Context, db *sql.DB) ([]embeddingGenerationRow, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT g.id, g.model, g.dimension, g.fingerprint, g.state,
+		       g.started_at, g.completed_at, g.activated_at, g.message_count,
+		       COUNT(p.message_id) AS pending_count
+		  FROM index_generations g
+		  LEFT JOIN pending_embeddings p ON p.generation_id = g.id
+		 GROUP BY g.id
+		 ORDER BY g.id`)
+	if err != nil {
+		return nil, fmt.Errorf("list embedding generations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []embeddingGenerationRow
+	for rows.Next() {
+		row, err := scanEmbeddingGeneration(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list embedding generations: %w", err)
+	}
+	return out, nil
+}
+
+func getEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID) (embeddingGenerationRow, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT g.id, g.model, g.dimension, g.fingerprint, g.state,
+		       g.started_at, g.completed_at, g.activated_at, g.message_count,
+		       COUNT(p.message_id) AS pending_count
+		  FROM index_generations g
+		  LEFT JOIN pending_embeddings p ON p.generation_id = g.id
+		 WHERE g.id = ?
+		 GROUP BY g.id`, int64(gen))
+	g, err := scanEmbeddingGeneration(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return embeddingGenerationRow{}, fmt.Errorf("%w: %d", vector.ErrUnknownGeneration, gen)
+	}
+	if err != nil {
+		return embeddingGenerationRow{}, fmt.Errorf("lookup generation %d: %w", gen, err)
+	}
+	return g, nil
+}
+
+func activeEmbeddingGeneration(ctx context.Context, db *sql.DB) (*embeddingGenerationRow, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT g.id, g.model, g.dimension, g.fingerprint, g.state,
+		       g.started_at, g.completed_at, g.activated_at, g.message_count,
+		       COUNT(p.message_id) AS pending_count
+		  FROM index_generations g
+		  LEFT JOIN pending_embeddings p ON p.generation_id = g.id
+		 WHERE g.state = ?
+		 GROUP BY g.id`, string(vector.GenerationActive))
+	g, err := scanEmbeddingGeneration(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lookup active generation: %w", err)
+	}
+	return &g, nil
+}
+
+func retireEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID) error {
+	res, err := db.ExecContext(ctx,
+		`UPDATE index_generations SET state = 'retired' WHERE id = ?`, int64(gen))
+	if err != nil {
+		return fmt.Errorf("retire generation %d: %w", gen, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("%w: %d", vector.ErrUnknownGeneration, gen)
+	}
+	return nil
+}
+
+func activateEmbeddingGeneration(ctx context.Context, db *sql.DB, gen vector.GenerationID) error {
+	now := time.Now().Unix()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin activate transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE index_generations
+		 SET state = 'retired', completed_at = COALESCE(completed_at, ?)
+		 WHERE state = 'active'`, now); err != nil {
+		return fmt.Errorf("retire previous active: %w", err)
+	}
+	res, err := tx.ExecContext(ctx,
+		`UPDATE index_generations
+		 SET state = 'active', activated_at = ?, completed_at = COALESCE(completed_at, ?)
+		 WHERE id = ? AND state = 'building'`, now, now, int64(gen))
+	if err != nil {
+		return fmt.Errorf("activate generation %d: %w", gen, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("generation %d not in %q state", gen, vector.GenerationBuilding)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit activate transaction: %w", err)
+	}
+	return nil
+}
+
+type generationScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanEmbeddingGeneration(s generationScanner) (embeddingGenerationRow, error) {
+	var row embeddingGenerationRow
+	var startedAt int64
+	var completedAt, activatedAt sql.NullInt64
+	if err := s.Scan(
+		&row.ID,
+		&row.Model,
+		&row.Dimension,
+		&row.Fingerprint,
+		&row.State,
+		&startedAt,
+		&completedAt,
+		&activatedAt,
+		&row.MessageCount,
+		&row.PendingCount,
+	); err != nil {
+		return embeddingGenerationRow{}, err
+	}
+	row.StartedAt = time.Unix(startedAt, 0)
+	if completedAt.Valid {
+		t := time.Unix(completedAt.Int64, 0)
+		row.CompletedAt = &t
+	}
+	if activatedAt.Valid {
+		t := time.Unix(activatedAt.Int64, 0)
+		row.ActivatedAt = &t
+	}
+	return row, nil
+}
+
+func formatGenerationTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func formatGenerationTimePtr(t *time.Time) string {
+	if t == nil {
+		return "-"
+	}
+	return formatGenerationTime(*t)
+}

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -93,7 +93,7 @@ func runEmbeddingsRetire(cmd *cobra.Command, args []string) error {
 
 	if !embeddingsRetireYes {
 		prompt := fmt.Sprintf("Retire generation %d (%s)? ", gen, row.Fingerprint)
-		if !confirmEmbed(prompt) {
+		if !confirmEmbed(cmd, prompt) {
 			return errors.New("aborted")
 		}
 	}
@@ -143,7 +143,7 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 			prompt += fmt.Sprintf(" and retire active generation %d (%s)", active.ID, active.Fingerprint)
 		}
 		prompt += "? "
-		if !confirmEmbed(prompt) {
+		if !confirmEmbed(cmd, prompt) {
 			return errors.New("aborted")
 		}
 	}

--- a/cmd/msgvault/cmd/identity.go
+++ b/cmd/msgvault/cmd/identity.go
@@ -40,7 +40,7 @@ case-insensitivity is handled at compare time by consumers, not at the store.`,
 }
 
 var identityListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   cmdUseList,
 	Short: "List confirmed identifiers across one or more accounts",
 	RunE:  runIdentityList,
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -546,7 +546,7 @@ func (s *Server) handleHybridSearch(
 				"vector search is not configured")
 		case errors.Is(err, vector.ErrIndexStale):
 			writeError(w, http.StatusServiceUnavailable, "index_stale",
-				"the vector index does not match the configured model; run `msgvault build-embeddings --full-rebuild`")
+				"the vector index does not match the configured model; run `msgvault embeddings build --full-rebuild`")
 		case errors.Is(err, vector.ErrIndexBuilding):
 			writeError(w, http.StatusServiceUnavailable, "index_building",
 				"the initial vector index is still being built")

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -52,7 +52,7 @@ func translateVectorErr(err error) *mcp.CallToolResult {
 	case errors.Is(err, vector.ErrIndexStale):
 		return mcp.NewToolResultError(
 			"index_stale: the vector index does not match the configured model; " +
-				"run `msgvault build-embeddings --full-rebuild`",
+				"run `msgvault embeddings build --full-rebuild`",
 		)
 	case errors.Is(err, vector.ErrIndexBuilding):
 		return mcp.NewToolResultError(
@@ -61,7 +61,7 @@ func translateVectorErr(err error) *mcp.CallToolResult {
 	case errors.Is(err, vector.ErrNoActiveGeneration):
 		return mcp.NewToolResultError(
 			"no_active_generation: vector search has no active index yet; " +
-				"run `msgvault build-embeddings` to build one",
+				"run `msgvault embeddings build` to build one",
 		)
 	case errors.Is(err, vector.ErrEmbeddingTimeout):
 		return mcp.NewToolResultError(

--- a/internal/scheduler/embed_job.go
+++ b/internal/scheduler/embed_job.go
@@ -46,7 +46,7 @@ type EmbedJob struct {
 	// vector.Config.GenerationFingerprint() — "model:dim:preprocess").
 	// When set, a building OR active generation whose fingerprint
 	// differs is left alone: the CLI is the only entry point that can
-	// resolve a mismatch (`build-embeddings --full-rebuild` or retire).
+	// resolve a mismatch (`embeddings build --full-rebuild` or retire).
 	// When empty, the daemon falls back to "any building generation"
 	// for building gens and "the active generation as-is" for active —
 	// see pickTarget for why empty-fingerprint plus a present building
@@ -164,7 +164,7 @@ func (j *EmbedJob) Run(ctx context.Context) {
 //     can activate. Building takes precedence over active even when
 //     active matches, because a stranded build is the bigger problem.
 //  2. Mismatched building generation — log and bail. Resolution
-//     requires the CLI (`msgvault build-embeddings --full-rebuild` or retire),
+//     requires the CLI (`msgvault embeddings build --full-rebuild` or retire),
 //     not the daemon.
 //  3. Active generation whose fingerprint matches config — incremental
 //     top-up. A mismatched active fingerprint is treated the same as a

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -709,7 +709,7 @@ func TestEmbedJob_Run_DoesNotActivateWhilePending(t *testing.T) {
 // daemon silently topping up an unrelated rebuild. When a building
 // generation's fingerprint differs from the configured one, the
 // daemon must bail out so the operator can resolve via the CLI
-// (`msgvault build-embeddings --full-rebuild` or retire the stale build).
+// (`msgvault embeddings build --full-rebuild` or retire the stale build).
 func TestEmbedJob_Run_LeavesMismatchedBuildingForCLI(t *testing.T) {
 	building := &vector.Generation{ID: 33, State: vector.GenerationBuilding, Fingerprint: "old:512"}
 	backend := &fakeBackend{

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -203,7 +203,7 @@ type EmbedConfig struct {
 }
 
 // EmbedScheduleConfig controls when the embed worker runs on its own
-// (outside of explicit `msgvault build-embeddings` invocations).
+// (outside of explicit `msgvault embeddings build` invocations).
 type EmbedScheduleConfig struct {
 	Cron         string `toml:"cron"`           // empty disables scheduled embedding
 	RunAfterSync bool   `toml:"run_after_sync"` // trigger after each successful sync

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -175,7 +175,7 @@ func (b *Backend) markGenerationSeeded(ctx context.Context, gen vector.Generatio
 // EnsureSeeded re-runs the initial seed pass for gen if seeded_at is
 // NULL. Used on the resume path so that a crash between
 // claimOrInsertBuilding and the original seedPending commit cannot
-// cause a later `msgvault build-embeddings` to "drain" zero pending rows and
+// cause a later `msgvault embeddings build` to "drain" zero pending rows and
 // activate an unseeded generation. Returns an error if gen no longer
 // exists or has been activated/retired (state != 'building'); the
 // caller should surface --full-rebuild guidance in that case.

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -140,7 +140,7 @@ func TestBackend_CreateGeneration_ResumeDoesNotReseedCompleted(t *testing.T) {
 // exists but seeded_at is NULL because the previous attempt died
 // before the seed transaction committed. A naive resume would skip
 // seedPending, leave pending_embeddings empty, and let
-// `msgvault build-embeddings` activate the unseeded generation — silently
+// `msgvault embeddings build` activate the unseeded generation — silently
 // replacing the prior active index with an empty one. The fix is to
 // re-run seedPending whenever seeded_at IS NULL on resume.
 func TestBackend_CreateGeneration_ResumeReseedsUnseededGeneration(t *testing.T) {


### PR DESCRIPTION
## Why
Issue #357 exposed a bad operational state in the vector embedding workflow: a rebuild can be interrupted or left building under one embedding fingerprint, and a later run with a different configured fingerprint refuses to continue until that existing generation is either activated or retired. Before this PR, those lifecycle states existed in `vectors.db` and in internal backend methods, but the CLI gave operators no supported way to inspect or resolve them. The practical recovery path was direct SQL against `index_generations`, which is brittle and easy to get wrong.

The change gives that state an explicit CLI surface. `msgvault embeddings list` makes active/building/retired generations visible, `resume` is the safe next action for a building generation with pending rows, `retire` handles stale or unwanted builds, and `activate` exists for recovery cases where a completed building generation should become the serving index. Activation stays guarded because the wrong activation can expose an incomplete index or a generation whose fingerprint does not match the current config.

The old top-level `build-embeddings` command remains as a deprecated compatibility alias so existing scripts do not break while the new `embeddings` namespace becomes the place for generation lifecycle commands.

Refs #357

## What changed
- Added `msgvault embeddings build`, `resume`, `list`, `retire`, and guarded `activate`.
- Kept `msgvault build-embeddings` as a deprecated alias.
- Updated vector-search guidance to point users at the new lifecycle commands.
- Routed embedding prompts, progress, and status output through Cobra command IO so tests and redirected/embedded command execution do not leak through process-level stdin/stdout/stderr.

## Validation
- `go test ./cmd/msgvault/cmd`
- `go test -tags 'fts5 sqlite_vec' ./cmd/msgvault/cmd`
- `go test ./cmd/msgvault/cmd ./internal/api ./internal/mcp ./internal/scheduler ./internal/vector ./internal/vector/embed ./internal/vector/hybrid`

Note: full `go test ./...` was also run during development and still fails in existing `internal/store` FTS/tokenless query tests unrelated to this command work.