### PR TITLE
Index deletion timestamps to unblock daemon cold start

### DIFF
--- a/cmd/msgvault/cmd/cache_staleness.go
+++ b/cmd/msgvault/cmd/cache_staleness.go
@@ -21,6 +21,31 @@ type cacheStaleness struct {
 	Reason      string
 }
 
+// deletedSinceBuildCountSQL counts exportable messages source-deleted since
+// the last cache build. It runs on every daemon start before the API server
+// binds, so it must be served by idx_messages_deleted_from_source_at rather
+// than a full messages scan (seconds of cold-start latency on a large
+// archive); the query-plan test locks that in.
+func deletedSinceBuildCountSQL() string {
+	return `
+		SELECT COUNT(*) FROM messages
+		WHERE deleted_from_source_at IS NOT NULL
+		  AND deleted_from_source_at >= ?
+		  AND ` + sentNonCalendarMessageWhere("")
+}
+
+// hiddenSinceBuildCountSQL counts exportable messages dedup-hidden since the
+// last cache build. Same cold-start constraint as deletedSinceBuildCountSQL:
+// it must be served by idx_messages_deleted_at.
+func hiddenSinceBuildCountSQL() string {
+	return `
+		SELECT COUNT(*) FROM messages
+		WHERE deleted_at IS NOT NULL
+		  AND deleted_at >= ?
+		  AND deleted_from_source_at IS NULL
+		  AND ` + sentNonCalendarMessageWhere("")
+}
+
 // cacheNeedsBuild checks if the analytics cache needs to be built or
 // updated. Collects all staleness signals before returning so that
 // e.g. a mixed add+delete sync correctly reports both.
