### PR TITLE
docs: document 0.17.1 release

### DIFF
--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -10,6 +10,10 @@ description: REST API for programmatic access to your msgvault archive, with opt
 
 The API is registered through Huma and exposes a generated OpenAPI document at `/openapi.json`; interactive docs are available at `/docs`. You can also run `msgvault openapi` to print the same checked-in contract without starting a daemon or opening the archive database. The OpenAPI `info.version` is the API schema version used for client/server compatibility; the running daemon binary version is exposed separately in the generated document metadata. The API queries the same archive database and attachment store as the CLI and TUI. SQLite is the default archive database; PostgreSQL is supported when `[data].database_url` is a PostgreSQL DSN. Keyword search and ordinary archive reads stay local to that database. If vector search is enabled, semantic and hybrid search also call the embedding endpoint configured in `[vector.embeddings]`. The server is designed for local integrations, dashboards, and automation scripts.
 
+Go integrations can use the generated client in `pkg/client`. The wrapper
+handles msgvault-specific response details such as deletion staging dry-runs
+returning `200` while created manifests return `201`.
+
 ## Quick Start
 
 Add a `[server]` section to your `config.toml`:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
+No notable changes yet.
+
+---
+
+## 0.17.1
+<small>2026-07-06</small>
+
 **New features**
 
 - Deletion staging endpoints on the HTTP API (schema 1.2.0):
@@ -15,6 +22,43 @@ All notable changes to msgvault, grouped by release.
   `GET /api/v1/deletions` lists staged manifests by status, and
   `DELETE /api/v1/deletions/{id}` cancels a pending or in-progress manifest.
   Execution still happens only through `delete-staged`.
