### PR TITLE
MCP: add search_in_message tool

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -36,6 +37,8 @@ const (
 	// the caller requests via max_chars. Prevents a single tool call from flooding
 	// the context window; callers page forward using offset.
 	maxBodyChars = 4000
+	// searchContextChars is the max byte length of each snippet in search_in_message.
+	searchContextChars = 300
 	// totalCountUnknown is returned when the backend cannot report a full match
 	// count (body FTS fallback, hybrid/vector ranking depth, or list_messages
 	// without a separate count query). Clients should use has_more for paging.
@@ -976,6 +979,78 @@ func contextWindow(bodyLen, pos, termLen, contextChars int) (start, end int) {
 	return start, end
 }
 
+func lineNumberAt(body string, byteOffset int) int {
+	if byteOffset <= 0 {
+		return 1
+	}
+	if byteOffset > len(body) {
+		byteOffset = len(body)
+	}
+	return 1 + strings.Count(body[:byteOffset], "\n")
+}
+
+// extractContextChar returns up to contextChars of body text centered on each
+// case-insensitive term match, merging overlapping windows.
+func extractContextChar(body string, terms []string, contextChars int) []string {
+	if body == "" || len(terms) == 0 || contextChars <= 0 {
+		return nil
+	}
+
+	lowerBody := strings.ToLower(body)
+
+	type span struct {
+		start, end int
+	}
+	var spans []span
+
+	for _, term := range terms {
+		if len(term) < 2 {
+			continue
+		}
+		lowerTerm := strings.ToLower(term)
+		termLen := len(term)
+		searchFrom := 0
+		for {
+			idx := strings.Index(lowerBody[searchFrom:], lowerTerm)
+			if idx < 0 {
+				break
+			}
+			pos := searchFrom + idx
+			searchFrom = pos + 1
+
+			start, end := contextWindow(len(body), pos, termLen, contextChars)
+			spans = append(spans, span{start: start, end: end})
+		}
+	}
+
+	if len(spans) == 0 {
+		return nil
+	}
+
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start == spans[j].start {
+			return spans[i].end < spans[j].end
+		}
+		return spans[i].start < spans[j].start
+	})
+
+	merged := []span{spans[0]}
+	for _, s := range spans[1:] {
+		last := &merged[len(merged)-1]
+		if s.start <= last.end {
+			last.end = max(last.end, s.end)
+			continue
+		}
+		merged = append(merged, s)
+	}
+
+	out := make([]string, 0, len(merged))
+	for _, s := range merged {
+		out = append(out, bodyByteSlice(body, s.start, s.end))
+	}
+	return out
+}
+
 type getMessageResponse struct {
 	ID                   int64                  `json:"id"`
 	SourceMessageID      string                 `json:"source_message_id"`
@@ -1097,6 +1172,72 @@ func (h *handlers) getMessage(ctx context.Context, req mcp.CallToolRequest) (*mc
 		Labels:               msg.Labels,
 		Attachments:          msg.Attachments,
 	})
+}
+
+type inMessageMatch struct {
+	CharOffset int    `json:"char_offset"`
+	Snippet    string `json:"snippet"`
+	Line       int    `json:"line"`
+}
+
+func (h *handlers) searchInMessage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	id, err := getIDArg(args, "id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	queryStr, _ := args["query"].(string)
+	queryStr = strings.TrimSpace(queryStr)
+	if queryStr == "" {
+		return mcp.NewToolResultError("query parameter is required"), nil
+	}
+
+	limit := limitArg(args, "limit", 10)
+	offset := limitArg(args, "offset", 0)
+
+	msg, err := h.engine.GetMessage(ctx, id)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("message not found: %v", err)), nil
+	}
+	if msg == nil {
+		return mcp.NewToolResultError("message not found"), nil
+	}
+
+	allMatches := findTermMatches(msg.BodyText, queryStr)
+	total := int64(len(allMatches))
+	if offset >= len(allMatches) {
+		return jsonResult(newPaginatedResponse([]inMessageMatch{}, total, offset))
+	}
+	end := min(offset+limit, len(allMatches))
+	return jsonResult(newPaginatedResponse(allMatches[offset:end], total, offset))
+}
+
+func findTermMatches(body, term string) []inMessageMatch {
+	if body == "" || term == "" {
+		return nil
+	}
+	lowerBody := strings.ToLower(body)
+	lowerTerm := strings.ToLower(term)
+	termLen := len(term)
+	var matches []inMessageMatch
+	searchFrom := 0
+	for {
+		idx := strings.Index(lowerBody[searchFrom:], lowerTerm)
+		if idx < 0 {
+			break
+		}
+		pos := searchFrom + idx
+		searchFrom = pos + 1
+		start, end := contextWindow(len(body), pos, termLen, searchContextChars)
+		matches = append(matches, inMessageMatch{
+			CharOffset: pos,
+			Snippet:    bodyByteSlice(body, start, end),
+			Line:       lineNumberAt(body, pos),
+		})
+	}
+	return matches
 }
 
 const maxAttachmentSize = 50 * 1024 * 1024 // 50MB

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -27,6 +27,7 @@ const (
 	ToolStageDeletion       = "stage_deletion"
 	ToolSearchByDomains     = "search_by_domains"
 	ToolFindSimilarMessages = "find_similar_messages"
+	ToolSearchInMessage     = "search_in_message"
 )
 
 // search_messages mode values (wire format).
