### PR TITLE
fix(install): Windows PowerShell 5.x redirect + arm64 fallback

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -64,10 +64,36 @@ function Invoke-WebRequestCompat {
     }
 }
 
+function Get-FinalUrl {
+    # Returns the URL that ultimately responded to a request, after any
+    # redirects were followed. The property differs by PowerShell edition:
+    # Windows PowerShell 5.x exposes HttpWebResponse.ResponseUri, while
+    # PowerShell 7+ exposes HttpResponseMessage.RequestMessage.RequestUri.
+    param($Response)
+    try {
+        if ($Response.BaseResponse.ResponseUri) {
+            return $Response.BaseResponse.ResponseUri.AbsoluteUri
+        }
+    } catch {}
+    try {
+        if ($Response.BaseResponse.RequestMessage.RequestUri) {
+            return $Response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+        }
+    } catch {}
+    return $null
+}
+
 function Get-LatestVersion {
-    # Use the HTML /releases/latest endpoint, which 302-redirects to
-    # /releases/tag/<version>. Unlike api.github.com it is not rate-limited
-    # at 60 req/hr per IP, so users behind shared NAT / VPN don't get 403.
+    # Resolve the latest release tag by following the /releases/latest
+    # 302 redirect to /releases/tag/<version> and reading the final URL.
+    # Using the HTML endpoint (not api.github.com) avoids the 60 req/hr
+    # per-IP rate limit, so users behind shared NAT / VPN don't get 403.
+    #
+    # We let Invoke-WebRequest follow the redirect rather than inspecting
+    # the Location header with MaximumRedirection=0: in Windows PowerShell
+    # 5.x that throws a System.InvalidOperationException (not a WebException
+    # with a usable .Response), which broke the install. A HEAD request
+    # follows the redirect without downloading the release page body.
     $url = "https://github.com/$repo/releases/latest"
 
     if ($PSVersionTable.PSVersion.Major -lt 6) {
@@ -76,36 +102,79 @@ function Get-LatestVersion {
 
     $params = @{
         Uri = $url
-        MaximumRedirection = 0
+        Method = 'Head'
         ErrorAction = 'Stop'
     }
     if ($PSVersionTable.PSVersion.Major -lt 6) {
         $params.UseBasicParsing = $true
     }
 
-    $location = $null
+    $finalUrl = $null
     try {
-        # PowerShell 7+ returns the 302 as a normal response.
         $response = Invoke-WebRequest @params
-        $location = $response.Headers.Location
+        $finalUrl = Get-FinalUrl $response
     } catch {
-        # PowerShell 5.x throws System.Net.WebException for 3xx when
-        # MaximumRedirection=0. The Location header lives on the response.
-        if ($_.Exception.Response) {
-            $location = $_.Exception.Response.Headers['Location']
-        } else {
-            throw "Failed to fetch latest version: $_"
-        }
+        throw "Failed to fetch latest version: $_"
     }
 
-    if ($location -is [array]) { $location = $location[0] }
-    if (-not $location) {
-        throw "Failed to fetch latest version: no Location header from $url"
+    if (-not $finalUrl) {
+        throw "Failed to fetch latest version: could not resolve release URL from $url"
     }
-    if ($location -notmatch '/releases/tag/([^/]+)/?$') {
-        throw "Failed to fetch latest version: unexpected redirect target $location"
+    if ($finalUrl -notmatch '/releases/tag/([^/]+)/?$') {
+        throw "Failed to fetch latest version: unexpected release URL $finalUrl"
     }
     return $Matches[1]
+}
+
+function Test-ReleaseAsset {
+    # Returns $true when the given release asset URL exists (HTTP 2xx),
+    # following the redirect to the storage backend. Used to detect
+    # whether a native build is published for the detected architecture.
+    param([string]$Url)
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+
+    $params = @{
+        Uri = $Url
+        Method = 'Head'
+        ErrorAction = 'Stop'
+    }
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $params.UseBasicParsing = $true
+    }
+
+    try {
+        $response = Invoke-WebRequest @params
+        return ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300)
+    } catch {
+        return $false
+    }
+}
+
+function Resolve-ReleaseArch {
+    # Returns the release arch to install for the detected CPU arch.
+    # Prefers a native build, but falls back to amd64 on arm64 because
+    # Windows on ARM transparently runs x64 binaries under emulation and
+    # no native windows/arm64 asset is published for every release.
+    # Returns $null when no usable asset exists.
+    param([string]$DetectedArch, [string]$Version)
+
+    $candidates = @($DetectedArch)
+    if ($DetectedArch -eq 'arm64') {
+        $candidates += 'amd64'
+    }
+
+    $versionNum = $Version.TrimStart('v')
+    foreach ($candidate in $candidates) {
+        $name = "msgvault_${versionNum}_windows_${candidate}.zip"
+        $url = "https://github.com/$repo/releases/download/$Version/$name"
+        if (Test-ReleaseAsset $url) {
+            return $candidate
+        }
+    }
+    return $null
 }
 
 function Get-InstallDir {
@@ -154,6 +223,17 @@ function Install-Msgvault {
 
     $version = Get-LatestVersion
     Write-Info "Latest version: $version"
+
+    $resolvedArch = Resolve-ReleaseArch -DetectedArch $arch -Version $version
+    if (-not $resolvedArch) {
+        Write-Err "Error: No Windows release asset found for $version (detected windows/$arch)."
+        Write-Err "See https://github.com/$repo for build-from-source instructions."
+        exit 1
+    }
+    if ($resolvedArch -ne $arch) {
+        Write-Warn "No native windows/$arch build for $version; installing windows/$resolvedArch (runs under emulation)."
+        $arch = $resolvedArch
+    }
 
     $versionNum = $version.TrimStart('v')
     $archiveName = "msgvault_${versionNum}_windows_${arch}.zip"


### PR DESCRIPTION
Fixes the Windows installer (`irm https://msgvault.io/install.ps1 | iex`), reported in #374.

## PowerShell 5.x: "maximum redirection count exceeded"

`Get-LatestVersion` requested `/releases/latest` with `MaximumRedirection = 0` and read the `Location` header off the redirect. That works in PowerShell 7+, but Windows PowerShell 5.x (the `powershell` host the one-liner uses) throws a `System.InvalidOperationException` for the 302 rather than a `WebException`, so `$_.Exception.Response` is null and the installer aborts. Now follow the 302 with a `HEAD` request and read the final resolved URL (`ResponseUri` on 5.x, `RequestMessage.RequestUri` on 7+).

## Windows arm64: 404 on a non-existent asset

`Get-Architecture` detects arm64, but the release matrix only publishes `windows_amd64`, so the arm64 download URL 404s. The installer now resolves the release arch before downloading: it prefers a native build and falls back to `windows_amd64` (which runs under Windows-on-ARM x64 emulation) with a clear warning. Once a native `windows/arm64` asset is published it is preferred automatically.

Ports the `install.ps1` fixes from agentsview `b328d24f`.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)