### PR TITLE
fix(mcp): reject Gmail-only list search operators

### DIFF
--- a/cmd/msgvault/cmd/testmain_windows_test.go
+++ b/cmd/msgvault/cmd/testmain_windows_test.go
@@ -12,6 +12,7 @@ import (
 const windowsCommandPackageTimeout = 20 * time.Minute
 
 func TestMain(m *testing.M) {
+	flag.Parse()
 	raiseWindowsCommandPackageTimeout()
 	os.Exit(m.Run())
 }

--- a/cmd/msgvault/cmd/testmain_windows_test.go
+++ b/cmd/msgvault/cmd/testmain_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package cmd
+
+import (
+	"flag"
+	"os"
+	"testing"
+	"time"
+)
+
+const windowsCommandPackageTimeout = 20 * time.Minute
+
+func TestMain(m *testing.M) {
+	raiseWindowsCommandPackageTimeout()
+	os.Exit(m.Run())
+}
+
+func raiseWindowsCommandPackageTimeout() {
+	timeoutFlag := flag.Lookup("test.timeout")
+	if timeoutFlag == nil {
+		return
+	}
+	current, err := time.ParseDuration(timeoutFlag.Value.String())
+	if err != nil || current <= 0 || current >= windowsCommandPackageTimeout {
+		return
+	}
+	_ = timeoutFlag.Value.Set(windowsCommandPackageTimeout.String())
+}

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -75,6 +75,9 @@ and `list_messages` default to `limit = 20` and cap it at 50. When a
 backend cannot report a full result count, `total` is `-1`; use
 `has_more` as the pagination signal. `list_messages` uses this
 `total = -1` shape because it does not run a separate count query.
+`search_messages` accepts msgvault's local subset of Gmail-like syntax.
+Gmail-only operators such as `list:` are rejected because msgvault does
+not index `List-ID` locally; use Gmail-side validation for those checks.
 
 `find_similar_messages` is only registered when the server starts with vector search configured. `search_messages` is always available, but `mode=vector` and `mode=hybrid` return `vector_not_enabled` when the server is not configured for vector search. Vector and hybrid queries require at least one free-text term (operator-only queries return `missing_free_text`). They support `offset`/`limit` pagination inside the configured hybrid ranking window; when `[vector.search].max_page_size_hybrid` is positive, an `offset` at or beyond that cap returns `pagination_limit`. Use `mode=fts` for deeper pagination or adjust that config cap.
 

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -14,6 +14,11 @@ msgvault search <query>
 
 ## Search Operators
 
+msgvault supports a local subset of Gmail-like search syntax. Gmail-only
+operators that depend on fields msgvault does not index locally, such as
+`list:` / `List-ID`, are not available in local search or MCP search. Use a
+Gmail connector query when you need Gmail itself to evaluate those operators.
+
 | Operator | Description | Example |
 |---|---|---|
 | `from:` | Sender address | `from:alice@example.com` |

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -257,6 +257,9 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 	}
 
 	q := search.Parse(queryStr)
+	if msg := unsupportedSearchOperatorMessage(q); msg != "" {
+		return mcp.NewToolResultError(msg), nil
+	}
 	if sourceID != nil {
 		q.AccountIDs = []int64{*sourceID}
 	}
@@ -288,6 +291,28 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 	}
 
 	return jsonResult(newPaginatedResponse(results, totalMatched, offset))
+}
+
+func unsupportedSearchOperatorMessage(q *search.Query) string {
+	if len(q.UnsupportedOperators) == 0 {
+		return ""
+	}
+
+	names := make([]string, 0, len(q.UnsupportedOperators))
+	seen := make(map[string]bool, len(q.UnsupportedOperators))
+	for _, op := range q.UnsupportedOperators {
+		name := op.Name + ":"
+		if !seen[name] {
+			names = append(names, name)
+			seen[name] = true
+		}
+	}
+
+	return fmt.Sprintf(
+		"unsupported_search_operator: %s is Gmail-only syntax; msgvault does not index List-ID locally. "+
+			"Use the Gmail connector for List-ID validation, or use msgvault-supported operators.",
+		strings.Join(names, ", "),
+	)
 }
 
 // hybridScoreBreakdown exposes fused-score components for debugging.
