### PR TITLE
Persist full-sync batch error counts

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -198,6 +198,7 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			for _, id := range newIDs {
 				s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, err)
 			}
+			checkpoint.ErrorsCount += int64(len(newIDs))
 			return nil, fmt.Errorf("fetch messages: %w", err)
 		}
 
@@ -360,6 +361,9 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 		// Process batch
 		result, err := s.processBatch(ctx, state.syncID, source.ID, listResp, labelMap, state.checkpoint, summary)
 		if err != nil {
+			if checkpointErr := s.store.UpdateSyncCheckpoint(state.syncID, state.checkpoint); checkpointErr != nil {
+				s.logger.Warn("failed to save checkpoint before failing sync", "error", checkpointErr)
+			}
 			_ = s.store.FailSync(state.syncID, err.Error())
 			return nil, err
 		}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -57,26 +57,28 @@ func TestFullSync_PanicReturnsError(t *testing.T) {
 }
 
 func TestFullSyncBatchFetchErrorUpdatesFailedSyncErrorCount(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	env := newTestEnv(t)
 	seedMessages(env, 2, 12345, "msg1", "msg2")
 	env.Syncer = New(&batchErrorAPI{MockAPI: env.Mock}, env.Store, nil)
 
 	_, err := env.Syncer.Full(env.Context, testEmail)
-	requirepkg.Error(t, err, "full sync should fail on whole-batch fetch error")
+	require.Error(err, "full sync should fail on whole-batch fetch error")
 
 	source, err := env.Store.GetSourceByIdentifier(testEmail)
-	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	require.NoError(err, "GetSourceByIdentifier")
 	run, err := env.Store.GetLatestSync(source.ID)
-	requirepkg.NoError(t, err, "GetLatestSync")
-	assertpkg.Equal(t, store.SyncStatusFailed, run.Status, "Status")
-	assertpkg.Equal(t, int64(2), run.ErrorsCount, "ErrorsCount")
+	require.NoError(err, "GetLatestSync")
+	assert.Equal(store.SyncStatusFailed, run.Status, "Status")
+	assert.Equal(int64(2), run.ErrorsCount, "ErrorsCount")
 
 	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
-	requirepkg.NoError(t, err, "ListSyncRunItems")
-	requirepkg.Len(t, items, 2, "error items")
+	require.NoError(err, "ListSyncRunItems")
+	require.Len(items, 2, "error items")
 	for _, item := range items {
-		assertpkg.Equal(t, "fetch", item.Phase, "Phase")
-		assertpkg.Equal(t, "batch_fetch_error", item.ErrorKind, "ErrorKind")
+		assert.Equal("fetch", item.Phase, "Phase")
+		assert.Equal("batch_fetch_error", item.ErrorKind, "ErrorKind")
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -35,6 +35,14 @@ func (p *panicOnBatchAPI) GetMessagesRawBatchWithErrors(_ context.Context, _ []s
 	panic("unexpected nil pointer in batch processing")
 }
 
+type batchErrorAPI struct {
+	*gmail.MockAPI
+}
+
+func (b *batchErrorAPI) GetMessagesRawBatchWithErrors(_ context.Context, _ []string) ([]gmail.RawMessageBatchResult, error) {
+	return nil, errors.New("batch fetch unavailable")
+}
+
 func TestFullSync_PanicReturnsError(t *testing.T) {
 	env := newTestEnv(t)
 	seedMessages(env, 1, 12345, "msg1")
@@ -46,6 +54,30 @@ func TestFullSync_PanicReturnsError(t *testing.T) {
 	_, err := env.Syncer.Full(env.Context, testEmail)
 	requirepkg.Error(t, err, "expected error from panic recovery")
 	assertpkg.ErrorContains(t, err, "panic")
+}
+
+func TestFullSyncBatchFetchErrorUpdatesFailedSyncErrorCount(t *testing.T) {
+	env := newTestEnv(t)
+	seedMessages(env, 2, 12345, "msg1", "msg2")
+	env.Syncer = New(&batchErrorAPI{MockAPI: env.Mock}, env.Store, nil)
+
+	_, err := env.Syncer.Full(env.Context, testEmail)
+	requirepkg.Error(t, err, "full sync should fail on whole-batch fetch error")
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	requirepkg.NoError(t, err, "GetSourceByIdentifier")
+	run, err := env.Store.GetLatestSync(source.ID)
+	requirepkg.NoError(t, err, "GetLatestSync")
+	assertpkg.Equal(t, store.SyncStatusFailed, run.Status, "Status")
+	assertpkg.Equal(t, int64(2), run.ErrorsCount, "ErrorsCount")
+
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	requirepkg.NoError(t, err, "ListSyncRunItems")
+	requirepkg.Len(t, items, 2, "error items")
+	for _, item := range items {
+		assertpkg.Equal(t, "fetch", item.Phase, "Phase")
+		assertpkg.Equal(t, "batch_fetch_error", item.ErrorKind, "ErrorKind")
+	}
 }
 
 // panicOnHistoryAPI wraps a MockAPI and panics when ListHistory is called.


### PR DESCRIPTION
Persist the sync checkpoint before failing a full sync when a whole batch fetch fails, so recorded per-item errors stay consistent with sync_runs.errors_count.

Adds a regression covering the failed full-sync batch-fetch path.