### PR TITLE
fix: tolerate null source import checksums

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -145,7 +145,7 @@ func TestStore_SourceImportItems(t *testing.T) {
 	assert.Equal("abc123", checksums["drive-file-1"], "imported checksum")
 
 	_, err = f.Store.DB().Exec(
-		`UPDATE source_import_items SET checksum = NULL WHERE source_id = ? AND provider = ? AND provider_id = ?`,
+		f.Store.Rebind(`UPDATE source_import_items SET checksum = NULL WHERE source_id = ? AND provider = ? AND provider_id = ?`),
 		src.ID, "drive", "drive-file-1",
 	)
 	require.NoError(err, "set checksum NULL")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -143,6 +143,18 @@ func TestStore_SourceImportItems(t *testing.T) {
 	checksums, err = f.Store.ListImportedSourceItemChecksums(src.ID, "drive")
 	require.NoError(err, "ListImportedSourceItemChecksums imported")
 	assert.Equal("abc123", checksums["drive-file-1"], "imported checksum")
+
+	_, err = f.Store.DB().Exec(
+		`UPDATE source_import_items SET checksum = NULL WHERE source_id = ? AND provider = ? AND provider_id = ?`,
+		src.ID, "drive", "drive-file-1",
+	)
+	require.NoError(err, "set checksum NULL")
+	got, err = f.Store.GetSourceImportItem(src.ID, "drive", "drive-file-1")
+	require.NoError(err, "GetSourceImportItem with NULL checksum")
+	assert.Empty(got.Checksum, "NULL checksum should surface as empty string")
+	checksums, err = f.Store.ListImportedSourceItemChecksums(src.ID, "drive")
+	require.NoError(err, "ListImportedSourceItemChecksums with NULL checksum")
+	assert.Empty(checksums["drive-file-1"], "NULL imported checksum should surface as empty string")
 }
 
 func TestStore_Conversation(t *testing.T) {

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -357,6 +357,7 @@ func (s *Store) UpsertSourceImportItem(item SourceImportItem) error {
 
 func (s *Store) GetSourceImportItem(sourceID int64, provider, providerID string) (*SourceImportItem, error) {
 	var item SourceImportItem
+	var checksum sql.NullString
 	err := s.db.QueryRow(`
 		SELECT id, source_id, provider, provider_id, name, checksum, size,
 		       modified_at, imported_at, status, records_imported, error_message
@@ -364,7 +365,7 @@ func (s *Store) GetSourceImportItem(sourceID int64, provider, providerID string)
 		WHERE source_id = ? AND provider = ? AND provider_id = ?
 	`, sourceID, provider, providerID).Scan(
 		&item.ID, &item.SourceID, &item.Provider, &item.ProviderID, &item.Name,
-		&item.Checksum, &item.Size, &item.ModifiedAt, &item.ImportedAt,
+		&checksum, &item.Size, &item.ModifiedAt, &item.ImportedAt,
 		&item.Status, &item.RecordsImported, &item.ErrorMessage,
 	)
 	if err == sql.ErrNoRows {
@@ -373,6 +374,7 @@ func (s *Store) GetSourceImportItem(sourceID int64, provider, providerID string)
 	if err != nil {
 		return nil, fmt.Errorf("get source import item: %w", err)
 	}
+	item.Checksum = checksum.String
 	return &item, nil
 }
 
@@ -388,11 +390,12 @@ func (s *Store) ListImportedSourceItemChecksums(sourceID int64, provider string)
 	defer func() { _ = rows.Close() }()
 	out := map[string]string{}
 	for rows.Next() {
-		var providerID, checksum string
+		var providerID string
+		var checksum sql.NullString
 		if err := rows.Scan(&providerID, &checksum); err != nil {
 			return nil, fmt.Errorf("scan source import item checksum: %w", err)
 		}
-		out[providerID] = checksum
+		out[providerID] = checksum.String
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate source import item checksums: %w", err)


### PR DESCRIPTION
## What changed
- Scan source import item checksums through sql.NullString in GetSourceImportItem and ListImportedSourceItemChecksums.
- Surface an empty checksum string when legacy/imported rows contain NULL.
- Add focused store coverage for NULL checksum rows.

## Why
Some source_import_items rows can have NULL checksum values, which previously caused scan errors when imported source items were read back.

## Impact
Nullable checksums no longer break source import lookup or imported checksum listing; non-NULL checksum behavior is unchanged.

## Validation
- gofmt on touched Go files
- go test -tags "fts5 sqlite_vec" ./internal/store
- make testify-helper-check
- go vet -tags "fts5 sqlite_vec" ./...