### PR TITLE
Update nix flake for v0.16.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
   sqlite,
 }:
 let
-  version = "0.15.2";
+  version = "0.16.0";
 in
 buildGoModule {
   pname = "msgvault";


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-MTAlu3po4fYs50QY2J4AlWmkSMhclX2YbL+IMtqEANY=`
- Updated version to `0.16.0`

Automated update via `scripts/update-nix-flake.sh`.