### PR TITLE
Update nix flake for v0.15.2

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
   sqlite,
 }:
 let
-  version = "0.15.1";
+  version = "0.15.2";
 in
 buildGoModule {
   pname = "msgvault";


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-Apa8gmFItEj62FxWS1Hfk0d8bGjvewkq4uZ+ftVcAEc=`
- Updated version to `0.15.2`

Automated update via `scripts/update-nix-flake.sh`.