### PR TITLE
Stop blocking CLI search on the FTS completeness probe

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2276,7 +2276,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.0.0
+  version: 1.1.0
 openapi: 3.1.0
 paths:
   /api/ping:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1038,6 +1038,8 @@ components:
       properties:
         index_built:
           type: boolean
+        index_state:
+          type: string
         indexed_messages:
           format: int64
           type: integer

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -135,11 +135,11 @@ func runHTTPSearch(cmd *cobra.Command, queryStr string) error {
 	}
 	defer func() { _ = s.Close() }()
 
+	prefix := "Searching..."
 	if info.Kind == HTTPStoreConfiguredRemote {
-		fmt.Fprintf(os.Stderr, "Searching %s...", info.URL)
-	} else {
-		fmt.Fprintf(os.Stderr, "Searching...")
+		prefix = fmt.Sprintf("Searching %s...", info.URL)
 	}
+	stopStatus := startSearchStatus(cmd.Context(), prefix, info)
 
 	hasAccount := searchAccount != "" || searchCollection != ""
 	logger.Info("search start",
@@ -163,7 +163,7 @@ func runHTTPSearch(cmd *cobra.Command, queryStr string) error {
 		Limit:        searchLimit,
 		Offset:       searchOffset,
 	})
-	fmt.Fprintf(os.Stderr, "\r                                                      \r")
+	stopStatus()
 	if err != nil {
 		logger.Warn("search failed",
 			"query_len", len(queryStr),

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -173,7 +173,12 @@ func runHTTPSearch(cmd *cobra.Command, queryStr string) error {
 		return query.HintRepairEncoding(fmt.Errorf("search: %w", err))
 	}
 	if resp.IndexBuilt {
+		// Pre-0.18 daemons built the index synchronously inside the request.
 		fmt.Fprintf(os.Stderr, "Built search index (%d messages indexed).\n", resp.IndexedMessages)
+	}
+	if resp.IndexState == "building" {
+		fmt.Fprintln(os.Stderr,
+			"Note: the search index is being rebuilt in the background; results may be incomplete until it finishes.")
 	}
 	if searchCollection != "" {
 		label := resp.ScopeLabel

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -176,9 +176,13 @@ func runHTTPSearch(cmd *cobra.Command, queryStr string) error {
 		// Pre-0.18 daemons built the index synchronously inside the request.
 		fmt.Fprintf(os.Stderr, "Built search index (%d messages indexed).\n", resp.IndexedMessages)
 	}
-	if resp.IndexState == "building" {
+	switch resp.IndexState {
+	case "building":
 		fmt.Fprintln(os.Stderr,
 			"Note: the search index is being rebuilt in the background; results may be incomplete until it finishes.")
+	case "checking":
+		fmt.Fprintln(os.Stderr,
+			"Note: search index completeness is still being verified in the background; results may be incomplete until it finishes.")
 	}
 	if searchCollection != "" {
 		label := resp.ScopeLabel

--- a/cmd/msgvault/cmd/search_status.go
+++ b/cmd/msgvault/cmd/search_status.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mattn/go-isatty"
+	"go.kenn.io/msgvault/internal/api"
+)
+
+// Vars rather than consts so tests can shorten them. The quiet window keeps
+// fast searches free of flicker; only a search that outlives it starts
+// showing elapsed time and daemon activity.
+var (
+	searchStatusQuietWindow = 3 * time.Second
+	searchStatusTick        = 2 * time.Second
+)
+
+// startSearchStatus prints the transient "Searching..." stderr line and keeps
+// it honest while the request runs: once the quiet window passes, the line
+// gains elapsed time and — when the daemon reports one via /health — the
+// operation the search is actually waiting on (e.g. "checking the search
+// index", which can take a minute on a large archive after a daemon
+// restart). The returned stop func erases the line; call it before printing
+// results.
+func startSearchStatus(ctx context.Context, prefix string, info HTTPStoreInfo) func() {
+	line := &searchStatusLine{
+		out:     os.Stderr,
+		prefix:  prefix,
+		fetchOp: daemonOperationFetcher(info.URL, httpStoreAPIKey(info)),
+		tty: isatty.IsTerminal(os.Stderr.Fd()) ||
+			isatty.IsCygwinTerminal(os.Stderr.Fd()),
+		start: time.Now(),
+	}
+	_, _ = fmt.Fprint(line.out, prefix)
+	line.width = len(prefix)
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		line.run(loopCtx)
+	}()
+	return func() {
+		cancel()
+		<-done
+		line.clear()
+	}
+}
+
+// searchStatusLine owns one in-place stderr status line. All fields are
+// written by the run goroutine only; stop's channel receive orders clear()
+// after the final render.
+type searchStatusLine struct {
+	out     io.Writer
+	prefix  string
+	fetchOp func(context.Context) *api.OperationHealth
+	tty     bool
+	start   time.Time
+	width   int
+	noticed bool
+}
+
+func (l *searchStatusLine) run(ctx context.Context) {
+	ticker := time.NewTicker(searchStatusTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		elapsed := time.Since(l.start)
+		if elapsed < searchStatusQuietWindow {
+			continue
+		}
+		l.render(elapsed, l.fetchOp(ctx))
+	}
+}
+
+func (l *searchStatusLine) render(elapsed time.Duration, op *api.OperationHealth) {
+	if !l.tty {
+		// A pipe gets no in-place updates, but the one fact worth a log
+		// line — the daemon is busy with something expensive — is still
+		// printed once.
+		if op != nil && op.Label != "" && !l.noticed {
+			l.noticed = true
+			_, _ = fmt.Fprintf(l.out, "\nDaemon is busy: %s. The search will finish when it does.\n",
+				op.Label)
+		}
+		return
+	}
+	line := formatSearchStatus(l.prefix, elapsed, op)
+	pad := max(0, l.width-len(line))
+	_, _ = fmt.Fprintf(l.out, "\r%s%s", line, strings.Repeat(" ", pad))
+	l.width = max(l.width, len(line))
+}
+
+// clear erases the status line so results start on a clean line.
+func (l *searchStatusLine) clear() {
+	_, _ = fmt.Fprintf(l.out, "\r%s\r", strings.Repeat(" ", l.width))
+}
+
+// formatSearchStatus renders one status line. The daemon operation label wins
+// over a bare elapsed count because it answers the actual question ("why is
+// this taking so long"); Busy without a label (unauthenticated /health
+// fallback) degrades to the elapsed-only form.
+func formatSearchStatus(prefix string, elapsed time.Duration, op *api.OperationHealth) string {
+	rounded := elapsed.Round(time.Second)
+	if op != nil && op.Label != "" {
+		return fmt.Sprintf("%s daemon is busy: %s (%s)", prefix, op.Label, rounded)
+	}
+	return fmt.Sprintf("%s (%s)", prefix, rounded)
+}
+
+// daemonOperationFetcher reports what the daemon is working on, best-effort:
+// nil when the daemon is idle, unreachable, or predates operation reporting.
+func daemonOperationFetcher(baseURL, apiKey string) func(context.Context) *api.OperationHealth {
+	return func(ctx context.Context) *api.OperationHealth {
+		health := fetchDaemonHealthWithAPIKey(ctx, baseURL, apiKey)
+		if health == nil {
+			return nil
+		}
+		return health.Operation
+	}
+}
+
+// httpStoreAPIKey returns the API key for the endpoint OpenHTTPStore
+// selected, for auxiliary requests (health polling) beside the main client.
+func httpStoreAPIKey(info HTTPStoreInfo) string {
+	if cfg == nil {
+		return ""
+	}
+	if info.Kind == HTTPStoreConfiguredRemote {
+		return cfg.Remote.APIKey
+	}
+	return cfg.Server.APIKey
+}

--- a/cmd/msgvault/cmd/search_status_test.go
+++ b/cmd/msgvault/cmd/search_status_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+)
+
+func TestFormatSearchStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		op      *api.OperationHealth
+		want    string
+	}{
+		{
+			name:    "elapsed only when daemon is idle",
+			elapsed: 12 * time.Second,
+			op:      nil,
+			want:    "Searching... (12s)",
+		},
+		{
+			name:    "daemon operation label wins",
+			elapsed: 45 * time.Second,
+			op:      &api.OperationHealth{Busy: true, Label: "checking the search index"},
+			want:    "Searching... daemon is busy: checking the search index (45s)",
+		},
+		{
+			name:    "busy without label degrades to elapsed only",
+			elapsed: 5 * time.Second,
+			op:      &api.OperationHealth{Busy: true},
+			want:    "Searching... (5s)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatSearchStatus("Searching...", tt.elapsed, tt.op))
+		})
+	}
+}
+
+func TestSearchStatusLineRenderTTYRewritesInPlace(t *testing.T) {
+	assert := assert.New(t)
+	var buf bytes.Buffer
+	l := &searchStatusLine{out: &buf, prefix: "Searching...", tty: true}
+
+	l.render(10*time.Second, &api.OperationHealth{
+		Busy:  true,
+		Label: "building the search index (100/400 messages)",
+	})
+	long := buf.String()
+	assert.True(strings.HasPrefix(long, "\r"), "render must return to line start")
+	assert.Contains(long, "building the search index (100/400 messages)")
+
+	buf.Reset()
+	l.render(12*time.Second, nil)
+	short := buf.String()
+	assert.Contains(short, "Searching... (12s)")
+	assert.Greater(len(short), len("\rSearching... (12s)"),
+		"a shorter line must be padded to erase the previous one")
+
+	buf.Reset()
+	l.clear()
+	cleared := buf.String()
+	assert.True(strings.HasPrefix(cleared, "\r") && strings.HasSuffix(cleared, "\r"),
+		"clear must blank the line and return to line start")
+	assert.Empty(strings.Trim(cleared, "\r "), "clear must write only spaces")
+}
+
+func TestSearchStatusLineRenderNonTTYPrintsNoticeOnce(t *testing.T) {
+	assert := assert.New(t)
+	var buf bytes.Buffer
+	l := &searchStatusLine{out: &buf, prefix: "Searching...", tty: false}
+
+	l.render(5*time.Second, nil)
+	assert.Empty(buf.String(), "no output while the daemon reports nothing")
+
+	op := &api.OperationHealth{Busy: true, Label: "checking the search index"}
+	l.render(7*time.Second, op)
+	l.render(9*time.Second, op)
+	notice := "Daemon is busy: checking the search index. The search will finish when it does."
+	assert.Equal(1, strings.Count(buf.String(), notice),
+		"the busy notice must be printed exactly once")
+}
+
+func TestStartSearchStatusLoopShowsDaemonActivity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	origQuiet, origTick := searchStatusQuietWindow, searchStatusTick
+	searchStatusQuietWindow = 0
+	searchStatusTick = 5 * time.Millisecond
+	t.Cleanup(func() {
+		searchStatusQuietWindow, searchStatusTick = origQuiet, origTick
+	})
+
+	var buf bytes.Buffer
+	fetched := make(chan struct{}, 1)
+	l := &searchStatusLine{
+		out:    &buf,
+		prefix: "Searching...",
+		tty:    true,
+		start:  time.Now(),
+		fetchOp: func(context.Context) *api.OperationHealth {
+			select {
+			case fetched <- struct{}{}:
+			default:
+			}
+			return &api.OperationHealth{Busy: true, Label: "checking the search index"}
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		l.run(ctx)
+	}()
+
+	// The render for a tick runs unconditionally after its fetch returns, so
+	// once a fetch is observed the corresponding render cannot be skipped by
+	// the cancel below.
+	select {
+	case <-fetched:
+	case <-time.After(time.Second):
+		require.FailNow("run loop never polled the daemon")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow("run loop must stop on cancel")
+	}
+
+	assert.Contains(buf.String(), "daemon is busy: checking the search index",
+		"the loop must render the daemon's reported operation")
+}

