### PR TITLE
feat(search): support message_type filters

### DIFF
--- a/cmd/msgvault/cmd/quickstart.md
+++ b/cmd/msgvault/cmd/quickstart.md
@@ -146,6 +146,7 @@ msgvault search "quarterly report" --limit 100 --offset 50
 | `newer_than:` | Relative date                        | `newer_than:7d`            |
 | `larger:`     | Minimum size                         | `larger:10M`               |
 | `smaller:`    | Maximum size                         | `smaller:100K`             |
+| `message_type:` | Message type                       | `message_type:sms`         |
 
 Bare words and `"quoted phrases"` perform full-text search across subject and body.
 

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -46,6 +46,7 @@ Supported operators (local mode only - remote uses simple text search):
   newer_than:  Relative date
   larger:      Size filter (5M, 100K)
   smaller:     Size filter
+  message_type: Message type filter (sms, mms, whatsapp, email)
 
 Bare words and "quoted phrases" perform full-text search.
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1738,6 +1738,7 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filter := parseMessageFilter(r)
+	q := search.Parse(queryStr)
 
 	// Reject filter fields that the search engines cannot honor.
 	// SenderName/RecipientName use display names that aren't indexed
@@ -1747,7 +1748,7 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 	// would silently return unscoped results.
 	if filter.SenderName != "" || filter.RecipientName != "" ||
 		filter.ConversationID != nil || filter.HasEmptyTargets() ||
