### PR TITLE
Skip unchanged IMAP folders on resync via UIDVALIDITY/UIDNEXT

### DIFF
--- a/cmd/msgvault/cmd/cliprogress_test.go
+++ b/cmd/msgvault/cmd/cliprogress_test.go
@@ -81,11 +81,55 @@ func TestCLIProgress_PlainModeThrottlesToItsInterval(t *testing.T) {
 	var buf bytes.Buffer
 	p := &CLIProgress{mode: progressModePlain, out: &buf}
 	p.OnStart(0)
-	p.lastPrint = time.Now().Add(-cliProgressPlainInterval + time.Second)
-	p.OnProgress(1000, 500, 100)
+	p.OnProgress(100, 50, 10) // first update always prints
+	first := buf.String()
+	require.NotEmpty(t, first, "the first update must print immediately")
 
-	assert.Empty(t, buf.String(),
+	p.OnProgress(1000, 500, 100)
+	assert.Equal(t, first, buf.String(),
 		"an update inside the plain interval must not print")
+}
+
+func TestCLIProgress_FirstProgressLinePrintsImmediately(t *testing.T) {
+	var buf bytes.Buffer
+	p := &CLIProgress{mode: progressModePlain, out: &buf}
+	p.OnStart(0) // sets lastPrint to now; the throttle alone would go silent for 30s
+	p.OnProgress(100, 100, 0)
+
+	assert.Contains(t, buf.String(), "Scanned: 100",
+		"the first page of a slow sync must produce output immediately")
+}
+
+func TestCLIProgress_ListProgressFinalSummaryAlwaysPrints(t *testing.T) {
+	assert := assert.New(t)
+	var buf bytes.Buffer
+	p := &CLIProgress{mode: progressModePlain, out: &buf}
+
+	// An instant resync: every folder unchanged, no intermediate updates
+	// survive the throttle, yet the summary must still appear.
+	p.OnIMAPListProgress(0, 4, "", 0, 0)
+	p.OnIMAPListProgress(4, 4, "INBOX", 0, 4)
+
+	out := buf.String()
+	assert.Contains(out, "Checking 4 folders...")
+	assert.Contains(out, "Checked 4 folders: 0 messages to examine, 4 unchanged (skipped)")
+	assert.True(p.printedAnything())
+}
+
+func TestCLIProgress_ListProgressIntermediateThrottled(t *testing.T) {
+	assert := assert.New(t)
+	var buf bytes.Buffer
+	p := &CLIProgress{mode: progressModePlain, out: &buf}
+
+	p.OnIMAPListProgress(0, 10, "", 0, 0)
+	first := buf.String()
+	p.OnIMAPListProgress(1, 10, "INBOX", 5, 0)
+	assert.Equal(first, buf.String(),
+		"intermediate updates inside the interval must not print")
+
+	p.lastListPrint = time.Now().Add(-time.Minute)
+	p.OnIMAPListProgress(2, 10, "Archive", 9, 0)
+	assert.Contains(buf.String(), "Checking folders: 2/10")
 }
 
 func TestCLIProgress_TTYModeRedrawsInPlace(t *testing.T) {

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/gmail"
+	imaplib "go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// listedIMAPClient returns an IMAP client that has enumerated the test
+// server, so it holds observed folder states ready for persistence.
+func listedIMAPClient(t *testing.T, addr string, opts ...imaplib.Option) *imaplib.Client {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	client := imaplib.NewClient(&imaplib.Config{
+		Host:     host,
+		Port:     port,
+		Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword, opts...)
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pageToken := ""
+	for {
+		resp, err := client.ListMessages(ctx, "", pageToken)
+		require.NoError(t, err)
+		if resp.NextPageToken == "" {
+			return client
+		}
+		pageToken = resp.NextPageToken
+	}
+}
+
+func TestSaveIMAPFolderStates_CleanRunPersists(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 1})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(t, err)
+
+	client := listedIMAPClient(t, addr)
+	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{}, 0)
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]imaplib.FolderState{
+		"INBOX":   {UIDValidity: loaded["INBOX"].UIDValidity, UIDNext: 3},
+		"Archive": {UIDValidity: loaded["Archive"].UIDValidity, UIDNext: 2},
+	}, loaded)
+}
+
+func TestSaveIMAPFolderStates_ErrorsBlockPersistence(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(t, err)
+
+	client := listedIMAPClient(t, addr)
+	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{Errors: 1}, 0)
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(t, err)
+	assert.Empty(t, loaded, "a run with fetch errors must not advance folder watermarks")
+}
+
+func TestSaveIMAPFolderStates_LimitTruncationBlocksPersistence(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 5})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(t, err)
+
+	client := listedIMAPClient(t, addr)
+	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{MessagesFound: 3}, 3)
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(t, err)
+	assert.Empty(t, loaded, "a --limit-truncated run must not advance folder watermarks")
+}
+
+func TestSaveIMAPFolderStates_NonIMAPClientIsNoOp(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("gmail", "alice@example.com")
+	require.NoError(t, err)
+
+	var notIMAP gmail.API
+	saveIMAPFolderStates(st, src, notIMAP, &gmail.SyncSummary{}, 0)
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+}
+
+func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(t, err)
+
+	first := listedIMAPClient(t, addr)
+	saveIMAPFolderStates(st, src, first, &gmail.SyncSummary{}, 0)
+	require.NoError(t, first.Close())
+
+	opts := imapFolderStateOptions(st, src)
+	require.NotEmpty(t, opts, "saved states must produce a client option")
+
+	second := listedIMAPClient(t, addr, opts...)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := second.ListMessages(ctx, "", "")
+	require.NoError(t, err)
+	assert.Empty(t, resp.Messages,
+		"a resync against an unchanged server must list no messages")
+}
+
+func TestSaveIMAPFolderStates_StoreRoundTripValues(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 42, UIDNext: 100},
+	}))
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]imaplib.FolderState{
+		"INBOX": {UIDValidity: 42, UIDNext: 100},
+	}, loaded)
+}

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -45,16 +45,17 @@ func listedIMAPClient(t *testing.T, addr string, opts ...imaplib.Option) *imapli
 }
 
 func TestSaveIMAPFolderStates_CleanRunPersists(t *testing.T) {
+	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 1})
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	client := listedIMAPClient(t, addr)
 	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{}, 0)
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal(t, map[string]imaplib.FolderState{
 		"INBOX":   {UIDValidity: loaded["INBOX"].UIDValidity, UIDNext: 3},
 		"Archive": {UIDValidity: loaded["Archive"].UIDValidity, UIDNext: 2},
@@ -62,92 +63,99 @@ func TestSaveIMAPFolderStates_CleanRunPersists(t *testing.T) {
 }
 
 func TestSaveIMAPFolderStates_ErrorsBlockPersistence(t *testing.T) {
+	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	client := listedIMAPClient(t, addr)
 	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{Errors: 1}, 0)
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Empty(t, loaded, "a run with fetch errors must not advance folder watermarks")
 }
 
 func TestSaveIMAPFolderStates_LimitTruncationBlocksPersistence(t *testing.T) {
+	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 5})
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	client := listedIMAPClient(t, addr)
 	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{MessagesFound: 3}, 3)
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Empty(t, loaded, "a --limit-truncated run must not advance folder watermarks")
 }
 
 func TestSaveIMAPFolderStates_NonIMAPClientIsNoOp(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("gmail", "alice@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	var notIMAP gmail.API
 	saveIMAPFolderStates(st, src, notIMAP, &gmail.SyncSummary{}, 0)
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Empty(t, loaded)
 }
 
 func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
+	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	first := listedIMAPClient(t, addr)
 	saveIMAPFolderStates(st, src, first, &gmail.SyncSummary{}, 0)
-	require.NoError(t, first.Close())
+	require.NoError(first.Close())
 
 	opts := imapFolderStateOptions(st, src, false)
-	require.NotEmpty(t, opts, "saved states must produce a client option")
+	require.NotEmpty(opts, "saved states must produce a client option")
 
 	second := listedIMAPClient(t, addr, opts...)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	resp, err := second.ListMessages(ctx, "", "")
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Empty(t, resp.Messages,
 		"a resync against an unchanged server must list no messages")
 }
 
 func TestIMAPFolderStateOptions_ForceRescanBypassesSavedStates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