@@ -118,12 +143,7 @@ func cacheNeedsBuild(dbPath, analyticsDir string) cacheStaleness {
 
 	syncAtStr := state.LastSyncAt.UTC().Format("2006-01-02 15:04:05")
 	var deletedSinceBuild int64
-	err = db.DB().QueryRow(`
-		SELECT COUNT(*) FROM messages
-		WHERE deleted_from_source_at IS NOT NULL
-		  AND deleted_from_source_at >= ?
-		  AND `+sentNonCalendarMessageWhere("")+`
-	`, syncAtStr).Scan(&deletedSinceBuild)
+	err = db.DB().QueryRow(deletedSinceBuildCountSQL(), syncAtStr).Scan(&deletedSinceBuild)
 	if err != nil {
 		return cacheStaleness{
 			NeedsBuild: true, FullRebuild: true,
@@ -146,13 +166,7 @@ func cacheNeedsBuild(dbPath, analyticsDir string) cacheStaleness {
 	// both source-deleted and dedup-hidden after LastSyncAt is reported
 	// once (as a deletion), not double-counted in the reason string.
 	var hiddenSinceBuild int64
-	err = db.DB().QueryRow(`
-		SELECT COUNT(*) FROM messages
-		WHERE deleted_at IS NOT NULL
-		  AND deleted_at >= ?
-		  AND deleted_from_source_at IS NULL
-		  AND `+sentNonCalendarMessageWhere("")+`
-	`, syncAtStr).Scan(&hiddenSinceBuild)
+	err = db.DB().QueryRow(hiddenSinceBuildCountSQL(), syncAtStr).Scan(&hiddenSinceBuild)
 	if err != nil {
 		return cacheStaleness{
 			NeedsBuild: true, FullRebuild: true,

--- a/cmd/msgvault/cmd/cache_staleness_test.go
+++ b/cmd/msgvault/cmd/cache_staleness_test.go
@@ -33,47 +33,50 @@ func explainQueryPlan(t *testing.T, s *store.Store, sql string, args ...any) str
 // before the API server binds, so a full scan on a cold page cache adds
 // multiple seconds to every cold-start CLI command on a large archive.
 func TestCacheStalenessCounts_UseDeletionIndexes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	// The Parquet cache staleness check is a SQLite-only ETL path;
 	// cacheNeedsBuild returns early for PostgreSQL DSNs.
 	s := testutil.NewSQLiteTestStore(t)
 
 	_, err := s.DB().Exec(
 		`INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'user@example.com')`)
-	require.NoError(t, err)
+	require.NoError(err)
 	_, err = s.DB().Exec(`INSERT INTO conversations
 		(id, source_id, source_conversation_id, conversation_type)
 		VALUES (1, 1, 'conv1', 'email')`)
-	require.NoError(t, err)
+	require.NoError(err)
 	_, err = s.DB().Exec(`INSERT INTO messages
 		(id, conversation_id, source_id, source_message_id, message_type, sent_at, deleted_from_source_at, deleted_at)
 		VALUES
 		(1, 1, 1, 'm1', 'email', '2025-01-01 00:00:00', NULL, NULL),
 		(2, 1, 1, 'm2', 'email', '2025-01-02 00:00:00', '2025-06-01 00:00:00', NULL),
 		(3, 1, 1, 'm3', 'email', '2025-01-03 00:00:00', NULL, '2025-06-02 00:00:00')`)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	for _, name := range []string{"idx_messages_deleted_from_source_at", "idx_messages_deleted_at"} {
 		var idxCount int
-		require.NoError(t, s.DB().QueryRow(
+		require.NoError(s.DB().QueryRow(
 			`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name = ?`, name,
 		).Scan(&idxCount))
-		assert.Equal(t, 1, idxCount, "%s should be created by InitSchema", name)
+		assert.Equal(1, idxCount, "%s should be created by InitSchema", name)
 	}
 
 	deletedPlan := explainQueryPlan(t, s, deletedSinceBuildCountSQL(), "2025-05-01 00:00:00")
-	assert.Contains(t, deletedPlan, "idx_messages_deleted_from_source_at",
+	assert.Contains(deletedPlan, "idx_messages_deleted_from_source_at",
 		"source-deleted COUNT should use the partial index, not a full scan:\n%s", deletedPlan)
-	assert.NotContains(t, deletedPlan, "SCAN messages", deletedPlan)
+	assert.NotContains(deletedPlan, "SCAN messages", deletedPlan)
 
 	hiddenPlan := explainQueryPlan(t, s, hiddenSinceBuildCountSQL(), "2025-05-01 00:00:00")
-	assert.Contains(t, hiddenPlan, "idx_messages_deleted_at",
+	assert.Contains(hiddenPlan, "idx_messages_deleted_at",
 		"dedup-hidden COUNT should use the partial index, not a full scan:\n%s", hiddenPlan)
-	assert.NotContains(t, hiddenPlan, "SCAN messages", hiddenPlan)
+	assert.NotContains(hiddenPlan, "SCAN messages", hiddenPlan)
 
 	// The queries still return correct counts through the indexes.
 	var deleted, hidden int64
-	require.NoError(t, s.DB().QueryRow(deletedSinceBuildCountSQL(), "2025-05-01 00:00:00").Scan(&deleted))
-	require.NoError(t, s.DB().QueryRow(hiddenSinceBuildCountSQL(), "2025-05-01 00:00:00").Scan(&hidden))
-	assert.Equal(t, int64(1), deleted)
-	assert.Equal(t, int64(1), hidden)
+	require.NoError(s.DB().QueryRow(deletedSinceBuildCountSQL(), "2025-05-01 00:00:00").Scan(&deleted))
+	require.NoError(s.DB().QueryRow(hiddenSinceBuildCountSQL(), "2025-05-01 00:00:00").Scan(&hidden))
+	assert.Equal(int64(1), deleted)
+	assert.Equal(int64(1), hidden)
 }

--- a/cmd/msgvault/cmd/cache_staleness_test.go
+++ b/cmd/msgvault/cmd/cache_staleness_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func explainQueryPlan(t *testing.T, s *store.Store, sql string, args ...any) string {
+	t.Helper()
+	rows, err := s.DB().Query("EXPLAIN QUERY PLAN "+sql, args...)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var b strings.Builder
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		b.WriteString(detail)
+		b.WriteString("\n")
+	}
+	require.NoError(t, rows.Err())
+	return b.String()
+}
+
+// TestCacheStalenessCounts_UseDeletionIndexes verifies the two deletion-status
+// COUNTs in cacheNeedsBuild are served by the partial deletion indexes instead
+// of full scans of the messages table. These queries run on every daemon start
+// before the API server binds, so a full scan on a cold page cache adds
+// multiple seconds to every cold-start CLI command on a large archive.
+func TestCacheStalenessCounts_UseDeletionIndexes(t *testing.T) {
+	// The Parquet cache staleness check is a SQLite-only ETL path;
+	// cacheNeedsBuild returns early for PostgreSQL DSNs.
+	s := testutil.NewSQLiteTestStore(t)
+
+	_, err := s.DB().Exec(
+		`INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'user@example.com')`)
+	require.NoError(t, err)
+	_, err = s.DB().Exec(`INSERT INTO conversations
+		(id, source_id, source_conversation_id, conversation_type)
+		VALUES (1, 1, 'conv1', 'email')`)
+	require.NoError(t, err)
+	_, err = s.DB().Exec(`INSERT INTO messages
+		(id, conversation_id, source_id, source_message_id, message_type, sent_at, deleted_from_source_at, deleted_at)
+		VALUES
+		(1, 1, 1, 'm1', 'email', '2025-01-01 00:00:00', NULL, NULL),
+		(2, 1, 1, 'm2', 'email', '2025-01-02 00:00:00', '2025-06-01 00:00:00', NULL),
+		(3, 1, 1, 'm3', 'email', '2025-01-03 00:00:00', NULL, '2025-06-02 00:00:00')`)
+	require.NoError(t, err)
+
+	for _, name := range []string{"idx_messages_deleted_from_source_at", "idx_messages_deleted_at"} {
+		var idxCount int
+		require.NoError(t, s.DB().QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name = ?`, name,
+		).Scan(&idxCount))
+		assert.Equal(t, 1, idxCount, "%s should be created by InitSchema", name)
+	}
+
+	deletedPlan := explainQueryPlan(t, s, deletedSinceBuildCountSQL(), "2025-05-01 00:00:00")
+	assert.Contains(t, deletedPlan, "idx_messages_deleted_from_source_at",
+		"source-deleted COUNT should use the partial index, not a full scan:\n%s", deletedPlan)
+	assert.NotContains(t, deletedPlan, "SCAN messages", deletedPlan)
+
+	hiddenPlan := explainQueryPlan(t, s, hiddenSinceBuildCountSQL(), "2025-05-01 00:00:00")
+	assert.Contains(t, hiddenPlan, "idx_messages_deleted_at",
+		"dedup-hidden COUNT should use the partial index, not a full scan:\n%s", hiddenPlan)
+	assert.NotContains(t, hiddenPlan, "SCAN messages", hiddenPlan)
+
+	// The queries still return correct counts through the indexes.
+	var deleted, hidden int64
+	require.NoError(t, s.DB().QueryRow(deletedSinceBuildCountSQL(), "2025-05-01 00:00:00").Scan(&deleted))
+	require.NoError(t, s.DB().QueryRow(hiddenSinceBuildCountSQL(), "2025-05-01 00:00:00").Scan(&hidden))
+	assert.Equal(t, int64(1), deleted)
+	assert.Equal(t, int64(1), hidden)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -800,6 +800,34 @@ func (s *Store) InitSchema() error {
 		}); err != nil {
 			return fmt.Errorf("create idx_messages_live_sent_at: %w", err)
 		}
+
+		// Partial indexes over the deletion timestamps. The analytics cache
+		// staleness check (cacheNeedsBuild) counts messages source-deleted or
+		// dedup-hidden since the last build on every daemon start, before the
+		// API server binds. Neither predicate is served by an existing index
+		// (idx_messages_deleted leads with source_id), so each COUNT was a
+		// full scan of the messages table — measured at ~4.5s on a cold page
+		// cache over a 2.5M-row archive, which was the entire cold-start
+		// latency of `msgvault search`. The partial form keeps the indexes
+		// proportional to the deleted rows only, so live-message insert and
+		// update paths pay no maintenance for them.
+		if err := s.runMaintenance(context.Background(), func(ctx context.Context, tx *loggedTx) error {
+			if _, err := tx.ExecContext(ctx, `
+				CREATE INDEX IF NOT EXISTS idx_messages_deleted_from_source_at
+				    ON messages(deleted_from_source_at)
+				    WHERE deleted_from_source_at IS NOT NULL
+			`); err != nil {
+				return err
+			}
+			_, err := tx.ExecContext(ctx, `
+				CREATE INDEX IF NOT EXISTS idx_messages_deleted_at
+				    ON messages(deleted_at)
+				    WHERE deleted_at IS NOT NULL
+			`)
+			return err
+		}); err != nil {
+			return fmt.Errorf("create deletion timestamp indexes: %w", err)
+		}
 	}
 
 	// Backfill last_modified for rows that predate the column. SQLite cannot


### PR DESCRIPTION
## What changed

- Added two partial SQLite indexes, created idempotently in `InitSchema`: `idx_messages_deleted_from_source_at` on `messages(deleted_from_source_at) WHERE deleted_from_source_at IS NOT NULL` and `idx_messages_deleted_at` on `messages(deleted_at) WHERE deleted_at IS NOT NULL`.
- Extracted the two staleness COUNT queries in `cacheNeedsBuild` into named helpers and added a query-plan test locking them to the new indexes.

## Why

After #437, a cold-start `msgvault search` (daemon not running) still took ~4.5s. The daemon startup log attributed 4.3s to `init_analytics_engine`, and inside it `cacheNeedsBuild`'s two deletion-status COUNTs were full scans of the 2.5M-row `messages` table (`idx_messages_deleted` leads with `source_id`, so it cannot serve the global timestamp predicates) — measured at 4.7s on a cold page cache. Both counts run before `start_api_server`, so every cold-start CLI command paid for them.

With the indexes, both COUNTs are index range scans (~0ms at real scale). The one-time index build on an existing archive runs under `runMaintenance` on the next daemon start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)