### PR TITLE
Record per-item sync errors

### DIFF
--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -353,6 +353,14 @@ func (a *storeAPIAdapter) GetLastSuccessfulSync(sourceID int64) (*store.SyncRun,
 	return a.store.GetLastSuccessfulSync(sourceID)
 }
 
+func (a *storeAPIAdapter) CountSyncRunItems(syncRunID int64, status string) (int64, error) {
+	return a.store.CountSyncRunItems(syncRunID, status)
+}
+
+func (a *storeAPIAdapter) ListSyncRunItems(syncRunID int64, status string, limit int) ([]store.SyncRunItem, error) {
+	return a.store.ListSyncRunItems(syncRunID, status, limit)
+}
+
 // schedulerAdapter adapts scheduler.Scheduler to api.SyncScheduler.
 // Since api.AccountStatus is a type alias for scheduler.AccountStatus,
 // the adapter methods are simple pass-throughs.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -31,6 +31,8 @@ import (
 // maxPageSize is the hard upper bound for any paginated endpoint.
 const maxPageSize = 500
 
+const sourceStatusItemErrorLimit = 10
+
 // StatsResponse represents the archive statistics.
 type StatsResponse struct {
 	TotalMessages int64             `json:"total_messages"`
@@ -80,18 +82,29 @@ type SourceStatus struct {
 
 // SyncRunStatus represents the API-visible details for a sync run.
 type SyncRunStatus struct {
-	ID                int64   `json:"id"`
-	SourceID          int64   `json:"source_id"`
-	StartedAt         string  `json:"started_at"`
-	CompletedAt       *string `json:"completed_at"`
-	Status            string  `json:"status"`
-	MessagesProcessed int64   `json:"messages_processed"`
-	MessagesAdded     int64   `json:"messages_added"`
-	MessagesUpdated   int64   `json:"messages_updated"`
-	ErrorsCount       int64   `json:"errors_count"`
-	ErrorMessage      *string `json:"error_message"`
-	CursorBefore      *string `json:"cursor_before"`
-	CursorAfter       *string `json:"cursor_after"`
+	ID                int64               `json:"id"`
+	SourceID          int64               `json:"source_id"`
+	StartedAt         string              `json:"started_at"`
+	CompletedAt       *string             `json:"completed_at"`
+	Status            string              `json:"status"`
+	MessagesProcessed int64               `json:"messages_processed"`
+	MessagesAdded     int64               `json:"messages_added"`
+	MessagesUpdated   int64               `json:"messages_updated"`
+	ErrorsCount       int64               `json:"errors_count"`
+	ErrorMessage      *string             `json:"error_message"`
+	CursorBefore      *string             `json:"cursor_before"`
+	CursorAfter       *string             `json:"cursor_after"`
+	SkippedCount      int64               `json:"skipped_count,omitempty"`
+	ItemErrors        []SyncRunItemStatus `json:"item_errors,omitempty"`
+}
+
+// SyncRunItemStatus represents one recent per-item sync error.
+type SyncRunItemStatus struct {
+	SourceMessageID string `json:"source_message_id"`
+	Phase           string `json:"phase"`
+	ErrorKind       string `json:"error_kind"`
+	ErrorMessage    string `json:"error_message"`
+	CreatedAt       string `json:"created_at"`
 }
 
 // SchedulerStatusResponse represents scheduler status.
@@ -779,20 +792,48 @@ func (s *Server) sourceStatus(statusStore SourceStatusStore, source *store.Sourc
 		return SourceStatus{}, fmt.Errorf("get active sync: %w", err)
 	}
 	status.ActiveSync = syncRunStatus(active)
+	if err := s.hydrateSyncRunStatus(statusStore, status.ActiveSync); err != nil {
+		return SourceStatus{}, err
+	}
 
 	latest, err := statusStore.GetLatestSync(source.ID)
 	if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 		return SourceStatus{}, fmt.Errorf("get latest sync: %w", err)
 	}
 	status.LatestSync = syncRunStatus(latest)
+	if err := s.hydrateSyncRunStatus(statusStore, status.LatestSync); err != nil {
+		return SourceStatus{}, err
+	}
 
 	lastSuccessful, err := statusStore.GetLastSuccessfulSync(source.ID)
 	if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
 		return SourceStatus{}, fmt.Errorf("get last successful sync: %w", err)
 	}
 	status.LastSuccessfulSync = syncRunStatus(lastSuccessful)
+	if err := s.hydrateSyncRunStatus(statusStore, status.LastSuccessfulSync); err != nil {
+		return SourceStatus{}, err
+	}
 
 	return status, nil
+}
+
+func (s *Server) hydrateSyncRunStatus(statusStore SourceStatusStore, status *SyncRunStatus) error {
+	if status == nil {
+		return nil
+	}
+
+	skippedCount, err := statusStore.CountSyncRunItems(status.ID, store.SyncRunItemStatusSkipped)
+	if err != nil {
+		return fmt.Errorf("count skipped sync items: %w", err)
+	}
+	status.SkippedCount = skippedCount
+
+	items, err := statusStore.ListSyncRunItems(status.ID, store.SyncRunItemStatusError, sourceStatusItemErrorLimit)
+	if err != nil {
+		return fmt.Errorf("list sync item errors: %w", err)
+	}
+	status.ItemErrors = syncRunItemStatuses(items)
+	return nil
 }
 
 func syncRunStatus(run *store.SyncRun) *SyncRunStatus {
@@ -823,6 +864,23 @@ func syncRunStatus(run *store.SyncRun) *SyncRunStatus {
 		status.CursorAfter = new(run.CursorAfter.String)
 	}
 	return status
+}
+
+func syncRunItemStatuses(items []store.SyncRunItem) []SyncRunItemStatus {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]SyncRunItemStatus, len(items))
+	for i, item := range items {
+		out[i] = SyncRunItemStatus{
+			SourceMessageID: item.SourceMessageID,
+			Phase:           item.Phase,
+			ErrorKind:       item.ErrorKind,
+			ErrorMessage:    item.ErrorMessage,
+			CreatedAt:       item.CreatedAt.UTC().Format(time.RFC3339),
+		}
+	}
+	return out
 }
 
 // handleTriggerSync manually triggers a sync for an account.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -182,6 +182,22 @@ func TestHandleSourceStatus(t *testing.T) {
 		MessagesAdded:     8,
 		MessagesUpdated:   2,
 	}), "UpdateSyncCheckpoint")
+	require.NoError(st.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       completedID,
+		SourceMessageID: "gmail-missing",
+		Phase:           "fetch",
+		Status:          store.SyncRunItemStatusSkipped,
+		ErrorKind:       "gmail_not_found",
+		ErrorMessage:    "not found: /messages/gmail-missing",
+	}), "RecordSyncRunItem skipped")
+	require.NoError(st.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       completedID,
+		SourceMessageID: "gmail-error",
+		Phase:           "ingest",
+		Status:          store.SyncRunItemStatusError,
+		ErrorKind:       "ingest_error",
+		ErrorMessage:    "parse MIME: malformed header",
+	}), "RecordSyncRunItem error")
 	require.NoError(st.CompleteSync(completedID, "history-2"), "CompleteSync")
 
 	runningID, err := st.StartSync(gmail.ID, "incremental")