--- a/cmd/msgvault/cmd/search_test.go
+++ b/cmd/msgvault/cmd/search_test.go
@@ -334,6 +334,66 @@ func searchHTTPDaemon(t *testing.T) (*httptest.Server, *atomic.Int32) {
 	return server, searchRequests
 }
 
+// TestSearchCmd_PrintsBackgroundIndexBuildNote verifies the CLI warns that
+// results may be incomplete when the daemon reports it is rebuilding the FTS
+// index in the background (index_state="building").
+func TestSearchCmd_PrintsBackgroundIndexBuildNote(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dataDir := t.TempDir()
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/ping", daemon.NewPingHandler(daemon.PingHandlerOptions{
+		Service: daemonService,
+		Version: Version,
+	}))
+	mux.HandleFunc("/api/v1/cli/search", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"results": [{
+				"id": 42,
+				"subject": "Lunch",
+				"from_email": "alice@example.com",
+				"sent_at": "2024-01-02T03:04:05Z"
+			}],
+			"index_state": "building"
+		}`))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	writeStatsHTTPDaemonRuntime(t, dataDir, server)
+
+	savedCfg := cfg
+	savedUseLocal := useLocal
+	defer func() {
+		cfg = savedCfg
+		useLocal = savedUseLocal
+		resetSearchFlags()
+	}()
+
+	cfg = &config.Config{
+		HomeDir: dataDir,
+		Data:    config.DataConfig{DataDir: dataDir},
+	}
+	useLocal = true
+
+	doneOut := captureStdout(t)
+	doneErr := captureStderr(t)
+	root := newTestRootCmd()
+	root.AddCommand(searchCmd)
+	root.SetArgs([]string{"search", "lunch"})
+
+	err := root.Execute()
+	out := doneOut()
+	errOut := doneErr()
+	require.NoError(err, "search command")
+
+	assert.Contains(out, "Lunch", "results still print")
+	assert.Contains(errOut,
+		"the search index is being rebuilt in the background; results may be incomplete",
+		"background build note")
+}
+
 func TestSearchCmd_AccountFlagWithoutQuery(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cmd/msgvault/cmd/search_test.go
+++ b/cmd/msgvault/cmd/search_test.go
@@ -566,6 +566,11 @@ func TestSearchCmd_AccountFlagDoesNotLeakAcrossInvocations(t *testing.T) {
 		SizeEstimate: 100,
 	})
 	require.NoError(err, "insert msg")
+	// Index the message up front: the daemon backfills the FTS index in the
+	// background now, and this test is about flag leakage, not backfill
+	// timing — the text query below must match deterministically.
+	_, err = s.BackfillFTS(nil)
+	require.NoError(err, "backfill FTS")
 	startStoreQueryAPIDaemon(t, tmpDir, s)
 
 	savedCfg := cfg

--- a/cmd/msgvault/cmd/search_test.go
+++ b/cmd/msgvault/cmd/search_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -334,64 +335,93 @@ func searchHTTPDaemon(t *testing.T) (*httptest.Server, *atomic.Int32) {
 	return server, searchRequests
 }
 
-// TestSearchCmd_PrintsBackgroundIndexBuildNote verifies the CLI warns that
-// results may be incomplete when the daemon reports it is rebuilding the FTS
-// index in the background (index_state="building").
-func TestSearchCmd_PrintsBackgroundIndexBuildNote(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	dataDir := t.TempDir()
-
-	mux := http.NewServeMux()
-	mux.Handle("/api/ping", daemon.NewPingHandler(daemon.PingHandlerOptions{
-		Service: daemonService,
-		Version: Version,
-	}))
-	mux.HandleFunc("/api/v1/cli/search", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"results": [{
-				"id": 42,
-				"subject": "Lunch",
-				"from_email": "alice@example.com",
-				"sent_at": "2024-01-02T03:04:05Z"
-			}],
-			"index_state": "building"
-		}`))
-	})
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-	writeStatsHTTPDaemonRuntime(t, dataDir, server)
-
-	savedCfg := cfg
-	savedUseLocal := useLocal
-	defer func() {
-		cfg = savedCfg
-		useLocal = savedUseLocal
-		resetSearchFlags()
-	}()
-
-	cfg = &config.Config{
-		HomeDir: dataDir,
-		Data:    config.DataConfig{DataDir: dataDir},
+// TestSearchCmd_PrintsBackgroundIndexNote verifies the CLI caveats results
+// whenever the daemon reports the FTS index is not yet known complete: a
+// rebuild in progress (index_state="building") and an unfinished completeness
+// probe (index_state="checking") get distinct notes; a complete index gets
+// none.
+func TestSearchCmd_PrintsBackgroundIndexNote(t *testing.T) {
+	tests := []struct {
+		name       string
+		indexState string
+		wantNote   string
+	}{
+		{
+			name:       "building warns about the rebuild",
+			indexState: "building",
+			wantNote:   "the search index is being rebuilt in the background; results may be incomplete",
+		},
+		{
+			name:       "checking warns the probe has not finished",
+			indexState: "checking",
+			wantNote:   "search index completeness is still being verified in the background; results may be incomplete",
+		},
+		{
+			name:       "complete index prints no note",
+			indexState: "",
+			wantNote:   "",
+		},
 	}
-	useLocal = true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			dataDir := t.TempDir()
 
-	doneOut := captureStdout(t)
-	doneErr := captureStderr(t)
-	root := newTestRootCmd()
-	root.AddCommand(searchCmd)
-	root.SetArgs([]string{"search", "lunch"})
+			mux := http.NewServeMux()
+			mux.Handle("/api/ping", daemon.NewPingHandler(daemon.PingHandlerOptions{
+				Service: daemonService,
+				Version: Version,
+			}))
+			mux.HandleFunc("/api/v1/cli/search", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{
+					"results": [{
+						"id": 42,
+						"subject": "Lunch",
+						"from_email": "alice@example.com",
+						"sent_at": "2024-01-02T03:04:05Z"
+					}],
+					"index_state": %q
+				}`, tt.indexState)
+			})
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+			writeStatsHTTPDaemonRuntime(t, dataDir, server)
 
-	err := root.Execute()
-	out := doneOut()
-	errOut := doneErr()
-	require.NoError(err, "search command")
+			savedCfg := cfg
+			savedUseLocal := useLocal
+			defer func() {
+				cfg = savedCfg
+				useLocal = savedUseLocal
+				resetSearchFlags()
+			}()
 
-	assert.Contains(out, "Lunch", "results still print")
-	assert.Contains(errOut,
-		"the search index is being rebuilt in the background; results may be incomplete",
-		"background build note")
+			cfg = &config.Config{
+				HomeDir: dataDir,
+				Data:    config.DataConfig{DataDir: dataDir},
+			}
+			useLocal = true
+
+			doneOut := captureStdout(t)
+			doneErr := captureStderr(t)
+			root := newTestRootCmd()
+			root.AddCommand(searchCmd)
+			root.SetArgs([]string{"search", "lunch"})
+
+			err := root.Execute()
+			out := doneOut()
+			errOut := doneErr()
+			require.NoError(err, "search command")
+
+			assert.Contains(out, "Lunch", "results still print")
+			if tt.wantNote == "" {
+				assert.NotContains(errOut, "Note:", "no index note for a complete index")
+			} else {
+				assert.Contains(errOut, tt.wantNote, "index state note")
+			}
+		})
+	}
 }
 
 func TestSearchCmd_AccountFlagWithoutQuery(t *testing.T) {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -707,6 +707,10 @@ func (a *storeAPIAdapter) NeedsFTSBackfill() bool {
 	return a.store.NeedsFTSBackfill()
 }
 
+func (a *storeAPIAdapter) NeedsFTSBackfillQuick() bool {
+	return a.store.NeedsFTSBackfillQuick()
+}
+
 func (a *storeAPIAdapter) BackfillFTS(progress func(done, total int64)) (int64, error) {
 	return a.store.BackfillFTS(progress)
 }

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -49,6 +49,7 @@ type CLIStore interface {
 	CountMessagesForSource(sourceID int64) (int64, error)
 	CountSourceDeletedMessages(sourceIDs ...int64) (int64, error)
 	NeedsFTSBackfill() bool
+	NeedsFTSBackfillQuick() bool
 	BackfillFTS(progress func(done, total int64)) (int64, error)
 	RebuildFTS(progress func(done, total int64)) (int64, error)
 }
@@ -1411,7 +1412,15 @@ func (s *Server) ensureCLISearchIndexAsync(cliStore CLIStore) string {
 		return ""
 	}
 	if s.ftsEnsureRunning.CompareAndSwap(false, true) {
-		s.ftsIndexState.Store(cliSearchIndexStateChecking)
+		// The quick probe (a couple of index lookups) classifies the initial
+		// state: a visibly stale index reports "building" right away, so the
+		// very first search already warns that results may be incomplete
+		// instead of staying silent for the minutes the full probe can take.
+		state := cliSearchIndexStateChecking
+		if cliStore.NeedsFTSBackfillQuick() {
+			state = cliSearchIndexStateBuilding
+		}
+		s.ftsIndexState.Store(state)
 		go s.runCLISearchIndexEnsure(cliStore)
 	}
 	state, _ := s.ftsIndexState.Load().(string)

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1431,13 +1431,15 @@ func (s *Server) runCLISearchIndexEnsure(cliStore CLIStore) {
 	defer s.ftsEnsureRunning.Store(false)
 	// The probe runs outside the operation gate, so a rebuild-fts can clear
 	// and repopulate the index while it scans. A "complete" observation is
-	// only memoized if no rebuild invalidated the index in the meantime;
-	// otherwise it is discarded and the next search re-triggers the worker.
-	// The backfill path below needs no generation check: it re-probes and
-	// backfills under the gate, serialized with rebuilds.
+	// only memoized when no rebuild was in progress at the snapshot (even
+	// generation — an odd one means a rebuild handler is mid-flight and the
+	// probe's read snapshot may predate its index clear) and none started
+	// since; otherwise it is discarded and the next search re-triggers the
+	// worker. The backfill path below needs no generation check: it
+	// re-probes and backfills under the gate, serialized with rebuilds.
 	rebuildGen := s.ftsRebuildGen.Load()
 	if !s.probeFTSBackfillNeeded(cliStore) {
-		if s.ftsRebuildGen.Load() == rebuildGen {
+		if rebuildGen%2 == 0 && s.ftsRebuildGen.Load() == rebuildGen {
 			s.ftsIndexComplete.Store(true)
 		}
 		s.ftsIndexState.Store("")
@@ -1520,10 +1522,17 @@ func (s *Server) handleCLIRebuildFTS(w http.ResponseWriter, _ *http.Request) {
 	// search re-probes (and serializes behind this POST via the operation
 	// gate) instead of trusting a stale "complete" cache while the index is
 	// mid-rebuild or left incomplete by a failed rebuild. Only a successful
-	// rebuild re-sets the flag. The generation bump makes an in-flight
-	// ensure worker discard a probe result observed before this
-	// invalidation (its probe runs outside the gate).
+	// rebuild re-sets the flag.
+	//
+	// The generation is seqlock-style: odd while this handler runs, bumped
+	// back to even on return. The ensure worker's ungated probe can overlap
+	// a rebuild in either direction — it may start before this bump and
+	// finish after (generation moved), or start after the bump while its
+	// read snapshot still predates the index clear (generation odd). It
+	// only memoizes a "complete" observation on an even, unchanged
+	// generation, so both interleavings discard the stale result.
 	s.ftsRebuildGen.Add(1)
+	defer s.ftsRebuildGen.Add(1)
 	s.ftsIndexComplete.Store(false)
 
 	var writeErr error

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -351,9 +351,23 @@ type cliSearchResponse struct {
 	Results          []query.MessageSummary `json:"results"`
 	ScopeLabel       string                 `json:"scope_label,omitempty"`
 	ScopeSourceCount int                    `json:"scope_source_count,omitempty"`
-	IndexBuilt       bool                   `json:"index_built,omitempty"`
-	IndexedMessages  int64                  `json:"indexed_messages,omitempty"`
+	// IndexBuilt/IndexedMessages are only set by daemons that built the FTS
+	// index synchronously inside the request (pre-0.18); current daemons
+	// build in the background and report IndexState instead. Kept in the
+	// schema so new CLIs understand old daemons.
+	IndexBuilt      bool  `json:"index_built,omitempty"`
+	IndexedMessages int64 `json:"indexed_messages,omitempty"`
+	// IndexState is "checking" while the FTS completeness probe runs and
+	// "building" while a backfill is repopulating the index (results may be
+	// incomplete); empty once the index is known complete.
+	IndexState string `json:"index_state,omitempty"`
 }
+
+// CLI search index states reported in cliSearchResponse.IndexState.
+const (
+	cliSearchIndexStateChecking = "checking"
+	cliSearchIndexStateBuilding = "building"
+)
 
 type CLIQueryMessageSummary query.MessageSummary
 
@@ -1367,48 +1381,12 @@ func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
 	resp := cliSearchResponse{
 		ScopeLabel:       scope.displayName(),
 		ScopeSourceCount: len(scope.sourceIDs()),
-	}
-	// Gate the backfill probe on a memoized completion flag: NeedsFTSBackfill
-	// scans every message when the index is already complete, so probing it on
-	// every request dominated CLI search latency. Once the index is confirmed
-	// complete, skip the probe entirely for the process lifetime.
-	//
-	// The probe and backfill both run inside a labeled activity so
-	// authenticated /health can tell a waiting client what its search is
-	// stuck on — the probe alone takes a minute on a large archive, and it
-	// runs before the operation gate would report anything.
-	if !s.ftsIndexComplete.Load() {
-		if s.probeFTSBackfillNeeded(cliStore) {
-			n, err := func() (int64, error) {
-				done, ok := s.beginLabeledOperationGateWork(r.Context(), "a search index build")
-				if !ok {
-					return 0, newAPIHTTPError(http.StatusServiceUnavailable, "server_busy", "server is busy or shutting down")
-				}
-				defer done()
-				if !cliStore.NeedsFTSBackfill() {
-					return 0, nil
-				}
-				return s.backfillFTSWithActivity(cliStore)
-			}()
-			if err != nil {
-				var apiErr *apiHTTPError
-				if errors.As(err, &apiErr) {
-					writeAPIHTTPError(w, apiErr)
-					return
-				}
-				s.logger.Error("failed to build CLI search index", "error", err)
-				writeError(w, http.StatusInternalServerError, "build_search_index_failed",
-					fmt.Sprintf("build search index: %v", err))
-				return
-			}
-			if n > 0 || !cliStore.NeedsFTSBackfill() {
-				resp.IndexBuilt = true
-				resp.IndexedMessages = n
-				s.ftsIndexComplete.Store(true)
-			}
-		} else {
-			s.ftsIndexComplete.Store(true)
-		}
+		// The FTS completeness probe scans every message (a minute on a
+		// large archive, once per daemon process), so the search never
+		// waits on it: the probe and any backfill run in the background
+		// and the response only reports their state so the CLI can warn
+		// that results may be incomplete while a backfill runs.
+		IndexState: s.ensureCLISearchIndexAsync(cliStore),
 	}
 
 	results, err := s.engine.Search(r.Context(), parsed, limit, offset)
@@ -1419,6 +1397,56 @@ func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
 	}
 	resp.Results = results
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// ensureCLISearchIndexAsync makes sure exactly one background worker is
+// verifying (and if needed, repopulating) the FTS index, and reports what
+// that worker is currently doing so the response can carry it. Searches
+// never wait on this work: the completeness probe alone scans every message
+// — a minute on a large archive — and it used to run inline on the first
+// search of every daemon process, which reads as a hung CLI. A failed
+// backfill clears the running flag so a later search retries.
+func (s *Server) ensureCLISearchIndexAsync(cliStore CLIStore) string {
+	if s.ftsIndexComplete.Load() {
+		return ""
+	}
+	if s.ftsEnsureRunning.CompareAndSwap(false, true) {
+		s.ftsIndexState.Store(cliSearchIndexStateChecking)
+		go s.runCLISearchIndexEnsure(cliStore)
+	}
+	state, _ := s.ftsIndexState.Load().(string)
+	return state
+}
+
+func (s *Server) runCLISearchIndexEnsure(cliStore CLIStore) {
+	defer s.ftsEnsureRunning.Store(false)
+	if !s.probeFTSBackfillNeeded(cliStore) {
+		s.ftsIndexComplete.Store(true)
+		s.ftsIndexState.Store("")
+		return
+	}
+	s.ftsIndexState.Store(cliSearchIndexStateBuilding)
+	// Background gate work, not request work: a backfill queued behind a
+	// long sync should wait its turn rather than force the sync to yield,
+	// since no request is blocked on it anymore.
+	done, ok := s.beginBackgroundOperationGateWork(context.Background(), "a search index build")
+	if !ok {
+		s.ftsIndexState.Store("")
+		return
+	}
+	defer done()
+	if !cliStore.NeedsFTSBackfill() {
+		s.ftsIndexComplete.Store(true)
+		s.ftsIndexState.Store("")
+		return
+	}
+	if _, err := s.backfillFTSWithActivity(cliStore); err != nil {
+		s.logger.Error("failed to build CLI search index", "error", err)
+		s.ftsIndexState.Store("")
+		return
+	}
+	s.ftsIndexComplete.Store(true)
+	s.ftsIndexState.Store("")
 }
 
 // probeFTSBackfillNeeded runs the expensive first-search completeness probe

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1372,8 +1372,13 @@ func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
 	// scans every message when the index is already complete, so probing it on
 	// every request dominated CLI search latency. Once the index is confirmed
 	// complete, skip the probe entirely for the process lifetime.
+	//
+	// The probe and backfill both run inside a labeled activity so
+	// authenticated /health can tell a waiting client what its search is
+	// stuck on — the probe alone takes a minute on a large archive, and it
+	// runs before the operation gate would report anything.
 	if !s.ftsIndexComplete.Load() {
-		if cliStore.NeedsFTSBackfill() {
+		if s.probeFTSBackfillNeeded(cliStore) {
 			n, err := func() (int64, error) {
 				done, ok := s.beginLabeledOperationGateWork(r.Context(), "a search index build")
 				if !ok {
@@ -1383,7 +1388,7 @@ func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
 				if !cliStore.NeedsFTSBackfill() {
 					return 0, nil
 				}
-				return cliStore.BackfillFTS(nil)
+				return s.backfillFTSWithActivity(cliStore)
 			}()
 			if err != nil {
 				var apiErr *apiHTTPError
@@ -1414,6 +1419,45 @@ func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
 	}
 	resp.Results = results
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// probeFTSBackfillNeeded runs the expensive first-search completeness probe
+// as a labeled activity, and logs the duration when it is slow enough to be
+// what a user just sat through.
+func (s *Server) probeFTSBackfillNeeded(cliStore CLIStore) bool {
+	end := s.beginActivity("checking the search index")
+	defer end()
+	started := time.Now()
+	needs := cliStore.NeedsFTSBackfill()
+	if elapsed := time.Since(started); elapsed > time.Second {
+		s.logger.Info("search index completeness probe finished",
+			"needs_backfill", needs,
+			"duration", elapsed.Round(time.Millisecond).String(),
+		)
+	}
+	return needs
+}
+
+// backfillFTSWithActivity runs the FTS backfill with its progress mirrored
+// into the activity label, so authenticated /health reports live counts
+// instead of the gate's static "a search index build".
+func (s *Server) backfillFTSWithActivity(cliStore CLIStore) (int64, error) {
+	end := s.beginActivity("building the search index")
+	defer end()
+	started := time.Now()
+	s.logger.Info("building CLI search index")
+	n, err := cliStore.BackfillFTS(func(done, total int64) {
+		s.setActivityLabel(fmt.Sprintf(
+			"building the search index (%d/%d messages)", done, total))
+	})
+	if err != nil {
+		return n, err
+	}
+	s.logger.Info("built CLI search index",
+		"indexed", n,
+		"duration", time.Since(started).Round(time.Millisecond).String(),
+	)
+	return n, nil
 }
 
 func (s *Server) handleCLIRebuildFTS(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1429,8 +1429,17 @@ func (s *Server) ensureCLISearchIndexAsync(cliStore CLIStore) string {
 
 func (s *Server) runCLISearchIndexEnsure(cliStore CLIStore) {
 	defer s.ftsEnsureRunning.Store(false)
+	// The probe runs outside the operation gate, so a rebuild-fts can clear
+	// and repopulate the index while it scans. A "complete" observation is
+	// only memoized if no rebuild invalidated the index in the meantime;
+	// otherwise it is discarded and the next search re-triggers the worker.
+	// The backfill path below needs no generation check: it re-probes and
+	// backfills under the gate, serialized with rebuilds.
+	rebuildGen := s.ftsRebuildGen.Load()
 	if !s.probeFTSBackfillNeeded(cliStore) {
-		s.ftsIndexComplete.Store(true)
+		if s.ftsRebuildGen.Load() == rebuildGen {
+			s.ftsIndexComplete.Store(true)
+		}
 		s.ftsIndexState.Store("")
 		return
 	}
@@ -1511,7 +1520,10 @@ func (s *Server) handleCLIRebuildFTS(w http.ResponseWriter, _ *http.Request) {
 	// search re-probes (and serializes behind this POST via the operation
 	// gate) instead of trusting a stale "complete" cache while the index is
 	// mid-rebuild or left incomplete by a failed rebuild. Only a successful
-	// rebuild re-sets the flag.
+	// rebuild re-sets the flag. The generation bump makes an in-flight
+	// ensure worker discard a probe result observed before this
+	// invalidation (its probe runs outside the gate).
+	s.ftsRebuildGen.Add(1)
 	s.ftsIndexComplete.Store(false)
 
 	var writeErr error

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1753,6 +1753,111 @@ func TestHandleCLISearchMemoizesFTSComplete(t *testing.T) {
 		"NeedsFTSBackfill should be probed once, then memoized")
 }
 
+// TestHandleCLISearchReportsProbeInAuthenticatedHealth verifies that while
+// the first search of a daemon's lifetime runs the expensive FTS completeness
+// probe, authenticated /health tells concurrent clients what the search is
+// stuck on instead of reporting an idle daemon.
+func TestHandleCLISearchReportsProbeInAuthenticatedHealth(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	probeEntered := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	st := &mockStore{needsFTSBackfillFunc: func() bool {
+		close(probeEntered)
+		<-releaseProbe
+		return false
+	}}
+	engine := &querytest.MockEngine{
+		SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return nil, nil
+		},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080, APIKey: "secret-key"}},
+		Store:  st,
+		Engine: engine,
+		Logger: testLogger(),
+	})
+
+	searchDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello", nil)
+		req.Header.Set("X-Api-Key", "secret-key")
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, req)
+		searchDone <- w
+	}()
+
+	select {
+	case <-probeEntered:
+	case <-time.After(time.Second):
+		require.FailNow("search never reached the FTS completeness probe")
+	}
+
+	healthReq := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	healthReq.Header.Set("X-Api-Key", "secret-key")
+	healthResp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(healthResp, healthReq)
+	require.Equal(http.StatusOK, healthResp.Code, "health status")
+	var health HealthResponse
+	require.NoError(json.Unmarshal(healthResp.Body.Bytes(), &health), "decode health body")
+	require.NotNil(health.Operation, "health must report the running probe")
+	assert.True(health.Operation.Busy, "probe must report busy")
+	assert.Equal("checking the search index", health.Operation.Label, "probe label")
+	assert.NotNil(health.Operation.StartedAt, "probe start time")
+
+	close(releaseProbe)
+	select {
+	case w := <-searchDone:
+		assert.Equal(http.StatusOK, w.Code, "search status: %s", w.Body.String())
+	case <-time.After(time.Second):
+		require.FailNow("search did not finish after probe release")
+	}
+
+	_, _, active := srv.currentActivity()
+	assert.False(active, "activity must be cleared once the probe finishes")
+}
+
+// TestHandleCLISearchBackfillProgressUpdatesActivityLabel verifies the FTS
+// backfill run by a first search mirrors its progress into the health
+// activity label, so a waiting client sees live counts rather than a static
+// gate label.
+func TestHandleCLISearchBackfillProgressUpdatesActivityLabel(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	st := &mockStore{needsFTSBackfill: true}
+	engine := &querytest.MockEngine{
+		SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return nil, nil
+		},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st,
+		Engine: engine,
+		Logger: testLogger(),
+	})
+
+	var labelDuringBackfill string
+	st.backfillFTSFunc = func(progress func(done, total int64)) (int64, error) {
+		progress(2, 4)
+		labelDuringBackfill, _, _ = srv.currentActivity()
+		return 4, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	require.Equal(http.StatusOK, w.Code, "search status: %s", w.Body.String())
+
+	assert.Equal("building the search index (2/4 messages)", labelDuringBackfill,
+		"activity label must carry backfill progress")
+	_, _, active := srv.currentActivity()
+	assert.False(active, "activity must be cleared once the backfill finishes")
+}
+
 func TestHandleCLIRebuildFTSStreamsProgress(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1695,6 +1695,68 @@ func TestHandleCLISearchDoesNotBlockOnIndexBuild(t *testing.T) {
 	assert.Empty(searchIndexState(), "state once the index is complete")
 }
 
+// TestHandleCLISearchProbeDiscardsResultStaleAfterRebuild reproduces the
+// probe/rebuild race (roborev finding on f91f6cb): the ensure worker's
+// completeness probe runs outside the operation gate, so a rebuild-fts can
+// invalidate the index while the probe scans the pre-rebuild state. A
+// "complete" observation from before the rebuild must be discarded — here
+// the rebuild fails, so re-memoizing complete=true would make later searches
+// trust an index the rebuild left partial.
+func TestHandleCLISearchProbeDiscardsResultStaleAfterRebuild(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	probeEntered := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	st := &mockStore{
+		needsFTSBackfillFunc: func() bool {
+			close(probeEntered)
+			<-releaseProbe
+			return false // observed the PRE-rebuild, complete index
+		},
+		rebuildFTSFunc: func(func(done, total int64)) (int64, error) {
+			return 0, errors.New("rebuild exploded mid-batch")
+		},
+	}
+	engine := &querytest.MockEngine{
+		SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return nil, nil
+		},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st,
+		Engine: engine,
+		Logger: testLogger(),
+	})
+
+	// First search spawns the ensure worker, which blocks inside the probe.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	require.Equal(http.StatusOK, w.Code, "search status: %s", w.Body.String())
+	select {
+	case <-probeEntered:
+	case <-time.After(time.Second):
+		require.FailNow("the search never spawned the FTS completeness probe")
+	}
+
+	// A rebuild starts and fails while the probe is still scanning.
+	resp := servePOSTTestRequest(srv, "/api/v1/cli/rebuild-fts")
+	requireNDJSONResponse(t, resp)
+	_ = decodeNDJSONEvents[cliRebuildFTSEvent](t, resp.Body)
+	require.False(srv.ftsIndexComplete.Load(),
+		"precondition: a failed rebuild leaves the completeness flag cleared")
+
+	// The probe finishes with its pre-rebuild observation; the worker must
+	// discard it rather than re-memoize complete=true over the failed rebuild.
+	close(releaseProbe)
+	require.Eventually(func() bool { return !srv.ftsEnsureRunning.Load() },
+		time.Second, 5*time.Millisecond, "ensure worker must finish")
+	assert.False(srv.ftsIndexComplete.Load(),
+		"a probe result observed before a rebuild must not be memoized")
+}
+
 // TestHandleCLISearchQuickCheckReportsBuildingImmediately verifies that when
 // the cheap tail-check already knows the index is stale, the very first
 // search reports index_state="building" — so the CLI warns about incomplete

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1620,13 +1620,25 @@ func TestHandleCLISearchCollectionScope(t *testing.T) {
 	assert.Empty(resp.Results, "results")
 }
 
-func TestHandleCLISearchBackfillBypassesStandardRequestTimeout(t *testing.T) {
+// TestHandleCLISearchDoesNotBlockOnIndexBuild is the core cold-start UX
+// contract: a search must return results immediately even while the FTS
+// completeness probe (a minute on a large archive) or a backfill is running,
+// reporting the background work's state instead of waiting on it.
+func TestHandleCLISearchDoesNotBlockOnIndexBuild(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
+
+	probeRelease := make(chan struct{})
+	backfillEntered := make(chan struct{})
+	backfillRelease := make(chan struct{})
 	st := &mockStore{
-		needsFTSBackfill: true,
+		needsFTSBackfillFunc: func() bool {
+			<-probeRelease // closed channel unblocks both probe calls
+			return true
+		},
 		backfillFTSFunc: func(func(done, total int64)) (int64, error) {
-			time.Sleep(40 * time.Millisecond)
+			close(backfillEntered)
+			<-backfillRelease
 			return 12, nil
 		},
 	}
@@ -1646,25 +1658,40 @@ func TestHandleCLISearchBackfillBypassesStandardRequestTimeout(t *testing.T) {
 		RequestTimeout: 5 * time.Millisecond,
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello&limit=10", nil)
-	w := httptest.NewRecorder()
-
-	srv.Router().ServeHTTP(w, req)
-
-	assert.Equal(http.StatusOK, w.Code, "status: %s", w.Body.String())
-
-	var resp struct {
-		Results []struct {
-			Subject string `json:"subject"`
-		} `json:"results"`
-		IndexBuilt      bool  `json:"index_built"`
-		IndexedMessages int64 `json:"indexed_messages"`
+	searchIndexState := func() string {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello&limit=10", nil)
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, req)
+		require.Equal(http.StatusOK, w.Code, "status: %s", w.Body.String())
+		var resp struct {
+			Results []struct {
+				Subject string `json:"subject"`
+			} `json:"results"`
+			IndexBuilt bool   `json:"index_built"`
+			IndexState string `json:"index_state"`
+		}
+		require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode response")
+		require.Len(resp.Results, 1, "results")
+		assert.Equal("match", resp.Results[0].Subject, "subject")
+		assert.False(resp.IndexBuilt, "index_built is a pre-0.18 synchronous-build field")
+		return resp.IndexState
 	}
-	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode response")
-	assert.True(resp.IndexBuilt, "index built")
-	assert.Equal(int64(12), resp.IndexedMessages, "indexed messages")
-	require.Len(resp.Results, 1, "results")
-	assert.Equal("match", resp.Results[0].Subject, "subject")
+
+	// The probe is blocked, so a search must still answer instantly.
+	assert.Equal("checking", searchIndexState(), "state while the probe runs")
+
+	close(probeRelease)
+	select {
+	case <-backfillEntered:
+	case <-time.After(time.Second):
+		require.FailNow("background worker never reached the backfill")
+	}
+	assert.Equal("building", searchIndexState(), "state while the backfill runs")
+
+	close(backfillRelease)
+	require.Eventually(func() bool { return srv.ftsIndexComplete.Load() },
+		time.Second, 5*time.Millisecond, "backfill completion must set the memo flag")
+	assert.Empty(searchIndexState(), "state once the index is complete")
 }
 
 func TestHandleCLISearchBackfillUsesOperationGate(t *testing.T) {
@@ -1695,13 +1722,11 @@ func TestHandleCLISearchBackfillUsesOperationGate(t *testing.T) {
 		OperationGate: gate,
 	})
 
+	// The search itself must not queue behind the held gate.
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello&limit=10", nil)
 	resp := httptest.NewRecorder()
-	done := make(chan struct{})
-	go func() {
-		srv.Router().ServeHTTP(resp, req)
-		close(done)
-	}()
+	srv.Router().ServeHTTP(resp, req)
+	assert.Equal(http.StatusOK, resp.Code, "status: %s", resp.Body.String())
 
 	select {
 	case <-backfillStarted:
@@ -1715,12 +1740,8 @@ func TestHandleCLISearchBackfillUsesOperationGate(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		require.FailNow("backfill did not start after gate release")
 	}
-	select {
-	case <-done:
-	case <-time.After(500 * time.Millisecond):
-		require.FailNow("search did not finish after gate release")
-	}
-	assert.Equal(http.StatusOK, resp.Code, "status: %s", resp.Body.String())
+	require.Eventually(func() bool { return srv.ftsIndexComplete.Load() },
+		time.Second, 5*time.Millisecond, "backfill completion must set the memo flag")
 }
 
 // TestHandleCLISearchMemoizesFTSComplete verifies that once the FTS index is
@@ -1742,21 +1763,29 @@ func TestHandleCLISearchMemoizesFTSComplete(t *testing.T) {
 		Logger: testLogger(),
 	})
 
-	for range 3 {
+	doSearch := func() {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello&limit=10", nil)
 		w := httptest.NewRecorder()
 		srv.Router().ServeHTTP(w, req)
 		assert.Equal(http.StatusOK, w.Code, "status: %s", w.Body.String())
 	}
 
+	doSearch()
+	// The probe runs in a background worker now; wait for it to confirm
+	// completeness before checking that later searches skip it.
+	require.Eventually(t, func() bool { return srv.ftsIndexComplete.Load() },
+		time.Second, 5*time.Millisecond, "probe must confirm the index complete")
+	doSearch()
+	doSearch()
+
 	assert.Equal(int32(1), st.needsFTSBackfillCalls.Load(),
 		"NeedsFTSBackfill should be probed once, then memoized")
 }
 
 // TestHandleCLISearchReportsProbeInAuthenticatedHealth verifies that while
-// the first search of a daemon's lifetime runs the expensive FTS completeness
-// probe, authenticated /health tells concurrent clients what the search is
-// stuck on instead of reporting an idle daemon.
+// the background worker spawned by the first search runs the expensive FTS
+// completeness probe, authenticated /health tells clients what the daemon is
+// doing instead of reporting it idle.
 func TestHandleCLISearchReportsProbeInAuthenticatedHealth(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -1780,19 +1809,17 @@ func TestHandleCLISearchReportsProbeInAuthenticatedHealth(t *testing.T) {
 		Logger: testLogger(),
 	})
 
-	searchDone := make(chan *httptest.ResponseRecorder, 1)
-	go func() {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello", nil)
-		req.Header.Set("X-Api-Key", "secret-key")
-		w := httptest.NewRecorder()
-		srv.Router().ServeHTTP(w, req)
-		searchDone <- w
-	}()
+	// The first search spawns the probe worker and returns without waiting.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello", nil)
+	req.Header.Set("X-Api-Key", "secret-key")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	assert.Equal(http.StatusOK, w.Code, "search status: %s", w.Body.String())
 
 	select {
 	case <-probeEntered:
 	case <-time.After(time.Second):
-		require.FailNow("search never reached the FTS completeness probe")
+		require.FailNow("the search never spawned the FTS completeness probe")
 	}
 
 	healthReq := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
@@ -1808,20 +1835,16 @@ func TestHandleCLISearchReportsProbeInAuthenticatedHealth(t *testing.T) {
 	assert.NotNil(health.Operation.StartedAt, "probe start time")
 
 	close(releaseProbe)
-	select {
-	case w := <-searchDone:
-		assert.Equal(http.StatusOK, w.Code, "search status: %s", w.Body.String())
-	case <-time.After(time.Second):
-		require.FailNow("search did not finish after probe release")
-	}
-
-	_, _, active := srv.currentActivity()
-	assert.False(active, "activity must be cleared once the probe finishes")
+	require.Eventually(func() bool {
+		_, _, active := srv.currentActivity()
+		return !active && srv.ftsIndexComplete.Load()
+	}, time.Second, 5*time.Millisecond,
+		"activity must clear and the memo flag must set once the probe finishes")
 }
 
-// TestHandleCLISearchBackfillProgressUpdatesActivityLabel verifies the FTS
-// backfill run by a first search mirrors its progress into the health
-// activity label, so a waiting client sees live counts rather than a static
+// TestHandleCLISearchBackfillProgressUpdatesActivityLabel verifies the
+// background FTS backfill mirrors its progress into the health activity
+// label, so clients polling /health see live counts rather than a static
 // gate label.
 func TestHandleCLISearchBackfillProgressUpdatesActivityLabel(t *testing.T) {
 	require := require.New(t)
@@ -1852,6 +1875,8 @@ func TestHandleCLISearchBackfillProgressUpdatesActivityLabel(t *testing.T) {
 	srv.Router().ServeHTTP(w, req)
 	require.Equal(http.StatusOK, w.Code, "search status: %s", w.Body.String())
 
+	require.Eventually(func() bool { return srv.ftsIndexComplete.Load() },
+		time.Second, 5*time.Millisecond, "background backfill must complete")
 	assert.Equal("building the search index (2/4 messages)", labelDuringBackfill,
 		"activity label must carry backfill progress")
 	_, _, active := srv.currentActivity()

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1677,7 +1677,8 @@ func TestHandleCLISearchDoesNotBlockOnIndexBuild(t *testing.T) {
 		return resp.IndexState
 	}
 
-	// The probe is blocked, so a search must still answer instantly.
+	// The full probe is blocked and the quick tail-check found nothing, so
+	// the first search answers instantly and quietly.
 	assert.Equal("checking", searchIndexState(), "state while the probe runs")
 
 	close(probeRelease)
@@ -1692,6 +1693,47 @@ func TestHandleCLISearchDoesNotBlockOnIndexBuild(t *testing.T) {
 	require.Eventually(func() bool { return srv.ftsIndexComplete.Load() },
 		time.Second, 5*time.Millisecond, "backfill completion must set the memo flag")
 	assert.Empty(searchIndexState(), "state once the index is complete")
+}
+
+// TestHandleCLISearchQuickCheckReportsBuildingImmediately verifies that when
+// the cheap tail-check already knows the index is stale, the very first
+// search reports index_state="building" — so the CLI warns about incomplete
+// results right away instead of staying silent for the minutes the full
+// completeness probe can take (roborev finding on 2328a4f).
+func TestHandleCLISearchQuickCheckReportsBuildingImmediately(t *testing.T) {
+	require := require.New(t)
+	probeRelease := make(chan struct{})
+	t.Cleanup(func() { close(probeRelease) })
+	st := &mockStore{
+		needsFTSBackfillQuick: true,
+		needsFTSBackfillFunc: func() bool {
+			<-probeRelease // full probe stays busy for the whole test
+			return false
+		},
+	}
+	engine := &querytest.MockEngine{
+		SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return nil, nil
+		},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st,
+		Engine: engine,
+		Logger: testLogger(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	require.Equal(http.StatusOK, w.Code, "status: %s", w.Body.String())
+
+	var resp struct {
+		IndexState string `json:"index_state"`
+	}
+	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode response")
+	assert.Equal(t, "building", resp.IndexState,
+		"a stale tail must be reported as building on the first response")
 }
 
 func TestHandleCLISearchBackfillUsesOperationGate(t *testing.T) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1757,6 +1757,67 @@ func TestHandleCLISearchProbeDiscardsResultStaleAfterRebuild(t *testing.T) {
 		"a probe result observed before a rebuild must not be memoized")
 }
 
+// TestHandleCLISearchProbeRefusesMemoizeDuringRebuild covers the second
+// probe/rebuild interleaving (roborev finding on a7752aa): the ensure worker
+// starts AFTER a rebuild is already mid-flight (generation bumped to odd),
+// and its probe's read snapshot may still predate the rebuild's index clear.
+// A "complete" observation under an odd generation must not be memoized —
+// here the rebuild is still running when the probe finishes, then fails.
+func TestHandleCLISearchProbeRefusesMemoizeDuringRebuild(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	rebuildEntered := make(chan struct{})
+	releaseRebuild := make(chan struct{})
+	st := &mockStore{
+		needsFTSBackfill: false, // probe sees the pre-clear "complete" index
+		rebuildFTSFunc: func(func(done, total int64)) (int64, error) {
+			close(rebuildEntered)
+			<-releaseRebuild
+			return 0, errors.New("rebuild exploded mid-batch")
+		},
+	}
+	engine := &querytest.MockEngine{
+		SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return nil, nil
+		},
+	}
+	srv := newCLIHandlerTestServer(st)
+	srv.engine = engine
+
+	rebuildDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rebuildDone <- servePOSTTestRequest(srv, "/api/v1/cli/rebuild-fts")
+	}()
+	select {
+	case <-rebuildEntered:
+	case <-time.After(time.Second):
+		require.FailNow("rebuild never started")
+	}
+
+	// A search arrives while the rebuild is mid-flight; its ensure worker
+	// probes the (snapshot-wise still complete) index.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/search?q=hello", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	require.Equal(http.StatusOK, w.Code, "search status: %s", w.Body.String())
+	require.Eventually(func() bool { return !srv.ftsEnsureRunning.Load() },
+		time.Second, 5*time.Millisecond, "ensure worker must finish")
+
+	assert.False(srv.ftsIndexComplete.Load(),
+		"a probe observation made while a rebuild is mid-flight must not be memoized")
+
+	close(releaseRebuild)
+	select {
+	case resp := <-rebuildDone:
+		requireNDJSONResponse(t, resp)
+	case <-time.After(time.Second):
+		require.FailNow("rebuild request did not finish")
+	}
+	assert.False(srv.ftsIndexComplete.Load(),
+		"the failed rebuild must leave the completeness flag cleared")
+}
+
 // TestHandleCLISearchQuickCheckReportsBuildingImmediately verifies that when
 // the cheap tail-check already knows the index is stale, the very first
 // search reports index_state="building" — so the CLI warns about incomplete

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -13,7 +13,14 @@ import (
 // APISchemaVersion is the version stamped into the OpenAPI document
 // (info.version). It tracks the HTTP wire contract, not the binary build
 // version, so clients can reason about compatibility independently of releases.
-const APISchemaVersion = "1.0.0"
+//
+// 1.1.0: GET /api/v1/cli/search no longer blocks on the FTS completeness
+// probe/backfill; it returns immediately and reports background index work in
+// the additive index_state field ("checking"/"building"). Clients older than
+// this field ignore it and see results without a completeness caveat during
+// that window — the same exposure GET /api/v1/search has always had. Additive
+// (minor bump): the major-version compatibility gate stays at 1.
+const APISchemaVersion = "1.1.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/operation_gate.go
+++ b/internal/api/operation_gate.go
@@ -414,6 +414,20 @@ func operationGateLabelFromPath(urlPath string) string {
 	return "msgvault " + name
 }
 
+// beginBackgroundOperationGateWork acquires the gate for daemon-owned
+// background work: unlike beginLabeledOperationGateWork it does not count as
+// a request waiter, so gate holders that yield to requests (scheduled syncs,
+// embed passes) are not interrupted by it.
+func (s *Server) beginBackgroundOperationGateWork(ctx context.Context, label string) (func(), bool) {
+	if s.operationGate == nil {
+		return func() {}, true
+	}
+	if lg, ok := s.operationGate.(LabeledOperationGate); ok {
+		return lg.BeginLabeledWorkContext(ctx, label)
+	}
+	return s.operationGate.BeginWorkContext(ctx)
+}
+
 func (s *Server) beginLabeledOperationGateWork(ctx context.Context, label string) (func(), bool) {
 	if s.operationGate == nil {
 		return func() {}, true

--- a/internal/api/operation_gate_test.go
+++ b/internal/api/operation_gate_test.go
@@ -675,3 +675,54 @@ func TestHealthOmitsOperationWhenGateIdle(t *testing.T) {
 	body := healthResponseForServer(t, srv)
 	assert.Nil(t, body.Operation, "idle gate must not report an operation")
 }
+
+// TestOperationHealthPrefersActivityOverGateLabel verifies a request-scoped
+// activity (which can carry live progress) wins over the gate holder's static
+// label, and that health falls back to the gate label once the activity ends.
+func TestOperationHealthPrefersActivityOverGateLabel(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	gate := NewSerialOperationGate()
+	srv := newOperationHealthTestServer(gate)
+
+	release, ok := gate.BeginLabeledWorkContext(context.Background(), "a search index build")
+	require.True(ok, "acquire gate")
+	defer release()
+
+	end := srv.beginActivity("building the search index")
+	srv.setActivityLabel("building the search index (2/4 messages)")
+
+	op := srv.operationHealth()
+	require.NotNil(op, "activity must be reported")
+	assert.Equal("building the search index (2/4 messages)", op.Label,
+		"activity label must win over the gate label")
+
+	end()
+	op = srv.operationHealth()
+	require.NotNil(op, "gate holder must still be reported after the activity ends")
+	assert.Equal("a search index build", op.Label, "gate label after activity end")
+}
+
+// TestBeginActivityNestingAndIdempotentEnd verifies overlapping activities
+// share one label (first begin wins, last end clears) and that calling an end
+// func twice does not clear a newer activity.
+func TestBeginActivityNestingAndIdempotentEnd(t *testing.T) {
+	assert := assert.New(t)
+	srv := newOperationHealthTestServer(nil)
+
+	endFirst := srv.beginActivity("checking the search index")
+	endSecond := srv.beginActivity("building the search index")
+
+	label, _, active := srv.currentActivity()
+	assert.True(active, "activity must be active while begun")
+	assert.Equal("checking the search index", label, "first begin sets the label")
+
+	endFirst()
+	endFirst() // second call must be a no-op, not a double decrement
+	_, _, active = srv.currentActivity()
+	assert.True(active, "activity must stay active until the last end")
+
+	endSecond()
+	_, _, active = srv.currentActivity()
+	assert.False(active, "last end must clear the activity")
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -151,6 +151,12 @@ type Server struct {
 	// a restart or `rebuild-fts` (the same limitation the /api/v1/search path
 	// already has, since it never backfills).
 	ftsIndexComplete atomic.Bool
+	// ftsEnsureRunning guards the single background probe/backfill worker
+	// spawned by CLI searches; ftsIndexState is what that worker is doing
+	// ("checking", "building", or "" when idle/complete) so search responses
+	// can report it. See ensureCLISearchIndexAsync.
+	ftsEnsureRunning atomic.Bool
+	ftsIndexState    atomic.Value
 	// activity reports request-scoped work that health should surface even
 	// though it runs outside (or with more detail than) the operation gate,
 	// e.g. the first-search FTS completeness probe and backfill progress.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -157,11 +157,12 @@ type Server struct {
 	// can report it. See ensureCLISearchIndexAsync.
 	ftsEnsureRunning atomic.Bool
 	ftsIndexState    atomic.Value
-	// ftsRebuildGen is bumped by handleCLIRebuildFTS when it invalidates the
-	// index. The ensure worker's completeness probe runs outside the
-	// operation gate, so its result can predate a concurrent rebuild; the
-	// worker snapshots this generation before probing and discards a stale
-	// "complete" observation instead of re-memoizing over the invalidation.
+	// ftsRebuildGen is a seqlock-style generation for index rebuilds:
+	// handleCLIRebuildFTS bumps it to odd on entry and back to even on
+	// return. The ensure worker's completeness probe runs outside the
+	// operation gate, so its result can predate a concurrent rebuild's
+	// index clear; the worker snapshots this generation before probing and
+	// memoizes a "complete" observation only on an even, unchanged value.
 	ftsRebuildGen atomic.Uint64
 	// activity reports request-scoped work that health should surface even
 	// though it runs outside (or with more detail than) the operation gate,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -151,7 +151,15 @@ type Server struct {
 	// a restart or `rebuild-fts` (the same limitation the /api/v1/search path
 	// already has, since it never backfills).
 	ftsIndexComplete atomic.Bool
-	cfgMu            sync.RWMutex // protects cfg.Accounts
+	// activity reports request-scoped work that health should surface even
+	// though it runs outside (or with more detail than) the operation gate,
+	// e.g. the first-search FTS completeness probe and backfill progress.
+	// See beginActivity / setActivityLabel / currentActivity.
+	activityMu    sync.Mutex
+	activityCount int
+	activityLabel string
+	activitySince time.Time
+	cfgMu         sync.RWMutex // protects cfg.Accounts
 	// vectorMu guards the vector subsystem state: the daemon installs
 	// hybridEngine/backend/vectorCfg from a background init goroutine
 	// after the server is already handling requests.
@@ -715,10 +723,15 @@ func (s *Server) operationBusyHealth() *OperationHealth {
 	return &OperationHealth{Busy: true}
 }
 
-// operationHealth reports what currently holds the operation gate, if the
-// gate can say. Unlabeled holders still get a generic label so clients can
-// tell "busy" from "idle".
+// operationHealth reports what the daemon is currently working on. A
+// request-scoped activity (which carries live progress detail) wins over the
+// operation gate holder's static label; the gate holder covers everything
+// else. Unlabeled holders still get a generic label so clients can tell
+// "busy" from "idle".
 func (s *Server) operationHealth() *OperationHealth {
+	if label, since, active := s.currentActivity(); active {
+		return &OperationHealth{Busy: true, Label: label, StartedAt: &since}
+	}
 	label, since, held := s.operationGateHolder()
 	if !held {
 		return nil
@@ -727,6 +740,53 @@ func (s *Server) operationHealth() *OperationHealth {
 		label = "an archive operation"
 	}
 	return &OperationHealth{Busy: true, Label: label, StartedAt: &since}
+}
+
+// beginActivity records that a request is doing labeled work the operation
+// gate cannot describe — either ungated work (the FTS completeness probe) or
+// gated work whose label should carry live progress (the FTS backfill). The
+// returned func ends the activity. Overlapping activities share one label:
+// the first begin sets it, the last end clears it.
+func (s *Server) beginActivity(label string) func() {
+	s.activityMu.Lock()
+	s.activityCount++
+	if s.activityCount == 1 {
+		s.activityLabel = label
+		s.activitySince = time.Now()
+	}
+	s.activityMu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.activityMu.Lock()
+			s.activityCount--
+			if s.activityCount == 0 {
+				s.activityLabel = ""
+				s.activitySince = time.Time{}
+			}
+			s.activityMu.Unlock()
+		})
+	}
+}
+
+// setActivityLabel updates the current activity's label in place so progress
+// callbacks can keep health output live (e.g. "building the search index
+// (12000/48000 messages)"). No-op when no activity is active.
+func (s *Server) setActivityLabel(label string) {
+	s.activityMu.Lock()
+	if s.activityCount > 0 {
+		s.activityLabel = label
+	}
+	s.activityMu.Unlock()
+}
+
+func (s *Server) currentActivity() (string, time.Time, bool) {
+	s.activityMu.Lock()
+	defer s.activityMu.Unlock()
+	if s.activityCount == 0 {
+		return "", time.Time{}, false
+	}
+	return s.activityLabel, s.activitySince, true
 }
 
 func (s *Server) operationGateHolder() (string, time.Time, bool) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -157,6 +157,12 @@ type Server struct {
 	// can report it. See ensureCLISearchIndexAsync.
 	ftsEnsureRunning atomic.Bool
 	ftsIndexState    atomic.Value
+	// ftsRebuildGen is bumped by handleCLIRebuildFTS when it invalidates the
+	// index. The ensure worker's completeness probe runs outside the
+	// operation gate, so its result can predate a concurrent rebuild; the
+	// worker snapshots this generation before probing and discards a stale
+	// "complete" observation instead of re-memoizing over the invalidation.
+	ftsRebuildGen atomic.Uint64
 	// activity reports request-scoped work that health should surface even
 	// though it runs outside (or with more detail than) the operation gate,
 	// e.g. the first-search FTS completeness probe and backfill progress.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -223,6 +223,9 @@ type mockStore struct {
 	messages         []APIMessage
 	total            int64
 	needsFTSBackfill bool
+	// needsFTSBackfillQuick is the cheap tail-check answer; independent of
+	// the full probe so tests can exercise their divergence.
+	needsFTSBackfillQuick bool
 	// needsFTSBackfillFunc overrides the needsFTSBackfill field when set, so
 	// tests can block inside the probe or vary its answer per call.
 	needsFTSBackfillFunc func() bool
@@ -439,6 +442,10 @@ func (m *mockStore) NeedsFTSBackfill() bool {
 		return m.needsFTSBackfillFunc()
 	}
 	return m.needsFTSBackfill
+}
+
+func (m *mockStore) NeedsFTSBackfillQuick() bool {
+	return m.needsFTSBackfillQuick
 }
 
 func (m *mockStore) BackfillFTS(progress func(done, total int64)) (int64, error) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -223,18 +223,21 @@ type mockStore struct {
 	messages         []APIMessage
 	total            int64
 	needsFTSBackfill bool
-	backfillFTSFunc  func(func(done, total int64)) (int64, error)
-	rebuildFTSFunc   func(func(done, total int64)) (int64, error)
-	buildCacheFunc   func(context.Context, bool, func(CLICacheBuildEvent) error) error
-	syncFunc         func(context.Context, CLISyncRequest, func(CLISyncEvent) error) error
-	verifyFunc       func(context.Context, CLIVerifyRequest, func(CLIVerifyEvent) error) error
-	repairFunc       func(context.Context, func(CLIRepairEncodingEvent) error) error
-	runFunc          func(context.Context, CLIRunRequest, func(CLIRunEvent) error) error
-	planCalendarFunc func(context.Context, CLIAddCalendarPlanRequest) (CLIAddCalendarPlanResponse, error)
-	planEmbedsFunc   func(context.Context, CLIEmbeddingsPlanRequest) (CLIEmbeddingsPlanResponse, error)
-	planDeleteFunc   func(context.Context, CLIDeleteStagedPlanRequest) (CLIDeleteStagedPlanResponse, error)
-	planDedupFunc    func(context.Context, CLIDeduplicatePlanRequest) (CLIDeduplicatePlanResponse, error)
-	saveManifestFunc func(context.Context, *deletion.Manifest) error
+	// needsFTSBackfillFunc overrides the needsFTSBackfill field when set, so
+	// tests can block inside the probe or vary its answer per call.
+	needsFTSBackfillFunc func() bool
+	backfillFTSFunc      func(func(done, total int64)) (int64, error)
+	rebuildFTSFunc       func(func(done, total int64)) (int64, error)
+	buildCacheFunc       func(context.Context, bool, func(CLICacheBuildEvent) error) error
+	syncFunc             func(context.Context, CLISyncRequest, func(CLISyncEvent) error) error
+	verifyFunc           func(context.Context, CLIVerifyRequest, func(CLIVerifyEvent) error) error
+	repairFunc           func(context.Context, func(CLIRepairEncodingEvent) error) error
+	runFunc              func(context.Context, CLIRunRequest, func(CLIRunEvent) error) error
+	planCalendarFunc     func(context.Context, CLIAddCalendarPlanRequest) (CLIAddCalendarPlanResponse, error)
+	planEmbedsFunc       func(context.Context, CLIEmbeddingsPlanRequest) (CLIEmbeddingsPlanResponse, error)
+	planDeleteFunc       func(context.Context, CLIDeleteStagedPlanRequest) (CLIDeleteStagedPlanResponse, error)
+	planDedupFunc        func(context.Context, CLIDeduplicatePlanRequest) (CLIDeduplicatePlanResponse, error)
+	saveManifestFunc     func(context.Context, *deletion.Manifest) error
 
 	// Error injection for the context-aware read paths, used to verify
 	// handlers map context deadline/cancellation to a structured 503.
@@ -432,6 +435,9 @@ func (m *mockStore) CountSourceDeletedMessages(...int64) (int64, error) {
 
 func (m *mockStore) NeedsFTSBackfill() bool {
 	m.needsFTSBackfillCalls.Add(1)
+	if m.needsFTSBackfillFunc != nil {
+		return m.needsFTSBackfillFunc()
+	}
 	return m.needsFTSBackfill
 }
 

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -158,8 +158,13 @@ type CLISearch struct {
 	Results          []query.MessageSummary `json:"results"`
 	ScopeLabel       string                 `json:"scope_label,omitempty"`
 	ScopeSourceCount int                    `json:"scope_source_count,omitempty"`
-	IndexBuilt       bool                   `json:"index_built,omitempty"`
-	IndexedMessages  int64                  `json:"indexed_messages,omitempty"`
+	// IndexBuilt/IndexedMessages come from pre-0.18 daemons that built the
+	// FTS index synchronously inside the search request. Current daemons
+	// build in the background and report IndexState ("checking" or
+	// "building") instead.
+	IndexBuilt      bool   `json:"index_built,omitempty"`
+	IndexedMessages int64  `json:"indexed_messages,omitempty"`
+	IndexState      string `json:"index_state,omitempty"`
 }
 
 type CLIHybridSearchRequest struct {

--- a/internal/daemonclient/convert.go
+++ b/internal/daemonclient/convert.go
@@ -230,6 +230,7 @@ func cliSearchFromGenerated(resp *generated.SearchCLIResponse) *CLISearch {
 		ScopeSourceCount: intValue(resp.ScopeSourceCount),
 		IndexBuilt:       boolValue(resp.IndexBuilt),
 		IndexedMessages:  int64Value(resp.IndexedMessages),
+		IndexState:       stringValue(resp.IndexState),
 	}
 }
 

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -92,6 +92,13 @@ type Dialect interface {
 	// FTSNeedsBackfill reports whether the FTS index needs to be populated.
 	FTSNeedsBackfill(db *sql.DB) bool
 
+	// FTSNeedsBackfillQuick is a cheap approximation of FTSNeedsBackfill for
+	// hot paths: it must never take longer than a few index lookups. True
+	// means the index is visibly behind (a backfill is certainly needed);
+	// false is not authoritative — on SQLite the MAX(rowid)-vs-MAX(id)
+	// comparison misses interior holes that only the full anti-join finds.
+	FTSNeedsBackfillQuick(db *sql.DB) bool
+
 	// FTSClearSQL returns the SQL to clear all FTS data before a full backfill.
 	FTSClearSQL() string
 

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -254,6 +254,13 @@ func (d *PostgreSQLDialect) FTSNeedsBackfill(db *sql.DB) bool {
 	return exists
 }
 
+// FTSNeedsBackfillQuick delegates to FTSNeedsBackfill: the EXISTS probe is
+// already index-served by idx_messages_search_fts_null, so the exact check
+// is as cheap as any approximation would be.
+func (d *PostgreSQLDialect) FTSNeedsBackfillQuick(db *sql.DB) bool {
+	return d.FTSNeedsBackfill(db)
+}
+
 // FTSClearSQL returns the SQL to clear all tsvector data.
 func (d *PostgreSQLDialect) FTSClearSQL() string {
 	return "UPDATE messages SET search_fts = NULL"

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -182,6 +182,26 @@ func (d *SQLiteDialect) FTSNeedsBackfill(db *sql.DB) bool {
 	return exists
 }
 
+// FTSNeedsBackfillQuick compares MAX(id) against MAX(rowid) — two B-tree
+// lookups, instant at any archive size. It catches the dominant staleness
+// (tail of the messages table not yet indexed: fresh import, interrupted
+// backfill) but misses interior holes; FTSNeedsBackfill stays authoritative.
+func (d *SQLiteDialect) FTSNeedsBackfillQuick(db *sql.DB) bool {
+	var msgMax int64
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT COALESCE(MAX(id), 0) FROM messages",
+	).Scan(&msgMax); err != nil || msgMax == 0 {
+		return false
+	}
+	var ftsMax int64
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT COALESCE(MAX(rowid), 0) FROM messages_fts",
+	).Scan(&ftsMax); err != nil {
+		return false
+	}
+	return ftsMax < msgMax
+}
+
 // FTSClearSQL returns the SQL to clear all FTS5 data.
 func (d *SQLiteDialect) FTSClearSQL() string {
 	return "DELETE FROM messages_fts"

--- a/internal/store/fts_needs_backfill_test.go
+++ b/internal/store/fts_needs_backfill_test.go
@@ -51,6 +51,32 @@ func TestStore_NeedsFTSBackfill_Transition(t *testing.T) {
 		"NeedsFTSBackfill must be false after a complete backfill")
 }
 
+// TestStore_NeedsFTSBackfillQuick_Transition verifies the cheap probe's
+// contract on both backends: true while the index tail is unindexed, false
+// once backfill completes. (Interior holes are explicitly out of contract on
+// SQLite — the full NeedsFTSBackfill anti-join is authoritative for those.)
+func TestStore_NeedsFTSBackfillQuick_Transition(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if !f.Store.FTS5Available() {
+		t.Skip("FTS5 not available")
+	}
+
+	const total = 20
+	ids := f.CreateMessages(total)
+	require.Len(ids, total)
+
+	assert.True(f.Store.NeedsFTSBackfillQuick(),
+		"quick probe must be true while the index tail is unindexed")
+
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	assert.False(f.Store.NeedsFTSBackfillQuick(),
+		"quick probe must be false after a complete backfill")
+}
+
 // TestStore_NeedsFTSBackfill_HoleAtLowestID (F4) verifies that a hole left at a
 // LOW id while later ids are indexed is detected on BOTH backends. This is the
 // case the old SQLite MAX(rowid)-vs-MAX(id) heuristic missed: the FTS MAX still

--- a/internal/store/migrate_init_schema_ledger_test.go
+++ b/internal/store/migrate_init_schema_ledger_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInitSchema_OneShotMigrationsGatedOnLedger verifies the two data
+// migrations InitSchema used to re-verify on every start (the attachments
+// dedupe and the messages.last_modified backfill — a full messages-table
+// scan, the dominant daemon-startup cost on a large archive) are gated on
+// the applied_migrations ledger:
+//
+//  1. a fresh InitSchema runs them once and records both sentinels,
+//  2. a later InitSchema with the sentinel present skips the work,
+//  3. clearing the sentinel makes the next InitSchema run it again.
+//
+// SQLite-only: it reseats applied_migrations rows directly, mirroring
+// TestEnsureParticipantsPhoneUniqueIndex_LegacyNonUnique.
+func TestInitSchema_OneShotMigrationsGatedOnLedger(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbPath := filepath.Join(t.TempDir(), "ledger.db")
+	st, err := Open(dbPath)
+	require.NoError(err, "Open")
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchema(), "first InitSchema")
+
+	for _, name := range []string{
+		migrationAttachmentsContentHashUnique,
+		migrationMessagesLastModifiedBackfill,
+	} {
+		applied, err := st.IsMigrationApplied(name)
+		require.NoError(err, "IsMigrationApplied %s", name)
+		assert.True(applied, "first InitSchema must record %s", name)
+	}
+
+	// Seed one message, then put it in the pre-migration state (NULL
+	// last_modified). The explicit NULL write sticks: the last_modified
+	// trigger's WHEN guard yields to explicit writes.
+	source, err := st.GetOrCreateSource("gmail", "alice@example.com")
+	require.NoError(err, "GetOrCreateSource")
+	convID, err := st.EnsureConversation(source.ID, "t1", "")
+	require.NoError(err, "EnsureConversation")
+	msgID, err := st.UpsertMessage(&Message{
+		SourceID: source.ID, ConversationID: convID,
+		SourceMessageID: "m1", MessageType: "email",
+		Subject: sql.NullString{String: "hello", Valid: true},
+	})
+	require.NoError(err, "UpsertMessage")
+	_, err = st.db.Exec(
+		`UPDATE messages SET last_modified = NULL WHERE id = ?`, msgID)
+	require.NoError(err, "null out last_modified")
+
+	lastModifiedIsNull := func() bool {
+		var isNull bool
+		require.NoError(st.db.QueryRow(
+			`SELECT last_modified IS NULL FROM messages WHERE id = ?`, msgID,
+		).Scan(&isNull), "read last_modified")
+		return isNull
+	}
+
+	// Sentinel present: re-running InitSchema must skip the backfill scan.
+	require.NoError(st.InitSchema(), "second InitSchema")
+	assert.True(lastModifiedIsNull(),
+		"backfill must not run while its sentinel is recorded")
+
+	// Sentinel cleared: the next InitSchema must backfill and re-record.
+	_, err = st.db.Exec(
+		`DELETE FROM applied_migrations WHERE name = ?`,
+		migrationMessagesLastModifiedBackfill)
+	require.NoError(err, "clear backfill sentinel")
+	require.NoError(st.InitSchema(), "third InitSchema")
+	assert.False(lastModifiedIsNull(),
+		"backfill must run once its sentinel is cleared")
+	applied, err := st.IsMigrationApplied(migrationMessagesLastModifiedBackfill)
+	require.NoError(err, "IsMigrationApplied after re-run")
+	assert.True(applied, "re-run must re-record the sentinel")
+}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -4,6 +4,16 @@ import (
 	"fmt"
 )
 
+// One-time data migrations run by InitSchema and gated on the
+// applied_migrations ledger. Without the gate their no-op verification
+// re-runs on every daemon start and scales with archive size (the
+// last_modified backfill alone is a full messages-table scan — seconds of
+// startup on a large archive).
+const (
+	migrationAttachmentsContentHashUnique = "attachments_content_hash_unique_index"
+	migrationMessagesLastModifiedBackfill = "messages_last_modified_backfill"
+)
+
 // IsMigrationApplied reports whether the named one-time data migration
 // has already run.
 func (s *Store) IsMigrationApplied(name string) (bool, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -700,28 +700,39 @@ func (s *Store) InitSchema() error {
 	// Legacy databases may hold duplicate (message_id, content_hash)
 	// attachment rows from the old SELECT-then-INSERT UpsertAttachment.
 	// Dedupe before creating the partial unique index that enforces
-	// idempotency going forward. Both steps are idempotent.
+	// idempotency going forward. Gated on the applied_migrations ledger:
+	// the dedupe's GROUP BY over the full attachments table is not free on
+	// a large archive, and it never finds work after the first run.
 	//
-	// Both run under runMaintenance: on a large archive the dedupe DELETE
-	// and the unique-index build over the full attachments table exceed the
-	// pool-wide 30s statement_timeout, so the maintenance escape hatch
-	// disables it for this transaction (finding S1). They share one tx so
-	// the index is built against the just-deduped table. No-op timeout reset
-	// on SQLite.
-	if err := s.runMaintenance(context.Background(), func(ctx context.Context, tx *loggedTx) error {
-		if err := s.dedupeAttachmentsBeforeUniqueIndex(ctx, tx); err != nil {
-			return fmt.Errorf("dedupe attachments: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx, `
-			CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_msg_content_hash
-			    ON attachments(message_id, content_hash)
-			    WHERE content_hash IS NOT NULL AND content_hash != ''
-		`); err != nil {
-			return fmt.Errorf("create idx_attachments_msg_content_hash: %w", err)
-		}
-		return nil
-	}); err != nil {
+	// Both steps run under runMaintenance: on a large archive the dedupe
+	// DELETE and the unique-index build over the full attachments table
+	// exceed the pool-wide 30s statement_timeout, so the maintenance escape
+	// hatch disables it for this transaction (finding S1). They share one tx
+	// so the index is built against the just-deduped table. No-op timeout
+	// reset on SQLite.
+	attachmentsMigrated, err := s.IsMigrationApplied(migrationAttachmentsContentHashUnique)
+	if err != nil {
 		return err
+	}
+	if !attachmentsMigrated {
+		if err := s.runMaintenance(context.Background(), func(ctx context.Context, tx *loggedTx) error {
+			if err := s.dedupeAttachmentsBeforeUniqueIndex(ctx, tx); err != nil {
+				return fmt.Errorf("dedupe attachments: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `
+				CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_msg_content_hash
+				    ON attachments(message_id, content_hash)
+				    WHERE content_hash IS NOT NULL AND content_hash != ''
+			`); err != nil {
+				return fmt.Errorf("create idx_attachments_msg_content_hash: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := s.MarkMigrationApplied(migrationAttachmentsContentHashUnique); err != nil {
+			return err
+		}
 	}
 
 	// Legacy databases may have idx_participants_phone as a non-unique
@@ -741,11 +752,23 @@ func (s *Store) InitSchema() error {
 	// migrations for DBs created before later columns were introduced:
 	// SQLite emits ALTER TABLE ADD COLUMN, PostgreSQL emits the equivalent
 	// ALTER TABLE ADD COLUMN IF NOT EXISTS list (including search_fts).
+	//
+	// lastModifiedColumnAdded tracks whether the last_modified ALTER
+	// actually fired, which forces the last_modified backfill below even if
+	// its ledger sentinel is present: a just-added column holds NULLs that
+	// must be stamped. Only SQLite can signal this — its ALTER errors with
+	// a duplicate-column error when the column exists, while PostgreSQL's
+	// IF NOT EXISTS form always succeeds; PG never needs the forced path
+	// because its ADD COLUMN carries DEFAULT CURRENT_TIMESTAMP, which
+	// backfills existing rows in the same statement.
+	lastModifiedColumnAdded := false
 	for _, m := range s.dialect.LegacyColumnMigrations() {
 		if _, err := s.db.Exec(m.SQL); err != nil {
 			if !s.dialect.IsDuplicateColumnError(err) {
 				return fmt.Errorf("migrate schema (%s): %w", m.Desc, err)
 			}
+		} else if m.Desc == "last_modified" && !s.IsPostgreSQL() {
+			lastModifiedColumnAdded = true
 		}
 	}
 
@@ -786,16 +809,29 @@ func (s *Store) InitSchema() error {
 	// (a NULL token would never satisfy `last_modified = ?` and the row would
 	// loop "needs embedding" forever). Idempotent and portable: on a fresh
 	// DB (or PostgreSQL, whose ADD COLUMN ... DEFAULT CURRENT_TIMESTAMP
-	// backfills automatically) no rows are NULL, so this is a no-op. Run
-	// under runMaintenance so the full-table UPDATE on a large archive is not
-	// cut off by the pool-wide statement_timeout (no-op reset on SQLite).
-	if err := s.runMaintenance(context.Background(), func(ctx context.Context, tx *loggedTx) error {
-		_, err := tx.ExecContext(ctx,
-			`UPDATE messages SET last_modified = `+s.dialect.Now()+
-				` WHERE last_modified IS NULL`)
+	// backfills automatically) no rows are NULL, so this is a no-op. Gated
+	// on the applied_migrations ledger: last_modified has no index, so the
+	// UPDATE's WHERE clause is a full scan of the messages table — the
+	// dominant cost of daemon startup on a large archive — and it never
+	// finds work after the first run. Run under runMaintenance so the
+	// full-table UPDATE on a large archive is not cut off by the pool-wide
+	// statement_timeout (no-op reset on SQLite).
+	lastModifiedMigrated, err := s.IsMigrationApplied(migrationMessagesLastModifiedBackfill)
+	if err != nil {
 		return err
-	}); err != nil {
-		return fmt.Errorf("backfill last_modified: %w", err)
+	}
+	if !lastModifiedMigrated || lastModifiedColumnAdded {
+		if err := s.runMaintenance(context.Background(), func(ctx context.Context, tx *loggedTx) error {
+			_, err := tx.ExecContext(ctx,
+				`UPDATE messages SET last_modified = `+s.dialect.Now()+
+					` WHERE last_modified IS NULL`)
+			return err
+		}); err != nil {
+			return fmt.Errorf("backfill last_modified: %w", err)
+		}
+		if err := s.MarkMigrationApplied(migrationMessagesLastModifiedBackfill); err != nil {
+			return err
+		}
 	}
 
 	// Create FTS indexes that depend on columns just added by the legacy

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -899,6 +899,16 @@ func (s *Store) NeedsFTSBackfill() bool {
 	return s.dialect.FTSNeedsBackfill(s.db.DB)
 }
 
+// NeedsFTSBackfillQuick is the cheap, hot-path-safe form of NeedsFTSBackfill:
+// true means a backfill is certainly needed; false may miss interior index
+// holes (SQLite) that only the full probe finds.
+func (s *Store) NeedsFTSBackfillQuick() bool {
+	if !s.fts5Available {
+		return false
+	}
+	return s.dialect.FTSNeedsBackfillQuick(s.db.DB)
+}
+
 // Stats holds database statistics.
 //
 // MessageCount is the count of active messages: those still present in the

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -834,6 +834,7 @@ func (c CliRebuildFTSEvent) Validate() error {
 
 type CliSearchResponse struct {
 	IndexBuilt       *bool                    `json:"index_built,omitempty"`
+	IndexState       *string                  `json:"index_state,omitempty"`
 	IndexedMessages  *int64                   `json:"indexed_messages,omitempty"`
 	Results          []CLIQueryMessageSummary `json:"results,omitempty" validate:"required"`
 	ScopeLabel       *string                  `json:"scope_label,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -967,6 +967,8 @@ components:
       properties:
         index_built:
           type: boolean
+        index_state:
+          type: string
         indexed_messages:
           format: int64
           type: integer

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2121,7 +2121,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.0.0
+  version: 1.1.0
 openapi: 3.0.3
 paths:
   /api/ping:


### PR DESCRIPTION
## What changed

- `msgvault search` no longer waits for the FTS index completeness probe or backfill. The first search after a daemon start used to run a full anti-join over every message inline (30–60s on a large archive, reproducible after every 20-minute idle shutdown); that work now runs in a single background worker and the search answers immediately from the index as-is — the same contract `/api/v1/search` has always had.
- Daemon startup no longer re-verifies one-shot data migrations. `init_archive_schema` re-ran the `messages.last_modified` backfill (a full messages-table scan) and the attachments content-hash dedupe on every start; both are now recorded in the existing `applied_migrations` ledger and skipped once applied. No schema change — the ledger table already existed.
- The search response reports background index work (`index_state`: `checking` or `building`) and the CLI prints a matching note that results may be incomplete until it finishes. `index_built`/`indexed_messages` stay in the schema for pre-0.18 daemons that build synchronously. A visibly stale index (cheap `MAX(id)` vs `MAX(rowid)` tail check; on PostgreSQL the index-served EXISTS probe) reports `building` on the very first response.
- Authenticated `/api/v1/health` now reports request-scoped activity the operation gate can't describe: `checking the search index` during the probe, and `building the search index (N/M messages)` with live backfill progress. Probe and backfill durations are logged to serve.log.
- While a search request is in flight past a 3-second quiet window, the CLI's `Searching...` line ticks with elapsed time and shows the daemon operation it is waiting on (from health polling); piped output gets a single notice line instead of in-place rewrites.

## Why

Cold-start searches hung for 30–60s with a static `Searching...` and no explanation anywhere — the completeness probe became a full scan in #385, the daemon-only model (#426) plus per-process memoization made it recur on every cold start, and the probe ran before the operation gate so even daemon health reported idle. On top of that, every daemon start paid ~9s re-verifying long-completed schema migrations.

Measured against a copy of a real 67GB archive: a full cold-start search (daemon spawn + schema init + query) drops from 40–60s to ~0.3s once the migration sentinels are recorded; the completeness probe (1m04s on that archive) runs in the background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)