### PR TITLE
Update nix flake for v0.15.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
   sqlite,
 }:
 let
-  version = "0.14.1";
+  version = "0.15.0";
 in
 buildGoModule {
   pname = "msgvault";


### PR DESCRIPTION
## Summary
- Bump `nix/package.nix` from 0.14.1 to 0.15.0 for the v0.15.0 release.
- `vendorHash` unchanged — no dependency changes since v0.14.1.

Completes the `scripts/update-nix-flake.sh` run for the v0.15.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)