-	require.NoError(t, st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
+	require.NoError(st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 42, UIDNext: 100},
 	}))
 
-	assert.Empty(t, imapFolderStateOptions(st, src, true),
+	assert.Empty(imapFolderStateOptions(st, src, true),
 		"--noresume must ignore saved folder states so every mailbox is re-enumerated")
-	assert.NotEmpty(t, imapFolderStateOptions(st, src, false))
+	assert.NotEmpty(imapFolderStateOptions(st, src, false))
 }
 
 func TestSaveIMAPFolderStates_StoreRoundTripValues(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
-	require.NoError(t, st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
+	require.NoError(st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 42, UIDNext: 100},
 	}))
 	loaded, err := loadIMAPFolderStates(st, src.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal(t, map[string]imaplib.FolderState{
 		"INBOX": {UIDValidity: 42, UIDNext: 100},
 	}, loaded)

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -112,7 +112,7 @@ func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
 	saveIMAPFolderStates(st, src, first, &gmail.SyncSummary{}, 0)
 	require.NoError(t, first.Close())
 
-	opts := imapFolderStateOptions(st, src)
+	opts := imapFolderStateOptions(st, src, false)
 	require.NotEmpty(t, opts, "saved states must produce a client option")
 
 	second := listedIMAPClient(t, addr, opts...)
@@ -122,6 +122,20 @@ func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, resp.Messages,
 		"a resync against an unchanged server must list no messages")
+}
+
+func TestIMAPFolderStateOptions_ForceRescanBypassesSavedStates(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 42, UIDNext: 100},
+	}))
+
+	assert.Empty(t, imapFolderStateOptions(st, src, true),
+		"--noresume must ignore saved folder states so every mailbox is re-enumerated")
+	assert.NotEmpty(t, imapFolderStateOptions(st, src, false))
 }
 
 func TestSaveIMAPFolderStates_StoreRoundTripValues(t *testing.T) {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1217,7 +1217,7 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 // on because IMAP page tokens are numeric offsets that don't survive
 // across processes (see syncfull.go).
 func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store) (*gmail.SyncSummary, error) {
-	apiClient, err := buildAPIClient(ctx, src, nil, nil, imapFolderStateOptions(s, src)...)
+	apiClient, err := buildAPIClient(ctx, src, nil, nil, imapFolderStateOptions(s, src, false)...)
 	if err != nil {
 		return nil, fmt.Errorf("build IMAP client: %w", err)
 	}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1211,12 +1211,13 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 }
 
 // runScheduledIMAPSync runs a full IMAP sync for the daemon. IMAP has
-// no incremental/history API, so we always do a full pass and rely on
-// the store to dedupe by message-id. NoResume is forced on because
-// IMAP page tokens are numeric offsets that don't survive across
-// processes (see syncfull.go).
+// no incremental/history API, so we do a full pass, skipping mailboxes
+// unchanged since the last completed sync (saved UIDVALIDITY/UIDNEXT)
+// and relying on the store to dedupe by message-id. NoResume is forced
+// on because IMAP page tokens are numeric offsets that don't survive
+// across processes (see syncfull.go).
 func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store) (*gmail.SyncSummary, error) {
-	apiClient, err := buildAPIClient(ctx, src, nil, nil)
+	apiClient, err := buildAPIClient(ctx, src, nil, nil, imapFolderStateOptions(s, src)...)
 	if err != nil {
 		return nil, fmt.Errorf("build IMAP client: %w", err)
 	}
@@ -1251,6 +1252,7 @@ func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store
 	if err != nil {
 		return nil, fmt.Errorf("IMAP sync failed: %w", err)
 	}
+	saveIMAPFolderStates(s, src, apiClient, summary, 0)
 	return summary, nil
 }
 

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -401,11 +401,16 @@ func saveIMAPFolderStates(s *store.Store, src *store.Source, apiClient gmail.API
 }
 
 func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), src *store.Source) error {
+	progress := &CLIProgress{}
+
 	// --noresume promises a fresh sync, so it must also bypass the
 	// saved folder watermarks and re-enumerate every mailbox. A clean
 	// completed run still saves fresh watermarks afterwards.
-	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil,
-		imapFolderStateOptions(s, src, syncNoResume)...)
+	imapOpts := imapFolderStateOptions(s, src, syncNoResume)
+	if src.SourceType == sourceTypeIMAP {
+		imapOpts = append(imapOpts, imaplib.WithListProgress(progress.OnIMAPListProgress))
+	}
+	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil, imapOpts...)
 	if err != nil {
 		return err
 	}
@@ -443,7 +448,7 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	// Create syncer with progress reporter
 	syncer := sync.New(apiClient, s, opts).
 		WithLogger(logger).
-		WithProgress(&CLIProgress{})
+		WithProgress(progress)
 
 	// Run sync
 	startTime := time.Now()
@@ -474,8 +479,11 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 		saveIMAPFolderStates(s, src, apiClient, summary, opts.Limit)
 	}
 
