### PR TITLE
MCP: paginate search_messages and list_messages

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -482,7 +482,7 @@ func (h *handlers) searchMessagesHybrid(
 	}
 
 	return jsonResult(searchMessagesHybridResponse{
-		paginatedResponse: newPaginatedResponseHasMore(page, offset, hasMore),
+		paginatedResponse: newPaginatedResponseNoTotal(page, offset, hasMore),
 		Mode:              mode,
 		PoolSaturated:     meta.PoolSaturated,
 		Generation: hybridGenerationSummary{

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -23,7 +23,70 @@ import (
 	"go.kenn.io/msgvault/internal/vector/hybrid"
 )
 
-const maxLimit = 1000
+const (
+	maxLimit               = 1000
+	maxSearchMessagesLimit = 50
+	defaultSearchLimit     = 20
+	// totalCountUnknown is returned when the backend cannot report a full match
+	// count (hybrid/vector ranking depth, or list_messages has_more without a
+	// separate count query). Clients should use has_more for paging.
+	totalCountUnknown = -1
+)
+
+type paginatedResponse[T any] struct {
+	Data     []T   `json:"data"`
+	Total    int64 `json:"total"`
+	Returned int   `json:"returned"`
+	Offset   int   `json:"offset"`
+	HasMore  bool  `json:"has_more"`
+}
+
+func newPaginatedResponse[T any](data []T, total int64, offset int) paginatedResponse[T] {
+	if data == nil {
+		data = []T{}
+	}
+	returned := len(data)
+	return paginatedResponse[T]{
+		Data:     data,
+		Total:    total,
+		Returned: returned,
+		Offset:   offset,
+		HasMore:  int64(offset+returned) < total,
+	}
+}
+
+// newPaginatedResponseHasMore builds a page when total match count is unknown.
+// When hasMore is false, total is exact (offset+returned). When hasMore is true,
+// total is totalCountUnknown — use has_more to fetch the next page.
+func newPaginatedResponseHasMore[T any](data []T, offset int, hasMore bool) paginatedResponse[T] {
+	if data == nil {
+		data = []T{}
+	}
+	returned := len(data)
+	total := int64(offset + returned)
+	if hasMore {
+		total = totalCountUnknown
+	}
+	return paginatedResponse[T]{
+		Data:     data,
+		Total:    total,
+		Returned: returned,
+		Offset:   offset,
+		HasMore:  hasMore,
+	}
+}
+
+func searchLimitArg(args map[string]any) int {
+	limit := limitArg(args, "limit", defaultSearchLimit)
+	if limit > maxSearchMessagesLimit {
+		return maxSearchMessagesLimit
+	}
+	return limit
+}
+
+func listLimitArg(args map[string]any) int {
+	return searchLimitArg(args)
+}
 
 type handlers struct {
 	engine         query.Engine
@@ -163,11 +226,6 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 	explain, _ := args["explain"].(bool)
 
 	if mode == "vector" || mode == "hybrid" {
-		if off := limitArg(args, "offset", 0); off > 0 {
-			return mcp.NewToolResultError(
-				"pagination_unsupported: mode=" + mode + " only supports offset=0",
-			), nil
-		}
 		return h.searchMessagesHybrid(ctx, args, queryStr, mode, explain)
 	}
 
@@ -177,7 +235,7 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 		), nil
 	}
 
-	limit := limitArg(args, "limit", 20)
+	limit := searchLimitArg(args)
 	offset := limitArg(args, "offset", 0)
 
 	// Look up account filter
@@ -208,7 +266,12 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 		}
 	}
 
-	return jsonResult(results)
+	totalMatched, err := h.engine.SearchFastCount(ctx, q, filter)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("search count failed: %v", err)), nil
+	}
+
+	return jsonResult(newPaginatedResponse(results, totalMatched, offset))
 }
 
 // hybridScoreBreakdown exposes fused-score components for debugging.
@@ -241,15 +304,13 @@ type hybridGenerationSummary struct {
 	State       string `json:"state"`
 }
 
-// hybridSearchResponse is the full response body for a mode=vector or
-// mode=hybrid request on the search_messages tool.
-type hybridSearchResponse struct {
-	Query         string                  `json:"query"`
+// searchMessagesHybridResponse is the paginated body for mode=vector|hybrid.
+type searchMessagesHybridResponse struct {
+	paginatedResponse[hybridMessageItem]
+
 	Mode          string                  `json:"mode"`
-	Returned      int                     `json:"returned"`
 	PoolSaturated bool                    `json:"pool_saturated"`
 	Generation    hybridGenerationSummary `json:"generation"`
-	Messages      []hybridMessageItem     `json:"messages"`
 }
 
 // searchMessagesHybrid runs vector or hybrid search via the configured
@@ -274,10 +335,8 @@ func (h *handlers) searchMessagesHybrid(
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	limit := limitArg(args, "limit", 20)
-	if maxPage := h.vectorCfg.Search.MaxPageSizeHybridClamp(); maxPage > 0 && limit > maxPage {
-		limit = maxPage
-	}
+	limit := searchLimitArg(args)
+	offset := limitArg(args, "offset", 0)
 
 	parsed := search.Parse(queryStr)
 	freeText := strings.Join(parsed.TextTerms, " ")
@@ -305,11 +364,26 @@ func (h *handlers) searchMessagesHybrid(
 		filter.SourceIDs = []int64{*sourceID}
 	}
 
+	maxPage := h.vectorCfg.Search.MaxPageSizeHybridClamp()
+	fetchLimit := offset + limit
+	if maxPage > 0 {
+		if offset >= maxPage {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"pagination_limit: offset %d exceeds hybrid ranking window (max %d); "+
+					"use mode=fts for deeper pagination",
+				offset, maxPage,
+			)), nil
+		}
+		if fetchLimit > maxPage {
+			fetchLimit = maxPage
+		}
+	}
+
 	req := hybrid.SearchRequest{
 		Mode:         hybrid.Mode(mode),
 		FreeText:     freeText,
 		Filter:       filter,
-		Limit:        limit,
+		Limit:        fetchLimit,
 		SubjectTerms: subjectTerms,
 		Explain:      explain,
 	}
@@ -367,11 +441,18 @@ func (h *handlers) searchMessagesHybrid(
 		items = append(items, item)
 	}
 