@@ -221,6 +237,13 @@ func TestHandleSourceStatus(t *testing.T) {
 	assert.Equal(completedID, got.LastSuccessfulSync.ID, "LastSuccessfulSync.ID")
 	assert.Equal(store.SyncStatusCompleted, got.LastSuccessfulSync.Status, "LastSuccessfulSync.Status")
 	assert.Equal(int64(10), got.LastSuccessfulSync.MessagesProcessed, "LastSuccessfulSync.MessagesProcessed")
+	assert.Equal(int64(1), got.LastSuccessfulSync.SkippedCount, "LastSuccessfulSync.SkippedCount")
+	require.Len(got.LastSuccessfulSync.ItemErrors, 1, "LastSuccessfulSync.ItemErrors")
+	assert.Equal("gmail-error", got.LastSuccessfulSync.ItemErrors[0].SourceMessageID, "LastSuccessfulSync.ItemErrors[0].SourceMessageID")
+	assert.Equal("ingest", got.LastSuccessfulSync.ItemErrors[0].Phase, "LastSuccessfulSync.ItemErrors[0].Phase")
+	assert.Equal("ingest_error", got.LastSuccessfulSync.ItemErrors[0].ErrorKind, "LastSuccessfulSync.ItemErrors[0].ErrorKind")
+	assert.Equal("parse MIME: malformed header", got.LastSuccessfulSync.ItemErrors[0].ErrorMessage, "LastSuccessfulSync.ItemErrors[0].ErrorMessage")
+	assert.NotEmpty(got.LastSuccessfulSync.ItemErrors[0].CreatedAt, "LastSuccessfulSync.ItemErrors[0].CreatedAt")
 	require.NotNil(got.LastSuccessfulSync.CursorAfter, "LastSuccessfulSync.CursorAfter")
 	assert.Equal("history-2", *got.LastSuccessfulSync.CursorAfter, "LastSuccessfulSync.CursorAfter")
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -39,6 +39,8 @@ type SourceStatusStore interface {
 	GetActiveSync(sourceID int64) (*store.SyncRun, error)
 	GetLatestSync(sourceID int64) (*store.SyncRun, error)
 	GetLastSuccessfulSync(sourceID int64) (*store.SyncRun, error)
+	CountSyncRunItems(syncRunID int64, status string) (int64, error)
+	ListSyncRunItems(syncRunID int64, status string, limit int) ([]store.SyncRunItem, error)
 }
 
 // StoreStats is an alias for store.Stats — single source of truth.

--- a/internal/gmail/api.go
+++ b/internal/gmail/api.go
@@ -96,6 +96,14 @@ type RawMessage struct {
 	Raw          []byte // Decoded from base64url
 }
 
+// RawMessageBatchResult is one per-message result from a batch raw fetch.
+// Message is nil when the fetch failed; Err preserves the per-message cause.
+type RawMessageBatchResult struct {
+	ID      string
+	Message *RawMessage
+	Err     error
+}
+
 // HistoryResponse contains changes since a history ID.
 type HistoryResponse struct {
 	History       []HistoryRecord

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -431,11 +431,28 @@ func isRateLimitError(body []byte) bool {
 
 // GetMessagesRawBatch fetches multiple messages in parallel with rate limiting.
 func (c *Client) GetMessagesRawBatch(ctx context.Context, messageIDs []string) ([]*RawMessage, error) {
+	batch, err := c.GetMessagesRawBatchWithErrors(ctx, messageIDs)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]*RawMessage, len(batch))
+	for i, result := range batch {
+		results[i] = result.Message
+	}
+	return results, nil
+}
+
+// GetMessagesRawBatchWithErrors fetches multiple messages in parallel with
+// rate limiting and preserves per-message fetch errors.
+func (c *Client) GetMessagesRawBatchWithErrors(ctx context.Context, messageIDs []string) ([]RawMessageBatchResult, error) {
 	if len(messageIDs) == 0 {
 		return nil, nil
 	}
 
-	results := make([]*RawMessage, len(messageIDs))
+	results := make([]RawMessageBatchResult, len(messageIDs))
+	for i, id := range messageIDs {
+		results[i].ID = id
+	}
 	sem := make(chan struct{}, c.concurrency)
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -452,6 +469,7 @@ func (c *Client) GetMessagesRawBatch(ctx context.Context, messageIDs []string) (
 
 			msg, err := c.GetMessageRaw(ctx, id)
 			if err != nil {
+				results[i].Err = err
 				// Log but don't fail the batch - allow partial results.
 				// 404s are expected (message deleted between history scan and fetch),
 				// so log at debug level to avoid noise during incremental sync.
@@ -464,7 +482,7 @@ func (c *Client) GetMessagesRawBatch(ctx context.Context, messageIDs []string) (
 				return nil
 			}
 
-			results[i] = msg
+			results[i].Message = msg
 			return nil
 		})
 	}

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -396,6 +396,20 @@ func TestGetMessagesRawBatch_LogLevels(t *testing.T) {
 
 	assert.True(foundDebug404, "expected debug log for msg_404 with message %q, got records: %v", "message deleted before fetch", records)
 	assert.True(foundWarnErr, "expected warn log for msg_err with message %q, got records: %v", "failed to fetch message", records)
+
+	batch, err := client.GetMessagesRawBatchWithErrors(ctx, []string{"msg_ok", "msg_404", "msg_err"})
+	requirepkg.NoError(t, err, "GetMessagesRawBatchWithErrors()")
+	requirepkg.Len(t, batch, 3, "batch results")
+	assert.Equal("msg_ok", batch[0].ID, "batch[0].ID")
+	assert.NotNil(batch[0].Message, "batch[0].Message")
+	assert.NoError(batch[0].Err, "batch[0].Err")
+	assert.Equal("msg_404", batch[1].ID, "batch[1].ID")
+	assert.Nil(batch[1].Message, "batch[1].Message")
+	var notFound *NotFoundError
+	assert.ErrorAs(batch[1].Err, &notFound, "batch[1].Err")
+	assert.Equal("msg_err", batch[2].ID, "batch[2].ID")
+	assert.Nil(batch[2].Message, "batch[2].Message")
+	assert.Error(batch[2].Err, "batch[2].Err")
 }
 
 // rewriteTransport rewrites requests from the Gmail API baseURL to a test server URL.

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -323,6 +323,7 @@ func (h *testLogHandler) getRecords() []logRecord {
 }
 
 func TestGetMessagesRawBatch_LogLevels(t *testing.T) {
+	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 	// Set up a test HTTP server that returns different responses per message ID.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -367,7 +368,7 @@ func TestGetMessagesRawBatch_LogLevels(t *testing.T) {
 
 	ctx := context.Background()
 	results, err := client.GetMessagesRawBatch(ctx, []string{"msg_ok", "msg_404", "msg_err"})
-	requirepkg.NoError(t, err, "GetMessagesRawBatch()")
+	require.NoError(err, "GetMessagesRawBatch()")
 
 	// msg_ok should succeed
 	assert.NotNil(results[0], "expected msg_ok to return a result")
@@ -398,18 +399,18 @@ func TestGetMessagesRawBatch_LogLevels(t *testing.T) {
 	assert.True(foundWarnErr, "expected warn log for msg_err with message %q, got records: %v", "failed to fetch message", records)
 
 	batch, err := client.GetMessagesRawBatchWithErrors(ctx, []string{"msg_ok", "msg_404", "msg_err"})
-	requirepkg.NoError(t, err, "GetMessagesRawBatchWithErrors()")
-	requirepkg.Len(t, batch, 3, "batch results")
+	require.NoError(err, "GetMessagesRawBatchWithErrors()")
+	require.Len(batch, 3, "batch results")
 	assert.Equal("msg_ok", batch[0].ID, "batch[0].ID")
 	assert.NotNil(batch[0].Message, "batch[0].Message")
-	assert.NoError(batch[0].Err, "batch[0].Err")
+	require.NoError(batch[0].Err, "batch[0].Err")
 	assert.Equal("msg_404", batch[1].ID, "batch[1].ID")
 	assert.Nil(batch[1].Message, "batch[1].Message")
 	var notFound *NotFoundError
-	assert.ErrorAs(batch[1].Err, &notFound, "batch[1].Err")
+	require.ErrorAs(batch[1].Err, &notFound, "batch[1].Err")
 	assert.Equal("msg_err", batch[2].ID, "batch[2].ID")
 	assert.Nil(batch[2].Message, "batch[2].Message")
-	assert.Error(batch[2].Err, "batch[2].Err")
+	require.Error(batch[2].Err, "batch[2].Err")
 }
 
 // rewriteTransport rewrites requests from the Gmail API baseURL to a test server URL.

--- a/internal/gmail/mock.go
+++ b/internal/gmail/mock.go
@@ -186,13 +186,29 @@ func (m *MockAPI) GetMessageRaw(ctx context.Context, messageID string) (*RawMess
 // in the results slice rather than failing the entire batch. Callers must
 // handle nil entries (see sync.go).
 func (m *MockAPI) GetMessagesRawBatch(ctx context.Context, messageIDs []string) ([]*RawMessage, error) {
-	results := make([]*RawMessage, len(messageIDs))
+	batch, err := m.GetMessagesRawBatchWithErrors(ctx, messageIDs)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]*RawMessage, len(batch))
+	for i, result := range batch {
+		results[i] = result.Message
+	}
+	return results, nil
+}
+
+// GetMessagesRawBatchWithErrors fetches multiple messages and preserves each
+// per-message error for sync diagnostics.
+func (m *MockAPI) GetMessagesRawBatchWithErrors(ctx context.Context, messageIDs []string) ([]RawMessageBatchResult, error) {
+	results := make([]RawMessageBatchResult, len(messageIDs))
 	for i, id := range messageIDs {
+		results[i].ID = id
 		msg, err := m.GetMessageRaw(ctx, id)
 		if err != nil {
+			results[i].Err = err
 			continue
 		}
-		results[i] = msg
+		results[i].Message = msg
 	}
 	return results, nil
 }

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -451,7 +451,7 @@ var exclusiveLockTables = []string{
 	"messages", "message_recipients", "message_labels", "message_bodies", "message_raw",
 	"attachments", "labels", "participants", "participant_identifiers", "reactions",
 	"collections", "collection_sources", "account_identities", "applied_migrations",
-	"source_import_items", "sync_checkpoints",
+	"source_import_items", "sync_run_items", "sync_checkpoints",
 }
 
 // BeginExclusive opens a transaction on conn and locks every table the

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -303,6 +303,21 @@ CREATE TABLE IF NOT EXISTS sync_runs (
     cursor_after TEXT
 );
 
+-- Per-item sync outcomes, for diagnosing partial sync completion.
+-- status='error' is actionable and contributes to sync_runs.errors_count.
+-- status='skipped' records expected item churn, such as Gmail messages that
+-- were deleted between a history/list response and raw-message fetch.
+CREATE TABLE IF NOT EXISTS sync_run_items (
+    id INTEGER PRIMARY KEY,
+    sync_run_id INTEGER NOT NULL REFERENCES sync_runs(id) ON DELETE CASCADE,
+    source_message_id TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error_kind TEXT NOT NULL,
+    error_message TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Sync checkpoints (for resumable imports)
 CREATE TABLE IF NOT EXISTS sync_checkpoints (
     source_id INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
@@ -389,6 +404,8 @@ CREATE INDEX IF NOT EXISTS idx_message_labels_label ON message_labels(label_id);
 
 -- Sync
 CREATE INDEX IF NOT EXISTS idx_sync_runs_source ON sync_runs(source_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sync_run_items_run_status
+    ON sync_run_items(sync_run_id, status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_source_import_items_source_provider
     ON source_import_items(source_id, provider, status);
 

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -263,6 +263,17 @@ CREATE TABLE IF NOT EXISTS sync_runs (
     cursor_after TEXT
 );
 
+CREATE TABLE IF NOT EXISTS sync_run_items (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    sync_run_id BIGINT NOT NULL REFERENCES sync_runs(id) ON DELETE CASCADE,
+    source_message_id TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error_kind TEXT NOT NULL,
+    error_message TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE IF NOT EXISTS sync_checkpoints (
     source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
     checkpoint_type TEXT NOT NULL,
@@ -381,6 +392,8 @@ CREATE INDEX IF NOT EXISTS idx_labels_source ON labels(source_id);
 CREATE INDEX IF NOT EXISTS idx_message_labels_label ON message_labels(label_id);
 
 CREATE INDEX IF NOT EXISTS idx_sync_runs_source ON sync_runs(source_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sync_run_items_run_status
+    ON sync_run_items(sync_run_id, status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_source_import_items_source_provider
     ON source_import_items(source_id, provider, status);
 

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -13,6 +13,9 @@ const (
 	SyncStatusRunning   = "running"
 	SyncStatusCompleted = "completed"
 	SyncStatusFailed    = "failed"
+
+	SyncRunItemStatusError   = "error"
+	SyncRunItemStatusSkipped = "skipped"
 )
 
 // ErrSyncRunNotFound is returned by the sync-run getters (GetActiveSync,
@@ -146,6 +149,20 @@ type Checkpoint struct {
 	ErrorsCount       int64
 }
 
+// SyncRunItem records an individual item outcome within a sync run.
+// Error items are actionable and count toward SyncRun.ErrorsCount; skipped
+// items preserve expected churn such as Gmail messages deleted before fetch.
+type SyncRunItem struct {
+	ID              int64
+	SyncRunID       int64
+	SourceMessageID string
+	Phase           string
+	Status          string
+	ErrorKind       string
+	ErrorMessage    string
+	CreatedAt       time.Time
+}
+
 type SourceImportItem struct {
 	ID              int64
 	SourceID        int64
@@ -260,6 +277,89 @@ func (s *Store) UpdateSyncCheckpoint(syncID int64, cp *Checkpoint) error {
 		WHERE id = ?
 	`, cp.PageToken, cp.MessagesProcessed, cp.MessagesAdded, cp.MessagesUpdated, cp.ErrorsCount, syncID)
 	return err
+}
+
+// RecordSyncRunItem records a per-item sync outcome for diagnostics.
+func (s *Store) RecordSyncRunItem(item SyncRunItem) error {
+	_, err := s.db.Exec(fmt.Sprintf(`
+		INSERT INTO sync_run_items (
+			sync_run_id, source_message_id, phase, status,
+			error_kind, error_message, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, %s)
+	`, s.dialect.Now()),
+		item.SyncRunID, item.SourceMessageID, item.Phase, item.Status,
+		item.ErrorKind, item.ErrorMessage,
+	)
+	if err != nil {
+		return fmt.Errorf("insert sync_run_item: %w", err)
+	}
+	return nil
+}
+
+// CountSyncRunItems returns the number of recorded per-item sync outcomes for
+// a run. If status is non-empty, only items with that status are counted.
+func (s *Store) CountSyncRunItems(syncRunID int64, status string) (int64, error) {
+	query := `SELECT COUNT(*) FROM sync_run_items WHERE sync_run_id = ?`
+	args := []any{syncRunID}
+	if status != "" {
+		query += ` AND status = ?`
+		args = append(args, status)
+	}
+	var count int64
+	if err := s.db.QueryRow(query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count sync_run_items: %w", err)
+	}
+	return count, nil
+}
+
+// ListSyncRunItems returns the newest recorded per-item sync outcomes for a
+// run. If status is non-empty, only items with that status are returned.
+func (s *Store) ListSyncRunItems(syncRunID int64, status string, limit int) ([]SyncRunItem, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	query := `
+		SELECT id, sync_run_id, source_message_id, phase, status,
+		       error_kind, error_message, created_at
+		FROM sync_run_items
+		WHERE sync_run_id = ?
+	`
+	args := []any{syncRunID}
+	if status != "" {
+		query += ` AND status = ?`
+		args = append(args, status)
+	}
+	query += ` ORDER BY created_at DESC, id DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list sync_run_items: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	items := make([]SyncRunItem, 0)
+	for rows.Next() {
+		var item SyncRunItem
+		var createdAt sql.NullTime
+		if err := rows.Scan(
+			&item.ID, &item.SyncRunID, &item.SourceMessageID, &item.Phase,
+			&item.Status, &item.ErrorKind, &item.ErrorMessage, &createdAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan sync_run_item: %w", err)
+		}
+		var err error
+		item.CreatedAt, err = requireNullTime(createdAt, "created_at")
+		if err != nil {
+			return nil, fmt.Errorf("sync_run_item %d: %w", item.ID, err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sync_run_items: %w", err)
+	}
+	return items, nil
 }
 
 // CompleteSync marks a sync as successfully completed.

--- a/internal/store/sync_test.go
+++ b/internal/store/sync_test.go
@@ -129,6 +129,71 @@ func TestStore_GetLatestSync(t *testing.T) {
 	assert.Equal(store.SyncStatusRunning, run.Status, "Status")
 }
 
+func TestStore_SyncRunItems(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	f := storetest.New(t)
+
+	syncID := f.StartSync()
+
+	require.NoError(f.Store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: "msg-skipped",
+		Phase:           "fetch",
+		Status:          store.SyncRunItemStatusSkipped,
+		ErrorKind:       "gmail_not_found",
+		ErrorMessage:    "not found: /messages/msg-skipped",
+	}), "RecordSyncRunItem skipped")
+	require.NoError(f.Store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: "msg-error",
+		Phase:           "ingest",
+		Status:          store.SyncRunItemStatusError,
+		ErrorKind:       "ingest_error",
+		ErrorMessage:    "parse MIME: malformed header",
+	}), "RecordSyncRunItem error")
+
+	errorCount, err := f.Store.CountSyncRunItems(syncID, store.SyncRunItemStatusError)
+	require.NoError(err, "CountSyncRunItems error")
+	assert.Equal(int64(1), errorCount, "error count")
+
+	skippedCount, err := f.Store.CountSyncRunItems(syncID, store.SyncRunItemStatusSkipped)
+	require.NoError(err, "CountSyncRunItems skipped")
+	assert.Equal(int64(1), skippedCount, "skipped count")
+
+	items, err := f.Store.ListSyncRunItems(syncID, store.SyncRunItemStatusError, 10)
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "items")
+	assert.Equal("msg-error", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("ingest", items[0].Phase, "Phase")
+	assert.Equal("ingest_error", items[0].ErrorKind, "ErrorKind")
+	assert.Equal("parse MIME: malformed header", items[0].ErrorMessage, "ErrorMessage")
+	assert.False(items[0].CreatedAt.IsZero(), "CreatedAt")
+}
+
+func TestStore_SyncRunItemsCascadeWithSyncRun(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	f := storetest.New(t)
+
+	syncID := f.StartSync()
+	require.NoError(f.Store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: "msg-error",
+		Phase:           "fetch",
+		Status:          store.SyncRunItemStatusError,
+		ErrorKind:       "fetch_error",
+		ErrorMessage:    "network unavailable",
+	}), "RecordSyncRunItem")
+
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`DELETE FROM sync_runs WHERE id = ?`), syncID)
+	require.NoError(err, "delete sync run")
+
+	count, err := f.Store.CountSyncRunItems(syncID, "")
+	require.NoError(err, "CountSyncRunItems")
+	assert.Equal(int64(0), count, "sync_run_items should cascade with sync_run")
+}
+
 // TestListSources_ParsesTimestamps verifies that ListSources correctly parses
 // timestamps for all returned sources.
 func TestListSources_ParsesTimestamps(t *testing.T) {

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -152,15 +152,26 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 
 		// Batch-fetch and ingest new messages
 		if len(newMsgIDs) > 0 {
-			rawMessages, fetchErr := s.client.GetMessagesRawBatch(ctx, newMsgIDs)
+			rawMessages, fetchErr := s.getMessagesRawBatchWithDiagnostics(ctx, newMsgIDs)
 			if fetchErr != nil {
 				s.logger.Warn("failed to batch fetch messages", "error", fetchErr)
+				for _, id := range newMsgIDs {
+					s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, fetchErr)
+				}
 				checkpoint.ErrorsCount += int64(len(newMsgIDs))
 			} else {
 				var insertedIDs []int64
-				for i, raw := range rawMessages {
+				for i, fetch := range rawMessages {
+					raw := fetch.Message
 					if raw == nil {
-						s.logger.Warn("failed to fetch message (nil response)", "id", newMsgIDs[i])
+						if isGmailNotFound(fetch.Err) {
+							s.logger.Debug("skipping message deleted before fetch", "id", newMsgIDs[i])
+							s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
+							continue
+						}
+						errMsg := syncItemErrorMessage(fetch.Err, errRawBatchMissing.Error())
+						s.logger.Warn("failed to fetch message", "id", newMsgIDs[i], "error", errMsg)
+						s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, fetch.Err)
 						checkpoint.ErrorsCount++
 						continue
 					}
@@ -168,6 +179,7 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 					insertedID, err := s.ingestMessage(source.ID, raw, threadID, labelMap)
 					if err != nil {
 						s.logger.Warn("failed to ingest added message", "id", newMsgIDs[i], "error", err)
+						s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
 						checkpoint.ErrorsCount++
 						continue
 					}
@@ -196,6 +208,9 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 		if len(deletedIDs) > 0 {
 			if err := s.store.MarkMessagesDeletedBatch(source.ID, deletedIDs); err != nil {
 				s.logger.Warn("failed to batch mark messages deleted", "error", err)
+				for _, id := range deletedIDs {
+					s.recordSyncItem(syncID, id, syncItemPhaseDelete, store.SyncRunItemStatusError, syncItemKindDeleteError, err)
+				}
 				checkpoint.ErrorsCount += int64(len(deletedIDs))
 			}
 		}

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -137,7 +137,7 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 			for _, msg := range record.MessagesDeleted {
 				deletedSet[msg.Message.ID] = true
 			}
-			s.processLabelChanges(ctx, source.ID, record, labelMap, existingMap, updatedExisting)
+			s.processLabelChanges(ctx, syncID, source.ID, record, labelMap, existingMap, updatedExisting, checkpoint, summary)
 		}
 		checkpoint.MessagesUpdated += int64(len(updatedExisting))
 		checkpoint.MessagesProcessed += int64(len(newMsgThreads) + len(deletedSet) + len(updatedExisting))
@@ -264,9 +264,9 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 
 // processLabelChanges handles label additions and removals for messages.
 // existingMap maps source_message_id -> internal message_id for known messages.
-func (s *Syncer) processLabelChanges(ctx context.Context, sourceID int64, record gmail.HistoryRecord, labelMap map[string]int64, existingMap map[string]int64, updatedExisting map[string]struct{}) {
+func (s *Syncer) processLabelChanges(ctx context.Context, syncID, sourceID int64, record gmail.HistoryRecord, labelMap map[string]int64, existingMap map[string]int64, updatedExisting map[string]struct{}, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) {
 	for _, item := range record.LabelsAdded {
-		updated, err := s.handleLabelChange(ctx, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, true, existingMap)
+		updated, err := s.handleLabelChange(ctx, syncID, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, true, existingMap, checkpoint, summary)
 		if err != nil {
 			s.logLabelChangeError("add", item.Message.ID, err)
 			continue
@@ -276,7 +276,7 @@ func (s *Syncer) processLabelChanges(ctx context.Context, sourceID int64, record
 		}
 	}
 	for _, item := range record.LabelsRemoved {
-		updated, err := s.handleLabelChange(ctx, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, false, existingMap)
+		updated, err := s.handleLabelChange(ctx, syncID, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, false, existingMap, checkpoint, summary)
 		if err != nil {
 			s.logLabelChangeError("remove", item.Message.ID, err)
 			continue
@@ -290,18 +290,27 @@ func (s *Syncer) processLabelChanges(ctx context.Context, sourceID int64, record
 // handleLabelChange processes a label addition or removal.
 // For existing messages, applies the label diff directly without any API calls.
 // For unknown messages with labels being added, fetches and ingests the message.
-func (s *Syncer) handleLabelChange(ctx context.Context, sourceID int64, messageID, threadID string, gmailLabelIDs []string, labelMap map[string]int64, isAdd bool, existingMap map[string]int64) (bool, error) {
+func (s *Syncer) handleLabelChange(ctx context.Context, syncID, sourceID int64, messageID, threadID string, gmailLabelIDs []string, labelMap map[string]int64, isAdd bool, existingMap map[string]int64, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) (bool, error) {
 	internalID, exists := existingMap[messageID]
 
 	if !exists {
 		// Message doesn't exist locally - if adding labels, we should fetch it
 		if isAdd {
+			checkpoint.MessagesProcessed++
 			raw, err := s.client.GetMessageRaw(ctx, messageID)
 			if err != nil {
+				if isGmailNotFound(err) {
+					s.recordSyncItem(syncID, messageID, syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, err)
+					return false, err
+				}
+				s.recordSyncItem(syncID, messageID, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, err)
+				checkpoint.ErrorsCount++
 				return false, err
 			}
 			insertedID, err := s.ingestMessage(sourceID, raw, threadID, labelMap)
 			if err != nil {
+				s.recordSyncItem(syncID, messageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
+				checkpoint.ErrorsCount++
 				return false, err
 			}
 			// Hook vector-search enqueue for the new message. A failed
@@ -314,6 +323,10 @@ func (s *Syncer) handleLabelChange(ctx context.Context, sourceID int64, messageI
 				if err := s.embedEnqueuer.EnqueueMessages(ctx, []int64{insertedID}); err != nil {
 					s.logger.Warn("vector enqueue failed", "ids", 1, "error", err)
 				}
+			}
+			checkpoint.MessagesAdded++
+			if raw != nil {
+				summary.BytesDownloaded += int64(len(raw.Raw))
 			}
 			return false, nil
 		}

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -137,7 +137,9 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 			for _, msg := range record.MessagesDeleted {
 				deletedSet[msg.Message.ID] = true
 			}
-			s.processLabelChanges(ctx, syncID, source.ID, record, labelMap, existingMap, updatedExisting, checkpoint, summary)
+		}
+		for _, record := range historyResp.History {
+			s.processLabelChanges(ctx, syncID, source.ID, record, labelMap, existingMap, newMsgThreads, updatedExisting, checkpoint, summary)
 		}
 		checkpoint.MessagesUpdated += int64(len(updatedExisting))
 		checkpoint.MessagesProcessed += int64(len(newMsgThreads) + len(deletedSet) + len(updatedExisting))
@@ -264,8 +266,13 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 
 // processLabelChanges handles label additions and removals for messages.
 // existingMap maps source_message_id -> internal message_id for known messages.
-func (s *Syncer) processLabelChanges(ctx context.Context, syncID, sourceID int64, record gmail.HistoryRecord, labelMap map[string]int64, existingMap map[string]int64, updatedExisting map[string]struct{}, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) {
+func (s *Syncer) processLabelChanges(ctx context.Context, syncID, sourceID int64, record gmail.HistoryRecord, labelMap map[string]int64, existingMap map[string]int64, newMsgThreads map[string]string, updatedExisting map[string]struct{}, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) {
 	for _, item := range record.LabelsAdded {
+		if _, exists := existingMap[item.Message.ID]; !exists {
+			if _, pending := newMsgThreads[item.Message.ID]; pending {
+				continue
+			}
+		}
 		updated, err := s.handleLabelChange(ctx, syncID, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, true, existingMap, checkpoint, summary)
 		if err != nil {
 			s.logLabelChangeError("add", item.Message.ID, err)

--- a/internal/sync/item_errors.go
+++ b/internal/sync/item_errors.go
@@ -1,0 +1,90 @@
+package sync
+
+import (
+	"context"
+	"errors"
+
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	syncItemPhaseFetch  = "fetch"
+	syncItemPhaseIngest = "ingest"
+	syncItemPhaseDelete = "delete"
+
+	syncItemKindBatchFetchError = "batch_fetch_error"
+	syncItemKindFetchError      = "fetch_error"
+	syncItemKindGmailNotFound   = "gmail_not_found"
+	syncItemKindIngestError     = "ingest_error"
+	syncItemKindDeleteError     = "delete_error"
+)
+
+var errRawBatchMissing = errors.New("missing raw message in batch result")
+
+type rawBatchWithErrors interface {
+	GetMessagesRawBatchWithErrors(context.Context, []string) ([]gmail.RawMessageBatchResult, error)
+}
+
+func (s *Syncer) getMessagesRawBatchWithDiagnostics(ctx context.Context, messageIDs []string) ([]gmail.RawMessageBatchResult, error) {
+	if client, ok := s.client.(rawBatchWithErrors); ok {
+		return client.GetMessagesRawBatchWithErrors(ctx, messageIDs)
+	}
+
+	rawMessages, err := s.client.GetMessagesRawBatch(ctx, messageIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]gmail.RawMessageBatchResult, len(messageIDs))
+	for i, id := range messageIDs {
+		var raw *gmail.RawMessage
+		if i < len(rawMessages) {
+			raw = rawMessages[i]
+		}
+		results[i] = gmail.RawMessageBatchResult{
+			ID:      id,
+			Message: raw,
+		}
+		if raw == nil {
+			results[i].Err = errRawBatchMissing
+		}
+	}
+	return results, nil
+}
+
+func isGmailNotFound(err error) bool {
+	var notFound *gmail.NotFoundError
+	return errors.As(err, &notFound)
+}
+
+func syncItemErrorMessage(err error, fallback string) string {
+	if err != nil {
+		return err.Error()
+	}
+	return fallback
+}
+
+func (s *Syncer) recordSyncItem(syncID int64, sourceMessageID, phase, status, kind string, err error) {
+	if sourceMessageID == "" {
+		sourceMessageID = "(unknown)"
+	}
+	errMsg := syncItemErrorMessage(err, kind)
+	if recErr := s.store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: sourceMessageID,
+		Phase:           phase,
+		Status:          status,
+		ErrorKind:       kind,
+		ErrorMessage:    errMsg,
+	}); recErr != nil {
+		s.logger.Warn("failed to record sync item",
+			"sync_id", syncID,
+			"source_message_id", sourceMessageID,
+			"phase", phase,
+			"status", status,
+			"error_kind", kind,
+			"error", recErr,
+		)
+	}
+}

--- a/internal/sync/item_errors.go
+++ b/internal/sync/item_errors.go
@@ -23,7 +23,7 @@ const (
 var errRawBatchMissing = errors.New("missing raw message in batch result")
 
 type rawBatchWithErrors interface {
-	GetMessagesRawBatchWithErrors(context.Context, []string) ([]gmail.RawMessageBatchResult, error)
+	GetMessagesRawBatchWithErrors(ctx context.Context, messageIDs []string) ([]gmail.RawMessageBatchResult, error)
 }
 
 func (s *Syncer) getMessagesRawBatchWithDiagnostics(ctx context.Context, messageIDs []string) ([]gmail.RawMessageBatchResult, error) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -159,7 +159,7 @@ type batchResult struct {
 }
 
 // processBatch processes a single batch of messages from a list response.
-func (s *Syncer) processBatch(ctx context.Context, sourceID int64, listResp *gmail.MessageListResponse, labelMap map[string]int64, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) (*batchResult, error) {
+func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listResp *gmail.MessageListResponse, labelMap map[string]int64, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) (*batchResult, error) {
 	result := &batchResult{}
 
 	if len(listResp.Messages) == 0 {
@@ -193,15 +193,27 @@ func (s *Syncer) processBatch(ctx context.Context, sourceID int64, listResp *gma
 
 	// Fetch and ingest new messages
 	if len(newIDs) > 0 {
-		rawMessages, err := s.client.GetMessagesRawBatch(ctx, newIDs)
+		rawMessages, err := s.getMessagesRawBatchWithDiagnostics(ctx, newIDs)
 		if err != nil {
+			for _, id := range newIDs {
+				s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, err)
+			}
 			return nil, fmt.Errorf("fetch messages: %w", err)
 		}
 
 		var insertedIDs []int64
-		for i, raw := range rawMessages {
+		for i, fetch := range rawMessages {
+			raw := fetch.Message
 			if raw == nil {
-				s.logger.Warn("failed to fetch message (nil response)", "id", newIDs[i])
+				if isGmailNotFound(fetch.Err) {
+					s.logger.Debug("skipping message deleted before fetch", "id", newIDs[i])
+					s.recordSyncItem(syncID, newIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
+					result.skipped++
+					continue
+				}
+				errMsg := syncItemErrorMessage(fetch.Err, errRawBatchMissing.Error())
+				s.logger.Warn("failed to fetch message", "id", newIDs[i], "error", errMsg)
+				s.recordSyncItem(syncID, newIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, fetch.Err)
 				checkpoint.ErrorsCount++
 				continue
 			}
@@ -230,6 +242,7 @@ func (s *Syncer) processBatch(ctx context.Context, sourceID int64, listResp *gma
 					continue
 				}
 				s.logger.Warn("failed to ingest message", "id", raw.ID, "error", err)
+				s.recordSyncItem(syncID, newIDs[i], syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
 				checkpoint.ErrorsCount++
 				continue
 			}
@@ -345,7 +358,7 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 		}
 
 		// Process batch
-		result, err := s.processBatch(ctx, source.ID, listResp, labelMap, state.checkpoint, summary)
+		result, err := s.processBatch(ctx, state.syncID, source.ID, listResp, labelMap, state.checkpoint, summary)
 		if err != nil {
 			_ = s.store.FailSync(state.syncID, err.Error())
 			return nil, err

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -31,6 +31,10 @@ func (p *panicOnBatchAPI) GetMessagesRawBatch(_ context.Context, _ []string) ([]
 	panic("unexpected nil pointer in batch processing")
 }
 
+func (p *panicOnBatchAPI) GetMessagesRawBatchWithErrors(_ context.Context, _ []string) ([]gmail.RawMessageBatchResult, error) {
+	panic("unexpected nil pointer in batch processing")
+}
+
 func TestFullSync_PanicReturnsError(t *testing.T) {
 	env := newTestEnv(t)
 	seedMessages(env, 1, 12345, "msg1")
@@ -115,10 +119,42 @@ func TestFullSyncWithErrors(t *testing.T) {
 	seedMessages(env, 3, 12345, "msg1", "msg2", "msg3")
 
 	// Make msg2 fail to fetch
-	env.Mock.GetMessageError["msg2"] = &gmail.NotFoundError{Path: "/messages/msg2"}
+	env.Mock.GetMessageError["msg2"] = errors.New("temporary fetch failure")
 
 	summary := runFullSync(t, env)
 	assertSummary(t, summary, WantSummary{Added: new(int64(2)), Errors: new(int64(1))})
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 1, "error items")
+	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
+	assertpkg.Equal(t, "fetch", items[0].Phase, "Phase")
+	assertpkg.Equal(t, "fetch_error", items[0].ErrorKind, "ErrorKind")
+}
+
+func TestFullSyncSkipsGmailNotFoundBeforeFetch(t *testing.T) {
+	env := newTestEnv(t)
+	seedMessages(env, 3, 12345, "msg1", "msg2", "msg3")
+
+	env.Mock.GetMessageError["msg2"] = &gmail.NotFoundError{Path: "/messages/msg2"}
+
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(2)), Errors: new(int64(0)), Skipped: new(int64(1))})
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusSkipped, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 1, "skipped items")
+	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
+	assertpkg.Equal(t, "fetch", items[0].Phase, "Phase")
+	assertpkg.Equal(t, "gmail_not_found", items[0].ErrorKind, "ErrorKind")
 }
 
 func TestMIMEParsing(t *testing.T) {
@@ -278,9 +314,9 @@ func TestFullSyncAllErrors(t *testing.T) {
 	env := newTestEnv(t)
 	seedMessages(env, 3, 12345, "msg1", "msg2", "msg3")
 
-	env.Mock.GetMessageError["msg1"] = &gmail.NotFoundError{Path: "/messages/msg1"}
-	env.Mock.GetMessageError["msg2"] = &gmail.NotFoundError{Path: "/messages/msg2"}
-	env.Mock.GetMessageError["msg3"] = &gmail.NotFoundError{Path: "/messages/msg3"}
+	env.Mock.GetMessageError["msg1"] = errors.New("temporary fetch failure 1")
+	env.Mock.GetMessageError["msg2"] = errors.New("temporary fetch failure 2")
+	env.Mock.GetMessageError["msg3"] = errors.New("temporary fetch failure 3")
 
 	summary := runFullSync(t, env)
 	assertSummary(t, summary, WantSummary{Added: new(int64(0)), Errors: new(int64(3))})
@@ -909,6 +945,16 @@ func TestFullSyncEmptyRawMIME(t *testing.T) {
 
 	summary := runFullSync(t, env)
 	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(1))})
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 1, "error items")
+	assertpkg.Equal(t, "msg-empty-raw", items[0].SourceMessageID, "SourceMessageID")
+	assertpkg.Equal(t, "ingest_error", items[0].ErrorKind, "ErrorKind")
 }
 
 func TestFullSyncEmptyThreadID(t *testing.T) {
@@ -1041,7 +1087,8 @@ func TestProcessBatch_EmptyBatch(t *testing.T) {
 		Messages: nil,
 	}
 
-	result, err := env.Syncer.processBatch(env.Context, source.ID, listResp, labelMap, checkpoint, summary)
+	syncID := startSyncRun(t, env, source.ID)
+	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
 	requirepkg.NoError(t, err, "processBatch")
 
 	assert.Equal(int64(0), result.processed, "processed")
@@ -1069,7 +1116,8 @@ func TestProcessBatch_AllNew(t *testing.T) {
 		},
 	}
 
-	result, err := env.Syncer.processBatch(env.Context, source.ID, listResp, labelMap, checkpoint, summary)
+	syncID := startSyncRun(t, env, source.ID)
+	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
 	requirepkg.NoError(t, err, "processBatch")
 
 	assert.Equal(int64(2), result.processed, "processed")
@@ -1099,7 +1147,8 @@ func TestProcessBatch_AllExisting(t *testing.T) {
 		},
 	}
 
-	result, err := env.Syncer.processBatch(env.Context, source.ID, listResp, labelMap, checkpoint, summary)
+	syncID := startSyncRun(t, env, source.ID)
+	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
 	requirepkg.NoError(t, err, "processBatch")
 
 	assert.Equal(int64(2), result.processed, "processed")
@@ -1132,7 +1181,8 @@ func TestProcessBatch_MixedNewAndExisting(t *testing.T) {
 		},
 	}
 
-	result, err := env.Syncer.processBatch(env.Context, source.ID, listResp, labelMap, checkpoint, summary)
+	syncID := startSyncRun(t, env, source.ID)
+	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
 	requirepkg.NoError(t, err, "processBatch")
 
 	assert.Equal(int64(2), result.processed, "processed")
@@ -1174,7 +1224,8 @@ func TestProcessBatch_OldestDatePropagation(t *testing.T) {
 		},
 	}
 
-	result, err := env.Syncer.processBatch(env.Context, source.ID, listResp, labelMap, checkpoint, summary)
+	syncID := startSyncRun(t, env, source.ID)
+	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
 	requirepkg.NoError(t, err, "processBatch")
 
 	// oldestDate should be Jan 10, 2024
@@ -1196,6 +1247,39 @@ func TestProcessBatch_ErrorsCount(t *testing.T) {
 
 	env.Mock.AddMessage("msg1", testMIME(), []string{"INBOX"})
 	// msg2 will return nil (simulating fetch failure)
+	env.Mock.GetMessageError["msg2"] = errors.New("temporary fetch failure")
+
+	listResp := &gmail.MessageListResponse{
+		Messages: []gmail.MessageID{
+			{ID: "msg1", ThreadID: "thread1"},
+			{ID: "msg2", ThreadID: "thread2"},
+		},
+	}
+
+	syncID := startSyncRun(t, env, source.ID)
+	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
+	requirepkg.NoError(t, err, "processBatch")
+
+	assertpkg.Equal(t, int64(1), result.added, "added")
+	assertpkg.Equal(t, int64(1), checkpoint.ErrorsCount, "ErrorsCount")
+
+	items, err := env.Store.ListSyncRunItems(syncID, store.SyncRunItemStatusError, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 1, "error items")
+	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
+	assertpkg.Equal(t, "fetch_error", items[0].ErrorKind, "ErrorKind")
+}
+
+func TestProcessBatch_GmailNotFoundIsSkipped(t *testing.T) {
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
+		"INBOX": {Name: "Inbox", Type: "system"},
+	})
+	checkpoint := &store.Checkpoint{}
+	summary := &gmail.SyncSummary{}
+
+	env.Mock.AddMessage("msg1", testMIME(), []string{"INBOX"})
 	env.Mock.GetMessageError["msg2"] = &gmail.NotFoundError{Path: "/messages/msg2"}
 
 	listResp := &gmail.MessageListResponse{
@@ -1205,11 +1289,19 @@ func TestProcessBatch_ErrorsCount(t *testing.T) {
 		},
 	}
 
-	result, err := env.Syncer.processBatch(env.Context, source.ID, listResp, labelMap, checkpoint, summary)
+	syncID := startSyncRun(t, env, source.ID)
+	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
 	requirepkg.NoError(t, err, "processBatch")
 
 	assertpkg.Equal(t, int64(1), result.added, "added")
-	assertpkg.Equal(t, int64(1), checkpoint.ErrorsCount, "ErrorsCount")
+	assertpkg.Equal(t, int64(1), result.skipped, "skipped")
+	assertpkg.Equal(t, int64(0), checkpoint.ErrorsCount, "ErrorsCount")
+
+	items, err := env.Store.ListSyncRunItems(syncID, store.SyncRunItemStatusSkipped, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 1, "skipped items")
+	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
+	assertpkg.Equal(t, "gmail_not_found", items[0].ErrorKind, "ErrorKind")
 }
 
 // TestAttachmentFilePermissions verifies that attachment files are saved with
@@ -1334,6 +1426,60 @@ func TestIncrementalSyncBatchNewMessages(t *testing.T) {
 	summary := runIncrementalSync(t, env)
 	assertSummary(t, summary, WantSummary{Added: new(int64(5))})
 	assertMessageCount(t, env.Store, 5)
+}
+
+func TestIncrementalSyncSkipsGmailNotFoundBeforeFetch(t *testing.T) {
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "12340")
+
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.Profile.HistoryID = 12350
+	env.Mock.AddMessage("new-ok", testMIME(), []string{"INBOX"})
+	env.Mock.GetMessageError["new-gone"] = &gmail.NotFoundError{Path: "/messages/new-gone"}
+
+	env.SetHistory(12350,
+		historyAdded("new-ok"),
+		historyAdded("new-gone"),
+	)
+
+	summary := runIncrementalSync(t, env)
+	assertSummary(t, summary, WantSummary{Found: new(int64(2)), Added: new(int64(1)), Errors: new(int64(0))})
+	assertMessageCount(t, env.Store, 1)
+
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusSkipped, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 1, "skipped items")
+	assertpkg.Equal(t, "new-gone", items[0].SourceMessageID, "SourceMessageID")
+	assertpkg.Equal(t, "gmail_not_found", items[0].ErrorKind, "ErrorKind")
+}
+
+func TestIncrementalSyncRecordsFetchErrors(t *testing.T) {
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "12340")
+
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.Profile.HistoryID = 12350
+	env.Mock.AddMessage("new-ok", testMIME(), []string{"INBOX"})
+	env.Mock.GetMessageError["new-error"] = errors.New("temporary fetch failure")
+
+	env.SetHistory(12350,
+		historyAdded("new-ok"),
+		historyAdded("new-error"),
+	)
+
+	summary := runIncrementalSync(t, env)
+	assertSummary(t, summary, WantSummary{Found: new(int64(2)), Added: new(int64(1)), Errors: new(int64(1))})
+	assertMessageCount(t, env.Store, 1)
+
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 1, "error items")
+	assertpkg.Equal(t, "new-error", items[0].SourceMessageID, "SourceMessageID")
+	assertpkg.Equal(t, "fetch_error", items[0].ErrorKind, "ErrorKind")
 }
 
 // TestIncrementalSyncMixedOperations tests a history page with adds, deletes,

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -115,6 +115,8 @@ func TestFullSyncResume(t *testing.T) {
 }
 
 func TestFullSyncWithErrors(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	seedMessages(env, 3, 12345, "msg1", "msg2", "msg3")
 
@@ -125,18 +127,20 @@ func TestFullSyncWithErrors(t *testing.T) {
 	assertSummary(t, summary, WantSummary{Added: new(int64(2)), Errors: new(int64(1))})
 
 	source, err := env.Store.GetSourceByIdentifier(testEmail)
-	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	require.NoError(err, "GetSourceByIdentifier")
 	run, err := env.Store.GetLastSuccessfulSync(source.ID)
-	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	require.NoError(err, "GetLastSuccessfulSync")
 	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 1, "error items")
-	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
-	assertpkg.Equal(t, "fetch", items[0].Phase, "Phase")
-	assertpkg.Equal(t, "fetch_error", items[0].ErrorKind, "ErrorKind")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "error items")
+	assert.Equal("msg2", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("fetch", items[0].Phase, "Phase")
+	assert.Equal("fetch_error", items[0].ErrorKind, "ErrorKind")
 }
 
 func TestFullSyncSkipsGmailNotFoundBeforeFetch(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	seedMessages(env, 3, 12345, "msg1", "msg2", "msg3")
 
@@ -146,15 +150,15 @@ func TestFullSyncSkipsGmailNotFoundBeforeFetch(t *testing.T) {
 	assertSummary(t, summary, WantSummary{Added: new(int64(2)), Errors: new(int64(0)), Skipped: new(int64(1))})
 
 	source, err := env.Store.GetSourceByIdentifier(testEmail)
-	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	require.NoError(err, "GetSourceByIdentifier")
 	run, err := env.Store.GetLastSuccessfulSync(source.ID)
-	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	require.NoError(err, "GetLastSuccessfulSync")
 	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusSkipped, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 1, "skipped items")
-	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
-	assertpkg.Equal(t, "fetch", items[0].Phase, "Phase")
-	assertpkg.Equal(t, "gmail_not_found", items[0].ErrorKind, "ErrorKind")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "skipped items")
+	assert.Equal("msg2", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("fetch", items[0].Phase, "Phase")
+	assert.Equal("gmail_not_found", items[0].ErrorKind, "ErrorKind")
 }
 
 func TestMIMEParsing(t *testing.T) {
@@ -930,6 +934,8 @@ func TestFullSyncDateFallbackToInternalDate(t *testing.T) {
 }
 
 func TestFullSyncEmptyRawMIME(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	env.Mock.Profile.MessagesTotal = 2
 	env.Mock.Profile.HistoryID = 12345
@@ -947,14 +953,14 @@ func TestFullSyncEmptyRawMIME(t *testing.T) {
 	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(1))})
 
 	source, err := env.Store.GetSourceByIdentifier(testEmail)
-	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	require.NoError(err, "GetSourceByIdentifier")
 	run, err := env.Store.GetLastSuccessfulSync(source.ID)
-	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	require.NoError(err, "GetLastSuccessfulSync")
 	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 1, "error items")
-	assertpkg.Equal(t, "msg-empty-raw", items[0].SourceMessageID, "SourceMessageID")
-	assertpkg.Equal(t, "ingest_error", items[0].ErrorKind, "ErrorKind")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "error items")
+	assert.Equal("msg-empty-raw", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("ingest_error", items[0].ErrorKind, "ErrorKind")
 }
 
 func TestFullSyncEmptyThreadID(t *testing.T) {
@@ -1237,6 +1243,8 @@ func TestProcessBatch_OldestDatePropagation(t *testing.T) {
 }
 
 func TestProcessBatch_ErrorsCount(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	source := env.CreateSource(t)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
@@ -1258,19 +1266,21 @@ func TestProcessBatch_ErrorsCount(t *testing.T) {
 
 	syncID := startSyncRun(t, env, source.ID)
 	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
-	requirepkg.NoError(t, err, "processBatch")
+	require.NoError(err, "processBatch")
 
-	assertpkg.Equal(t, int64(1), result.added, "added")
-	assertpkg.Equal(t, int64(1), checkpoint.ErrorsCount, "ErrorsCount")
+	assert.Equal(int64(1), result.added, "added")
+	assert.Equal(int64(1), checkpoint.ErrorsCount, "ErrorsCount")
 
 	items, err := env.Store.ListSyncRunItems(syncID, store.SyncRunItemStatusError, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 1, "error items")
-	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
-	assertpkg.Equal(t, "fetch_error", items[0].ErrorKind, "ErrorKind")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "error items")
+	assert.Equal("msg2", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("fetch_error", items[0].ErrorKind, "ErrorKind")
 }
 
 func TestProcessBatch_GmailNotFoundIsSkipped(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	source := env.CreateSource(t)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
@@ -1291,17 +1301,17 @@ func TestProcessBatch_GmailNotFoundIsSkipped(t *testing.T) {
 
 	syncID := startSyncRun(t, env, source.ID)
 	result, err := env.Syncer.processBatch(env.Context, syncID, source.ID, listResp, labelMap, checkpoint, summary)
-	requirepkg.NoError(t, err, "processBatch")
+	require.NoError(err, "processBatch")
 
-	assertpkg.Equal(t, int64(1), result.added, "added")
-	assertpkg.Equal(t, int64(1), result.skipped, "skipped")
-	assertpkg.Equal(t, int64(0), checkpoint.ErrorsCount, "ErrorsCount")
+	assert.Equal(int64(1), result.added, "added")
+	assert.Equal(int64(1), result.skipped, "skipped")
+	assert.Equal(int64(0), checkpoint.ErrorsCount, "ErrorsCount")
 
 	items, err := env.Store.ListSyncRunItems(syncID, store.SyncRunItemStatusSkipped, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 1, "skipped items")
-	assertpkg.Equal(t, "msg2", items[0].SourceMessageID, "SourceMessageID")
-	assertpkg.Equal(t, "gmail_not_found", items[0].ErrorKind, "ErrorKind")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "skipped items")
+	assert.Equal("msg2", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("gmail_not_found", items[0].ErrorKind, "ErrorKind")
 }
 
 // TestAttachmentFilePermissions verifies that attachment files are saved with
@@ -1429,6 +1439,8 @@ func TestIncrementalSyncBatchNewMessages(t *testing.T) {
 }
 
 func TestIncrementalSyncSkipsGmailNotFoundBeforeFetch(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	source := env.CreateSourceWithHistory(t, "12340")
 
@@ -1447,15 +1459,17 @@ func TestIncrementalSyncSkipsGmailNotFoundBeforeFetch(t *testing.T) {
 	assertMessageCount(t, env.Store, 1)
 
 	run, err := env.Store.GetLastSuccessfulSync(source.ID)
-	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	require.NoError(err, "GetLastSuccessfulSync")
 	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusSkipped, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 1, "skipped items")
-	assertpkg.Equal(t, "new-gone", items[0].SourceMessageID, "SourceMessageID")
-	assertpkg.Equal(t, "gmail_not_found", items[0].ErrorKind, "ErrorKind")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "skipped items")
+	assert.Equal("new-gone", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("gmail_not_found", items[0].ErrorKind, "ErrorKind")
 }
 
 func TestIncrementalSyncRecordsFetchErrors(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	source := env.CreateSourceWithHistory(t, "12340")
 
@@ -1474,12 +1488,101 @@ func TestIncrementalSyncRecordsFetchErrors(t *testing.T) {
 	assertMessageCount(t, env.Store, 1)
 
 	run, err := env.Store.GetLastSuccessfulSync(source.ID)
-	requirepkg.NoError(t, err, "GetLastSuccessfulSync")
+	require.NoError(err, "GetLastSuccessfulSync")
 	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 1, "error items")
-	assertpkg.Equal(t, "new-error", items[0].SourceMessageID, "SourceMessageID")
-	assertpkg.Equal(t, "fetch_error", items[0].ErrorKind, "ErrorKind")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "error items")
+	assert.Equal("new-error", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("fetch_error", items[0].ErrorKind, "ErrorKind")
+}
+
+func TestIncrementalSyncRecordsLabelAddFetchErrors(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "12340")
+
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12350
+	env.Mock.GetMessageError["label-fetch-error"] = errors.New("temporary fetch failure")
+
+	env.SetHistory(12350,
+		historyLabelAdded("label-fetch-error", "INBOX"),
+	)
+
+	summary := runIncrementalSync(t, env)
+	assertSummary(t, summary, WantSummary{Found: new(int64(1)), Added: new(int64(0)), Errors: new(int64(1))})
+	assertMessageCount(t, env.Store, 0)
+
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	require.NoError(err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "error items")
+	assert.Equal("label-fetch-error", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("fetch", items[0].Phase, "Phase")
+	assert.Equal("fetch_error", items[0].ErrorKind, "ErrorKind")
+}
+
+func TestIncrementalSyncRecordsLabelAddGmailNotFound(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "12340")
+
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12350
+	env.Mock.GetMessageError["label-gone"] = &gmail.NotFoundError{Path: "/messages/label-gone"}
+
+	env.SetHistory(12350,
+		historyLabelAdded("label-gone", "INBOX"),
+	)
+
+	summary := runIncrementalSync(t, env)
+	assertSummary(t, summary, WantSummary{Found: new(int64(1)), Added: new(int64(0)), Errors: new(int64(0))})
+	assertMessageCount(t, env.Store, 0)
+
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	require.NoError(err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusSkipped, 10)
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "skipped items")
+	assert.Equal("label-gone", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("fetch", items[0].Phase, "Phase")
+	assert.Equal("gmail_not_found", items[0].ErrorKind, "ErrorKind")
+}
+
+func TestIncrementalSyncRecordsLabelAddIngestErrors(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "12340")
+
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12350
+	env.Mock.Messages["label-ingest-error"] = &gmail.RawMessage{
+		ID:       "label-ingest-error",
+		ThreadID: "thread_label-ingest-error",
+		LabelIDs: []string{"INBOX"},
+		Raw:      []byte{},
+	}
+
+	env.SetHistory(12350,
+		historyLabelAdded("label-ingest-error", "INBOX"),
+	)
+
+	summary := runIncrementalSync(t, env)
+	assertSummary(t, summary, WantSummary{Found: new(int64(1)), Added: new(int64(0)), Errors: new(int64(1))})
+	assertMessageCount(t, env.Store, 0)
+
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	require.NoError(err, "GetLastSuccessfulSync")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 1, "error items")
+	assert.Equal("label-ingest-error", items[0].SourceMessageID, "SourceMessageID")
+	assert.Equal("ingest", items[0].Phase, "Phase")
+	assert.Equal("ingest_error", items[0].ErrorKind, "ErrorKind")
 }
 
 // TestIncrementalSyncMixedOperations tests a history page with adds, deletes,

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1585,6 +1585,43 @@ func TestIncrementalSyncRecordsLabelAddIngestErrors(t *testing.T) {
 	assert.Equal("ingest_error", items[0].ErrorKind, "ErrorKind")
 }
 
+func TestIncrementalSyncDedupesMessageAddedAndLabelAddedForSameUnknownMessage(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "12340")
+
+	raw := testMIME()
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12350
+	env.Mock.AddMessage("new-with-label", raw, []string{"INBOX", "STARRED"})
+
+	env.SetHistory(12350, gmail.HistoryRecord{
+		MessagesAdded: []gmail.HistoryMessage{
+			{Message: gmail.MessageID{ID: "new-with-label", ThreadID: "thread_new-with-label"}},
+		},
+		LabelsAdded: []gmail.HistoryLabelChange{
+			{
+				Message:  gmail.MessageID{ID: "new-with-label", ThreadID: "thread_new-with-label"},
+				LabelIDs: []string{"STARRED"},
+			},
+		},
+	})
+
+	summary := runIncrementalSync(t, env)
+	assertSummary(t, summary, WantSummary{Found: new(int64(1)), Added: new(int64(1)), Errors: new(int64(0))})
+	assert.Equal(int64(len(raw)), summary.BytesDownloaded, "BytesDownloaded")
+	assertMessageCount(t, env.Store, 1)
+	assert.Equal([]string{"new-with-label"}, env.Mock.GetMessageCalls, "GetMessageRaw calls")
+	assertMessageHasLabel(t, env.Store, "new-with-label", "STARRED")
+
+	run, err := env.Store.GetLastSuccessfulSync(source.ID)
+	require.NoError(err, "GetLastSuccessfulSync")
+	itemCount, err := env.Store.CountSyncRunItems(run.ID, "")
+	require.NoError(err, "CountSyncRunItems")
+	assert.Zero(itemCount, "sync_run_items")
+}
+
 // TestIncrementalSyncMixedOperations tests a history page with adds, deletes,
 // and label changes all at once.
 func TestIncrementalSyncMixedOperations(t *testing.T) {

--- a/internal/sync/testenv_test.go
+++ b/internal/sync/testenv_test.go
@@ -114,6 +114,13 @@ func runIncrementalSync(t *testing.T, env *TestEnv) *gmail.SyncSummary {
 	return summary
 }
 
+func startSyncRun(t *testing.T, env *TestEnv, sourceID int64) int64 {
+	t.Helper()
+	syncID, err := env.Store.StartSync(sourceID, "full")
+	require.NoError(t, err, "StartSync")
+	return syncID
+}
+
 // WantSummary specifies expected SyncSummary values. Nil fields are not checked.
 type WantSummary struct {
 	Added   *int64


### PR DESCRIPTION
## Summary
- record per-item sync outcomes so completed syncs with partial failures are diagnosable
- treat Gmail messages deleted before raw fetch as skipped instead of actionable errors
- expose skipped counts and recent item errors in source status responses

## Notes
This keeps `errors_count` focused on actionable item failures while preserving expected Gmail churn for diagnostics.