-	// Print summary
-	fmt.Println()
+	// Print summary; skip the spacer when no progress lines were
+	// printed so a no-op sync doesn't emit stacked blank lines.
+	if progress.printedAnything() {
+		fmt.Println()
+	}
 	fmt.Println("Sync complete!")
 	fmt.Printf("  Duration:      %s\n", summary.Duration.Round(time.Second))
 	fmt.Printf("  Messages:      %d found, %d added, %d skipped\n",
@@ -549,6 +557,9 @@ const (
 const (
 	cliProgressTTYInterval   = 2 * time.Second
 	cliProgressPlainInterval = 30 * time.Second
+	// Folder listing is much faster per item than message fetching, so
+	// plain-mode listing updates can come more often without flooding.
+	cliListPlainInterval = 15 * time.Second
 )
 
 type CLIProgress struct {
@@ -561,6 +572,16 @@ type CLIProgress struct {
 	skipped   int64
 	mode      progressOutputMode
 	out       io.Writer // defaults to os.Stdout; tests inject a buffer
+
+	printedProgress bool      // a sync progress line has been printed
+	printedList     bool      // a folder-listing line has been printed
+	lastListPrint   time.Time // throttle for intermediate listing updates
+}
+
+// printedAnything reports whether any progress output was emitted,
+// so callers can avoid stacking blank lines around silent syncs.
+func (p *CLIProgress) printedAnything() bool {
+	return p.printedProgress || p.printedList
 }
 
 func (p *CLIProgress) OnStart(total int64) {
@@ -596,6 +617,53 @@ func (p *CLIProgress) OnLatestDate(date time.Time) {
 	p.latestDate = date
 }
 
+// OnIMAPListProgress renders mailbox-enumeration progress for IMAP
+// syncs (the phase before any message is fetched, which is otherwise
+// silent). The first and final updates always print; the final one is
+// a permanent summary line so even an instant all-skipped resync shows
+// what happened.
+func (p *CLIProgress) OnIMAPListProgress(done, total int, mailbox string, found, unchanged int) {
+	tty := p.outputMode() == progressModeTTY
+
+	if done >= total {
+		prefix := ""
+		if tty && p.printedList {
+			prefix = "\r" // overwrite the in-place listing line
+		}
+		skipNote := ""
+		if unchanged > 0 {
+			skipNote = fmt.Sprintf(", %d unchanged (skipped)", unchanged)
+		}
+		// Trailing spaces overwrite leftovers of a longer in-place line.
+		_, _ = fmt.Fprintf(p.writer(),
+			"%s  Checked %d folders: %d messages to examine%s                    \n",
+			prefix, total, found, skipNote)
+		p.printedList = true
+		return
+	}
+
+	interval := cliProgressTTYInterval
+	if !tty {
+		interval = cliListPlainInterval
+	}
+	if p.printedList && time.Since(p.lastListPrint) < interval {
+		return
+	}
+	p.printedList = true
+	p.lastListPrint = time.Now()
+
+	if tty {
+		_, _ = fmt.Fprintf(p.writer(),
+			"\r  Checking folders: %d/%d (%s)    ", done, total, mailbox)
+		return
+	}
+	if done == 0 {
+		_, _ = fmt.Fprintf(p.writer(), "  Checking %d folders...\n", total)
+		return
+	}
+	_, _ = fmt.Fprintf(p.writer(), "  Checking folders: %d/%d\n", done, total)
+}
+
 func (p *CLIProgress) outputMode() progressOutputMode {
 	if p.mode == progressModeAuto {
 		if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
@@ -617,13 +685,16 @@ func (p *CLIProgress) writer() io.Writer {
 func (p *CLIProgress) printProgress() {
 	// Throttle: an in-place line can refresh every 2 seconds, but each
 	// plain-mode update is a permanent line, so those come every 30.
+	// The first line always prints so a slow fetch (IMAP especially)
+	// shows signs of life as soon as the first page completes.
 	interval := cliProgressTTYInterval
 	if p.outputMode() == progressModePlain {
 		interval = cliProgressPlainInterval
 	}
-	if time.Since(p.lastPrint) < interval {
+	if p.printedProgress && time.Since(p.lastPrint) < interval {
 		return
 	}
+	p.printedProgress = true
 	p.lastPrint = time.Now()
 
 	elapsed := time.Since(p.startTime)

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -229,7 +229,7 @@ func runSyncFullLocal(cmd *cobra.Command, args []string) error {
 // caller-provided getOAuthMgr factory. Pass nil to use oauth.Scopes; pass
 // oauth.ScopesDeletion (or another set) for workflows that need elevated
 // access.
-func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(string) (*oauth.Manager, error), saScopes []string) (gmail.API, error) {
+func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(string) (*oauth.Manager, error), saScopes []string, imapOpts ...imaplib.Option) (gmail.API, error) {
 	switch src.SourceType {
 	case sourceTypeGmail, "":
 		appName := sourceOAuthApp(src)
@@ -278,6 +278,7 @@ func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(str
 
 		var opts []imaplib.Option
 		opts = append(opts, imaplib.WithLogger(logger))
+		opts = append(opts, imapOpts...)
 
 		var since, before time.Time
 		if syncAfter != "" {
@@ -328,8 +329,78 @@ func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(str
 	}
 }
 
+// loadIMAPFolderStates returns the saved per-mailbox states in the map
+// form the IMAP client consumes.
+func loadIMAPFolderStates(s *store.Store, sourceID int64) (map[string]imaplib.FolderState, error) {
+	saved, err := s.GetIMAPFolderStates(sourceID)
+	if err != nil {
+		return nil, err
+	}
+	states := make(map[string]imaplib.FolderState, len(saved))
+	for _, st := range saved {
+		states[st.Mailbox] = imaplib.FolderState{
+			UIDValidity: st.UIDValidity,
+			UIDNext:     st.UIDNext,
+		}
+	}
+	return states, nil
+}
+
+// imapFolderStateOptions loads saved per-mailbox states for an IMAP
+// source so its client can skip unchanged mailboxes during listing.
+// Load failures only cost the optimization, so they are logged and
+// swallowed.
+func imapFolderStateOptions(s *store.Store, src *store.Source) []imaplib.Option {
+	if src.SourceType != sourceTypeIMAP {
+		return nil
+	}
+	states, err := loadIMAPFolderStates(s, src.ID)
+	if err != nil {
+		logger.Warn("failed to load IMAP folder states", "source", src.Identifier, "error", err)
+		return nil
+	}
+	if len(states) == 0 {
+		return nil
+	}
+	return []imaplib.Option{imaplib.WithFolderStates(states)}
+}
+
+// saveIMAPFolderStates persists the per-mailbox states observed during
+// listing, but only after a sync that completed cleanly: an
+// interrupted, truncated (--limit), or partly failed run must not
+// advance the watermarks, or the messages it skipped would never be
+// fetched. Save failures only cost the next run's speedup, so they are
+// logged and swallowed.
+func saveIMAPFolderStates(s *store.Store, src *store.Source, apiClient gmail.API, summary *gmail.SyncSummary, limit int) {
+	imapClient, ok := apiClient.(*imaplib.Client)
+	if !ok || summary == nil {
+		return
+	}
+	if summary.Errors > 0 {
+		return
+	}
+	if limit > 0 && summary.MessagesFound >= int64(limit) {
+		return
+	}
+	observed := imapClient.ObservedFolderStates()
+	if len(observed) == 0 {
+		return
+	}
+	states := make([]store.IMAPFolderState, 0, len(observed))
+	for mailbox, st := range observed {
+		states = append(states, store.IMAPFolderState{
+			Mailbox:     mailbox,
+			UIDValidity: st.UIDValidity,
+			UIDNext:     st.UIDNext,
+		})
+	}
+	if err := s.UpsertIMAPFolderStates(src.ID, states); err != nil {
+		logger.Warn("failed to save IMAP folder states", "source", src.Identifier, "error", err)
+	}
+}
+
 func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), src *store.Source) error {
-	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil)
+	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil, imapFolderStateOptions(s, src)...)
 	if err != nil {
 		return err
 	}
@@ -392,6 +463,10 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 			return nil
 		}
 		return fmt.Errorf("sync failed: %w", err)
+	}
+
+	if src.SourceType == sourceTypeIMAP {
+		saveIMAPFolderStates(s, src, apiClient, summary, opts.Limit)
 	}
 
 	// Print summary

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -348,10 +348,11 @@ func loadIMAPFolderStates(s *store.Store, sourceID int64) (map[string]imaplib.Fo
 
 // imapFolderStateOptions loads saved per-mailbox states for an IMAP
 // source so its client can skip unchanged mailboxes during listing.
-// Load failures only cost the optimization, so they are logged and
-// swallowed.
-func imapFolderStateOptions(s *store.Store, src *store.Source) []imaplib.Option {
-	if src.SourceType != sourceTypeIMAP {
+// forceRescan (--noresume) bypasses the saved states so every mailbox
+// is freshly enumerated. Load failures only cost the optimization, so
+// they are logged and swallowed.
+func imapFolderStateOptions(s *store.Store, src *store.Source, forceRescan bool) []imaplib.Option {
+	if forceRescan || src.SourceType != sourceTypeIMAP {
 		return nil
 	}
 	states, err := loadIMAPFolderStates(s, src.ID)
@@ -400,7 +401,11 @@ func saveIMAPFolderStates(s *store.Store, src *store.Source, apiClient gmail.API
 }
 
 func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), src *store.Source) error {
-	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil, imapFolderStateOptions(s, src)...)
+	// --noresume promises a fresh sync, so it must also bypass the
+	// saved folder watermarks and re-enumerate every mailbox. A clean
+	// completed run still saves fresh watermarks afterwards.
+	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil,
+		imapFolderStateOptions(s, src, syncNoResume)...)
 	if err != nil {
 		return err
 	}
@@ -698,7 +703,7 @@ func imapSkipReason(src *store.Source) (string, error) {
 
 func init() {
 	syncFullCmd.Flags().StringVar(&syncQuery, "query", "", "Gmail search query")
-	syncFullCmd.Flags().BoolVar(&syncNoResume, "noresume", false, "Force fresh sync (don't resume)")
+	syncFullCmd.Flags().BoolVar(&syncNoResume, "noresume", false, "Force fresh sync (don't resume; re-enumerates all IMAP folders)")
 	syncFullCmd.Flags().StringVar(&syncBefore, "before", "", "Only messages before this date (YYYY-MM-DD)")
 	syncFullCmd.Flags().StringVar(&syncAfter, "after", "", "Only messages after this date (YYYY-MM-DD)")
 	syncFullCmd.Flags().IntVar(&syncLimit, "limit", 0, "Limit number of messages (for testing)")

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -39,14 +39,24 @@ func WithDateFilter(since, before time.Time) Option {
 	}
 }
 
+// WithListProgress sets a callback reporting mailbox-enumeration
+// progress during the first ListMessages call of a session. See the
+// listProgress field for the callback contract.
+func WithListProgress(fn func(done, total int, mailbox string, found, unchanged int)) Option {
+	return func(c *Client) { c.listProgress = fn }
+}
+
 // fetchChunkSize is the maximum number of UIDs per UID FETCH command.
 // Large FETCH sets cause server-side timeouts on big mailboxes; chunking
 // keeps each round-trip short.
 const fetchChunkSize = 50
 
-// listPageSize is the number of message IDs returned per ListMessages call.
-// Matches typical Gmail page size so the sync loop checkpoints frequently.
-const listPageSize = 500
+// listPageSize is the number of message IDs returned per ListMessages
+// call. Each page ends with a checkpoint write and a progress update,
+// and IMAP fetches are slow enough (single connection, chunked FETCH)
+// that Gmail-sized 500-message pages left half-minute gaps between
+// progress updates.
+const listPageSize = 100
 
 // Client implements gmail.API for IMAP servers.
 type Client struct {
@@ -70,6 +80,14 @@ type Client struct {
 
 	priorFolderStates    map[string]FolderState // saved states from the last completed sync
 	observedFolderStates map[string]FolderState // states captured during this session's listing
+
+	// listProgress, when set, is invoked during message-list
+	// enumeration: once with done=0 after the mailbox list is known,
+	// then after each mailbox is checked (the final call has
+	// done == total). found is the running message-ID count and
+	// unchanged the running count of mailboxes skipped via saved
+	// folder state.
+	listProgress func(done, total int, mailbox string, found, unchanged int)
 }
 
 // NewClient creates a new IMAP client.
@@ -507,11 +525,8 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 
 	var messages []gmailapi.MessageID
 	var unchangedFolders int
-	for _, mailbox := range listMailboxes {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
 
+	listOne := func(mailbox string) {
 		var minUID imap.UID
 		var observed *FolderState
 		if trackFolders {
@@ -529,7 +544,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 						// no new messages possible, skip enumeration.
 						c.observedFolderStates[mailbox] = status
 						unchangedFolders++
-						continue
+						return
 					}
 					// Only new messages need listing.
 					minUID = imap.UID(prior.UIDNext)
@@ -540,7 +555,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		uids, err := c.enumerateMailbox(ctx, mailbox, minUID)
 		if err != nil {
 			c.logger.Warn("skipping mailbox", "mailbox", mailbox, "error", err)
-			continue
+			return
 		}
 		if observed != nil {
 			c.observedFolderStates[mailbox] = *observed
@@ -552,6 +567,19 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			})
 		}
 		c.logger.Debug("listed mailbox", "mailbox", mailbox, "count", len(uids))
+	}
+
+	if c.listProgress != nil {
+		c.listProgress(0, len(listMailboxes), "", 0, 0)
+	}
+	for i, mailbox := range listMailboxes {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		listOne(mailbox)
+		if c.listProgress != nil {
+			c.listProgress(i+1, len(listMailboxes), mailbox, len(messages), unchangedFolders)
+		}
 	}
 	if unchangedFolders > 0 {
 		c.logger.Info("skipped unchanged mailboxes",

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -67,6 +67,9 @@ type Client struct {
 	seenRFC822IDs    map[string]bool      // dedup across All Mail + Trash/Spam
 	since            time.Time            // IMAP SINCE date filter (zero = no filter)
 	before           time.Time            // IMAP BEFORE date filter (zero = no filter)
+
+	priorFolderStates    map[string]FolderState // saved states from the last completed sync
+	observedFolderStates map[string]FolderState // states captured during this session's listing
 }
 
 // NewClient creates a new IMAP client.
@@ -257,10 +260,12 @@ func (c *Client) listMailboxesLocked() ([]string, error) {
 	return names, nil
 }
 
-// enumerateMailbox lists all UIDs in a single mailbox. It handles
-// network errors with one reconnect attempt.
+// enumerateMailbox lists UIDs in a single mailbox. A non-zero minUID
+// restricts the search to UIDs at or above it (new messages since a
+// saved UIDNEXT watermark). It handles network errors with one
+// reconnect attempt.
 func (c *Client) enumerateMailbox(
-	ctx context.Context, mailbox string,
+	ctx context.Context, mailbox string, minUID imap.UID,
 ) ([]imap.UID, error) {
 	if err := c.selectMailbox(mailbox); err != nil {
 		if isNetworkError(err) {
@@ -285,6 +290,9 @@ func (c *Client) enumerateMailbox(
 	}
 	if !c.before.IsZero() {
 		criteria.Before = c.before
+	}
+	if minUID > 0 {
+		criteria.UID = []imap.UIDSet{{imap.UIDRange{Start: minUID, Stop: 0}}}
 	}
 
 	searchData, err := c.conn.UIDSearch(
@@ -404,7 +412,7 @@ func (c *Client) buildLabelMap(
 			continue
 		}
 
-		uids, err := c.enumerateMailbox(ctx, mailbox)
+		uids, err := c.enumerateMailbox(ctx, mailbox, 0)
 		if err != nil {
 			c.logger.Warn("skipping mailbox for label map",
 				"mailbox", mailbox, "error", err)
@@ -487,16 +495,55 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		}
 	}
 
+	// Folder-state tracking skips unchanged mailboxes via STATUS
+	// UIDVALIDITY/UIDNEXT. Disabled under a date filter (a filtered
+	// run does not fetch everything up to UIDNEXT, so the watermark
+	// would be wrong) and when an \All mailbox exists (the label map
+	// needs full enumeration of every folder).
+	trackFolders := c.since.IsZero() && c.before.IsZero() && c.allMailFolder == ""
+	if trackFolders {
+		c.observedFolderStates = make(map[string]FolderState, len(listMailboxes))
+	}
+
 	var messages []gmailapi.MessageID
+	var unchangedFolders int
 	for _, mailbox := range listMailboxes {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
-		uids, err := c.enumerateMailbox(ctx, mailbox)
+		var minUID imap.UID
+		var observed *FolderState
+		if trackFolders {
+			status, err := c.statusFolder(ctx, mailbox)
+			if err != nil {
+				c.logger.Warn("STATUS failed, enumerating mailbox fully",
+					"mailbox", mailbox, "error", err)
+			} else {
+				observed = &status
+				if prior, ok := c.priorFolderStates[mailbox]; ok &&
+					prior.UIDValidity == status.UIDValidity &&
+					prior.UIDNext <= status.UIDNext {
+					if prior.UIDNext == status.UIDNext {
+						// Unchanged since the last completed sync:
+						// no new messages possible, skip enumeration.
+						c.observedFolderStates[mailbox] = status
+						unchangedFolders++
+						continue
+					}
+					// Only new messages need listing.
+					minUID = imap.UID(prior.UIDNext)
+				}
+			}
+		}
+
+		uids, err := c.enumerateMailbox(ctx, mailbox, minUID)
 		if err != nil {
 			c.logger.Warn("skipping mailbox", "mailbox", mailbox, "error", err)
 			continue
+		}
+		if observed != nil {
+			c.observedFolderStates[mailbox] = *observed
 		}
 		for _, uid := range uids {
 			messages = append(messages, gmailapi.MessageID{
@@ -505,6 +552,10 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			})
 		}
 		c.logger.Debug("listed mailbox", "mailbox", mailbox, "count", len(uids))
+	}
+	if unchangedFolders > 0 {
+		c.logger.Info("skipped unchanged mailboxes",
+			"unchanged", unchangedFolders, "total", len(listMailboxes))
 	}
 
 	c.messageListCache = messages

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -50,62 +50,69 @@ func listAllMessages(t *testing.T, client *Client) []string {
 }
 
 func TestListMessages_RecordsFolderStates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
 	client := newTestClient(t, addr)
 
 	ids := listAllMessages(t, client)
-	assert.Len(t, ids, 5)
+	assert.Len(ids, 5)
 
 	states := client.ObservedFolderStates()
-	require.Contains(t, states, "INBOX")
-	require.Contains(t, states, "Archive")
-	assert.Equal(t, uint32(3), states["INBOX"].UIDNext)
-	assert.Equal(t, uint32(4), states["Archive"].UIDNext)
-	assert.NotZero(t, states["INBOX"].UIDValidity)
+	require.Contains(states, "INBOX")
+	require.Contains(states, "Archive")
+	assert.Equal(uint32(3), states["INBOX"].UIDNext)
+	assert.Equal(uint32(4), states["Archive"].UIDNext)
+	assert.NotZero(states["INBOX"].UIDValidity)
 }
 
 func TestListMessages_SkipsUnchangedFolders(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
 
 	first := newTestClient(t, addr)
-	require.Len(t, listAllMessages(t, first), 5)
+	require.Len(listAllMessages(t, first), 5)
 	saved := first.ObservedFolderStates()
-	require.NoError(t, first.Close())
+	require.NoError(first.Close())
 
 	second := newTestClient(t, addr, WithFolderStates(saved))
 	ids := listAllMessages(t, second)
-	assert.Empty(t, ids, "unchanged folders must not be re-enumerated")
-	assert.Equal(t, saved, second.ObservedFolderStates(),
+	assert.Empty(ids, "unchanged folders must not be re-enumerated")
+	assert.Equal(saved, second.ObservedFolderStates(),
 		"unchanged folders keep their saved state for the next save")
 }
 
 func TestListMessages_ListsOnlyNewMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
 
 	first := newTestClient(t, addr)
-	require.Len(t, listAllMessages(t, first), 5)
+	require.Len(listAllMessages(t, first), 5)
 	saved := first.ObservedFolderStates()
-	require.NoError(t, first.Close())
+	require.NoError(first.Close())
 
 	testutil.AppendIMAPMessage(t, user, "INBOX")
 
 	second := newTestClient(t, addr, WithFolderStates(saved))
 	ids := listAllMessages(t, second)
-	assert.Equal(t, []string{"INBOX|3"}, ids,
+	assert.Equal([]string{"INBOX|3"}, ids,
 		"only the message appended after the saved state should be listed")
 
 	states := second.ObservedFolderStates()
-	assert.Equal(t, uint32(4), states["INBOX"].UIDNext)
-	assert.Equal(t, saved["Archive"], states["Archive"])
+	assert.Equal(uint32(4), states["INBOX"].UIDNext)
+	assert.Equal(saved["Archive"], states["Archive"])
 }
 
 func TestListMessages_UIDValidityChangeForcesFullRescan(t *testing.T) {
+	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
 
 	first := newTestClient(t, addr)
-	require.Len(t, listAllMessages(t, first), 2)
+	require.Len(listAllMessages(t, first), 2)
 	saved := first.ObservedFolderStates()
-	require.NoError(t, first.Close())
+	require.NoError(first.Close())
 
 	// Simulate the server invalidating its UID space.
 	stale := map[string]FolderState{
@@ -118,19 +125,21 @@ func TestListMessages_UIDValidityChangeForcesFullRescan(t *testing.T) {
 }
 
 func TestListMessages_DateFilterDisablesFolderTracking(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
 
 	first := newTestClient(t, addr)
-	require.Len(t, listAllMessages(t, first), 2)
+	require.Len(listAllMessages(t, first), 2)
 	saved := first.ObservedFolderStates()
-	require.NoError(t, first.Close())
+	require.NoError(first.Close())
 
 	since := time.Now().Add(-24 * time.Hour)
 	second := newTestClient(t, addr,
 		WithFolderStates(saved),
 		WithDateFilter(since, time.Time{}))
 	ids := listAllMessages(t, second)
-	assert.Len(t, ids, 2, "date-filtered runs must ignore saved folder states")
-	assert.Nil(t, second.ObservedFolderStates(),
+	assert.Len(ids, 2, "date-filtered runs must ignore saved folder states")
+	assert.Nil(second.ObservedFolderStates(),
 		"date-filtered runs must not record folder states")
 }

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1,0 +1,136 @@
+package imap
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func newTestClient(t *testing.T, addr string, opts ...Option) *Client {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	client := NewClient(&Config{
+		Host:     host,
+		Port:     port,
+		Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword, opts...)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// listAllMessages drains every page of ListMessages.
+func listAllMessages(t *testing.T, client *Client) []string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var ids []string
+	pageToken := ""
+	for {
+		resp, err := client.ListMessages(ctx, "", pageToken)
+		require.NoError(t, err)
+		for _, msg := range resp.Messages {
+			ids = append(ids, msg.ID)
+		}
+		if resp.NextPageToken == "" {
+			return ids
+		}
+		pageToken = resp.NextPageToken
+	}
+}
+
+func TestListMessages_RecordsFolderStates(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
+	client := newTestClient(t, addr)
+
+	ids := listAllMessages(t, client)
+	assert.Len(t, ids, 5)
+
+	states := client.ObservedFolderStates()
+	require.Contains(t, states, "INBOX")
+	require.Contains(t, states, "Archive")
+	assert.Equal(t, uint32(3), states["INBOX"].UIDNext)
+	assert.Equal(t, uint32(4), states["Archive"].UIDNext)
+	assert.NotZero(t, states["INBOX"].UIDValidity)
+}
+
+func TestListMessages_SkipsUnchangedFolders(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
+
+	first := newTestClient(t, addr)
+	require.Len(t, listAllMessages(t, first), 5)
+	saved := first.ObservedFolderStates()
+	require.NoError(t, first.Close())
+
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	ids := listAllMessages(t, second)
+	assert.Empty(t, ids, "unchanged folders must not be re-enumerated")
+	assert.Equal(t, saved, second.ObservedFolderStates(),
+		"unchanged folders keep their saved state for the next save")
+}
+
+func TestListMessages_ListsOnlyNewMessages(t *testing.T) {
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
+
+	first := newTestClient(t, addr)
+	require.Len(t, listAllMessages(t, first), 5)
+	saved := first.ObservedFolderStates()
+	require.NoError(t, first.Close())
+
+	testutil.AppendIMAPMessage(t, user, "INBOX")
+
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	ids := listAllMessages(t, second)
+	assert.Equal(t, []string{"INBOX|3"}, ids,
+		"only the message appended after the saved state should be listed")
+
+	states := second.ObservedFolderStates()
+	assert.Equal(t, uint32(4), states["INBOX"].UIDNext)
+	assert.Equal(t, saved["Archive"], states["Archive"])
+}
+
+func TestListMessages_UIDValidityChangeForcesFullRescan(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+
+	first := newTestClient(t, addr)
+	require.Len(t, listAllMessages(t, first), 2)
+	saved := first.ObservedFolderStates()
+	require.NoError(t, first.Close())
+
+	// Simulate the server invalidating its UID space.
+	stale := map[string]FolderState{
+		"INBOX": {UIDValidity: saved["INBOX"].UIDValidity + 1, UIDNext: saved["INBOX"].UIDNext},
+	}
+
+	second := newTestClient(t, addr, WithFolderStates(stale))
+	ids := listAllMessages(t, second)
+	assert.Len(t, ids, 2, "UIDVALIDITY mismatch must trigger full enumeration")
+}
+
+func TestListMessages_DateFilterDisablesFolderTracking(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+
+	first := newTestClient(t, addr)
+	require.Len(t, listAllMessages(t, first), 2)
+	saved := first.ObservedFolderStates()
+	require.NoError(t, first.Close())
+
+	since := time.Now().Add(-24 * time.Hour)
+	second := newTestClient(t, addr,
+		WithFolderStates(saved),
+		WithDateFilter(since, time.Time{}))
+	ids := listAllMessages(t, second)
+	assert.Len(t, ids, 2, "date-filtered runs must ignore saved folder states")
+	assert.Nil(t, second.ObservedFolderStates(),
+		"date-filtered runs must not record folder states")
+}

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -105,6 +105,44 @@ func TestListMessages_ListsOnlyNewMessages(t *testing.T) {
 	assert.Equal(saved["Archive"], states["Archive"])
 }
 
+type listProgressCall struct {
+	done, total      int
+	mailbox          string
+	found, unchanged int
+}
+
+func TestListMessages_ReportsListProgress(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
+
+	var calls []listProgressCall
+	record := func(done, total int, mailbox string, found, unchanged int) {
+		calls = append(calls, listProgressCall{done, total, mailbox, found, unchanged})
+	}
+
+	first := newTestClient(t, addr, WithListProgress(record))
+	require.Len(listAllMessages(t, first), 5)
+
+	require.Len(calls, 3, "one initial call plus one per mailbox")
+	assert.Equal(listProgressCall{done: 0, total: 2}, calls[0])
+	final := calls[2]
+	assert.Equal(2, final.done)
+	assert.Equal(2, final.total)
+	assert.Equal(5, final.found)
+	assert.Equal(0, final.unchanged)
+
+	// A resync with saved states reports every folder as unchanged.
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+	calls = nil
+	second := newTestClient(t, addr, WithListProgress(record), WithFolderStates(saved))
+	require.Empty(listAllMessages(t, second))
+	final = calls[len(calls)-1]
+	assert.Equal(0, final.found)
+	assert.Equal(2, final.unchanged)
+}
+
 func TestListMessages_UIDValidityChangeForcesFullRescan(t *testing.T) {
 	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -1,0 +1,73 @@
+package imap
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	imap "github.com/emersion/go-imap/v2"
+)
+
+// FolderState is the change-detection state of one mailbox: the
+// UIDVALIDITY/UIDNEXT pair reported by STATUS. Under an unchanged
+// UIDVALIDITY, UIDNEXT only advances when messages are added, so a
+// mailbox whose pair matches the state saved after the last completed
+// sync cannot contain messages the archive has not seen.
+type FolderState struct {
+	UIDValidity uint32
+	UIDNext     uint32
+}
+
+// WithFolderStates provides per-mailbox states saved after the last
+// completed sync. During message listing, mailboxes whose current
+// STATUS matches the saved state are skipped without enumeration, and
+// changed mailboxes are searched only for UIDs at or above the saved
+// UIDNEXT. Ignored when a date filter is active or when the server
+// exposes an \All mailbox (Gmail-style virtual folders need full
+// enumeration for label mapping).
+func WithFolderStates(states map[string]FolderState) Option {
+	return func(c *Client) { c.priorFolderStates = states }
+}
+
+// ObservedFolderStates returns the per-mailbox states captured during
+// the last message-list enumeration, for persistence after a completed
+// sync. Mailboxes whose STATUS or enumeration failed are absent, so
+// saved state for them is left untouched. Returns nil when folder
+// tracking was disabled (date filter, \All mailbox, or no listing yet).
+func (c *Client) ObservedFolderStates() map[string]FolderState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.observedFolderStates == nil {
+		return nil
+	}
+	states := make(map[string]FolderState, len(c.observedFolderStates))
+	maps.Copy(states, c.observedFolderStates)
+	return states
+}
+
+// statusFolder fetches UIDVALIDITY and UIDNEXT for a mailbox via
+// STATUS, retrying once through a reconnect on network errors.
+// Caller must hold mu.
+func (c *Client) statusFolder(ctx context.Context, mailbox string) (FolderState, error) {
+	opts := &imap.StatusOptions{UIDNext: true, UIDValidity: true}
+	data, err := c.conn.Status(mailbox, opts).Wait()
+	if err != nil && isNetworkError(err) {
+		c.logger.Warn("network error during STATUS, reconnecting",
+			"mailbox", mailbox, "error", err)
+		if reconErr := c.reconnect(ctx); reconErr != nil {
+			return FolderState{}, fmt.Errorf(
+				"reconnect failed during STATUS of %q: %w", mailbox, reconErr)
+		}
+		data, err = c.conn.Status(mailbox, opts).Wait()
+	}
+	if err != nil {
+		return FolderState{}, fmt.Errorf("STATUS %q: %w", mailbox, err)
+	}
+	if data.UIDNext == 0 {
+		return FolderState{}, fmt.Errorf("STATUS %q returned no UIDNEXT", mailbox)
+	}
+	return FolderState{
+		UIDValidity: data.UIDValidity,
+		UIDNext:     uint32(data.UIDNext),
+	}, nil
+}

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -501,6 +501,8 @@ func (d *PostgreSQLDialect) IsFTSValueTooLargeError(err error) bool {
 //     and cascade-reachable from sources — a real race before it was added here.
 //   - sync_checkpoints: cascade-reachable from sources; no writer today, but
 //     included so a future checkpoint writer cannot race the cascade.
+//   - imap_folder_state: written by UpsertIMAPFolderStates after IMAP syncs
+//     and cascade-reachable from sources.
 //
 // collections is included (despite not being a direct sources cascade target)
 // so a concurrent collection rename cannot race the collection_sources cascade.
@@ -510,6 +512,7 @@ var exclusiveLockTables = []string{
 	"attachments", "labels", "participants", "participant_identifiers", "reactions",
 	"collections", "collection_sources", "account_identities", "applied_migrations",
 	"source_import_items", "sync_run_items", "sync_checkpoints",
+	"imap_folder_state",
 }
 
 // BeginExclusive opens a transaction on conn and locks every table the

--- a/internal/store/imap_folder_state.go
+++ b/internal/store/imap_folder_state.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"fmt"
+)
+
+// IMAPFolderState records the UIDVALIDITY and UIDNEXT of one IMAP
+// mailbox as observed at the start of the last fully completed sync.
+// A mailbox whose current values match the saved ones has received no
+// new messages since that sync and can be skipped entirely.
+type IMAPFolderState struct {
+	Mailbox     string
+	UIDValidity uint32
+	UIDNext     uint32
+}
+
+// GetIMAPFolderStates returns the saved per-mailbox sync states for a source.
+func (s *Store) GetIMAPFolderStates(sourceID int64) ([]IMAPFolderState, error) {
+	rows, err := s.db.Query(`
+		SELECT mailbox, uidvalidity, uidnext
+		FROM imap_folder_state
+		WHERE source_id = ?
+	`, sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("query imap folder states for source %d: %w", sourceID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var states []IMAPFolderState
+	for rows.Next() {
+		var st IMAPFolderState
+		if err := rows.Scan(&st.Mailbox, &st.UIDValidity, &st.UIDNext); err != nil {
+			return nil, fmt.Errorf("scan imap folder state: %w", err)
+		}
+		states = append(states, st)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate imap folder states: %w", err)
+	}
+	return states, nil
+}
+
+// UpsertIMAPFolderStates saves per-mailbox sync states for a source,
+// overwriting any existing state for the same mailbox. States for
+// mailboxes not in the given slice are left untouched.
+func (s *Store) UpsertIMAPFolderStates(sourceID int64, states []IMAPFolderState) error {
+	for _, st := range states {
+		_, err := s.db.Exec(fmt.Sprintf(`
+			INSERT INTO imap_folder_state (source_id, mailbox, uidvalidity, uidnext, updated_at)
+			VALUES (?, ?, ?, ?, %s)
+			ON CONFLICT(source_id, mailbox) DO UPDATE SET
+				uidvalidity = excluded.uidvalidity,
+				uidnext = excluded.uidnext,
+				updated_at = %s
+		`, s.dialect.Now(), s.dialect.Now()),
+			sourceID, st.Mailbox, st.UIDValidity, st.UIDNext)
+		if err != nil {
+			return fmt.Errorf("upsert imap folder state for %q: %w", st.Mailbox, err)
+		}
+	}
+	return nil
+}

--- a/internal/store/imap_folder_state_test.go
+++ b/internal/store/imap_folder_state_test.go
@@ -10,47 +10,50 @@ import (
 )
 
 func TestIMAPFolderStates_EmptyForNewSource(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	source, err := st.GetOrCreateSource("imap", "folders-empty@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	states, err := st.GetIMAPFolderStates(source.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Empty(t, states)
 }
 
 func TestIMAPFolderStates_RoundTrip(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	source, err := st.GetOrCreateSource("imap", "folders-roundtrip@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	saved := []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 1234, UIDNext: 501},
 		{Mailbox: "Archive/2009", UIDValidity: 99, UIDNext: 100000},
 	}
-	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, saved))
+	require.NoError(st.UpsertIMAPFolderStates(source.ID, saved))
 
 	states, err := st.GetIMAPFolderStates(source.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.ElementsMatch(t, saved, states)
 }
 
 func TestIMAPFolderStates_UpsertOverwrites(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	source, err := st.GetOrCreateSource("imap", "folders-overwrite@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
-	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
+	require.NoError(st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 10},
 		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20},
 	}))
 	// INBOX advances; Sent is untouched by this save.
-	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
+	require.NoError(st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15},
 	}))
 
 	states, err := st.GetIMAPFolderStates(source.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.ElementsMatch(t, []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15},
 		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20},
@@ -58,32 +61,34 @@ func TestIMAPFolderStates_UpsertOverwrites(t *testing.T) {
 }
 
 func TestIMAPFolderStates_IsolatedPerSource(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	a, err := st.GetOrCreateSource("imap", "folders-a@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 	b, err := st.GetOrCreateSource("imap", "folders-b@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
-	require.NoError(t, st.UpsertIMAPFolderStates(a.ID, []store.IMAPFolderState{
+	require.NoError(st.UpsertIMAPFolderStates(a.ID, []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 7, UIDNext: 70},
 	}))
 
 	states, err := st.GetIMAPFolderStates(b.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Empty(t, states)
 }
 
 func TestIMAPFolderStates_MaxUint32Values(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	source, err := st.GetOrCreateSource("imap", "folders-max@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	saved := []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 4294967295, UIDNext: 4294967295},
 	}
-	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, saved))
+	require.NoError(st.UpsertIMAPFolderStates(source.ID, saved))
 
 	states, err := st.GetIMAPFolderStates(source.ID)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal(t, saved, states)
 }

--- a/internal/store/imap_folder_state_test.go
+++ b/internal/store/imap_folder_state_test.go
@@ -1,0 +1,89 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestIMAPFolderStates_EmptyForNewSource(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "folders-empty@example.com")
+	require.NoError(t, err)
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(t, err)
+	assert.Empty(t, states)
+}
+
+func TestIMAPFolderStates_RoundTrip(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "folders-roundtrip@example.com")
+	require.NoError(t, err)
+
+	saved := []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 1234, UIDNext: 501},
+		{Mailbox: "Archive/2009", UIDValidity: 99, UIDNext: 100000},
+	}
+	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, saved))
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, saved, states)
+}
+
+func TestIMAPFolderStates_UpsertOverwrites(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "folders-overwrite@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 10},
+		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20},
+	}))
+	// INBOX advances; Sent is untouched by this save.
+	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15},
+	}))
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15},
+		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20},
+	}, states)
+}
+
+func TestIMAPFolderStates_IsolatedPerSource(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	a, err := st.GetOrCreateSource("imap", "folders-a@example.com")
+	require.NoError(t, err)
+	b, err := st.GetOrCreateSource("imap", "folders-b@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, st.UpsertIMAPFolderStates(a.ID, []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 7, UIDNext: 70},
+	}))
+
+	states, err := st.GetIMAPFolderStates(b.ID)
+	require.NoError(t, err)
+	assert.Empty(t, states)
+}
+
+func TestIMAPFolderStates_MaxUint32Values(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "folders-max@example.com")
+	require.NoError(t, err)
+
+	saved := []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 4294967295, UIDNext: 4294967295},
+	}
+	require.NoError(t, st.UpsertIMAPFolderStates(source.ID, saved))
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(t, err)
+	assert.Equal(t, saved, states)
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -384,6 +384,20 @@ CREATE TABLE IF NOT EXISTS sync_checkpoints (
     PRIMARY KEY (source_id, checkpoint_type)
 );
 