-	return jsonResult(hybridSearchResponse{
-		Query:         queryStr,
-		Mode:          mode,
-		Returned:      len(items),
-		PoolSaturated: meta.PoolSaturated,
+	var page []hybridMessageItem
+	if offset < len(items) {
+		end := min(offset+limit, len(items))
+		page = items[offset:end]
+	}
+	hasMore := offset+limit < len(items) ||
+		(meta.PoolSaturated && len(hits) >= fetchLimit)
+
+	return jsonResult(searchMessagesHybridResponse{
+		paginatedResponse: newPaginatedResponseHasMore(page, offset, hasMore),
+		Mode:              mode,
+		PoolSaturated:     meta.PoolSaturated,
 		Generation: hybridGenerationSummary{
 			ID:          int64(meta.Generation.ID),
 			Model:       meta.Generation.Model,
@@ -379,7 +460,6 @@ func (h *handlers) searchMessagesHybrid(
 			Fingerprint: meta.Generation.Fingerprint,
 			State:       string(meta.Generation.State),
 		},
-		Messages: items,
 	})
 }
 
@@ -698,7 +778,7 @@ func (h *handlers) listMessages(ctx context.Context, req mcp.CallToolRequest) (*
 	filter := query.MessageFilter{
 		SourceID: sourceID,
 		Pagination: query.Pagination{
-			Limit:  limitArg(args, "limit", 20),
+			Limit:  listLimitArg(args) + 1,
 			Offset: limitArg(args, "offset", 0),
 		},
 	}
@@ -732,7 +812,14 @@ func (h *handlers) listMessages(ctx context.Context, req mcp.CallToolRequest) (*
 		return mcp.NewToolResultError(fmt.Sprintf("list failed: %v", err)), nil
 	}
 
-	return jsonResult(results)
+	pageLimit := listLimitArg(args)
+	offset := filter.Pagination.Offset
+	hasMore := len(results) > pageLimit
+	if hasMore {
+		results = results[:pageLimit]
+	}
+
+	return jsonResult(newPaginatedResponseHasMore(results, offset, hasMore))
 }
 
 // getStatsResponse is the JSON body returned by the get_stats MCP tool.

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -386,9 +386,10 @@ func (h *handlers) searchMessagesHybrid(
 	}
 
 	maxPage := h.vectorCfg.Search.MaxPageSizeHybridClamp()
-	requestedFetch := offset + limit
-	fetchLimit := requestedFetch
-	fetchWasClamped := false
+	requestedEnd := offset + limit
+	wantedFetch := requestedEnd + 1 // probe one past the page end for has_more
+	fetchLimit := wantedFetch
+	hitMaxPageCap := false
 	if maxPage > 0 {
 		if offset >= maxPage {
 			return mcp.NewToolResultError(fmt.Sprintf(
@@ -399,7 +400,7 @@ func (h *handlers) searchMessagesHybrid(
 		}
 		if fetchLimit > maxPage {
 			fetchLimit = maxPage
-			fetchWasClamped = true
+			hitMaxPageCap = wantedFetch > maxPage
 		}
 	}
 
@@ -470,13 +471,14 @@ func (h *handlers) searchMessagesHybrid(
 		end := min(offset+limit, len(items))
 		page = items[offset:end]
 	}
-	hasMore := offset+limit < len(items)
-	// Pool saturation can mean more ranked hits exist beyond fetchLimit, but
-	// only advertise has_more when the next page is actually servable. When
-	// fetchLimit was clamped to maxPage, offset+limit may exceed maxPage and
-	// the handler would reject the follow-up request.
-	if !hasMore && !fetchWasClamped {
-		hasMore = meta.PoolSaturated && len(hits) >= fetchLimit
+	nextPageServable := maxPage == 0 || requestedEnd < maxPage
+	hasMore := false
+	if nextPageServable {
+		if requestedEnd < len(items) {
+			hasMore = true
+		} else if !hitMaxPageCap && meta.PoolSaturated && len(hits) >= fetchLimit {
+			hasMore = true
+		}
 	}
 
 	return jsonResult(searchMessagesHybridResponse{

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -27,9 +27,6 @@ const (
 	maxLimit               = 1000
 	maxSearchMessagesLimit = 50
 	defaultSearchLimit     = 20
-	searchModeFTS          = "fts"
-	searchModeVector       = "vector"
-	searchModeHybrid       = "hybrid"
 	// totalCountUnknown is returned when the backend cannot report a full match
 	// count (body FTS fallback, hybrid/vector ranking depth, or list_messages
 	// without a separate count query). Clients should use has_more for paging.

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -27,10 +27,12 @@ const (
 	maxLimit               = 1000
 	maxSearchMessagesLimit = 50
 	defaultSearchLimit     = 20
+	searchModeFTS          = "fts"
+	searchModeVector       = "vector"
+	searchModeHybrid       = "hybrid"
 	// totalCountUnknown is returned when the backend cannot report a full match
 	// count (body FTS fallback, hybrid/vector ranking depth, or list_messages
-	// has_more without a separate count query). Clients should use has_more for
-	// paging.
+	// without a separate count query). Clients should use has_more for paging.
 	totalCountUnknown = -1
 )
 
@@ -56,27 +58,6 @@ func newPaginatedResponse[T any](data []T, total int64, offset int) paginatedRes
 	}
 }
 
-// newPaginatedResponseHasMore builds a page when total match count is unknown.
-// When hasMore is false, total is exact (offset+returned). When hasMore is true,
-// total is totalCountUnknown — use has_more to fetch the next page.
-func newPaginatedResponseHasMore[T any](data []T, offset int, hasMore bool) paginatedResponse[T] {
-	if data == nil {
-		data = []T{}
-	}
-	returned := len(data)
-	total := int64(offset + returned)
-	if hasMore {
-		total = totalCountUnknown
-	}
-	return paginatedResponse[T]{
-		Data:     data,
-		Total:    total,
-		Returned: returned,
-		Offset:   offset,
-		HasMore:  hasMore,
-	}
-}
-
 // newPaginatedResponseNoTotal builds a page when the backend cannot report a
 // total match count. total is always totalCountUnknown; use has_more to page.
 func newPaginatedResponseNoTotal[T any](data []T, offset int, hasMore bool) paginatedResponse[T] {
@@ -94,6 +75,9 @@ func newPaginatedResponseNoTotal[T any](data []T, offset int, hasMore bool) pagi
 
 func searchLimitArg(args map[string]any) int {
 	limit := limitArg(args, "limit", defaultSearchLimit)
+	if limit <= 0 {
+		return defaultSearchLimit
+	}
 	if limit > maxSearchMessagesLimit {
 		return maxSearchMessagesLimit
 	}
@@ -851,7 +835,7 @@ func (h *handlers) listMessages(ctx context.Context, req mcp.CallToolRequest) (*
 		results = results[:pageLimit]
 	}
 
-	return jsonResult(newPaginatedResponseHasMore(results, offset, hasMore))
+	return jsonResult(newPaginatedResponseNoTotal(results, offset, hasMore))
 }
 
 // getStatsResponse is the JSON body returned by the get_stats MCP tool.

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -28,8 +28,9 @@ const (
 	maxSearchMessagesLimit = 50
 	defaultSearchLimit     = 20
 	// totalCountUnknown is returned when the backend cannot report a full match
-	// count (hybrid/vector ranking depth, or list_messages has_more without a
-	// separate count query). Clients should use has_more for paging.
+	// count (body FTS fallback, hybrid/vector ranking depth, or list_messages
+	// has_more without a separate count query). Clients should use has_more for
+	// paging.
 	totalCountUnknown = -1
 )
 
@@ -71,6 +72,21 @@ func newPaginatedResponseHasMore[T any](data []T, offset int, hasMore bool) pagi
 		Data:     data,
 		Total:    total,
 		Returned: returned,
+		Offset:   offset,
+		HasMore:  hasMore,
+	}
+}
+
+// newPaginatedResponseNoTotal builds a page when the backend cannot report a
+// total match count. total is always totalCountUnknown; use has_more to page.
+func newPaginatedResponseNoTotal[T any](data []T, offset int, hasMore bool) paginatedResponse[T] {
+	if data == nil {
+		data = []T{}
+	}
+	return paginatedResponse[T]{
+		Data:     data,
+		Total:    totalCountUnknown,
+		Returned: len(data),
 		Offset:   offset,
 		HasMore:  hasMore,
 	}
@@ -260,10 +276,15 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 
 	// If fast search returns nothing and query has free text, try full FTS.
 	if len(results) == 0 && len(q.TextTerms) > 0 {
-		results, err = h.engine.Search(ctx, q, limit, offset)
+		results, err = h.engine.Search(ctx, q, limit+1, offset)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 		}
+		hasMore := len(results) > limit
+		if hasMore {
+			results = results[:limit]
+		}
+		return jsonResult(newPaginatedResponseNoTotal(results, offset, hasMore))
 	}
 
 	totalMatched, err := h.engine.SearchFastCount(ctx, q, filter)

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -386,7 +386,9 @@ func (h *handlers) searchMessagesHybrid(
 	}
 
 	maxPage := h.vectorCfg.Search.MaxPageSizeHybridClamp()
-	fetchLimit := offset + limit
+	requestedFetch := offset + limit
+	fetchLimit := requestedFetch
+	fetchWasClamped := false
 	if maxPage > 0 {
 		if offset >= maxPage {
 			return mcp.NewToolResultError(fmt.Sprintf(
@@ -397,6 +399,7 @@ func (h *handlers) searchMessagesHybrid(
 		}
 		if fetchLimit > maxPage {
 			fetchLimit = maxPage
+			fetchWasClamped = true
 		}
 	}
 
@@ -467,8 +470,14 @@ func (h *handlers) searchMessagesHybrid(
 		end := min(offset+limit, len(items))
 		page = items[offset:end]
 	}
-	hasMore := offset+limit < len(items) ||
-		(meta.PoolSaturated && len(hits) >= fetchLimit)
+	hasMore := offset+limit < len(items)
+	// Pool saturation can mean more ranked hits exist beyond fetchLimit, but
+	// only advertise has_more when the next page is actually servable. When
+	// fetchLimit was clamped to maxPage, offset+limit may exceed maxPage and
+	// the handler would reject the follow-up request.
+	if !hasMore && !fetchWasClamped {
+		hasMore = meta.PoolSaturated && len(hits) >= fetchLimit
+	}
 
 	return jsonResult(searchMessagesHybridResponse{
 		paginatedResponse: newPaginatedResponseHasMore(page, offset, hasMore),

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -237,17 +237,17 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 
 	mode, _ := args["mode"].(string)
 	if mode == "" {
-		mode = "fts"
+		mode = searchModeFTS
 	}
 	explain, _ := args["explain"].(bool)
 
-	if mode == "vector" || mode == "hybrid" {
+	if mode == searchModeVector || mode == searchModeHybrid {
 		return h.searchMessagesHybrid(ctx, args, queryStr, mode, explain)
 	}
 
-	if mode != "fts" {
+	if mode != searchModeFTS {
 		return mcp.NewToolResultError(
-			fmt.Sprintf("invalid mode %q: must be fts, vector, or hybrid", mode),
+			fmt.Sprintf("invalid mode %q: must be %s, %s, or %s", mode, searchModeFTS, searchModeVector, searchModeHybrid),
 		), nil
 	}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -186,7 +186,9 @@ func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr string) e
 func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 	if !vectorAvailable {
 		return mcp.NewTool(ToolSearchMessages,
-			mcp.WithDescription("Search emails using Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. (This server is not configured for vector search; only keyword FTS is available.)"),
+			mcp.WithDescription("Search emails using Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+				"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
+				"(This server is not configured for vector search; only keyword FTS is available.)"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithString("query",
 				mcp.Required(),
@@ -198,7 +200,11 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 		)
 	}
 	return mcp.NewTool(ToolSearchMessages,
-		mcp.WithDescription("Search emails using Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. Vector search is configured: set mode=vector for pure semantic search or mode=hybrid to fuse BM25 and vector ranking via RRF. Vector/hybrid modes require free-text terms in the query; filter-only queries must use mode=fts."),
+		mcp.WithDescription("Search emails using Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+			"All modes paginate via offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
+			"total=-1 means the full match count is unknown — use has_more. "+
+			"Vector/hybrid ranking depth is capped by max_page_size_hybrid in config; beyond that use mode=fts. "+
+			"Vector search is configured: set mode=vector for pure semantic search or mode=hybrid to fuse BM25 and vector ranking via RRF. Vector/hybrid modes require free-text terms in the query; filter-only queries must use mode=fts."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("query",
 			mcp.Required(),
@@ -206,10 +212,8 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 		),
 		withAccount(),
 		withLimit("20"),
-		// offset is FTS-only here. Vector/hybrid responses don't page —
-		// callers should bump limit (capped by max_page_size_hybrid) instead.
 		mcp.WithNumber("offset",
-			mcp.Description("Number of results to skip for pagination (default 0). Only valid for mode=fts; mode=vector and mode=hybrid reject offset>0 with pagination_unsupported."),
+			mcp.Description("Number of results to skip for pagination (default 0)."),
 		),
 		mcp.WithString("mode",
 			mcp.Description("Search mode: fts (default, keyword only), vector (semantic only), or hybrid (BM25 + vector fused via RRF)"),
@@ -258,7 +262,9 @@ func exportAttachmentTool() mcp.Tool {
 
 func listMessagesTool() mcp.Tool {
 	return mcp.NewTool(ToolListMessages,
-		mcp.WithDescription("List messages with optional filters. Returns message summaries sorted by date."),
+		mcp.WithDescription("List messages with optional filters. Returns message summaries sorted by date. "+
+			"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
+			"total=-1 when has_more is true (full count unknown)."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		withAccount(),
 		mcp.WithString("from",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -29,6 +29,13 @@ const (
 	ToolFindSimilarMessages = "find_similar_messages"
 )
 
+// search_messages mode values (wire format).
+const (
+	searchModeFTS    = "fts"
+	searchModeVector = "vector"
+	searchModeHybrid = "hybrid"
+)
+
 // Common argument helpers for recurring tool option definitions.
 
 func withLimit(defaultDesc string) mcp.ToolOption {
@@ -217,7 +224,7 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 		),
 		mcp.WithString("mode",
 			mcp.Description("Search mode: fts (default, keyword only), vector (semantic only), or hybrid (BM25 + vector fused via RRF)"),
-			mcp.Enum("fts", "vector", "hybrid"),
+			mcp.Enum(searchModeFTS, searchModeVector, searchModeHybrid),
 		),
 		mcp.WithBoolean("explain",
 			mcp.Description("Include per-signal scores in the response (for debugging or ranking inspection)"),

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -271,7 +271,7 @@ func listMessagesTool() mcp.Tool {
 	return mcp.NewTool(ToolListMessages,
 		mcp.WithDescription("List messages with optional filters. Returns message summaries sorted by date. "+
 			"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
-			"total=-1 when has_more is true (full count unknown)."),
+			"total=-1 because the full count is not computed; use has_more for paging."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		withAccount(),
 		mcp.WithString("from",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -348,9 +348,10 @@ func TestSearchMessages_HybridModePagination(t *testing.T) {
 		Data []struct {
 			ID int64 `json:"id"`
 		} `json:"data"`
-		Offset   int  `json:"offset"`
-		Returned int  `json:"returned"`
-		HasMore  bool `json:"has_more"`
+		Offset   int   `json:"offset"`
+		Returned int   `json:"returned"`
+		Total    int64 `json:"total"`
+		HasMore  bool  `json:"has_more"`
 	}
 	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
@@ -363,13 +364,15 @@ func TestSearchMessages_HybridModePagination(t *testing.T) {
 	require.Len(resp.Data, 1, "data")
 	assert.Equal(int64(20), resp.Data[0].ID, "second ranked hit")
 	assert.Equal(1, resp.Offset, "offset")
+	assert.Equal(int64(totalCountUnknown), resp.Total, "total")
 	assert.True(resp.HasMore, "has_more")
 }
 
 func TestSearchMessages_HybridPagination_NoUnreachableHasMore(t *testing.T) {
 	// Regression: offset=40&limit=20 with max_page_size_hybrid=50 fetches the
 	// last 10 hits in-window. Pool saturation must not set has_more=true when
-	// the next page (offset=60) exceeds the ranking window.
+	// the next page (offset=60) exceeds the ranking window. total must stay -1
+	// because additional corpus matches may exist beyond the ranking window.
 	maxPage := 50
 	hits := make([]vector.Hit, maxPage)
 	msgs := make(map[int64]*query.MessageDetail, maxPage)
@@ -399,7 +402,8 @@ func TestSearchMessages_HybridPagination_NoUnreachableHasMore(t *testing.T) {
 		Data []struct {
 			ID int64 `json:"id"`
 		} `json:"data"`
-		HasMore bool `json:"has_more"`
+		Total   int64 `json:"total"`
+		HasMore bool  `json:"has_more"`
 	}
 	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
@@ -410,6 +414,7 @@ func TestSearchMessages_HybridPagination_NoUnreachableHasMore(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	require.Len(resp.Data, 10, "data")
+	assert.Equal(int64(totalCountUnknown), resp.Total, "total")
 	assert.False(resp.HasMore, "has_more")
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
@@ -455,7 +460,8 @@ func TestSearchMessages_HybridPagination_NoHasMoreAtMaxPageBoundary(t *testing.T
 		Data []struct {
 			ID int64 `json:"id"`
 		} `json:"data"`
-		HasMore bool `json:"has_more"`
+		Total   int64 `json:"total"`
+		HasMore bool  `json:"has_more"`
 	}
 	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
@@ -466,6 +472,7 @@ func TestSearchMessages_HybridPagination_NoHasMoreAtMaxPageBoundary(t *testing.T
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	require.Len(resp.Data, 20, "data")
+	assert.Equal(int64(totalCountUnknown), resp.Total, "total")
 	assert.False(resp.HasMore, "has_more")
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -421,6 +421,117 @@ func TestSearchMessages_HybridPagination_NoUnreachableHasMore(t *testing.T) {
 	assert.Contains(resultText(t, r), "pagination_limit")
 }
 
+func TestSearchMessages_HybridPagination_NoHasMoreAtMaxPageBoundary(t *testing.T) {
+	// Regression: offset=30&limit=20 with max_page_size_hybrid=50 fills the
+	// ranking window (requestedEnd=50). has_more must be false even when the
+	// pool is saturated — the next page (offset=50) is rejected.
+	const maxPage = 50
+	const hitCount = 50
+	hits := make([]vector.Hit, hitCount)
+	msgs := make(map[int64]*query.MessageDetail, hitCount)
+	for i := range hitCount {
+		id := int64(i + 1)
+		hits[i] = vector.Hit{MessageID: id, Score: 1.0 - float64(i)*0.01}
+		msgs[id] = testutil.NewMessageDetail(id).WithBodyText("hit").BuildPtr()
+	}
+	backend := &fakeBackend{
+		active: vector.Generation{
+			ID: 1, Model: "fake", Dimension: 4,
+			Fingerprint: "fake:4", State: vector.GenerationActive,
+		},
+		searchHits: hits,
+	}
+	engine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 4}, hybrid.Config{
+		ExpectedFingerprint: "fake:4", RRFK: 60, KPerSignal: 10,
+	})
+	h := &handlers{
+		engine:       &querytest.MockEngine{Messages: msgs},
+		hybridEngine: engine,
+		backend:      backend,
+		vectorCfg:    vector.Config{Search: vector.SearchConfig{MaxPageSizeHybrid: new(maxPage)}},
+	}
+
+	type hybridPage struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+		HasMore bool `json:"has_more"`
+	}
+	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
+		"query":  "hit",
+		"mode":   "vector",
+		"offset": float64(30),
+		"limit":  float64(20),
+	})
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	require.Len(resp.Data, 20, "data")
+	assert.False(resp.HasMore, "has_more")
+
+	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
+		"query":  "hit",
+		"mode":   "vector",
+		"offset": float64(50),
+		"limit":  float64(20),
+	})
+	assert.Contains(resultText(t, r), "pagination_limit")
+}
+
+func TestSearchMessages_HybridPagination_ProbeRowDetectsMore(t *testing.T) {
+	// Regression: hybrid must fetch offset+limit+1 rows so has_more is true
+	// when additional in-window fused results exist (not only when the pool
+	// is saturated past the ranking window).
+	const hitCount = 25
+	hits := make([]vector.Hit, hitCount)
+	msgs := make(map[int64]*query.MessageDetail, hitCount)
+	for i := range hitCount {
+		id := int64(i + 1)
+		hits[i] = vector.Hit{MessageID: id, Score: 1.0 - float64(i)*0.01}
+		msgs[id] = testutil.NewMessageDetail(id).WithBodyText("hit").BuildPtr()
+	}
+	backend := &fakeBackend{
+		active: vector.Generation{
+			ID: 1, Model: "fake", Dimension: 4,
+			Fingerprint: "fake:4", State: vector.GenerationActive,
+		},
+		searchHits: hits,
+	}
+	engine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 4}, hybrid.Config{
+		ExpectedFingerprint: "fake:4", RRFK: 60, KPerSignal: 50,
+	})
+	h := &handlers{
+		engine:       &querytest.MockEngine{Messages: msgs},
+		hybridEngine: engine,
+		backend:      backend,
+		vectorCfg:    vector.Config{},
+	}
+
+	type hybridPage struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+		HasMore bool `json:"has_more"`
+	}
+	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
+		"query": "hit",
+		"mode":  "vector",
+		"limit": float64(20),
+	})
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	require.Len(resp.Data, 20, "data")
+	assert.True(resp.HasMore, "has_more")
+
+	resp2 := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
+		"query":  "hit",
+		"mode":   "vector",
+		"offset": float64(20),
+		"limit":  float64(20),
+	})
+	require.Len(resp2.Data, 5, "data page 2")
+	assert.False(resp2.HasMore, "has_more page 2")
+}
+
 func TestSearchMessages_UnknownMode(t *testing.T) {
 	h := newTestHandlers(&querytest.MockEngine{})
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -48,6 +48,22 @@ type attachmentMeta struct {
 	Size     int64  `json:"size"`
 }
 
+type paginatedSearchMessages struct {
+	Data     []query.MessageSummary `json:"data"`
+	Total    int64                  `json:"total"`
+	Returned int                    `json:"returned"`
+	Offset   int                    `json:"offset"`
+	HasMore  bool                   `json:"has_more"`
+}
+
+type paginatedListMessages struct {
+	Data     []query.MessageSummary `json:"data"`
+	Total    int64                  `json:"total"`
+	Returned int                    `json:"returned"`
+	Offset   int                    `json:"offset"`
+	HasMore  bool                   `json:"has_more"`
+}
+
 // newTestHandlers creates a handlers instance with the given mock engine.
 func newTestHandlers(eng *querytest.MockEngine) *handlers {
 	return &handlers{engine: eng}
@@ -99,10 +115,10 @@ func TestSearchMessages(t *testing.T) {
 	h := newTestHandlers(eng)
 
 	t.Run("valid query", func(t *testing.T) {
-		msgs := runTool[[]query.MessageSummary](t, "search_messages", h.searchMessages, map[string]any{"query": "from:alice"})
-		requirepkg.Len(t, msgs, 1, "msgs")
-		assertpkg.Equal(t, "Hello", msgs[0].Subject, "subject")
-		assertpkg.Equal(t, "thread-abc", msgs[0].SourceConversationID, "SourceConversationID")
+		resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{"query": "from:alice"})
+		requirepkg.Len(t, resp.Data, 1, "data")
+		assertpkg.Equal(t, "Hello", resp.Data[0].Subject, "subject")
+		assertpkg.Equal(t, "thread-abc", resp.Data[0].SourceConversationID, "SourceConversationID")
 	})
 
 	t.Run("missing query", func(t *testing.T) {
@@ -119,9 +135,9 @@ func TestSearchFallbackToFTS(t *testing.T) {
 	}
 	h := newTestHandlers(eng)
 
-	msgs := runTool[[]query.MessageSummary](t, "search_messages", h.searchMessages, map[string]any{"query": "important meeting notes"})
-	requirepkg.Len(t, msgs, 1, "FTS fallback msgs")
-	assertpkg.Equal(t, int64(2), msgs[0].ID, "FTS fallback ID")
+	resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{"query": "important meeting notes"})
+	requirepkg.Len(t, resp.Data, 1, "FTS fallback data")
+	assertpkg.Equal(t, int64(2), resp.Data[0].ID, "FTS fallback ID")
 }
 
 func TestSearchMessages_HybridModeNotConfigured(t *testing.T) {
@@ -283,19 +299,56 @@ func TestSearchMessages_HybridPoolSaturatedAlwaysEmitted(t *testing.T) {
 	assertpkg.Equal(t, "false", string(val), "pool_saturated")
 }
 
-func TestSearchMessages_HybridModePaginationUnsupported(t *testing.T) {
-	// offset>0 must be rejected before any hybrid-engine lookup. The
-	// pagination check runs first, so a missing hybridEngine does not
-	// mask the pagination_unsupported error.
-	h := newTestHandlers(&querytest.MockEngine{})
+func TestSearchMessages_HybridModePagination(t *testing.T) {
+	const msgID = int64(77)
+	backend := &fakeBackend{
+		active: vector.Generation{
+			ID: 1, Model: "fake", Dimension: 4,
+			Fingerprint: "fake:4", State: vector.GenerationActive,
+		},
+		searchHits: []vector.Hit{
+			{MessageID: 10, Score: 0.9},
+			{MessageID: 20, Score: 0.8},
+			{MessageID: msgID, Score: 0.7},
+		},
+	}
+	engine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 4}, hybrid.Config{
+		ExpectedFingerprint: "fake:4", RRFK: 60, KPerSignal: 10,
+	})
+	mockEng := &querytest.MockEngine{
+		Messages: map[int64]*query.MessageDetail{
+			10: testutil.NewMessageDetail(10).WithBodyText("first hit").BuildPtr(),
+			20: testutil.NewMessageDetail(20).WithBodyText("second hit").BuildPtr(),
+			77: testutil.NewMessageDetail(msgID).WithBodyText("third hit").BuildPtr(),
+		},
+	}
+	h := &handlers{
+		engine:       mockEng,
+		hybridEngine: engine,
+		backend:      backend,
+		vectorCfg:    vector.Config{},
+	}
 
-	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
-		"query":  "meeting notes",
+	type hybridPage struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+		Offset   int  `json:"offset"`
+		Returned int  `json:"returned"`
+		HasMore  bool `json:"has_more"`
+	}
+	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
+		"query":  "hit",
 		"mode":   "vector",
 		"offset": float64(1),
+		"limit":  float64(1),
 	})
-	txt := resultText(t, r)
-	assertpkg.Contains(t, txt, "pagination_unsupported", "expected 'pagination_unsupported' error, got: %s")
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	require.Len(resp.Data, 1, "data")
+	assert.Equal(int64(20), resp.Data[0].ID, "second ranked hit")
+	assert.Equal(1, resp.Offset, "offset")
+	assert.True(resp.HasMore, "has_more")
 }
 
 func TestSearchMessages_UnknownMode(t *testing.T) {
@@ -452,13 +505,14 @@ func TestListMessages(t *testing.T) {
 	h := newTestHandlers(eng)
 
 	t.Run("valid filters", func(t *testing.T) {
-		msgs := runTool[[]query.MessageSummary](t, "list_messages", h.listMessages, map[string]any{
+		resp := runTool[paginatedListMessages](t, "list_messages", h.listMessages, map[string]any{
 			"from":  "alice@example.com",
 			"after": "2024-01-01",
 			"limit": float64(10),
 		})
-		requirepkg.Len(t, msgs, 1, "msgs")
-		assertpkg.Equal(t, "thread-list", msgs[0].SourceConversationID, "SourceConversationID")
+		requirepkg.Len(t, resp.Data, 1, "data")
+		assertpkg.Equal(t, "thread-list", resp.Data[0].SourceConversationID, "SourceConversationID")
+		assertpkg.False(t, resp.HasMore, "has_more")
 	})
 
 	errorCases := []struct {
@@ -937,11 +991,11 @@ func TestAccountFilter(t *testing.T) {
 	h := newTestHandlers(eng)
 
 	t.Run("search with valid account", func(t *testing.T) {
-		msgs := runTool[[]query.MessageSummary](t, "search_messages", h.searchMessages, map[string]any{
+		resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{
 			"query":   "test",
 			"account": "alice@gmail.com",
 		})
-		assertpkg.Len(t, msgs, 1, "msgs")
+		assertpkg.Len(t, resp.Data, 1, "data")
 	})
 
 	t.Run("search with invalid account", func(t *testing.T) {
@@ -954,10 +1008,10 @@ func TestAccountFilter(t *testing.T) {
 	})
 
 	t.Run("list with valid account", func(t *testing.T) {
-		msgs := runTool[[]query.MessageSummary](t, "list_messages", h.listMessages, map[string]any{
+		resp := runTool[paginatedListMessages](t, "list_messages", h.listMessages, map[string]any{
 			"account": "bob@gmail.com",
 		})
-		assertpkg.Len(t, msgs, 1, "msgs")
+		assertpkg.Len(t, resp.Data, 1, "data")
 	})
 
 	t.Run("list with invalid account", func(t *testing.T) {
@@ -987,11 +1041,11 @@ func TestAccountFilter(t *testing.T) {
 
 	t.Run("empty account means no filter", func(t *testing.T) {
 		// Empty string should not filter - return all results
-		msgs := runTool[[]query.MessageSummary](t, "search_messages", h.searchMessages, map[string]any{
+		resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{
 			"query":   "test",
 			"account": "",
 		})
-		assertpkg.Len(t, msgs, 1, "msgs")
+		assertpkg.Len(t, resp.Data, 1, "data")
 	})
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -366,6 +366,61 @@ func TestSearchMessages_HybridModePagination(t *testing.T) {
 	assert.True(resp.HasMore, "has_more")
 }
 
+func TestSearchMessages_HybridPagination_NoUnreachableHasMore(t *testing.T) {
+	// Regression: offset=40&limit=20 with max_page_size_hybrid=50 fetches the
+	// last 10 hits in-window. Pool saturation must not set has_more=true when
+	// the next page (offset=60) exceeds the ranking window.
+	maxPage := 50
+	hits := make([]vector.Hit, maxPage)
+	msgs := make(map[int64]*query.MessageDetail, maxPage)
+	for i := range maxPage {
+		id := int64(i + 1)
+		hits[i] = vector.Hit{MessageID: id, Score: 1.0 - float64(i)*0.01}
+		msgs[id] = testutil.NewMessageDetail(id).WithBodyText("hit").BuildPtr()
+	}
+	backend := &fakeBackend{
+		active: vector.Generation{
+			ID: 1, Model: "fake", Dimension: 4,
+			Fingerprint: "fake:4", State: vector.GenerationActive,
+		},
+		searchHits: hits,
+	}
+	engine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 4}, hybrid.Config{
+		ExpectedFingerprint: "fake:4", RRFK: 60, KPerSignal: 10,
+	})
+	h := &handlers{
+		engine:       &querytest.MockEngine{Messages: msgs},
+		hybridEngine: engine,
+		backend:      backend,
+		vectorCfg:    vector.Config{Search: vector.SearchConfig{MaxPageSizeHybrid: &maxPage}},
+	}
+
+	type hybridPage struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+		HasMore bool `json:"has_more"`
+	}
+	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
+		"query":  "hit",
+		"mode":   "vector",
+		"offset": float64(40),
+		"limit":  float64(20),
+	})
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	require.Len(resp.Data, 10, "data")
+	assert.False(resp.HasMore, "has_more")
+
+	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
+		"query":  "hit",
+		"mode":   "vector",
+		"offset": float64(60),
+		"limit":  float64(20),
+	})
+	assert.Contains(resultText(t, r), "pagination_limit")
+}
+
 func TestSearchMessages_UnknownMode(t *testing.T) {
 	h := newTestHandlers(&querytest.MockEngine{})
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/query/querytest"
+	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/testutil"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -127,17 +127,31 @@ func TestSearchMessages(t *testing.T) {
 }
 
 func TestSearchFallbackToFTS(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+
 	eng := &querytest.MockEngine{
 		SearchFastResults: nil, // fast returns nothing
-		SearchResults: []query.MessageSummary{
-			testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+		SearchFunc: func(_ context.Context, _ *search.Query, limit, offset int) ([]query.MessageSummary, error) {
+			assert.Equal(2, limit, "FTS fallback should fetch one extra row for has_more")
+			assert.Equal(0, offset, "offset")
+			return []query.MessageSummary{
+				testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+				testutil.NewMessageSummary(3).WithSubject("Second body match").Build(),
+			}, nil
 		},
 	}
 	h := newTestHandlers(eng)
 
-	resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{"query": "important meeting notes"})
-	requirepkg.Len(t, resp.Data, 1, "FTS fallback data")
-	assertpkg.Equal(t, int64(2), resp.Data[0].ID, "FTS fallback ID")
+	resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{
+		"query": "important meeting notes",
+		"limit": float64(1),
+	})
+	require.Len(resp.Data, 1, "FTS fallback data")
+	assert.Equal(int64(2), resp.Data[0].ID, "FTS fallback ID")
+	assert.Equal(int64(totalCountUnknown), resp.Total, "FTS fallback total")
+	assert.Equal(1, resp.Returned, "returned")
+	assert.True(resp.HasMore, "has_more")
 }
 
 func TestSearchMessages_HybridModeNotConfigured(t *testing.T) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -162,7 +162,7 @@ func TestSearchMessages_HybridModeNotConfigured(t *testing.T) {
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
 		"query": "meeting notes",
-		"mode":  "hybrid",
+		"mode":  searchModeHybrid,
 	})
 	txt := resultText(t, r)
 	assertpkg.Contains(t, txt, "vector_not_enabled", "expected 'vector_not_enabled' error, got: %s")
@@ -203,7 +203,7 @@ func TestSearchMessages_HybridErrIndexBuilding(t *testing.T) {
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
 		"query": "anything",
-		"mode":  "hybrid",
+		"mode":  searchModeHybrid,
 	})
 	txt := resultText(t, r)
 	assertpkg.Contains(t, txt, "index_building", "expected 'index_building' error, got: %s")
@@ -222,7 +222,7 @@ func TestSearchMessages_HybridErrNotEnabled(t *testing.T) {
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
 		"query": "anything",
-		"mode":  "hybrid",
+		"mode":  searchModeHybrid,
 	})
 	txt := resultText(t, r)
 	assertpkg.Contains(t, txt, "vector_not_enabled", "expected 'vector_not_enabled' error, got: %s")
@@ -272,7 +272,7 @@ func TestSearchMessages_HybridFilterOnlyReturnsMissingFreeText(t *testing.T) {
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
 		"query": "from:alice@example.com",
-		"mode":  "vector",
+		"mode":  searchModeVector,
 	})
 	txt := resultText(t, r)
 	assertpkg.Contains(t, txt, "missing_free_text", "expected 'missing_free_text' error, got: %s")
@@ -304,7 +304,7 @@ func TestSearchMessages_HybridPoolSaturatedAlwaysEmitted(t *testing.T) {
 
 	r := callToolDirect(t, "search_messages", h.searchMessages, map[string]any{
 		"query": "hello world",
-		"mode":  "vector",
+		"mode":  searchModeVector,
 	})
 	require.False(r.IsError, "unexpected error: %s", resultText(t, r))
 	var raw map[string]json.RawMessage
@@ -355,7 +355,7 @@ func TestSearchMessages_HybridModePagination(t *testing.T) {
 	}
 	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
-		"mode":   "vector",
+		"mode":   searchModeVector,
 		"offset": float64(1),
 		"limit":  float64(1),
 	})
@@ -407,7 +407,7 @@ func TestSearchMessages_HybridPagination_NoUnreachableHasMore(t *testing.T) {
 	}
 	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
-		"mode":   "vector",
+		"mode":   searchModeVector,
 		"offset": float64(40),
 		"limit":  float64(20),
 	})
@@ -419,7 +419,7 @@ func TestSearchMessages_HybridPagination_NoUnreachableHasMore(t *testing.T) {
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
-		"mode":   "vector",
+		"mode":   searchModeVector,
 		"offset": float64(60),
 		"limit":  float64(20),
 	})
@@ -465,7 +465,7 @@ func TestSearchMessages_HybridPagination_NoHasMoreAtMaxPageBoundary(t *testing.T
 	}
 	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
-		"mode":   "vector",
+		"mode":   searchModeVector,
 		"offset": float64(30),
 		"limit":  float64(20),
 	})
@@ -477,7 +477,7 @@ func TestSearchMessages_HybridPagination_NoHasMoreAtMaxPageBoundary(t *testing.T
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
-		"mode":   "vector",
+		"mode":   searchModeVector,
 		"offset": float64(50),
 		"limit":  float64(20),
 	})
@@ -521,7 +521,7 @@ func TestSearchMessages_HybridPagination_ProbeRowDetectsMore(t *testing.T) {
 	}
 	resp := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query": "hit",
-		"mode":  "vector",
+		"mode":  searchModeVector,
 		"limit": float64(20),
 	})
 	require := requirepkg.New(t)
@@ -531,7 +531,7 @@ func TestSearchMessages_HybridPagination_ProbeRowDetectsMore(t *testing.T) {
 
 	resp2 := runTool[hybridPage](t, "search_messages", h.searchMessages, map[string]any{
 		"query":  "hit",
-		"mode":   "vector",
+		"mode":   searchModeVector,
 		"offset": float64(20),
 		"limit":  float64(20),
 	})

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -155,6 +155,40 @@ func TestSearchFallbackToFTS(t *testing.T) {
 	assert.True(resp.HasMore, "has_more")
 }
 
+func TestSearchMessages_NonPositiveLimitUsesDefault(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		limit float64
+	}{
+		{name: "zero", limit: 0},
+		{name: "negative", limit: -5},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assertpkg.New(t)
+			eng := &querytest.MockEngine{
+				SearchFastFunc: func(_ context.Context, _ *search.Query, _ query.MessageFilter, gotLimit, offset int) ([]query.MessageSummary, error) {
+					assert.Equal(defaultSearchLimit, gotLimit, "limit")
+					assert.Equal(0, offset, "offset")
+					return []query.MessageSummary{
+						testutil.NewMessageSummary(1).WithSubject("Hello").Build(),
+					}, nil
+				},
+				SearchFastCountFunc: func(context.Context, *search.Query, query.MessageFilter) (int64, error) {
+					return 1, nil
+				},
+			}
+			h := newTestHandlers(eng)
+
+			resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{
+				"query": "hello",
+				"limit": tt.limit,
+			})
+			assert.Equal(1, resp.Returned, "returned")
+			assert.Equal(int64(1), resp.Total, "total")
+		})
+	}
+}
+
 func TestSearchMessages_HybridModeNotConfigured(t *testing.T) {
 	// Handlers constructed without a hybridEngine must reject
 	// mode=hybrid (and mode=vector) with a vector_not_enabled error.
@@ -715,6 +749,27 @@ func TestListMessages(t *testing.T) {
 			runToolExpectError(t, "list_messages", h.listMessages, tt.args)
 		})
 	}
+}
+
+func TestListMessages_TotalUnknownWithoutCount(t *testing.T) {
+	assert := assertpkg.New(t)
+
+	eng := &querytest.MockEngine{
+		ListMessagesFunc: func(_ context.Context, filter query.MessageFilter) ([]query.MessageSummary, error) {
+			assert.Equal(defaultSearchLimit+1, filter.Pagination.Limit, "limit includes has_more probe")
+			assert.Equal(1000, filter.Pagination.Offset, "offset")
+			return nil, nil
+		},
+	}
+	h := newTestHandlers(eng)
+
+	resp := runTool[paginatedListMessages](t, "list_messages", h.listMessages, map[string]any{
+		"offset": float64(1000),
+	})
+	assert.Empty(resp.Data, "data")
+	assert.Equal(int64(totalCountUnknown), resp.Total, "total")
+	assert.Equal(0, resp.Returned, "returned")
+	assert.False(resp.HasMore, "has_more")
 }
 
 func TestAggregateInvalidDates(t *testing.T) {


### PR DESCRIPTION
Currently the MCP tool retrieves huge amounts of data with each call, which can overwhelm the context window and crash the conversation in a single response.  I've been using vibe-coded improvements in my local copy that greatly narrow what is fed back to the LLM, so it can find things more efficiently and quickly and not waste so much tokens/money, and am going to start submitting PRs for them:

1. https://github.com/endolith/msgvault/pull/6
2. https://github.com/endolith/msgvault/pull/7
3. https://github.com/endolith/msgvault/pull/8
4. https://github.com/endolith/msgvault/pull/9

(These were written by Cursor so I'm not entirely sure how they work or if they're optimal.)

This is the first (and it might still need work):

---

## What changed

`search_messages` and `list_messages` previously returned bare arrays (or, for vector/hybrid mode, a custom envelope with hits under `messages`). Both tools now return a shared paginated envelope.

**Before — default keyword mode:**
```json
[
  { "id": 1, "subject": "...", "from": [...] }
]
```

**Before — vector/hybrid mode:**
```json
{
  "query": "...",
  "mode": "hybrid",
  "returned": 20,
  "pool_saturated": false,
  "generation": { ... },
  "messages": [
    { "id": 1, "subject": "...", "from": [...] }
  ]
}
```

**Before — list_messages:**
```json
[
  { "id": 1, "subject": "...", "from": [...] }
]
```

**After — all three:**
```json
{
  "data": [ { "id": 1, "subject": "...", "from": [...] } ],
  "total": 143,
  "returned": 20,
  "offset": 0,
  "has_more": true
}
```

Vector/hybrid mode keeps its extra metadata alongside:
```json
{
  "data": [ { "id": 1, "subject": "...", "from": [...] } ],
  "total": -1,
  "returned": 20,
  "offset": 0,
  "has_more": true,
  "mode": "hybrid",
  "pool_saturated": false,
  "generation": { ... }
}
```

## Fields

| Field | Meaning |
|---|---|
| `data` | The result rows (was top-level array or `messages`) |
| `total` | Total matching rows, or `-1` when unknown |
| `returned` | Number of rows in this response |
| `offset` | Starting position of this page |
| `has_more` | Whether another page exists |

`total` is exact for keyword search (reported by `SearchFastCount`). It is `-1` for vector/hybrid modes (since the ranking window is bounded and doesn't enumerate all matches), and for the body-FTS fallback path (since no count query exists for full-text search). When `total=-1`, use `has_more` to determine whether to fetch the next page.   [This seems kludgy to me; maybe there's a better way.]

## Behavior changes

- **Breaking:** responses are no longer bare arrays. Clients must read `.data`.
- **Breaking:** vector/hybrid hits move from `.messages` to `.data`. 
  - [or should it have been the other way around?  The shared envelope should follow the existing `.messages` convention?]
- Vector/hybrid now supports `offset` pagination within the ranking window. Previously `offset > 0` was rejected with a `pagination_unsupported` error.
- `list_messages` now detects more pages by fetching one extra row internally rather than running a separate count query.
- Search and list results are now capped at 50 rows per call (previously the shared cap was 1000).

## What comes next

Subsequent PRs will change `get_message` to a narrower windowed body, and a new `search_in_message` tool. Both use the same `offset`/`returned`/`has_more` vocabulary established here, so LLM clients can read and search large messages without the full body ever filling the context window.