### PR TITLE
Update nix flake for v0.17.1

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
   sqlite,
 }:
 let
-  version = "0.17.0";
+  version = "0.17.1";
 in
 buildGoModule {
   pname = "msgvault";


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-0O5CZoaQ/R9euikP0L9sRkwDuflosh4PdPjUqXXPr40=`
- Updated version to `0.17.1`

Automated update via `scripts/update-nix-flake.sh`.