### PR TITLE
chore: update stale wesm/msgvault URLs to kenn-io

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ curl -fsSL https://msgvault.io/install.sh | bash
 powershell -ExecutionPolicy ByPass -c "irm https://msgvault.io/install.ps1 | iex"
 ```
 
-The installer detects your OS and architecture, downloads the latest release from [GitHub Releases](https://github.com/wesm/msgvault/releases), verifies the SHA-256 checksum, and installs the binary. You can review the script ([bash](https://msgvault.io/install.sh), [PowerShell](https://msgvault.io/install.ps1)) before running, or download a release binary directly from GitHub.
+The installer detects your OS and architecture, downloads the latest release from [GitHub Releases](https://github.com/kenn-io/msgvault/releases), verifies the SHA-256 checksum, and installs the binary. You can review the script ([bash](https://msgvault.io/install.sh), [PowerShell](https://msgvault.io/install.ps1)) before running, or download a release binary directly from GitHub.
 
 To build from source instead (requires **Go 1.25+** and a C/C++ compiler for CGO and to statically link DuckDB):
 
 ```bash
-git clone https://github.com/wesm/msgvault.git
+git clone https://github.com/kenn-io/msgvault.git
 cd msgvault
 make install
 ```
@@ -275,7 +275,7 @@ Join the [msgvault Discord](https://discord.gg/fDnmxB8Wkq) to ask questions, sha
 ## Development
 
 ```bash
-git clone https://github.com/wesm/msgvault.git
+git clone https://github.com/kenn-io/msgvault.git
 cd msgvault
 make install-hooks  # install pre-commit hook (requires prek)
 make test           # run tests

--- a/docs/accounts-identities-collections-dedup/README.md
+++ b/docs/accounts-identities-collections-dedup/README.md
@@ -7,8 +7,8 @@ on April 8, alongside the [implementation plan](https://github.com/jesserobbins/
 and [test plan](https://github.com/jesserobbins/msgvault/commit/df61cee)
 committed earlier the same day. The unified model that emerged over
 the next four weeks is proposed in upstream issue
-[wesm/msgvault#278](https://github.com/wesm/msgvault/issues/278) and
-ships via [PR #304](https://github.com/wesm/msgvault/pull/304).
+[kenn-io/msgvault#278](https://github.com/kenn-io/msgvault/issues/278) and
+ships via [PR #304](https://github.com/kenn-io/msgvault/pull/304).
 
 ## What you need to know
 

--- a/docs/msgvault_integration.md
+++ b/docs/msgvault_integration.md
@@ -2,7 +2,7 @@
 
 ## What Is msgvault?
 
-[msgvault](https://github.com/wesm/msgvault) is an open-source, local-first
+[msgvault](https://github.com/kenn-io/msgvault) is an open-source, local-first
 email archival tool by Wes McKinney (creator of pandas, Apache Arrow). Written
 in Go, single binary. Archives a lifetime of email and chat with offline search,
 analytics, and AI query via MCP.

--- a/docs/msgvault_pg_issue_draft.md
+++ b/docs/msgvault_pg_issue_draft.md
@@ -1,6 +1,6 @@
 # GitHub Issue Draft: Database Backend Abstraction (PostgreSQL Support)
 
-> To be filed at: https://github.com/wesm/msgvault/issues
+> To be filed at: https://github.com/kenn-io/msgvault/issues
 
 ---
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -41,7 +41,7 @@ buildGoModule {
 
   meta = {
     description = "Offline Gmail archive with full-text search";
-    homepage = "https://github.com/wesm/msgvault";
+    homepage = "https://github.com/kenn-io/msgvault";
     license = lib.licenses.asl20;
     mainProgram = "msgvault";
   };

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -78,7 +78,7 @@ echo ""
 echo "Release $TAG created and pushed successfully!"
 echo "GitHub Actions will create the release with the changelog from the tag message."
 echo ""
-echo "GitHub release URL: https://github.com/wesm/msgvault/releases/tag/$TAG"
+echo "GitHub release URL: https://github.com/kenn-io/msgvault/releases/tag/$TAG"
 
 # Offer to update nix flake
 if [ -f "$REPO_ROOT/flake.nix" ] && command -v nix &>/dev/null; then


### PR DESCRIPTION
The repository was renamed `wesm` → `kenn-io`; GitHub still serves the old path via redirect, so several hardcoded `wesm/msgvault` URLs lingered in the tree. This points them at the canonical owner.

**Updated:** `README.md` (releases link + clone URLs), `docs/` (integration, PG issue draft, accounts-dedup links), `scripts/release.sh` (release URL), and `nix/package.nix` (`homepage`).

**Left untouched:** the `@wesm` maintainer handle (CODEOWNERS, dependabot, spec credit), `github.com/wesm` / `wesm/roborev`, and test fixtures — none of which refer to the old repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
