### PR TITLE
fix: normalize importer message/reaction dates to UTC

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -216,7 +216,11 @@ func (s *Syncer) processBatch(ctx context.Context, sourceID int64, listResp *gma
 			// Track oldest message date for progress display
 			// Gmail returns messages newest-to-oldest, so oldest shows where we've reached
 			if raw.InternalDate > 0 {
-				msgDate := time.UnixMilli(raw.InternalDate)
+				// .UTC() to match how InternalDate is normalized everywhere
+				// else (the stored message date and parsed.Date both use
+				// .UTC()); without it oldestDate carries the local zone and
+				// callers reading its calendar day are off by one east of UTC.
+				msgDate := time.UnixMilli(raw.InternalDate).UTC()
 				if result.oldestDate.IsZero() || msgDate.Before(result.oldestDate) {
 					result.oldestDate = msgDate
 				}

--- a/internal/whatsapp/importer.go
+++ b/internal/whatsapp/importer.go
@@ -468,7 +468,7 @@ func (imp *Importer) Import(ctx context.Context, waDBPath string, opts ImportOpt
 							reactorID = selfParticipantID
 						}
 
-						createdAt := time.Unix(r.Timestamp/1000, 0)
+						createdAt := time.Unix(r.Timestamp/1000, 0).UTC()
 						if err := imp.store.UpsertReaction(messageID, reactorID, reactionTypeEmoji, reactionValue, createdAt); err != nil {
 							summary.Errors++
 							imp.progress.OnError(fmt.Errorf("upsert reaction: %w", err))

--- a/internal/whatsapp/mapping.go
+++ b/internal/whatsapp/mapping.go
@@ -42,8 +42,12 @@ func mapMessage(msg waMessage, conversationID, sourceID int64, senderID sql.Null
 	sentAt := sql.NullTime{}
 	if msg.Timestamp > 0 {
 		// WhatsApp timestamps are in milliseconds since epoch.
+		// .UTC() to match how every other importer normalizes stored
+		// message dates; without it SentAt carries the local zone and
+		// Parquet year-partitioning / calendar-day reads are off by one
+		// near boundaries east of UTC.
 		sentAt = sql.NullTime{
-			Time:  time.Unix(msg.Timestamp/1000, (msg.Timestamp%1000)*1e6),
+			Time:  time.Unix(msg.Timestamp/1000, (msg.Timestamp%1000)*1e6).UTC(),
 			Valid: true,
 		}
 	}

--- a/internal/whatsapp/mapping_test.go
+++ b/internal/whatsapp/mapping_test.go
@@ -286,6 +286,8 @@ func TestChatTitle(t *testing.T) {
 }
 
 func TestMapMessageSentAtIsUTC(t *testing.T) {
+	assert := assertpkg.New(t)
+
 	// 2024-01-10T12:00:00Z in milliseconds. On a machine east of UTC
 	// (e.g. NZ) a non-UTC SentAt would read back as Jan 11 and carry the
 	// local zone — wrong for Parquet year-partitioning and date display.
@@ -293,9 +295,9 @@ func TestMapMessageSentAtIsUTC(t *testing.T) {
 	got := mapMessage(msg, 1, 1, sql.NullInt64{})
 
 	requirepkg.True(t, got.SentAt.Valid, "SentAt should be set")
-	assertpkg.Equal(t, "UTC", got.SentAt.Time.Location().String(), "SentAt must be normalized to UTC")
+	assert.Equal("UTC", got.SentAt.Time.Location().String(), "SentAt must be normalized to UTC")
 	y, m, d := got.SentAt.Time.Date()
-	assertpkg.Equal(t, 2024, y, "year")
-	assertpkg.Equal(t, 1, int(m), "month")
-	assertpkg.Equal(t, 10, d, "day")
+	assert.Equal(2024, y, "year")
+	assert.Equal(1, int(m), "month")
+	assert.Equal(10, d, "day")
 }

--- a/internal/whatsapp/mapping_test.go
+++ b/internal/whatsapp/mapping_test.go
@@ -284,3 +284,18 @@ func TestChatTitle(t *testing.T) {
 	}
 	assertpkg.Equal(t, "+447700900000", chatTitle(direct), "chatTitle(direct)")
 }
+
+func TestMapMessageSentAtIsUTC(t *testing.T) {
+	// 2024-01-10T12:00:00Z in milliseconds. On a machine east of UTC
+	// (e.g. NZ) a non-UTC SentAt would read back as Jan 11 and carry the
+	// local zone — wrong for Parquet year-partitioning and date display.
+	msg := waMessage{Timestamp: 1704888000000}
+	got := mapMessage(msg, 1, 1, sql.NullInt64{})
+
+	requirepkg.True(t, got.SentAt.Valid, "SentAt should be set")
+	assertpkg.Equal(t, "UTC", got.SentAt.Time.Location().String(), "SentAt must be normalized to UTC")
+	y, m, d := got.SentAt.Time.Date()
+	assertpkg.Equal(t, 2024, y, "year")
+	assertpkg.Equal(t, 1, int(m), "month")
+	assertpkg.Equal(t, 10, d, "day")
+}


### PR DESCRIPTION
## What

Several importers built `time.Time` values from epoch timestamps with `time.Unix`/`time.UnixMilli` but **without `.UTC()`**, leaving them in the runner's local zone — while the rest of each importer stores dates in UTC. Any code reading the calendar day (or the Parquet year partition) is then off by one in zones east of UTC.

Fixes:
- `internal/sync/sync.go` — `processBatch` oldest-message date (progress tracking).
- `internal/whatsapp/mapping.go` — message `SentAt`.
- `internal/whatsapp/importer.go` — reaction `createdAt`.

## Why it matters

`TestProcessBatch_OldestDatePropagation` fails on any machine east of UTC (e.g. NZ): the fixture `2024-01-10T12:00:00Z` reads back as Jan 11 local. The tests are correct; the production code was the bug. Adds `TestMapMessageSentAtIsUTC` (asserts the stored zone is UTC, machine-independent).

## Possible later fixes (out of scope here)

The same `time.Unix(...)`-without-`.UTC()` pattern also appears in the embedding-generation status timestamps, but these are **operator-facing status values** round-tripped from unix-int columns (not message dates), so they don't affect partitioning/dedup/cross-system date semantics. Local-time display is arguably fine; normalizing them to UTC would be a consistency-only follow-up. Sites:
- `cmd/msgvault/cmd/embeddings_manage.go` — `StartedAt`, `SeededAt`, `CompletedAt`, `ActivatedAt`.
- `internal/vector/pgvector/backend.go` — `StartedAt`, `CompletedAt`, `ActivatedAt`.
- `internal/vector/sqlitevec/backend.go` — `StartedAt`, `CompletedAt`, `ActivatedAt`.

Left unchanged here to avoid churning working code on a style call; documented so a future pass can decide.

## Scope

Independent of the Teams PR (#398) — branched from `main`, touches only `internal/sync` and `internal/whatsapp`.