### PR TITLE
docs: document 0.17.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,13 @@ or restore them later:
 
 ```bash
 msgvault backup init --repo ~/Backups/msgvault
-msgvault backup create
-msgvault backup verify --all --quick
-msgvault backup restore --target ~/msgvault-restored
+msgvault backup create --repo ~/Backups/msgvault
+msgvault backup verify --all --quick --repo ~/Backups/msgvault
+msgvault backup restore --target ~/msgvault-restored --repo ~/Backups/msgvault
 ```
+
+Set `repo` under `[backup]` in `config.toml` to omit `--repo` from every
+command after `init`.
 
 See the [Backup guide](https://msgvault.io/usage/backup/) for repository format,
 secret-handling flags, restore proof, and operating recommendations.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,18 @@ Archive a lifetime of email. Analytics and search in milliseconds, entirely offl
 
 Your messages are yours. Decades of correspondence, attachments, and history shouldn't be locked behind a web interface or an API. By default, msgvault downloads a complete local copy and then everything runs offline. Search, analytics, and the MCP server all work against your msgvault archive with no mailbox network access required. If you configure a remote deployment, the archive lives on your own server rather than a hosted msgvault service.
 
-Currently supports Gmail, Google Calendar, and IMAP sync, plus offline imports from MBOX exports and Apple Mail (.emlx) directories.
+Currently supports Gmail, Google Calendar, Microsoft Teams, and IMAP sync, plus
+offline imports from MBOX exports, Apple Mail (.emlx) directories, PST archives,
+and common chat/text export formats.
 
 ## Features
 
 - **Full Gmail backup**: raw MIME, attachments, labels, and metadata
 - **Google Calendar sync**: archive events, organizers, and attendees; searchable alongside email
+- **Microsoft Teams sync**: archive delegated Graph chats, channels, replies, and inline media with `message_type = teams`
 - **IMAP sync**: archive mail from any standard IMAP server
-- **MBOX / Apple Mail import**: import email from MBOX exports or Apple Mail (.emlx) directories
+- **Incremental backup snapshots**: verifiable `msgvault backup` repositories for the SQLite archive and attachments
+- **MBOX / Apple Mail / PST import**: import email from local export formats
 - **Interactive TUI**: drill-down analytics over your entire message history, powered by DuckDB over Parquet — connects to a remote `msgvault serve` instance or runs locally
 - **Full-text search**: FTS5 with Gmail-like query syntax (`from:`, `has:attachment`, date ranges)
 - **MCP server**: access your full archive at the speed of thought in Claude Desktop and other MCP-capable AI agents
@@ -90,8 +94,11 @@ msgvault tui
 | `sync EMAIL` | Sync only new/changed messages |
 | `add-calendar EMAIL` | Authorize read-only Google Calendar access and register calendars |
 | `sync-calendar NAME\|EMAIL` | Sync Google Calendar events (full first run, then incremental) |
+| `add-teams EMAIL` | Authorize delegated Microsoft Graph access for Teams |
+| `sync-teams EMAIL` | Sync Microsoft Teams chats and channels |
+| `backup` | Initialize, create, list, verify, and restore backup snapshots |
 | `tui` | Launch the interactive TUI (`--account` to filter, `--local` to bypass HTTP) |
-| `search QUERY` | Search messages (`--account` to filter, `--json` for machine output) |
+| `search QUERY` | Search messages (`--account` and `--message-type` to filter, `--json` for machine output) |
 | `show-message ID` | View full message details (`--json` for machine output) |
 | `mcp` | Start the MCP server for AI assistant integration |
 | `serve` | Run the API/scheduler or manage the background daemon (`start`, `status`, `stop`, `restart`) |
@@ -200,6 +207,36 @@ msgvault search "standup" --message-type calendar_event
 By default only calendars you own or can write to are synced (add `--all-calendars` for subscribed and holiday calendars). Calendar sync is read-only and never modifies your Google Calendar. Cancelled events are kept (marked cancelled), not deleted, so your archive preserves that a meeting once existed. The Calendar API must be enabled on your Google Cloud OAuth project.
 
 Msgvault stores Google OAuth refresh tokens under the Msgvault home directory with file permissions restricted to the current user. Tokens and client secrets are not written into `config.toml`, logs, README examples, or exported fixtures.
+
+### Microsoft Teams
+
+Archive Microsoft Teams chats and channels through delegated Microsoft Graph
+sync. Teams uses the `[microsoft]` OAuth app config but stores a separate
+`teams_<email>.json` token from Outlook/IMAP OAuth.
+
+```bash
+msgvault add-teams user@example.com
+msgvault sync-teams user@example.com
+msgvault search "incident review" --message-type teams
+```
+
+See the [Microsoft Teams guide](https://msgvault.io/usage/teams/) for Graph
+permissions, scheduling, channel sync behavior, and inline media backfill.
+
+### Backup Snapshots
+
+Create an append-only backup repository, take incremental snapshots, and verify
+or restore them later:
+
+```bash
+msgvault backup init --repo ~/Backups/msgvault
+msgvault backup create
+msgvault backup verify --all --quick
+msgvault backup restore --target ~/msgvault-restored
+```
+
+See the [Backup guide](https://msgvault.io/usage/backup/) for repository format,
+secret-handling flags, restore proof, and operating recommendations.
 
 ## Configuration
 

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -155,6 +155,7 @@ Paginated message list.
     {
       "id": 12345,
       "subject": "Q4 Planning",
+      "message_type": "email",
       "from": "alice@example.com",
       "to": ["bob@example.com"],
       "cc": ["carol@example.com"],
@@ -170,6 +171,61 @@ Paginated message list.
 
 ---
 
+### Filter messages {#get-apiv1messagesfilter}
+
+**Endpoint:** `GET /api/v1/messages/filter`
+
+List messages with structured filters backed by the query engine. This is the
+API equivalent of drilling into aggregate/search results and is the endpoint to
+use for message-type filtering when you do not need full-text ranking.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `sender` / `sender_name` | string | — | Sender address/phone or display-name filter |
+| `recipient` / `recipient_name` | string | — | Recipient address/phone or display-name filter |
+| `domain` | string | — | Participant domain filter |
+| `label` | string | — | Label filter |
+| `message_type` | string | — | Stored message type, for example `email`, `teams`, `calendar_event`, or `sms` |
+| `source_id` | int | — | Restrict to one source |
+| `conversation_id` | int | — | Restrict to one conversation/thread |
+| `after` / `before` | date | — | RFC3339 or `YYYY-MM-DD` bounds |
+| `attachments_only` | bool | `false` | Only include messages with attachments |
+| `hide_deleted` | bool | `false` | Exclude messages marked deleted at the source |
+| `offset` | int | `0` | Zero-based row offset |
+| `limit` | int | `500` | Maximum rows to return; capped at 500 outside conversation fetches |
+| `sort` | enum | `date` | `date`, `size`, or `subject` |
+| `direction` | enum | `desc` | `asc` or `desc` |
+
+**Response:**
+
+```json
+{
+  "count": 1,
+  "has_more": false,
+  "offset": 0,
+  "limit": 500,
+  "messages": [
+    {
+      "id": 12345,
+      "subject": "Incident review",
+      "message_type": "teams",
+      "from": "alice@example.com",
+      "to": [],
+      "sent_at": "2026-07-01T15:30:00Z",
+      "snippet": "Follow-up from the channel discussion...",
+      "labels": [],
+      "has_attachments": false,
+      "size_bytes": 0
+    }
+  ]
+}
+```
+
+The companion `GET /api/v1/messages/gmail-ids` endpoint accepts the same filter
+parameters and returns matching Gmail source message IDs for email workflows.
+
+---
+
 ### Message details {#get-apiv1messagesid}
 
 **Endpoint:** `GET /api/v1/messages/{id}`
@@ -182,6 +238,7 @@ Full message details including body and attachment metadata.
 {
   "id": 12345,
   "subject": "Q4 Planning",
+  "message_type": "email",
   "from": "alice@example.com",
   "to": ["bob@example.com"],
   "cc": ["carol@example.com"],
@@ -251,7 +308,16 @@ to `mode=fts` instead.
 | `mode` | enum | `fts` | `fts`, `vector`, or `hybrid` |
 | `page` | int | `1` | Page number (FTS only — vector/hybrid reject `page>1`) |
 | `page_size` | int | `20` | Results per page (max 100 for FTS, max `[vector].search.max_page_size_hybrid` for vector/hybrid) |
+| `message_type` | string | — | Message-type filter; repeat or comma-separate for multiple values |
+| `account` | string | — | Restrict to one account/source |
+| `collection` | string | — | Restrict to one collection |
 | `explain` | 0/1 | `0` | When `1` and `mode=vector|hybrid`, include per-signal scores |
+
+`message_type` uses the same values as local search: `email`,
+`calendar_event`, `teams`, `sms`, `mms`, `whatsapp`, `imessage`,
+`fbmessenger`, `synctech_sms_call`, `google_voice_text`,
+`google_voice_call`, and `google_voice_voicemail`. The query string can also
+carry `message_type:` / `message_type=` operators inside `q`.
 
 **Response (mode=fts, default):**
 
@@ -265,6 +331,7 @@ to `mode=fts` instead.
     {
       "id": 12345,
       "subject": "Q4 Planning",
+      "message_type": "email",
       "from": "alice@example.com",
       "to": ["bob@example.com"],
       "cc": ["carol@example.com"],
@@ -298,6 +365,7 @@ to `mode=fts` instead.
     {
       "id": 12345,
       "subject": "Q2 planning offsite agenda",
+      "message_type": "email",
       "from": "alice@example.com",
       "to": ["team@example.com"],
       "sent_at": "2024-01-15T10:30:00Z",

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -221,8 +221,14 @@ use for message-type filtering when you do not need full-text ranking.
 }
 ```
 
-The companion `GET /api/v1/messages/gmail-ids` endpoint accepts the same filter
-parameters and returns matching Gmail source message IDs for email workflows.
+The companion `GET /api/v1/messages/gmail-ids` endpoint returns matching Gmail
+source message IDs for email workflows such as deletion staging. It honors a
+subset of these parameters: `sender` / `sender_name`, `recipient` /
+`recipient_name`, `domain`, `label`, `source_id`, and `limit`. Results are
+always restricted to Gmail sources, exclude deleted messages, and are ordered
+newest-first; the remaining `/messages/filter` parameters (`message_type`,
+`conversation_id`, `after` / `before`, `attachments_only`, `hide_deleted`,
+`offset`, `sort`, `direction`) are ignored.
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -3,7 +3,7 @@ title: Architecture Overview
 description: Package structure and data flow.
 ---
 
-msgvault syncs your Gmail, IMAP, and Microsoft 365 accounts to a local SQLite database by default and can import local PST/MBOX archives, Apple Mail exports, and chats/texts from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore. PostgreSQL is available as an opt-in backend for new archives. Keyword search, analytics, the TUI, and the MCP server run against the configured archive database, Parquet metadata exports where available, and local attachment files. Optional vector search calls the embedding endpoint configured in `[vector.embeddings]` to build/query semantic vectors, then stores those vectors in `vectors.db` on SQLite or pgvector tables on PostgreSQL.
+msgvault syncs your Gmail, Google Calendar, IMAP, Microsoft 365 mail, and Microsoft Teams accounts to a local SQLite database by default and can import local PST/MBOX archives, Apple Mail exports, and chats/texts from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore. PostgreSQL is available as an opt-in backend for new archives. Keyword search, analytics, the TUI, and the MCP server run against the configured archive database, Parquet metadata exports where available, and local attachment files. Optional vector search calls the embedding endpoint configured in `[vector.embeddings]` to build/query semantic vectors, then stores those vectors in `vectors.db` on SQLite or pgvector tables on PostgreSQL.
 
 <img src="/assets/static/how-it-works.svg" alt="msgvault architecture: Gmail API syncs to SQLite, then offline Parquet analytics, FTS5 search, TUI, and MCP Server" style="width: 100%; max-width: 960px; margin: 1.5rem auto; display: block;" />
 
@@ -17,8 +17,12 @@ msgvault/
 │   ├── tui/                 # Bubble Tea TUI
 │   ├── query/               # DuckDB/SQL query engines
 │   ├── store/               # SQLite/PostgreSQL database access
+│   ├── backup/              # Snapshot repository capture/verify/restore
+│   ├── pack/                # Backup pack-file encoding
 │   ├── deletion/            # Deletion staging and manifest
 │   ├── gmail/               # Gmail API client
+│   ├── gcal/                # Google Calendar API client
+│   ├── calsync/             # Google Calendar sync orchestration
 │   ├── sync/                # Sync orchestration
 │   ├── imap/                # IMAP client (go-imap/v2)
 │   ├── importer/            # Local email import orchestration
@@ -34,6 +38,7 @@ msgvault/
 │   ├── fbmessenger/         # Facebook Messenger DYI import
 │   ├── synctechsms/         # SMS Backup & Restore import
 │   ├── microsoft/           # Microsoft 365 OAuth
+│   ├── teams/               # Microsoft Teams Graph ingestion
 │   ├── oauth/               # OAuth2 flows (browser + device)
 │   └── mime/                # MIME parsing
 ├── go.mod
@@ -46,7 +51,10 @@ msgvault/
 |---|---|
 | `cmd/` | Cobra CLI commands, config loading |
 | `internal/store` | SQLite and PostgreSQL database operations, schema management |
+| `internal/backup` | Backup repository snapshots, manifests, verification, and restore |
+| `internal/pack` | Backup pack-file framing, compression, and object integrity |
 | `internal/sync` | Sync orchestration, MIME parsing, checkpoint management |
+| `internal/gcal` / `internal/calsync` | Google Calendar API client and event sync |
 | `internal/imap` | IMAP client, connection management, credential storage |
 | `internal/importer` | Local email import orchestration and message ingestion |
 | `internal/mbox` | MBOX format reader (mboxo/mboxrd) |
@@ -66,6 +74,7 @@ msgvault/
 | `internal/fbmessenger` | Facebook Messenger Download Your Information parsing and import |
 | `internal/synctechsms` | SMS Backup & Restore XML/ZIP parsing and Drive source sync |
 | `internal/microsoft` | Microsoft 365 OAuth flow |
+| `internal/teams` | Microsoft Teams Graph client mapping, sync cursors, and importer |
 | `internal/mime` | MIME message parsing, charset detection |
 
 ## Design Decisions

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -24,7 +24,7 @@ All message data (metadata, labels, participants, and raw MIME) lives in the con
 | Column | Type | Description |
 |---|---|---|
 | `id` | INTEGER PK | Auto-increment |
-| `source_type` | TEXT | `gmail`, `imap`, `mbox`, `pst`, `apple-mail`, `whatsapp`, `apple_messages`, `google_voice`, `facebook_messenger`, `synctech_sms` |
+| `source_type` | TEXT | `gmail`, `imap`, `gcal`, `teams`, `mbox`, `pst`, `apple-mail`, `whatsapp`, `apple_messages`, `google_voice`, `facebook_messenger`, `synctech_sms` |
 | `identifier` | TEXT | Email address or phone number |
 | `display_name` | TEXT | Account display name |
 | `sync_cursor` | TEXT | Sync cursor (Gmail history ID for Gmail accounts) |
@@ -49,7 +49,7 @@ All message data (metadata, labels, participants, and raw MIME) lives in the con
 | `conversation_id` | INTEGER FK | References `conversations` |
 | `source_id` | INTEGER FK | References `sources` |
 | `source_message_id` | TEXT | Source-specific message ID |
-| `message_type` | TEXT | `email`, `whatsapp`, `imessage`, `google_voice_text`, `teams` |
+| `message_type` | TEXT | `email`, `calendar_event`, `teams`, `sms`, `mms`, `whatsapp`, `imessage`, `fbmessenger`, `synctech_sms_call`, `google_voice_text`, `google_voice_call`, `google_voice_voicemail` |
 | `sent_at` | DATETIME | Send timestamp |
 | `sender_id` | INTEGER FK | References `participants` |
 | `subject` | TEXT | Message subject |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,8 +7,40 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
+No notable changes yet.
+
+---
+
+## 0.17.0
+<small>2026-07-04</small>
+
 **New features**
 
+- `msgvault backup` adds incremental, verifiable archive snapshots with
+  `init`, `create`, `list`, `verify`, and `restore`. Snapshots capture the
+  SQLite database, attachments, deletion audit files, and optional config/token
+  extras into an append-only repository with byte-level verification.
+- Google Calendar archive support via `msgvault add-calendar` and
+  `msgvault sync-calendar`, including read-only event sync, recurring series,
+  cancellations, scheduled `[[gcal]]` sync, and search with
+  `--message-type calendar_event`.
+- Microsoft Teams archive support via delegated Microsoft Graph sync.
+  `msgvault add-teams` authorizes Graph access, `msgvault sync-teams` imports
+  chats and channels, Teams messages are stored with `message_type = teams`,
+  and `backfill-teams-media` can re-fetch hosted inline media for already
+  imported messages.
+- Search and query paths now understand message-type scoping. Local search
+  accepts `message_type:` / `message_type=` query operators and the
+  `--message-type` flag; HTTP, MCP, aggregate, and SQL-backed query surfaces
+  expose the stored `message_type` so email, calendar events, text messages,
+  Teams messages, and other imported records can be separated cleanly.
+- Scoped embedding builds can restrict a vector generation to selected message
+  types through `[vector.embed.scope].message_types`, with vector/hybrid search
+  rejecting incompatible unscoped queries instead of treating a partial index as
+  complete.
+- The HTTP API is now generated through Huma with a checked-in OpenAPI contract
+  (`msgvault openapi`, `/openapi.json`) and a generated Go client under
+  `pkg/client`.
 - Archive-access CLI commands now route through a msgvault daemon (the
   configured remote server, or a local background daemon that starts on
   demand and idles out after `[server].daemon_idle_timeout`). The daemon is
@@ -19,18 +51,26 @@ All notable changes to msgvault, grouped by release.
 - Daemon lifecycle management via `msgvault serve start|status|stop|restart`,
   with automatic restart of older local daemons on binary upgrade
   (`[server].daemon_auto_restart`).
-- The HTTP API is now generated through Huma with a checked-in OpenAPI
-  contract (`msgvault openapi`, `/openapi.json`) and a generated Go client
-  under `pkg/client`.
-- Google Calendar archive support via `msgvault add-calendar` and
-  `msgvault sync-calendar`, including read-only event sync, recurring series,
-  cancellations, scheduled `[[gcal]]` sync, and search with
-  `--message-type calendar_event`.
 
 **Improvements**
 
-- Scoped embedding generations can target selected message types, and local
-  full-text search now honors `--message-type` filters consistently.
+- IMAP resyncs skip unchanged folders using the mailbox `UIDVALIDITY` and
+  `UIDNEXT` values captured after the previous completed sync.
+- `msgvault serve stop` now explains long shutdown waits by reporting the
+  daemon operation it is waiting for and periodically printing elapsed wait
+  updates.
+- MCP `get_message` reads large message bodies in windows instead of loading
+  the whole body at once.
+- Vector embedding maintenance no longer uses a separate pending queue.
+  Coverage is tracked per message with `embed_gen`, so rebuilds, repairs, and
+  daemon top-ups all share the same scan-and-fill path.
+- Full-sync batch errors are counted and persisted on the sync run, making
+  source status and diagnostics more accurate after partial failures.
+- The documentation site now lives in the repository, including CLI, API,
+  setup, backup, calendar, daemon, PostgreSQL, and vector-search docs plus the
+  docs build/check scripts.
+- macOS users can install through Homebrew with `brew install msgvault`.
+- The TUI migration to Bubble Tea v2 is complete.
 
 **Deprecations**
 
@@ -38,6 +78,45 @@ All notable changes to msgvault, grouped by release.
   `mcp --force-sql`, and `mcp --no-sqlite-scanner` are deprecated (removal
   planned for a later release); engine and cache selection moved to the
   `[analytics]` config section.
+
+**Bug fixes**
+
+- MCP list/search requests now reject Gmail-only `list:` / `List-ID` search
+  operators instead of treating them as local full-text terms.
+- DuckDB query engines re-probe Parquet schema columns when the cache is
+  rebuilt or replaced underneath a running process.
+- Empty `subject:` and empty text search terms no longer match every message.
+- Facebook Messenger imports preserve multiple attachments on one message
+  instead of collapsing them into a single row.
+- Imported message and reaction timestamps are normalized to UTC.
+- TUI startup avoids mixed SQLite access while the daemon owns archive writes.
+- API server documentation no longer overflows its sidebar on narrow layouts.
+- Release publishing and the Nix update flow were corrected for the new module
+  and release packaging.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for the backup repository
+  commands, daemon-only CLI routing, daemon lifecycle/status improvements,
+  IMAP folder-state skipping, the in-repo documentation site, OpenAPI/client
+  generation, API docs polish, TUI startup fix, and release/Nix publishing
+  fixes.
+- Thanks to [danshapiro](https://github.com/danshapiro) for Google Calendar
+  sync, message-type filters, scoped embedding builds, and persisted full-sync
+  batch error counts.
+- Thanks to [Nat Torkington](https://github.com/njt) for Microsoft Teams
+  ingestion and the Facebook Messenger multi-attachment fix.
+- Thanks to [Yuriy Grinberg](https://github.com/webgress) for replacing the
+  pending embedding queue with per-message embedding generations.
+- Thanks to [endolith](https://github.com/endolith) for windowed MCP message
+  body reads.
+- Thanks to [Lazare Rossillon](https://github.com/Lazare-42) for re-probing
+  Parquet schemas when the analytics cache changes underneath a running query
+  engine.
+- Thanks to [Matthew Sweeney](https://github.com/sweenzor) for the Homebrew
+  installation instructions.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
+  finishing the Bubble Tea v2 TUI migration.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,8 +59,8 @@ No notable changes yet.
 - `msgvault serve stop` now explains long shutdown waits by reporting the
   daemon operation it is waiting for and periodically printing elapsed wait
   updates.
-- MCP `get_message` reads large message bodies in windows instead of loading
-  the whole body at once.
+- MCP `get_message` returns large message bodies in windows instead of
+  returning the whole body in one response.
 - Vector embedding maintenance no longer uses a separate pending queue.
   Coverage is tracked per message with `embed_gen`, so rebuilds, repairs, and
   daemon top-ups all share the same scan-and-fill path.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -488,13 +488,15 @@ repository.
 
 ```bash
 msgvault backup init --repo ~/Backups/msgvault
-msgvault backup create
-msgvault backup list
-msgvault backup verify
-msgvault backup restore --target ~/msgvault-restored
+msgvault backup create --repo ~/Backups/msgvault
+msgvault backup list --repo ~/Backups/msgvault
+msgvault backup verify --repo ~/Backups/msgvault
+msgvault backup restore --target ~/msgvault-restored --repo ~/Backups/msgvault
 ```
 
-Every backup subcommand accepts `--repo` to override `[backup].repo`.
+Every backup subcommand requires a repository: pass `--repo`, or set
+`[backup].repo` in `config.toml` to omit it. `backup init` initializes the
+repository directory but does not modify `config.toml`.
 `backup create` is routed through the selected daemon so the daemon can freeze a
 consistent SQLite snapshot while it scans pages and attachments. `backup verify`
 and `backup restore` run locally against the repository because they do not

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -122,6 +122,30 @@ After adding the account, sync it with `msgvault sync-full`.
 
 ---
 
+## add-teams
+
+Authorize a Microsoft Teams account through delegated Microsoft Graph OAuth and
+register a `teams` source.
+
+```bash
+msgvault add-teams <email>
+msgvault add-teams <email> --tenant <tenant-id>
+```
+
+This stores a Teams Graph token under `tokens/teams_<email>.json`, separate from
+the Microsoft IMAP token used by `add-o365`. Requires `[microsoft].client_id` in
+`config.toml` and the Graph permissions documented in
+[Microsoft Teams](/usage/teams/).
+
+| Flag | Default | Description |
+|---|---|---|
+| `--tenant` | `common` | Azure AD tenant ID to use for authorization |
+| `--no-default-identity` | `false` | Do not auto-confirm the email address as this source's "me" identity |
+
+After adding the account, sync it with `msgvault sync-teams`.
+
+---
+
 ## sync-full
 
 Download all messages from a Gmail or IMAP account. When called without an email argument, syncs all configured syncable accounts.
@@ -160,6 +184,52 @@ daemon serializes this work with other archive mutations.
 
 ---
 
+## sync-teams
+
+Sync Microsoft Teams chats and channels for an authorized account.
+
+```bash
+msgvault sync-teams <email>
+msgvault sync-teams <email> --no-channels
+msgvault sync-teams <email> --limit 100
+msgvault sync-teams <email> --full
+```
+
+Full versus incremental sync is detected from stored cursors and checkpoints.
+`--full` ignores those cursors and re-fetches messages, upserting rows in place
+so importer upgrades can repair existing data without creating duplicates.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--no-channels` | `false` | Sync chats only and skip team channels |
+| `--limit` | `0` | Maximum messages per conversation (`0` = unlimited) |
+| `--full` | `false` | Ignore stored cursor and re-fetch every message |
+
+See [Microsoft Teams](/usage/teams/) for setup, scheduling, search, and inline
+media backfill.
+
+---
+
+## backfill-teams-media
+
+Re-fetch Microsoft Teams inline hosted-content media for already imported
+messages.
+
+```bash
+msgvault backfill-teams-media <email>
+msgvault backfill-teams-media <email> --only-incomplete
+```
+
+The command scans stored Teams HTML bodies for Graph `hostedContents` URLs and
+downloads those images into the attachment store. It is idempotent because
+attachments are content-addressed.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--only-incomplete` | `false` | Retry only messages whose inline media is still missing |
+
+---
+
 ## add-calendar
 
 Authorize read-only Google Calendar access for an account and register its calendars for sync. If the account already has a Gmail token, re-consent bundles Gmail + Calendar so Gmail access is not dropped — keep both checked on the consent screen. The Calendar API must be enabled on the OAuth project. By default only owned/writable calendars are registered.
@@ -180,7 +250,7 @@ msgvault add-calendar <email> [flags]
 
 ## sync-calendar
 
-Sync Google Calendar events for an account. The account is resolved from a `[[gcal]]` config entry (by name or email) or used directly as an email. The first run (or `--full`) does a full sync that registers calendars; later runs are incremental via the Calendar `syncToken`. Events are stored as searchable records (`message_type = calendar_event`) and embedded for semantic search when vector search is enabled. Cancelled events are retained and marked cancelled, never deleted. Sync is read-only.
+Sync Google Calendar events for an account. The account is resolved from a `[[gcal]]` config entry (by name or email) or used directly as an email. The first run (or `--full`) does a full sync that registers calendars; later runs are incremental via the Calendar `syncToken`. Events are stored as searchable records (`message_type = calendar_event`) and become eligible for semantic search when the embedding worker runs. Cancelled events are retained and marked cancelled, never deleted. Sync is read-only.
 
 ```bash
 msgvault sync-calendar <name|email> [flags]
@@ -411,6 +481,93 @@ msgvault sync-synctech-sms <name>
 
 ---
 
+## backup
+
+Create, list, verify, and restore incremental archive snapshots in a backup
+repository.
+
+```bash
+msgvault backup init --repo ~/Backups/msgvault
+msgvault backup create
+msgvault backup list
+msgvault backup verify
+msgvault backup restore --target ~/msgvault-restored
+```
+
+Every backup subcommand accepts `--repo` to override `[backup].repo`.
+`backup create` is routed through the selected daemon so the daemon can freeze a
+consistent SQLite snapshot while it scans pages and attachments. `backup verify`
+and `backup restore` run locally against the repository because they do not
+write the live archive.
+
+### backup init
+
+```bash
+msgvault backup init --repo <dir>
+```
+
+| Flag | Description |
+|---|---|
+| `--repo <dir>` | Backup repository directory |
+
+### backup create
+
+```bash
+msgvault backup create [flags]
+```
+
+| Flag | Description |
+|---|---|
+| `--repo <dir>` | Backup repository directory |
+| `--include-config` | Include `config.toml` verbatim; may contain API keys |
+| `--include-tokens` | Include OAuth token files |
+| `--allow-plaintext-secrets` | Allow config/tokens in an unencrypted repository |
+| `--tag <text>` | Optional label recorded on the snapshot manifest |
+| `--force-unlock` | Break a stale exclusive repository lock before creating |
+| `--jobs N` | Concurrent attachment capture workers; `0` uses one per CPU |
+
+### backup list
+
+```bash
+msgvault backup list [--repo <dir>]
+```
+
+Prints snapshot ID, creation time, message count, bytes added, and tag.
+
+### backup verify
+
+```bash
+msgvault backup verify [snapshot] [flags]
+```
+
+| Flag | Description |
+|---|---|
+| `--repo <dir>` | Backup repository directory |
+| `--all` | Verify every snapshot instead of only the latest |
+| `--quick` | Skip reading and hash-verifying content blobs |
+| `--force-unlock` | Break a stale exclusive repository lock before verifying |
+| `--jobs N` | Concurrent pack readers; `0` uses one per CPU |
+
+### backup restore
+
+```bash
+msgvault backup restore [snapshot] --target <dir> [flags]
+```
+
+| Flag | Description |
+|---|---|
+| `--repo <dir>` | Backup repository directory |
+| `--target <dir>` | Directory to restore into (required) |
+| `--overwrite` | Allow restoring into a non-empty target directory |
+| `--force-unlock` | Break a stale exclusive repository lock before restoring |
+| `--jobs N` | Concurrent pack readers; `0` uses one per CPU |
+
+Restoring into the live archive home of a running daemon is refused. See
+[Backup](/usage/backup/) for repository format, scheduling, verification, and
+privacy details.
+
+---
+
 ## search
 
 Search the archive with Gmail-like query syntax. Supports keyword (FTS5), semantic, and hybrid modes.
@@ -426,6 +583,7 @@ msgvault search <query> [flags]
 | `--json` | Output results as JSON |
 | `--account` | Limit results to a specific account |
 | `--collection` | Limit results to all member accounts of a collection |
+| `--message-type` | Limit results to one or more message types, e.g. `email`, `teams`, `calendar_event`, `sms` |
 | `--mode` | Search mode: `fts` (default), `vector`, or `hybrid`. `vector` and `hybrid` require vector search to be configured. |
 | `--explain` | Include per-signal scores (RRF, BM25, vector) in the output. Only applies to `--mode vector` and `--mode hybrid`. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,11 @@ daemon_auto_restart = "newer" # newer, never, or always
 engine = "auto"
 auto_build_cache = true
 
+[backup]
+# Default repository for `msgvault backup`.
+repo = "~/Backups/msgvault"
+zstd_level = 0
+
 [remote]
 # Remote msgvault endpoint for CLI remote mode
 url = "http://nas-ip:8080"
@@ -99,6 +104,10 @@ strip_html = true
 strip_base64 = true
 strip_url_tracking = true
 collapse_whitespace = true
+
+[vector.embed.scope]
+# Empty means embed the full archive. Set this for partial generations.
+message_types = ["sms", "mms"]
 
 [[synctech_sms.sources]]
 name = "phone-backups"
@@ -157,14 +166,15 @@ When `service_account_key` is configured, `msgvault add-account <email>` validat
 
 ### `[microsoft]`
 
-Configuration for Microsoft 365 / Outlook.com OAuth. Required only if you use `add-o365`.
+Configuration for Microsoft 365 / Outlook.com OAuth and Microsoft Teams Graph
+sync. Required only if you use `add-o365`, `add-teams`, or `sync-teams`.
 
 | Key | Default | Description |
 |---|---|---|
 | `client_id` | — | Azure AD Application (client) ID (required) |
 | `tenant_id` | `common` | Azure AD tenant ID; `common` allows both personal and org accounts |
 
-See [OAuth Setup: Microsoft 365](/guides/oauth-setup/#microsoft-365-outlook-hotmail) for app registration steps.
+See [OAuth Setup: Microsoft 365](/guides/oauth-setup/#microsoft-365-outlook-hotmail) for app registration steps. Teams uses the same `client_id` but requests Microsoft Graph scopes and stores tokens under `tokens/teams_<email>.json`; Outlook/Hotmail IMAP OAuth uses `tokens/microsoft_<email>.json`.
 
 ### `[log]`
 
@@ -220,6 +230,16 @@ Settings for daemon-side aggregate query behavior. The TUI, MCP server, and aggr
 | `auto_build_cache` | `true` | Build a stale or missing Parquet cache before the daemon opens DuckDB for aggregate views |
 
 Deprecated in 0.17.0: per-command analytics flags such as `msgvault tui --force-sql`, `msgvault mcp --force-sql`, `msgvault tui --no-cache-build`, and `--no-sqlite-scanner` were replaced by this daemon-level section. Use `engine = "sql"` for live SQL, `auto_build_cache = false` to skip automatic daemon cache builds, or `msgvault build-cache` to prebuild cache files on the daemon host. If `engine = "duckdb"` and the cache cannot be built or opened, `msgvault serve` fails instead of silently falling back.
+
+### `[backup]`
+
+Default settings for `msgvault backup`. See [Backup](/usage/backup/) for the
+capture, verify, and restore workflow.
+
+| Key | Default | Description |
+|---|---|---|
+| `repo` | — | Default backup repository directory used when a backup subcommand omits `--repo` |
+| `zstd_level` | `0` | Compression level for backup pack files. `0` uses msgvault's built-in default; otherwise use `1` through `19` |
 
 ### `[remote]`
 
@@ -339,6 +359,23 @@ Hybrid ranking parameters applied at query time.
 | `k_per_signal` | `100` | Candidate pool size drawn from each signal (BM25 or vector) before fusion. |
 | `subject_boost` | `2.0` | Multiplier applied when a query term matches a message's subject line. |
 | `max_page_size_hybrid` | `50` | Hard cap on `page_size` for vector/hybrid responses. Set to `0` to disable clamping. |
+
+#### `[vector.embed.scope]`
+
+Optional scope for newly built embedding generations. The zero value embeds the
+full archive. A scoped generation embeds only matching `messages.message_type`
+values:
+
+```toml
+[vector.embed.scope]
+message_types = ["teams"]
+```
+
+Scoped generations are intentionally partial. Vector and hybrid queries against
+a scoped index must include a compatible `message_type` filter, such as
+`msgvault search "release planning" --mode hybrid --message-type teams`; an
+unscoped vector/hybrid query returns `index_scope_mismatch` instead of using the
+partial index as if it covered the full archive.
 
 #### `[vector.embed.schedule]`
 

--- a/docs/guides/oauth-setup.md
+++ b/docs/guides/oauth-setup.md
@@ -297,8 +297,36 @@ Personal accounts (hotmail.com, outlook.com, live.com, msn.com) connect to `outl
 To restrict to a specific tenant at authorization time:
 
 ```bash
-msgvault add-o365 you@company.com --tenant your-org-tenant-id
+msgvault add-o365 you@example.com --tenant your-org-tenant-id
 ```
+
+### Microsoft Teams Graph Sync
+
+Teams ingestion uses the same `[microsoft] client_id` and redirect URI, but it
+requests Microsoft Graph delegated scopes and stores a separate token file under
+`tokens/teams_<email>.json`. The `microsoft_<email>.json` token created by
+`add-o365` is for IMAP and is not reused for Teams.
+
+If you will archive Teams chats and channels, add these **Microsoft Graph**
+delegated permissions to the app registration:
+
+- `Chat.Read`
+- `ChannelMessage.Read.All`
+- `Team.ReadBasic.All`
+- `Channel.ReadBasic.All`
+- `User.Read`
+- `User.ReadBasic.All`
+
+Then authorize and sync Teams:
+
+```bash
+msgvault add-teams you@example.com
+msgvault sync-teams you@example.com
+```
+
+Some organizations require administrator consent before delegated channel
+message permissions can be used. See [Microsoft Teams](/usage/teams/) for the
+full Teams workflow.
 
 ### Sync Your Email
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: msgvault
-description: Offline email and message archive with full-text search, interactive TUI, and multi-account support. Import from Gmail, IMAP, PST, MBOX, Apple Mail, WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore.
+description: Offline email and message archive with full-text search, interactive TUI, backup snapshots, and multi-account support. Sync Gmail, IMAP, Google Calendar, and Microsoft Teams; import PST, MBOX, Apple Mail, WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore.
 ---
 
 # msgvault
@@ -18,8 +18,9 @@ search, and local AI workflows.
   <img src="/assets/generated/tui-senders.svg" alt="msgvault TUI showing the Senders view" loading="eager">
 </figure>
 
-Supports Gmail sync, Google Calendar sync, IMAP, Microsoft 365, PST import, MBOX
-import, Apple Mail import, and chat/text import (WhatsApp, iMessage, Google Voice,
+Supports Gmail sync, Google Calendar sync, Microsoft Teams sync, IMAP,
+Microsoft 365 mail, verifiable backup snapshots, PST import, MBOX import,
+Apple Mail import, and chat/text import (WhatsApp, iMessage, Google Voice,
 Facebook Messenger, and SMS Backup & Restore).
 
 Read the [Introduction](/introduction/) to learn more about why this project
@@ -40,12 +41,12 @@ powershell -ExecutionPolicy ByPass -c "irm https://msgvault.io/install.ps1 | iex
 Then [set up OAuth credentials](/guides/oauth-setup/) and [start
 syncing](/setup/). You can also [build from source](/setup/#build-from-source).
 
-!!! note "New in 0.15.0"
-    PST archive import, Facebook Messenger DYI import, SyncTech SMS Backup &
-    Restore import, account collections, per-account identities, reversible
-    deduplication workflows, Google service account delegation, MCP
-    StreamableHTTP, and API access to HTML email bodies and inline images. See
-    the [Changelog](/changelog/) for the full release notes.
+!!! note "New in 0.17.0"
+    Backup repositories, Google Calendar sync, Microsoft Teams delegated Graph
+    sync, message-type filtering, scoped embedding generations, OpenAPI docs
+    and generated client support, daemon-owned CLI archive access, faster IMAP
+    resyncs, and the completed Bubble Tea v2 TUI migration. See the
+    [Changelog](/changelog/) for the full release notes.
 
 ## Why msgvault?
 
@@ -73,6 +74,14 @@ disk that you own and control.
   <section>
     <h3>Calendar Sync</h3>
     <p>Archive Google Calendar alongside email. Events — including organizers, attendees, recurring series, and cancellations — become searchable by keyword and by meaning, and their participants dedupe with your email contacts. Read-only and incremental.</p>
+  </section>
+  <section>
+    <h3>Teams Sync</h3>
+    <p>Archive Microsoft Teams chats, channels, replies, link attachments, and inline media through delegated Microsoft Graph. Teams records use <code>message_type = teams</code> so they can be searched and queried separately from email.</p>
+  </section>
+  <section>
+    <h3>Backup Snapshots</h3>
+    <p>Create incremental, append-only backup repositories for the SQLite archive and attachments. Verify snapshots byte-for-byte, restore into a fresh archive home, and sync the repository off-site with ordinary file tools.</p>
   </section>
   <section>
     <h3>Lightning-Fast TUI</h3>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,8 +24,9 @@ This means:
   over the years.
 
 I started with Gmail but I want all my life's messages in this system,
-including WhatsApp, iMessage, Google Voice, Facebook Messenger, SMS
-Backup & Restore archives, and old local email archives.
+including Google Calendar, Microsoft Teams, WhatsApp, iMessage, Google Voice,
+Facebook Messenger, SMS Backup & Restore archives, and old local email
+archives.
 
 I suspect I am not the only one who has felt this way. **I hope you
 will join me in this revolution to liberate our life's messages from

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -284,3 +284,38 @@ msgvault sync-calendar you@gmail.com
 Calendar sync is read-only. Events become searchable with
 `--message-type calendar_event`; see [Google Calendar](/usage/calendar/) for the
 full workflow, scheduled sync, and headless-server setup.
+
+## Optional: Sync Microsoft Teams
+
+To archive Teams chats and channels, add Microsoft Graph permissions to your
+Microsoft app registration, authorize Teams, then sync:
+
+```bash
+msgvault add-teams user@example.com
+msgvault sync-teams user@example.com
+```
+
+Teams messages become searchable with `--message-type teams`. See
+[Microsoft Teams](/usage/teams/) for required Graph permissions, scheduling,
+and inline media backfill.
+
+## Optional: Configure Backups
+
+Create a backup repository before relying on the archive as your source of
+truth:
+
+```bash
+msgvault backup init --repo ~/Backups/msgvault
+msgvault backup create --repo ~/Backups/msgvault
+msgvault backup verify --repo ~/Backups/msgvault
+```
+
+Record the repository in `config.toml` so future commands can omit `--repo`:
+
+```toml
+[backup]
+repo = "~/Backups/msgvault"
+```
+
+See [Backup](/usage/backup/) for restore, verification, scheduling, and
+secret-handling details.

--- a/docs/usage/backup.md
+++ b/docs/usage/backup.md
@@ -62,6 +62,7 @@ Takes a snapshot. Flags:
 | `--allow-plaintext-secrets` | Permit config/tokens in an unencrypted repository |
 | `--tag STR` | Free-form label shown by `backup list` |
 | `--force-unlock` | Override a fresh repository lock (see Locking) |
+| `--jobs N` | Concurrent attachment capture workers (default: one per CPU; use `1` for serial reads on spinning disks or NAS shares) |
 
 When the msgvault daemon is running, `backup create` coordinates with it automatically: the command is proxied through the daemon, which briefly pauses conflicting maintenance operations while the backup pins a consistent read of the database. The pause lasts only as long as it takes to checkpoint the WAL and open a read transaction — normal syncing and reads continue while pages are scanned. A watchdog on the daemon side guarantees a crashed backup can never leave the daemon wedged.
 

--- a/docs/usage/calendar.md
+++ b/docs/usage/calendar.md
@@ -113,9 +113,11 @@ msgvault search "after:2024-01-01 before:2024-04-01" --message-type calendar_eve
 When [vector search](/usage/vector-search/) is enabled, events become eligible
 for embedding after sync and can be found semantically with `--mode vector` or
 `--mode hybrid` once the embedding worker has processed them. For manual
-`sync-calendar` runs, follow up with `msgvault embeddings build`; scheduled
-daemon syncs can trigger embedding automatically with
-`[vector.embed.schedule].run_after_sync = true`.
+`sync-calendar` runs, follow up with `msgvault embeddings build`. In the
+daemon, scheduled `[[gcal]]` syncs do not trigger the
+`[vector.embed.schedule].run_after_sync` hook (it applies to scheduled
+account syncs such as Gmail, IMAP, and Teams); newly synced events are
+picked up by the embed worker's `[vector.embed.schedule].cron` schedule.
 
 ## Scheduled sync (daemon)
 

--- a/docs/usage/calendar.md
+++ b/docs/usage/calendar.md
@@ -110,9 +110,12 @@ msgvault search "standup" --message-type calendar_event
 msgvault search "after:2024-01-01 before:2024-04-01" --message-type calendar_event
 ```
 
-When [vector search](/usage/vector-search/) is enabled, events are embedded
-during sync and can be found semantically with `--mode vector` or
-`--mode hybrid`.
+When [vector search](/usage/vector-search/) is enabled, events become eligible
+for embedding after sync and can be found semantically with `--mode vector` or
+`--mode hybrid` once the embedding worker has processed them. For manual
+`sync-calendar` runs, follow up with `msgvault embeddings build`; scheduled
+daemon syncs can trigger embedding automatically with
+`[vector.embed.schedule].run_after_sync = true`.
 
 ## Scheduled sync (daemon)
 

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -47,11 +47,11 @@ The MCP server exposes the following tools to connected AI clients:
 
 | Tool | Description | Parameters |
 |---|---|---|
-| `search_messages` | Search with Gmail-like query syntax. When [vector search](/usage/vector-search/) is configured, supports semantic and hybrid modes. | `query` (string, required), `mode` (string: `fts`/`vector`/`hybrid`, default `fts`), `explain` (bool), `limit` (int), `offset` (int), `account` (string), `message_type` (string) |
+| `search_messages` | Search with Gmail-like query syntax. When [vector search](/usage/vector-search/) is configured, supports semantic and hybrid modes. | `query` (string, required), `mode` (string: `fts`/`vector`/`hybrid`, default `fts`), `explain` (bool), `limit` (int), `offset` (int), `account` (string) |
 | `find_similar_messages` | Nearest-neighbor search from a seed message's embedding. Requires vector search to be configured and an active index generation. | `message_id` (int, required), `limit` (int), `account` (string), `message_type` (string), `after` (string), `before` (string), `has_attachment` (bool) |
 | `search_by_domains` | Find messages where any participant (`from`, `to`, or `cc`) belongs to one of several domains, regardless of direction. | `domains` (comma-separated string, required), `limit` (int), `offset` (int), `after` (string), `before` (string) |
-| `get_message` | Get full message details by ID | `id` (int) |
-| `list_messages` | List messages with filters | `from` (string), `to` (string), `label` (string), `message_type` (string), `after` (string), `before` (string), `has_attachment` (bool), `limit` (int), `offset` (int), `account` (string) |
+| `get_message` | Get message details with windowed body paging | `id` (int, required), `offset` (int), `center_at` (int), `max_chars` (int), `body_format` (string: `auto`/`text`/`html`), `full_body` (bool) |
+| `list_messages` | List messages with filters | `from` (string), `to` (string), `label` (string), `after` (string), `before` (string), `has_attachment` (bool), `limit` (int), `offset` (int), `account` (string) |
 | `get_attachment` | Get attachment content by ID | `attachment_id` (int) |
 | `export_attachment` | Save attachment to filesystem | `attachment_id` (int), `destination` (string) |
 | `get_stats` | Archive overview statistics. Includes vector index state when configured. | — |
@@ -78,12 +78,16 @@ backend cannot report a full result count, `total` is `-1`; use
 `search_messages` accepts msgvault's local subset of Gmail-like syntax.
 Gmail-only operators such as `list:` are rejected because msgvault does
 not index `List-ID` locally; use Gmail-side validation for those checks.
-Use `message_type` to restrict mixed archives to values such as `email`,
-`calendar_event`, `teams`, `sms`, or `mms`.
+To restrict mixed archives to values such as `email`, `calendar_event`,
+`teams`, `sms`, or `mms`, include a `message_type:` operator in the query
+(for example `message_type:teams incident review`). `find_similar_messages`
+accepts a dedicated `message_type` parameter; `list_messages` does not
+support message-type filtering.
 
-`get_message` reads large bodies in windows, so retrieving unusually large
-messages does not require the MCP server to load the full body into memory at
-once.
+`get_message` returns large bodies in windows: each response carries one
+slice of the body plus `body_length`, `body_returned`, `offset`, and
+`has_more`, so unusually large messages are paged across calls instead of
+being returned in a single response.
 
 `find_similar_messages` is only registered when the server starts with vector search configured. `search_messages` is always available, but `mode=vector` and `mode=hybrid` return `vector_not_enabled` when the server is not configured for vector search. Vector and hybrid queries require at least one free-text term (operator-only queries return `missing_free_text`). They support `offset`/`limit` pagination inside the configured hybrid ranking window; when `[vector.search].max_page_size_hybrid` is positive, an `offset` at or beyond that cap returns `pagination_limit`. Use `mode=fts` for deeper pagination or adjust that config cap.
 

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -47,11 +47,11 @@ The MCP server exposes the following tools to connected AI clients:
 
 | Tool | Description | Parameters |
 |---|---|---|
-| `search_messages` | Search with Gmail-like query syntax. When [vector search](/usage/vector-search/) is configured, supports semantic and hybrid modes. | `query` (string, required), `mode` (string: `fts`/`vector`/`hybrid`, default `fts`), `explain` (bool), `limit` (int), `offset` (int), `account` (string) |
-| `find_similar_messages` | Nearest-neighbor search from a seed message's embedding. Requires vector search to be configured and an active index generation. | `message_id` (int, required), `limit` (int), `account` (string), `after` (string), `before` (string), `has_attachment` (bool) |
+| `search_messages` | Search with Gmail-like query syntax. When [vector search](/usage/vector-search/) is configured, supports semantic and hybrid modes. | `query` (string, required), `mode` (string: `fts`/`vector`/`hybrid`, default `fts`), `explain` (bool), `limit` (int), `offset` (int), `account` (string), `message_type` (string) |
+| `find_similar_messages` | Nearest-neighbor search from a seed message's embedding. Requires vector search to be configured and an active index generation. | `message_id` (int, required), `limit` (int), `account` (string), `message_type` (string), `after` (string), `before` (string), `has_attachment` (bool) |
 | `search_by_domains` | Find messages where any participant (`from`, `to`, or `cc`) belongs to one of several domains, regardless of direction. | `domains` (comma-separated string, required), `limit` (int), `offset` (int), `after` (string), `before` (string) |
 | `get_message` | Get full message details by ID | `id` (int) |
-| `list_messages` | List messages with filters | `from` (string), `to` (string), `label` (string), `after` (string), `before` (string), `has_attachment` (bool), `limit` (int), `offset` (int), `account` (string) |
+| `list_messages` | List messages with filters | `from` (string), `to` (string), `label` (string), `message_type` (string), `after` (string), `before` (string), `has_attachment` (bool), `limit` (int), `offset` (int), `account` (string) |
 | `get_attachment` | Get attachment content by ID | `attachment_id` (int) |
 | `export_attachment` | Save attachment to filesystem | `attachment_id` (int), `destination` (string) |
 | `get_stats` | Archive overview statistics. Includes vector index state when configured. | — |
@@ -78,6 +78,12 @@ backend cannot report a full result count, `total` is `-1`; use
 `search_messages` accepts msgvault's local subset of Gmail-like syntax.
 Gmail-only operators such as `list:` are rejected because msgvault does
 not index `List-ID` locally; use Gmail-side validation for those checks.
+Use `message_type` to restrict mixed archives to values such as `email`,
+`calendar_event`, `teams`, `sms`, or `mms`.
+
+`get_message` reads large bodies in windows, so retrieving unusually large
+messages does not require the MCP server to load the full body into memory at
+once.
 
 `find_similar_messages` is only registered when the server starts with vector search configured. `search_messages` is always available, but `mode=vector` and `mode=hybrid` return `vector_not_enabled` when the server is not configured for vector search. Vector and hybrid queries require at least one free-text term (operator-only queries return `missing_free_text`). They support `offset`/`limit` pagination inside the configured hybrid ranking window; when `[vector.search].max_page_size_hybrid` is positive, an `offset` at or beyond that cap returns `pagination_limit`. Use `mode=fts` for deeper pagination or adjust that config cap.
 

--- a/docs/usage/querying.md
+++ b/docs/usage/querying.md
@@ -100,6 +100,37 @@ msgvault query "
 "
 ```
 
+### Filter by message type
+
+Mixed archives store email, calendar events, Teams messages, and text-message
+imports in the same `messages` table. Use the `message_type` column to keep SQL
+reports scoped:
+
+```bash
+# Teams activity by month
+msgvault query --format table "
+  SELECT month, count(*) AS messages
+  FROM messages
+  WHERE message_type = 'teams'
+  GROUP BY month
+  ORDER BY month DESC
+  LIMIT 12
+"
+
+# Recent calendar records in the archive
+msgvault query --format table "
+  SELECT sent_at, subject, from_email
+  FROM v_messages
+  WHERE message_type = 'calendar_event'
+  ORDER BY sent_at DESC
+  LIMIT 20
+"
+```
+
+Known values include `email`, `calendar_event`, `teams`, `sms`, `mms`,
+`whatsapp`, `imessage`, `fbmessenger`, `synctech_sms_call`,
+`google_voice_text`, `google_voice_call`, and `google_voice_voicemail`.
+
 ### Label statistics
 
 ```bash

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -34,6 +34,7 @@ Gmail connector query when you need Gmail itself to evaluate those operators.
 | `newer_than:` | Relative date | `newer_than:30d` |
 | `larger:` | Minimum size | `larger:5M`, `100K` |
 | `smaller:` | Maximum size | `smaller:1M` |
+| `message_type:` | Stored message type | `message_type:teams`, `message_type=calendar_event` |
 
 Bare words and `"quoted phrases"` perform full-text search across message subjects and bodies.
 
@@ -91,19 +92,31 @@ SQLite FTS ranking is weighted to better match PostgreSQL-backed search behavior
 
 ## Filtering by Message Type
 
-Archives can hold more than email — Google Calendar events, text messages, and
-call logs all live in the same database. Restrict a search to one kind with
-`--message-type`:
+Archives can hold more than email — Google Calendar events, Microsoft Teams
+messages, text messages, calls, voicemails, and Messenger imports all live in
+the same database. Restrict a search to one or more kinds with the
+`message_type:` operator or the repeatable/comma-separated `--message-type`
+flag:
 
 ```bash
 # Only Google Calendar events
 msgvault search "standup" --message-type calendar_event
 
+# Only Microsoft Teams messages
+msgvault search "message_type:teams incident review"
+
 # Only SMS/MMS text messages
-msgvault search "dinner" --message-type sms
+msgvault search "dinner" --message-type sms --message-type mms
 ```
 
-Values include `calendar_event`, `sms`, `mms`, and `synctech_sms_call`.
+Valid values are `email`, `calendar_event`, `sms`, `mms`, `whatsapp`,
+`imessage`, `teams`, `fbmessenger`, `synctech_sms_call`, `google_voice_text`,
+`google_voice_call`, and `google_voice_voicemail`. `message_type:email`
+also includes legacy rows whose type is empty because older msgvault versions
+created them before the column existed.
+
+The same message-type scoping is available in HTTP search via the
+`message_type` query parameter and in MCP `search_messages` / `list_messages`.
 
 ## JSON Output
 

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -116,7 +116,9 @@ also includes legacy rows whose type is empty because older msgvault versions
 created them before the column existed.
 
 The same message-type scoping is available in HTTP search via the
-`message_type` query parameter and in MCP `search_messages` / `list_messages`.
+`message_type` query parameter. In MCP, include a `message_type:` operator in
+the `search_messages` query; `find_similar_messages` accepts a `message_type`
+parameter.
 
 ## JSON Output
 

--- a/docs/usage/teams.md
+++ b/docs/usage/teams.md
@@ -1,0 +1,152 @@
+---
+title: Microsoft Teams
+description: Archive Microsoft Teams chats and channels through delegated Microsoft Graph sync.
+---
+
+msgvault can archive Microsoft Teams chats and channel messages into the same
+local archive as email, calendar events, and text-message imports. Teams
+messages are stored with `message_type = teams`, so they can be searched,
+queried, and embedded without mixing them into ordinary email-only workflows.
+
+Teams sync is read-only: msgvault reads messages through Microsoft Graph and
+does not send messages, edit Teams content, or modify channel membership.
+
+## Prerequisites
+
+Teams ingestion uses Microsoft Graph delegated OAuth, not IMAP. It requires the
+same `[microsoft]` `client_id` config block used by `add-o365`, but it stores a
+separate Graph token under `tokens/teams_<email>.json`. An Outlook IMAP token
+created by `add-o365` does not authorize Teams sync.
+
+Register a Microsoft Entra app as described in
+[OAuth Setup](/guides/oauth-setup/#microsoft-365-outlook-hotmail), with:
+
+- Redirect URI: `http://localhost:8089/callback/microsoft`
+- Public client flows enabled
+- Delegated Microsoft Graph permissions:
+  `Chat.Read`, `ChannelMessage.Read.All`, `Team.ReadBasic.All`,
+  `Channel.ReadBasic.All`, `User.Read`, and `User.ReadBasic.All`
+
+Some tenants require an administrator to grant consent for channel-message
+permissions before users can authorize the app.
+
+Configure msgvault:
+
+```toml
+[microsoft]
+client_id = "your-azure-app-client-id"
+# tenant_id = "your-org-tenant-id"  # optional; default is "common"
+```
+
+## Authorize Teams
+
+```bash
+msgvault add-teams user@example.com
+```
+
+The command opens a browser, requests the Graph scopes above, verifies the
+returned identity, stores the token as `teams_user@example.com.json`, creates a
+`teams` source, and confirms the account email as the default "me" identity.
+
+| Flag | Description |
+|---|---|
+| `--tenant` | Azure AD tenant ID for this authorization; defaults to `common` |
+| `--no-default-identity` | Do not auto-confirm the email address as this source's "me" identity |
+
+## Sync Teams
+
+```bash
+# Full first run or incremental later runs are auto-detected.
+msgvault sync-teams user@example.com
+
+# Chats only
+msgvault sync-teams user@example.com --no-channels
+
+# Test with a per-conversation limit
+msgvault sync-teams user@example.com --limit 100
+
+# Re-fetch all messages and upsert them in place
+msgvault sync-teams user@example.com --full
+```
+
+The first run walks chats, joined teams, channels, root channel messages, and
+replies. Later runs resume from stored cursors and checkpoints. If a run is
+interrupted, re-run `sync-teams`; completed conversations are skipped and
+incomplete ones continue.
+
+| Flag | Description |
+|---|---|
+| `--no-channels` | Sync chats only and skip team channels |
+| `--limit` | Maximum messages per conversation (`0` means no limit) |
+| `--full` | Ignore stored cursors and re-fetch every message, repairing/backfilling rows in place |
+
+## What Gets Archived
+
+- One-on-one chats, group chats, meeting chats, team channels, and channel
+  replies.
+- Plain-text body text derived from Graph HTML bodies, plus the original HTML
+  body when present.
+- Sender and conversation members as participants, so Teams contacts can appear
+  in the same contact graph as email and text-message contacts.
+- The original Graph message JSON in raw-message storage with format
+  `teams_json`.
+- Link attachments as attachment references.
+- Inline hosted-content images downloaded into msgvault's attachment store.
+- Call-recording event links in the searchable body text.
+
+Deleted Teams messages are marked deleted in the archive when Graph reports a
+`deletedDateTime`; existing rows are not silently left active.
+
+## Inline Media Backfill
+
+If you imported Teams messages before inline hosted-content downloads were
+available, or a transient Graph error left some inline images missing, run:
+
+```bash
+msgvault backfill-teams-media user@example.com
+msgvault backfill-teams-media user@example.com --only-incomplete
+```
+
+The backfill scans stored Teams HTML bodies for `hostedContents` URLs and
+downloads those images into the attachment store. It is idempotent because
+attachment storage is content-addressed.
+
+## Scheduled Sync
+
+`msgvault serve` can schedule Teams syncs through the normal `[[accounts]]`
+block after `add-teams` creates the source and token:
+
+```toml
+[[accounts]]
+email = "user@example.com"
+schedule = "*/30 * * * *"
+enabled = true
+```
+
+The scheduler resolves the entry to the `teams` source when that account has a
+Teams source. Scheduled Teams syncs include channels.
+
+## Search and Query
+
+Teams messages use `message_type = teams`:
+
+```bash
+msgvault search "incident review" --message-type teams
+msgvault search "message_type:teams incident review"
+msgvault query --format table "
+  SELECT sent_at, from_email, subject, snippet
+  FROM v_messages
+  WHERE message_type = 'teams'
+  ORDER BY sent_at DESC
+  LIMIT 20
+"
+```
+
+Manual `sync-teams` does not run the embedding worker immediately. If vector
+search is enabled and you want newly synced Teams messages in semantic/hybrid
+results, run `msgvault embeddings build` after the sync, or configure
+`[vector.embed.schedule].run_after_sync = true` for scheduled daemon syncs.
+
+In the [TUI](/usage/tui/), press `m` to switch from Email mode to Texts mode.
+Teams direct chats, group chats, and channel conversations appear alongside
+other text/chat sources in that view.

--- a/docs/usage/text-messages.md
+++ b/docs/usage/text-messages.md
@@ -1,9 +1,9 @@
 ---
 title: Text Messages
-description: Import chats and text messages from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore into msgvault.
+description: Import chats and text messages from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore, and browse Teams conversations, in msgvault.
 ---
 
-msgvault can import chats and text messages from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore. Imported messages are stored in the same database as email, and you can browse text conversations in the [TUI](/usage/tui/) by pressing `m` to switch to text mode.
+msgvault can import chats and text messages from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore. It can also sync Microsoft Teams chats and channels through [Microsoft Teams](/usage/teams/). These records are stored in the same database as email, and you can browse text/chat conversations in the [TUI](/usage/tui/) by pressing `m` to switch to text mode.
 
 ## import-whatsapp
 
@@ -245,7 +245,7 @@ Imports use checkpoint-based resumption. If interrupted (Ctrl+C, power loss), ru
 
 ## After Importing
 
-Most chat import commands rebuild the analytics cache automatically after import. If a newly imported source does not appear in aggregate views immediately, run `msgvault build-cache`. Your imported texts are then available for TUI browsing.
+Most chat import commands rebuild the analytics cache automatically after import. If a newly imported or synced source does not appear in aggregate views immediately, run `msgvault build-cache`. Your imported texts and Teams conversations are then available for TUI browsing.
 
 ```bash
 # Launch the TUI and press 'm' for text mode

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -88,7 +88,7 @@ Press `t` from any view to jump directly to the Time view. The Time view aggrega
 
 ## Text Messages
 
-Press `m` to toggle between Email and Texts mode. This mode is only available when text/chat data has been imported. See [Text Messages](/usage/text-messages/) for details on importing WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore conversations.
+Press `m` to toggle between Email and Texts mode. This mode is only available when text/chat data has been imported or synced. See [Text Messages](/usage/text-messages/) for details on importing WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore conversations, and [Microsoft Teams](/usage/teams/) for Teams sync.
 
 Text mode provides the following view types. Press `g` to cycle through them:
 

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -133,6 +133,10 @@ max_page_size_hybrid = 50                # hard cap on vector/hybrid page_size
 [vector.embed.schedule]
 cron = "*/5 * * * *"                     # embed worker cron (5-field); empty disables cron
 run_after_sync = true                    # run a pass after every successful scheduled sync
+
+[vector.embed.scope]
+# Optional: leave empty for the full archive, or restrict new generations.
+message_types = ["teams"]
 ```
 
 The `[vector]` section only takes effect when `enabled = true` **and**
@@ -278,6 +282,7 @@ trigger).
 | Ingest path | Runs the embed worker? |
 |---|---|
 | Manual `sync-full` / `sync` (Gmail, IMAP) | No. Run `msgvault embeddings build` afterward |
+| Manual `sync-calendar` / `sync-teams` | No. Run `msgvault embeddings build` afterward |
 | Scheduled syncs in `msgvault serve` | Yes, when `[vector.embed.schedule].run_after_sync = true` |
 | `import-pst`, `import-emlx`, `import-mbox` | No. Re-run `--full-rebuild` after large imports |
 | Chat/text imports (iMessage, WhatsApp, Google Voice, Messenger, SyncTech SMS) | No. Run a full rebuild after importing if you want chats included |
@@ -314,6 +319,35 @@ self-recovers: the next edit to that message bumps `last_modified` (and
 `repair-encoding` clears its coverage stamp outright), and a full rebuild
 (`embeddings build --full-rebuild`) or the periodic full-scan backstop
 re-embeds it regardless.
+
+## Scoped Generations
+
+Large mixed archives can build a vector index for only selected message types:
+
+```toml
+[vector.embed.scope]
+message_types = ["teams"]
+```
+
+The scope is part of the generation fingerprint. Changing it requires
+`msgvault embeddings build --full-rebuild --yes`, just like changing the model
+or preprocessing policy. Scoped generations are useful when you want semantic
+search for a newer corpus such as Teams or SMS without embedding decades of
+email immediately.
+
+A scoped index is intentionally partial, so vector and hybrid search require an
+explicit compatible message-type filter:
+
+```bash
+msgvault search "release planning" --mode hybrid --message-type teams
+msgvault search "message_type:teams release planning" --mode vector
+```
+
+If the active generation is scoped to `teams`, an unscoped vector/hybrid query
+or a query scoped to `email` returns `index_scope_mismatch`. Use `mode=fts` for
+unscoped keyword searches, add the matching message-type filter, or rebuild an
+unscoped generation by clearing `[vector.embed.scope].message_types` and running
+a full rebuild.
 
 ## Search
 
@@ -391,6 +425,7 @@ conditions as command errors rather than structured codes.
 | `index_stale` | Active generation's fingerprint does not match the current model, dimension, preprocessing policy, `max_input_chars`, or embedding output policy. | Run `msgvault embeddings build --full-rebuild --yes`. |
 | `index_building` | No active generation yet; one is being built. | Finish running `msgvault embeddings build` or wait for the scheduler. Use `mode=fts` for the interim. |
 | `missing_free_text` | `mode=vector` or `mode=hybrid` used with a filter-only query (no free text to embed). | Add free-text terms to `q`, or switch to `mode=fts`. |
+| `index_scope_mismatch` | The active vector generation was built for selected message types and the query is unscoped or asks for a type outside that scope. | Add a compatible `message_type` filter, use `mode=fts`, or rebuild an unscoped generation. |
 | `pagination_unsupported` | HTTP request asked for `page>1` with `mode=vector|hybrid`. | Use `page=1` with a larger `page_size` instead. |
 | `pagination_limit` | MCP `search_messages` asked for an `offset` at or beyond a positive `[vector.search].max_page_size_hybrid` cap in `mode=vector|hybrid`. | Use `mode=fts` for deeper pagination, request an earlier page, or raise/disable the hybrid page-size cap. |
 | `invalid_mode` | `mode=` value other than `fts`, `vector`, `hybrid`. | Pick one of those. |

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -283,7 +283,8 @@ trigger).
 |---|---|
 | Manual `sync-full` / `sync` (Gmail, IMAP) | No. Run `msgvault embeddings build` afterward |
 | Manual `sync-calendar` / `sync-teams` | No. Run `msgvault embeddings build` afterward |
-| Scheduled syncs in `msgvault serve` | Yes, when `[vector.embed.schedule].run_after_sync = true` |
+| Scheduled account syncs in `msgvault serve` (Gmail, IMAP, Teams) | Yes, when `[vector.embed.schedule].run_after_sync = true` |
+| Scheduled `[[gcal]]` calendar syncs in `msgvault serve` | No. Picked up by the embed worker's `[vector.embed.schedule].cron` schedule |
 | `import-pst`, `import-emlx`, `import-mbox` | No. Re-run `--full-rebuild` after large imports |
 | Chat/text imports (iMessage, WhatsApp, Google Voice, Messenger, SyncTech SMS) | No. Run a full rebuild after importing if you want chats included |
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -25,6 +25,7 @@ nav = [
     {"Importing Local Email" = "usage/importing.md"},
     {"Text Messages" = "usage/text-messages.md"},
     {"Google Calendar" = "usage/calendar.md"},
+    {"Microsoft Teams" = "usage/teams.md"},
     {"Exporting Data" = "usage/exporting.md"},
     {"Analytics & Stats" = "usage/analytics.md"},
     {"SQL Queries" = "usage/querying.md"},


### PR DESCRIPTION
## Why

0.17.0 shipped a broad set of user-facing surfaces, and the existing docs only covered part of the release. The release notes and docs need to match the implementation so users can discover backup, Teams sync, message-type filtering, scoped embeddings, and the daemon/API changes from the public site.

## What changed

- Adds a full 0.17.0 changelog entry with code-verified entries and contributor acknowledgements.
- Adds a dedicated Microsoft Teams guide covering Graph permissions, tokens, sync/backfill commands, scheduling, search, and embeddings.
- Expands README, setup, CLI, API, config, search/query, MCP, vector-search, calendar, TUI, text-message, index, and architecture docs for the 0.17.0 surfaces.

## Validation

- `make docs-check`

## Deploy

Docs deployment is manual after merge: run `make docs-deploy` (or the project's docs deploy flow) so the public site picks up the release docs.