### PR TITLE
Forbid tautological bash content checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ stub the primary commands, and only assert that the stub saw expected arguments.
 Exercise the production path, a real validator/parser, or a built artifact
 instead. See `CLAUDE.md` for the full rule and narrow exception.
 
+Do not add bash tests that grep shell scripts, workflows, config files, or docs
+for expected implementation text. Those checks are usually tautological; prefer
+real execution, parser/tool-native validation, or a documented manual release
+check.
+
 ## Custom Helpers
 
 `internal/testutil` retains non-assertion helpers (`MakeSet`, `NewTestStore`, fixture builders, etc.). It no longer provides `AssertEqual` / `MustNoErr` / similar — those were removed in favor of calling testify directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,11 @@ tree or a built artifact. If a fake command is truly needed, the test must prove
 a stable external contract or regression that cannot be covered by the real
 path, and the commit message must explain why.
 
+Do not add bash tests that grep shell scripts, workflows, config files, or docs
+for expected implementation text. Those checks are usually tautological. Use
+real execution, parser/tool-native validation, or a documented manual release
+check instead.
+
 **Mapping rule:**
 - `require.X` — halts the test on failure (replaces what was `t.Fatalf` / `t.Fatal`). Use for setup operations or when subsequent assertions would be meaningless on failure.
 - `assert.X` — continues after failure (replaces what was `t.Errorf` / `t.Error`). Use for independent value checks where reporting multiple failures helps debugging.


### PR DESCRIPTION
The existing fake-TDD guidance already discouraged stub-only shell tests, but it did not explicitly cover content-grep assertions over scripts, workflows, config, and docs.

This extends the guidance so future shell workflow tests prove behavior through real execution, parser-backed checks, tool-native validation, or explicit manual release checks instead of matching implementation strings.