-		filter.MessageType != "" {
+		filter.MessageType != "" || len(q.MessageTypes) > 0 {
 		writeError(w, http.StatusBadRequest, "unsupported_filter",
 			"Fast search does not support sender_name, recipient_name, "+
 				"conversation_id, empty_targets, or message_type filters")
@@ -1774,8 +1775,6 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 	} else if limit > maxPageSize {
 		limit = maxPageSize
 	}
-
-	q := search.Parse(queryStr)
 
 	result, err := s.engine.SearchFastWithStats(r.Context(), q, queryStr, filter, statsGroupBy, limit, offset)
 	if err != nil {
@@ -1812,6 +1811,7 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filter := parseMessageFilter(r)
+	q := search.Parse(queryStr)
 
 	// Reject filter fields that this deep-search engine path cannot
 	// honor. Without this check the parameters parse
@@ -1819,7 +1819,7 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	// escape the current drill-down scope.
 	if filter.SenderName != "" || filter.RecipientName != "" ||
 		filter.TimeRange.Period != "" || filter.ConversationID != nil ||
-		filter.HasEmptyTargets() || filter.MessageType != "" {
+		filter.HasEmptyTargets() || filter.MessageType != "" || len(q.MessageTypes) > 0 {
 		writeError(w, http.StatusBadRequest, "unsupported_filter",
 			"Deep search does not support sender_name, recipient_name, "+
 				"time_period, conversation_id, empty_targets, or "+
@@ -1838,7 +1838,6 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		limit = 100
 	}
 
-	q := search.Parse(queryStr)
 	merged := query.MergeFilterIntoQuery(q, filter)
 
 	// Fetch one extra row to determine has_more accurately.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1743,12 +1743,12 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 	// Reject filter fields that the search engines cannot honor.
 	// SenderName/RecipientName use display names that aren't indexed
 	// for search, ConversationID scoping isn't implemented, and
-	// EmptyValueTargets is an aggregate-only concept. MessageType is
-	// not honored by this fast-search engine path — accepting it here
-	// would silently return unscoped results.
+	// EmptyValueTargets is an aggregate-only concept. The parsed
+	// message_type: operator is honored by the query engine; the
+	// filter parameter form is still list-search-only.
 	if filter.SenderName != "" || filter.RecipientName != "" ||
 		filter.ConversationID != nil || filter.HasEmptyTargets() ||
-		filter.MessageType != "" || len(q.MessageTypes) > 0 {
+		filter.MessageType != "" {
 		writeError(w, http.StatusBadRequest, "unsupported_filter",
 			"Fast search does not support sender_name, recipient_name, "+
 				"conversation_id, empty_targets, or message_type filters")
@@ -1819,7 +1819,7 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	// escape the current drill-down scope.
 	if filter.SenderName != "" || filter.RecipientName != "" ||
 		filter.TimeRange.Period != "" || filter.ConversationID != nil ||
-		filter.HasEmptyTargets() || filter.MessageType != "" || len(q.MessageTypes) > 0 {
+		filter.HasEmptyTargets() || filter.MessageType != "" {
 		writeError(w, http.StatusBadRequest, "unsupported_filter",
 			"Deep search does not support sender_name, recipient_name, "+
 				"time_period, conversation_id, empty_targets, or "+

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -471,6 +471,8 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		mode = "fts"
 	}
 	explain := r.URL.Query().Get("explain") == "1"
+	parsedQuery := parseSearchQueryRequest(r, query)
+	parsedQuery.HideDeleted = true
 
 	if mode == "vector" || mode == "hybrid" {
 		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
@@ -486,7 +488,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		if maxPage := s.vectorCfg.Search.MaxPageSizeHybridClamp(); maxPage > 0 && pageSize > maxPage {
 			pageSize = maxPage
 		}
-		s.handleHybridSearch(w, r, query, mode, explain, pageSize)
+		s.handleHybridSearch(w, r, query, parsedQuery, mode, explain, pageSize)
 		return
 	}
 
@@ -506,9 +508,6 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset := (page - 1) * pageSize
-
-	parsedQuery := search.Parse(query)
-	parsedQuery.HideDeleted = true
 
 	var (
 		messages []store.APIMessage
@@ -540,13 +539,26 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func parseSearchQueryRequest(r *http.Request, query string) *search.Query {
+	parsed := search.Parse(query)
+	for _, raw := range r.URL.Query()["message_type"] {
+		for typ := range strings.SplitSeq(raw, ",") {
+			typ = strings.TrimSpace(strings.ToLower(typ))
+			if typ != "" {
+				parsed.MessageTypes = append(parsed.MessageTypes, typ)
+			}
+		}
+	}
+	return parsed
+}
+
 // handleHybridSearch runs vector or hybrid search via the configured
 // hybrid engine. Returns 503 when the engine is not configured or the
 // index is stale/building; otherwise returns RRF-ranked hits hydrated
 // through the message store.
 func (s *Server) handleHybridSearch(
 	w http.ResponseWriter, r *http.Request,
-	q, mode string, explain bool, pageSize int,
+	q string, parsed *search.Query, mode string, explain bool, pageSize int,
 ) {
 	if s.hybridEngine == nil {
 		writeError(w, http.StatusServiceUnavailable, "vector_not_enabled",
@@ -556,7 +568,6 @@ func (s *Server) handleHybridSearch(
 	ctx := r.Context()
 	start := time.Now()
 
-	parsed := search.Parse(q)
 	freeText := strings.Join(parsed.TextTerms, " ")
 	// Vector/hybrid search requires text to embed; filter-only
 	// queries have no query vector to rank by. Callers that want
@@ -1732,9 +1743,8 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 	// SenderName/RecipientName use display names that aren't indexed
 	// for search, ConversationID scoping isn't implemented, and
 	// EmptyValueTargets is an aggregate-only concept. MessageType is
-	// not propagated by MergeFilterIntoQuery — accepting it here would
-	// silently return unscoped results, so reject until the search
-	// pipeline gains a message_type predicate.
+	// not honored by this fast-search engine path — accepting it here
+	// would silently return unscoped results.
 	if filter.SenderName != "" || filter.RecipientName != "" ||
 		filter.ConversationID != nil || filter.HasEmptyTargets() ||
 		filter.MessageType != "" {
@@ -1803,11 +1813,10 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 
 	filter := parseMessageFilter(r)
 
-	// Reject filter fields that MergeFilterIntoQuery cannot represent
-	// in search.Query. Without this check the parameters parse
+	// Reject filter fields that this deep-search engine path cannot
+	// honor. Without this check the parameters parse
 	// successfully but silently do nothing, letting deep search
-	// escape the current drill-down scope. MessageType is one of these
-	// silently-dropped fields.
+	// escape the current drill-down scope.
 	if filter.SenderName != "" || filter.RecipientName != "" ||
 		filter.TimeRange.Period != "" || filter.ConversationID != nil ||
 		filter.HasEmptyTargets() || filter.MessageType != "" {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1322,6 +1322,8 @@ func TestSearchRejectsMessageTypeFilter(t *testing.T) {
 	for _, path := range []string{
 		"/api/v1/search/fast?q=hello&message_type=sms",
 		"/api/v1/search/deep?q=hello&message_type=sms",
+		"/api/v1/search/fast?q=message_type:sms%20hello",
+		"/api/v1/search/deep?q=message_type:sms%20hello",
 	} {
 		t.Run(path, func(t *testing.T) {
 			engine := &querytest.MockEngine{}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1314,10 +1314,10 @@ func TestHandleFastSearchInvalidViewType(t *testing.T) {
 }
 
 // TestSearchRejectsMessageTypeFilter guards against silently dropping
-// the message_type filter. MergeFilterIntoQuery does not propagate
-// MessageType, so accepting it in fast/deep search would let
+// the message_type filter. The fast/deep query engine paths do not
+// honor MessageType, so accepting it there would let
 // /search/fast?q=hello&message_type=sms return unscoped results. Reject
-// until the search pipeline gains a message_type predicate.
+// until those routes gain end-to-end message_type support.
 func TestSearchRejectsMessageTypeFilter(t *testing.T) {
 	for _, path := range []string{
 		"/api/v1/search/fast?q=hello&message_type=sms",
@@ -1636,6 +1636,42 @@ func TestHandleSearch_HybridFilterOnlyReturnsBadRequest(t *testing.T) {
 	assertpkg.Equal(t, "missing_free_text", errResp.Error, "error")
 }
 
+func TestHandleSearch_VectorMessageTypeParamReachesFilter(t *testing.T) {
+	store := &mockStore{
+		messages: []APIMessage{{
+			ID:          42,
+			Subject:     "Lunch",
+			MessageType: "sms",
+			Snippet:     "grab lunch",
+		}},
+	}
+	backend := &fakeVectorBackend{
+		active: &vector.Generation{
+			ID: 1, Model: "fake", Dimension: 4,
+			Fingerprint: "fake:4", State: vector.GenerationActive,
+		},
+		searchHits: []vector.Hit{{MessageID: 42, Score: 0.9, Rank: 1}},
+	}
+	engine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 4}, hybrid.Config{
+		ExpectedFingerprint: "fake:4", RRFK: 60, KPerSignal: 10,
+	})
+	srv := NewServerWithOptions(ServerOptions{
+		Config:       &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:        store,
+		HybridEngine: engine,
+		Backend:      backend,
+		Logger:       testLogger(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/search?q=lunch&mode=vector&message_type=sms", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	requirepkg.Equal(t, http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assertpkg.Equal(t, []string{"sms"}, backend.searchFilter.MessageTypes, "MessageTypes")
+}
+
 // TestHandleSearch_HybridResponseItemShape regression-guards the
 // hybrid response item shape: each result must be a MessageSummary
 // (snake-case fields shared with /api/v1/search FTS mode), not a
@@ -1875,11 +1911,12 @@ func TestHandleQuery_SQLiteEngine503(t *testing.T) {
 // that need canned ANN hits set searchHits/searchErr; Stats and the
 // generation-resolution paths use the other fields.
 type fakeVectorBackend struct {
-	active     *vector.Generation
-	building   *vector.Generation
-	stats      vector.Stats
-	searchHits []vector.Hit
-	searchErr  error
+	active       *vector.Generation
+	building     *vector.Generation
+	stats        vector.Stats
+	searchHits   []vector.Hit
+	searchErr    error
+	searchFilter vector.Filter
 }
 
 func (f *fakeVectorBackend) CreateGeneration(_ context.Context, _ string, _ int, _ string) (vector.GenerationID, error) {
@@ -1904,8 +1941,9 @@ func (f *fakeVectorBackend) Upsert(_ context.Context, _ vector.GenerationID, _ [
 	return errors.New("not implemented")
 }
 func (f *fakeVectorBackend) Search(
-	_ context.Context, _ vector.GenerationID, _ []float32, _ int, _ vector.Filter,
+	_ context.Context, _ vector.GenerationID, _ []float32, _ int, filter vector.Filter,
 ) ([]vector.Hit, error) {
+	f.searchFilter = filter
 	return f.searchHits, f.searchErr
 }
 func (f *fakeVectorBackend) Delete(_ context.Context, _ vector.GenerationID, _ []int64) error {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/query/querytest"
 	"go.kenn.io/msgvault/internal/remote"
+	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 	"go.kenn.io/msgvault/internal/vector"
@@ -1313,17 +1314,14 @@ func TestHandleFastSearchInvalidViewType(t *testing.T) {
 	assertpkg.Equal(t, "invalid_view_type", errResp["error"], "error")
 }
 
-// TestSearchRejectsMessageTypeFilter guards against silently dropping
-// the message_type filter. The fast/deep query engine paths do not
-// honor MessageType, so accepting it there would let
-// /search/fast?q=hello&message_type=sms return unscoped results. Reject
-// until those routes gain end-to-end message_type support.
-func TestSearchRejectsMessageTypeFilter(t *testing.T) {
+// TestSearchRejectsMessageTypeFilterParam guards against silently dropping
+// the message_type filter parameter. Fast/deep search support the parsed
+// message_type: operator, but parseMessageFilter's parameter form is still
+// list-search-only and must not be accepted as a no-op.
+func TestSearchRejectsMessageTypeFilterParam(t *testing.T) {
 	for _, path := range []string{
 		"/api/v1/search/fast?q=hello&message_type=sms",
 		"/api/v1/search/deep?q=hello&message_type=sms",
-		"/api/v1/search/fast?q=message_type:sms%20hello",
-		"/api/v1/search/deep?q=message_type:sms%20hello",
 	} {
 		t.Run(path, func(t *testing.T) {
 			engine := &querytest.MockEngine{}
@@ -1340,6 +1338,94 @@ func TestSearchRejectsMessageTypeFilter(t *testing.T) {
 			requirepkg.Equal(t, "unsupported_filter", errResp["error"], "error")
 		})
 	}
+}
+
+func TestSearchParsedMessageTypeFilterReachesEngine(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "fast", path: "/api/v1/search/fast?q=message_type:sms%20hello"},
+		{name: "deep", path: "/api/v1/search/deep?q=message_type:sms%20hello"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &querytest.MockEngine{
+				Stats: &query.TotalStats{},
+				SearchFastWithStatsFunc: func(_ context.Context, q *search.Query, _ string, _ query.MessageFilter, _ query.ViewType, _, _ int) (*query.SearchFastResult, error) {
+					assertpkg.Equal(t, []string{"sms"}, q.MessageTypes, "fast MessageTypes")
+					return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
+				},
+				SearchFunc: func(_ context.Context, q *search.Query, _, _ int) ([]query.MessageSummary, error) {
+					assertpkg.Equal(t, []string{"sms"}, q.MessageTypes, "deep MessageTypes")
+					return nil, nil
+				},
+			}
+			srv := newTestServerWithEngine(t, engine)
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+
+			srv.Router().ServeHTTP(w, req)
+
+			requirepkg.Equal(t, http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+		})
+	}
+}
+
+func TestRemoteSearchParsedMessageTypeThroughAPI(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	engine := &querytest.MockEngine{
+		SearchFunc: func(_ context.Context, q *search.Query, _, _ int) ([]query.MessageSummary, error) {
+			assert.Equal([]string{"sms"}, q.MessageTypes, "MessageTypes")
+			assert.Equal([]string{"hello"}, q.TextTerms, "TextTerms")
+			return []query.MessageSummary{{
+				ID:          7,
+				Subject:     "hello",
+				MessageType: "sms",
+				SentAt:      time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+			}}, nil
+		},
+		SearchFastWithStatsFunc: func(_ context.Context, q *search.Query, _ string, _ query.MessageFilter, _ query.ViewType, _, _ int) (*query.SearchFastResult, error) {
+			assert.Equal([]string{"sms"}, q.MessageTypes, "fast MessageTypes")
+			assert.Equal([]string{"hello"}, q.TextTerms, "fast TextTerms")
+			return &query.SearchFastResult{
+				Messages: []query.MessageSummary{{
+					ID:          8,
+					Subject:     "hello fast",
+					MessageType: "sms",
+					SentAt:      time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+				}},
+				TotalCount: 1,
+				Stats:      &query.TotalStats{MessageCount: 1},
+			}, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	httpSrv := httptest.NewServer(srv.Router())
+	defer httpSrv.Close()
+
+	remoteEngine, err := remote.NewEngine(remote.Config{
+		URL:           httpSrv.URL,
+		AllowInsecure: true,
+	})
+	require.NoError(err, "NewEngine")
+
+	results, err := remoteEngine.Search(context.Background(), &search.Query{
+		TextTerms:    []string{"hello"},
+		MessageTypes: []string{"sms"},
+	}, 10, 0)
+	require.NoError(err, "remote Search")
+	require.Len(results, 1, "results")
+	assert.Equal("sms", results[0].MessageType, "MessageType")
+
+	fastResults, err := remoteEngine.SearchFast(context.Background(), &search.Query{
+		TextTerms:    []string{"hello"},
+		MessageTypes: []string{"sms"},
+	}, query.MessageFilter{}, 10, 0)
+	require.NoError(err, "remote SearchFast")
+	require.Len(fastResults, 1, "fast results")
+	assert.Equal("sms", fastResults[0].MessageType, "fast MessageType")
 }
 
 func TestHandleDeepSearch(t *testing.T) {

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1162,10 +1162,11 @@ func (e *DuckDBEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 	var args []any
 
 	// Restrict to email messages only; NULL and '' handle pre-message_type data.
-	conditions = append(conditions,
-		emailOnlyFilterMsg,
-		store.LiveMessagesWhere("msg", opts.HideDeletedFromSource),
-	)
+	hasSearchMessageTypes := opts.SearchQuery != "" && len(search.Parse(opts.SearchQuery).MessageTypes) > 0
+	if !hasSearchMessageTypes {
+		conditions = append(conditions, emailOnlyFilterMsg)
+	}
+	conditions = append(conditions, store.LiveMessagesWhere("msg", opts.HideDeletedFromSource))
 	conditions, args = appendSourceFilter(conditions, args, "msg.", opts.SourceID, opts.SourceIDs)
 
 	if opts.WithAttachmentsOnly {

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -577,6 +577,14 @@ func (e *DuckDBEngine) buildNonTextSearchConditions(q *search.Query, keyColumns 
 		conditions = append(conditions, "msg.size_estimate < ?")
 		args = append(args, *q.SmallerThan)
 	}
+	if len(q.MessageTypes) > 0 {
+		placeholders := make([]string, len(q.MessageTypes))
+		for i, typ := range q.MessageTypes {
+			placeholders[i] = "?"
+			args = append(args, typ)
+		}
+		conditions = append(conditions, fmt.Sprintf("msg.message_type IN (%s)", strings.Join(placeholders, ",")))
+	}
 
 	return conditions, args
 }
@@ -1653,6 +1661,14 @@ func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offse
 		conditions = append(conditions, "m.size_estimate < ?")
 		args = append(args, *q.SmallerThan)
 	}
+	if len(q.MessageTypes) > 0 {
+		placeholders := make([]string, len(q.MessageTypes))
+		for i, typ := range q.MessageTypes {
+			placeholders[i] = "?"
+			args = append(args, typ)
+		}
+		conditions = append(conditions, fmt.Sprintf("m.message_type IN (%s)", strings.Join(placeholders, ",")))
+	}
 
 	// Full-text search: use ILIKE fallback (FTS5 not available via sqlite_scan)
 	// Only search subject/snippet; body is in separate table, use FTS for body search
@@ -2442,12 +2458,12 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 	var conditions []string
 	var args []any
 
-	// Restrict to email messages only; NULL and '' handle pre-message_type data.
 	// Apply basic filter conditions (ignoring join flags for search - we handle those differently)
-	conditions = append(conditions,
-		emailOnlyFilterMsg,
-		store.LiveMessagesWhere("msg", filter.HideDeletedFromSource),
-	)
+	if len(q.MessageTypes) == 0 {
+		// Restrict to email messages only; NULL and '' handle pre-message_type data.
+		conditions = append(conditions, emailOnlyFilterMsg)
+	}
+	conditions = append(conditions, store.LiveMessagesWhere("msg", filter.HideDeletedFromSource))
 	conditions, args = appendSourceFilter(conditions, args, "msg.", filter.SourceID, filter.SourceIDs)
 	if filter.After != nil {
 		conditions = append(conditions, "msg.sent_at >= CAST(? AS TIMESTAMP)")
@@ -2598,6 +2614,14 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 	if q.SmallerThan != nil {
 		conditions = append(conditions, "msg.size_estimate < ?")
 		args = append(args, *q.SmallerThan)
+	}
+	if len(q.MessageTypes) > 0 {
+		placeholders := make([]string, len(q.MessageTypes))
+		for i, typ := range q.MessageTypes {
+			placeholders[i] = "?"
+			args = append(args, typ)
+		}
+		conditions = append(conditions, fmt.Sprintf("msg.message_type IN (%s)", strings.Join(placeholders, ",")))
 	}
 
 	// Account filter

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -1060,6 +1060,69 @@ func TestDuckDBEngine_SearchFast_MessageTypeFilter(t *testing.T) {
 	assert.NotEqual(emailMsg, results[0].ID, "email message must not leak into sms search")
 }
 
+func TestDuckDBEngine_SearchFastWithStats_MessageTypeFilter(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@example.com")
+	b.AddMessage(MessageOpt{
+		Subject:      "lunch plans",
+		Snippet:      "lunch tacos",
+		SizeEstimate: 1000,
+		MessageType:  "email",
+	})
+	smsMsg := b.AddMessage(MessageOpt{
+		Subject:      "lunch plans",
+		Snippet:      "lunch sushi",
+		SizeEstimate: 2000,
+		MessageType:  "sms",
+	})
+
+	engine := b.BuildEngine()
+	result, err := engine.SearchFastWithStats(
+		context.Background(),
+		search.Parse("message_type:sms lunch"),
+		"message_type:sms lunch",
+		MessageFilter{},
+		ViewSenders,
+		100,
+		0,
+	)
+	require.NoError(err, "SearchFastWithStats")
+	require.Len(result.Messages, 1, "message_type:sms should scope the search")
+	assert.Equal(smsMsg, result.Messages[0].ID, "ID")
+	require.NotNil(result.Stats, "Stats")
+	assert.Equal(int64(1), result.Stats.MessageCount, "Stats.MessageCount")
+	assert.Equal(int64(2000), result.Stats.TotalSize, "Stats.TotalSize")
+}
+
+func TestDuckDBEngine_GetTotalStats_MessageTypeFilter(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@example.com")
+	b.AddMessage(MessageOpt{
+		Subject:      "lunch plans",
+		Snippet:      "lunch tacos",
+		SizeEstimate: 1000,
+		MessageType:  "email",
+	})
+	b.AddMessage(MessageOpt{
+		Subject:      "lunch plans",
+		Snippet:      "lunch sushi",
+		SizeEstimate: 2000,
+		MessageType:  "sms",
+	})
+
+	engine := b.BuildEngine()
+	stats, err := engine.GetTotalStats(context.Background(), StatsOptions{
+		SearchQuery: "message_type:sms lunch",
+	})
+	require.NoError(err, "GetTotalStats")
+	assert.Equal(int64(1), stats.MessageCount, "MessageCount")
+	assert.Equal(int64(2000), stats.TotalSize, "TotalSize")
+}
+
 // TestDuckDBEngine_ListMessages_DateFilter verifies that After/Before date filters
 // work with DuckDB's TIMESTAMP column (regression: VARCHAR params need CAST).
 func TestDuckDBEngine_ListMessages_DateFilter(t *testing.T) {

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -1035,6 +1035,31 @@ func TestDuckDBEngine_SearchFast(t *testing.T) {
 	})
 }
 
+func TestDuckDBEngine_SearchFast_MessageTypeFilter(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@example.com")
+	emailMsg := b.AddMessage(MessageOpt{
+		Subject:     "lunch plans",
+		Snippet:     "lunch tacos",
+		MessageType: "email",
+	})
+	smsMsg := b.AddMessage(MessageOpt{
+		Subject:     "lunch plans",
+		Snippet:     "lunch sushi",
+		MessageType: "sms",
+	})
+
+	engine := b.BuildEngine()
+	results, err := engine.SearchFast(context.Background(), search.Parse("message_type:sms lunch"), MessageFilter{}, 100, 0)
+	require.NoError(err, "SearchFast")
+	require.Len(results, 1, "message_type:sms should scope the text search")
+	assert.Equal(smsMsg, results[0].ID, "ID")
+	assert.Equal("sms", results[0].MessageType, "MessageType")
+	assert.NotEqual(emailMsg, results[0].ID, "email message must not leak into sms search")
+}
+
 // TestDuckDBEngine_ListMessages_DateFilter verifies that After/Before date filters
 // work with DuckDB's TIMESTAMP column (regression: VARCHAR params need CAST).
 func TestDuckDBEngine_ListMessages_DateFilter(t *testing.T) {

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1525,6 +1525,14 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 		conditions = append(conditions, "m.size_estimate < ?")
 		args = append(args, *q.SmallerThan)
 	}
+	if len(q.MessageTypes) > 0 {
+		placeholders := make([]string, len(q.MessageTypes))
+		for i, typ := range q.MessageTypes {
+			placeholders[i] = "?"
+			args = append(args, typ)
+		}
+		conditions = append(conditions, fmt.Sprintf("m.message_type IN (%s)", strings.Join(placeholders, ",")))
+	}
 
 	// Full-text search: use dialect FTS if available, fall back to LIKE.
 	if len(q.TextTerms) > 0 {

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1026,8 +1026,10 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 	var searchConditions []string
 	var searchArgs []any
 	var searchFTSJoin string
+	hasSearchMessageTypes := false
 	if opts.SearchQuery != "" {
 		q := search.Parse(opts.SearchQuery)
+		hasSearchMessageTypes = len(q.MessageTypes) > 0
 		searchConditions, searchArgs, searchFTSJoin = e.buildSearchQueryParts(ctx, q)
 	}
 
@@ -1038,10 +1040,10 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 	// Restrict to email messages only; NULL and '' handle pre-message_type data.
 	// Exclude rows soft-deleted by deduplicate; gate source-deleted on
 	// opts.HideDeletedFromSource via the helper.
-	conditions = append(conditions,
-		emailOnlyFilterM,
-		store.LiveMessagesWhere("m", opts.HideDeletedFromSource),
-	)
+	if !hasSearchMessageTypes {
+		conditions = append(conditions, emailOnlyFilterM)
+	}
+	conditions = append(conditions, store.LiveMessagesWhere("m", opts.HideDeletedFromSource))
 	conditions, args = appendSourceFilter(
 		conditions, args, "m.", opts.SourceID, opts.SourceIDs,
 	)

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -1058,6 +1058,21 @@ func TestGetTotalStatsWithSearchQuery(t *testing.T) {
 	assert.Equal(int64(10000+5000), stats.AttachmentSize, "SearchQuery=Hello attachment size")
 }
 
+func TestGetTotalStatsWithSearchQuery_MessageTypeFilter(t *testing.T) {
+	assert := assertpkg.New(t)
+	env := newTestEnv(t)
+
+	_, err := env.DB.Exec(`UPDATE messages SET message_type = ? WHERE id = ?`, "sms", int64(2))
+	requirepkg.NoError(t, err, "mark message as sms")
+
+	stats := env.MustGetTotalStats(StatsOptions{SearchQuery: "message_type:sms Hello"})
+
+	assert.Equal(int64(1), stats.MessageCount, "SearchQuery=message_type:sms messages")
+	assert.Equal(int64(2000), stats.TotalSize, "SearchQuery=message_type:sms total size")
+	assert.Equal(int64(2), stats.AttachmentCount, "SearchQuery=message_type:sms attachments")
+	assert.Equal(int64(10000+5000), stats.AttachmentSize, "SearchQuery=message_type:sms attachment size")
+}
+
 // TestGetTotalStatsWithSearchQuery_FromFilter verifies that from: search
 // filters are applied correctly to stats.
 func TestGetTotalStatsWithSearchQuery_FromFilter(t *testing.T) {

--- a/internal/query/sqlite_search_test.go
+++ b/internal/query/sqlite_search_test.go
@@ -94,6 +94,20 @@ func TestSearch_Filters(t *testing.T) {
 	}
 }
 
+func TestSearch_MessageTypeFilter(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	env := newTestEnv(t)
+
+	_, err := env.DB.Exec(`UPDATE messages SET message_type = ? WHERE id = ?`, "sms", int64(2))
+	require.NoError(err, "mark message as sms")
+
+	results := env.MustSearch(search.Parse("message_type:sms Hello"), 100, 0)
+	require.Len(results, 1, "message_type:sms should scope the text search")
+	assert.Equal(int64(2), results[0].ID, "ID")
+	assert.Equal("sms", results[0].MessageType, "MessageType")
+}
+
 func TestSearch_CaseInsensitiveFallback(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/internal/remote/engine.go
+++ b/internal/remote/engine.go
@@ -788,6 +788,9 @@ func buildSearchQueryString(q *search.Query) string {
 	for _, label := range q.Labels {
 		parts = append(parts, "label:"+label)
 	}
+	for _, typ := range q.MessageTypes {
+		parts = append(parts, "message_type:"+typ)
+	}
 	if q.HasAttachment != nil && *q.HasAttachment {
 		parts = append(parts, "has:attachment")
 	}

--- a/internal/remote/engine_test.go
+++ b/internal/remote/engine_test.go
@@ -11,6 +11,7 @@ import (
 	assertpkg "github.com/stretchr/testify/assert"
 	requirepkg "github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/search"
 )
 
 func TestEngineListMessagesPreservesDeletedAt(t *testing.T) {
@@ -93,4 +94,34 @@ func TestEngineGetMessageSummariesByIDs_CarriesFromAndAttachmentCount(t *testing
 	assert.Equal("alice@example.com", s.FromEmail, "FromEmail")
 	assert.Equal(2, s.AttachmentCount, "AttachmentCount")
 	assert.True(s.HasAttachments, "HasAttachments")
+}
+
+func TestEngineSearchSerializesMessageTypes(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/search/deep", r.URL.Path, "path")
+		gotQuery := r.URL.Query().Get("q")
+		assert.Contains(gotQuery, "message_type:sms", "q should preserve parsed message_type filters")
+		assert.Contains(gotQuery, "lunch", "q should preserve text terms")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages": []map[string]any{},
+			"count":    0,
+			"has_more": false,
+			"offset":   0,
+			"limit":    10,
+			"query":    gotQuery,
+		})
+	}))
+	defer srv.Close()
+
+	store := &Store{baseURL: srv.URL, httpClient: srv.Client()}
+	engine := NewEngineFromStore(store)
+
+	_, err := engine.Search(context.Background(), &search.Query{
+		TextTerms:    []string{"lunch"},
+		MessageTypes: []string{"sms"},
+	}, 10, 0)
+	require.NoError(err, "Search")
 }

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -23,6 +23,7 @@ type Query struct {
 	LargerThan    *int64     // larger: filter (bytes)
 	SmallerThan   *int64     // smaller: filter (bytes)
 	AccountIDs    []int64    // in: account filter (one or more source IDs)
+	MessageTypes  []string   // message_type filter (e.g. sms, mms, whatsapp)
 	HideDeleted   bool       // exclude messages where deleted_from_source_at IS NOT NULL
 }
 
@@ -40,7 +41,8 @@ func (q *Query) IsEmpty() bool {
 		q.AfterDate == nil &&
 		q.LargerThan == nil &&
 		q.SmallerThan == nil &&
-		len(q.AccountIDs) == 0
+		len(q.AccountIDs) == 0 &&
+		len(q.MessageTypes) == 0
 }
 
 // operatorFn handles a parsed operator:value pair by applying it to the query.
@@ -179,6 +181,11 @@ var operators = map[string]operatorFn{
 			q.SmallerThan = size
 		}
 	},
+	"message_type": func(q *Query, v string, _ time.Time) {
+		if v = strings.TrimSpace(strings.ToLower(v)); v != "" {
+			q.MessageTypes = append(q.MessageTypes, v)
+		}
+	},
 }
 
 // Parser holds configuration for query parsing.
@@ -201,6 +208,7 @@ func NewParser() *Parser {
 //   - before:, after: - date filters (YYYY-MM-DD)
 //   - older_than:, newer_than: - relative date filters (e.g., 7d, 2w, 1m, 1y)
 //   - larger:, smaller: - size filters (e.g., 5M, 100K)
+//   - message_type: or message_type= - message type filter (e.g., sms)
 //   - Bare words and "quoted phrases" - full-text search
 func (p *Parser) Parse(queryStr string) *Query {
 	q := &Query{}
@@ -216,9 +224,8 @@ func (p *Parser) Parse(queryStr string) *Query {
 			continue
 		}
 
-		if before, after, ok := strings.Cut(token, ":"); ok {
-			op := strings.ToLower(before)
-			value := unquote(after)
+		if op, value, ok := splitOperatorToken(token); ok {
+			value = unquote(value)
 
 			if handler, ok := operators[op]; ok {
 				handler(q, value, now)
@@ -237,6 +244,18 @@ func (p *Parser) Parse(queryStr string) *Query {
 // Parse is a convenience function that parses using default settings.
 func Parse(queryStr string) *Query {
 	return NewParser().Parse(queryStr)
+}
+
+// splitOperatorToken recognizes Gmail-style operator:value tokens and the
+// message_type=value form used by HTTP callers that mirror the API parameter.
+func splitOperatorToken(token string) (op, value string, ok bool) {
+	if before, after, found := strings.Cut(token, ":"); found {
+		return strings.ToLower(before), after, true
+	}
+	if before, after, found := strings.Cut(token, "="); found && strings.EqualFold(before, "message_type") {
+		return "message_type", after, true
+	}
+	return "", "", false
 }
 
 // unquote removes surrounding double quotes from a string if present.
@@ -379,7 +398,8 @@ func (q *Query) HasOperators() bool {
 		q.BeforeDate != nil ||
 		q.AfterDate != nil ||
 		q.LargerThan != nil ||
-		q.SmallerThan != nil
+		q.SmallerThan != nil ||
+		len(q.MessageTypes) > 0
 }
 
 // parseSize parses size strings like 5M, 100K, 1G into bytes.

--- a/internal/search/parser_test.go
+++ b/internal/search/parser_test.go
@@ -183,6 +183,32 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name: "MessageType",
+			tests: []testCase{
+				{
+					name:  "colon operator",
+					query: "message_type:sms lunch",
+					want: Query{
+						MessageTypes: []string{"sms"},
+						TextTerms:    []string{"lunch"},
+					},
+				},
+				{
+					name:  "equals operator",
+					query: "message_type=sms lunch",
+					want: Query{
+						MessageTypes: []string{"sms"},
+						TextTerms:    []string{"lunch"},
+					},
+				},
+				{
+					name:  "normalizes value",
+					query: "message_type:SMS",
+					want:  Query{MessageTypes: []string{"sms"}},
+				},
+			},
+		},
+		{
 			name: "HasAttachment",
 			tests: []testCase{
 				{

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -480,6 +480,17 @@ func (s *Store) searchMessagesQueryImpl(
 		args = append(args, "%"+escapeLike(strings.ToLower(term))+"%")
 	}
 
+	// message_type: / message_type= filter.
+	if len(q.MessageTypes) > 0 {
+		placeholders := make([]string, len(q.MessageTypes))
+		for i, typ := range q.MessageTypes {
+			placeholders[i] = "?"
+			args = append(args, typ)
+		}
+		conditions = append(conditions,
+			"m.message_type IN ("+strings.Join(placeholders, ",")+")")
+	}
+
 	// has:attachment
 	if q.HasAttachment != nil && *q.HasAttachment {
 		conditions = append(conditions,

--- a/internal/store/api_search_test.go
+++ b/internal/store/api_search_test.go
@@ -150,6 +150,8 @@ func TestSearchMessages_LegacyRawString(t *testing.T) {
 }
 
 func TestSearchMessagesQuery_MessageTypeFilter(t *testing.T) {
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
 	f := storetest.New(t)
 
 	emailMsg := f.NewMessage().
@@ -169,18 +171,18 @@ func TestSearchMessagesQuery_MessageTypeFilter(t *testing.T) {
 	_, err := f.Store.DB().Exec(
 		f.Store.Rebind(`UPDATE messages SET message_type = ? WHERE id = ?`),
 		"sms", smsMsg)
-	requirepkg.NoError(t, err, "mark sms")
-	requirepkg.NoError(t, f.Store.UpsertMessageBody(smsMsg,
+	require.NoError(err, "mark sms")
+	require.NoError(f.Store.UpsertMessageBody(smsMsg,
 		sql.NullString{String: "lunch sushi", Valid: true},
 		sql.NullString{}), "UpsertMessageBody sms")
 
 	_, err = f.Store.BackfillFTS(nil)
-	requirepkg.NoError(t, err, "BackfillFTS")
+	require.NoError(err, "BackfillFTS")
 
 	msgs, total, err := f.Store.SearchMessagesQuery(search.Parse("message_type=sms lunch"), 0, 50)
-	requirepkg.NoError(t, err, "SearchMessagesQuery")
-	requirepkg.Equal(t, int64(1), total, "total")
-	requirepkg.Len(t, msgs, 1, "messages")
-	assertpkg.Equal(t, "sms", msgs[0].MessageType, "MessageType")
-	assertpkg.Equal(t, smsMsg, msgs[0].ID, "ID")
+	require.NoError(err, "SearchMessagesQuery")
+	require.Equal(int64(1), total, "total")
+	require.Len(msgs, 1, "messages")
+	assert.Equal("sms", msgs[0].MessageType, "MessageType")
+	assert.Equal(smsMsg, msgs[0].ID, "ID")
 }

--- a/internal/store/api_search_test.go
+++ b/internal/store/api_search_test.go
@@ -148,3 +148,39 @@ func TestSearchMessages_LegacyRawString(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchMessagesQuery_MessageTypeFilter(t *testing.T) {
+	f := storetest.New(t)
+
+	emailMsg := f.NewMessage().
+		WithSourceMessageID("message-type-email").
+		WithSubject("lunch plans").
+		WithSnippet("grab tacos").
+		Create(t, f.Store)
+	requirepkg.NoError(t, f.Store.UpsertMessageBody(emailMsg,
+		sql.NullString{String: "lunch tacos", Valid: true},
+		sql.NullString{}), "UpsertMessageBody email")
+
+	smsMsg := f.NewMessage().
+		WithSourceMessageID("message-type-sms").
+		WithSubject("lunch plans").
+		WithSnippet("grab sushi").
+		Create(t, f.Store)
+	_, err := f.Store.DB().Exec(
+		f.Store.Rebind(`UPDATE messages SET message_type = ? WHERE id = ?`),
+		"sms", smsMsg)
+	requirepkg.NoError(t, err, "mark sms")
+	requirepkg.NoError(t, f.Store.UpsertMessageBody(smsMsg,
+		sql.NullString{String: "lunch sushi", Valid: true},
+		sql.NullString{}), "UpsertMessageBody sms")
+
+	_, err = f.Store.BackfillFTS(nil)
+	requirepkg.NoError(t, err, "BackfillFTS")
+
+	msgs, total, err := f.Store.SearchMessagesQuery(search.Parse("message_type=sms lunch"), 0, 50)
+	requirepkg.NoError(t, err, "SearchMessagesQuery")
+	requirepkg.Equal(t, int64(1), total, "total")
+	requirepkg.Len(t, msgs, 1, "messages")
+	assertpkg.Equal(t, "sms", msgs[0].MessageType, "MessageType")
+	assertpkg.Equal(t, smsMsg, msgs[0].ID, "ID")
+}

--- a/internal/vector/backend.go
+++ b/internal/vector/backend.go
@@ -79,6 +79,7 @@ type Chunk struct {
 //     internal/store/api.go so the vector and SQLite paths agree.
 //   - SubjectSubstrings each add one `m.subject LIKE ? ESCAPE '\'`
 //     condition, ANDed together (all substrings must match).
+//   - MessageTypes restricts m.message_type by exact value.
 //   - After/Before are half-open against m.sent_at:
 //     `>= After` and `< Before`.
 //   - LargerThan/SmallerThan compare against m.size_estimate.
@@ -94,6 +95,7 @@ type Filter struct {
 	LargerThan        *int64   // `larger:` — strictly greater than
 	SmallerThan       *int64   // `smaller:` — strictly less than
 	SubjectSubstrings []string // one per `subject:` term (ANDed)
+	MessageTypes      []string // exact m.message_type values; empty = unrestricted
 }
 
 // IsEmpty reports whether the filter has no restrictions. A zero-value
@@ -110,7 +112,8 @@ func (f Filter) IsEmpty() bool {
 		f.Before == nil &&
 		f.LargerThan == nil &&
 		f.SmallerThan == nil &&
-		len(f.SubjectSubstrings) == 0
+		len(f.SubjectSubstrings) == 0 &&
+		len(f.MessageTypes) == 0
 }
 
 // Hit is one search result.

--- a/internal/vector/hybrid/engine_test.go
+++ b/internal/vector/hybrid/engine_test.go
@@ -56,6 +56,7 @@ func newEngineFixture(t *testing.T) *engineFixture {
 CREATE TABLE messages (
     id INTEGER PRIMARY KEY,
     subject TEXT,
+    message_type TEXT NOT NULL DEFAULT 'email',
     source_id INTEGER,
     sender_id INTEGER,
     has_attachments INTEGER DEFAULT 0,

--- a/internal/vector/hybrid/filter.go
+++ b/internal/vector/hybrid/filter.go
@@ -92,6 +92,9 @@ func BuildFilter(ctx context.Context, db *sql.DB, rebind func(string) string, q 
 	if len(q.SubjectTerms) > 0 {
 		f.SubjectSubstrings = append([]string(nil), q.SubjectTerms...)
 	}
+	if len(q.MessageTypes) > 0 {
+		f.MessageTypes = append([]string(nil), q.MessageTypes...)
+	}
 	return f, nil
 }
 

--- a/internal/vector/hybrid/filter_test.go
+++ b/internal/vector/hybrid/filter_test.go
@@ -105,6 +105,16 @@ func TestBuildFilter_SizeAndSubjectAndDate(t *testing.T) {
 	assert.NotNil(f.Before, "Before should be parsed")
 }
 
+func TestBuildFilter_MessageType(t *testing.T) {
+	ctx := context.Background()
+	db := newFilterTestDB(t)
+
+	f, err := BuildFilter(ctx, db, nil, search.Parse(`message_type=sms message_type:mms lunch`))
+	requirepkg.NoError(t, err, "BuildFilter")
+
+	assertpkg.Equal(t, []string{"sms", "mms"}, f.MessageTypes, "MessageTypes")
+}
+
 // TestBuildFilter_LabelsAndAttachments checks the label: and
 // has:attachment operators.
 func TestBuildFilter_LabelsAndAttachments(t *testing.T) {

--- a/internal/vector/pgvector/backend.go
+++ b/internal/vector/pgvector/backend.go
@@ -787,6 +787,28 @@ func int64Array(ids []int64) string {
 	return sb.String()
 }
 
+// textArray formats a string slice as a PostgreSQL array literal.
+// Bound via $N::text[].
+func textArray(values []string) string {
+	var sb strings.Builder
+	sb.WriteByte('{')
+	for i, v := range values {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteByte('"')
+		for _, r := range v {
+			if r == '"' || r == '\\' {
+				sb.WriteByte('\\')
+			}
+			sb.WriteRune(r)
+		}
+		sb.WriteByte('"')
+	}
+	sb.WriteByte('}')
+	return sb.String()
+}
+
 // parseVectorLiteral decodes pgvector's text output ("[1,2,3]") back
 // into a []float32 of length dim. Returns an error if the row reports
 // a different number of components — guards against accidentally

--- a/internal/vector/pgvector/backend_filter_test.go
+++ b/internal/vector/pgvector/backend_filter_test.go
@@ -23,6 +23,7 @@ func TestBackendSearchStructuredFilters(t *testing.T) {
 	_, err := db.ExecContext(ctx, `
 		UPDATE messages
 		   SET source_id = CASE id WHEN 1 THEN 10 WHEN 2 THEN 20 ELSE 30 END,
+		       message_type = CASE id WHEN 1 THEN 'email' WHEN 2 THEN 'sms' ELSE 'mms' END,
 		       has_attachments = (id = 2),
 		       size_estimate = CASE id WHEN 1 THEN 100 WHEN 2 THEN 200 ELSE 300 END,
 		       sent_at = CASE id
@@ -85,6 +86,11 @@ func TestBackendSearchStructuredFilters(t *testing.T) {
 		{
 			name:   "has attachment",
 			filter: vector.Filter{HasAttachment: &yes},
+			want:   []int64{2},
+		},
+		{
+			name:   "message type",
+			filter: vector.Filter{MessageTypes: []string{"sms"}},
 			want:   []int64{2},
 		},
 		{

--- a/internal/vector/pgvector/backend_testhelpers_test.go
+++ b/internal/vector/pgvector/backend_testhelpers_test.go
@@ -95,6 +95,7 @@ func testSetupPGSchema(t *testing.T, db *sql.DB) {
 			source_id BIGINT,
 			sender_id BIGINT,
 			subject TEXT,
+			message_type TEXT NOT NULL DEFAULT 'email',
 			has_attachments BOOLEAN DEFAULT FALSE,
 			size_estimate BIGINT,
 			sent_at TIMESTAMPTZ,

--- a/internal/vector/pgvector/filter.go
+++ b/internal/vector/pgvector/filter.go
@@ -34,6 +34,9 @@ func buildPGFilterClauses(f vector.Filter, bind func(any) string) []string {
 	if len(f.SourceIDs) > 0 {
 		clauses = append(clauses, fmt.Sprintf("m.source_id = ANY(%s::bigint[])", bind(int64Array(f.SourceIDs))))
 	}
+	if len(f.MessageTypes) > 0 {
+		clauses = append(clauses, fmt.Sprintf("m.message_type = ANY(%s::text[])", bind(textArray(f.MessageTypes))))
+	}
 	for _, group := range f.SenderGroups {
 		if len(group) == 0 {
 			continue

--- a/internal/vector/pgvector/fused_test.go
+++ b/internal/vector/pgvector/fused_test.go
@@ -314,6 +314,32 @@ func TestFusedSearch_FilterBySource(t *testing.T) {
 	assert.False(t, saturated, "pool size 2 < KPerSignal 10 must not saturate")
 }
 
+func TestFusedSearch_FilterByMessageType(t *testing.T) {
+	f := newFusedFixture(t)
+	base := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+	f.seedMsg(t, 1, "email topic", "topic body", 10, base, false)
+	f.seedMsg(t, 2, "sms topic", "topic body", 10, base.Add(time.Hour), false)
+	_, err := f.db.ExecContext(f.ctx,
+		`UPDATE messages SET message_type = CASE id WHEN 1 THEN 'email' ELSE 'sms' END WHERE id IN (1, 2)`)
+	require.NoError(t, err, "seed message_type")
+	f.embedAll(t, map[int64][]float32{
+		1: unitVec(4, 0),
+		2: unitVec(4, 1),
+	})
+
+	hits, saturated, err := f.b.FusedSearch(f.ctx, vector.FusedRequest{
+		FTSTerms:   []string{"topic"},
+		Generation: f.gen,
+		Filter:     vector.Filter{MessageTypes: []string{"sms"}},
+		KPerSignal: 10,
+		Limit:      10,
+		RRFK:       60,
+	})
+	require.NoError(t, err, "FusedSearch")
+	assert.False(t, saturated, "saturated should be false")
+	assert.Equal(t, []int64{2}, fusedIDs(hits), "message_type=sms hits")
+}
+
 func TestFusedSearch_FilterByDateRange(t *testing.T) {
 	f := seedThree(t)
 	after := time.Date(2025, 1, 16, 0, 0, 0, 0, time.UTC) // exclude msg 1

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -1160,6 +1160,12 @@ func (b *Backend) filteredMessageIDs(ctx context.Context, f vector.Filter) ([]in
 			args = append(args, id)
 		}
 	}
+	if len(f.MessageTypes) > 0 {
+		clauses = append(clauses, inStringClause("m.message_type", f.MessageTypes))
+		for _, typ := range f.MessageTypes {
+			args = append(args, typ)
+		}
+	}
 	// Sender filters: one EXISTS per group, AND'd across groups so
 	// repeated `from:` operators each become an independent
 	// message-level requirement. Each group matches solely against
@@ -1275,6 +1281,16 @@ func (b *Backend) filteredMessageIDs(ctx context.Context, f vector.Filter) ([]in
 func inClause(col string, ids []int64) string {
 	placeholders := make([]string, len(ids))
 	for i := range ids {
+		placeholders[i] = "?"
+	}
+	return fmt.Sprintf("%s IN (%s)", col, strings.Join(placeholders, ","))
+}
+
+// inStringClause returns "col IN (?,?,?)" for string values. Caller must
+// append the values to the args slice in the same order.
+func inStringClause(col string, values []string) string {
+	placeholders := make([]string, len(values))
+	for i := range values {
 		placeholders[i] = "?"
 	}
 	return fmt.Sprintf("%s IN (%s)", col, strings.Join(placeholders, ","))

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -827,20 +827,21 @@ func TestBackend_Search_NewFilterFields(t *testing.T) {
 	require.NoError(err, "reset")
 
 	rows := []struct {
-		id      int64
-		size    int64
-		subject string
-		to, cc  int64
+		id          int64
+		size        int64
+		subject     string
+		messageType string
+		to, cc      int64
 	}{
-		{1, 100_000, "quarterly planning", 10, 0},
-		{2, 5_000_000, "quarterly review", 20, 10},
-		{3, 100_000, "lunch", 20, 0},
-		{4, 20_000_000, "quarterly deep dive", 30, 0},
+		{1, 100_000, "quarterly planning", "email", 10, 0},
+		{2, 5_000_000, "quarterly review", "sms", 20, 10},
+		{3, 100_000, "lunch", "sms", 20, 0},
+		{4, 20_000_000, "quarterly deep dive", "email", 30, 0},
 	}
 	for _, r := range rows {
 		_, err := b.mainDB.ExecContext(ctx,
-			`INSERT INTO messages (id, subject, size_estimate) VALUES (?, ?, ?)`,
-			r.id, r.subject, r.size)
+			`INSERT INTO messages (id, subject, size_estimate, message_type) VALUES (?, ?, ?, ?)`,
+			r.id, r.subject, r.size, r.messageType)
 		require.NoErrorf(err, "insert msg %d", r.id)
 		if r.to != 0 {
 			_, err := b.mainDB.ExecContext(ctx,
@@ -901,12 +902,17 @@ func TestBackend_Search_NewFilterFields(t *testing.T) {
 		got := matched(t, vector.Filter{SubjectSubstrings: []string{"quarterly", "deep"}})
 		assertpkg.Truef(t, got[4] && !got[1] && !got[2] && !got[3], "subject=[quarterly, deep]: got %v, want {4}", got)
 	})
+	t.Run("MessageTypes", func(t *testing.T) {
+		got := matched(t, vector.Filter{MessageTypes: []string{"sms"}})
+		assertpkg.Truef(t, got[2] && got[3] && !got[1] && !got[4], "MessageTypes=[sms]: got %v, want {2,3}", got)
+	})
 	t.Run("CombinedFilter", func(t *testing.T) {
 		size := int64(1_000_000)
 		got := matched(t, vector.Filter{
 			ToGroups:          [][]int64{{20}},
 			LargerThan:        &size,
 			SubjectSubstrings: []string{"quarterly"},
+			MessageTypes:      []string{"sms"},
 		})
 		assertpkg.Truef(t, got[2] && !got[1] && !got[3] && !got[4], "combined to=20 + >1MB + quarterly: got %v, want {2}", got)
 	})

--- a/internal/vector/sqlitevec/backend_testhelpers_test.go
+++ b/internal/vector/sqlitevec/backend_testhelpers_test.go
@@ -89,6 +89,7 @@ func openFusedMainDB(t *testing.T) (*sql.DB, string) {
 CREATE TABLE messages (
     id INTEGER PRIMARY KEY,
     subject TEXT,
+    message_type TEXT NOT NULL DEFAULT 'email',
     source_id INTEGER,
     sender_id INTEGER,
     has_attachments INTEGER DEFAULT 0,

--- a/internal/vector/sqlitevec/fused.go
+++ b/internal/vector/sqlitevec/fused.go
@@ -54,6 +54,11 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	}
 	defer func() { _ = conn.Close() }()
 
+	hasMessageType, err := sqliteColumnExists(ctx, conn, "messages", "message_type")
+	if err != nil {
+		return nil, false, err
+	}
+
 	sourceIDs, err := idsToJSON(req.Filter.SourceIDs)
 	if err != nil {
 		return nil, false, fmt.Errorf("encode source_ids: %w", err)
@@ -145,9 +150,14 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	// guarantees the ceiling's "is this message included" predicate
 	// stays bit-for-bit aligned with the live one without forcing
 	// callers (or the test suite) to keep two copies in sync.
+	messageTypeSQL := `AND (:message_types IS NULL OR 0)`
+	if hasMessageType {
+		messageTypeSQL = `AND (:message_types IS NULL OR m.message_type IN (SELECT value FROM json_each(:message_types)))`
+	}
+
 	filterWhere := fmt.Sprintf(`%s
        AND (:source_ids IS NULL OR m.source_id IN (SELECT value FROM json_each(:source_ids)))
-       AND (:message_types IS NULL OR m.message_type IN (SELECT value FROM json_each(:message_types)))
+       %s
        %s
        %s
        %s
@@ -161,7 +171,7 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
              SELECT 1 FROM json_each(:subject_patterns) sp
               WHERE m.subject IS NULL OR m.subject NOT LIKE sp.value ESCAPE '\'))
        %s`,
-		store.LiveMessagesWhere("m", true), senderGroupSQL, toGroupSQL, ccGroupSQL, bccGroupSQL, labelGroupSQL)
+		store.LiveMessagesWhere("m", true), messageTypeSQL, senderGroupSQL, toGroupSQL, ccGroupSQL, bccGroupSQL, labelGroupSQL)
 
 	// buildQuery interpolates a fresh query string for a given chunkK,
 	// so the widening loop below can re-issue the fused CTE with a
@@ -475,6 +485,32 @@ func stringsToJSON(values []string) (sql.NullString, error) {
 		return sql.NullString{}, fmt.Errorf("marshal strings: %w", err)
 	}
 	return sql.NullString{Valid: true, String: string(buf)}, nil
+}
+
+func sqliteColumnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")")
+	if err != nil {
+		return false, fmt.Errorf("inspect %s columns: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, fmt.Errorf("scan %s columns: %w", table, err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterate %s columns: %w", table, err)
+	}
+	return false, nil
 }
 
 // senderGroupClauses produces the SQL fragment and named args for

--- a/internal/vector/sqlitevec/fused.go
+++ b/internal/vector/sqlitevec/fused.go
@@ -58,6 +58,10 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	if err != nil {
 		return nil, false, fmt.Errorf("encode source_ids: %w", err)
 	}
+	messageTypes, err := stringsToJSON(req.Filter.MessageTypes)
+	if err != nil {
+		return nil, false, fmt.Errorf("encode message_types: %w", err)
+	}
 	senderGroupSQL, senderGroupArgs, err := senderGroupClauses(req.Filter.SenderGroups)
 	if err != nil {
 		return nil, false, fmt.Errorf("encode sender_groups: %w", err)
@@ -143,6 +147,7 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	// callers (or the test suite) to keep two copies in sync.
 	filterWhere := fmt.Sprintf(`%s
        AND (:source_ids IS NULL OR m.source_id IN (SELECT value FROM json_each(:source_ids)))
+       AND (:message_types IS NULL OR m.message_type IN (SELECT value FROM json_each(:message_types)))
        %s
        %s
        %s
@@ -262,6 +267,7 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
 	// named binds when its placeholder count check fails.
 	filterArgs := []any{
 		sql.Named("source_ids", sourceIDs),
+		sql.Named("message_types", messageTypes),
 		sql.Named("has_attachment", hasAttachment),
 		sql.Named("after", after),
 		sql.Named("before", before),
@@ -455,6 +461,18 @@ func idsToJSON(ids []int64) (sql.NullString, error) {
 	buf, err := json.Marshal(ids)
 	if err != nil {
 		return sql.NullString{}, fmt.Errorf("marshal ids: %w", err)
+	}
+	return sql.NullString{Valid: true, String: string(buf)}, nil
+}
+
+// stringsToJSON encodes a string slice as a JSON array for json_each filters.
+func stringsToJSON(values []string) (sql.NullString, error) {
+	if len(values) == 0 {
+		return sql.NullString{}, nil
+	}
+	buf, err := json.Marshal(values)
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf("marshal strings: %w", err)
 	}
 	return sql.NullString{Valid: true, String: string(buf)}, nil
 }

--- a/internal/vector/sqlitevec/fused_test.go
+++ b/internal/vector/sqlitevec/fused_test.go
@@ -316,6 +316,40 @@ CREATE TABLE message_recipients (
 	return db
 }
 
+func openFusedMainWithoutMessageType(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	requirepkg.NoError(t, err, "open main")
+	t.Cleanup(func() { _ = db.Close() })
+	schema := `
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY,
+    subject TEXT,
+    source_id INTEGER,
+    sender_id INTEGER,
+    has_attachments INTEGER DEFAULT 0,
+    size_estimate INTEGER,
+    sent_at DATETIME,
+    deleted_at DATETIME,
+    deleted_from_source_at DATETIME
+);
+CREATE VIRTUAL TABLE messages_fts USING fts5(subject, body, content='', contentless_delete=1);
+CREATE TABLE message_labels (
+    message_id INTEGER NOT NULL,
+    label_id INTEGER NOT NULL,
+    PRIMARY KEY (message_id, label_id)
+);
+CREATE TABLE message_recipients (
+    id INTEGER PRIMARY KEY,
+    message_id INTEGER NOT NULL,
+    recipient_type TEXT NOT NULL,
+    participant_id INTEGER NOT NULL
+);`
+	_, err = db.Exec(schema)
+	requirepkg.NoError(t, err, "schema")
+	return db
+}
+
 func formatInt(n int64) string { return strconv.FormatInt(n, 10) }
 
 // TestFusedSearch_PinnedPoolKeepsAttach regression-guards the pool
@@ -542,6 +576,48 @@ func TestFusedSearch_MessageTypeFilter(t *testing.T) {
 		got[h.MessageID] = true
 	}
 	assertpkg.Equal(t, map[int64]bool{2: true, 3: true}, got, "message_type=sms hits")
+}
+
+func TestFusedSearch_LegacySchemaWithoutMessageType(t *testing.T) {
+	require := requirepkg.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.db")
+	main := openFusedMainWithoutMessageType(t, mainPath)
+
+	_, err := main.ExecContext(ctx, `INSERT INTO messages (id, subject) VALUES (?, ?)`, 1, "legacy topic")
+	require.NoError(err, "insert message")
+	_, err = main.ExecContext(ctx,
+		`INSERT INTO messages_fts (rowid, subject, body) VALUES (?, ?, ?)`,
+		1, "legacy topic", "topic body")
+	require.NoError(err, "insert fts")
+
+	b, err := Open(ctx, Options{
+		Path:      filepath.Join(dir, "vectors.db"),
+		MainPath:  mainPath,
+		Dimension: 768,
+		MainDB:    main,
+	})
+	require.NoError(err, "Open")
+	t.Cleanup(func() { _ = b.Close() })
+
+	gid, err := b.CreateGeneration(ctx, "m", 768, "")
+	require.NoError(err, "CreateGeneration")
+	require.NoError(b.Upsert(ctx, gid, []vector.Chunk{
+		{MessageID: 1, Vector: unitVec(768, 0)},
+	}), "Upsert")
+	require.NoError(b.ActivateGeneration(ctx, gid, true), "Activate")
+
+	hits, _, err := b.FusedSearch(ctx, vector.FusedRequest{
+		FTSTerms:   []string{"topic"},
+		Generation: gid,
+		KPerSignal: 10,
+		Limit:      10,
+		RRFK:       60,
+	})
+	require.NoError(err, "FusedSearch")
+	require.Len(hits, 1, "legacy message should still be searchable")
+	assertpkg.Equal(t, int64(1), hits[0].MessageID, "legacy hit")
 }
 
 // TestFusedSearch_SenderMatchesFromRecipientOnly confirms the sender

--- a/internal/vector/sqlitevec/fused_test.go
+++ b/internal/vector/sqlitevec/fused_test.go
@@ -290,6 +290,7 @@ func openFusedMainWithSchema(t *testing.T, path string) *sql.DB {
 CREATE TABLE messages (
     id INTEGER PRIMARY KEY,
     subject TEXT,
+    message_type TEXT NOT NULL DEFAULT 'email',
     source_id INTEGER,
     sender_id INTEGER,
     has_attachments INTEGER DEFAULT 0,
@@ -484,6 +485,63 @@ func TestFusedSearch_AfterBeforeBoundaries_TextDate(t *testing.T) {
 			assertpkg.Lenf(t, got, len(c.want), "got %d hits, want %d (got=%v want=%v)", len(got), len(c.want), got, c.want)
 		})
 	}
+}
+
+func TestFusedSearch_MessageTypeFilter(t *testing.T) {
+	require := requirepkg.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.db")
+	main := openFusedMainWithSchema(t, mainPath)
+
+	rows := []struct {
+		id          int64
+		messageType string
+	}{
+		{1, "email"},
+		{2, "sms"},
+		{3, "sms"},
+		{4, "mms"},
+	}
+	for _, r := range rows {
+		_, err := main.ExecContext(ctx,
+			`INSERT INTO messages (id, message_type) VALUES (?, ?)`,
+			r.id, r.messageType)
+		require.NoErrorf(err, "insert msg %d", r.id)
+		_, err = main.ExecContext(ctx,
+			`INSERT INTO messages_fts (rowid, subject, body) VALUES (?, ?, ?)`,
+			r.id, "", "topic")
+		require.NoErrorf(err, "insert fts %d", r.id)
+	}
+
+	b, err := Open(ctx, Options{
+		Path:      filepath.Join(dir, "vectors.db"),
+		MainPath:  mainPath,
+		Dimension: 768,
+		MainDB:    main,
+	})
+	require.NoError(err, "Open")
+	t.Cleanup(func() { _ = b.Close() })
+
+	gid, err := b.CreateGeneration(ctx, "m", 768, "")
+	require.NoError(err, "CreateGeneration")
+	require.NoError(b.ActivateGeneration(ctx, gid, true), "Activate")
+
+	hits, _, err := b.FusedSearch(ctx, vector.FusedRequest{
+		FTSTerms:   []string{"topic"},
+		Generation: gid,
+		Filter:     vector.Filter{MessageTypes: []string{"sms"}},
+		KPerSignal: 10,
+		Limit:      10,
+		RRFK:       60,
+	})
+	requirepkg.NoError(t, err, "FusedSearch")
+
+	got := make(map[int64]bool, len(hits))
+	for _, h := range hits {
+		got[h.MessageID] = true
+	}
+	assertpkg.Equal(t, map[int64]bool{2: true, 3: true}, got, "message_type=sms hits")
 }
 
 // TestFusedSearch_SenderMatchesFromRecipientOnly confirms the sender


### PR DESCRIPTION
Adds first-class message_type filtering across text, API, vector, and hybrid search.

- Parses message_type/type search filters into structured queries.
- Applies message-type filters in store/API search and vector/hybrid backends.
- Documents the filter in command quickstart search help.