### PR TITLE
fix: harden Synctech Drive sync lifecycle

### DIFF
--- a/cmd/msgvault/cmd/add_synctech_sms_drive.go
+++ b/cmd/msgvault/cmd/add_synctech_sms_drive.go
@@ -154,7 +154,23 @@ func ensureConfiguredSynctechSMSSource(st *store.Store, src config.SynctechSMSSo
 	return source, nil
 }
 
+// validateSynctechSMSDriveSource checks the required Drive source fields.
+// It runs before Drive client construction so a misconfigured source
+// surfaces a clear config error instead of an OAuth/token failure.
+func validateSynctechSMSDriveSource(src config.SynctechSMSSource) error {
+	if src.GoogleAccount == "" {
+		return fmt.Errorf("synctech-sms source %q google_account is required", src.Name)
+	}
+	if src.FolderID == "" {
+		return fmt.Errorf("synctech-sms source %q folder_id is required", src.Name)
+	}
+	return nil
+}
+
 func runSynctechSMSDriveSource(ctx context.Context, st *store.Store, src config.SynctechSMSSource, opts synctechsms.ImportOptions) error {
+	if err := validateSynctechSMSDriveSource(src); err != nil {
+		return err
+	}
 	client, err := newSynctechSMSDriveClient(ctx, src)
 	if err != nil {
 		return err
@@ -163,11 +179,8 @@ func runSynctechSMSDriveSource(ctx context.Context, st *store.Store, src config.
 }
 
 func runSynctechSMSDriveSourceWithClient(ctx context.Context, st *store.Store, src config.SynctechSMSSource, opts synctechsms.ImportOptions, client synctechsms.DriveClient) (retErr error) {
-	if src.GoogleAccount == "" {
-		return fmt.Errorf("synctech-sms source %q google_account is required", src.Name)
-	}
-	if src.FolderID == "" {
-		return fmt.Errorf("synctech-sms source %q folder_id is required", src.Name)
+	if err := validateSynctechSMSDriveSource(src); err != nil {
+		return err
 	}
 	source, err := ensureConfiguredSynctechSMSSource(st, src, opts)
 	if err != nil {

--- a/cmd/msgvault/cmd/add_synctech_sms_drive.go
+++ b/cmd/msgvault/cmd/add_synctech_sms_drive.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -108,43 +109,93 @@ func runConfiguredSynctechSMSSource(ctx context.Context, src config.SynctechSMSS
 		return err
 	}
 	defer func() { _ = st.Close() }()
+	return runConfiguredSynctechSMSSourceWithStore(ctx, st, src)
+}
+
+func runConfiguredSynctechSMSSourceWithStore(ctx context.Context, st *store.Store, src config.SynctechSMSSource) error {
 	opts := synctechImportOptions(src)
+	if opts.OwnerPhone == "" {
+		return fmt.Errorf("synctech-sms source %q owner_phone is required", src.Name)
+	}
+	var err error
 	switch src.Backend {
 	case "", "local":
 		if src.Path == "" {
 			return fmt.Errorf("synctech-sms source %q path is required for local backend", src.Name)
 		}
-		_, err := synctechsms.NewImporter(st, opts).ImportPath(src.Path)
-		return err
+		if _, err := ensureConfiguredSynctechSMSSource(st, src, opts); err != nil {
+			return err
+		}
+		_, err = synctechsms.NewImporter(st, opts).ImportPath(src.Path)
 	case "drive":
-		return runSynctechSMSDriveSource(ctx, st, src, opts)
+		err = runSynctechSMSDriveSource(ctx, st, src, opts)
 	default:
 		return fmt.Errorf("unsupported synctech-sms backend %q", src.Backend)
 	}
+	if err != nil {
+		return err
+	}
+	rebuildCacheAfterScheduledSync(ctx, "synctech-sms:"+src.Name)
+	return nil
+}
+
+func ensureConfiguredSynctechSMSSource(st *store.Store, src config.SynctechSMSSource, opts synctechsms.ImportOptions) (*store.Source, error) {
+	if opts.OwnerPhone == "" {
+		return nil, fmt.Errorf("synctech-sms source %q owner_phone is required", src.Name)
+	}
+	source, err := st.GetOrCreateSource(synctechsms.SourceType, opts.OwnerPhone)
+	if err != nil {
+		return nil, fmt.Errorf("get source: %w", err)
+	}
+	confirmDefaultIdentity(io.Discard, st, source.ID, src.Name, opts.OwnerPhone, "account-identifier")
+	if err := runPostSourceCreateMigrations(st); err != nil {
+		return nil, fmt.Errorf("post-source-create migrations: %w", err)
+	}
+	return source, nil
 }
 
 func runSynctechSMSDriveSource(ctx context.Context, st *store.Store, src config.SynctechSMSSource, opts synctechsms.ImportOptions) error {
+	client, err := newSynctechSMSDriveClient(ctx, src)
+	if err != nil {
+		return err
+	}
+	return runSynctechSMSDriveSourceWithClient(ctx, st, src, opts, client)
+}
+
+func runSynctechSMSDriveSourceWithClient(ctx context.Context, st *store.Store, src config.SynctechSMSSource, opts synctechsms.ImportOptions, client synctechsms.DriveClient) (retErr error) {
 	if src.GoogleAccount == "" {
 		return fmt.Errorf("synctech-sms source %q google_account is required", src.Name)
 	}
 	if src.FolderID == "" {
 		return fmt.Errorf("synctech-sms source %q folder_id is required", src.Name)
 	}
-	client, err := newSynctechSMSDriveClient(ctx, src)
+	source, err := ensureConfiguredSynctechSMSSource(st, src, opts)
 	if err != nil {
 		return err
 	}
-	source, err := st.GetOrCreateSource(synctechsms.SourceType, src.OwnerPhone)
+	syncID, err := st.StartSync(source.ID, synctechsms.AdapterName)
 	if err != nil {
-		return fmt.Errorf("get source: %w", err)
+		return fmt.Errorf("start sync: %w", err)
 	}
+	completed := false
+	defer func() {
+		if !completed && retErr != nil {
+			if failErr := st.FailSync(syncID, retErr.Error()); failErr != nil {
+				logger.Error("failed to mark synctech-sms Drive sync failed",
+					"source", src.Name,
+					"sync_id", syncID,
+					"error", failErr,
+				)
+			}
+		}
+	}()
 	files, err := client.ListBackupFiles(ctx, src.FolderID)
 	if err != nil {
-		return err
+		return fmt.Errorf("list Drive backup files: %w", err)
 	}
 	imported, err := st.ListImportedSourceItemChecksums(source.ID, "drive")
 	if err != nil {
-		return err
+		return fmt.Errorf("list imported Drive checksums: %w", err)
 	}
 	stableAfter, err := time.ParseDuration(src.StableAfter)
 	if err != nil {
@@ -156,15 +207,42 @@ func runSynctechSMSDriveSource(ctx context.Context, st *store.Store, src config.
 		return fmt.Errorf("create staging directory: %w", err)
 	}
 	imp := synctechsms.NewImporter(st, opts)
+	var summary synctechsms.ImportSummary
 	for _, file := range selected {
-		if err := importOneDriveBackup(ctx, st, imp, client, source.ID, file, stagingDir); err != nil {
+		fileSummary, err := importOneDriveBackup(ctx, st, imp, client, source.ID, file, stagingDir)
+		if err != nil {
 			return err
 		}
+		summary.FilesSeen += fileSummary.FilesSeen
+		summary.FilesImported += fileSummary.FilesImported
+		summary.SMSImported += fileSummary.SMSImported
+		summary.MMSImported += fileSummary.MMSImported
+		summary.CallsImported += fileSummary.CallsImported
+		summary.AttachmentsImported += fileSummary.AttachmentsImported
 	}
+	if summary.FilesImported > 0 {
+		if err := st.RecomputeConversationStats(source.ID); err != nil {
+			return fmt.Errorf("recompute conversation stats: %w", err)
+		}
+	}
+	totalRecords := int64(summary.SMSImported + summary.MMSImported + summary.CallsImported)
+	if err := st.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+		MessagesProcessed: totalRecords,
+		MessagesAdded:     totalRecords,
+	}); err != nil {
+		return fmt.Errorf("update sync checkpoint: %w", err)
+	}
+	if err := st.TouchSourceLastSyncAt(source.ID); err != nil {
+		return fmt.Errorf("touch source last sync: %w", err)
+	}
+	if err := st.CompleteSync(syncID, ""); err != nil {
+		return fmt.Errorf("complete sync: %w", err)
+	}
+	completed = true
 	return nil
 }
 
-func importOneDriveBackup(ctx context.Context, st *store.Store, imp *synctechsms.Importer, client synctechsms.DriveClient, sourceID int64, file synctechsms.DriveFile, stagingDir string) error {
+func importOneDriveBackup(ctx context.Context, st *store.Store, imp *synctechsms.Importer, client synctechsms.DriveClient, sourceID int64, file synctechsms.DriveFile, stagingDir string) (synctechsms.ImportSummary, error) {
 	staged := filepath.Join(stagingDir, file.ID+"-"+filepath.Base(file.Name))
 	// Defer cleanup before the download starts so a partial file from a
 	// failed DownloadToFile is removed too, not just successful imports.
@@ -183,26 +261,29 @@ func importOneDriveBackup(ctx context.Context, st *store.Store, imp *synctechsms
 		Status:     "pending",
 	}
 	if err := st.UpsertSourceImportItem(item); err != nil {
-		return err
+		return synctechsms.ImportSummary{}, err
 	}
 	if err := client.DownloadToFile(ctx, file.ID, staged); err != nil {
 		item.Status = "failed"
 		item.ErrorMessage = sql.NullString{String: err.Error(), Valid: true}
 		_ = st.UpsertSourceImportItem(item)
-		return err
+		return synctechsms.ImportSummary{}, err
 	}
-	summary, err := imp.ImportPath(staged)
+	summary, err := imp.ImportPathIntoSource(sourceID, staged)
 	if err != nil {
 		item.Status = "failed"
 		item.ErrorMessage = sql.NullString{String: err.Error(), Valid: true}
 		_ = st.UpsertSourceImportItem(item)
-		return err
+		return summary, err
 	}
 	item.Status = "imported"
 	item.ImportedAt = sql.NullTime{Time: time.Now(), Valid: true}
 	item.RecordsImported = summary.SMSImported + summary.MMSImported + summary.CallsImported
 	item.ErrorMessage = sql.NullString{}
-	return st.UpsertSourceImportItem(item)
+	if err := st.UpsertSourceImportItem(item); err != nil {
+		return summary, err
+	}
+	return summary, nil
 }
 
 func newSynctechSMSDriveClient(ctx context.Context, src config.SynctechSMSSource) (synctechsms.DriveClient, error) {

--- a/cmd/msgvault/cmd/add_synctech_sms_drive_test.go
+++ b/cmd/msgvault/cmd/add_synctech_sms_drive_test.go
@@ -1,14 +1,21 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	assertpkg "github.com/stretchr/testify/assert"
 	requirepkg "github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/synctechsms"
+	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
 
 func TestAddSynctechSMSDriveWritesConfigWithoutSecrets(t *testing.T) {
@@ -41,4 +48,257 @@ func TestAddSynctechSMSDriveWritesConfigWithoutSecrets(t *testing.T) {
 	clientSecretKey := "client" + "_secret\""
 	assert.NotContains(lower, refreshTokenKey, "config contains secret material:\n%s", text)
 	assert.NotContains(lower, clientSecretKey, "config contains secret material:\n%s", text)
+}
+
+func TestSynctechSMSDriveRunUsesSingleOuterSyncRun(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	home := t.TempDir()
+	cfg = config.NewDefaultConfig()
+	cfg.HomeDir = home
+	cfg.Data.DataDir = home
+	f := storetest.New(t)
+	src := synctechDriveTestSource()
+	file := synctechsms.DriveFile{
+		ID:           "backup-1",
+		Name:         "sms.xml",
+		Checksum:     "sum-1",
+		Size:         128,
+		ModifiedTime: time.Now().Add(-20 * time.Minute),
+	}
+	client := fakeSynctechDriveClient{
+		files: []synctechsms.DriveFile{file},
+		downloads: map[string]string{
+			"backup-1": `<smses count="1">
+  <sms address="+15551234567" date="1717214400000" type="1" body="hello from drive" read="1" status="-1" contact_name="Alice" />
+</smses>`,
+		},
+	}
+
+	err := runSynctechSMSDriveSourceWithClient(context.Background(), f.Store, src, synctechImportOptions(src), client)
+	require.NoError(err, "runSynctechSMSDriveSourceWithClient")
+
+	source := getSynctechSource(t, f.Store, src.OwnerPhone)
+	assert.Equal(1, countSyncRuns(t, f.Store, source.ID), "sync run count")
+	run := getOnlySyncRun(t, f.Store, source.ID)
+	assert.Equal(store.SyncStatusCompleted, run.Status, "sync status")
+	assert.Equal(int64(1), run.MessagesProcessed, "messages processed")
+	assert.Equal(int64(1), run.MessagesAdded, "messages added")
+	assert.True(getSynctechSource(t, f.Store, src.OwnerPhone).LastSyncAt.Valid, "last_sync_at should be touched")
+
+	item := getSourceImportItem(t, f.Store, source.ID, "drive", "backup-1")
+	assert.Equal("imported", item.Status, "source import status")
+	assert.Equal(1, item.RecordsImported, "records imported")
+	assert.False(item.ErrorMessage.Valid, "source import error")
+	assertSourceMessageCount(t, f.Store, source.ID, 1)
+	assertSourceConversationMessageCount(t, f.Store, source.ID, 1)
+}
+
+func TestSynctechSMSDriveRunSetsUpIdentityAndPostSourceMigration(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	home := t.TempDir()
+	savedCfg := cfg
+	t.Cleanup(func() {
+		cfg = savedCfg
+	})
+	cfg = config.NewDefaultConfig()
+	cfg.HomeDir = home
+	cfg.Data.DataDir = home
+	cfg.Identity.Addresses = []string{"legacy@example.com"}
+	st := testutil.NewTestStore(t)
+	emailSource, err := st.GetOrCreateSource("gmail", "mailbox@example.com")
+	require.NoError(err, "GetOrCreateSource")
+
+	src := synctechDriveTestSource()
+	client := fakeSynctechDriveClient{}
+
+	err = runSynctechSMSDriveSourceWithClient(context.Background(), st, src, synctechImportOptions(src), client)
+	require.NoError(err, "runSynctechSMSDriveSourceWithClient")
+
+	synctechSource := getSynctechSource(t, st, src.OwnerPhone)
+	synctechIDs, err := st.ListAccountIdentities(synctechSource.ID)
+	require.NoError(err, "ListAccountIdentities synctech")
+	require.Len(synctechIDs, 1, "Synctech should keep only its owner-phone identity")
+	assert.Equal(src.OwnerPhone, synctechIDs[0].Address, "Synctech identity address")
+	assert.Equal("account-identifier", synctechIDs[0].SourceSignal, "Synctech identity signal")
+
+	emailIDs, err := st.ListAccountIdentities(emailSource.ID)
+	require.NoError(err, "ListAccountIdentities gmail")
+	require.Len(emailIDs, 1, "post-source migration should run for eligible email sources")
+	assert.Equal("legacy@example.com", emailIDs[0].Address, "migrated identity address")
+	assert.Equal("config_migration", emailIDs[0].SourceSignal, "migrated identity signal")
+
+	applied, err := st.IsMigrationApplied("legacy_identity_to_per_account")
+	require.NoError(err, "IsMigrationApplied")
+	assert.True(applied, "post-source migration sentinel should be set")
+}
+
+func TestSynctechSMSDriveRunRecordsZeroSelectedPoll(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	home := t.TempDir()
+	cfg = config.NewDefaultConfig()
+	cfg.HomeDir = home
+	cfg.Data.DataDir = home
+	f := storetest.New(t)
+	src := synctechDriveTestSource()
+	src.StableAfter = "1h"
+	client := fakeSynctechDriveClient{
+		files: []synctechsms.DriveFile{{
+			ID:           "backup-1",
+			Name:         "sms.xml",
+			Checksum:     "sum-1",
+			Size:         128,
+			ModifiedTime: time.Now().Add(-5 * time.Minute),
+		}},
+	}
+
+	err := runSynctechSMSDriveSourceWithClient(context.Background(), f.Store, src, synctechImportOptions(src), client)
+	require.NoError(err, "runSynctechSMSDriveSourceWithClient")
+
+	source := getSynctechSource(t, f.Store, src.OwnerPhone)
+	assert.Equal(1, countSyncRuns(t, f.Store, source.ID), "sync run count")
+	run := getOnlySyncRun(t, f.Store, source.ID)
+	assert.Equal(store.SyncStatusCompleted, run.Status, "sync status")
+	assert.Equal(int64(0), run.MessagesProcessed, "messages processed")
+	assert.Equal(int64(0), run.MessagesAdded, "messages added")
+	assert.True(getSynctechSource(t, f.Store, src.OwnerPhone).LastSyncAt.Valid, "last_sync_at should be touched")
+	assertSourceMessageCount(t, f.Store, source.ID, 0)
+}
+
+func TestSynctechSMSDriveRunMarksOuterSyncFailedOnDownloadError(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	home := t.TempDir()
+	cfg = config.NewDefaultConfig()
+	cfg.HomeDir = home
+	cfg.Data.DataDir = home
+	f := storetest.New(t)
+	src := synctechDriveTestSource()
+	downloadErr := errors.New("download unavailable")
+	client := fakeSynctechDriveClient{
+		files: []synctechsms.DriveFile{{
+			ID:           "backup-1",
+			Name:         "sms.xml",
+			Checksum:     "sum-1",
+			Size:         128,
+			ModifiedTime: time.Now().Add(-20 * time.Minute),
+		}},
+		downloadErr: downloadErr,
+	}
+
+	err := runSynctechSMSDriveSourceWithClient(context.Background(), f.Store, src, synctechImportOptions(src), client)
+	require.ErrorIs(err, downloadErr, "runSynctechSMSDriveSourceWithClient")
+
+	source := getSynctechSource(t, f.Store, src.OwnerPhone)
+	assert.Equal(1, countSyncRuns(t, f.Store, source.ID), "sync run count")
+	run := getOnlySyncRun(t, f.Store, source.ID)
+	assert.Equal(store.SyncStatusFailed, run.Status, "sync status")
+	require.True(run.ErrorMessage.Valid, "sync error_message")
+	assert.Contains(run.ErrorMessage.String, downloadErr.Error(), "sync error_message")
+
+	item := getSourceImportItem(t, f.Store, source.ID, "drive", "backup-1")
+	assert.Equal("failed", item.Status, "source import status")
+	require.True(item.ErrorMessage.Valid, "source import error")
+	assert.Contains(item.ErrorMessage.String, downloadErr.Error(), "source import error")
+}
+
+type fakeSynctechDriveClient struct {
+	files       []synctechsms.DriveFile
+	downloads   map[string]string
+	listErr     error
+	downloadErr error
+}
+
+func (f fakeSynctechDriveClient) ListBackupFiles(context.Context, string) ([]synctechsms.DriveFile, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.files, nil
+}
+
+func (f fakeSynctechDriveClient) DownloadToFile(_ context.Context, fileID, path string) error {
+	if f.downloadErr != nil {
+		return f.downloadErr
+	}
+	return os.WriteFile(path, []byte(f.downloads[fileID]), 0o600)
+}
+
+func synctechDriveTestSource() config.SynctechSMSSource {
+	return config.SynctechSMSSource{
+		Name:               "pixel",
+		Enabled:            true,
+		Backend:            "drive",
+		FolderID:           "drive-folder-id",
+		GoogleAccount:      "user@example.com",
+		OwnerPhone:         "+15550000001",
+		StableAfter:        "10m",
+		IncludeSMS:         true,
+		IncludeMMS:         true,
+		IncludeCalls:       true,
+		IncludeAttachments: true,
+	}
+}
+
+func getSynctechSource(t *testing.T, st *store.Store, ownerPhone string) *store.Source {
+	t.Helper()
+	sources, err := st.ListSources(synctechsms.SourceType)
+	requirepkg.NoError(t, err, "ListSources")
+	for _, source := range sources {
+		if source.Identifier == ownerPhone {
+			return source
+		}
+	}
+	requirepkg.Failf(t, "synctech source not found", "owner_phone=%s sources=%#v", ownerPhone, sources)
+	return nil
+}
+
+func countSyncRuns(t *testing.T, st *store.Store, sourceID int64) int {
+	t.Helper()
+	var got int
+	err := st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM sync_runs WHERE source_id = ?`), sourceID).Scan(&got)
+	requirepkg.NoError(t, err, "count sync runs")
+	return got
+}
+
+func getOnlySyncRun(t *testing.T, st *store.Store, sourceID int64) store.SyncRun {
+	t.Helper()
+	var run store.SyncRun
+	err := st.DB().QueryRow(st.Rebind(`
+		SELECT id, source_id, started_at, completed_at, status,
+		       messages_processed, messages_added, messages_updated, errors_count,
+		       error_message, cursor_before, cursor_after
+		FROM sync_runs
+		WHERE source_id = ?
+	`), sourceID).Scan(
+		&run.ID, &run.SourceID, &run.StartedAt, &run.CompletedAt, &run.Status,
+		&run.MessagesProcessed, &run.MessagesAdded, &run.MessagesUpdated, &run.ErrorsCount,
+		&run.ErrorMessage, &run.CursorBefore, &run.CursorAfter,
+	)
+	requirepkg.NoError(t, err, "get sync run")
+	return run
+}
+
+func getSourceImportItem(t *testing.T, st *store.Store, sourceID int64, provider, providerID string) *store.SourceImportItem {
+	t.Helper()
+	item, err := st.GetSourceImportItem(sourceID, provider, providerID)
+	requirepkg.NoError(t, err, "GetSourceImportItem")
+	return item
+}
+
+func assertSourceMessageCount(t *testing.T, st *store.Store, sourceID int64, want int) {
+	t.Helper()
+	var got int
+	err := st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM messages WHERE source_id = ?`), sourceID).Scan(&got)
+	requirepkg.NoError(t, err, "count source messages")
+	assertpkg.Equal(t, want, got, "source message count")
+}
+
+func assertSourceConversationMessageCount(t *testing.T, st *store.Store, sourceID int64, want int) {
+	t.Helper()
+	var got int
+	err := st.DB().QueryRow(st.Rebind(`SELECT COALESCE(MAX(message_count), 0) FROM conversations WHERE source_id = ?`), sourceID).Scan(&got)
+	requirepkg.NoError(t, err, "read conversation message_count")
+	assertpkg.Equal(t, want, got, "conversation message_count")
 }

--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -898,6 +898,32 @@ func globalConfigFlagArgs() []string {
 	return args
 }
 
+// rebuildCacheAfterScheduledSync rebuilds the Parquet cache if it is stale
+// after a scheduled sync. The cache is SQLite-only, so it is skipped on
+// PostgreSQL DSNs. The build runs in a subprocess (see buildCacheSubprocess)
+// to keep DuckDB's bundled SQLite library out of a long-lived daemon's
+// address space (issue #379).
+func rebuildCacheAfterScheduledSync(ctx context.Context, identifier string) {
+	dbPath := cfg.DatabaseDSN()
+	if store.IsPostgresURL(dbPath) {
+		return
+	}
+	analyticsDir := cfg.AnalyticsDir()
+	staleness := cacheNeedsBuild(dbPath, analyticsDir)
+	if !staleness.NeedsBuild {
+		return
+	}
+	logger.Info("rebuilding cache after sync",
+		"identifier", identifier, "reason", staleness.Reason,
+		"full_rebuild", staleness.FullRebuild)
+	if err := buildCacheSubprocess(ctx, staleness.FullRebuild); err != nil {
+		logger.Error("cache build failed", "error", err)
+		// Don't fail the sync for cache build errors.
+	} else {
+		logger.Info("cache build completed")
+	}
+}
+
 func init() {
 	rootCmd.AddCommand(buildCacheCmd)
 	rootCmd.AddCommand(cacheStatsCmd)

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -186,7 +186,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			Name:     jobName,
 			Schedule: source.Schedule,
 			Run: func(ctx context.Context) error {
-				return runConfiguredSynctechSMSSource(ctx, source)
+				return runConfiguredSynctechSMSSourceWithStore(ctx, s, source)
 			},
 		}); err != nil {
 			logger.Error("failed to schedule synctech-sms source", "source", source.Name, "error", err)
@@ -433,27 +433,8 @@ func runScheduledSync(ctx context.Context, identifier string, s *store.Store, ge
 		"duration", time.Since(startTime),
 	)
 
-	// Rebuild cache if stale (covers new messages and deletions). The
-	// Parquet cache is SQLite-only; skip on PostgreSQL DSNs.
-	dbPath := cfg.DatabaseDSN()
-	if store.IsPostgresURL(dbPath) {
-		return nil
-	}
-	analyticsDir := cfg.AnalyticsDir()
-	if staleness := cacheNeedsBuild(dbPath, analyticsDir); staleness.NeedsBuild {
-		logger.Info("rebuilding cache after sync",
-			"identifier", identifier, "reason", staleness.Reason,
-			"full_rebuild", staleness.FullRebuild)
-		// Build in a subprocess: buildCache uses DuckDB's bundled SQLite
-		// library, which corrupts the daemon's own long-lived go-sqlite3
-		// connections' WAL/lock state when run in-process (issue #379).
-		if err := buildCacheSubprocess(ctx, staleness.FullRebuild); err != nil {
-			logger.Error("cache build failed", "error", err)
-			// Don't fail the sync for cache build errors
-		} else {
-			logger.Info("cache build completed")
-		}
-	}
+	// Rebuild cache if stale (covers new messages and deletions).
+	rebuildCacheAfterScheduledSync(ctx, identifier)
 
 	return nil
 }

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -530,6 +530,18 @@ func (s *Store) UpdateSourceSyncCursor(sourceID int64, cursor string) error {
 	return err
 }
 
+// TouchSourceLastSyncAt records that a source-level sync completed even when
+// the adapter does not maintain a cursor.
+func (s *Store) TouchSourceLastSyncAt(sourceID int64) error {
+	now := s.dialect.Now()
+	_, err := s.db.Exec(fmt.Sprintf(`
+		UPDATE sources
+		SET last_sync_at = %s, updated_at = %s
+		WHERE id = ?
+	`, now, now), sourceID)
+	return err
+}
+
 // ListSources returns all sources, optionally filtered by source type.
 // Pass an empty string to return all sources.
 func (s *Store) ListSources(sourceType string) ([]*Source, error) {

--- a/internal/synctechsms/importer.go
+++ b/internal/synctechsms/importer.go
@@ -31,10 +31,6 @@ func (i *Importer) ImportPath(path string) (ImportSummary, error) {
 	if strings.TrimSpace(i.opts.OwnerPhone) == "" {
 		return ImportSummary{}, errors.New("owner phone is required for synctech-sms imports")
 	}
-	files, err := DiscoverBackupFiles(path)
-	if err != nil {
-		return ImportSummary{}, err
-	}
 	src, err := i.store.GetOrCreateSource(SourceType, i.opts.OwnerPhone)
 	if err != nil {
 		return ImportSummary{}, fmt.Errorf("get source: %w", err)
@@ -43,7 +39,7 @@ func (i *Importer) ImportPath(path string) (ImportSummary, error) {
 	if err != nil {
 		return ImportSummary{}, fmt.Errorf("start sync: %w", err)
 	}
-	summary, importErr := i.importFiles(src.ID, files)
+	summary, importErr := i.ImportPathIntoSource(src.ID, path)
 	if importErr != nil {
 		_ = i.store.FailSync(syncID, importErr.Error())
 		return summary, importErr
@@ -60,7 +56,24 @@ func (i *Importer) ImportPath(path string) (ImportSummary, error) {
 	return summary, nil
 }
 
-func (i *Importer) importFiles(sourceID int64, files []BackupFile) (ImportSummary, error) {
+// ImportPathIntoSource imports Synctech SMS backup records into an existing
+// source without starting, completing, or failing a sync run. Callers that own
+// a broader lifecycle, such as Google Drive polling, use this to avoid nested
+// sync_runs.
+func (i *Importer) ImportPathIntoSource(sourceID int64, path string) (ImportSummary, error) {
+	if strings.TrimSpace(i.opts.OwnerPhone) == "" {
+		return ImportSummary{}, errors.New("owner phone is required for synctech-sms imports")
+	}
+	files, err := DiscoverBackupFiles(path)
+	if err != nil {
+		return ImportSummary{}, err
+	}
+	return i.ImportFilesIntoSource(sourceID, files)
+}
+
+// ImportFilesIntoSource imports already-discovered backup files into an
+// existing source without owning sync lifecycle.
+func (i *Importer) ImportFilesIntoSource(sourceID int64, files []BackupFile) (ImportSummary, error) {
 	var summary ImportSummary
 	summary.FilesSeen = len(files)
 	for _, file := range files {


### PR DESCRIPTION
## What changed
- Scheduled Synctech SMS Drive syncs now use the daemon's already-open store when run from `serve`.
- Drive polls create one outer source-level `sync_runs` row, including zero-selected polls, and fail that run on list/checksum/stability/download/import/checkpoint errors.
- Drive imports now import backup files into the existing source lifecycle instead of creating nested sync runs per downloaded backup.
- Successful Drive polls update checkpoint counts, touch `sources.last_sync_at`, and recompute conversation stats when files import.
- Scheduled cache rebuild logic is shared by Gmail/IMAP and configured Synctech syncs.

## Why
This keeps scheduled Drive sync lifecycle state accurate and avoids duplicate stores/runs that can obscure failures or freshness.

## Impact
Configured Drive sync status, freshness, and analytics cache updates should now reflect every poll, including no-op polls and failed polls.

## Validation
- `go test -tags "fts5 sqlite_vec" ./cmd/msgvault/cmd ./internal/synctechsms ./internal/store`
- `make testify-helper-check`
- `go vet -tags "fts5 sqlite_vec" ./...`