+- The generated Go client includes deletion staging support through
+  `StageDeletion`, including both dry-run (`200`) and create (`201`)
+  responses.
+- `msgvault search` now reports full-text index readiness while the daemon is
+  checking or rebuilding the CLI search index, with long-running searches
+  showing the daemon activity they are waiting on.
+
+**Improvements**
+
+- CLI search no longer waits for the full-text index completeness probe or
+  backfill before returning results. Index checks and backfills run in the
+  background, and responses identify when results may be incomplete until the
+  index catches up.
+- SQLite archives now index deletion timestamps so daemon cold starts avoid
+  full-table deletion checks while deciding whether the analytics cache is
+  stale.
+- Automated dependency updates now use Renovate, and project dependencies were
+  refreshed.
+
+**Bug fixes**
+
+- IMAP UID enumeration now constrains searches to fetchable UID ranges and
+  raw fetches no longer depend on fragile `ENVELOPE` parsing, improving
+  robustness on servers such as iCloud IMAP.
+- API-staged deletion manifests now reject empty or unknown filter input,
+  enforce single-account selections, record the raw staging request, and avoid
+  same-second manifest ID collisions.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for the deletion staging
+  API and client support, non-blocking CLI search status reporting, deletion
+  timestamp indexes, and dependency refresh.
+- Thanks to [Tim Kersten](https://github.com/io41) for the IMAP UID
+  enumeration and raw-fetch robustness fixes.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
+  migrating automated dependency updates to Renovate.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,11 +41,11 @@ powershell -ExecutionPolicy ByPass -c "irm https://msgvault.io/install.ps1 | iex
 Then [set up OAuth credentials](/guides/oauth-setup/) and [start
 syncing](/setup/). You can also [build from source](/setup/#build-from-source).
 
-!!! note "New in 0.17.0"
-    Backup repositories, Google Calendar sync, Microsoft Teams delegated Graph
-    sync, message-type filtering, scoped embedding generations, OpenAPI docs
-    and generated client support, daemon-owned CLI archive access, faster IMAP
-    resyncs, and the completed Bubble Tea v2 TUI migration. See the
+!!! note "New in 0.17.1"
+    HTTP clients can now stage, list, and cancel deletion manifests through the
+    web API; CLI search reports when the full-text index is checking or
+    rebuilding instead of blocking on that work; IMAP sync is more robust on
+    servers with unusual UID or raw-fetch behavior. See the
     [Changelog](/changelog/) for the full release notes.
 
 ## Why msgvault?

--- a/docs/usage/deletion.md
+++ b/docs/usage/deletion.md
@@ -29,6 +29,28 @@ You can also stage deletions through the [MCP server](/usage/chat/) by asking an
 
 The MCP `stage_deletion` tool creates a manifest through the selected daemon, the same format as TUI-staged deletions. Nothing is deleted until you run `msgvault delete-staged` from the CLI. See [MCP Server](/usage/chat/#staged-deletion-via-mcp) for details.
 
+## Staging via HTTP API
+
+Web dashboards and automation scripts can stage deletion manifests through the
+[web API](/api-server/#post-apiv1deletions) without constructing a manifest
+themselves. `POST /api/v1/deletions` accepts structured filters and/or
+internal message IDs, resolves the Gmail IDs on the server, and supports
+`"dry_run": true` to preview the count and a sample before writing anything.
+
+The API can also list and cancel staged manifests:
+
+```bash
+curl -H "Authorization: Bearer $MSGVAULT_API_KEY" \
+  http://localhost:8080/api/v1/deletions
+
+curl -X DELETE -H "Authorization: Bearer $MSGVAULT_API_KEY" \
+  http://localhost:8080/api/v1/deletions/20260706-153000-old-newsletters-a1b2
+```
+
+API staging still only creates or cancels local manifests. Remote deletion
+continues to require the explicit `delete-staged` execution step and the
+`MSGVAULT_ENABLE_REMOTE_DELETE=1` guard.
+
 ## Staging Steps
 
 **From the TUI:**
@@ -43,6 +65,12 @@ The MCP `stage_deletion` tool creates a manifest through the selected daemon, th
 1. Ask the assistant to stage messages matching your criteria
 2. The assistant calls `stage_deletion`, which creates a pending manifest
 3. Review with `msgvault delete-staged --list` or `msgvault show-deletion <batch-id>`
+
+**From the HTTP API:**
+
+1. Send a dry-run `POST /api/v1/deletions` request to confirm the selection
+2. Send the same request without `dry_run` to create a pending manifest
+3. Review with `GET /api/v1/deletions` or the CLI commands above
 
 ## Selection Keys
 

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -10,7 +10,11 @@ msgvault search <query>
 ```
 
 !!! note
-    The full-text search index (FTS5) is populated automatically during sync. If you upgraded from an older version of msgvault that did not include FTS5, the index will be backfilled automatically the first time you run a search, launch the TUI, or start the MCP server.
+    The full-text search index (FTS5) is populated automatically during sync.
+    If an older archive needs an index backfill, msgvault checks and rebuilds
+    the index in the background. Search returns immediately from the index as
+    it exists now and reports when results may be incomplete while the daemon
+    is still checking or building.
 
 ## Search Operators
 

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -11,11 +11,19 @@ VERSION="${1:-NEXT}"
 START_TAG="$2"
 EXTRA_INSTRUCTIONS="$3"
 AGENT="${CHANGELOG_AGENT:-codex}"
+CHANGELOG_PATHS=(
+    .
+    ':(exclude)docs/**'
+    ':(exclude)README.md'
+    ':(exclude)CLAUDE.md'
+    ':(exclude)AGENTS.md'
+)
 
 # Determine the starting point
 if [ -n "$START_TAG" ] && [ "$START_TAG" != "-" ]; then
     # Use provided start tag
     RANGE="$START_TAG..HEAD"
+    RANGE_LABEL="$START_TAG"
     echo "Generating changelog from $START_TAG to HEAD..." >&2
 else
     # Auto-detect previous tag
@@ -24,19 +32,22 @@ else
         # No previous tag, use first commit
         FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD)
         RANGE="$FIRST_COMMIT..HEAD"
+        RANGE_LABEL="$FIRST_COMMIT"
         echo "No previous release found. Generating changelog for all commits..." >&2
     else
         RANGE="$PREV_TAG..HEAD"
+        RANGE_LABEL="$PREV_TAG"
         echo "Generating changelog from $PREV_TAG to HEAD..." >&2
     fi
 fi
 
-# Get commit log for changelog generation
-COMMITS=$(git log $RANGE --pretty=format:"- %s (%h)" --no-merges)
-DIFF_STAT=$(git diff --stat $RANGE)
+# Get commit log for changelog generation. Documentation-only changes are
+# intentionally excluded from release-note material.
+COMMITS=$(git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges -- "${CHANGELOG_PATHS[@]}")
+DIFF_STAT=$(git diff --stat "$RANGE" -- "${CHANGELOG_PATHS[@]}")
 
 if [ -z "$COMMITS" ]; then
-    echo "No commits since $PREV_TAG" >&2
+    echo "No non-documentation commits since $RANGE_LABEL" >&2
     exit 0
 fi
 
@@ -68,6 +79,7 @@ Please generate a concise, user-focused changelog. Group changes into sections l
 - Bug Fixes
 
 Focus on user-visible changes. Skip internal refactoring unless it affects users.
+Skip documentation-only changes and do not add documentation-update bullets.
 Keep descriptions brief (one line each). Use present tense.
 Do NOT mention bugs that were introduced and fixed within this same release cycle.
 ${EXTRA_INSTRUCTIONS:+

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -11,6 +11,7 @@ VERSION="${1:-NEXT}"
 START_TAG="$2"
 EXTRA_INSTRUCTIONS="$3"
 AGENT="${CHANGELOG_AGENT:-codex}"
+REPO_ROOT=$(git rev-parse --show-toplevel)
 CHANGELOG_PATHS=(
     .
     ':(exclude)docs/**'
@@ -27,10 +28,10 @@ if [ -n "$START_TAG" ] && [ "$START_TAG" != "-" ]; then
     echo "Generating changelog from $START_TAG to HEAD..." >&2
 else
     # Auto-detect previous tag
-    PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+    PREV_TAG=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "")
     if [ -z "$PREV_TAG" ]; then
         # No previous tag, use first commit
-        FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD)
+        FIRST_COMMIT=$(git -C "$REPO_ROOT" rev-list --max-parents=0 HEAD)
         RANGE="$FIRST_COMMIT..HEAD"
         RANGE_LABEL="$FIRST_COMMIT"
         echo "No previous release found. Generating changelog for all commits..." >&2
@@ -43,8 +44,8 @@ fi
 
 # Get commit log for changelog generation. Documentation-only changes are
 # intentionally excluded from release-note material.
-COMMITS=$(git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges -- "${CHANGELOG_PATHS[@]}")
-DIFF_STAT=$(git diff --stat "$RANGE" -- "${CHANGELOG_PATHS[@]}")
+COMMITS=$(git -C "$REPO_ROOT" log "$RANGE" --pretty=format:"- %s (%h)" --no-merges -- "${CHANGELOG_PATHS[@]}")
+DIFF_STAT=$(git -C "$REPO_ROOT" diff --stat "$RANGE" -- "${CHANGELOG_PATHS[@]}")
 
 if [ -z "$COMMITS" ]; then
     echo "No non-documentation commits since $RANGE_LABEL" >&2

--- a/scripts/changelog_test.go
+++ b/scripts/changelog_test.go
@@ -1,0 +1,82 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangelogSkipsDocumentationOnlyChanges(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	tempDir := t.TempDir()
+	repo := filepath.Join(tempDir, "repo")
+	binDir := filepath.Join(tempDir, "bin")
+	require.NoError(os.MkdirAll(repo, 0o755))
+	require.NoError(os.MkdirAll(binDir, 0o755))
+
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Test User")
+	git(t, repo, "config", "user.email", "test@example.invalid")
+
+	writeAssetFile(t, repo, "cmd/msgvault/main.go", "package main")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "seed")
+	git(t, repo, "tag", "v0.1.0")
+
+	writeAssetFile(t, repo, "docs/usage.md", "# Usage docs")
+	writeAssetFile(t, repo, "README.md", "# README docs")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "docs: expand release documentation")
+
+	writeAssetFile(t, repo, "internal/api/deletions.go", "package api")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "Add deletion staging endpoints")
+
+	scriptPath := installScript(t, repo, filepath.Join("scripts", "changelog.sh"))
+	writeExecutableFile(t, filepath.Join(binDir, "codex"), fakeCodexPromptEchoer())
+
+	cmd := exec.Command("bash", scriptPath, "NEXT", "v0.1.0")
+	cmd.Dir = repo
+	cmd.Env = envWithPath(binDir + string(os.PathListSeparator) + os.Getenv("PATH"))
+	output, err := cmd.CombinedOutput()
+	require.NoError(err, string(output))
+
+	text := string(output)
+	assert.Contains(text, "Add deletion staging endpoints")
+	assert.Contains(text, "internal/api/deletions.go")
+	assert.NotContains(text, "docs: expand release documentation")
+	assert.NotContains(text, "docs/usage.md")
+	assert.NotContains(text, "README.md")
+}
+
+func fakeCodexPromptEchoer() string {
+	return `#!/usr/bin/env bash
+set -euo pipefail
+
+output=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$output" ]]; then
+  printf 'missing -o output path\n' >&2
+  exit 1
+fi
+
+cat > "$output"
+`
+}

--- a/scripts/changelog_test.go
+++ b/scripts/changelog_test.go
@@ -42,18 +42,21 @@ func TestChangelogSkipsDocumentationOnlyChanges(t *testing.T) {
 
 	for _, dir := range []string{repo, filepath.Join(repo, "scripts")} {
 		t.Run(filepath.Base(dir), func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
 			cmd := exec.Command("bash", scriptPath, "NEXT", "v0.1.0")
 			cmd.Dir = dir
 			cmd.Env = envWithPath(binDir + string(os.PathListSeparator) + os.Getenv("PATH"))
 			output, err := cmd.CombinedOutput()
-			require.NoError(t, err, string(output))
+			require.NoError(err, string(output))
 
 			text := string(output)
-			assert.Contains(t, text, "Add deletion staging endpoints")
-			assert.Contains(t, text, "internal/api/deletions.go")
-			assert.NotContains(t, text, "docs: expand release documentation")
-			assert.NotContains(t, text, "docs/usage.md")
-			assert.NotContains(t, text, "README.md")
+			assert.Contains(text, "Add deletion staging endpoints")
+			assert.Contains(text, "internal/api/deletions.go")
+			assert.NotContains(text, "docs: expand release documentation")
+			assert.NotContains(text, "docs/usage.md")
+			assert.NotContains(text, "README.md")
 		})
 	}
 }

--- a/scripts/changelog_test.go
+++ b/scripts/changelog_test.go
@@ -11,14 +11,13 @@ import (
 )
 
 func TestChangelogSkipsDocumentationOnlyChanges(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
+	requireT := require.New(t)
 
 	tempDir := t.TempDir()
 	repo := filepath.Join(tempDir, "repo")
 	binDir := filepath.Join(tempDir, "bin")
-	require.NoError(os.MkdirAll(repo, 0o755))
-	require.NoError(os.MkdirAll(binDir, 0o755))
+	requireT.NoError(os.MkdirAll(repo, 0o755))
+	requireT.NoError(os.MkdirAll(binDir, 0o755))
 
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Test User")
@@ -41,18 +40,22 @@ func TestChangelogSkipsDocumentationOnlyChanges(t *testing.T) {
 	scriptPath := installScript(t, repo, filepath.Join("scripts", "changelog.sh"))
 	writeExecutableFile(t, filepath.Join(binDir, "codex"), fakeCodexPromptEchoer())
 
-	cmd := exec.Command("bash", scriptPath, "NEXT", "v0.1.0")
-	cmd.Dir = repo
-	cmd.Env = envWithPath(binDir + string(os.PathListSeparator) + os.Getenv("PATH"))
-	output, err := cmd.CombinedOutput()
-	require.NoError(err, string(output))
+	for _, dir := range []string{repo, filepath.Join(repo, "scripts")} {
+		t.Run(filepath.Base(dir), func(t *testing.T) {
+			cmd := exec.Command("bash", scriptPath, "NEXT", "v0.1.0")
+			cmd.Dir = dir
+			cmd.Env = envWithPath(binDir + string(os.PathListSeparator) + os.Getenv("PATH"))
+			output, err := cmd.CombinedOutput()
+			require.NoError(t, err, string(output))
 
-	text := string(output)
-	assert.Contains(text, "Add deletion staging endpoints")
-	assert.Contains(text, "internal/api/deletions.go")
-	assert.NotContains(text, "docs: expand release documentation")
-	assert.NotContains(text, "docs/usage.md")
-	assert.NotContains(text, "README.md")
+			text := string(output)
+			assert.Contains(t, text, "Add deletion staging endpoints")
+			assert.Contains(t, text, "internal/api/deletions.go")
+			assert.NotContains(t, text, "docs: expand release documentation")
+			assert.NotContains(t, text, "docs/usage.md")
+			assert.NotContains(t, text, "README.md")
+		})
+	}
 }
 
 func fakeCodexPromptEchoer() string {


### PR DESCRIPTION
0.17.1 needs a dated public release entry now that the tag is cut, and users should be able to find the new HTTP deletion staging workflow and non-blocking full-text index status behavior from the docs site instead of only from release commits. This moves the deletion API note out of Unreleased into a 0.17.1 changelog section and updates the homepage, deletion guide, search guide, and API reference around those surfaces.

Future generated changelogs should stay focused on product changes, not the documentation work required to publish a release. `scripts/changelog.sh` now excludes documentation-only commits from the commit log and diff summary it sends to the generator, and anchors those git queries at the repository root so invoking the script from `scripts/` cannot narrow the release scope.