@@ -122,6 +123,7 @@ func newMCPServer(opts ServeOptions) *server.MCPServer {
 	s.AddTool(searchMessagesTool(vectorAvailable), h.searchMessages)
 	s.AddTool(getMessageTool(), h.getMessage)
 	s.AddTool(getAttachmentTool(), h.getAttachment)
+	s.AddTool(searchInMessageTool(), h.searchInMessage)
 	s.AddTool(exportAttachmentTool(), h.exportAttachment)
 	s.AddTool(listMessagesTool(), h.listMessages)
 	s.AddTool(getStatsTool(), h.getStats)
@@ -295,6 +297,26 @@ func exportAttachmentTool() mcp.Tool {
 		mcp.WithString("destination",
 			mcp.Description("Directory to save the file to (default: ~/Downloads)"),
 		),
+	)
+}
+
+func searchInMessageTool() mcp.Tool {
+	return mcp.NewTool(ToolSearchInMessage,
+		mcp.WithDescription("Find all occurrences of a term within one message body. Returns each match with a character-centered snippet, line number, and char_offset (byte offset into body_text). "+
+			"Use char_offset with get_message center_at to read a larger window around any match."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithNumber("id",
+			mcp.Required(),
+			mcp.Description("Message ID"),
+		),
+		mcp.WithString("query",
+			mcp.Required(),
+			mcp.Description("Term to find in the message body"),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum matches to return (default 10)"),
+		),
+		withOffset(),
 	)
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -98,6 +98,14 @@ type getMessageResp struct {
 	ConversationID int64  `json:"conversation_id"`
 }
 
+type paginatedInMessageMatches struct {
+	Data     []inMessageMatch `json:"data"`
+	Total    int64            `json:"total"`
+	Returned int              `json:"returned"`
+	Offset   int              `json:"offset"`
+	HasMore  bool             `json:"has_more"`
+}
+
 // newTestHandlers creates a handlers instance with the given mock engine.
 func newTestHandlers(eng *querytest.MockEngine) *handlers {
 	return &handlers{engine: eng}
@@ -746,6 +754,74 @@ func TestBodyByteSlice(t *testing.T) {
 	})
 }
 
+func TestExtractContextChar(t *testing.T) {
+	t.Run("short body", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := "The resistor value should be 5.1k ohms not 10k as previously stated."
+		snippets := extractContextChar(body, []string{"5.1k"}, 200)
+		require.Len(snippets, 1)
+		assert.Contains(snippets[0], "5.1k")
+		assert.LessOrEqual(len(snippets[0]), 200)
+	})
+
+	t.Run("long quoted line", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		quoted := strings.Repeat("> This is quoted history that should not bloat the snippet. ", 40)
+		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
+		snippets := extractContextChar(body, []string{"5.1k"}, 300)
+		require.Len(snippets, 1)
+		assert.Contains(snippets[0], "5.1k")
+		assert.Len(snippets[0], 300)
+		assert.NotContains(snippets[0], strings.Repeat("> This", 10))
+	})
+
+	t.Run("overlapping matches merge", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := "foo bar foo baz"
+		snippets := extractContextChar(body, []string{"foo"}, 20)
+		require.Len(snippets, 1)
+		assert.Equal(body, snippets[0])
+	})
+
+	t.Run("match near start", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := "needle" + strings.Repeat("x", 500)
+		snippets := extractContextChar(body, []string{"needle"}, 100)
+		require.Len(snippets, 1)
+		assert.Len(snippets[0], 100)
+		assert.Equal(body[:100], snippets[0])
+	})
+
+	t.Run("match near end", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := strings.Repeat("a", 500) + "needle"
+		snippets := extractContextChar(body, []string{"needle"}, 100)
+		require.Len(snippets, 1)
+		assert.Len(snippets[0], 100)
+		assert.Equal(body[len(body)-100:], snippets[0])
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.Nil(extractContextChar("hello world", []string{"zzz"}, 300))
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.Nil(extractContextChar("", []string{"foo"}, 300))
+	})
+
+	t.Run("short term skipped", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.Nil(extractContextChar("abc", []string{"a"}, 300))
+	})
+}
+
 func TestSearchMessages_UnknownMode(t *testing.T) {
 	h := newTestHandlers(&querytest.MockEngine{})
 
@@ -1185,6 +1261,61 @@ func TestAggregateInvalidDates(t *testing.T) {
 			runToolExpectError(t, "aggregate", h.aggregate, tt.args)
 		})
 	}
