### PR TITLE
Add Beeper Desktop archive core: internal/beeper importer package

### DIFF
--- a/internal/beeper/client.go
+++ b/internal/beeper/client.go
@@ -1,0 +1,242 @@
+package beeper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	maxRetries = 8
+	// DefaultBaseURL is the Beeper Desktop API loopback address.
+	DefaultBaseURL = "http://localhost:23373"
+	// defaultQPS bounds request rate against the live Beeper Desktop app. The
+	// API is loopback-only, so this protects the user's running client rather
+	// than any remote quota.
+	defaultQPS = 20
+)
+
+// ErrNotFound reports a 404 from the Beeper Desktop API (e.g. a message or
+// chat that no longer exists). Callers distinguish it from transient errors.
+var ErrNotFound = errors.New("not found")
+
+// TokenFunc returns a bearer token for a Beeper Desktop API request.
+type TokenFunc func(context.Context) (string, error)
+
+// Client is a read-only Beeper Desktop API client. It exposes only GET
+// endpoints by construction, so the archiver can never mutate Beeper state.
+type Client struct {
+	baseURL string
+	token   TokenFunc
+	http    *http.Client
+	limiter *rate.Limiter
+}
+
+// NewClient creates a Client. baseURL is injected so tests can point at
+// httptest servers. qps controls the token-bucket rate limit (default 20).
+func NewClient(baseURL string, token TokenFunc, qps float64) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	if qps <= 0 {
+		qps = defaultQPS
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 60 * time.Second},
+		limiter: rate.NewLimiter(rate.Limit(qps), 1),
+	}
+}
+
+// get fetches path, respecting the rate limiter and retrying on 429/5xx with
+// Retry-After or exponential back-off.
+func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
+	reqURL := c.baseURL + path
+	for attempt := range maxRetries {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("wait for beeper rate limit: %w", err)
+		}
+		tok, err := c.token(ctx)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Accept", "application/json")
+		resp, err := c.http.Do(req)
+		if err != nil {
+			if errors.Is(err, syscall.ECONNREFUSED) {
+				return nil, fmt.Errorf("connect to Beeper Desktop at %s (is Beeper Desktop running?): %w", c.baseURL, err)
+			}
+			return nil, err
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("beeper GET %s: read body: %w", reqURL, readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("beeper GET %s: close body: %w", reqURL, closeErr)
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusOK:
+			return body, nil
+		case resp.StatusCode == http.StatusUnauthorized:
+			return nil, fmt.Errorf("beeper GET %s: unauthorized (401): the access token was rejected; mint a new token in Beeper Desktop (Settings > Developer) and re-run 'msgvault add-beeper'", reqURL)
+		case resp.StatusCode == http.StatusNotFound:
+			return nil, fmt.Errorf("beeper GET %s: %w", reqURL, ErrNotFound)
+		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+			continue
+		default:
+			return nil, fmt.Errorf("beeper GET %s: status %d: %s", reqURL, resp.StatusCode, string(body))
+		}
+	}
+	return nil, fmt.Errorf("beeper GET %s: exhausted %d retries", reqURL, maxRetries)
+}
+
+// retryAfter parses a Retry-After header value (seconds) or falls back to
+// exponential back-off capped at 60 s.
+func retryAfter(header string, attempt int) time.Duration {
+	if header != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
+}
+
+// getJSON fetches path and unmarshals the JSON body into out.
+func (c *Client) getJSON(ctx context.Context, path string, out any) error {
+	body, err := c.get(ctx, path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, out)
+}
+
+// ListAccounts returns the chat accounts connected to Beeper Desktop.
+func (c *Client) ListAccounts(ctx context.Context) ([]Account, error) {
+	var out []Account
+	if err := c.getJSON(ctx, "/v1/accounts", &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SearchChatsParams filters a chat search page.
+type SearchChatsParams struct {
+	AccountID         string
+	Cursor            string // opaque; paired with direction=before
+	LastActivityAfter time.Time
+}
+
+// SearchChats fetches one page of chats for an account, ordered by last
+// activity (most recent first). Page onward with direction=before using
+// OldestCursor.
+func (c *Client) SearchChats(ctx context.Context, p SearchChatsParams) (*SearchChatsOutput, error) {
+	q := url.Values{}
+	q.Set("limit", "200")
+	q.Set("type", "any")
+	if p.AccountID != "" {
+		q.Add("accountIDs", p.AccountID)
+	}
+	if p.Cursor != "" {
+		q.Set("cursor", p.Cursor)
+		q.Set("direction", "before")
+	}
+	if !p.LastActivityAfter.IsZero() {
+		q.Set("lastActivityAfter", p.LastActivityAfter.UTC().Format(time.RFC3339))
+	}
+	var out SearchChatsOutput
+	if err := c.getJSON(ctx, "/v1/chats/search?"+q.Encode(), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AllChats pages through every chat matching p, invoking fn per chat.
+func (c *Client) AllChats(ctx context.Context, p SearchChatsParams, fn func(Chat) error) error {
+	for {
+		page, err := c.SearchChats(ctx, p)
+		if err != nil {
+			return err
+		}
+		for _, ch := range page.Items {
+			if err := fn(ch); err != nil {
+				return err
+			}
+		}
+		if !page.HasMore || page.OldestCursor == "" {
+			return nil
+		}
+		p.Cursor = page.OldestCursor
+	}
+}
+
+// GetChat fetches one chat with its full participant list
+// (maxParticipantCount=-1 returns all members).
+func (c *Client) GetChat(ctx context.Context, chatID string) (*Chat, error) {
+	var out Chat
+	path := "/v1/chats/" + url.PathEscape(chatID) + "?maxParticipantCount=-1"
+	if err := c.getJSON(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ListMessagesPage fetches one page (~20 items) of a chat's messages. cursor
+// is opaque; direction is "before" (older) or "after" (newer). Both empty
+// fetch the newest page. Page-at-a-time is deliberate: the importer owns the
+// loop so it can checkpoint between pages.
+func (c *Client) ListMessagesPage(ctx context.Context, chatID, cursor, direction string) (*ListMessagesOutput, error) {
+	q := url.Values{}
+	if cursor != "" {
+		q.Set("cursor", cursor)
+		if direction != "" {
+			q.Set("direction", direction)
+		}
+	}
+	path := "/v1/chats/" + url.PathEscape(chatID) + "/messages"
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	var out ListMessagesOutput
+	if err := c.getJSON(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetMessage fetches a single message by ID (used to refresh reaction targets
+// and to verify the sync-state anchor probe).
+func (c *Client) GetMessage(ctx context.Context, chatID, messageID string) (*Message, error) {
+	var out Message
+	path := "/v1/chats/" + url.PathEscape(chatID) + "/messages/" + url.PathEscape(messageID)
+	if err := c.getJSON(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/beeper/client_test.go
+++ b/internal/beeper/client_test.go
@@ -1,0 +1,148 @@
+package beeper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientRetriesOn429(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	accounts, err := c.ListAccounts(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, accounts)
+	assert.EqualValues(t, 3, calls.Load())
+}
+
+func TestClientUnauthorizedMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	_, err := c.ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add-beeper")
+	assert.Contains(t, err.Error(), "Beeper Desktop")
+}
+
+func TestClientNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"nope"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	_, err := c.GetMessage(context.Background(), "!c:x", "1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestClientContextCancelDuringBackoff(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	start := time.Now()
+	_, err := c.ListAccounts(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 5*time.Second, "must abort backoff on ctx cancel")
+}
+
+func TestClientSendsBearerToken(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	_, err := c.ListAccounts(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-token", got)
+}
+
+func TestSearchChatsParams(t *testing.T) {
+	f := newFakeBeeper(t)
+	f.addChat(&fakeChat{ID: "!a:x", AccountID: "signal", Network: "Signal", Title: "A", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)})
+	f.addChat(&fakeChat{ID: "!b:x", AccountID: "signal", Network: "Signal", Title: "B", Type: "single",
+		LastActivity: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)})
+	f.addChat(&fakeChat{ID: "!c:x", AccountID: "whatsapp", Network: "WhatsApp", Title: "C", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)})
+	srv := f.server()
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	out, err := c.SearchChats(context.Background(), SearchChatsParams{
+		AccountID:         "signal",
+		LastActivityAfter: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Items, 1)
+	assert.Equal(t, "!a:x", out.Items[0].ID, "account and activity filters must both apply")
+}
+
+func TestListMessagesPagination(t *testing.T) {
+	f := newFakeBeeper(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ch := &fakeChat{ID: "!p:x", AccountID: "signal", Network: "Signal", Title: "P", Type: "single", LastActivity: base}
+	for i := range 45 {
+		ch.Msgs = append(ch.Msgs, fakeMsg{
+			ID: "m" + strconv.Itoa(i), SortKey: i, Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text: "msg", SenderID: "@a:x", SenderName: "A",
+		})
+	}
+	f.addChat(ch)
+	srv := f.server()
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	ctx := context.Background()
+
+	// Newest page first, then walk older to exhaustion.
+	var total int
+	page, err := c.ListMessagesPage(ctx, "!p:x", "", "")
+	require.NoError(t, err)
+	total += len(page.Items)
+	for page.HasMore {
+		page, err = c.ListMessagesPage(ctx, "!p:x", page.OldestCursor, "before")
+		require.NoError(t, err)
+		total += len(page.Items)
+	}
+	assert.Equal(t, 45, total)
+
+	// Walk newer from a mid-chat cursor: 24 newer messages remain, so the
+	// first page is full and more are available.
+	after, err := c.ListMessagesPage(ctx, "!p:x", "20", "after")
+	require.NoError(t, err)
+	assert.Len(t, after.Items, 20)
+	assert.True(t, after.HasMore)
+}

--- a/internal/beeper/fake_server_test.go
+++ b/internal/beeper/fake_server_test.go
@@ -1,0 +1,359 @@
+package beeper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeMsg is one message held by the fake Beeper server. Messages live in a
+// per-chat slice ordered oldest→newest; SortKey doubles as the cursor value.
+type fakeMsg struct {
+	ID              string
+	SortKey         int
+	Timestamp       time.Time
+	Type            string // "" defaults to TEXT
+	Text            string
+	SenderID        string
+	SenderName      string
+	IsSender        bool
+	IsDeleted       bool
+	IsHidden        bool
+	EditedTimestamp *time.Time
+	LinkedMessageID string
+	Mentions        []string
+	Reactions       []map[string]any
+	Attachments     []map[string]any
+}
+
+type fakeChat struct {
+	ID           string
+	AccountID    string
+	Network      string
+	Title        string
+	Type         string // "single" | "group"
+	LastActivity time.Time
+	Participants []map[string]any
+	// ParticipantsTruncated makes the search listing report hasMore=true so
+	// the importer fetches the chat detail for the full list.
+	ParticipantsTruncated bool
+	Msgs                  []fakeMsg // oldest → newest
+}
+
+// fakeBeeper simulates the Beeper Desktop API surface the importer uses,
+// with sortKey-cursor pagination semantics matching the real API.
+type fakeBeeper struct {
+	t        *testing.T
+	pageSize int
+
+	mu    sync.Mutex
+	chats []*fakeChat
+	reqs  []string // "PATH?QUERY" per request, in order
+}
+
+func newFakeBeeper(t *testing.T) *fakeBeeper {
+	t.Helper()
+	return &fakeBeeper{t: t, pageSize: 20}
+}
+
+func (f *fakeBeeper) addChat(ch *fakeChat) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.chats = append(f.chats, ch)
+}
+
+func (f *fakeBeeper) chat(id string) *fakeChat {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chats {
+		if ch.ID == id {
+			return ch
+		}
+	}
+	return nil
+}
+
+// appendMsg adds a message to a chat and advances its LastActivity.
+func (f *fakeBeeper) appendMsg(chatID string, m fakeMsg) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chats {
+		if ch.ID == chatID {
+			ch.Msgs = append(ch.Msgs, m)
+			if m.Timestamp.After(ch.LastActivity) {
+				ch.LastActivity = m.Timestamp
+			}
+			return
+		}
+	}
+	f.t.Fatalf("appendMsg: unknown chat %s", chatID)
+}
+
+// requests returns the request log ("PATH?QUERY" entries).
+func (f *fakeBeeper) requests() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.reqs...)
+}
+
+func (f *fakeBeeper) resetRequests() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reqs = nil
+}
+
+func (f *fakeBeeper) server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		entry := r.URL.Path
+		if r.URL.RawQuery != "" {
+			entry += "?" + r.URL.RawQuery
+		}
+		f.reqs = append(f.reqs, entry)
+		f.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case path == "/v1/accounts":
+			f.writeAccounts(w)
+		case path == "/v1/chats/search":
+			f.writeChatSearch(w, r)
+		case strings.HasPrefix(path, "/v1/chats/"):
+			rest := strings.TrimPrefix(path, "/v1/chats/")
+			switch parts := strings.SplitN(rest, "/", 3); {
+			case len(parts) == 1:
+				f.writeChat(w, parts[0])
+			case len(parts) == 2 && parts[1] == "messages":
+				f.writeMessages(w, r, parts[0])
+			case len(parts) == 3 && parts[1] == "messages":
+				f.writeMessage(w, parts[0], parts[2])
+			default:
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			}
+		default:
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		}
+	}))
+}
+
+func (f *fakeBeeper) writeAccounts(w http.ResponseWriter) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	seen := map[string]bool{}
+	out := []map[string]any{}
+	for _, ch := range f.chats {
+		if seen[ch.AccountID] {
+			continue
+		}
+		seen[ch.AccountID] = true
+		out = append(out, map[string]any{
+			"accountID": ch.AccountID,
+			"network":   ch.Network,
+			"user":      map[string]any{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+		})
+	}
+	writeJSON(f.t, w, out)
+}
+
+func (f *fakeBeeper) writeChatSearch(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	q := r.URL.Query()
+	accountID := q.Get("accountIDs")
+	var after time.Time
+	if v := q.Get("lastActivityAfter"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			http.Error(w, `{"error":"bad lastActivityAfter"}`, http.StatusBadRequest)
+			return
+		}
+		after = t
+	}
+	items := []map[string]any{}
+	for _, ch := range f.chats {
+		if accountID != "" && ch.AccountID != accountID {
+			continue
+		}
+		if !after.IsZero() && !ch.LastActivity.After(after) {
+			continue
+		}
+		items = append(items, f.chatJSON(ch, true))
+	}
+	writeJSON(f.t, w, map[string]any{
+		"items": items, "hasMore": false, "oldestCursor": nil, "newestCursor": nil,
+	})
+}
+
+func (f *fakeBeeper) writeChat(w http.ResponseWriter, chatID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chats {
+		if ch.ID == chatID {
+			writeJSON(f.t, w, f.chatJSON(ch, false))
+			return
+		}
+	}
+	http.Error(w, `{"error":"chat not found"}`, http.StatusNotFound)
+}
+
+// chatJSON renders a chat. Listing entries truncate the participant list when
+// ParticipantsTruncated is set (mirroring the API's 20-participant cap on
+// search results); the detail endpoint always returns everyone.
+func (f *fakeBeeper) chatJSON(ch *fakeChat, listing bool) map[string]any {
+	parts := ch.Participants
+	hasMore := false
+	if listing && ch.ParticipantsTruncated {
+		parts = parts[:1]
+		hasMore = true
+	}
+	if parts == nil {
+		parts = []map[string]any{}
+	}
+	return map[string]any{
+		"id":        ch.ID,
+		"accountID": ch.AccountID,
+		"network":   ch.Network,
+		"title":     ch.Title,
+		"type":      ch.Type,
+		"participants": map[string]any{
+			"items": parts, "hasMore": hasMore, "total": len(ch.Participants),
+		},
+		"lastActivity": ch.LastActivity.UTC().Format(time.RFC3339Nano),
+		"unreadCount":  0,
+	}
+}
+
+func (f *fakeBeeper) writeMessages(w http.ResponseWriter, r *http.Request, chatID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var ch *fakeChat
+	for _, c := range f.chats {
+		if c.ID == chatID {
+			ch = c
+			break
+		}
+	}
+	if ch == nil {
+		http.Error(w, `{"error":"chat not found"}`, http.StatusNotFound)
+		return
+	}
+	q := r.URL.Query()
+	cursor := q.Get("cursor")
+	direction := q.Get("direction")
+	if cursor != "" && direction == "" {
+		direction = "before"
+	}
+
+	msgs := ch.Msgs // oldest → newest
+	var window []fakeMsg
+	var hasMore bool
+	switch {
+	case cursor == "":
+		start := max(0, len(msgs)-f.pageSize)
+		window = msgs[start:]
+		hasMore = start > 0
+	case direction == "before":
+		cur, _ := strconv.Atoi(cursor)
+		end := sort.Search(len(msgs), func(i int) bool { return msgs[i].SortKey >= cur })
+		start := max(0, end-f.pageSize)
+		window = msgs[start:end]
+		hasMore = start > 0
+	default: // "after"
+		cur, _ := strconv.Atoi(cursor)
+		start := sort.Search(len(msgs), func(i int) bool { return msgs[i].SortKey > cur })
+		end := min(len(msgs), start+f.pageSize)
+		window = msgs[start:end]
+		hasMore = end < len(msgs)
+	}
+
+	items := make([]map[string]any, 0, len(window))
+	// The real API returns pages newest-first.
+	for _, m := range slices.Backward(window) {
+		items = append(items, f.messageJSON(ch, &m))
+	}
+	out := map[string]any{"items": items, "hasMore": hasMore}
+	if len(window) > 0 {
+		out["oldestCursor"] = strconv.Itoa(window[0].SortKey)
+		out["newestCursor"] = strconv.Itoa(window[len(window)-1].SortKey)
+	} else {
+		out["oldestCursor"] = nil
+		out["newestCursor"] = nil
+	}
+	writeJSON(f.t, w, out)
+}
+
+func (f *fakeBeeper) writeMessage(w http.ResponseWriter, chatID, messageID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chats {
+		if ch.ID != chatID {
+			continue
+		}
+		for i := range ch.Msgs {
+			if ch.Msgs[i].ID == messageID {
+				writeJSON(f.t, w, f.messageJSON(ch, &ch.Msgs[i]))
+				return
+			}
+		}
+	}
+	http.Error(w, `{"error":"message not found"}`, http.StatusNotFound)
+}
+
+func (f *fakeBeeper) messageJSON(ch *fakeChat, m *fakeMsg) map[string]any {
+	typ := m.Type
+	if typ == "" {
+		typ = "TEXT"
+	}
+	out := map[string]any{
+		"id":         m.ID,
+		"chatID":     ch.ID,
+		"accountID":  ch.AccountID,
+		"senderID":   m.SenderID,
+		"senderName": m.SenderName,
+		"timestamp":  m.Timestamp.UTC().Format(time.RFC3339Nano),
+		"sortKey":    strconv.Itoa(m.SortKey),
+		"type":       typ,
+		"isSender":   m.IsSender,
+		"isDeleted":  m.IsDeleted,
+	}
+	if m.Text != "" {
+		out["text"] = m.Text
+	}
+	if m.IsHidden {
+		out["isHidden"] = true
+	}
+	if m.EditedTimestamp != nil {
+		out["editedTimestamp"] = m.EditedTimestamp.UTC().Format(time.RFC3339Nano)
+	}
+	if m.LinkedMessageID != "" {
+		out["linkedMessageID"] = m.LinkedMessageID
+	}
+	if m.Mentions != nil {
+		out["mentions"] = m.Mentions
+	}
+	if m.Reactions != nil {
+		out["reactions"] = m.Reactions
+	}
+	if m.Attachments != nil {
+		out["attachments"] = m.Attachments
+	}
+	return out
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("encode fake response: %v", err)
+	}
+}
+
+func testToken(context.Context) (string, error) { return "test-token", nil }

