### PR TITLE
fix(serve): isolate DuckDB's SQLite from the daemon to stop WAL corruption

### DIFF
--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -870,7 +870,9 @@ func buildCacheSubprocess(ctx context.Context, fullRebuild bool) error {
 		args = append(args, "--full-rebuild")
 	}
 
-	cmd := exec.CommandContext(ctx, exe, args...)
+	// exe is this binary (os.Executable) and args are our own fixed
+	// subcommand plus operator-controlled config flags, not untrusted input.
+	cmd := exec.CommandContext(ctx, exe, args...) //nolint:gosec // exe is os.Executable; args are internally constructed
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("build-cache subprocess: %w; output: %s",

--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -826,6 +828,72 @@ func rebuildCacheAfterWrite(dbPath string) {
 	if !result.Skipped {
 		logger.Info("cache rebuilt", "exported", result.ExportedCount)
 	}
+}
+
+// buildCacheSubprocess runs `msgvault build-cache` as a child process
+// instead of calling buildCache in-process.
+//
+// The daemon (`serve`) holds a long-lived go-sqlite3 connection to the
+// SQLite database for its entire lifetime. buildCache, in turn, uses
+// DuckDB's sqlite_scanner extension, which statically links its OWN copy
+// of the SQLite library and ATTACHes the same database file. Two
+// independent SQLite library instances in one process do not share the
+// unix VFS's in-process POSIX advisory-lock and WAL-index bookkeeping, so
+// when DuckDB's copy opens/closes the WAL it can drop the daemon's
+// advisory locks and leave the on-disk -wal/-shm inconsistent with the
+// daemon's in-memory WAL-index. After that, every newly-opened go-sqlite3
+// connection in the process fails with "disk I/O error: no such file or
+// directory" until the daemon restarts (see issue #379).
+//
+// Running build-cache in a fresh process keeps DuckDB's SQLite copy out of
+// the daemon's address space entirely, so the daemon's own connections are
+// never affected.
+//
+// Global flags that affect config resolution (--config, --home, --local)
+// are forwarded so the child loads identical configuration. --no-log-file
+// keeps the child from writing to the daemon's log file; its output is
+// captured and surfaced on failure instead.
+func buildCacheSubprocess(ctx context.Context, fullRebuild bool) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate msgvault executable: %w", err)
+	}
+
+	// Serialize with each other so parallel per-account syncs in the
+	// daemon don't spawn concurrent cache builds racing on shared files.
+	buildCacheMu.Lock()
+	defer buildCacheMu.Unlock()
+
+	args := globalConfigFlagArgs()
+	args = append(args, "--no-log-file", "build-cache")
+	if fullRebuild {
+		args = append(args, "--full-rebuild")
+	}
+
+	cmd := exec.CommandContext(ctx, exe, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("build-cache subprocess: %w; output: %s",
+			err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// globalConfigFlagArgs reconstructs the persistent flags that affect
+// configuration resolution so a child process loads the same config as
+// the running one.
+func globalConfigFlagArgs() []string {
+	var args []string
+	if cfgFile != "" {
+		args = append(args, "--config", cfgFile)
+	}
+	if homeDir != "" {
+		args = append(args, "--home", homeDir)
+	}
+	if useLocal {
+		args = append(args, "--local")
+	}
+	return args
 }
 
 func init() {

--- a/cmd/msgvault/cmd/build_cache_test.go
+++ b/cmd/msgvault/cmd/build_cache_test.go
@@ -1718,3 +1718,39 @@ func BenchmarkBuildCacheIncremental(b *testing.B) {
 		}
 	}
 }
+
+// TestGlobalConfigFlagArgs verifies that the persistent flags affecting
+// config resolution are forwarded to the build-cache subprocess so it
+// loads identical configuration to the daemon that spawned it.
+func TestGlobalConfigFlagArgs(t *testing.T) {
+	// Save and restore the package globals these flags bind to.
+	origCfg, origHome, origLocal := cfgFile, homeDir, useLocal
+	t.Cleanup(func() { cfgFile, homeDir, useLocal = origCfg, origHome, origLocal })
+
+	tests := []struct {
+		name    string
+		cfgFile string
+		homeDir string
+		local   bool
+		want    []string
+	}{
+		{name: "none set", want: nil},
+		{name: "config only", cfgFile: "/etc/msgvault.toml", want: []string{"--config", "/etc/msgvault.toml"}},
+		{name: "home only", homeDir: "/data/msgvault", want: []string{"--home", "/data/msgvault"}},
+		{name: "local only", local: true, want: []string{"--local"}},
+		{
+			name:    "all set",
+			cfgFile: "/etc/msgvault.toml",
+			homeDir: "/data/msgvault",
+			local:   true,
+			want:    []string{"--config", "/etc/msgvault.toml", "--home", "/data/msgvault", "--local"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgFile, homeDir, useLocal = tt.cfgFile, tt.homeDir, tt.local
+			assertpkg.Equal(t, tt.want, globalConfigFlagArgs())
+		})
+	}
+}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -127,8 +127,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 	} else {
 		staleness := cacheNeedsBuild(dbPath, analyticsDir)
 		if !staleness.NeedsBuild && query.HasCompleteParquetData(analyticsDir) {
+			// DisableSQLiteScanner keeps DuckDB's bundled SQLite library
+			// from ATTACHing the live database for the daemon's entire
+			// lifetime, which would corrupt the daemon's own go-sqlite3
+			// connections' WAL/lock state (issue #379). Detail queries
+			// route through the shared go-sqlite3 connection instead;
+			// aggregates still read Parquet.
 			duckEngine, engineErr := query.NewDuckDBEngine(
 				analyticsDir, dbPath, s.DB(),
+				query.DuckDBOptions{DisableSQLiteScanner: true},
 			)
 			if engineErr != nil {
 				logger.Warn("DuckDB engine failed, falling back to SQLite",
@@ -418,15 +425,14 @@ func runScheduledSync(ctx context.Context, identifier string, s *store.Store, ge
 		logger.Info("rebuilding cache after sync",
 			"identifier", identifier, "reason", staleness.Reason,
 			"full_rebuild", staleness.FullRebuild)
-		result, err := buildCache(
-			dbPath, analyticsDir, staleness.FullRebuild)
-		if err != nil {
+		// Build in a subprocess: buildCache uses DuckDB's bundled SQLite
+		// library, which corrupts the daemon's own long-lived go-sqlite3
+		// connections' WAL/lock state when run in-process (issue #379).
+		if err := buildCacheSubprocess(ctx, staleness.FullRebuild); err != nil {
 			logger.Error("cache build failed", "error", err)
 			// Don't fail the sync for cache build errors
-		} else if !result.Skipped {
-			logger.Info("cache build completed",
-				"exported", result.ExportedCount,
-			)
+		} else {
+			logger.Info("cache build completed")
 		}
 	}
 


### PR DESCRIPTION
Fixes #379.

## Why

After ~2 days of `msgvault serve` uptime, every post-sync analytics cache rebuild starts failing with `disk I/O error: no such file or directory` and keeps failing on every 15-minute sync until the daemon is restarted. Gmail sync itself is unaffected — only the Parquet analytics cache stops refreshing.

The daemon holds one long-lived go-sqlite3 connection (WAL mode) for its whole lifetime. Cache builds and the long-lived DuckDB query engine reach the *same* database file through DuckDB's `sqlite_scanner` extension, which statically links its **own independent copy** of SQLite. Two SQLite libraries in one process don't share the unix VFS's in-process POSIX advisory-lock and WAL-index bookkeeping, so when DuckDB's copy opens/closes the WAL it can drop the daemon's advisory locks and leave the on-disk `-wal`/`-shm` inconsistent with the daemon's in-memory WAL-index. From then on every *newly opened* go-sqlite3 connection in the process errors out, while the existing connection and any fresh process stay healthy.

That split-brain exactly matches the reported signature: a manual `msgvault build-cache` and a daemon restart both clear it, and the flip happens right after a heavy full rebuild. Beyond the visible errors, this is a latent database-corruption risk (e.g. a checkpoint racing the split lock state), so it's worth fixing structurally rather than papering over with a restart watchdog.

## What changed

Keep DuckDB's SQLite copy out of the daemon's address space entirely:

- Post-sync cache builds now run as a child `build-cache` process instead of in-process, forwarding the config-resolution flags (`--config`, `--home`, `--local`) so the child loads identical configuration.
- The daemon's long-lived DuckDB engine is created with `DisableSQLiteScanner`, so message-detail queries route through the shared go-sqlite3 connection rather than a second persistent `ATTACH`. Aggregate queries still read Parquet, so the analytics fast path is unchanged.

After this, the daemon process only ever has go-sqlite3 touching the database; DuckDB only reads Parquet in-process. Operators running a restart watchdog as a workaround can retire it.

The same two-copies overlap exists in short-lived CLI paths (TUI auto-build, post-sync-full rebuild), but those processes exit immediately, which is why the bug has only ever surfaced in the long-running daemon; those paths are left unchanged.

## Validation

`go build/vet/test ./cmd/...` pass. Added `TestGlobalConfigFlagArgs` covering the subprocess flag passthrough.