### PR TITLE
Update nix flake for v0.17.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
   sqlite,
 }:
 let
-  version = "0.16.0";
+  version = "0.17.0";
 in
 buildGoModule {
   pname = "msgvault";


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-CpbYq8AvVdcHUZL+a8RKvqdhJbFORYDSJvF4GAIkx2U=`
- Updated version to `0.17.0`

Automated update via `scripts/update-nix-flake.sh`.