+}
+
+func TestSearchInMessage(t *testing.T) {
+	t.Run("reports line and centered snippet", func(t *testing.T) {
+		body := "line one\nline two has the resistor value should be 5.1k ohms\nline three"
+		eng := &querytest.MockEngine{
+			Messages: map[int64]*query.MessageDetail{
+				10: testutil.NewMessageDetail(10).WithBodyText(body).BuildPtr(),
+			},
+		}
+		h := newTestHandlers(eng)
+
+		resp := runTool[paginatedInMessageMatches](t, "search_in_message", h.searchInMessage, map[string]any{
+			"id":    float64(10),
+			"query": "resistor",
+		})
+		require.Len(t, resp.Data, 1, "matches")
+		assert.Equal(t, 2, resp.Data[0].Line, "line")
+		assert.Contains(t, resp.Data[0].Snippet, "resistor")
+	})
+
+	t.Run("long quoted line", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		quoted := strings.Repeat("> quoted history should not bloat the snippet. ", 40)
+		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
+		eng := &querytest.MockEngine{
+			Messages: map[int64]*query.MessageDetail{
+				11: testutil.NewMessageDetail(11).WithBodyText(body).BuildPtr(),
+			},
+		}
+		h := newTestHandlers(eng)
+
+		resp := runTool[paginatedInMessageMatches](t, "search_in_message", h.searchInMessage, map[string]any{
+			"id":    float64(11),
+			"query": "5.1k",
+		})
+		require.Len(resp.Data, 1, "matches")
+		assert.Contains(resp.Data[0].Snippet, "5.1k")
+		assert.LessOrEqual(len(resp.Data[0].Snippet), searchContextChars)
+		assert.NotContains(resp.Data[0].Snippet, strings.Repeat("> quoted", 5))
+	})
+
+	t.Run("nil message without error", func(t *testing.T) {
+		eng := &querytest.MockEngine{
+			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+				return nil, nil //nolint:nilnil // mirrors Engine.GetMessage not-found contract
+			},
+		}
+		h := newTestHandlers(eng)
+		runToolExpectError(t, "search_in_message", h.searchInMessage, map[string]any{
+			"id":    float64(42),
+			"query": "resistor",
+		})
+	})
 }
 
 // createAttachmentFixture creates a content-addressed file under dir using the given hash.


### PR DESCRIPTION
- Adds the search_in_message MCP tool (keyword search within one message body, returns char_offset + snippet + line)
- Pairs with merged get_message paging via center_at=<char_offset>

New tool finds all occurrences of a term in one message body, returning char_offset, line, and a centered snippet per match. Adds extractContextChar helper (used by search results in a follow-up PR) with UTF-8-safe windows.

Continuation of #421 and #388. See also https://github.com/endolith/msgvault/pull/15