--- a/internal/beeper/importer.go
+++ b/internal/beeper/importer.go
@@ -1,0 +1,689 @@
+package beeper
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const sourceTypeBeeper = "beeper"
+
+const (
+	// checkpointPageInterval flushes the sync checkpoint every N pages inside a
+	// single chat backfill. Per-chat-only checkpointing is insufficient here:
+	// one chat can hold over a million messages (tens of thousands of pages).
+	checkpointPageInterval = 25
+	// reconcileWindow bounds the head re-walk that catches in-place edits,
+	// deletions, and reaction changes the incremental cursor cannot see.
+	reconcileWindow = 24 * time.Hour
+	// maxReconcilePages caps the reconciliation walk for pathologically busy chats.
+	maxReconcilePages = 50
+)
+
+// replyPair links a reply to its parent by source message ID.
+type replyPair struct {
+	child  string
+	parent string
+}
+
+// chatContext carries per-chat state through the persist call chain.
+type chatContext struct {
+	chatID   string
+	convID   int64
+	sourceID int64
+	syncID   int64
+	replies  []replyPair
+	// persisted collects internal message IDs for embedding enqueue.
+	persisted []int64
+}
+
+// Importer ingests Beeper Desktop messages into the msgvault store. One
+// Import run covers one Beeper account (= one msgvault source).
+type Importer struct {
+	store  *store.Store
+	client *Client
+	res    *participantResolver
+}
+
+// NewImporter creates an Importer backed by the given store and Beeper client.
+func NewImporter(s *store.Store, c *Client) *Importer {
+	return &Importer{store: s, client: c, res: newParticipantResolver(s)}
+}
+
+// Import runs a backfill-then-incremental sync of opts.AccountID's chats.
+// New chats backfill their full locally-available history (resumable across
+// interrupted runs); completed chats fetch only messages newer than the
+// stored cursor. Returns a summary of the run.
+func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
+	start := time.Now()
+	if opts.AccountID == "" {
+		return nil, errors.New("beeper account ID required")
+	}
+	src, err := imp.store.GetOrCreateSource(sourceTypeBeeper, opts.AccountID)
+	if err != nil {
+		return nil, err
+	}
+	sum := &ImportSummary{SourceID: src.ID}
+
+	// Build the starting SyncState by merging the last successful sync's cursor
+	// (baseline) with the latest interrupted checkpoint (if any), so a resumed
+	// run skips already-covered work. opts.Full skips this entirely so every
+	// message is re-fetched and re-persisted (repair path).
+	state := NewSyncState()
+	if !opts.Full {
+		if prev, perr := imp.store.GetLastSuccessfulSync(src.ID); perr == nil && prev != nil && prev.CursorAfter.Valid {
+			if s, lerr := LoadSyncState(prev.CursorAfter.String); lerr == nil {
+				state = s
+			}
+		}
+		if cp, cerr := imp.store.GetLatestCheckpointedSync(src.ID); cerr == nil && cp != nil && cp.CursorBefore.Valid {
+			if cpState, lerr := LoadSyncState(cp.CursorBefore.String); lerr == nil {
+				state.Merge(cpState)
+			}
+		}
+	}
+
+	syncID, err := imp.store.StartSync(src.ID, sourceTypeBeeper)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = imp.store.FailSync(syncID, err.Error())
+		}
+	}()
+
+	// Message IDs are only unique per Beeper installation; verify the anchor
+	// message still exists unchanged before trusting stored cursors.
+	if err = imp.verifyAnchor(ctx, state.Anchor); err != nil {
+		return sum, err
+	}
+
+	chats, err := imp.enumerateChats(ctx, syncID, opts, state, sum)
+	if err != nil {
+		return sum, err
+	}
+
+	maxActivity := parseWatermark(state.ListWatermark)
+	total := len(chats)
+	for idx := range chats {
+		ch := &chats[idx]
+		if err = ctx.Err(); err != nil {
+			return sum, err
+		}
+		if opts.ChatID != "" && ch.ID != opts.ChatID {
+			continue
+		}
+		if ch.LastActivity.After(maxActivity) {
+			maxActivity = ch.LastActivity
+		}
+		var convCount int64
+		convCount, err = imp.syncChat(ctx, syncID, src.ID, ch, opts, state, sum)
+		if err != nil {
+			return sum, err
+		}
+		sum.ChatsProcessed++
+		if opts.Progress != nil {
+			opts.Progress(fmt.Sprintf("chat %d/%d (%s): %d messages", idx+1, total, ch.Network, convCount))
+		}
+		// Flush checkpoint so an interrupted run can resume from this point.
+		imp.checkpoint(syncID, state, sum)
+	}
+	// Advance the discovery watermark only for unscoped, fetch-clean runs: a
+	// scoped run never visited the other chats, and a fetch error means some
+	// chat's messages are still missing — both must stay discoverable.
+	if opts.ChatID == "" && sum.FetchErrors == 0 && !maxActivity.IsZero() {
+		state.ListWatermark = formatWatermark(maxActivity)
+	}
+
+	if err = imp.store.RecomputeConversationStats(src.ID); err != nil {
+		return sum, err
+	}
+	blob, _ := state.Marshal()
+	if err = imp.store.CompleteSync(syncID, blob); err != nil {
+		return sum, err
+	}
+	sum.Duration = time.Since(start)
+	return sum, nil
+}
+
+// verifyAnchor re-fetches the anchor probe message and fails when it is gone
+// or its timestamp changed, indicating the installation re-assigned message
+// IDs (reinstall/re-index). Failing fast prevents silently duplicating the
+// whole archive under new IDs.
+func (imp *Importer) verifyAnchor(ctx context.Context, a *AnchorProbe) error {
+	if a == nil {
+		return nil
+	}
+	m, err := imp.client.GetMessage(ctx, a.ChatID, a.MessageID)
+	if errors.Is(err, ErrNotFound) {
+		return fmt.Errorf("beeper message IDs appear re-assigned (Beeper Desktop reinstall or re-index?): anchor message %s no longer exists; remove and re-add this account to avoid duplicate archives", a.MessageID)
+	}
+	if err != nil {
+		return fmt.Errorf("verify beeper sync anchor: %w", err)
+	}
+	if !m.Timestamp.Equal(a.Timestamp) {
+		return fmt.Errorf("beeper message IDs appear re-assigned (Beeper Desktop reinstall or re-index?): anchor message %s changed timestamp; remove and re-add this account to avoid duplicate archives", a.MessageID)
+	}
+	return nil
+}
+
+// enumerateChats lists the chats this run must visit: every chat with
+// activity after the watermark (all chats on first/full runs), plus any chat
+// whose backfill is unfinished even without new activity.
+func (imp *Importer) enumerateChats(ctx context.Context, syncID int64, opts ImportOptions, state *SyncState, sum *ImportSummary) ([]Chat, error) {
+	params := SearchChatsParams{AccountID: opts.AccountID}
+	if !opts.Full && state.ListWatermark != "" {
+		if wm := parseWatermark(state.ListWatermark); !wm.IsZero() {
+			// Overlap by an hour so clock skew or a mid-listing crash cannot
+			// permanently hide a chat from enumeration.
+			params.LastActivityAfter = wm.Add(-time.Hour)
+		}
+	}
+	var chats []Chat
+	seen := map[string]bool{}
+	err := imp.client.AllChats(ctx, params, func(ch Chat) error {
+		seen[ch.ID] = true
+		chats = append(chats, ch)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	for chatID, cs := range state.Chats {
+		if cs == nil || cs.Done || seen[chatID] {
+			continue
+		}
+		detail, gerr := imp.client.GetChat(ctx, chatID)
+		if errors.Is(gerr, ErrNotFound) {
+			// The chat no longer exists in Beeper (left/deleted); there is
+			// nothing more to fetch. Mark it complete so it stops pinning the
+			// discovery watermark; the archived messages are kept.
+			cs.Done = true
+			imp.recordItem(syncID, chatID, "fetch", store.SyncRunItemStatusSkipped, "beeper_chat_gone", gerr)
+			continue
+		}
+		if gerr != nil {
+			imp.recordItem(syncID, chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
+			sum.FetchErrors++
+			sum.Errors++
+			continue
+		}
+		chats = append(chats, *detail)
+	}
+	return chats, nil
+}
+
+// syncChat ensures the conversation and its participants, then backfills or
+// incrementally extends the chat's messages. Returns the number of messages
+// processed for this chat.
+func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *Chat, opts ImportOptions, state *SyncState, sum *ImportSummary) (int64, error) {
+	// Chat search returns at most 20 participants per chat; fetch the full
+	// list only when it is truncated.
+	detail := ch
+	if ch.Participants.HasMore {
+		d, gerr := imp.client.GetChat(ctx, ch.ID)
+		if gerr != nil {
+			imp.recordItem(syncID, ch.ID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
+			sum.FetchErrors++
+			sum.Errors++
+		} else {
+			detail = d
+		}
+	}
+	convID, err := imp.store.EnsureConversationWithType(sourceID, ch.ID, conversationType(ch.Type), ch.Title)
+	if err != nil {
+		return 0, err
+	}
+	for i := range detail.Participants.Items {
+		p := &detail.Participants.Items[i]
+		pid, rerr := imp.res.resolveUser(&p.User)
+		if rerr != nil {
+			return 0, rerr
+		}
+		if pid == 0 {
+			continue
+		}
+		role := "member"
+		if p.IsAdmin {
+			role = "admin"
+		}
+		if cerr := imp.store.EnsureConversationParticipant(convID, pid, role); cerr != nil {
+			sum.Errors++
+		}
+	}
+
+	cc := &chatContext{chatID: ch.ID, convID: convID, sourceID: sourceID, syncID: syncID}
+	cs := state.Chat(ch.ID)
+	before := sum.MessagesProcessed
+
+	// A chat that was empty when backfilled has Done set but no incremental
+	// cursor; re-walk it from scratch (cheap) so its first messages are seen.
+	if !cs.Done || cs.Newest == "" {
+		err = imp.backfillChat(ctx, cc, cs, opts, state, sum)
+	} else {
+		err = imp.incrementalChat(ctx, cc, cs, sum)
+		if err == nil {
+			err = imp.reconcileChat(ctx, cc, sum)
+		}
+	}
+	if err != nil {
+		return sum.MessagesProcessed - before, err
+	}
+
+	imp.flushReplies(cc, sum)
+	imp.enqueueEmbeddings(ctx, opts, sum, cc.persisted)
+	return sum.MessagesProcessed - before, nil
+}
+
+// backfillChat walks the chat's history oldest-ward (direction=before) from
+// the stored resume cursor until the beginning of locally-available history.
+// The incremental cursor (Newest) is primed from the first page so later runs
+// can extend forward. Fetch errors leave the chat resumable rather than
+// failing the run.
+func (imp *Importer) backfillChat(ctx context.Context, cc *chatContext, cs *ChatState, opts ImportOptions, state *SyncState, sum *ImportSummary) error {
+	pages := 0
+	processed := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		cursor, direction := cs.Oldest, "before"
+		if cursor == "" {
+			direction = "" // first page: newest messages
+		}
+		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, direction)
+		if err != nil {
+			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		if cs.Newest == "" && page.NewestCursor != "" {
+			cs.Newest = page.NewestCursor
+		}
+		for i := range page.Items {
+			if err := imp.processMessage(ctx, cc, &page.Items[i], false, sum); err != nil {
+				return err
+			}
+			processed++
+		}
+		if state.Anchor == nil {
+			state.Anchor = anchorFrom(cc.chatID, page.Items)
+		}
+		if page.OldestCursor != "" {
+			cs.Oldest = page.OldestCursor
+		}
+		pages++
+		if pages%checkpointPageInterval == 0 {
+			imp.checkpoint(cc.syncID, state, sum)
+		}
+		if !page.HasMore {
+			cs.Done = true
+			return nil
+		}
+		if opts.Limit > 0 && processed >= opts.Limit {
+			return nil // resumable: Done stays false
+		}
+		if page.OldestCursor == "" {
+			// Defensive: hasMore without a cursor would loop on the same page.
+			return nil
+		}
+	}
+}
+
+// incrementalChat fetches messages newer than the stored cursor
+// (direction=after, oldest→newest) and advances the cursor.
+func (imp *Importer) incrementalChat(ctx context.Context, cc *chatContext, cs *ChatState, sum *ImportSummary) error {
+	cursor := cs.Newest
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, "after")
+		if err != nil {
+			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		for i := range page.Items {
+			if err := imp.processMessage(ctx, cc, &page.Items[i], true, sum); err != nil {
+				return err
+			}
+		}
+		if page.NewestCursor != "" {
+			cursor = page.NewestCursor
+			cs.Newest = cursor
+		}
+		if !page.HasMore || page.NewestCursor == "" {
+			return nil
+		}
+	}
+}
+
+// reconcileChat re-walks the head of the chat (newest-ward pages) re-upserting
+// messages from the last reconcileWindow. This catches in-place edits,
+// deletions, and reaction changes on recent messages, which the forward-only
+// incremental cursor cannot observe. Changes older than the window are only
+// repaired by --full runs (documented limitation).
+func (imp *Importer) reconcileChat(ctx context.Context, cc *chatContext, sum *ImportSummary) error {
+	cutoff := time.Now().Add(-reconcileWindow)
+	cursor, direction := "", ""
+	for range maxReconcilePages {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, direction)
+		if err != nil {
+			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		reachedCutoff := false
+		for i := range page.Items {
+			m := &page.Items[i]
+			if m.Timestamp.Before(cutoff) {
+				reachedCutoff = true
+				continue
+			}
+			// Backfill mode: embedded reactions[] on each message are
+			// authoritative here, so REACTION events need no target refetch.
+			if err := imp.processMessage(ctx, cc, m, false, sum); err != nil {
+				return err
+			}
+		}
+		if reachedCutoff || !page.HasMore || page.OldestCursor == "" {
+			return nil
+		}
+		cursor, direction = page.OldestCursor, "before"
+	}
+	return nil
+}
+
+// processMessage routes one message event: REACTION events refresh their
+// target (incremental only), deletions tombstone, hidden events are skipped,
+// and everything else persists.
+func (imp *Importer) processMessage(ctx context.Context, cc *chatContext, m *Message, incremental bool, sum *ImportSummary) error {
+	if m.Type == "REACTION" {
+		// The target message's embedded reactions[] are the authoritative
+		// current state. During backfill/reconcile the target is visited
+		// anyway; during incremental the target is older than the cursor, so
+		// refetch and re-persist it (refreshing reactions and any edit).
+		if !incremental || m.LinkedMessageID == "" {
+			return nil
+		}
+		target, err := imp.client.GetMessage(ctx, cc.chatID, m.LinkedMessageID)
+		if err != nil {
+			imp.recordItem(cc.syncID, m.ID, "reaction", store.SyncRunItemStatusSkipped, "beeper_reaction_target_missing", err)
+			return nil
+		}
+		if target.IsDeleted {
+			if derr := imp.store.MarkMessageDeleted(cc.sourceID, target.ID); derr != nil {
+				sum.Errors++
+			}
+			return nil
+		}
+		if target.IsHidden || target.Type == "REACTION" {
+			return nil
+		}
+		if err := imp.persistMessage(cc, target, true, sum); err != nil {
+			return err
+		}
+		sum.ReactionsRefreshed++
+		return nil
+	}
+	if m.IsDeleted {
+		if err := imp.store.MarkMessageDeleted(cc.sourceID, m.ID); err != nil {
+			sum.Errors++
+		}
+		sum.MessagesProcessed++
+		return nil
+	}
+	if m.IsHidden {
+		sum.HiddenSkipped++
+		return nil
+	}
+	err := imp.persistMessage(cc, m, incremental, sum)
+	if err == nil {
+		sum.MessagesProcessed++
+	}
+	return err
+}
+
+// persistMessage writes a single message via the granular store path.
+// Store-level failures are fatal (they indicate DB problems, not item churn);
+// per-item auxiliary failures (FTS, recipients, reactions) are counted and
+// recorded but do not abort the run.
+func (imp *Importer) persistMessage(cc *chatContext, m *Message, incremental bool, sum *ImportSummary) error {
+	msg, text := mapMessage(m, cc.convID, cc.sourceID)
+	senderPID, err := imp.res.resolveID(m.SenderID, m.SenderName)
+	if err != nil {
+		return err
+	}
+	if senderPID != 0 {
+		msg.SenderID = sql.NullInt64{Int64: senderPID, Valid: true}
+		if cerr := imp.store.EnsureConversationParticipant(cc.convID, senderPID, "member"); cerr != nil {
+			sum.Errors++
+		}
+	}
+	messageID, err := imp.store.UpsertMessage(&msg)
+	if err != nil {
+		return err
+	}
+	if err := imp.store.UpsertMessageBody(messageID, sql.NullString{String: text, Valid: text != ""}, sql.NullString{}); err != nil {
+		return err
+	}
+	// Archive the exact original message JSON. m.Raw is captured verbatim at
+	// decode time (Message.UnmarshalJSON) so it preserves every API field
+	// including ones we do not model; fall back to re-marshalling only if a
+	// message was constructed without going through a decode.
+	raw := []byte(m.Raw)
+	if len(raw) == 0 {
+		marshaled, merr := json.Marshal(m)
+		if merr != nil {
+			return fmt.Errorf("marshal beeper message raw archive: %w", merr)
+		}
+		raw = marshaled
+	}
+	if err := imp.store.UpsertMessageRawWithFormat(messageID, raw, "beeper_json"); err != nil {
+		return fmt.Errorf("archive beeper message raw: %w", err)
+	}
+	if err := imp.store.UpsertFTS(messageID, "", text, m.SenderName, "", ""); err != nil {
+		sum.Errors++
+	}
+	if m.EditedTimestamp != nil && !m.EditedTimestamp.IsZero() {
+		if err := imp.store.SetMessageEdited(messageID); err != nil {
+			sum.Errors++
+		}
+	}
+
+	// Mentions become "mention" recipient rows. No from/to rows are written:
+	// sender attribution lives in messages.sender_id and membership in
+	// conversation_participants (WhatsApp-importer precedent), which avoids a
+	// messages × group-size row explosion.
+	var mentionIDs []int64
+	var mentionNames []string
+	for _, uid := range m.Mentions {
+		if uid == "" || uid == "@room" {
+			continue
+		}
+		pid, rerr := imp.res.resolveID(uid, "")
+		if rerr != nil {
+			return rerr
+		}
+		if pid == 0 {
+			continue
+		}
+		mentionIDs = append(mentionIDs, pid)
+		mentionNames = append(mentionNames, "")
+	}
+	mentionIDs, mentionNames = dedupRecipients(mentionIDs, mentionNames)
+	if err := imp.store.ReplaceMessageRecipients(messageID, "mention", mentionIDs, mentionNames); err != nil {
+		sum.Errors++
+	}
+
+	// Embedded reactions carry no timestamp; approximate created_at with the
+	// target message's timestamp (cosmetic only).
+	reactions := make([]store.ReactionRef, 0, len(m.Reactions))
+	for _, rc := range m.Reactions {
+		pid, rerr := imp.res.resolveID(rc.ParticipantID, "")
+		if rerr != nil {
+			return rerr
+		}
+		if pid == 0 {
+			continue
+		}
+		typ := "key"
+		if rc.Emoji {
+			typ = "emoji"
+		}
+		reactions = append(reactions, store.ReactionRef{
+			ParticipantID: pid,
+			Type:          typ,
+			Value:         rc.ReactionKey,
+			CreatedAt:     m.Timestamp,
+		})
+	}
+	if err := imp.store.ReplaceReactions(messageID, reactions); err != nil {
+		sum.Errors++
+	}
+
+	if m.LinkedMessageID != "" {
+		if incremental {
+			// Incremental messages reply to older, already-archived parents.
+			if err := imp.store.SetReplyTo(cc.sourceID, m.ID, m.LinkedMessageID); err != nil {
+				sum.Errors++
+			}
+		} else {
+			// Backfill walks newest→oldest, so the parent is not yet
+			// archived; buffer and link after the walk.
+			cc.replies = append(cc.replies, replyPair{child: m.ID, parent: m.LinkedMessageID})
+		}
+	}
+
+	cc.persisted = append(cc.persisted, messageID)
+	sum.MessagesAdded++
+	return nil
+}
+
+// flushReplies links buffered reply pairs now that both sides of each pair
+// have been archived. SetReplyTo is idempotent; pairs whose parents are
+// beyond locally-available history resolve to NULL.
+func (imp *Importer) flushReplies(cc *chatContext, sum *ImportSummary) {
+	for _, rp := range cc.replies {
+		if err := imp.store.SetReplyTo(cc.sourceID, rp.child, rp.parent); err != nil {
+			sum.Errors++
+		}
+	}
+	cc.replies = cc.replies[:0]
+}
+
+func (imp *Importer) enqueueEmbeddings(ctx context.Context, opts ImportOptions, sum *ImportSummary, messageIDs []int64) {
+	if opts.EmbedEnqueuer == nil || len(messageIDs) == 0 {
+		return
+	}
+	if err := opts.EmbedEnqueuer.EnqueueMessages(ctx, messageIDs); err != nil {
+		sum.Errors++
+	}
+}
+
+// checkpoint persists the sync state mid-run so an interrupted run resumes.
+func (imp *Importer) checkpoint(syncID int64, state *SyncState, sum *ImportSummary) {
+	blob, err := state.Marshal()
+	if err != nil {
+		return
+	}
+	_ = imp.store.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+		PageToken:         blob,
+		MessagesProcessed: sum.MessagesProcessed,
+		MessagesAdded:     sum.MessagesAdded,
+		ErrorsCount:       sum.Errors,
+	})
+}
+
+// recordItem records a per-item outcome on the sync run. syncID 0 (item
+// failures before the run row exists) is skipped.
+func (imp *Importer) recordItem(syncID int64, sourceMessageID, phase, status, kind string, err error) {
+	if syncID == 0 {
+		return
+	}
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	_ = imp.store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: sourceMessageID,
+		Phase:           phase,
+		Status:          status,
+		ErrorKind:       kind,
+		ErrorMessage:    msg,
+	})
+}
+
+// anchorFrom picks a stable anchor message from a page: a regular content
+// message (not a reaction, tombstone, or hidden event), preferring the newest.
+func anchorFrom(chatID string, items []Message) *AnchorProbe {
+	var best *Message
+	for i := range items {
+		m := &items[i]
+		if m.Type == "REACTION" || m.IsDeleted || m.IsHidden {
+			continue
+		}
+		if best == nil || m.Timestamp.After(best.Timestamp) {
+			best = m
+		}
+	}
+	if best == nil {
+		return nil
+	}
+	return &AnchorProbe{ChatID: chatID, MessageID: best.ID, Timestamp: best.Timestamp}
+}
+
+// dedupRecipients removes duplicate participant IDs from ids/names slices,
+// preserving first-seen order and skipping zero IDs.
+func dedupRecipients(ids []int64, names []string) ([]int64, []string) {
+	seen := make(map[int64]struct{}, len(ids))
+	outIDs := make([]int64, 0, len(ids))
+	outNames := make([]string, 0, len(ids))
+	for i, id := range ids {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		outIDs = append(outIDs, id)
+		n := ""
+		if i < len(names) {
+			n = names[i]
+		}
+		outNames = append(outNames, n)
+	}
+	return outIDs, outNames
+}
+
+func parseWatermark(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// formatWatermark renders a fixed-width UTC RFC3339 string so watermarks are
+// order-comparable as strings (see SyncState.Merge).
+func formatWatermark(t time.Time) string {
+	return t.UTC().Truncate(time.Second).Format(time.RFC3339)
+}

--- a/internal/beeper/importer_test.go
+++ b/internal/beeper/importer_test.go
@@ -1,0 +1,584 @@
+package beeper
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type recordingEnqueuer struct {
+	ids []int64
+}
+
+func (e *recordingEnqueuer) EnqueueMessages(_ context.Context, ids []int64) error {
+	e.ids = append(e.ids, ids...)
+	return nil
+}
+
+// e2eChat builds a chat exercising every persist path: replies, reactions,
+// deletions, hidden events, edits, transcriptions, and mentions. Timestamps
+// are older than the reconcile window so head re-walks terminate immediately.
+func e2eChat() *fakeChat {
+	base := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!e2e:beeper.local", AccountID: "signal", Network: "Signal",
+		Title: "E2E", Type: "group",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@15550100010:beeper.local", "fullName": "Alice", "phoneNumber": "+15550100010", "isAdmin": true},
+			{"id": "@signal_bob:beeper.local", "fullName": "Bob", "email": "bob@example.com"},
+		},
+	}
+	for i := range 45 {
+		m := fakeMsg{
+			ID: "m" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "hello " + strconv.Itoa(i),
+			SenderID:  "@15550100010:beeper.local", SenderName: "Alice",
+		}
+		switch i {
+		case 10:
+			m.Reactions = []map[string]any{
+				{"id": "@signal_bob:beeper.local", "reactionKey": "👍", "participantID": "@signal_bob:beeper.local", "emoji": true},
+			}
+		case 20:
+			m.LinkedMessageID = "m5"
+		case 30:
+			m.IsDeleted = true
+		case 31:
+			m.IsHidden = true
+		case 40:
+			edited := m.Timestamp.Add(time.Hour)
+			m.EditedTimestamp = &edited
+		case 41:
+			m.Type = "VOICE"
+			m.Text = ""
+			m.Attachments = []map[string]any{
+				{"id": "mxc://x/voice41", "type": "audio", "isVoiceNote": true,
+					"transcription": map[string]any{"transcription": "call me back tomorrow", "engine": "test"}},
+			}
+		case 42:
+			m.Mentions = []string{"@signal_bob:beeper.local", "@room"}
+		}
+		ch.Msgs = append(ch.Msgs, m)
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	return ch
+}
+
+func newTestImporter(t *testing.T, f *fakeBeeper) (*Importer, *store.Store, func()) {
+	t.Helper()
+	srv := f.server()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, NewClient(srv.URL, testToken, 10000))
+	return imp, st, srv.Close
+}
+
+func TestImportBackfillEndToEnd(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	enq := &recordingEnqueuer{}
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal", EmbedEnqueuer: enq})
+	require.NoError(err)
+
+	assert.EqualValues(1, sum.ChatsProcessed)
+	assert.EqualValues(44, sum.MessagesProcessed, "43 persisted + 1 deletion tombstone")
+	assert.EqualValues(43, sum.MessagesAdded)
+	assert.EqualValues(1, sum.HiddenSkipped)
+	assert.EqualValues(0, sum.Errors)
+	assert.Len(enq.ids, 43)
+
+	var msgCount int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&msgCount))
+	assert.Equal(43, msgCount)
+
+	// Conversation and its full participant list (admin role preserved).
+	var convID int64
+	var convType string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id, conversation_type FROM conversations WHERE source_conversation_id = ?`,
+	), "!e2e:beeper.local").Scan(&convID, &convType))
+	assert.Equal("group_chat", convType)
+	var partCount, adminCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ?`), convID).Scan(&partCount))
+	assert.Equal(3, partCount)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ? AND role='admin'`), convID).Scan(&adminCount))
+	assert.Equal(1, adminCount)
+
+	// Phone participant deduped by E.164, sender attribution set.
+	var alicePID int64
+	require.NoError(st.DB().QueryRow(
+		`SELECT id FROM participants WHERE phone_number = '+15550100010'`).Scan(&alicePID))
+	var senderCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE sender_id = ? AND message_type='beeper'`), alicePID).Scan(&senderCount))
+	assert.Equal(43, senderCount)
+
+	// Reply linked to its parent.
+	var parentID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "m5").Scan(&parentID))
+	var linkedParent sql.NullInt64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT reply_to_message_id FROM messages WHERE source_message_id = ?`), "m20").Scan(&linkedParent))
+	require.True(linkedParent.Valid)
+	assert.Equal(parentID, linkedParent.Int64)
+
+	// Embedded reaction persisted.
+	var reactionValue string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT r.reaction_value FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ?`), "m10").Scan(&reactionValue))
+	assert.Equal("👍", reactionValue)
+
+	// Edit flag set.
+	var isEdited bool
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT is_edited FROM messages WHERE source_message_id = ?`), "m40").Scan(&isEdited))
+	assert.True(isEdited)
+
+	// Voice transcription is searchable (body + FTS).
+	var voiceBody string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT b.body_text FROM message_bodies b
+		JOIN messages m ON m.id = b.message_id
+		WHERE m.source_message_id = ?`), "m41").Scan(&voiceBody))
+	assert.Contains(voiceBody, "[voice message]")
+	assert.Contains(voiceBody, "call me back tomorrow")
+	var ftsHits int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'tomorrow'`).Scan(&ftsHits))
+	assert.Equal(1, ftsHits)
+
+	// Mentions become mention recipient rows; @room is skipped; no from/to rows.
+	var mentionCount, fromToCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'mention'`), "m42").Scan(&mentionCount))
+	assert.Equal(1, mentionCount)
+	require.NoError(st.DB().QueryRow(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.message_type = 'beeper' AND mr.recipient_type IN ('from','to')`).Scan(&fromToCount))
+	assert.Zero(fromToCount)
+
+	// Raw JSON archived with the beeper_json format tag.
+	var rawFormat string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mr.raw_format FROM message_raw mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ?`), "m10").Scan(&rawFormat))
+	assert.Equal("beeper_json", rawFormat)
+
+	// Sync state persisted: backfill complete, incremental cursor primed, anchor set.
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	require.True(run.CursorAfter.Valid)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	cs := state.Chats["!e2e:beeper.local"]
+	require.NotNil(cs)
+	assert.True(cs.Done)
+	assert.NotEmpty(cs.Newest)
+	require.NotNil(state.Anchor)
+	assert.NotEmpty(state.ListWatermark)
+
+	// Conversation stats recomputed.
+	var statCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT message_count FROM conversations WHERE id = ?`), convID).Scan(&statCount))
+	assert.Equal(43, statCount)
+}
+
+func TestImportSecondRunIncremental(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// Three new messages arrive.
+	now := time.Now().UTC().Truncate(time.Second)
+	for i := range 3 {
+		f.appendMsg("!e2e:beeper.local", fakeMsg{
+			ID: "new" + strconv.Itoa(i), SortKey: 100 + i,
+			Timestamp: now.Add(time.Duration(i-3) * time.Minute),
+			Text:      "fresh " + strconv.Itoa(i),
+			SenderID:  "@signal_bob:beeper.local", SenderName: "Bob",
+		})
+	}
+
+	f.resetRequests()
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	// The reconcile pass may re-upsert recent messages, so MessagesAdded can
+	// exceed 3; the DB count is the duplicate-free ground truth.
+	assert.GreaterOrEqual(sum.MessagesAdded, int64(3))
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(46, total, "no duplicates on re-run")
+
+	// The second run must be cursor-driven: chat discovery filtered by
+	// activity, message fetches either direction=after (incremental) or the
+	// cursor-less head page (reconcile) — never a direction=before backfill.
+	var sawActivityFilter bool
+	for _, req := range f.requests() {
+		if strings.HasPrefix(req, "/v1/chats/search") {
+			sawActivityFilter = sawActivityFilter || strings.Contains(req, "lastActivityAfter=")
+		}
+		if strings.Contains(req, "/messages?") {
+			assert.NotContains(req, "direction=before", "second run must not re-backfill: %s", req)
+		}
+	}
+	assert.True(sawActivityFilter, "second run must filter chat discovery by lastActivityAfter")
+}
+
+func TestImportResumeAfterLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	base := time.Now().Add(-60 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!big:beeper.local", AccountID: "signal", Network: "Signal", Title: "Big", Type: "single",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+		},
+	}
+	for i := range 100 {
+		ch.Msgs = append(ch.Msgs, fakeMsg{
+			ID: "b" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "bulk " + strconv.Itoa(i),
+			SenderID:  "@signal_ann:beeper.local", SenderName: "Ann",
+		})
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	// Run 1: limited — backfill stops early but stays resumable.
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal", Limit: 30})
+	require.NoError(err)
+
+	var afterRun1 int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&afterRun1))
+	require.Less(afterRun1, 100)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotNil(state.Chats["!big:beeper.local"])
+	assert.False(state.Chats["!big:beeper.local"].Done, "limited backfill must stay resumable")
+
+	// Run 2: unlimited — resumes from the stored cursor without refetching.
+	f.resetRequests()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(100, total)
+
+	for _, req := range f.requests() {
+		if strings.Contains(req, "/messages?") && strings.Contains(req, "direction=before") {
+			assert.Contains(req, "cursor=", "resumed backfill must continue from the stored cursor: %s", req)
+		}
+	}
+
+	// Chat now complete.
+	run, err = st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err = LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	assert.True(state.Chats["!big:beeper.local"].Done)
+}
+
+func TestImportReactionEventRefreshesTarget(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// Bob reacts to an old message: the network delivers a REACTION event and
+	// the target's embedded reactions[] now include it.
+	ch := f.chat("!e2e:beeper.local")
+	ch.Msgs[5].Reactions = []map[string]any{
+		{"id": "@signal_bob:beeper.local", "reactionKey": "❤️", "participantID": "@signal_bob:beeper.local", "emoji": true},
+	}
+	f.appendMsg("!e2e:beeper.local", fakeMsg{
+		ID: "react1", SortKey: 200, Timestamp: time.Now().UTC().Truncate(time.Second),
+		Type: "REACTION", IsHidden: true, LinkedMessageID: "m5",
+		SenderID: "@signal_bob:beeper.local", SenderName: "Bob",
+	})
+
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	assert.EqualValues(1, sum.ReactionsRefreshed)
+
+	var reactionValue string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT r.reaction_value FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ?`), "m5").Scan(&reactionValue))
+	assert.Equal("❤️", reactionValue)
+
+	// The REACTION event itself must not become a message row.
+	var eventRows int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "react1").Scan(&eventRows))
+	assert.Zero(eventRows)
+}
+
+func TestImportReconcileCatchesRecentDeletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	// Recent chat: all messages inside the reconcile window.
+	base := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!recent:beeper.local", AccountID: "signal", Network: "Signal", Title: "Recent", Type: "single",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+		},
+	}
+	for i := range 5 {
+		ch.Msgs = append(ch.Msgs, fakeMsg{
+			ID: "r" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "recent " + strconv.Itoa(i),
+			SenderID:  "@signal_ann:beeper.local", SenderName: "Ann",
+		})
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// The sender deletes r2 in place; the chat sees new activity so the next
+	// run visits it and the reconcile pass observes the tombstone.
+	f.chat("!recent:beeper.local").Msgs[2].IsDeleted = true
+	f.appendMsg("!recent:beeper.local", fakeMsg{
+		ID: "r5", SortKey: 5, Timestamp: time.Now().UTC().Truncate(time.Second),
+		Text: "newest", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+	})
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var deletedAt sql.NullTime
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT deleted_from_source_at FROM messages WHERE source_message_id = ?`), "r2").Scan(&deletedAt))
+	assert.True(deletedAt.Valid, "reconcile pass must tombstone recent deletions")
+
+	// The archived content survives deletion — that is the point of the archive.
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT b.body_text FROM message_bodies b
+		JOIN messages m ON m.id = b.message_id
+		WHERE m.source_message_id = ?`), "r2").Scan(&body))
+	assert.Equal("recent 2", body)
+}
+
+func TestImportAnchorMismatchFailsFast(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotNil(state.Anchor)
+
+	// Simulate a reinstall/re-index: the anchor message ID now maps to a
+	// different message (timestamp changed).
+	ch := f.chat("!e2e:beeper.local")
+	for i := range ch.Msgs {
+		if ch.Msgs[i].ID == state.Anchor.MessageID {
+			ch.Msgs[i].Timestamp = ch.Msgs[i].Timestamp.Add(time.Hour)
+		}
+	}
+
+	var before int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&before))
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.Error(err)
+	assert.Contains(err.Error(), "re-assigned")
+	assert.Contains(err.Error(), "re-add")
+
+	var after int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&after))
+	assert.Equal(before, after, "no rows may be written after an anchor mismatch")
+
+	// The failure is recorded on the sync run.
+	var status string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT status FROM sync_runs WHERE source_id = ? ORDER BY id DESC LIMIT 1`), src.ID).Scan(&status))
+	assert.Equal("failed", status)
+}
+
+func TestImportTruncatedParticipantsFetchesDetail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	base := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!grp:beeper.local", AccountID: "signal", Network: "Signal", Title: "Grp", Type: "group",
+		ParticipantsTruncated: true,
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+			{"id": "@signal_bea:beeper.local", "fullName": "Bea"},
+		},
+		Msgs: []fakeMsg{{
+			ID: "g0", SortKey: 0, Timestamp: base, Text: "hi",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+		}},
+		LastActivity: base,
+	}
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var convID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM conversations WHERE source_conversation_id = ?`), "!grp:beeper.local").Scan(&convID))
+	var partCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ?`), convID).Scan(&partCount))
+	assert.Equal(3, partCount, "truncated listing must trigger a full-detail fetch")
+}
+
+func TestImportFullRepairsWithoutDuplicates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal", Full: true})
+	require.NoError(err)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(43, total, "--full re-walk must upsert in place")
+}
+
+func TestImportEmptyChatPicksUpLaterMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(&fakeChat{
+		ID: "!empty:beeper.local", AccountID: "signal", Network: "Signal", Title: "Empty", Type: "single",
+		Participants: []map[string]any{{"id": "@me:beeper.local", "isSelf": true}},
+		LastActivity: time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second),
+	})
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	require.Zero(total)
+
+	// The chat's first-ever message arrives after the empty backfill.
+	f.appendMsg("!empty:beeper.local", fakeMsg{
+		ID: "first", SortKey: 1, Timestamp: time.Now().UTC().Truncate(time.Second),
+		Text: "hello at last", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+	})
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(1, total, "a chat that was empty at backfill must still pick up later messages")
+}
+
+func TestImportScopedToSingleChat(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	base := time.Now().Add(-10 * 24 * time.Hour).UTC().Truncate(time.Second)
+	f.addChat(&fakeChat{
+		ID: "!other:beeper.local", AccountID: "signal", Network: "Signal", Title: "Other", Type: "single",
+		Participants: []map[string]any{{"id": "@me:beeper.local", "isSelf": true}},
+		Msgs: []fakeMsg{{ID: "o0", SortKey: 0, Timestamp: base, Text: "other",
+			SenderID: "@signal_zed:beeper.local", SenderName: "Zed"}},
+		LastActivity: base,
+	})
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal", ChatID: "!other:beeper.local"})
+	require.NoError(err)
+	assert.EqualValues(1, sum.ChatsProcessed)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(1, total)
+}

--- a/internal/beeper/mapping.go
+++ b/internal/beeper/mapping.go
@@ -1,0 +1,98 @@
+package beeper
+
+import (
+	"database/sql"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// MessageType is the msgvault message_type for all Beeper-archived messages.
+// The originating network (WhatsApp, Signal, …) is distinguished by the
+// per-account source, not by message_type: Beeper's network set is open-ended,
+// while message_type values live in fixed lists across the query layer.
+const MessageType = "beeper"
+
+func snippet(text string) string {
+	r := []rune(text)
+	if len(r) > 100 {
+		return string(r[:100])
+	}
+	return text
+}
+
+// placeholderBody synthesizes a searchable body line for messages that carry
+// no text (media, stickers, locations).
+func placeholderBody(m *Message) string {
+	switch m.Type {
+	case "IMAGE":
+		return "[image]"
+	case "VIDEO":
+		return "[video]"
+	case "VOICE":
+		return "[voice message]"
+	case "AUDIO":
+		return "[audio]"
+	case "STICKER":
+		return "[sticker]"
+	case "LOCATION":
+		return "[location]"
+	case "FILE":
+		for _, att := range m.Attachments {
+			if att.FileName != "" {
+				return "[file: " + att.FileName + "]"
+			}
+		}
+		return "[file]"
+	default:
+		return ""
+	}
+}
+
+// bodyText renders the plain-text body: the message text (or a placeholder
+// for text-less media), plus any voice-note transcriptions so they are
+// visible to FTS and embeddings.
+func bodyText(m *Message) string {
+	var parts []string
+	if text := strings.TrimSpace(m.Text); text != "" {
+		parts = append(parts, text)
+	} else if ph := placeholderBody(m); ph != "" {
+		parts = append(parts, ph)
+	}
+	for _, att := range m.Attachments {
+		if att.Transcription != nil && strings.TrimSpace(att.Transcription.Transcription) != "" {
+			parts = append(parts, "🎤 transcript: "+strings.TrimSpace(att.Transcription.Transcription))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// mapMessage converts a Beeper API Message into a store.Message plus the
+// plain-text body. conversationID and sourceID are internal DB IDs. The
+// message's own numeric id is the source_message_id (unique per installation;
+// guarded by the SyncState anchor probe).
+func mapMessage(m *Message, conversationID, sourceID int64) (store.Message, string) {
+	text := bodyText(m)
+	msg := store.Message{
+		ConversationID:  conversationID,
+		SourceID:        sourceID,
+		SourceMessageID: m.ID,
+		MessageType:     MessageType,
+		SentAt:          sql.NullTime{Time: m.Timestamp, Valid: !m.Timestamp.IsZero()},
+		ReceivedAt:      sql.NullTime{Time: m.Timestamp, Valid: !m.Timestamp.IsZero()},
+		IsFromMe:        m.IsSender,
+		Snippet:         sql.NullString{String: snippet(text), Valid: text != ""},
+		HasAttachments:  len(m.Attachments) > 0,
+		AttachmentCount: len(m.Attachments),
+	}
+	return msg, text
+}
+
+// conversationType maps a Beeper chat type to the msgvault conversation type:
+// "single" becomes "direct_chat"; everything else becomes "group_chat".
+func conversationType(chatType string) string {
+	if chatType == "single" {
+		return "direct_chat"
+	}
+	return "group_chat"
+}

--- a/internal/beeper/mapping_test.go
+++ b/internal/beeper/mapping_test.go
@@ -1,0 +1,79 @@
+package beeper
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBodyText(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  Message
+		want string
+	}{
+		{"plain text", Message{Type: "TEXT", Text: "hello"}, "hello"},
+		{"image placeholder", Message{Type: "IMAGE"}, "[image]"},
+		{"video placeholder", Message{Type: "VIDEO"}, "[video]"},
+		{"voice placeholder", Message{Type: "VOICE"}, "[voice message]"},
+		{"sticker placeholder", Message{Type: "STICKER"}, "[sticker]"},
+		{"location placeholder", Message{Type: "LOCATION"}, "[location]"},
+		{"location with text keeps text", Message{Type: "LOCATION", Text: "123 Main St"}, "123 Main St"},
+		{"file with name", Message{Type: "FILE", Attachments: []Attachment{{FileName: "report.pdf"}}}, "[file: report.pdf]"},
+		{"file without name", Message{Type: "FILE"}, "[file]"},
+		{"media with caption keeps caption", Message{Type: "IMAGE", Text: "look at this"}, "look at this"},
+		{
+			"voice transcription appended",
+			Message{Type: "VOICE", Attachments: []Attachment{{IsVoiceNote: true, Transcription: &Transcription{Transcription: "call me back"}}}},
+			"[voice message]\n🎤 transcript: call me back",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bodyText(&tt.msg))
+		})
+	}
+}
+
+func TestMapMessage(t *testing.T) {
+	ts := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	m := Message{
+		ID:        "12345",
+		Timestamp: ts,
+		Type:      "TEXT",
+		Text:      "hello world",
+		IsSender:  true,
+		Attachments: []Attachment{
+			{FileName: "a.png"}, {FileName: "b.png"},
+		},
+	}
+	msg, text := mapMessage(&m, 7, 3)
+	assert.Equal(t, int64(7), msg.ConversationID)
+	assert.Equal(t, int64(3), msg.SourceID)
+	assert.Equal(t, "12345", msg.SourceMessageID)
+	assert.Equal(t, "beeper", msg.MessageType)
+	assert.True(t, msg.IsFromMe)
+	require.True(t, msg.SentAt.Valid)
+	assert.True(t, msg.SentAt.Time.Equal(ts))
+	require.True(t, msg.ReceivedAt.Valid)
+	assert.True(t, msg.HasAttachments)
+	assert.Equal(t, 2, msg.AttachmentCount)
+	assert.Equal(t, "hello world", text)
+	assert.Equal(t, "hello world", msg.Snippet.String)
+	assert.False(t, msg.Subject.Valid, "chat messages have no subject")
+}
+
+func TestMapMessageSnippetTruncation(t *testing.T) {
+	long := strings.Repeat("é", 150)
+	msg, _ := mapMessage(&Message{ID: "1", Timestamp: time.Now(), Text: long}, 1, 1)
+	assert.Len(t, []rune(msg.Snippet.String), 100)
+}
+
+func TestConversationType(t *testing.T) {
+	assert.Equal(t, "direct_chat", conversationType("single"))
+	assert.Equal(t, "group_chat", conversationType("group"))
+	assert.Equal(t, "group_chat", conversationType("anything-else"))
+}

--- a/internal/beeper/participants.go
+++ b/internal/beeper/participants.go
@@ -1,0 +1,87 @@
+package beeper
+
+import (
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// participantIdentifierType namespaces Beeper user IDs in
+// participant_identifiers. The IDs are Beeper-local Matrix-style IDs
+// (@x:beeper.local), not federated Matrix IDs.
+const participantIdentifierType = "beeper"
+
+// participantResolver resolves Beeper users to msgvault participant IDs,
+// cached per run by Beeper user ID.
+//
+// Resolution ladder (exclusive — EnsureParticipantByIdentifier creates a new
+// participant for unseen identifiers, so calling two rungs for one person
+// would fork them):
+//  1. E.164 phone number → EnsureParticipantByPhone, deduping people across
+//     Beeper and native SMS/WhatsApp archives.
+//  2. Email → EnsureParticipant, deduping against mail archives.
+//  3. Beeper user ID → EnsureParticipantByIdentifier("beeper", …).
+//
+// Phone/email are only present on chat participant entries, so the resolver
+// is seeded from each chat's participant list; message senders then hit the
+// cache by user ID. Senders absent from the list (departed members) fall
+// through to rung 3.
+type participantResolver struct {
+	store *store.Store
+	cache map[string]int64
+}
+
+func newParticipantResolver(s *store.Store) *participantResolver {
+	return &participantResolver{store: s, cache: map[string]int64{}}
+}
+
+func (r *participantResolver) resolveUser(u *User) (int64, error) {
+	if u == nil || u.ID == "" {
+		return 0, nil
+	}
+	if pid, ok := r.cache[u.ID]; ok {
+		return pid, nil
+	}
+	var pid int64
+	var err error
+	switch {
+	case strings.HasPrefix(u.PhoneNumber, "+"):
+		pid, err = r.store.EnsureParticipantByPhone(u.PhoneNumber, u.FullName, participantIdentifierType)
+	case strings.Contains(u.Email, "@"):
+		pid, err = r.byEmail(u.Email, u.FullName)
+	default:
+		pid, err = r.store.EnsureParticipantByIdentifier(participantIdentifierType, u.ID, u.FullName)
+	}
+	if err != nil {
+		return 0, err
+	}
+	r.cache[u.ID] = pid
+	return pid, nil
+}
+
+// resolveID resolves a bare Beeper user ID (message sender, mention, reactor)
+// with an optional display name. Cache misses fall through to rung 3 of the
+// ladder since no phone/email is available on bare IDs.
+func (r *participantResolver) resolveID(userID, displayName string) (int64, error) {
+	if userID == "" {
+		return 0, nil
+	}
+	if pid, ok := r.cache[userID]; ok {
+		return pid, nil
+	}
+	pid, err := r.store.EnsureParticipantByIdentifier(participantIdentifierType, userID, displayName)
+	if err != nil {
+		return 0, err
+	}
+	r.cache[userID] = pid
+	return pid, nil
+}
+
+func (r *participantResolver) byEmail(email, displayName string) (int64, error) {
+	email = strings.ToLower(email)
+	domain := ""
+	if at := strings.LastIndex(email, "@"); at >= 0 {
+		domain = email[at+1:]
+	}
+	return r.store.EnsureParticipant(email, displayName, domain)
+}

--- a/internal/beeper/participants_test.go
+++ b/internal/beeper/participants_test.go
@@ -1,0 +1,132 @@
+package beeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestResolveUserPhoneRungDedupesAcrossSources(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// A native SMS/WhatsApp import already created this person by phone.
+	existing, err := st.EnsureParticipantByPhone("+15550100001", "Alice Native", "whatsapp")
+	require.NoError(t, err)
+
+	pid, err := r.resolveUser(&User{
+		ID:          "@15550100001:local-whatsapp.localhost",
+		PhoneNumber: "+15550100001",
+		FullName:    "Alice",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, existing, pid, "phone rung must dedupe with native imports")
+}
+
+func TestResolveUserEmailRung(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	existing, err := st.EnsureParticipant("bob@example.com", "Bob Mail", "example.com")
+	require.NoError(t, err)
+
+	pid, err := r.resolveUser(&User{
+		ID:       "@linkedin_bob:beeper.local",
+		Email:    "Bob@Example.com",
+		FullName: "Bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, existing, pid, "email rung must lowercase and dedupe with mail archives")
+}
+
+func TestResolveUserIdentifierFallback(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	pid, err := r.resolveUser(&User{ID: "@signal_uuid:beeper.local", FullName: "Carol"})
+	require.NoError(t, err)
+	require.NotZero(t, pid)
+
+	var identifierType, identifierValue string
+	require.NoError(t, st.DB().QueryRow(
+		`SELECT identifier_type, identifier_value FROM participant_identifiers WHERE participant_id = ?`, pid,
+	).Scan(&identifierType, &identifierValue))
+	assert.Equal(t, "beeper", identifierType)
+	assert.Equal(t, "@signal_uuid:beeper.local", identifierValue)
+}
+
+func TestResolveUserLadderIsExclusive(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// A phone-resolvable user must resolve through the phone rung only: the
+	// Matrix ID must never become its own identifier row (calling two rungs
+	// would fork the person on later bare-ID lookups).
+	pid, err := r.resolveUser(&User{
+		ID:          "@15550100002:local-whatsapp.localhost",
+		PhoneNumber: "+15550100002",
+		Email:       "dave@example.com", // phone wins over email
+		FullName:    "Dave",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, pid)
+
+	var matrixIDRows int
+	require.NoError(t, st.DB().QueryRow(
+		`SELECT COUNT(*) FROM participant_identifiers WHERE identifier_value = '@15550100002:local-whatsapp.localhost'`,
+	).Scan(&matrixIDRows))
+	assert.Zero(t, matrixIDRows)
+
+	var phone string
+	require.NoError(t, st.DB().QueryRow(
+		`SELECT phone_number FROM participants WHERE id = ?`, pid,
+	).Scan(&phone))
+	assert.Equal(t, "+15550100002", phone)
+
+	// The phone rung records the phone under the beeper identifier namespace.
+	var phoneIdentRows int
+	require.NoError(t, st.DB().QueryRow(
+		`SELECT COUNT(*) FROM participant_identifiers WHERE participant_id = ? AND identifier_type = 'beeper' AND identifier_value = '+15550100002'`, pid,
+	).Scan(&phoneIdentRows))
+	assert.Equal(t, 1, phoneIdentRows)
+}
+
+func TestResolveUserCache(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	u := &User{ID: "@x:beeper.local", FullName: "X"}
+	first, err := r.resolveUser(u)
+	require.NoError(t, err)
+	second, err := r.resolveUser(u)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestResolveIDHitsSeededCache(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// Seeding from the chat participant list (phone rung)…
+	seeded, err := r.resolveUser(&User{
+		ID:          "@15550100003:local-whatsapp.localhost",
+		PhoneNumber: "+15550100003",
+		FullName:    "Eve",
+	})
+	require.NoError(t, err)
+
+	// …means a later bare sender ID resolves to the same person, not a fork.
+	pid, err := r.resolveID("@15550100003:local-whatsapp.localhost", "Eve")
+	require.NoError(t, err)
+	assert.Equal(t, seeded, pid)
+}
+
+func TestResolveIDEmpty(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+	pid, err := r.resolveID("", "nobody")
+	require.NoError(t, err)
+	assert.Zero(t, pid)
+}

--- a/internal/beeper/syncstate.go
+++ b/internal/beeper/syncstate.go
@@ -1,0 +1,103 @@
+package beeper
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ChatState tracks one chat's sync progress.
+//
+// Newest is the cursor to resume incremental fetches from (direction=after).
+// Oldest is the backfill resume point (direction=before); it advances as the
+// backfill walks toward the beginning of history. Done means the backfill
+// reached the beginning of the chat's locally-available history.
+type ChatState struct {
+	Newest string `json:"newest,omitempty"`
+	Oldest string `json:"oldest,omitempty"`
+	Done   bool   `json:"done,omitempty"`
+}
+
+// AnchorProbe fingerprints the Beeper installation's message-ID space.
+// Message IDs are only unique per installation; a reinstall or re-index could
+// re-assign them, which would silently corrupt incremental dedup. Each run
+// re-fetches the anchor message and aborts on mismatch instead.
+type AnchorProbe struct {
+	ChatID    string    `json:"chat_id"`
+	MessageID string    `json:"message_id"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// SyncState holds per-chat incremental cursors for one Beeper account source,
+// persisted as JSON in sync_runs.cursor_after (and checkpointed mid-run in
+// cursor_before).
+type SyncState struct {
+	Chats map[string]*ChatState `json:"chats"` // key = chat ID (Matrix room ID)
+	// Anchor is set once after the first message is archived; see AnchorProbe.
+	Anchor *AnchorProbe `json:"anchor,omitempty"`
+	// ListWatermark is the max chat lastActivity observed (RFC3339); the next
+	// incremental run enumerates only chats active after it.
+	ListWatermark string `json:"list_watermark,omitempty"`
+}
+
+func NewSyncState() *SyncState {
+	return &SyncState{Chats: map[string]*ChatState{}}
+}
+
+func LoadSyncState(blob string) (*SyncState, error) {
+	s := NewSyncState()
+	if blob == "" {
+		return s, nil
+	}
+	if err := json.Unmarshal([]byte(blob), s); err != nil {
+		return nil, err
+	}
+	if s.Chats == nil {
+		s.Chats = map[string]*ChatState{}
+	}
+	return s, nil
+}
+
+func (s *SyncState) Marshal() (string, error) {
+	b, err := json.Marshal(s)
+	return string(b), err
+}
+
+// Chat returns the (created-if-missing) state for chatID.
+func (s *SyncState) Chat(chatID string) *ChatState {
+	cs, ok := s.Chats[chatID]
+	if !ok {
+		cs = &ChatState{}
+		s.Chats[chatID] = cs
+	}
+	return cs
+}
+
+// Merge incorporates cursors from other into s. Cursors are opaque API tokens
+// that cannot be compared by value; like the Teams deltaLink merge, we prefer
+// other's non-empty values wholesale on the assumption that other represents a
+// more recent (checkpoint) run whose cursors are at least as advanced. Done
+// flags are OR'd. The later ListWatermark wins (RFC3339 is order-comparable).
+func (s *SyncState) Merge(other *SyncState) {
+	if other == nil {
+		return
+	}
+	for chatID, ocs := range other.Chats {
+		if ocs == nil {
+			continue
+		}
+		cs := s.Chat(chatID)
+		if ocs.Newest != "" {
+			cs.Newest = ocs.Newest
+		}
+		if ocs.Oldest != "" {
+			cs.Oldest = ocs.Oldest
+		}
+		cs.Done = cs.Done || ocs.Done
+	}
+	if s.Anchor == nil {
+		s.Anchor = other.Anchor
+	}
+	if other.ListWatermark > s.ListWatermark {
+		s.ListWatermark = other.ListWatermark
+	}
+}

