### PR TITLE
Fix update check and setup image after wesm -> kenn-io rename

### DIFF
--- a/cmd/msgvault/cmd/setup.go
+++ b/cmd/msgvault/cmd/setup.go
@@ -276,7 +276,7 @@ rate_limit_qps = 5
 	// Create docker-compose.yml
 	dockerCompose := fmt.Sprintf(`services:
   msgvault:
-    image: ghcr.io/wesm/msgvault:latest
+    image: ghcr.io/kenn-io/msgvault:latest
     container_name: msgvault
     user: root  # Required for Synology NAS ACLs
     restart: unless-stopped

--- a/cmd/msgvault/cmd/setup_test.go
+++ b/cmd/msgvault/cmd/setup_test.go
@@ -54,7 +54,7 @@ func TestCreateNASBundle(t *testing.T) {
 	require.NoError(err, "read docker-compose.yml")
 	composeStr := string(composeData)
 	assert.Contains(composeStr, "9090:8080", "docker-compose.yml should map port 9090:8080")
-	assert.Contains(composeStr, "ghcr.io/wesm/msgvault", "docker-compose.yml should reference the msgvault image")
+	assert.Contains(composeStr, "ghcr.io/kenn-io/msgvault", "docker-compose.yml should reference the msgvault image")
 }
 
 func TestCreateNASBundle_NoSecrets(t *testing.T) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -27,8 +27,8 @@ const (
 	// githubLatestReleaseURL is the HTML endpoint that 302-redirects to
 	// /releases/tag/<tag>. Unlike api.github.com it is not rate-limited
 	// at 60 req/hr per IP for unauthenticated callers.
-	githubLatestReleaseURL    = "https://github.com/wesm/msgvault/releases/latest"
-	githubReleaseDownloadBase = "https://github.com/wesm/msgvault/releases/download"
+	githubLatestReleaseURL    = "https://github.com/kenn-io/msgvault/releases/latest"
+	githubReleaseDownloadBase = "https://github.com/kenn-io/msgvault/releases/download"
 	updateUserAgent           = "msgvault-update"
 	cacheFileName             = "update_check.json"
 	cacheDuration             = 1 * time.Hour

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -342,6 +343,21 @@ func TestIsNewer(t *testing.T) {
 	}
 }
 
+// TestUpdateURLsTargetCanonicalRepo guards the only manual sync point between
+// the updater and the repository's GitHub location. When the org was renamed
+// (wesm -> kenn-io) these constants were missed, so GitHub served a repo-rename
+// 301 that resolveLatestTag rejected with "unexpected redirect target". This
+// fails loudly if the URLs ever drift from the canonical repo again.
+func TestUpdateURLsTargetCanonicalRepo(t *testing.T) {
+	t.Parallel()
+	const wantPrefix = "https://github.com/kenn-io/msgvault/"
+	assert := assertpkg.New(t)
+	assert.Truef(strings.HasPrefix(githubLatestReleaseURL, wantPrefix),
+		"githubLatestReleaseURL must target the canonical repo, got %q", githubLatestReleaseURL)
+	assert.Truef(strings.HasPrefix(githubReleaseDownloadBase, wantPrefix),
+		"githubReleaseDownloadBase must target the canonical repo, got %q", githubReleaseDownloadBase)
+}
+
 func TestResolveLatestTag(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -354,13 +370,13 @@ func TestResolveLatestTag(t *testing.T) {
 		{
 			name:     "valid 302 redirect",
 			status:   http.StatusFound,
-			location: "https://github.com/wesm/msgvault/releases/tag/v0.30.1",
+			location: "https://github.com/kenn-io/msgvault/releases/tag/v0.30.1",
 			wantTag:  "v0.30.1",
 		},
 		{
 			name:     "pre-release tag",
 			status:   http.StatusFound,
-			location: "https://github.com/wesm/msgvault/releases/tag/v0.9.0-rc1",
+			location: "https://github.com/kenn-io/msgvault/releases/tag/v0.9.0-rc1",
 			wantTag:  "v0.9.0-rc1",
 		},
 		{
@@ -371,13 +387,13 @@ func TestResolveLatestTag(t *testing.T) {
 		{
 			name:       "redirect target without /tag/",
 			status:     http.StatusFound,
-			location:   "https://github.com/wesm/msgvault/releases",
+			location:   "https://github.com/kenn-io/msgvault/releases",
 			wantErrSub: "unexpected redirect target",
 		},
 		{
 			name:       "empty tag after /tag/",
 			status:     http.StatusFound,
-			location:   "https://github.com/wesm/msgvault/releases/tag/",
+			location:   "https://github.com/kenn-io/msgvault/releases/tag/",
 			wantErrSub: "empty tag",
 		},
 	}


### PR DESCRIPTION
After the repository moved from the `wesm` org to `kenn-io`, two hardcoded
references to the old org broke at runtime.

- `msgvault update` failed with `unexpected redirect target`. The updater's
  release URLs still pointed at `github.com/wesm/msgvault`, so GitHub's
  repo-rename redirect was rejected before the release tag could be resolved.
  The URLs now point at `github.com/kenn-io/msgvault`, and a guard test fails
  if they drift from the canonical repo again.

- `msgvault setup` generated a `docker-compose.yml` referencing
  `ghcr.io/wesm/msgvault:latest`, but CI publishes the image to
  `ghcr.io/kenn-io/msgvault`. Docker/NAS deploys from `setup` now reference the
  current image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)