@@ -355,6 +380,9 @@ func (h *handlers) searchMessagesHybrid(
 	offset := limitArg(args, "offset", 0)
 
 	parsed := search.Parse(queryStr)
+	if msg := unsupportedSearchOperatorMessage(parsed); msg != "" {
+		return mcp.NewToolResultError(msg), nil
+	}
 	freeText := strings.Join(parsed.TextTerms, " ")
 
 	// mode=vector|hybrid requires at least one free-text term; filter-only
@@ -1211,6 +1239,9 @@ func (h *handlers) stageDeletion(ctx context.Context, req mcp.CallToolRequest) (
 	if hasQuery {
 		// Query-based search
 		q := search.Parse(queryStr)
+		if msg := unsupportedSearchOperatorMessage(q); msg != "" {
+			return mcp.NewToolResultError(msg), nil
+		}
 		if sourceID != nil {
 			q.AccountIDs = []int64{*sourceID}
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -193,7 +193,8 @@ func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr string) e
 func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 	if !vectorAvailable {
 		return mcp.NewTool(ToolSearchMessages,
-			mcp.WithDescription("Search emails using Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+			mcp.WithDescription("Search emails using a subset of Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+				"Gmail-only operators such as list: are rejected because msgvault does not index List-ID locally. "+
 				"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
 				"(This server is not configured for vector search; only keyword FTS is available.)"),
 			mcp.WithReadOnlyHintAnnotation(true),
@@ -207,7 +208,8 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 		)
 	}
 	return mcp.NewTool(ToolSearchMessages,
-		mcp.WithDescription("Search emails using Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+		mcp.WithDescription("Search emails using a subset of Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+			"Gmail-only operators such as list: are rejected because msgvault does not index List-ID locally. "+
 			"All modes paginate via offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
 			"total=-1 means the full match count is unknown — use has_more. "+
 			"Vector/hybrid ranking depth is capped by max_page_size_hybrid in config; beyond that use mode=fts. "+

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -139,6 +139,13 @@ func TestSearchMessages(t *testing.T) {
 	t.Run("missing query", func(t *testing.T) {
 		runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{})
 	})
+
+	t.Run("unsupported Gmail list operator rejected", func(t *testing.T) {
+		r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{"query": "list:(alerts.example.com)"})
+		txt := resultText(t, r)
+		assertpkg.Contains(t, txt, "unsupported_search_operator", "expected unsupported-operator error, got: %s")
+		assertpkg.Contains(t, txt, "list:", "expected list operator context, got: %s")
+	})
 }
 
 func TestSearchFallbackToFTS(t *testing.T) {
@@ -1683,6 +1690,19 @@ func TestStageDeletion(t *testing.T) {
 		)
 		txt := resultText(t, r)
 		assertpkg.Contains(t, txt, "not both", "expected mutual exclusion error, got: %s")
+	})
+
+	t.Run("query with unsupported Gmail list operator rejected", func(t *testing.T) {
+		dataDir := t.TempDir()
+		h := &handlers{engine: eng, dataDir: dataDir}
+
+		r := runToolExpectError(
+			t, "stage_deletion", h.stageDeletion,
+			map[string]any{"query": "list:(alerts.example.com)"},
+		)
+		txt := resultText(t, r)
+		assertpkg.Contains(t, txt, "unsupported_search_operator", "expected unsupported-operator error, got: %s")
+		assertpkg.Contains(t, txt, "list:", "expected list operator context, got: %s")
 	})
 
 	t.Run("no filters rejected", func(t *testing.T) {

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -25,6 +25,19 @@ type Query struct {
 	AccountIDs    []int64    // in: account filter (one or more source IDs)
 	MessageTypes  []string   // message_type filter (e.g. sms, mms, whatsapp, teams)
 	HideDeleted   bool       // exclude messages where deleted_from_source_at IS NOT NULL
+
+	// UnsupportedOperators records recognized Gmail operators that msgvault
+	// does not implement locally. The original token is still kept as a text
+	// term for backwards-compatible callers; front doors that need strict
+	// validation can reject the query before searching.
+	UnsupportedOperators []UnsupportedOperator
+}
+
+// UnsupportedOperator describes a parsed operator that is known to be Gmail
+// syntax but is not supported by msgvault's local search engine.
+type UnsupportedOperator struct {
+	Name  string
+	Token string
 }
 
 // IsEmpty returns true if the query has no search criteria.
@@ -188,6 +201,11 @@ var operators = map[string]operatorFn{
 	},
 }
 
+var unsupportedOperators = map[string]bool{
+	"list":    true,
+	"list-id": true,
+}
+
 // Parser holds configuration for query parsing.
 type Parser struct {
 	Now func() time.Time // Time source (mockable for testing)
@@ -230,6 +248,12 @@ func (p *Parser) Parse(queryStr string) *Query {
 			if handler, ok := operators[op]; ok {
 				handler(q, value, now)
 			} else {
+				if unsupportedOperators[op] {
+					q.UnsupportedOperators = append(q.UnsupportedOperators, UnsupportedOperator{
+						Name:  op,
+						Token: token,
+					})
+				}
 				q.TextTerms = append(q.TextTerms, token)
 			}
 			continue


### PR DESCRIPTION
MCP search previously accepted Gmail-only list syntax as plain text because the local parser had no way to mark unsupported operators. That made agent-side validation look successful even when `List-ID` was never evaluated by msgvault.

This rejects known Gmail-only list operators in MCP search and query-based deletion staging before any engine query runs. The parser still preserves the old text-token behavior for callers that do not opt into strict validation, so the change is scoped to MCP surfaces where a false positive is risky.

The docs and MCP tool descriptions now call this a local subset of Gmail-like syntax and point List-ID validation back to Gmail-side evaluation.