--- a/internal/beeper/syncstate_test.go
+++ b/internal/beeper/syncstate_test.go
@@ -1,0 +1,86 @@
+package beeper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncStateRoundTrip(t *testing.T) {
+	s := NewSyncState()
+	s.Chat("!a:x").Newest = "100"
+	s.Chat("!a:x").Oldest = "5"
+	s.Chat("!b:x").Done = true
+	s.Anchor = &AnchorProbe{ChatID: "!a:x", MessageID: "42", Timestamp: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+	s.ListWatermark = "2026-01-02T03:04:05Z"
+
+	blob, err := s.Marshal()
+	require.NoError(t, err)
+
+	got, err := LoadSyncState(blob)
+	require.NoError(t, err)
+	assert.Equal(t, s.Chats["!a:x"], got.Chats["!a:x"])
+	assert.Equal(t, s.Chats["!b:x"], got.Chats["!b:x"])
+	require.NotNil(t, got.Anchor)
+	assert.Equal(t, "42", got.Anchor.MessageID)
+	assert.True(t, got.Anchor.Timestamp.Equal(s.Anchor.Timestamp))
+	assert.Equal(t, s.ListWatermark, got.ListWatermark)
+}
+
+func TestLoadSyncStateEmpty(t *testing.T) {
+	s, err := LoadSyncState("")
+	require.NoError(t, err)
+	require.NotNil(t, s.Chats)
+	assert.Empty(t, s.Chats)
+	assert.Nil(t, s.Anchor)
+}
+
+func TestLoadSyncStateInvalid(t *testing.T) {
+	_, err := LoadSyncState("{not json")
+	require.Error(t, err)
+}
+
+func TestSyncStateMerge(t *testing.T) {
+	base := NewSyncState()
+	base.Chat("!a:x").Newest = "10"
+	base.Chat("!a:x").Oldest = "5"
+	base.Chat("!keep:x").Newest = "77"
+	base.ListWatermark = "2026-01-01T00:00:00Z"
+	base.Anchor = &AnchorProbe{ChatID: "!a:x", MessageID: "1"}
+
+	// Checkpoint from an interrupted, more advanced run.
+	cp := NewSyncState()
+	cp.Chat("!a:x").Newest = "20"
+	cp.Chat("!a:x").Done = true
+	cp.Chat("!new:x").Oldest = "3"
+	cp.ListWatermark = "2026-02-01T00:00:00Z"
+	cp.Anchor = &AnchorProbe{ChatID: "!other:x", MessageID: "9"}
+
+	base.Merge(cp)
+
+	assert.Equal(t, "20", base.Chats["!a:x"].Newest, "checkpoint cursor wins")
+	assert.Equal(t, "5", base.Chats["!a:x"].Oldest, "empty checkpoint field keeps baseline")
+	assert.True(t, base.Chats["!a:x"].Done, "done flags OR")
+	assert.Equal(t, "77", base.Chats["!keep:x"].Newest, "untouched chats survive")
+	assert.Equal(t, "3", base.Chats["!new:x"].Oldest, "new chats copied")
+	assert.Equal(t, "2026-02-01T00:00:00Z", base.ListWatermark, "later watermark wins")
+	assert.Equal(t, "1", base.Anchor.MessageID, "existing anchor is never replaced")
+}
+
+func TestSyncStateMergeNil(t *testing.T) {
+	base := NewSyncState()
+	base.Chat("!a:x").Newest = "10"
+	base.Merge(nil)
+	assert.Equal(t, "10", base.Chats["!a:x"].Newest)
+}
+
+func TestSyncStateMergeFillsAnchor(t *testing.T) {
+	base := NewSyncState()
+	cp := NewSyncState()
+	cp.Anchor = &AnchorProbe{ChatID: "!a:x", MessageID: "9"}
+	base.Merge(cp)
+	require.NotNil(t, base.Anchor)
+	assert.Equal(t, "9", base.Anchor.MessageID)
+}

--- a/internal/beeper/token.go
+++ b/internal/beeper/token.go
@@ -1,0 +1,93 @@
+package beeper
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/msgvault/internal/fileutil"
+)
+
+// tokenFile stores the Beeper Desktop access token. There is a single Beeper
+// Desktop per machine (loopback-only API), so the file is a singleton rather
+// than per-identifier.
+type tokenFile struct {
+	AccessToken string `json:"access_token"`
+}
+
+// TokenPath returns the path of the Beeper Desktop token file.
+func TokenPath(tokensDir string) string {
+	return filepath.Join(tokensDir, "beeper.json")
+}
+
+// SaveToken saves the Beeper Desktop access token. Uses atomic temp-file +
+// rename to avoid partial writes, and fileutil.Secure* helpers for Windows
+// DACL hardening.
+func SaveToken(tokensDir, token string) error {
+	if err := fileutil.SecureMkdirAll(tokensDir, 0700); err != nil {
+		return fmt.Errorf("create tokens dir: %w", err)
+	}
+	data, err := json.Marshal(tokenFile{AccessToken: token}) //nolint:gosec // serialized to a 0600 file on the user's own machine
+	if err != nil {
+		return err
+	}
+	path := TokenPath(tokensDir)
+
+	tmpFile, err := os.CreateTemp(tokensDir, ".beeper-token-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp token file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp token file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp token file: %w", err)
+	}
+	if err := fileutil.SecureChmod(tmpPath, 0600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp token file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename temp token file: %w", err)
+	}
+	return nil
+}
+
+// LoadToken loads the Beeper Desktop access token.
+func LoadToken(tokensDir string) (string, error) {
+	data, err := os.ReadFile(TokenPath(tokensDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.New("no Beeper Desktop token found (run 'add-beeper' first)")
+		}
+		return "", fmt.Errorf("read beeper token: %w", err)
+	}
+	var tf tokenFile
+	if err := json.Unmarshal(data, &tf); err != nil {
+		return "", fmt.Errorf("parse beeper token: %w", err)
+	}
+	return tf.AccessToken, nil
+}
+
+// HasToken returns true if a Beeper Desktop token file exists.
+func HasToken(tokensDir string) bool {
+	_, err := os.Stat(TokenPath(tokensDir))
+	return err == nil
+}
+
+// DeleteToken removes the Beeper Desktop token file. Missing file is not an error.
+func DeleteToken(tokensDir string) error {
+	err := os.Remove(TokenPath(tokensDir))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/beeper/token_test.go
+++ b/internal/beeper/token_test.go
@@ -1,0 +1,42 @@
+package beeper
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	assert.False(t, HasToken(dir))
+	_, err := LoadToken(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add-beeper")
+
+	require.NoError(t, SaveToken(dir, "secret-token"))
+	assert.True(t, HasToken(dir))
+
+	got, err := LoadToken(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "secret-token", got)
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(TokenPath(dir))
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	}
+
+	// Overwrite is atomic and replaces the value.
+	require.NoError(t, SaveToken(dir, "rotated"))
+	got, err = LoadToken(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "rotated", got)
+
+	require.NoError(t, DeleteToken(dir))
+	assert.False(t, HasToken(dir))
+	require.NoError(t, DeleteToken(dir), "double delete is not an error")
+}