+-- Per-mailbox IMAP sync state from the last fully completed sync.
+-- UIDVALIDITY/UIDNEXT let subsequent syncs skip mailboxes that have
+-- not changed instead of re-enumerating every folder.
+CREATE TABLE IF NOT EXISTS imap_folder_state (
+    source_id INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    mailbox TEXT NOT NULL,
+    uidvalidity INTEGER NOT NULL,
+    uidnext INTEGER NOT NULL,
+
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (source_id, mailbox)
+);
+
 -- Imported source items (files/objects already processed for resumable adapters)
 CREATE TABLE IF NOT EXISTS source_import_items (
     id INTEGER PRIMARY KEY,

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -295,6 +295,17 @@ CREATE TABLE IF NOT EXISTS sync_checkpoints (
     PRIMARY KEY (source_id, checkpoint_type)
 );
 
+CREATE TABLE IF NOT EXISTS imap_folder_state (
+    source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    mailbox TEXT NOT NULL,
+    uidvalidity BIGINT NOT NULL,
+    uidnext BIGINT NOT NULL,
+
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (source_id, mailbox)
+);
+
 CREATE TABLE IF NOT EXISTS source_import_items (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -1,0 +1,66 @@
+package testutil
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	imap "github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+	"github.com/stretchr/testify/require"
+)
+
+// IMAPTestUsername and IMAPTestPassword are the credentials accepted by
+// the server returned from StartIMAPMemServer.
+const (
+	IMAPTestUsername = "alice@example.com"
+	IMAPTestPassword = "secret"
+)
+
+type imapLiteral struct {
+	*bytes.Reader
+}
+
+func (l imapLiteral) Size() int64 { return int64(l.Len()) }
+
+// AppendIMAPMessage appends one synthetic RFC822 message to a mailbox
+// of an in-memory IMAP test user.
+func AppendIMAPMessage(t *testing.T, user *imapmemserver.User, mailbox string) {
+	t.Helper()
+	body := []byte("From: alice@example.com\r\nTo: bob@example.com\r\n\r\nbody\r\n")
+	_, err := user.Append(mailbox, imapLiteral{bytes.NewReader(body)}, &imap.AppendOptions{})
+	require.NoError(t, err)
+}
+
+// StartIMAPMemServer runs an in-memory IMAP server with the given
+// mailboxes and per-mailbox message counts, returning its listen
+// address and the user handle for later mutation. The server is shut
+// down via t.Cleanup.
+func StartIMAPMemServer(t *testing.T, messagesPerMailbox map[string]int) (string, *imapmemserver.User) {
+	t.Helper()
+
+	user := imapmemserver.NewUser(IMAPTestUsername, IMAPTestPassword)
+	for mailbox, count := range messagesPerMailbox {
+		require.NoError(t, user.Create(mailbox, nil))
+		for range count {
+			AppendIMAPMessage(t, user, mailbox)
+		}
+	}
+	memServer := imapmemserver.New()
+	memServer.AddUser(user)
+
+	server := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return memServer.NewSession(), nil, nil
+		},
+		InsecureAuth: true,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = server.Serve(ln) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	return ln.Addr().String(), user
+}


### PR DESCRIPTION
Every IMAP sync re-enumerated every mailbox (SELECT + UID SEARCH per folder) because the client kept no state between sessions, so a resync of a large archive walked every historical folder again.

## What changed

- New `imap_folder_state` table stores each mailbox's UIDVALIDITY/UIDNEXT as of the last fully completed sync (SQLite + PostgreSQL schemas).
- On the next sync, one STATUS per mailbox decides what to do: unchanged pair → folder skipped with no enumeration; UIDNEXT advanced → search only `UID <saved>:*` for new messages; UIDVALIDITY changed → full re-enumeration of that folder.
- Watermarks are saved only after a clean complete run — not after an interrupt, fetch errors, `--limit`, or `--after`/`--before` — so skipped messages always remain eligible for fetch.
- Tracking is disabled when the server advertises an `\All` mailbox (label mapping needs full enumeration there); servers without `\All` (e.g. Fastmail) get the full benefit.
- Both the CLI sync path and the daemon's scheduled IMAP sync use the saved state.

## Usage

No new flags. The first sync that completes after this change saves the per-folder state; subsequent resyncs skip unchanged folders automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)