--- a/internal/beeper/types.go
+++ b/internal/beeper/types.go
@@ -1,0 +1,184 @@
+package beeper
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// ---- Beeper Desktop API objects (see /v1/spec, "Beeper Client API") ----
+
+// Account is a chat account connected to Beeper Desktop (one per network login).
+type Account struct {
+	AccountID string `json:"accountID"`
+	Network   string `json:"network"` // human-friendly name; may be empty
+	User      User   `json:"user"`
+}
+
+// User identifies a person on a network. Only fields the importer consumes
+// are modelled; the archived raw JSON preserves everything else.
+type User struct {
+	ID          string `json:"id"` // Matrix-style user ID, e.g. "@signal_<uuid>:beeper.local"
+	Username    string `json:"username"`
+	PhoneNumber string `json:"phoneNumber"` // E.164 when present
+	Email       string `json:"email"`
+	FullName    string `json:"fullName"`
+	IsSelf      bool   `json:"isSelf"`
+}
+
+// Participant is a chat member: a User plus membership metadata.
+type Participant struct {
+	User
+
+	IsAdmin bool `json:"isAdmin"`
+}
+
+// ChatParticipants wraps the (possibly truncated) participant list of a chat.
+type ChatParticipants struct {
+	Items   []Participant `json:"items"`
+	HasMore bool          `json:"hasMore"`
+	Total   int           `json:"total"`
+}
+
+// Chat is a conversation on one account.
+type Chat struct {
+	ID           string           `json:"id"` // Matrix room ID, globally unique
+	AccountID    string           `json:"accountID"`
+	Network      string           `json:"network"`
+	Title        string           `json:"title"`
+	Type         string           `json:"type"` // "single" | "group"
+	Participants ChatParticipants `json:"participants"`
+	LastActivity time.Time        `json:"lastActivity"`
+}
+
+// Reaction is one participant's reaction to a message.
+type Reaction struct {
+	ID            string `json:"id"`
+	ReactionKey   string `json:"reactionKey"`
+	ParticipantID string `json:"participantID"`
+	Emoji         bool   `json:"emoji"`
+}
+
+// Transcription is an attachment transcription (voice notes).
+type Transcription struct {
+	Transcription string `json:"transcription"`
+}
+
+// Attachment is a media attachment on a message. The id is typically an
+// mxc:// URL fetchable via GET /v1/assets/serve?url=.
+type Attachment struct {
+	ID            string         `json:"id"`
+	Type          string         `json:"type"` // unknown | img | video | audio
+	SrcURL        string         `json:"srcURL"`
+	MimeType      string         `json:"mimeType"`
+	FileName      string         `json:"fileName"`
+	FileSize      float64        `json:"fileSize"`
+	IsGif         bool           `json:"isGif"`
+	IsSticker     bool           `json:"isSticker"`
+	IsVoiceNote   bool           `json:"isVoiceNote"`
+	Duration      float64        `json:"duration"` // seconds
+	Transcription *Transcription `json:"transcription"`
+	Size          *struct {
+		Width  float64 `json:"width"`
+		Height float64 `json:"height"`
+	} `json:"size"`
+}
+
+// Message is one message event. type distinguishes regular content
+// (TEXT/NOTICE/media types/LOCATION) from REACTION events.
+type Message struct {
+	ID              string       `json:"id"` // numeric string, unique per installation
+	ChatID          string       `json:"chatID"`
+	AccountID       string       `json:"accountID"`
+	SenderID        string       `json:"senderID"`
+	SenderName      string       `json:"senderName"`
+	Timestamp       time.Time    `json:"timestamp"`
+	SortKey         string       `json:"sortKey"`
+	Type            string       `json:"type"`
+	Text            string       `json:"text"`
+	EditedTimestamp *time.Time   `json:"editedTimestamp"`
+	IsSender        bool         `json:"isSender"`
+	IsHidden        bool         `json:"isHidden"`
+	IsDeleted       bool         `json:"isDeleted"`
+	Attachments     []Attachment `json:"attachments"`
+	LinkedMessageID string       `json:"linkedMessageID"` // reply target (or reaction target for REACTION events)
+	Mentions        []string     `json:"mentions"`        // mentioned user IDs or "@room"; null for legacy messages
+	Reactions       []Reaction   `json:"reactions"`
+	// Raw holds the exact original JSON for this message, captured during decode
+	// (see UnmarshalJSON). It is archived verbatim so no API field is lost to
+	// our partial struct modelling.
+	Raw json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON decodes a Message while retaining the exact original bytes in
+// Raw, so the archived raw blob is lossless even for fields we do not model.
+func (m *Message) UnmarshalJSON(b []byte) error {
+	type alias Message // avoid recursion into this method
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*m = Message(a)
+	m.Raw = append(json.RawMessage(nil), b...)
+	return nil
+}
+
+// ListMessagesOutput is the page envelope of GET /v1/chats/{chatID}/messages.
+// Cursors are opaque; direction=before pages older, direction=after newer.
+type ListMessagesOutput struct {
+	Items        []Message `json:"items"`
+	HasMore      bool      `json:"hasMore"`
+	OldestCursor string    `json:"oldestCursor"`
+	NewestCursor string    `json:"newestCursor"`
+}
+
+// SearchChatsOutput is the page envelope of GET /v1/chats/search.
+type SearchChatsOutput struct {
+	Items        []Chat `json:"items"`
+	HasMore      bool   `json:"hasMore"`
+	OldestCursor string `json:"oldestCursor"`
+	NewestCursor string `json:"newestCursor"`
+}
+
+// ---- Importer options/summary ----
+
+// ImportOptions configures one Import run for a single Beeper account
+// (= one msgvault source).
+type ImportOptions struct {
+	// AccountID is the Beeper account to sync (e.g. "whatsapp", "signal").
+	// It doubles as the msgvault source identifier.
+	AccountID string
+	// Limit caps the number of messages processed per chat (0 = no limit).
+	// A limited backfill leaves the chat resumable, not complete.
+	Limit int
+	// Full ignores the prior sync cursor and any interrupted checkpoint so
+	// every chat is re-walked and every message re-persisted (repair path).
+	Full bool
+	// ChatID restricts the run to a single chat (scoped runs/debugging).
+	ChatID string
+	// Progress, if non-nil, is called after each chat with a human-readable
+	// status line. Safe to leave nil (silent mode).
+	Progress func(msg string) `json:"-"`
+	// EmbedEnqueuer, if non-nil, queues persisted message IDs for vector
+	// embedding. Enqueue failures are counted but do not abort the import.
+	EmbedEnqueuer EmbedEnqueuer `json:"-"`
+}
+
+type EmbedEnqueuer interface {
+	EnqueueMessages(ctx context.Context, messageIDs []int64) error
+}
+
+type ImportSummary struct {
+	Duration           time.Duration
+	SourceID           int64
+	ChatsProcessed     int64
+	MessagesProcessed  int64
+	MessagesAdded      int64
+	ReactionsRefreshed int64
+	HiddenSkipped      int64
+	// FetchErrors counts Beeper API fetch failures (a subset of Errors). Any
+	// fetch failure keeps the discovery watermark from advancing so the
+	// affected chats are re-visited next run.
+	FetchErrors int64
+	Errors      int64
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -947,6 +947,14 @@ func (s *Store) SetReplyTo(sourceID int64, childSourceMessageID, parentSourceMes
 	return err
 }
 
+// SetMessageEdited marks a message as edited at the source. UpsertMessage
+// does not write is_edited, so importers that observe an edit flag call this
+// after upserting.
+func (s *Store) SetMessageEdited(messageID int64) error {
+	_, err := s.db.Exec(`UPDATE messages SET is_edited = TRUE WHERE id = ?`, messageID)
+	return err
+}
+
 // MarkMessageDeleted marks a message as deleted from the source.
 func (s *Store) MarkMessageDeleted(sourceID int64, sourceMessageID string) error {
 	_, err := s.db.Exec(fmt.Sprintf(`

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -544,7 +544,7 @@ func (s *Store) GetLastSuccessfulSync(sourceID int64) (*SyncRun, error) {
 		       error_message, cursor_before, cursor_after
 		FROM sync_runs
 		WHERE source_id = ? AND status = 'completed'
-		ORDER BY completed_at DESC
+		ORDER BY completed_at DESC, id DESC
 		LIMIT 1
 	`, sourceID)
 


### PR DESCRIPTION
Part 1 of 3 of a Beeper Desktop integration: archives every chat network bridged through [Beeper Desktop](https://developers.beeper.com/desktop-api/) — WhatsApp, Signal, Telegram, Instagram, LinkedIn, X, Facebook, Beeper/Matrix — via its documented local REST API on `localhost:23373`. This PR is the standalone `internal/beeper` package with tests; part 2 wires CLI/config/scheduler/docs, part 3 adds attachment download.

## What changed

- **Read-only API client**: exposes only GET endpoints by construction, so the archiver can never mutate Beeper state. Rate-limited (default 20 QPS), retries 429/5xx honoring `Retry-After`, actionable errors for 401 (mint a token) and connection-refused (Beeper not running).
- **Importer**: one msgvault source per Beeper network account (`source_type="beeper"`, identifier = Beeper accountID) so each network gets its own account filter and stats. Full-history backfill walks newest→oldest with resumable checkpoints every 25 pages (a single chat can exceed a million messages); later runs are cursor-driven incremental, discovering active chats via `lastActivityAfter`. A bounded 24-hour head re-walk catches in-place edits, deletions, and reaction changes that a forward-only cursor cannot observe.
- **Data mapping**: messages persist as `message_type="beeper"` with FTS text (including voice-note transcriptions), mention recipients, reactions, reply links, and soft-deletion tombstones — content archived before a network deletion stays archived. The verbatim API JSON is stored as `beeper_json`.
- **Identity**: participants resolve through an exclusive ladder — E.164 phone → email → Beeper user ID — deduping people against existing SMS/WhatsApp/mail archives.
- **Safety**: Beeper message IDs are only unique per installation; the sync state stores an anchor probe and a reinstall/re-index fails fast with instructions instead of silently duplicating the archive.
- **Store**: new `SetMessageEdited` helper (no writer for `is_edited` existed); `GetLastSuccessfulSync` now tie-breaks same-second completions by `id` so back-to-back syncs load the correct cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)