### PR TITLE
Add Beeper Desktop chat archiving

### DIFF
--- a/cmd/msgvault/cmd/add_beeper.go
+++ b/cmd/msgvault/cmd/add_beeper.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/beeper"
+	"go.kenn.io/msgvault/internal/clirun"
+)
+
+var (
+	addBeeperTokenFile         string
+	noDefaultIdentityAddBeeper bool
+)
+
+func newAddBeeperCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-beeper",
+		Short: "Add Beeper Desktop as an archive source",
+		Long: `Add Beeper Desktop as an archive source.
+
+Beeper Desktop bridges many chat networks (WhatsApp, Signal, Telegram,
+Instagram, LinkedIn, X, Facebook, ...) into one local app with a read-only
+API on localhost. Each connected network account becomes its own msgvault
+source, so networks stay separately filterable and searchable.
+
+Requires Beeper Desktop to be running on this machine. Mint an access token
+in Beeper Desktop (Settings > Developer) and provide it via --token-file,
+the MSGVAULT_BEEPER_TOKEN environment variable, or the interactive prompt.
+
+Use [beeper].accounts / exclude_accounts in config.toml to limit which
+networks are archived (e.g. exclude "whatsapp" if you already archive it
+with import-whatsapp).
+
+Examples:
+  msgvault add-beeper
+  msgvault add-beeper --token-file ~/beeper-token.txt
+  MSGVAULT_BEEPER_TOKEN="..." msgvault add-beeper`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				token, err := readAddBeeperToken(cmd)
+				if err != nil {
+					return err
+				}
+				// The Beeper Desktop API is loopback-only: validate locally
+				// when the daemon shares this machine so problems fail fast;
+				// with a remote daemon, validation happens daemon-side against
+				// the Beeper Desktop running there.
+				if IsRemoteMode() {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Remote daemon configured: it must run beside its own Beeper Desktop, which will validate the token.")
+				} else {
+					accounts, err := beeperClient(token).ListAccounts(cmd.Context())
+					if err != nil {
+						return err
+					}
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Connected to Beeper Desktop (%d accounts)\n", len(accounts))
+				}
+				return runDaemonCLICommandHTTPFromCobraWithEnv(cmd, args, map[string]string{
+					clirun.EnvBeeperToken: token,
+				})
+			}
+
+			token := os.Getenv(clirun.EnvBeeperToken)
+			if token == "" {
+				return errors.New("missing Beeper token in daemon subprocess (set MSGVAULT_BEEPER_TOKEN)")
+			}
+			accounts, err := beeperClient(token).ListAccounts(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if err := beeper.SaveToken(cfg.TokensDir(), token); err != nil {
+				return fmt.Errorf("save beeper token: %w", err)
+			}
+
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			added := 0
+			for _, acct := range accounts {
+				if !cfg.Beeper.AccountIncluded(acct.AccountID) {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Skipping %s (filtered by [beeper] config)\n", acct.AccountID)
+					continue
+				}
+				source, err := s.GetOrCreateSource(sourceTypeBeeper, acct.AccountID)
+				if err != nil {
+					return fmt.Errorf("create source for %s: %w", acct.AccountID, err)
+				}
+				if err := s.UpdateSourceDisplayName(source.ID, beeperSourceDisplayName(acct)); err != nil {
+					return fmt.Errorf("set display name for %s: %w", acct.AccountID, err)
+				}
+				if !noDefaultIdentityAddBeeper {
+					confirmDefaultIdentity(cmd.OutOrStdout(), s, source.ID,
+						acct.AccountID, beeperSelfIdentity(acct), "account-identifier")
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Added %s (%s)\n", acct.AccountID, beeperSourceDisplayName(acct))
+				added++
+			}
+			if err := runPostSourceCreateMigrations(s); err != nil {
+				return fmt.Errorf("post-source-create migrations: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nBeeper Desktop added: %d account(s).\n", added)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nYou can now run:")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  msgvault sync-beeper")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&addBeeperTokenFile, "token-file", "", "read the Beeper Desktop access token from this file")
+	cmd.Flags().BoolVar(&noDefaultIdentityAddBeeper, "no-default-identity", false, noDefaultIdentityHelp)
+	return cmd
+}
+
+// beeperClient builds a Beeper Desktop API client from the configured URL and
+// rate limit with a static token.
+func beeperClient(token string) *beeper.Client {
+	// An empty URL selects the client's loopback default.
+	return beeper.NewClient(cfg.Beeper.URL,
+		func(context.Context) (string, error) { return token, nil },
+		cfg.Beeper.RateLimitQPS)
+}
+
+// beeperSourceDisplayName renders a human-readable source name, preferring
+// the network name ("Beeper WhatsApp") over the raw accountID.
+func beeperSourceDisplayName(acct beeper.Account) string {
+	if acct.Network != "" {
+		return "Beeper " + acct.Network
+	}
+	return "Beeper " + acct.AccountID
+}
+
+// beeperSelfIdentity picks the best own-identity value for a Beeper account:
+// phone, then email, then the Beeper user ID.
+func beeperSelfIdentity(acct beeper.Account) string {
+	switch {
+	case acct.User.PhoneNumber != "":
+		return acct.User.PhoneNumber
+	case acct.User.Email != "":
+		return acct.User.Email
+	default:
+		return acct.User.ID
+	}
+}
+
+// readAddBeeperToken resolves the access token: env var, then --token-file,
+// then interactive masked prompt / piped stdin.
+func readAddBeeperToken(cmd *cobra.Command) (string, error) {
+	if envToken := os.Getenv(clirun.EnvBeeperToken); envToken != "" {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Using token from %s environment variable\n", clirun.EnvBeeperToken); err != nil {
+			return "", fmt.Errorf("write token source notice: %w", err)
+		}
+		return envToken, nil
+	}
+	if addBeeperTokenFile != "" {
+		data, err := os.ReadFile(addBeeperTokenFile)
+		if err != nil {
+			return "", fmt.Errorf("read token file: %w", err)
+		}
+		token := strings.TrimSpace(string(data))
+		if token == "" {
+			return "", fmt.Errorf("token file %s is empty", addBeeperTokenFile)
+		}
+		return token, nil
+	}
+
+	prompt := "Beeper Desktop access token (Settings > Developer):"
+	method, promptOut := choosePasswordStrategy(
+		isatty.IsTerminal(os.Stdin.Fd()),
+		isatty.IsCygwinTerminal(os.Stdin.Fd()),
+		isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd()),
+		isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()),
+	)
+	switch method {
+	case passwordInteractive:
+		return readPasswordInteractive(prompt, promptOut)
+	case passwordNoPrompt:
+		return "", errors.New("cannot read token: no terminal available for prompt (try --token-file, piping the token via stdin, or setting MSGVAULT_BEEPER_TOKEN)")
+	case passwordPipe:
+		return readPasswordFromPipe(os.Stdin)
+	default:
+		return "", errors.New("cannot determine token input method")
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(newAddBeeperCmd())
+}

--- a/cmd/msgvault/cmd/attachment_maintenance.go
+++ b/cmd/msgvault/cmd/attachment_maintenance.go
@@ -205,6 +205,21 @@ func registerAttachmentMaintenanceJob(sched *scheduler.Scheduler, maintenance *a
 	})
 }
 
+func registerScheduledBeeperJob(
+	sched *scheduler.Scheduler,
+	schedule string,
+	maintenance *attachmentMaintenance,
+	run func(context.Context) error,
+) error {
+	return sched.AddJob(scheduler.Job{
+		Name:     "beeper",
+		Schedule: schedule,
+		Run: func(ctx context.Context) error {
+			return runScheduledSource(ctx, maintenance, true, run)
+		},
+	})
+}
+
 // attachmentProducingCommand reports whether the first command word names a
 // generic daemon CLI operation that can create loose attachments.
 func attachmentProducingCommand(args []string) bool {
@@ -212,7 +227,8 @@ func attachmentProducingCommand(args []string) bool {
 		return false
 	}
 	switch args[0] {
-	case "backfill-teams-media",
+	case "backfill-beeper-media",
+		"backfill-teams-media",
 		"import",
 		"import-emlx",
 		"import-gvoice",
@@ -222,6 +238,7 @@ func attachmentProducingCommand(args []string) bool {
 		"import-pst",
 		"import-synctech-sms",
 		"import-whatsapp",
+		"sync-beeper",
 		"sync-synctech-sms",
 		"sync-teams":
 		return true

--- a/cmd/msgvault/cmd/attachment_maintenance_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_test.go
@@ -325,6 +325,35 @@ func TestRunScheduledSourcePacksOnlySuccessfulAttachmentSources(t *testing.T) {
 	}
 }
 
+func TestRegisterScheduledBeeperJobPacksAfterSuccessfulSync(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newAttachmentMaintenanceFixture(t)
+	hash := f.addLoose([]byte("scheduled beeper payload"))
+	sched := scheduler.New(func(context.Context, string) error { return nil }).WithLogger(f.maintenance.logger)
+	t.Cleanup(func() {
+		ctx := sched.Stop()
+		<-ctx.Done()
+	})
+	syncCalls := 0
+
+	require.NoError(registerScheduledBeeperJob(
+		sched,
+		"*/30 * * * *",
+		f.maintenance,
+		func(context.Context) error {
+			syncCalls++
+			assert.Nil(f.packedEntry(hash), "packing must happen after Beeper sync")
+			return nil
+		},
+	))
+	require.True(sched.IsJobScheduled("beeper"))
+
+	require.NoError(sched.TriggerJob("beeper"))
+	assert.Equal(1, syncCalls)
+	assert.NotNil(f.packedEntry(hash))
+}
+
 func TestRegisterAttachmentMaintenanceJobAndTrigger(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -459,6 +488,7 @@ func TestAutomaticRepackLogsCommittedSiblingProgressBeforeAggregateWarning(t *te
 
 func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 	allowlisted := []string{
+		"backfill-beeper-media",
 		"backfill-teams-media",
 		"import",
 		"import-emlx",
@@ -469,6 +499,7 @@ func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 		"import-pst",
 		"import-synctech-sms",
 		"import-whatsapp",
+		"sync-beeper",
 		"sync-synctech-sms",
 		"sync-teams",
 	}

--- a/cmd/msgvault/cmd/backfill_beeper_media.go
+++ b/cmd/msgvault/cmd/backfill_beeper_media.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var backfillBeeperMediaAccounts []string
+
+func newBackfillBeeperMediaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backfill-beeper-media",
+		Short: "Retry pending Beeper attachment downloads",
+		Long: `Retry pending Beeper attachment downloads.
+
+Attachments that failed to download during sync-beeper (Beeper Desktop asset
+temporarily unavailable, over the size cap at the time, transient errors)
+leave a pending marker. This command re-fetches those messages from Beeper
+Desktop and downloads their media into the attachment store. Idempotent:
+already-downloaded attachments are content-addressed and skipped.
+
+Examples:
+  msgvault backfill-beeper-media
+  msgvault backfill-beeper-media --account signal`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+
+			imp, accountIDs, dbPath, cleanup, err := openBeeperImporter(backfillBeeperMediaAccounts)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			ctx, stop := withInterruptCancel(cmd, "\nInterrupted. Stopping...")
+			defer stop()
+
+			for _, accountID := range accountIDs {
+				opts := beeperImportOptions(accountID)
+				opts.Progress = func(s string) { _, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+s) }
+				sum, err := imp.BackfillMedia(ctx, opts)
+				if ctx.Err() != nil {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nInterrupted — re-run backfill-beeper-media to resume (idempotent).")
+					rebuildCacheAfterWrite(dbPath)
+					return nil
+				}
+				if err != nil {
+					rebuildCacheAfterWrite(dbPath)
+					return fmt.Errorf("beeper media backfill failed for %s: %w", accountID, err)
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+					"%s: %d messages checked, %d attachments downloaded, %d still pending (%s)\n",
+					accountID, sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending,
+					sum.Duration.Round(time.Second))
+				if sum.Errors > 0 {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %d errors — see sync run items; re-run to retry\n", sum.Errors)
+				}
+			}
+
+			rebuildCacheAfterWrite(dbPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringArrayVar(&backfillBeeperMediaAccounts, "account", nil, "Beeper accountID to backfill (repeatable; default: all registered accounts)")
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newBackfillBeeperMediaCmd())
+}

--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -8,6 +8,7 @@ const (
 	sourceTypeMbox     = "mbox"
 	sourceTypeTeams    = "teams"
 	sourceTypeCalendar = "gcal"
+	sourceTypeBeeper   = "beeper"
 )
 
 // Analytics dataset / SQLite table names: the Parquet subdirectory under

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/beeper"
 	imaplib "go.kenn.io/msgvault/internal/imap"
 	"go.kenn.io/msgvault/internal/microsoft"
 	"go.kenn.io/msgvault/internal/oauth"
@@ -220,6 +221,22 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr,
 				"Warning: could not remove Microsoft Graph token: %v\n", err,
 			)
+		}
+	case sourceTypeBeeper:
+		// The token is shared by every Beeper network-account source; only
+		// remove it when the last one is gone. The source row was already
+		// removed above, so any remaining rows belong to other accounts.
+		remaining, lerr := s.ListSources(sourceTypeBeeper)
+		if lerr != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not check remaining beeper sources: %v\n", lerr,
+			)
+		} else if len(remaining) == 0 {
+			if err := beeper.DeleteToken(cfg.TokensDir()); err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not remove Beeper token: %v\n", err,
+				)
+			}
 		}
 	case sourceTypeIMAP:
 		if source.SyncConfig.Valid && source.SyncConfig.String != "" {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -282,12 +282,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 			"hint", `set a cron schedule (e.g. "*/30 * * * *") on the [beeper] entry`)
 	}
 	if cfg.Beeper.Enabled && cfg.Beeper.Schedule != "" {
-		if err := sched.AddJob(scheduler.Job{
-			Name:     "beeper",
-			Schedule: cfg.Beeper.Schedule,
-			Run: func(ctx context.Context) error {
-				return runConfiguredBeeperSync(ctx, s)
-			},
+		if err := registerScheduledBeeperJob(sched, cfg.Beeper.Schedule, attachmentMaint, func(ctx context.Context) error {
+			return runConfiguredBeeperSync(ctx, s)
 		}); err != nil {
 			logger.Error("failed to schedule beeper sync", "error", err)
 		} else {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -277,6 +277,24 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("schedule attachment maintenance: %w", err)
 	}
 
+	if cfg.Beeper.Enabled && cfg.Beeper.Schedule == "" {
+		logger.Warn("beeper is enabled but has no schedule — the daemon will not sync it; its freshness will eventually go stale",
+			"hint", `set a cron schedule (e.g. "*/30 * * * *") on the [beeper] entry`)
+	}
+	if cfg.Beeper.Enabled && cfg.Beeper.Schedule != "" {
+		if err := sched.AddJob(scheduler.Job{
+			Name:     "beeper",
+			Schedule: cfg.Beeper.Schedule,
+			Run: func(ctx context.Context) error {
+				return runConfiguredBeeperSync(ctx, s)
+			},
+		}); err != nil {
+			logger.Error("failed to schedule beeper sync", "error", err)
+		} else {
+			logger.Info("scheduled beeper sync", "schedule", cfg.Beeper.Schedule)
+		}
+	}
+
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 

--- a/cmd/msgvault/cmd/sync_beeper.go
+++ b/cmd/msgvault/cmd/sync_beeper.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/beeper"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var (
+	syncBeeperLimit    int
+	syncBeeperFull     bool
+	syncBeeperAccounts []string
+	syncBeeperNoMedia  bool
+)
+
+func newSyncBeeperCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync-beeper",
+		Short: "Sync chats from Beeper Desktop (all bridged networks)",
+		Long: `Sync chats from Beeper Desktop for every registered Beeper account.
+
+The first run backfills each chat's full locally-available history; later
+runs are incremental, fetching only new activity. Backfills are resumable:
+re-run after an interruption and the sync continues where it stopped.
+
+Requires Beeper Desktop to be running on this machine (run 'add-beeper'
+first). Use --full to ignore stored cursors and re-fetch every message;
+re-fetched messages are upserted in place, so this repairs existing rows
+without creating duplicates.
+
+Examples:
+  msgvault sync-beeper
+  msgvault sync-beeper --account signal --account telegram
+  msgvault sync-beeper --limit 500
+  msgvault sync-beeper --full`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+
+			imp, accountIDs, dbPath, cleanup, err := openBeeperImporter(syncBeeperAccounts)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			ctx, stop := withInterruptCancel(cmd, "\nInterrupted. Saving checkpoint...")
+			defer stop()
+
+			var syncErrors []string
+			for _, accountID := range accountIDs {
+				if ctx.Err() != nil {
+					break
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Syncing Beeper account %s\n", accountID)
+				opts := beeperImportOptions(accountID)
+				opts.Limit = syncBeeperLimit
+				opts.Full = syncBeeperFull
+				opts.NoMedia = opts.NoMedia || syncBeeperNoMedia
+				opts.Progress = func(s string) { _, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+s) }
+				sum, err := imp.Import(ctx, opts)
+				if ctx.Err() != nil {
+					break
+				}
+				// One broken network must not block the others; collect and
+				// keep syncing (same convention as the multi-account sync
+				// commands and the beeper scheduler path).
+				if err != nil {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", accountID, err))
+					continue
+				}
+				printBeeperSummary(cmd, accountID, sum)
+			}
+
+			// Successful accounts' messages must reach the analytics cache
+			// regardless of interruptions or per-account failures.
+			rebuildCacheAfterWrite(dbPath)
+			if ctx.Err() != nil {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nInterrupted — re-run sync-beeper to resume.")
+				return nil
+			}
+			if len(syncErrors) > 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nErrors:")
+				for _, e := range syncErrors {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", e)
+				}
+				return fmt.Errorf("%d account(s) failed to sync: %s",
+					len(syncErrors), strings.Join(syncErrors, "; "))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&syncBeeperLimit, "limit", 0, "max messages per chat this run (0 = no limit; limited backfills resume on the next run)")
+	cmd.Flags().BoolVar(&syncBeeperFull, "full", false, "ignore stored cursors and re-fetch every message (repairs/backfills existing rows in place)")
+	cmd.Flags().StringArrayVar(&syncBeeperAccounts, "account", nil, "Beeper accountID to sync (repeatable; default: all registered accounts)")
+	cmd.Flags().BoolVar(&syncBeeperNoMedia, "no-media", false, "skip attachment downloads for this run")
+	return cmd
+}
+
+func printBeeperSummary(cmd *cobra.Command, accountID string, sum *beeper.ImportSummary) {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s done in %s: %d chats, %d messages (%d added)",
+		accountID, sum.Duration.Round(time.Second), sum.ChatsProcessed, sum.MessagesProcessed, sum.MessagesAdded)
+	if sum.ReactionsRefreshed > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d reactions refreshed", sum.ReactionsRefreshed)
+	}
+	if sum.AttachmentsDownloaded > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d attachments", sum.AttachmentsDownloaded)
+	}
+	if sum.AttachmentsPending > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media pending (see backfill-beeper-media)", sum.AttachmentsPending)
+	}
+	if sum.Errors > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d errors", sum.Errors)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+}
+
+// resolveBeeperSyncAccounts returns the Beeper accountIDs to sync: the
+// explicit flag values, or every registered beeper source that passes the
+// config include/exclude filters.
+func resolveBeeperSyncAccounts(s *store.Store, flagAccounts []string) ([]string, error) {
+	if len(flagAccounts) > 0 {
+		return flagAccounts, nil
+	}
+	sources, err := s.ListSources(sourceTypeBeeper)
+	if err != nil {
+		return nil, fmt.Errorf("list beeper sources: %w", err)
+	}
+	var out []string
+	for _, src := range sources {
+		if cfg.Beeper.AccountIncluded(src.Identifier) {
+			out = append(out, src.Identifier)
+		}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no Beeper accounts registered (run 'add-beeper' first)")
+	}
+	return out, nil
+}
+
+// beeperImportOptions builds the config-derived import options shared by the
+// CLI and scheduler paths (flag overlays are applied by the CLI caller).
+func beeperImportOptions(accountID string) beeper.ImportOptions {
+	return beeper.ImportOptions{
+		AccountID:      accountID,
+		AttachmentsDir: cfg.AttachmentsDir(),
+		NoMedia:        !cfg.Beeper.MediaEnabled(),
+		MaxMediaBytes:  cfg.Beeper.MaxMediaBytes(),
+	}
+}
+
+// openBeeperImporter performs the shared beeper-command prologue: open the
+// store, load the token, resolve the target accounts, and build the importer.
+// The returned cleanup closes the store.
+func openBeeperImporter(flagAccounts []string) (imp *beeper.Importer, accountIDs []string, dbPath string, cleanup func(), err error) {
+	s, cleanup, err := openWritableStoreAndInitForIngest()
+	if err != nil {
+		return nil, nil, "", nil, err
+	}
+	token, err := beeper.LoadToken(cfg.TokensDir())
+	if err != nil {
+		cleanup()
+		return nil, nil, "", nil, err
+	}
+	accountIDs, err = resolveBeeperSyncAccounts(s, flagAccounts)
+	if err != nil {
+		cleanup()
+		return nil, nil, "", nil, err
+	}
+	return beeper.NewImporter(s, beeperClient(token)), accountIDs, cfg.DatabaseDSN(), cleanup, nil
+}
+
+// withInterruptCancel derives a context canceled on SIGINT/SIGTERM, printing
+// note to stderr on the first signal. The returned stop must be deferred.
+func withInterruptCancel(cmd *cobra.Command, note string) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(cmd.Context())
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-sigChan:
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), note)
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, func() { signal.Stop(sigChan); cancel() }
+}
+
+// runConfiguredBeeperSync is the daemon scheduler entrypoint: an incremental
+// sync of every registered Beeper account. Per-account failures are collected
+// so one broken account does not starve the others, and the analytics cache is
+// rebuilt regardless so successful accounts' messages become visible.
+func runConfiguredBeeperSync(ctx context.Context, s *store.Store) error {
+	token, err := beeper.LoadToken(cfg.TokensDir())
+	if err != nil {
+		return err
+	}
+	accountIDs, err := resolveBeeperSyncAccounts(s, nil)
+	if err != nil {
+		return err
+	}
+	imp := beeper.NewImporter(s, beeperClient(token))
+
+	var errs []error
+	synced := 0
+	for _, accountID := range accountIDs {
+		if ctx.Err() != nil {
+			break
+		}
+		if _, err := imp.Import(ctx, beeperImportOptions(accountID)); err != nil {
+			errs = append(errs, fmt.Errorf("beeper %s: %w", accountID, err))
+		} else {
+			synced++
+		}
+	}
+	if synced > 0 {
+		rebuildCacheAfterScheduledSync(ctx, "beeper")
+	}
+	if ctx.Err() != nil {
+		errs = append(errs, ctx.Err())
+	}
+	return errors.Join(errs...)
+}
+
+func init() {
+	rootCmd.AddCommand(newSyncBeeperCmd())
+}

--- a/cmd/msgvault/cmd/sync_beeper.go
+++ b/cmd/msgvault/cmd/sync_beeper.go
@@ -199,7 +199,7 @@ func withInterruptCancel(cmd *cobra.Command, note string) (context.Context, func
 // runConfiguredBeeperSync is the daemon scheduler entrypoint: an incremental
 // sync of every registered Beeper account. Per-account failures are collected
 // so one broken account does not starve the others, and the analytics cache is
-// rebuilt regardless so successful accounts' messages become visible.
+// rebuilt after any attempt so partial writes become visible too.
 func runConfiguredBeeperSync(ctx context.Context, s *store.Store) error {
 	token, err := beeper.LoadToken(cfg.TokensDir())
 	if err != nil {
@@ -210,21 +210,32 @@ func runConfiguredBeeperSync(ctx context.Context, s *store.Store) error {
 		return err
 	}
 	imp := beeper.NewImporter(s, beeperClient(token))
+	return runScheduledBeeperAttempts(ctx, accountIDs,
+		func(accountID string) error {
+			_, err := imp.Import(ctx, beeperImportOptions(accountID))
+			return err
+		},
+		func() { rebuildCacheAfterScheduledSync(context.WithoutCancel(ctx), "beeper") },
+	)
+}
 
+// runScheduledBeeperAttempts keeps per-account failures isolated while
+// rebuilding analytics after any import attempt, since even a failed or
+// canceled attempt may have committed messages from healthy chats.
+func runScheduledBeeperAttempts(ctx context.Context, accountIDs []string, attempt func(string) error, rebuild func()) error {
 	var errs []error
-	synced := 0
+	attempted := 0
 	for _, accountID := range accountIDs {
 		if ctx.Err() != nil {
 			break
 		}
-		if _, err := imp.Import(ctx, beeperImportOptions(accountID)); err != nil {
+		attempted++
+		if err := attempt(accountID); err != nil {
 			errs = append(errs, fmt.Errorf("beeper %s: %w", accountID, err))
-		} else {
-			synced++
 		}
 	}
-	if synced > 0 {
-		rebuildCacheAfterScheduledSync(ctx, "beeper")
+	if attempted > 0 {
+		rebuild()
 	}
 	if ctx.Err() != nil {
 		errs = append(errs, ctx.Err())

--- a/cmd/msgvault/cmd/sync_beeper.go
+++ b/cmd/msgvault/cmd/sync_beeper.go
@@ -128,12 +128,28 @@ func printBeeperSummary(cmd *cobra.Command, accountID string, sum *beeper.Import
 // explicit flag values, or every registered beeper source that passes the
 // config include/exclude filters.
 func resolveBeeperSyncAccounts(s *store.Store, flagAccounts []string) ([]string, error) {
-	if len(flagAccounts) > 0 {
-		return flagAccounts, nil
-	}
 	sources, err := s.ListSources(sourceTypeBeeper)
 	if err != nil {
 		return nil, fmt.Errorf("list beeper sources: %w", err)
+	}
+	if len(flagAccounts) > 0 {
+		registered := make(map[string]struct{}, len(sources))
+		for _, src := range sources {
+			registered[src.Identifier] = struct{}{}
+		}
+		seen := make(map[string]struct{}, len(flagAccounts))
+		out := make([]string, 0, len(flagAccounts))
+		for _, accountID := range flagAccounts {
+			if _, ok := registered[accountID]; !ok {
+				return nil, fmt.Errorf("beeper account %q is not registered (run 'add-beeper' first)", accountID)
+			}
+			if _, duplicate := seen[accountID]; duplicate {
+				continue
+			}
+			seen[accountID] = struct{}{}
+			out = append(out, accountID)
+		}
+		return out, nil
 	}
 	var out []string
 	for _, src := range sources {

--- a/cmd/msgvault/cmd/sync_beeper_routing_test.go
+++ b/cmd/msgvault/cmd/sync_beeper_routing_test.go
@@ -2,12 +2,38 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/clirun"
 )
+
+func TestScheduledBeeperAttemptsRebuildAfterPartialFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var attempted []string
+	rebuilds := 0
+	err := runScheduledBeeperAttempts(
+		context.Background(),
+		[]string{"signal", "telegram"},
+		func(accountID string) error {
+			attempted = append(attempted, accountID)
+			if accountID == "signal" {
+				return errors.New("partial sync")
+			}
+			return nil
+		},
+		func() { rebuilds++ },
+	)
+
+	require.ErrorContains(err, "beeper signal: partial sync")
+	assert.Equal([]string{"signal", "telegram"}, attempted, "one failure must not starve later accounts")
+	assert.Equal(1, rebuilds, "any attempted import may write messages and must trigger a cache rebuild")
+}
 
 func resetSyncBeeperRoutingGlobals(t *testing.T) {
 	t.Helper()

--- a/cmd/msgvault/cmd/sync_beeper_routing_test.go
+++ b/cmd/msgvault/cmd/sync_beeper_routing_test.go
@@ -9,7 +9,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/clirun"
+	"go.kenn.io/msgvault/internal/testutil"
 )
+
+func TestResolveBeeperSyncAccountsValidatesAndDeduplicatesExplicitIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	_, err := st.GetOrCreateSource(sourceTypeBeeper, "signal")
+	require.NoError(err)
+	_, err = st.GetOrCreateSource(sourceTypeBeeper, "telegram")
+	require.NoError(err)
+
+	accounts, err := resolveBeeperSyncAccounts(st, []string{"signal", "signal", "telegram"})
+	require.NoError(err)
+	assert.Equal([]string{"signal", "telegram"}, accounts)
+
+	_, err = resolveBeeperSyncAccounts(st, []string{"signal", "typo"})
+	require.ErrorContains(err, `beeper account "typo" is not registered`)
+}
 
 func TestScheduledBeeperAttemptsRebuildAfterPartialFailure(t *testing.T) {
 	assert := assert.New(t)

--- a/cmd/msgvault/cmd/sync_beeper_routing_test.go
+++ b/cmd/msgvault/cmd/sync_beeper_routing_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/clirun"
+)
+
+func resetSyncBeeperRoutingGlobals(t *testing.T) {
+	t.Helper()
+	oldLimit := syncBeeperLimit
+	oldFull := syncBeeperFull
+	oldAccounts := syncBeeperAccounts
+	t.Cleanup(func() {
+		syncBeeperLimit = oldLimit
+		syncBeeperFull = oldFull
+		syncBeeperAccounts = oldAccounts
+	})
+	syncBeeperLimit = 0
+	syncBeeperFull = false
+	syncBeeperAccounts = nil
+}
+
+func TestSyncBeeperCommandUsesDaemonRunner(t *testing.T) {
+	assert := assert.New(t)
+
+	resetSyncBeeperRoutingGlobals(t)
+
+	server, requests := newDaemonCLIRunnerTestServer(t, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{
+			"sync-beeper",
+			"--account=signal",
+			"--account=telegram",
+			"--full",
+			"--limit=25",
+		}, req.Args, "args")
+	}, `{"type":"stdout","data":"Syncing Beeper account signal\n"}`, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+
+	var stdout bytes.Buffer
+	cmd := newSyncBeeperCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"--account", "signal",
+		"--account", "telegram",
+		"--full",
+		"--limit", "25",
+	})
+
+	require.NoError(t, cmd.Execute(), "sync-beeper")
+	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
+	assert.Contains(stdout.String(), "Syncing Beeper account signal")
+}
+
+func TestAddBeeperCommandForwardsTokenEnv(t *testing.T) {
+	assert := assert.New(t)
+
+	server, requests := newDaemonCLIRunnerTestServer(t, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{"add-beeper"}, req.Args, "args")
+		assert.Equal("test-token-123", req.Env[clirun.EnvBeeperToken], "token env forwarded")
+	}, `{"type":"stdout","data":"Added signal\n"}`, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+	t.Setenv(clirun.EnvBeeperToken, "test-token-123")
+
+	var stdout bytes.Buffer
+	cmd := newAddBeeperCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{})
+
+	// The test harness runs in remote-daemon mode, so the local Beeper
+	// Desktop preflight is skipped and validation is deferred to the daemon.
+	require.NoError(t, cmd.Execute(), "add-beeper")
+	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
+	assert.Contains(stdout.String(), "Added signal")
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -230,6 +230,75 @@ attachments are content-addressed.
 
 ---
 
+## add-beeper
+
+Register the chat accounts bridged through a locally running
+[Beeper Desktop](/usage/beeper/) as `beeper` sources, one per network.
+
+```bash
+msgvault add-beeper
+msgvault add-beeper --token-file ~/beeper-token.txt
+MSGVAULT_BEEPER_TOKEN="..." msgvault add-beeper
+```
+
+Requires Beeper Desktop running on the same machine and an access token
+minted in Beeper Desktop (Settings → Developer). The token is stored at
+`tokens/beeper.json`. Accounts filtered out by `[beeper].accounts` /
+`exclude_accounts` in `config.toml` are skipped.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--token-file` | | Read the access token from a file instead of prompting |
+| `--no-default-identity` | `false` | Do not auto-confirm each account's own identity as that source's "me" identity |
+
+After adding, sync with `msgvault sync-beeper`.
+
+---
+
+## sync-beeper
+
+Sync chats from Beeper Desktop for every registered Beeper account (all
+bridged networks). The first run backfills full locally-available history and
+is resumable; later runs are incremental. Per-account failures do not stop the
+run: remaining accounts still sync, the analytics cache is rebuilt for the
+successful ones, and the command exits non-zero listing the failures. Without
+`--account`, the `[beeper]` config `accounts`/`exclude_accounts` filters
+select which registered sources sync. See [Beeper](/usage/beeper/).
+
+```bash
+msgvault sync-beeper
+msgvault sync-beeper --account signal --account telegram
+msgvault sync-beeper --full
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--account` | all registered | Beeper accountID to sync (repeatable) |
+| `--limit` | `0` | Max messages per chat this run (0 = no limit; limited backfills resume next run) |
+| `--full` | `false` | Ignore stored cursors and re-fetch every message (repairs rows in place) |
+| `--no-media` | `false` | Skip attachment downloads for this run |
+
+---
+
+## backfill-beeper-media
+
+Retry pending Beeper attachment downloads (media that failed or exceeded the
+size cap during `sync-beeper`). Idempotent: attachments are content-addressed.
+If the source message is gone (deleted in Beeper), its pending markers are
+cleared permanently — already-downloaded attachments are kept. Transient fetch
+errors keep the marker and count as still pending, so re-running retries them.
+
+```bash
+msgvault backfill-beeper-media
+msgvault backfill-beeper-media --account signal
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--account` | all registered | Beeper accountID to backfill (repeatable) |
+
+---
+
 ## add-calendar
 
 Authorize read-only Google Calendar access for an account and register its calendars for sync. If the account already has a Gmail token, re-consent bundles Gmail + Calendar so Gmail access is not dropped — keep both checked on the consent screen. The Calendar API must be enabled on the OAuth project. By default only owned/writable calendars are registered.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,6 +307,36 @@ enabled = true
 | `schedule` | — | Cron expression used by `msgvault serve` |
 | `enabled` | `false` | Whether the source is daemon-scheduled |
 
+### `[beeper]`
+
+Archive chats from a locally running [Beeper Desktop](/usage/beeper/). A single
+block (not a list): the Beeper Desktop API is loopback-only, so there is one
+instance per machine and the daemon must run beside it. Authorize first with
+`msgvault add-beeper`.
+
+```toml
+[beeper]
+# url = "http://localhost:23373"  # Beeper Desktop API (default)
+enabled = true                    # gate for the daemon schedule
+schedule = "*/30 * * * *"         # 5-field cron; empty = manual sync only
+accounts = []                     # accountID include filter (empty = all)
+exclude_accounts = []             # skip networks archived natively, e.g. ["whatsapp"]
+rate_limit_qps = 20               # request rate against the local API
+media = true                      # download attachment bytes
+max_media_mb = 100                # per-attachment download cap (MiB)
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `url` | `http://localhost:23373` | Beeper Desktop API base URL |
+| `enabled` | `false` | Whether the daemon schedules Beeper sync |
+| `schedule` | — | Cron expression used by `msgvault serve` |
+| `accounts` | all | Beeper accountIDs to sync (include filter) |
+| `exclude_accounts` | — | Beeper accountIDs to skip (wins over `accounts`) |
+| `rate_limit_qps` | `20` | Request rate limit against the local API |
+| `media` | `true` | Download attachment bytes (failed downloads retry via `backfill-beeper-media`) |
+| `max_media_mb` | `100` | Per-attachment download cap in MiB (over-cap media leaves a retry marker) |
+
 ### `[vector]`
 
 Top-level toggle and backend marker for semantic/hybrid search. SQLite vector search requires a build with `sqlite_vec` support (default via `make build`). PostgreSQL vector search requires a build with the `pgvector` tag and a PostgreSQL `[data].database_url`. See [Vector Search](/usage/vector-search/) for prerequisites, initial embedding, and the full workflow.

--- a/docs/usage/beeper.md
+++ b/docs/usage/beeper.md
@@ -1,0 +1,141 @@
+---
+title: Beeper
+description: Archive every chat network bridged through Beeper Desktop via its local API.
+---
+
+[Beeper Desktop](https://www.beeper.com) bridges many chat networks — WhatsApp,
+Signal, Telegram, Instagram, LinkedIn, X, Facebook Messenger, and more — into
+one app. msgvault can archive all of them at once through Beeper Desktop's
+local API. Each connected network account becomes its own msgvault source, so
+a Signal thread and a Telegram thread stay separately filterable, while all
+Beeper-archived messages share `message_type = beeper` for search.
+
+Beeper sync is strictly read-only: msgvault only calls read endpoints of the
+local API and never sends, edits, archives, or marks anything in Beeper.
+
+## Prerequisites
+
+- Beeper Desktop installed and running on the same machine as the msgvault
+  daemon (the API listens on `localhost:23373` only).
+- A Beeper Desktop access token: in Beeper Desktop open **Settings →
+  Developer** and create an access token.
+
+## Add Beeper
+
+```bash
+msgvault add-beeper
+```
+
+The command validates the token against the running Beeper Desktop, stores it
+at `tokens/beeper.json` (0600), and registers one `beeper` source per
+connected network account (e.g. `signal`, `telegram`, `whatsapp`).
+
+Provide the token via the interactive prompt, `--token-file <path>`, or the
+`MSGVAULT_BEEPER_TOKEN` environment variable:
+
+```bash
+MSGVAULT_BEEPER_TOKEN="..." msgvault add-beeper
+msgvault add-beeper --token-file ~/beeper-token.txt
+```
+
+| Flag | Description |
+|---|---|
+| `--token-file` | Read the access token from a file |
+| `--no-default-identity` | Do not auto-confirm each account's own identity (phone/email) as that source's "me" identity |
+
+## Sync
+
+```bash
+# First run backfills all history; later runs are incremental.
+msgvault sync-beeper
+
+# Only specific networks.
+msgvault sync-beeper --account signal --account telegram
+
+# Repair path: re-fetch everything, upserting in place.
+msgvault sync-beeper --full
+```
+
+The first sync walks every chat's full locally-available history. This is a
+large one-time job for big archives (the API serves ~20 messages per request),
+but it is fully resumable: interrupt it any time and the next run continues
+from the saved checkpoint. Later runs only fetch chats with new activity.
+
+Recent messages (last 24 hours) are re-checked on every incremental run so
+edits, deletions, and reaction changes are captured; older in-place changes
+are only picked up by `--full` runs.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--account` | all registered | Beeper accountID to sync (repeatable) |
+| `--limit` | `0` | Max messages per chat this run (limited backfills resume next run) |
+| `--full` | `false` | Ignore stored cursors and re-fetch every message (repairs rows in place) |
+| `--no-media` | `false` | Skip attachment downloads for this run |
+
+## What is archived
+
+- Message text, sender, timestamps, and per-network conversation threads
+  (groups keep their member lists and admin roles).
+- Reactions, reply relationships, mentions, and edit/deletion markers —
+  content that was archived before a deletion stays archived.
+- Voice-note transcriptions (when Beeper has them) are appended to the message
+  body so they are searchable.
+- Attachments (photos, videos, voice notes, files) are downloaded during sync
+  into msgvault's content-addressed attachment store. Downloads that fail (or
+  exceed `max_media_mb`) leave a pending marker and the message is archived
+  anyway; retry them later with `msgvault backfill-beeper-media`. Use
+  `--no-media` or `media = false` to skip downloads — note that skipped-by-flag
+  downloads leave no pending markers, so `backfill-beeper-media` will not fetch
+  them later; re-enable media and run `sync-beeper --full` instead.
+- The verbatim Beeper API JSON for every message (`raw_format = beeper_json`),
+  so nothing is lost even where msgvault's relational model is narrower.
+
+Because Beeper's API serves what Beeper Desktop has synced locally, archive
+depth equals your local Beeper history: a freshly added Beeper account may
+only have recent messages until Beeper finishes its own backfill.
+
+## Scheduled sync
+
+Let the daemon run incremental syncs on a schedule:
+
+```toml
+[beeper]
+enabled = true
+schedule = "*/30 * * * *"
+```
+
+## Configuration
+
+```toml
+[beeper]
+# url = "http://localhost:23373"   # Beeper Desktop API (default)
+enabled = true                     # gate for the daemon schedule below
+schedule = "*/30 * * * *"          # 5-field cron; empty = manual sync only
+accounts = []                      # accountID include filter (empty = all)
+exclude_accounts = []              # e.g. ["whatsapp"] — see below
+rate_limit_qps = 20                # request rate against the local API
+media = true                       # download attachment bytes
+max_media_mb = 100                 # per-attachment size cap
+```
+
+### Overlap with native importers
+
+If you already archive a network natively (e.g. `import-whatsapp` or
+`import-imessage`), pick one path per network: msgvault does not deduplicate
+messages across sources. Add the Beeper accountID to `exclude_accounts` to
+keep Beeper sync away from that network. If both paths do run, the rows remain
+separable (different sources and different `message_type` values), and
+participants still unify across archives via phone-number and email matching
+(the Beeper user ID is also persisted as an identifier, so later runs keep
+resolving to the same person).
+
+## Caveats
+
+- **Reinstalling Beeper Desktop**: Beeper's message IDs are only stable per
+  installation. msgvault verifies several anchor messages (across distinct
+  chats) on every run; ordinary churn like deleting an anchored chat is
+  tolerated, and only when no anchor survives are recently archived messages
+  checked against the source. If the installation was rebuilt, the sync stops
+  with an error; remove and re-add the Beeper sources in that case.
+- **Remote daemons**: the Beeper API is loopback-only, so the msgvault daemon
+  must run on the same machine as Beeper Desktop.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -26,6 +26,7 @@ nav = [
     {"Text Messages" = "usage/text-messages.md"},
     {"Google Calendar" = "usage/calendar.md"},
     {"Microsoft Teams" = "usage/teams.md"},
+    {"Beeper" = "usage/beeper.md"},
     {"Exporting Data" = "usage/exporting.md"},
     {"Analytics & Stats" = "usage/analytics.md"},
     {"SQL Queries" = "usage/querying.md"},

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1029,11 +1029,13 @@ func cliRunCommandAllowed(args []string) bool {
 	}
 	switch args[0] {
 	case "add-account",
+		"add-beeper",
 		"add-calendar",
 		"add-imap",
 		"add-o365",
 		"add-synctech-sms-drive",
 		"add-teams",
+		"backfill-beeper-media",
 		"backfill-teams-media",
 		"build-embeddings",
 		"cancel-deletion",
@@ -1056,6 +1058,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"repack-attachments",
 		"remove-account",
 		"show-deletion",
+		"sync-beeper",
 		"sync-calendar",
 		"sync-synctech-sms",
 		"sync-teams":

--- a/internal/beeper/anchors.go
+++ b/internal/beeper/anchors.go
@@ -1,0 +1,171 @@
+package beeper
+
+// The reinstall guard. Beeper message IDs are plain per-installation rowids:
+// a reinstall or re-index keeps the (network-derived) chat IDs but re-assigns
+// every message ID, which would silently corrupt cursor-based dedup. Anchor
+// probes — recent messages remembered with their timestamps across several
+// distinct chats — fingerprint the installation and are verified before any
+// stored cursor is trusted.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// maxAnchors is how many distinct chats fingerprint the installation.
+// Multiple probes keep ordinary churn (the user deleting one anchored chat)
+// distinguishable from a reinstall, which invalidates all of them.
+const maxAnchors = 3
+
+// archivedSampleTolerance allows for timestamp precision differences between
+// the API and the archive's stored sent_at (driver/backend rounding). A
+// re-assigned message ID would land at an unrelated timestamp.
+const archivedSampleTolerance = 2 * time.Second
+
+// verifyAnchors re-fetches the anchor probe messages. A changed timestamp on
+// any probe means the installation re-assigned message IDs: fail fast,
+// because continuing would silently duplicate the whole archive. Missing
+// probes are ordinary churn (deleted messages or chats) as long as one probe
+// survives; when none does — or none was armed — recently archived messages
+// arbitrate before any stored cursor is trusted.
+func (imp *Importer) verifyAnchors(ctx context.Context, syncID, sourceID int64, state *SyncState) error {
+	kept := make([]AnchorProbe, 0, len(state.Anchors))
+	for _, a := range state.Anchors {
+		m, err := imp.client.GetMessage(ctx, a.ChatID, a.MessageID)
+		switch {
+		case err == nil:
+			if !m.Timestamp.Equal(a.Timestamp) {
+				return fmt.Errorf("beeper message IDs appear re-assigned (Beeper Desktop reinstall or re-index?): anchor message %s changed timestamp; remove and re-add this account to avoid duplicate archives", a.MessageID)
+			}
+			kept = append(kept, a)
+		case errors.Is(err, ErrNotFound):
+			imp.recordItem(syncID, a.MessageID, "anchor", store.SyncRunItemStatusSkipped, "beeper_anchor_lost", err)
+		default:
+			// Transient probe failure: neither evidence of a reinstall nor of
+			// ordinary churn — retry next run instead of alarming the user.
+			return fmt.Errorf("verify beeper sync anchor: %w", err)
+		}
+	}
+	state.Anchors = kept
+	if len(kept) == 0 {
+		return imp.verifyArchivedSample(ctx, sourceID)
+	}
+	return nil
+}
+
+// verifyArchivedSample checks whether recently archived messages still
+// resolve to the same content at the source. It is the tie-breaker when no
+// anchor probe survives (and the fallback when none was armed): a match means
+// the losses were ordinary churn; different content or nothing resolving
+// means the installation was rebuilt and stored cursors must not be trusted.
+// A no-op for accounts with nothing archived yet.
+func (imp *Importer) verifyArchivedSample(ctx context.Context, sourceID int64) error {
+	refs, err := imp.store.ListRecentMessagesForSource(sourceID, 5)
+	if err != nil {
+		return err
+	}
+	if len(refs) == 0 {
+		return nil // nothing archived yet, nothing to corrupt
+	}
+	for _, ref := range refs {
+		m, err := imp.client.GetMessage(ctx, ref.ChatID, ref.SourceMessageID)
+		switch {
+		case err == nil:
+			diff := m.Timestamp.Sub(ref.SentAt)
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff <= archivedSampleTolerance {
+				return nil // the archive still matches the source
+			}
+			return fmt.Errorf("beeper message IDs appear re-assigned (Beeper Desktop reinstall or re-index?): archived message %s resolves to different content; remove and re-add this account to avoid duplicate archives", ref.SourceMessageID)
+		case errors.Is(err, ErrNotFound):
+			continue
+		default:
+			return fmt.Errorf("verify beeper sync anchor: %w", err)
+		}
+	}
+	return fmt.Errorf("beeper message IDs appear re-assigned (Beeper Desktop reinstall or re-index?): no anchor and none of the %d most recently archived messages resolve at the source; remove and re-add this account to avoid duplicate archives", len(refs))
+}
+
+// rearmAnchors tops the anchor set back up to maxAnchors, probing the heads
+// of the most recently active chats first and falling back to chats known
+// from prior runs when this run enumerated none (quiet account) — the guard
+// must not stay weakened just because nothing happened lately. Best-effort; a
+// failure leaves the remaining slots for the next run to fill.
+func (imp *Importer) rearmAnchors(ctx context.Context, chats []Chat, state *SyncState) {
+	if len(state.Anchors) >= maxAnchors {
+		return
+	}
+	anchored := make(map[string]bool, len(state.Anchors))
+	for _, a := range state.Anchors {
+		anchored[a.ChatID] = true
+	}
+	const maxProbes = 8
+	candidates := make([]string, 0, maxProbes)
+	for i := range chats {
+		if len(candidates) >= maxProbes {
+			break
+		}
+		if !anchored[chats[i].ID] {
+			candidates = append(candidates, chats[i].ID)
+		}
+	}
+	for chatID := range state.Chats {
+		if len(candidates) >= maxProbes {
+			break
+		}
+		if !anchored[chatID] {
+			candidates = append(candidates, chatID)
+		}
+	}
+	for _, chatID := range candidates {
+		if len(state.Anchors) >= maxAnchors {
+			return
+		}
+		page, err := imp.client.ListMessagesPage(ctx, chatID, "", "")
+		if err != nil {
+			return
+		}
+		armAnchorFromPage(state, chatID, page.Items)
+	}
+}
+
+// armAnchorFromPage adds an anchor probe from a page of messages when the
+// anchor set is below target and the chat is not already anchored.
+func armAnchorFromPage(state *SyncState, chatID string, items []Message) {
+	if len(state.Anchors) >= maxAnchors {
+		return
+	}
+	for _, a := range state.Anchors {
+		if a.ChatID == chatID {
+			return
+		}
+	}
+	if a := anchorFrom(chatID, items); a != nil {
+		state.Anchors = append(state.Anchors, *a)
+	}
+}
+
+// anchorFrom picks a stable anchor message from a page: a regular content
+// message (not a reaction, tombstone, or hidden event), preferring the newest.
+func anchorFrom(chatID string, items []Message) *AnchorProbe {
+	var best *Message
+	for i := range items {
+		m := &items[i]
+		if m.Type == "REACTION" || m.IsDeleted || m.IsHidden {
+			continue
+		}
+		if best == nil || m.Timestamp.After(best.Timestamp) {
+			best = m
+		}
+	}
+	if best == nil {
+		return nil
+	}
+	return &AnchorProbe{ChatID: chatID, MessageID: best.ID, Timestamp: best.Timestamp}
+}

--- a/internal/beeper/anchors_test.go
+++ b/internal/beeper/anchors_test.go
@@ -1,0 +1,234 @@
+package beeper
+
+// Tests for the reinstall guard (anchors.go): probe verification, the
+// archived-sample arbiter, and re-arming.
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportAnchorMismatchFailsFast(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotEmpty(state.Anchors)
+
+	// Simulate a reinstall/re-index: the anchor message ID now maps to a
+	// different message (timestamp changed).
+	ch := f.chat("!e2e:beeper.local")
+	for i := range ch.Msgs {
+		if ch.Msgs[i].ID == state.Anchors[0].MessageID {
+			ch.Msgs[i].Timestamp = ch.Msgs[i].Timestamp.Add(time.Hour)
+		}
+	}
+
+	var before int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&before))
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.Error(err)
+	assert.Contains(err.Error(), "re-assigned")
+	assert.Contains(err.Error(), "re-add")
+
+	// The failure is recorded on the sync run, and the resume state was
+	// checkpointed before the anchor check so no progress is lost.
+	var status string
+	var cursorBefore sql.NullString
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT status, cursor_before FROM sync_runs WHERE source_id = ? ORDER BY id DESC LIMIT 1`), src.ID).Scan(&status, &cursorBefore))
+	assert.Equal("failed", status)
+	require.True(cursorBefore.Valid)
+	preserved, err := LoadSyncState(cursorBefore.String)
+	require.NoError(err)
+	assert.NotEmpty(preserved.Chats, "early checkpoint must preserve the resume state")
+
+	// --full must not bypass the check: it exists precisely so a repair run
+	// against a reinstalled Beeper cannot silently duplicate the archive.
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal", Full: true})
+	require.Error(err)
+	assert.Contains(err.Error(), "re-assigned")
+
+	var after int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&after))
+	assert.Equal(before, after, "no rows may be written after an anchor mismatch")
+}
+
+func TestImportAnchorLostMessageReanchors(t *testing.T) {
+	require := require.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotEmpty(state.Anchors)
+
+	// The anchor message is deleted for everyone (gone from the API) but its
+	// chat still exists: ordinary churn, not a reinstall — the sync must
+	// continue and not demand a re-add.
+	ch := f.chat("!e2e:beeper.local")
+	for i := range ch.Msgs {
+		if ch.Msgs[i].ID == state.Anchors[0].MessageID {
+			ch.Msgs = append(ch.Msgs[:i], ch.Msgs[i+1:]...)
+			break
+		}
+	}
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err, "a lost anchor message with a live chat must not fail the sync")
+
+	// The run must re-arm a replacement anchor: persisting a nil anchor would
+	// leave the reinstall guard disabled for every following run.
+	run, err = st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	rearmed, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotEmpty(rearmed.Anchors, "anchor must be re-armed in the same run")
+	require.NotEqual(state.Anchors[0].MessageID, rearmed.Anchors[0].MessageID)
+}
+
+func TestRearmAnchorFallsBackToKnownChats(t *testing.T) {
+	require := require.New(t)
+
+	// A quiet account can enumerate zero chats in a run; re-arming must fall
+	// back to chats known from prior runs or the reinstall guard would stay
+	// disabled until new activity happens to arrive.
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, _, done := newTestImporter(t, f)
+	defer done()
+
+	state := NewSyncState()
+	state.EnsureChat("!e2e:beeper.local").Done = true
+	imp.rearmAnchors(context.Background(), nil, state)
+	require.NotEmpty(state.Anchors, "re-arm must probe chats known from state when none were enumerated")
+	require.Equal("!e2e:beeper.local", state.Anchors[0].ChatID)
+}
+
+func TestVerifyAnchorsChatChurnVsReinstall(t *testing.T) {
+	require := require.New(t)
+
+	// Two chats, anchors in both. Deleting one anchored chat is ordinary
+	// churn (the other anchor still verifies); losing every anchored chat is
+	// reinstall evidence and must block the account.
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	base := time.Now().Add(-20 * 24 * time.Hour).UTC().Truncate(time.Second)
+	f.addChat(&fakeChat{
+		ID: "!second:beeper.local", AccountID: "signal", Network: "Signal", Title: "Second", Type: "single",
+		Participants: []map[string]any{{"id": "@me:beeper.local", "isSelf": true}},
+		Msgs: []fakeMsg{{ID: "s0", SortKey: 0, Timestamp: base, Text: "hello",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann"}},
+		LastActivity: base,
+	})
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.Len(state.Anchors, 2, "both chats must be anchored")
+
+	// Churn: the user deletes one anchored chat entirely — the sync must
+	// continue on the strength of the surviving anchor.
+	f.mu.Lock()
+	f.chats = f.chats[:1] // drop !second
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err, "deleting one anchored chat is churn, not a reinstall")
+
+	// Reinstall: every anchor message and its chat are gone.
+	f.mu.Lock()
+	f.chats = nil
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.Error(err)
+	require.Contains(err.Error(), "re-add")
+}
+
+func TestVerifyAnchorsZeroAnchorsFallsBackToArchivedSample(t *testing.T) {
+	require := require.New(t)
+
+	// A run can legitimately complete with zero anchors (all lost to churn,
+	// re-arm failed). The guard must not lapse: the next run verifies against
+	// recently archived messages instead.
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// Fabricate the zero-anchor baseline a failed re-arm would leave behind.
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	state.Anchors = nil
+	blob, err := state.Marshal()
+	require.NoError(err)
+	syncID, err := st.StartSync(src.ID, "beeper")
+	require.NoError(err)
+	require.NoError(st.CompleteSync(syncID, blob))
+
+	// Intact installation: the archived sample verifies and the run passes
+	// (and re-arms).
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	run, err = st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	rearmed, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotEmpty(rearmed.Anchors, "the passing run must re-arm")
+
+	// Reinstalled installation (IDs re-assigned): strip anchors again and
+	// shift every message's timestamp — the sample must block the run.
+	syncID, err = st.StartSync(src.ID, "beeper")
+	require.NoError(err)
+	require.NoError(st.CompleteSync(syncID, blob))
+	ch := f.chat("!e2e:beeper.local")
+	for i := range ch.Msgs {
+		ch.Msgs[i].Timestamp = ch.Msgs[i].Timestamp.Add(2 * time.Hour)
+	}
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.Error(err)
+	require.Contains(err.Error(), "re-add")
+}

--- a/internal/beeper/client.go
+++ b/internal/beeper/client.go
@@ -1,0 +1,271 @@
+package beeper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	maxRetries = 8
+	// DefaultBaseURL is the Beeper Desktop API loopback address.
+	DefaultBaseURL = "http://localhost:23373"
+	// defaultQPS bounds request rate against the live Beeper Desktop app. The
+	// API is loopback-only, so this protects the user's running client rather
+	// than any remote quota.
+	defaultQPS = 20
+)
+
+// ErrNotFound reports a 404 from the Beeper Desktop API (e.g. a message or
+// chat that no longer exists). Callers distinguish it from transient errors.
+var ErrNotFound = errors.New("not found")
+
+// ErrAssetTooLarge reports an asset exceeding the caller's size cap; the cap
+// is enforced while reading so oversized bodies are never fully buffered.
+var ErrAssetTooLarge = errors.New("asset exceeds size cap")
+
+// TokenFunc returns a bearer token for a Beeper Desktop API request.
+type TokenFunc func(context.Context) (string, error)
+
+// Client is a read-only Beeper Desktop API client. It exposes only GET
+// endpoints by construction, so the archiver can never mutate Beeper state.
+type Client struct {
+	baseURL string
+	token   TokenFunc
+	http    *http.Client
+	limiter *rate.Limiter
+}
+
+// NewClient creates a Client. baseURL is injected so tests can point at
+// httptest servers. qps controls the token-bucket rate limit (default 20).
+func NewClient(baseURL string, token TokenFunc, qps float64) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	if qps <= 0 {
+		qps = defaultQPS
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 60 * time.Second},
+		limiter: rate.NewLimiter(rate.Limit(qps), 1),
+	}
+}
+
+// get fetches path, respecting the rate limiter and retrying on 429/5xx with
+// Retry-After or exponential back-off.
+func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
+	return c.fetch(ctx, path, 0)
+}
+
+// fetch is get with an optional response-size cap (0 = unlimited). Bodies are
+// read through a limited reader, so an over-cap asset costs at most
+// maxBytes+1 of memory regardless of what the server sends.
+func (c *Client) fetch(ctx context.Context, path string, maxBytes int64) ([]byte, error) {
+	reqURL := c.baseURL + path
+	for attempt := range maxRetries {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("wait for beeper rate limit: %w", err)
+		}
+		tok, err := c.token(ctx)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Accept", "application/json")
+		resp, err := c.http.Do(req)
+		if err != nil {
+			if errors.Is(err, syscall.ECONNREFUSED) {
+				return nil, fmt.Errorf("connect to Beeper Desktop at %s (is Beeper Desktop running?): %w", c.baseURL, err)
+			}
+			return nil, err
+		}
+		if maxBytes > 0 && resp.ContentLength > maxBytes {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("beeper GET %s: %d bytes: %w", reqURL, resp.ContentLength, ErrAssetTooLarge)
+		}
+		reader := io.Reader(resp.Body)
+		if maxBytes > 0 {
+			reader = io.LimitReader(resp.Body, maxBytes+1)
+		}
+		body, readErr := io.ReadAll(reader)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("beeper GET %s: read body: %w", reqURL, readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("beeper GET %s: close body: %w", reqURL, closeErr)
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusOK:
+			if maxBytes > 0 && int64(len(body)) > maxBytes {
+				return nil, fmt.Errorf("beeper GET %s: %w", reqURL, ErrAssetTooLarge)
+			}
+			return body, nil
+		case resp.StatusCode == http.StatusUnauthorized:
+			return nil, fmt.Errorf("beeper GET %s: unauthorized (401): the access token was rejected; mint a new token in Beeper Desktop (Settings > Developer) and re-run 'msgvault add-beeper'", reqURL)
+		case resp.StatusCode == http.StatusNotFound:
+			return nil, fmt.Errorf("beeper GET %s: %w", reqURL, ErrNotFound)
+		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+			continue
+		default:
+			return nil, fmt.Errorf("beeper GET %s: status %d: %s", reqURL, resp.StatusCode, string(body))
+		}
+	}
+	return nil, fmt.Errorf("beeper GET %s: exhausted %d retries", reqURL, maxRetries)
+}
+
+// retryAfter parses a Retry-After header value (seconds) or falls back to
+// exponential back-off capped at 60 s.
+func retryAfter(header string, attempt int) time.Duration {
+	if header != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
+}
+
+// getJSON fetches path and unmarshals the JSON body into out.
+func (c *Client) getJSON(ctx context.Context, path string, out any) error {
+	body, err := c.get(ctx, path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, out)
+}
+
+// ListAccounts returns the chat accounts connected to Beeper Desktop.
+func (c *Client) ListAccounts(ctx context.Context) ([]Account, error) {
+	var out []Account
+	if err := c.getJSON(ctx, "/v1/accounts", &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SearchChatsParams filters a chat search page.
+type SearchChatsParams struct {
+	AccountID         string
+	Cursor            string // opaque; paired with direction=before
+	LastActivityAfter time.Time
+}
+
+// SearchChats fetches one page of chats for an account, ordered by last
+// activity (most recent first). Page onward with direction=before using
+// OldestCursor.
+func (c *Client) SearchChats(ctx context.Context, p SearchChatsParams) (*SearchChatsOutput, error) {
+	q := url.Values{}
+	q.Set("limit", "200")
+	q.Set("type", "any")
+	if p.AccountID != "" {
+		q.Add("accountIDs", p.AccountID)
+	}
+	if p.Cursor != "" {
+		q.Set("cursor", p.Cursor)
+		q.Set("direction", "before")
+	}
+	if !p.LastActivityAfter.IsZero() {
+		q.Set("lastActivityAfter", p.LastActivityAfter.UTC().Format(time.RFC3339))
+	}
+	var out SearchChatsOutput
+	if err := c.getJSON(ctx, "/v1/chats/search?"+q.Encode(), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AllChats pages through every chat matching p, invoking fn per chat.
+func (c *Client) AllChats(ctx context.Context, p SearchChatsParams, fn func(Chat) error) error {
+	for {
+		page, err := c.SearchChats(ctx, p)
+		if err != nil {
+			return err
+		}
+		for _, ch := range page.Items {
+			if err := fn(ch); err != nil {
+				return err
+			}
+		}
+		if !page.HasMore || page.OldestCursor == "" {
+			return nil
+		}
+		p.Cursor = page.OldestCursor
+	}
+}
+
+// GetChat fetches one chat with its full participant list
+// (maxParticipantCount=-1 returns all members).
+func (c *Client) GetChat(ctx context.Context, chatID string) (*Chat, error) {
+	var out Chat
+	path := "/v1/chats/" + url.PathEscape(chatID) + "?maxParticipantCount=-1"
+	if err := c.getJSON(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ListMessagesPage fetches one page (~20 items) of a chat's messages. cursor
+// is opaque; direction is "before" (older) or "after" (newer). Both empty
+// fetch the newest page. Page-at-a-time is deliberate: the importer owns the
+// loop so it can checkpoint between pages.
+func (c *Client) ListMessagesPage(ctx context.Context, chatID, cursor, direction string) (*ListMessagesOutput, error) {
+	q := url.Values{}
+	if cursor != "" {
+		q.Set("cursor", cursor)
+		if direction != "" {
+			q.Set("direction", direction)
+		}
+	}
+	path := "/v1/chats/" + url.PathEscape(chatID) + "/messages"
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	var out ListMessagesOutput
+	if err := c.getJSON(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetAssetBytes downloads an asset (attachment media) by its mxc:// style
+// URL via the assets/serve endpoint. Reads are capped at maxBytes (see
+// ErrAssetTooLarge); asset sizes are untrusted remote metadata.
+func (c *Client) GetAssetBytes(ctx context.Context, assetURL string, maxBytes int64) ([]byte, error) {
+	return c.fetch(ctx, "/v1/assets/serve?url="+url.QueryEscape(assetURL), maxBytes)
+}
+
+// GetMessage fetches a single message by ID (used to refresh reaction targets
+// and to verify the sync-state anchor probe).
+func (c *Client) GetMessage(ctx context.Context, chatID, messageID string) (*Message, error) {
+	var out Message
+	path := "/v1/chats/" + url.PathEscape(chatID) + "/messages/" + url.PathEscape(messageID)
+	if err := c.getJSON(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/beeper/client_test.go
+++ b/internal/beeper/client_test.go
@@ -1,0 +1,164 @@
+package beeper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientRetriesOn429(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	accounts, err := c.ListAccounts(context.Background())
+	require.NoError(err)
+	assert.Empty(accounts)
+	assert.EqualValues(3, calls.Load())
+}
+
+func TestClientUnauthorizedMessage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	_, err := c.ListAccounts(context.Background())
+	require.Error(err)
+	assert.Contains(err.Error(), "add-beeper")
+	assert.Contains(err.Error(), "Beeper Desktop")
+}
+
+func TestClientNotFound(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"nope"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	_, err := c.GetMessage(context.Background(), "!c:x", "1")
+	require.Error(err)
+	assert.ErrorIs(err, ErrNotFound)
+}
+
+func TestClientContextCancelDuringBackoff(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	start := time.Now()
+	_, err := c.ListAccounts(ctx)
+	require.Error(err)
+	require.ErrorIs(err, context.DeadlineExceeded)
+	assert.Less(time.Since(start), 5*time.Second, "must abort backoff on ctx cancel")
+}
+
+func TestClientSendsBearerToken(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	_, err := c.ListAccounts(context.Background())
+	require.NoError(err)
+	assert.Equal("Bearer test-token", got)
+}
+
+func TestSearchChatsParams(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.addChat(&fakeChat{ID: "!a:x", AccountID: "signal", Network: "Signal", Title: "A", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)})
+	f.addChat(&fakeChat{ID: "!b:x", AccountID: "signal", Network: "Signal", Title: "B", Type: "single",
+		LastActivity: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)})
+	f.addChat(&fakeChat{ID: "!c:x", AccountID: "whatsapp", Network: "WhatsApp", Title: "C", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)})
+	srv := f.server()
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	out, err := c.SearchChats(context.Background(), SearchChatsParams{
+		AccountID:         "signal",
+		LastActivityAfter: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(err)
+	require.Len(out.Items, 1)
+	assert.Equal("!a:x", out.Items[0].ID, "account and activity filters must both apply")
+}
+
+func TestListMessagesPagination(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ch := &fakeChat{ID: "!p:x", AccountID: "signal", Network: "Signal", Title: "P", Type: "single", LastActivity: base}
+	for i := range 45 {
+		ch.Msgs = append(ch.Msgs, fakeMsg{
+			ID: "m" + strconv.Itoa(i), SortKey: i, Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text: "msg", SenderID: "@a:x", SenderName: "A",
+		})
+	}
+	f.addChat(ch)
+	srv := f.server()
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	ctx := context.Background()
+
+	// Newest page first, then walk older until the empty end-of-history page
+	// (the live API's hasMore flag is not a reliable termination signal).
+	var total int
+	cursor, direction := "", ""
+	for range 10 {
+		page, err := c.ListMessagesPage(ctx, "!p:x", cursor, direction)
+		require.NoError(err)
+		if len(page.Items) == 0 {
+			assert.Empty(page.OldestCursor, "empty page carries null cursors")
+			break
+		}
+		total += len(page.Items)
+		cursor, direction = page.OldestCursor, "before"
+	}
+	assert.Equal(45, total)
+
+	// Walk newer from a mid-chat cursor: the page advances exclusively.
+	after, err := c.ListMessagesPage(ctx, "!p:x", "20", "after")
+	require.NoError(err)
+	assert.Len(after.Items, 20)
+}

--- a/internal/beeper/doc.go
+++ b/internal/beeper/doc.go
@@ -1,0 +1,17 @@
+// Package beeper archives chats from the local Beeper Desktop API into the
+// msgvault store. Each connected network account (whatsapp, signal, …)
+// becomes its own msgvault source, so networks stay separately filterable
+// while all rows share message_type "beeper".
+//
+// Import processes each chat in phases: backfill walks history oldest-ward
+// with resumable, checkpointed cursors; incremental extends past the stored
+// cursor; and reconcile re-walks the recent head to catch edits, deletions,
+// and reaction changes a forward-only cursor cannot see. The client is
+// GET-only by construction, so the archiver can never mutate Beeper state.
+//
+// Beeper message IDs are unique only per installation. Anchor probes
+// (anchors.go) fingerprint the installation and are verified before any
+// stored cursor is trusted: a reinstall or re-index aborts the run instead of
+// silently duplicating the archive. Failed or over-cap media downloads leave
+// pending marker rows that BackfillMedia retries later.
+package beeper

--- a/internal/beeper/fake_server_test.go
+++ b/internal/beeper/fake_server_test.go
@@ -1,0 +1,426 @@
+package beeper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMsg is one message held by the fake Beeper server. Messages live in a
+// per-chat slice ordered oldest→newest; SortKey doubles as the cursor value.
+type fakeMsg struct {
+	ID              string
+	SortKey         int
+	Timestamp       time.Time
+	Type            string // "" defaults to TEXT
+	Text            string
+	SenderID        string
+	SenderName      string
+	IsSender        bool
+	IsDeleted       bool
+	IsHidden        bool
+	EditedTimestamp *time.Time
+	LinkedMessageID string
+	Mentions        []string
+	Reactions       []map[string]any
+	Attachments     []map[string]any
+}
+
+type fakeChat struct {
+	ID           string
+	AccountID    string
+	Network      string
+	Title        string
+	Type         string // "single" | "group"
+	LastActivity time.Time
+	Participants []map[string]any
+	// ParticipantsTruncated makes the search listing report hasMore=true so
+	// the importer fetches the chat detail for the full list.
+	ParticipantsTruncated bool
+	// StuckHead emulates a misbehaving live API whose direction=after pages
+	// re-serve the head with a non-advancing cursor.
+	StuckHead bool
+	// TailCountdown emulates the live API's degenerate end-of-history
+	// behavior: once a before-walk passes the oldest message, pages re-serve
+	// the oldest messages under a synthetic decrementing cursor instead of
+	// coming back empty.
+	TailCountdown bool
+	Msgs          []fakeMsg // oldest → newest
+}
+
+// fakeBeeper simulates the Beeper Desktop API surface the importer uses,
+// with sortKey-cursor pagination semantics matching the real API.
+type fakeBeeper struct {
+	t        *testing.T
+	pageSize int
+
+	mu     sync.Mutex
+	chats  []*fakeChat
+	assets map[string][]byte // asset URL (mxc://...) -> bytes served by /v1/assets/serve
+	// failMessageGets makes GET /v1/chats/{id}/messages/{mid} answer 400
+	// (a non-retryable transient error) for the listed message IDs.
+	failMessageGets map[string]bool
+	// failMessageLists does the same for GET /v1/chats/{id}/messages.
+	failMessageLists map[string]bool
+	// cancelAfterPages invokes cancelFn once after that many message-list
+	// pages have been fully served (0 = disabled), emulating a mid-walk
+	// interrupt between pages.
+	cancelAfterPages int
+	cancelFn         func()
+	pagesServed      int
+	reqs             []string // "PATH?QUERY" per request, in order
+}
+
+func newFakeBeeper(t *testing.T) *fakeBeeper {
+	t.Helper()
+	return &fakeBeeper{t: t, pageSize: 20, assets: map[string][]byte{}, failMessageGets: map[string]bool{}, failMessageLists: map[string]bool{}}
+}
+
+// setMessageListFailure toggles a 400 response for message-list fetches of a chat.
+func (f *fakeBeeper) setMessageListFailure(chatID string, fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failMessageLists[chatID] = fail
+}
+
+// setMessageGetFailure toggles a 400 response for single-message fetches of id.
+func (f *fakeBeeper) setMessageGetFailure(id string, fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failMessageGets[id] = fail
+}
+
+// setAsset makes an asset URL downloadable via /v1/assets/serve.
+func (f *fakeBeeper) setAsset(url string, data []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.assets[url] = data
+}
+
+func (f *fakeBeeper) addChat(ch *fakeChat) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.chats = append(f.chats, ch)
+}
+
+func (f *fakeBeeper) chat(id string) *fakeChat {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chats {
+		if ch.ID == id {
+			return ch
+		}
+	}
+	return nil
+}
+
+// appendMsg adds a message to a chat and advances its LastActivity.
+func (f *fakeBeeper) appendMsg(chatID string, m fakeMsg) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chats {
+		if ch.ID == chatID {
+			ch.Msgs = append(ch.Msgs, m)
+			if m.Timestamp.After(ch.LastActivity) {
+				ch.LastActivity = m.Timestamp
+			}
+			return
+		}
+	}
+	require.Failf(f.t, "appendMsg failed", "unknown chat %s", chatID)
+}
+
+// requests returns the request log ("PATH?QUERY" entries).
+func (f *fakeBeeper) requests() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.reqs...)
+}
+
+func (f *fakeBeeper) resetRequests() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reqs = nil
+}
+
+func (f *fakeBeeper) server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		entry := r.URL.Path
+		if r.URL.RawQuery != "" {
+			entry += "?" + r.URL.RawQuery
+		}
+		f.reqs = append(f.reqs, entry)
+		f.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case path == "/v1/assets/serve":
+			f.writeAsset(w, r)
+		case path == "/v1/chats/search":
+			f.writeChatSearch(w, r)
+		case strings.HasPrefix(path, "/v1/chats/"):
+			rest := strings.TrimPrefix(path, "/v1/chats/")
+			switch parts := strings.SplitN(rest, "/", 3); {
+			case len(parts) == 1:
+				f.writeChat(w, parts[0])
+			case len(parts) == 2 && parts[1] == "messages":
+				f.writeMessages(w, r, parts[0])
+			case len(parts) == 3 && parts[1] == "messages":
+				f.writeMessage(w, parts[0], parts[2])
+			default:
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+			}
+		default:
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		}
+	}))
+}
+
+func (f *fakeBeeper) writeAsset(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, ok := f.assets[r.URL.Query().Get("url")]
+	if !ok {
+		http.Error(w, `{"error":"asset not found"}`, http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	_, _ = w.Write(data)
+}
+
+func (f *fakeBeeper) writeChatSearch(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	q := r.URL.Query()
+	accountID := q.Get("accountIDs")
+	var after time.Time
+	if v := q.Get("lastActivityAfter"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			http.Error(w, `{"error":"bad lastActivityAfter"}`, http.StatusBadRequest)
+			return
+		}
+		after = t
+	}
+	items := []map[string]any{}
+	for _, ch := range f.chats {
+		if accountID != "" && ch.AccountID != accountID {
+			continue
+		}
+		if !after.IsZero() && !ch.LastActivity.After(after) {
+			continue
+		}
+		items = append(items, f.chatJSON(ch, true))
+	}
+	writeJSON(f.t, w, map[string]any{
+		"items": items, "hasMore": false, "oldestCursor": nil, "newestCursor": nil,
+	})
+}
+
+func (f *fakeBeeper) writeChat(w http.ResponseWriter, chatID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.chats {
+		if ch.ID == chatID {
+			writeJSON(f.t, w, f.chatJSON(ch, false))
+			return
+		}
+	}
+	http.Error(w, `{"error":"chat not found"}`, http.StatusNotFound)
+}
+
+// chatJSON renders a chat. Listing entries truncate the participant list when
+// ParticipantsTruncated is set (mirroring the API's 20-participant cap on
+// search results); the detail endpoint always returns everyone.
+func (f *fakeBeeper) chatJSON(ch *fakeChat, listing bool) map[string]any {
+	parts := ch.Participants
+	hasMore := false
+	if listing && ch.ParticipantsTruncated {
+		parts = parts[:1]
+		hasMore = true
+	}
+	if parts == nil {
+		parts = []map[string]any{}
+	}
+	return map[string]any{
+		"id":        ch.ID,
+		"accountID": ch.AccountID,
+		"network":   ch.Network,
+		"title":     ch.Title,
+		"type":      ch.Type,
+		"participants": map[string]any{
+			"items": parts, "hasMore": hasMore, "total": len(ch.Participants),
+		},
+		"lastActivity": ch.LastActivity.UTC().Format(time.RFC3339Nano),
+		"unreadCount":  0,
+	}
+}
+
+func (f *fakeBeeper) writeMessages(w http.ResponseWriter, r *http.Request, chatID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pagesServed++
+	if f.cancelAfterPages > 0 && f.pagesServed == f.cancelAfterPages && f.cancelFn != nil {
+		defer f.cancelFn() // after the response is written
+	}
+	var ch *fakeChat
+	for _, c := range f.chats {
+		if c.ID == chatID {
+			ch = c
+			break
+		}
+	}
+	if ch == nil {
+		http.Error(w, `{"error":"chat not found"}`, http.StatusNotFound)
+		return
+	}
+	if f.failMessageLists[chatID] {
+		http.Error(w, `{"error":"transient"}`, http.StatusBadRequest)
+		return
+	}
+	q := r.URL.Query()
+	cursor := q.Get("cursor")
+	direction := q.Get("direction")
+	if cursor != "" && direction == "" {
+		direction = "before"
+	}
+
+	msgs := ch.Msgs // oldest → newest
+	var window []fakeMsg
+	switch {
+	case cursor == "":
+		start := max(0, len(msgs)-f.pageSize)
+		window = msgs[start:]
+	case direction == "before":
+		cur, _ := strconv.Atoi(cursor)
+		end := sort.Search(len(msgs), func(i int) bool { return msgs[i].SortKey >= cur })
+		start := max(0, end-f.pageSize)
+		window = msgs[start:end]
+	default: // "after"
+		cur, _ := strconv.Atoi(cursor)
+		start := sort.Search(len(msgs), func(i int) bool { return msgs[i].SortKey > cur })
+		end := min(len(msgs), start+f.pageSize)
+		window = msgs[start:end]
+	}
+
+	// Non-advancing head emulation: direction=after re-serves the head page
+	// under the caller's own cursor.
+	if ch.StuckHead && direction == "after" && cursor != "" {
+		start := max(0, len(msgs)-f.pageSize)
+		window = msgs[start:]
+	}
+
+	oldestCursor := ""
+	if len(window) > 0 {
+		oldestCursor = strconv.Itoa(window[0].SortKey)
+	}
+	// Degenerate end-of-history emulation: past the oldest message, re-serve
+	// the oldest few under a synthetic decrementing cursor (live API quirk).
+	if ch.TailCountdown && direction == "before" && len(window) == 0 && len(msgs) > 0 {
+		window = msgs[:min(3, len(msgs))]
+		cur, _ := strconv.Atoi(cursor)
+		oldestCursor = strconv.Itoa(cur - 1)
+	}
+
+	items := make([]map[string]any, 0, len(window))
+	// The real API returns pages newest-first.
+	for _, m := range slices.Backward(window) {
+		items = append(items, f.messageJSON(ch, &m))
+	}
+	// Like the live API, hasMore is not a reliable termination signal: it
+	// stays true even on the final and even on empty pages.
+	out := map[string]any{"items": items, "hasMore": true}
+	if len(window) > 0 {
+		out["oldestCursor"] = oldestCursor
+		out["newestCursor"] = strconv.Itoa(window[len(window)-1].SortKey)
+		if ch.StuckHead && direction == "after" && cursor != "" {
+			out["newestCursor"] = cursor
+		}
+	} else {
+		out["oldestCursor"] = nil
+		out["newestCursor"] = nil
+	}
+	writeJSON(f.t, w, out)
+}
+
+func (f *fakeBeeper) writeMessage(w http.ResponseWriter, chatID, messageID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failMessageGets[messageID] {
+		http.Error(w, `{"error":"transient"}`, http.StatusBadRequest)
+		return
+	}
+	for _, ch := range f.chats {
+		if ch.ID != chatID {
+			continue
+		}
+		for i := range ch.Msgs {
+			if ch.Msgs[i].ID == messageID {
+				writeJSON(f.t, w, f.messageJSON(ch, &ch.Msgs[i]))
+				return
+			}
+		}
+	}
+	http.Error(w, `{"error":"message not found"}`, http.StatusNotFound)
+}
+
+func (f *fakeBeeper) messageJSON(ch *fakeChat, m *fakeMsg) map[string]any {
+	typ := m.Type
+	if typ == "" {
+		typ = "TEXT"
+	}
+	out := map[string]any{
+		"id":         m.ID,
+		"chatID":     ch.ID,
+		"accountID":  ch.AccountID,
+		"senderID":   m.SenderID,
+		"senderName": m.SenderName,
+		"timestamp":  m.Timestamp.UTC().Format(time.RFC3339Nano),
+		"sortKey":    strconv.Itoa(m.SortKey),
+		"type":       typ,
+		"isSender":   m.IsSender,
+		"isDeleted":  m.IsDeleted,
+	}
+	if m.Text != "" {
+		out["text"] = m.Text
+	}
+	if m.IsHidden {
+		out["isHidden"] = true
+	}
+	if m.EditedTimestamp != nil {
+		out["editedTimestamp"] = m.EditedTimestamp.UTC().Format(time.RFC3339Nano)
+	}
+	if m.LinkedMessageID != "" {
+		out["linkedMessageID"] = m.LinkedMessageID
+	}
+	if m.Mentions != nil {
+		out["mentions"] = m.Mentions
+	}
+	if m.Reactions != nil {
+		out["reactions"] = m.Reactions
+	}
+	if m.Attachments != nil {
+		out["attachments"] = m.Attachments
+	}
+	return out
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	assert.NoError(t, json.NewEncoder(w).Encode(v), "encode fake response")
+}
+
+func testToken(context.Context) (string, error) { return "test-token", nil }

--- a/internal/beeper/importer.go
+++ b/internal/beeper/importer.go
@@ -181,6 +181,15 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 	// Mid-run checkpoints are throttled, so persist the final counters before
 	// completing (CompleteSync only writes status and cursor).
 	imp.checkpointNow(syncID, state, sum)
+	if sum.FetchErrors > 0 {
+		// Page failures are isolated so healthy chats still sync, but the run
+		// must remain failed and caller-visible. The checkpoint above preserves
+		// all partial progress for the next attempt; the deferred FailSync marks
+		// the run consistently for diagnostics and scheduler monitoring.
+		sum.Duration = time.Since(start)
+		err = fmt.Errorf("partial Beeper sync: %d fetch error(s)", sum.FetchErrors)
+		return sum, err
+	}
 	blob, _ := state.Marshal()
 	if err = imp.store.CompleteSync(syncID, blob); err != nil {
 		return sum, err

--- a/internal/beeper/importer.go
+++ b/internal/beeper/importer.go
@@ -1,0 +1,770 @@
+package beeper
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const sourceTypeBeeper = "beeper"
+
+// errRetryPage aborts the current chat walk without advancing its cursor, so
+// the next run re-fetches the same page (upserts make that idempotent).
+var errRetryPage = errors.New("retry page next run")
+
+// checkpointMinInterval throttles checkpoint flushes: the state blob is
+// O(chats) JSON, so rewriting it after every chat of a large account is
+// mostly wasted I/O. Interruption loses at most this much progress.
+// A variable so tests can disable the throttle.
+var checkpointMinInterval = 15 * time.Second
+
+const (
+	// checkpointPageInterval flushes the sync checkpoint every N pages inside a
+	// single chat backfill. Per-chat-only checkpointing is insufficient here:
+	// one chat can hold over a million messages (tens of thousands of pages).
+	checkpointPageInterval = 25
+	// reconcileWindow bounds the head re-walk that catches in-place edits,
+	// deletions, and reaction changes the incremental cursor cannot see.
+	reconcileWindow = 24 * time.Hour
+	// maxReconcilePages caps the reconciliation walk for pathologically busy chats.
+	maxReconcilePages = 50
+)
+
+// chatScope carries per-chat state through the persist call chain: the chat
+// and store IDs, the run options, and the chat's cursor state (whose
+// PendingReplies buffer persistMessage appends to, keeping checkpoints
+// consistent with the cursor by construction).
+type chatScope struct {
+	chatID   string
+	convID   int64
+	sourceID int64
+	syncID   int64
+	opts     ImportOptions
+	cs       *ChatState
+}
+
+// Importer ingests Beeper Desktop messages into the msgvault store. One
+// Import run covers one Beeper account (= one msgvault source).
+type Importer struct {
+	store  *store.Store
+	client *Client
+	res    *participantResolver
+	// lastCheckpoint throttles checkpoint flushes (see checkpointMinInterval).
+	lastCheckpoint time.Time
+}
+
+// NewImporter creates an Importer backed by the given store and Beeper client.
+func NewImporter(s *store.Store, c *Client) *Importer {
+	return &Importer{store: s, client: c, res: newParticipantResolver(s)}
+}
+
+// loadResumeState rebuilds the sync state for a source: the last successful
+// run's cursor blob (baseline) merged with the latest interrupted checkpoint,
+// so a resumed run skips already-covered work.
+func (imp *Importer) loadResumeState(sourceID int64) *SyncState {
+	state := NewSyncState()
+	if prev, err := imp.store.GetLastSuccessfulSync(sourceID); err == nil && prev != nil && prev.CursorAfter.Valid {
+		if s, lerr := LoadSyncState(prev.CursorAfter.String); lerr == nil {
+			state = s
+		}
+	}
+	if cp, err := imp.store.GetLatestCheckpointedSync(sourceID); err == nil && cp != nil && cp.CursorBefore.Valid {
+		if cpState, lerr := LoadSyncState(cp.CursorBefore.String); lerr == nil {
+			state.Merge(cpState)
+		}
+	}
+	return state
+}
+
+// Import runs a backfill-then-incremental sync of opts.AccountID's chats.
+// New chats backfill their full locally-available history (resumable across
+// interrupted runs); completed chats fetch only messages newer than the
+// stored cursor. Returns a summary of the run.
+func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
+	start := time.Now()
+	if opts.AccountID == "" {
+		return nil, errors.New("beeper account ID required")
+	}
+	src, err := imp.store.GetOrCreateSource(sourceTypeBeeper, opts.AccountID)
+	if err != nil {
+		return nil, err
+	}
+	sum := &ImportSummary{SourceID: src.ID}
+
+	state := imp.loadResumeState(src.ID)
+	if opts.Full {
+		// Repair path: drop all cursors so every message is re-fetched and
+		// upserted in place — but keep the anchors. Skipping their
+		// verification would let a --full run against a reinstalled Beeper
+		// Desktop (re-assigned message IDs) silently duplicate the archive.
+		anchors := state.Anchors
+		state = NewSyncState()
+		state.Anchors = anchors
+	}
+
+	syncID, err := imp.store.StartSync(src.ID, sourceTypeBeeper)
+	if err != nil {
+		return nil, err
+	}
+	// Failures below must ASSIGN to err (never shadow it with :=) so this
+	// defer records them on the run.
+	defer func() {
+		if err != nil {
+			_ = imp.store.FailSync(syncID, err.Error())
+		}
+	}()
+
+	// Persist the merged resume state immediately: if this run fails before
+	// its first checkpoint (Beeper not running, anchor mismatch), the next run
+	// finds it here instead of losing the previous run's progress — the store
+	// only exposes the newest run's checkpoint.
+	imp.checkpointNow(syncID, state, sum)
+
+	// Message IDs are only unique per Beeper installation; verify the anchor
+	// messages still exist unchanged before trusting stored cursors.
+	if err = imp.verifyAnchors(ctx, syncID, src.ID, state); err != nil {
+		return sum, err
+	}
+
+	chats, err := imp.enumerateChats(ctx, syncID, opts, state, sum)
+	if err != nil {
+		return sum, err
+	}
+
+	// Reconciliation re-walks each active chat's last-24h head to catch
+	// in-place edits/deletions/reaction changes the forward-only cursor cannot
+	// see. Cheap on re-runs: already-stored media is never re-downloaded.
+	reconcileCutoff := start.Add(-reconcileWindow)
+
+	maxActivity := parseWatermark(state.ListWatermark)
+	total := len(chats)
+	for idx := range chats {
+		ch := &chats[idx]
+		if err = ctx.Err(); err != nil {
+			return sum, err
+		}
+		if ch.LastActivity.After(maxActivity) {
+			maxActivity = ch.LastActivity
+		}
+		var convCount int64
+		convCount, err = imp.syncChat(ctx, syncID, src.ID, ch, opts, state, reconcileCutoff, sum)
+		if err != nil {
+			return sum, err
+		}
+		sum.ChatsProcessed++
+		if opts.Progress != nil {
+			opts.Progress(fmt.Sprintf("chat %d/%d (%s): %d messages", idx+1, total, ch.Network, convCount))
+		}
+		// Flush checkpoint so an interrupted run can resume from this point.
+		imp.checkpoint(syncID, state, sum)
+	}
+	// Advance the discovery watermark only for fetch-clean runs: a fetch error
+	// means some chat's messages are still missing, so it must stay
+	// discoverable by the next run's lastActivityAfter filter.
+	if sum.FetchErrors == 0 && !maxActivity.IsZero() {
+		state.ListWatermark = formatWatermark(maxActivity)
+	}
+
+	// Never complete a run under-anchored: incremental-only runs skip the
+	// backfill path that normally arms probes, and persisting none would
+	// leave the reinstall guard on its slower archived-sample fallback.
+	imp.rearmAnchors(ctx, chats, state)
+
+	if err = imp.store.RecomputeConversationStats(src.ID); err != nil {
+		return sum, err
+	}
+	// Mid-run checkpoints are throttled, so persist the final counters before
+	// completing (CompleteSync only writes status and cursor).
+	imp.checkpointNow(syncID, state, sum)
+	blob, _ := state.Marshal()
+	if err = imp.store.CompleteSync(syncID, blob); err != nil {
+		return sum, err
+	}
+	sum.Duration = time.Since(start)
+	return sum, nil
+}
+
+// enumerateChats lists the chats this run must visit: every chat with
+// activity after the watermark (all chats on first/full runs), plus any chat
+// whose backfill is unfinished even without new activity.
+func (imp *Importer) enumerateChats(ctx context.Context, syncID int64, opts ImportOptions, state *SyncState, sum *ImportSummary) ([]Chat, error) {
+	params := SearchChatsParams{AccountID: opts.AccountID}
+	if !opts.Full && state.ListWatermark != "" {
+		if wm := parseWatermark(state.ListWatermark); !wm.IsZero() {
+			// Overlap by an hour so clock skew or a mid-listing crash cannot
+			// permanently hide a chat from enumeration.
+			params.LastActivityAfter = wm.Add(-time.Hour)
+		}
+	}
+	var chats []Chat
+	seen := map[string]bool{}
+	err := imp.client.AllChats(ctx, params, func(ch Chat) error {
+		seen[ch.ID] = true
+		chats = append(chats, ch)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	for chatID, cs := range state.Chats {
+		if cs == nil || cs.Done || seen[chatID] {
+			continue
+		}
+		detail, gerr := imp.client.GetChat(ctx, chatID)
+		if errors.Is(gerr, ErrNotFound) {
+			// The chat no longer exists in Beeper (left/deleted); there is
+			// nothing more to fetch. Mark it complete so it stops pinning the
+			// discovery watermark; the archived messages are kept.
+			cs.Done = true
+			imp.recordItem(syncID, chatID, "fetch", store.SyncRunItemStatusSkipped, "beeper_chat_gone", gerr)
+			continue
+		}
+		if gerr != nil {
+			imp.recordItem(syncID, chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
+			sum.FetchErrors++
+			sum.Errors++
+			continue
+		}
+		chats = append(chats, *detail)
+	}
+	return chats, nil
+}
+
+// syncChat ensures the conversation and its participants, then backfills or
+// incrementally extends the chat's messages. Returns the number of messages
+// processed for this chat.
+func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *Chat, opts ImportOptions, state *SyncState, reconcileCutoff time.Time, sum *ImportSummary) (int64, error) {
+	convID, err := imp.ensureConversation(ctx, syncID, sourceID, ch, sum)
+	if err != nil {
+		return 0, err
+	}
+
+	cs := state.EnsureChat(ch.ID)
+	cc := &chatScope{chatID: ch.ID, convID: convID, sourceID: sourceID, syncID: syncID, opts: opts, cs: cs}
+	before := sum.MessagesProcessed
+
+	// A chat that was empty when backfilled has Done set but no incremental
+	// cursor; re-walk it from scratch (cheap) so its first messages are seen.
+	if !cs.Done || cs.Newest == "" {
+		err = imp.backfillChat(ctx, cc, state, sum)
+	} else {
+		err = imp.incrementalChat(ctx, cc, sum)
+		if err == nil {
+			err = imp.reconcileChat(ctx, cc, reconcileCutoff, sum)
+		}
+	}
+	if err != nil {
+		return sum.MessagesProcessed - before, err
+	}
+
+	// Reply pairs link parents by lookup, so flushing waits until the
+	// backfill has actually archived the parents; until then the pairs ride
+	// along in the checkpointed chat state.
+	if cs.Done {
+		imp.flushReplies(cc, sum)
+	}
+	return sum.MessagesProcessed - before, nil
+}
+
+// ensureConversation upserts the conversation row and its membership,
+// fetching the full participant list when the search listing truncated it
+// (chat search returns at most 20 participants per chat).
+func (imp *Importer) ensureConversation(ctx context.Context, syncID, sourceID int64, ch *Chat, sum *ImportSummary) (int64, error) {
+	detail := ch
+	if ch.Participants.HasMore {
+		d, gerr := imp.client.GetChat(ctx, ch.ID)
+		if gerr != nil {
+			imp.recordItem(syncID, ch.ID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
+			sum.FetchErrors++
+			sum.Errors++
+		} else {
+			detail = d
+		}
+	}
+	convID, err := imp.store.EnsureConversationWithType(sourceID, ch.ID, conversationType(ch.Type), ch.Title)
+	if err != nil {
+		return 0, err
+	}
+	for i := range detail.Participants.Items {
+		p := &detail.Participants.Items[i]
+		pid, rerr := imp.res.resolveUser(&p.User)
+		if rerr != nil {
+			return 0, rerr
+		}
+		if pid == 0 {
+			continue
+		}
+		role := "member"
+		if p.IsAdmin {
+			role = "admin"
+		}
+		if cerr := imp.store.EnsureConversationParticipant(convID, pid, role); cerr != nil {
+			sum.Errors++
+		}
+	}
+	return convID, nil
+}
+
+// recentIDWindow remembers the message IDs of the last few pages of a
+// backfill walk. The live API's degenerate end-of-history pages re-serve the
+// immediately preceding tail, so a few pages of memory detect them — and stay
+// bounded on multi-million-message chats.
+type recentIDWindow struct {
+	pages []map[string]struct{}
+	max   int
+}
+
+// recentIDWindowPages bounds the duplicate-detection window (see recentIDWindow).
+const recentIDWindowPages = 5
+
+func newRecentIDWindow(maxPages int) *recentIDWindow {
+	return &recentIDWindow{max: maxPages}
+}
+
+func (w *recentIDWindow) contains(id string) bool {
+	for _, page := range w.pages {
+		if _, ok := page[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *recentIDWindow) add(pageIDs []string) {
+	page := make(map[string]struct{}, len(pageIDs))
+	for _, id := range pageIDs {
+		page[id] = struct{}{}
+	}
+	w.pages = append(w.pages, page)
+	if len(w.pages) > w.max {
+		w.pages = w.pages[1:]
+	}
+}
+
+// backfillChat walks the chat's history oldest-ward (direction=before) from
+// the stored resume cursor until the beginning of locally-available history.
+// The incremental cursor (Newest) is primed from the first page so later runs
+// can extend forward. Fetch errors leave the chat resumable rather than
+// failing the run.
+func (imp *Importer) backfillChat(ctx context.Context, cc *chatScope, state *SyncState, sum *ImportSummary) error {
+	cs := cc.cs
+	pages := 0
+	processed := 0
+	recent := newRecentIDWindow(recentIDWindowPages)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		cursor, direction := cs.Oldest, "before"
+		if cursor == "" {
+			direction = "" // first page: newest messages
+		}
+		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, direction)
+		if err != nil {
+			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		if cs.Newest == "" && page.NewestCursor != "" {
+			cs.Newest = page.NewestCursor
+		}
+		// The live API does not report hasMore=false at the beginning of
+		// history (observed stuck true): exhaustion is signalled by an empty
+		// page with null cursors.
+		if len(page.Items) == 0 {
+			cs.Done = true
+			return nil
+		}
+		// Near the beginning of history the live API degenerates: it re-serves
+		// the oldest messages under a synthetic decrementing cursor, still with
+		// hasMore=true. Skip items this walk already persisted and treat a page
+		// with nothing new as end-of-history.
+		pageIDs := make([]string, 0, len(page.Items))
+		newItems := 0
+		for i := range page.Items {
+			m := &page.Items[i]
+			pageIDs = append(pageIDs, m.ID)
+			if recent.contains(m.ID) {
+				continue
+			}
+			newItems++
+			if err := imp.processMessage(ctx, cc, m, false, sum); err != nil {
+				return err
+			}
+			processed++
+		}
+		recent.add(pageIDs)
+		armAnchorFromPage(state, cc.chatID, page.Items)
+		if newItems == 0 {
+			cs.Done = true
+			return nil
+		}
+		if page.OldestCursor != "" {
+			cs.Oldest = page.OldestCursor
+		}
+		pages++
+		if pages%checkpointPageInterval == 0 {
+			imp.checkpoint(cc.syncID, state, sum)
+		}
+		if !page.HasMore {
+			cs.Done = true
+			return nil
+		}
+		if cc.opts.Limit > 0 && processed >= cc.opts.Limit {
+			return nil // resumable: Done stays false
+		}
+		if page.OldestCursor == "" {
+			// Defensive: hasMore without a cursor would loop on the same page.
+			return nil
+		}
+	}
+}
+
+// incrementalChat fetches messages newer than the stored cursor
+// (direction=after, oldest→newest) and advances the cursor.
+func (imp *Importer) incrementalChat(ctx context.Context, cc *chatScope, sum *ImportSummary) error {
+	cs := cc.cs
+	cursor := cs.Newest
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, "after")
+		if err != nil {
+			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		// An empty page (null cursors) marks the head; hasMore is not a
+		// reliable signal on the live API.
+		if len(page.Items) == 0 {
+			return nil
+		}
+		for i := range page.Items {
+			if err := imp.processMessage(ctx, cc, &page.Items[i], true, sum); err != nil {
+				if errors.Is(err, errRetryPage) {
+					return nil // cursor not advanced; next run retries this page
+				}
+				return err
+			}
+		}
+		// A non-advancing cursor means the API is re-serving the same page
+		// (same misbehavior the backfill defends against): stop rather than
+		// spin forever.
+		if page.NewestCursor == "" || page.NewestCursor == cursor {
+			return nil
+		}
+		cursor = page.NewestCursor
+		cs.Newest = cursor
+		if !page.HasMore {
+			return nil
+		}
+	}
+}
+
+// reconcileChat re-walks the head of the chat (newest-ward pages) re-upserting
+// messages newer than cutoff. This catches in-place edits, deletions, and
+// reaction changes on recent messages, which the forward-only incremental
+// cursor cannot observe. Changes older than the window are only repaired by
+// --full runs (documented limitation).
+func (imp *Importer) reconcileChat(ctx context.Context, cc *chatScope, cutoff time.Time, sum *ImportSummary) error {
+	cursor, direction := "", ""
+	for range maxReconcilePages {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, direction)
+		if err != nil {
+			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		reachedCutoff := false
+		for i := range page.Items {
+			m := &page.Items[i]
+			if m.Timestamp.Before(cutoff) {
+				reachedCutoff = true
+				continue
+			}
+			// Targets in this window are re-persisted anyway, refreshing
+			// their embedded reactions[], so REACTION events need no refetch.
+			if err := imp.processMessage(ctx, cc, m, false, sum); err != nil {
+				return err
+			}
+		}
+		if reachedCutoff || len(page.Items) == 0 || !page.HasMore || page.OldestCursor == "" {
+			return nil
+		}
+		cursor, direction = page.OldestCursor, "before"
+	}
+	return nil
+}
+
+// processMessage routes one message event: REACTION events refresh their
+// target (when refetchReactionTarget is set), deletions tombstone, hidden
+// events are skipped, and everything else persists.
+func (imp *Importer) processMessage(ctx context.Context, cc *chatScope, m *Message, refetchReactionTarget bool, sum *ImportSummary) error {
+	if m.Type == "REACTION" {
+		// The target message's embedded reactions[] are the authoritative
+		// current state. Backfill and reconcile walks visit the target
+		// anyway; only the incremental walk must refetch it (the target is
+		// older than its cursor).
+		if !refetchReactionTarget || m.LinkedMessageID == "" {
+			return nil
+		}
+		return imp.refreshReactionTarget(ctx, cc, m, sum)
+	}
+	if m.IsDeleted {
+		if err := imp.store.MarkMessageDeleted(cc.sourceID, m.ID); err != nil {
+			sum.Errors++
+		}
+		sum.MessagesProcessed++
+		return nil
+	}
+	if m.IsHidden {
+		return nil
+	}
+	err := imp.persistMessage(ctx, cc, m, sum)
+	if err == nil {
+		sum.MessagesProcessed++
+	}
+	return err
+}
+
+// refreshReactionTarget re-fetches and re-persists the message a REACTION
+// event points at, refreshing its embedded reactions (and any edit). A 404
+// target is expected churn; other fetch failures return errRetryPage so the
+// incremental cursor does not advance past the event — the reaction would
+// otherwise be lost, since its target is outside the reconcile window.
+func (imp *Importer) refreshReactionTarget(ctx context.Context, cc *chatScope, m *Message, sum *ImportSummary) error {
+	target, err := imp.client.GetMessage(ctx, cc.chatID, m.LinkedMessageID)
+	if errors.Is(err, ErrNotFound) {
+		imp.recordItem(cc.syncID, m.ID, "reaction", store.SyncRunItemStatusSkipped, "beeper_reaction_target_missing", err)
+		return nil
+	}
+	if err != nil {
+		imp.recordItem(cc.syncID, m.ID, "reaction", store.SyncRunItemStatusError, "beeper_fetch_error", err)
+		sum.FetchErrors++
+		sum.Errors++
+		return errRetryPage
+	}
+	if target.IsDeleted {
+		if derr := imp.store.MarkMessageDeleted(cc.sourceID, target.ID); derr != nil {
+			sum.Errors++
+		}
+		return nil
+	}
+	if target.IsHidden || target.Type == "REACTION" {
+		return nil
+	}
+	if err := imp.persistMessage(ctx, cc, target, sum); err != nil {
+		return err
+	}
+	sum.ReactionsRefreshed++
+	return nil
+}
+
+// persistMessage writes a single message via the granular store path.
+// Store-level failures are fatal (they indicate DB problems, not item churn);
+// per-item auxiliary failures (FTS, recipients, reactions) are counted and
+// recorded but do not abort the run.
+func (imp *Importer) persistMessage(ctx context.Context, cc *chatScope, m *Message, sum *ImportSummary) error {
+	msg, text := mapMessage(m, cc.convID, cc.sourceID)
+	senderPID, err := imp.res.resolveID(m.SenderID, m.SenderName)
+	if err != nil {
+		return err
+	}
+	if senderPID != 0 {
+		msg.SenderID = sql.NullInt64{Int64: senderPID, Valid: true}
+		if cerr := imp.store.EnsureConversationParticipant(cc.convID, senderPID, "member"); cerr != nil {
+			sum.Errors++
+		}
+	}
+	messageID, err := imp.store.UpsertMessage(&msg)
+	if err != nil {
+		return err
+	}
+	if err := imp.store.UpsertMessageBody(messageID, sql.NullString{String: text, Valid: text != ""}, sql.NullString{}); err != nil {
+		return err
+	}
+	// Archive the exact original message JSON. m.Raw is captured verbatim at
+	// decode time (Message.UnmarshalJSON) so it preserves every API field
+	// including ones we do not model; fall back to re-marshalling only if a
+	// message was constructed without going through a decode.
+	raw := []byte(m.Raw)
+	if len(raw) == 0 {
+		marshaled, merr := json.Marshal(m)
+		if merr != nil {
+			return fmt.Errorf("marshal beeper message raw archive: %w", merr)
+		}
+		raw = marshaled
+	}
+	if err := imp.store.UpsertMessageRawWithFormat(messageID, raw, "beeper_json"); err != nil {
+		return fmt.Errorf("archive beeper message raw: %w", err)
+	}
+	if err := imp.store.UpsertFTS(messageID, "", text, m.SenderName, "", ""); err != nil {
+		sum.Errors++
+	}
+	if m.EditedTimestamp != nil && !m.EditedTimestamp.IsZero() {
+		if err := imp.store.SetMessageEdited(messageID); err != nil {
+			sum.Errors++
+		}
+	}
+
+	if !cc.opts.NoMedia && cc.opts.AttachmentsDir != "" {
+		imp.persistAttachments(ctx, cc.syncID, messageID, m, cc.opts, sum)
+	}
+
+	if err := imp.persistMentions(messageID, m, sum); err != nil {
+		return err
+	}
+	if err := imp.persistReactions(messageID, m, sum); err != nil {
+		return err
+	}
+
+	// Pages arrive newest-first, so a reply can precede its parent even
+	// within one page; buffer all pairs in the (checkpointed) chat state and
+	// link after the walk.
+	if m.LinkedMessageID != "" {
+		cc.cs.PendingReplies = append(cc.cs.PendingReplies, [2]string{m.ID, m.LinkedMessageID})
+	}
+
+	sum.MessagesAdded++
+	return nil
+}
+
+// persistMentions writes "mention" recipient rows. No from/to rows are
+// written: sender attribution lives in messages.sender_id and membership in
+// conversation_participants (WhatsApp-importer precedent), which avoids a
+// messages × group-size row explosion.
+func (imp *Importer) persistMentions(messageID int64, m *Message, sum *ImportSummary) error {
+	var ids []int64
+	seen := map[int64]struct{}{}
+	for _, uid := range m.Mentions {
+		if uid == "" || uid == "@room" {
+			continue
+		}
+		pid, err := imp.res.resolveID(uid, "")
+		if err != nil {
+			return err
+		}
+		if _, dup := seen[pid]; pid == 0 || dup {
+			continue
+		}
+		seen[pid] = struct{}{}
+		ids = append(ids, pid)
+	}
+	if err := imp.store.ReplaceMessageRecipients(messageID, "mention", ids, make([]string, len(ids))); err != nil {
+		sum.Errors++
+	}
+	return nil
+}
+
+// persistReactions replaces the message's reactions from the embedded set.
+// Embedded reactions carry no timestamp; created_at approximates with the
+// target message's timestamp (cosmetic only).
+func (imp *Importer) persistReactions(messageID int64, m *Message, sum *ImportSummary) error {
+	reactions := make([]store.ReactionRef, 0, len(m.Reactions))
+	for _, rc := range m.Reactions {
+		pid, err := imp.res.resolveID(rc.ParticipantID, "")
+		if err != nil {
+			return err
+		}
+		if pid == 0 {
+			continue
+		}
+		typ := "key"
+		if rc.Emoji {
+			typ = "emoji"
+		}
+		reactions = append(reactions, store.ReactionRef{
+			ParticipantID: pid,
+			Type:          typ,
+			Value:         rc.ReactionKey,
+			CreatedAt:     m.Timestamp,
+		})
+	}
+	if err := imp.store.ReplaceReactions(messageID, reactions); err != nil {
+		sum.Errors++
+	}
+	return nil
+}
+
+// flushReplies links the chat's buffered reply pairs now that both sides of
+// each pair have been archived. SetReplyTo is idempotent; pairs whose parents
+// are beyond locally-available history resolve to NULL.
+func (imp *Importer) flushReplies(cc *chatScope, sum *ImportSummary) {
+	for _, pr := range cc.cs.PendingReplies {
+		if err := imp.store.SetReplyTo(cc.sourceID, pr[0], pr[1]); err != nil {
+			sum.Errors++
+		}
+	}
+	cc.cs.PendingReplies = nil
+}
+
+// checkpoint persists the sync state mid-run so an interrupted run resumes.
+// Flushes are throttled — the blob is O(chats) JSON (see checkpointMinInterval).
+func (imp *Importer) checkpoint(syncID int64, state *SyncState, sum *ImportSummary) {
+	if time.Since(imp.lastCheckpoint) < checkpointMinInterval {
+		return
+	}
+	imp.checkpointNow(syncID, state, sum)
+}
+
+// checkpointNow persists the sync state unconditionally: for the initial
+// resume-state write and the final counters, which must never be skipped.
+func (imp *Importer) checkpointNow(syncID int64, state *SyncState, sum *ImportSummary) {
+	blob, err := state.Marshal()
+	if err != nil {
+		return
+	}
+	if imp.store.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+		PageToken:         blob,
+		MessagesProcessed: sum.MessagesProcessed,
+		MessagesAdded:     sum.MessagesAdded,
+		ErrorsCount:       sum.Errors,
+	}) == nil {
+		imp.lastCheckpoint = time.Now()
+	}
+}
+
+// recordItem records a per-item outcome on the sync run.
+func (imp *Importer) recordItem(syncID int64, sourceMessageID, phase, status, kind string, err error) {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	_ = imp.store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: sourceMessageID,
+		Phase:           phase,
+		Status:          status,
+		ErrorKind:       kind,
+		ErrorMessage:    msg,
+	})
+}
+
+func parseWatermark(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// formatWatermark renders a fixed-width UTC RFC3339 string so watermarks are
+// order-comparable as strings (see SyncState.Merge).
+func formatWatermark(t time.Time) string {
+	return t.UTC().Truncate(time.Second).Format(time.RFC3339)
+}

--- a/internal/beeper/importer.go
+++ b/internal/beeper/importer.go
@@ -47,6 +47,15 @@ type chatScope struct {
 	opts               ImportOptions
 	cs                 *ChatState
 	membershipComplete bool
+	budgetUsed         int
+}
+
+func (cc *chatScope) limitReached() bool {
+	return cc.opts.Limit > 0 && cc.budgetUsed >= cc.opts.Limit
+}
+
+func (cc *chatScope) chargeBudget(processed int) {
+	cc.budgetUsed += processed
 }
 
 // Importer ingests Beeper Desktop messages into the msgvault store. One
@@ -239,6 +248,9 @@ func (imp *Importer) enumerateChats(ctx context.Context, syncID int64, opts Impo
 			continue
 		}
 		if gerr != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			imp.recordItem(syncID, chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
 			sum.FetchErrors++
 			sum.Errors++
@@ -271,7 +283,7 @@ func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *C
 		err = imp.backfillChat(ctx, cc, state, sum)
 	} else {
 		err = imp.incrementalChat(ctx, cc, sum)
-		if err == nil {
+		if err == nil && !cc.limitReached() {
 			err = imp.reconcileChat(ctx, cc, reconcileCutoff, sum)
 		}
 	}
@@ -297,6 +309,9 @@ func (imp *Importer) ensureConversation(ctx context.Context, syncID, sourceID in
 	if ch.Participants.HasMore {
 		d, gerr := imp.client.GetChat(ctx, ch.ID)
 		if gerr != nil {
+			if ctx.Err() != nil {
+				return 0, false, ctx.Err()
+			}
 			imp.recordItem(syncID, ch.ID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
 			sum.FetchErrors++
 			sum.Errors++
@@ -383,11 +398,13 @@ func (w *recentIDWindow) add(pageIDs []string) {
 func (imp *Importer) backfillChat(ctx context.Context, cc *chatScope, state *SyncState, sum *ImportSummary) error {
 	cs := cc.cs
 	pages := 0
-	processed := 0
 	recent := newRecentIDWindow(recentIDWindowPages)
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		if cc.limitReached() {
+			return nil
 		}
 		cursor, direction := cs.Oldest, "before"
 		if cursor == "" {
@@ -395,6 +412,9 @@ func (imp *Importer) backfillChat(ctx context.Context, cc *chatScope, state *Syn
 		}
 		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, direction)
 		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
@@ -426,8 +446,8 @@ func (imp *Importer) backfillChat(ctx context.Context, cc *chatScope, state *Syn
 			if err := imp.processMessage(ctx, cc, m, false, sum); err != nil {
 				return err
 			}
-			processed++
 		}
+		cc.chargeBudget(newItems)
 		recent.add(pageIDs)
 		armAnchorFromPage(state, cc.chatID, page.Items)
 		if newItems == 0 {
@@ -445,7 +465,7 @@ func (imp *Importer) backfillChat(ctx context.Context, cc *chatScope, state *Syn
 			cs.Done = true
 			return nil
 		}
-		if cc.opts.Limit > 0 && processed >= cc.opts.Limit {
+		if cc.limitReached() {
 			return nil // resumable: Done stays false
 		}
 		if page.OldestCursor == "" {
@@ -464,8 +484,14 @@ func (imp *Importer) incrementalChat(ctx context.Context, cc *chatScope, sum *Im
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		if cc.limitReached() {
+			return nil
+		}
 		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, "after")
 		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
@@ -476,6 +502,7 @@ func (imp *Importer) incrementalChat(ctx context.Context, cc *chatScope, sum *Im
 		if len(page.Items) == 0 {
 			return nil
 		}
+		processed := 0
 		for i := range page.Items {
 			if err := imp.processMessage(ctx, cc, &page.Items[i], true, sum); err != nil {
 				if errors.Is(err, errRetryPage) {
@@ -483,7 +510,9 @@ func (imp *Importer) incrementalChat(ctx context.Context, cc *chatScope, sum *Im
 				}
 				return err
 			}
+			processed++
 		}
+		cc.chargeBudget(processed)
 		// A non-advancing cursor means the API is re-serving the same page
 		// (same misbehavior the backfill defends against): stop rather than
 		// spin forever.
@@ -492,6 +521,9 @@ func (imp *Importer) incrementalChat(ctx context.Context, cc *chatScope, sum *Im
 		}
 		cursor = page.NewestCursor
 		cs.Newest = cursor
+		if cc.limitReached() {
+			return nil
+		}
 		if !page.HasMore {
 			return nil
 		}
@@ -509,14 +541,21 @@ func (imp *Importer) reconcileChat(ctx context.Context, cc *chatScope, cutoff ti
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		if cc.limitReached() {
+			return nil
+		}
 		page, err := imp.client.ListMessagesPage(ctx, cc.chatID, cursor, direction)
 		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			imp.recordItem(cc.syncID, cc.chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
 			return nil
 		}
 		reachedCutoff := false
+		processed := 0
 		for i := range page.Items {
 			m := &page.Items[i]
 			if m.Timestamp.Before(cutoff) {
@@ -528,8 +567,10 @@ func (imp *Importer) reconcileChat(ctx context.Context, cc *chatScope, cutoff ti
 			if err := imp.processMessage(ctx, cc, m, false, sum); err != nil {
 				return err
 			}
+			processed++
 		}
-		if reachedCutoff || len(page.Items) == 0 || !page.HasMore || page.OldestCursor == "" {
+		cc.chargeBudget(processed)
+		if cc.limitReached() || reachedCutoff || len(page.Items) == 0 || !page.HasMore || page.OldestCursor == "" {
 			return nil
 		}
 		cursor, direction = page.OldestCursor, "before"
@@ -580,6 +621,9 @@ func (imp *Importer) refreshReactionTarget(ctx context.Context, cc *chatScope, m
 		return nil
 	}
 	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		imp.recordItem(cc.syncID, m.ID, "reaction", store.SyncRunItemStatusError, "beeper_fetch_error", err)
 		sum.FetchErrors++
 		sum.Errors++

--- a/internal/beeper/importer.go
+++ b/internal/beeper/importer.go
@@ -131,7 +131,8 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 		return sum, err
 	}
 
-	chats, err := imp.enumerateChats(ctx, syncID, opts, state, sum)
+	reconcileCutoff := start.Add(-reconcileWindow)
+	chats, err := imp.enumerateChats(ctx, syncID, opts, state, reconcileCutoff, sum)
 	if err != nil {
 		return sum, err
 	}
@@ -139,8 +140,6 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 	// Reconciliation re-walks each active chat's last-24h head to catch
 	// in-place edits/deletions/reaction changes the forward-only cursor cannot
 	// see. Cheap on re-runs: already-stored media is never re-downloaded.
-	reconcileCutoff := start.Add(-reconcileWindow)
-
 	maxActivity := parseWatermark(state.ListWatermark)
 	total := len(chats)
 	for idx := range chats {
@@ -189,16 +188,21 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 	return sum, nil
 }
 
-// enumerateChats lists the chats this run must visit: every chat with
-// activity after the watermark (all chats on first/full runs), plus any chat
-// whose backfill is unfinished even without new activity.
-func (imp *Importer) enumerateChats(ctx context.Context, syncID int64, opts ImportOptions, state *SyncState, sum *ImportSummary) ([]Chat, error) {
+// enumerateChats lists the chats this run must visit: every chat active in
+// the discovery overlap or reconciliation window (all chats on first/full
+// runs), plus any chat whose backfill is unfinished even without new activity.
+func (imp *Importer) enumerateChats(ctx context.Context, syncID int64, opts ImportOptions, state *SyncState, reconcileCutoff time.Time, sum *ImportSummary) ([]Chat, error) {
 	params := SearchChatsParams{AccountID: opts.AccountID}
 	if !opts.Full && state.ListWatermark != "" {
 		if wm := parseWatermark(state.ListWatermark); !wm.IsZero() {
 			// Overlap by an hour so clock skew or a mid-listing crash cannot
-			// permanently hide a chat from enumeration.
+			// permanently hide a chat from enumeration. Also include every chat
+			// inside the reconciliation window so in-place changes are revisited
+			// even when their LastActivity did not advance.
 			params.LastActivityAfter = wm.Add(-time.Hour)
+			if reconcileCutoff.Before(params.LastActivityAfter) {
+				params.LastActivityAfter = reconcileCutoff
+			}
 		}
 	}
 	var chats []Chat

--- a/internal/beeper/importer.go
+++ b/internal/beeper/importer.go
@@ -40,12 +40,13 @@ const (
 // PendingReplies buffer persistMessage appends to, keeping checkpoints
 // consistent with the cursor by construction).
 type chatScope struct {
-	chatID   string
-	convID   int64
-	sourceID int64
-	syncID   int64
-	opts     ImportOptions
-	cs       *ChatState
+	chatID             string
+	convID             int64
+	sourceID           int64
+	syncID             int64
+	opts               ImportOptions
+	cs                 *ChatState
+	membershipComplete bool
 }
 
 // Importer ingests Beeper Desktop messages into the msgvault store. One
@@ -243,13 +244,16 @@ func (imp *Importer) enumerateChats(ctx context.Context, syncID int64, opts Impo
 // incrementally extends the chat's messages. Returns the number of messages
 // processed for this chat.
 func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *Chat, opts ImportOptions, state *SyncState, reconcileCutoff time.Time, sum *ImportSummary) (int64, error) {
-	convID, err := imp.ensureConversation(ctx, syncID, sourceID, ch, sum)
+	convID, membershipComplete, err := imp.ensureConversation(ctx, syncID, sourceID, ch, sum)
 	if err != nil {
 		return 0, err
 	}
 
 	cs := state.EnsureChat(ch.ID)
-	cc := &chatScope{chatID: ch.ID, convID: convID, sourceID: sourceID, syncID: syncID, opts: opts, cs: cs}
+	cc := &chatScope{
+		chatID: ch.ID, convID: convID, sourceID: sourceID, syncID: syncID,
+		opts: opts, cs: cs, membershipComplete: membershipComplete,
+	}
 	before := sum.MessagesProcessed
 
 	// A chat that was empty when backfilled has Done set but no incremental
@@ -278,8 +282,9 @@ func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *C
 // ensureConversation upserts the conversation row and its membership,
 // fetching the full participant list when the search listing truncated it
 // (chat search returns at most 20 participants per chat).
-func (imp *Importer) ensureConversation(ctx context.Context, syncID, sourceID int64, ch *Chat, sum *ImportSummary) (int64, error) {
+func (imp *Importer) ensureConversation(ctx context.Context, syncID, sourceID int64, ch *Chat, sum *ImportSummary) (int64, bool, error) {
 	detail := ch
+	membershipComplete := !ch.Participants.HasMore
 	if ch.Participants.HasMore {
 		d, gerr := imp.client.GetChat(ctx, ch.ID)
 		if gerr != nil {
@@ -288,17 +293,19 @@ func (imp *Importer) ensureConversation(ctx context.Context, syncID, sourceID in
 			sum.Errors++
 		} else {
 			detail = d
+			membershipComplete = !d.Participants.HasMore
 		}
 	}
 	convID, err := imp.store.EnsureConversationWithType(sourceID, ch.ID, conversationType(ch.Type), ch.Title)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
+	members := make([]store.ConversationParticipantRef, 0, len(detail.Participants.Items))
 	for i := range detail.Participants.Items {
 		p := &detail.Participants.Items[i]
 		pid, rerr := imp.res.resolveUser(&p.User)
 		if rerr != nil {
-			return 0, rerr
+			return 0, false, rerr
 		}
 		if pid == 0 {
 			continue
@@ -307,11 +314,20 @@ func (imp *Importer) ensureConversation(ctx context.Context, syncID, sourceID in
 		if p.IsAdmin {
 			role = "admin"
 		}
-		if cerr := imp.store.EnsureConversationParticipant(convID, pid, role); cerr != nil {
-			sum.Errors++
+		members = append(members, store.ConversationParticipantRef{ParticipantID: pid, Role: role})
+	}
+	if membershipComplete {
+		if err := imp.store.ReplaceConversationParticipants(convID, members); err != nil {
+			return 0, false, err
+		}
+	} else {
+		for _, member := range members {
+			if cerr := imp.store.EnsureConversationParticipant(convID, member.ParticipantID, member.Role); cerr != nil {
+				sum.Errors++
+			}
 		}
 	}
-	return convID, nil
+	return convID, membershipComplete, nil
 }
 
 // recentIDWindow remembers the message IDs of the last few pages of a
@@ -588,8 +604,10 @@ func (imp *Importer) persistMessage(ctx context.Context, cc *chatScope, m *Messa
 	}
 	if senderPID != 0 {
 		msg.SenderID = sql.NullInt64{Int64: senderPID, Valid: true}
-		if cerr := imp.store.EnsureConversationParticipant(cc.convID, senderPID, "member"); cerr != nil {
-			sum.Errors++
+		if !cc.membershipComplete {
+			if cerr := imp.store.EnsureConversationParticipant(cc.convID, senderPID, "member"); cerr != nil {
+				sum.Errors++
+			}
 		}
 	}
 	messageID, err := imp.store.UpsertMessage(&msg)

--- a/internal/beeper/importer_fts_test.go
+++ b/internal/beeper/importer_fts_test.go
@@ -1,0 +1,40 @@
+//go:build fts5
+
+package beeper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// TestImportIndexesFTS verifies imported messages (including voice-note
+// transcriptions) land in the SQLite FTS5 index. Gated on the fts5 build tag
+// and skipped on PostgreSQL, which uses a tsvector column instead of the
+// messages_fts vtable (fbmessenger FTS test pattern).
+func TestImportIndexesFTS(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	testutil.SkipIfPostgres(t, "directly MATCH-queries the SQLite FTS5 vtable")
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	require.True(st.FTS5Available(), "fts5 build tag set but FTS5 unavailable")
+
+	var ftsHits int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'tomorrow'`).Scan(&ftsHits))
+	assert.Equal(1, ftsHits, "voice transcription must be FTS-indexed")
+
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM messages_fts`).Scan(&ftsHits))
+	assert.Equal(43, ftsHits, "every persisted message must be FTS-indexed")
+}

--- a/internal/beeper/importer_test.go
+++ b/internal/beeper/importer_test.go
@@ -1,0 +1,826 @@
+package beeper
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// e2eChat builds a chat exercising every persist path: replies, reactions,
+// deletions, hidden events, edits, transcriptions, and mentions. Timestamps
+// are older than the reconcile window so head re-walks terminate immediately.
+func e2eChat() *fakeChat {
+	base := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!e2e:beeper.local", AccountID: "signal", Network: "Signal",
+		Title: "E2E", Type: "group",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@15550100010:beeper.local", "fullName": "Alice", "phoneNumber": "+15550100010", "isAdmin": true},
+			{"id": "@signal_bob:beeper.local", "fullName": "Bob", "email": "bob@example.com"},
+		},
+	}
+	for i := range 45 {
+		m := fakeMsg{
+			ID: "m" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "hello " + strconv.Itoa(i),
+			SenderID:  "@15550100010:beeper.local", SenderName: "Alice",
+		}
+		switch i {
+		case 10:
+			m.Reactions = []map[string]any{
+				{"id": "@signal_bob:beeper.local", "reactionKey": "👍", "participantID": "@signal_bob:beeper.local", "emoji": true},
+			}
+		case 20:
+			m.LinkedMessageID = "m5"
+		case 30:
+			m.IsDeleted = true
+		case 31:
+			m.IsHidden = true
+		case 40:
+			edited := m.Timestamp.Add(time.Hour)
+			m.EditedTimestamp = &edited
+		case 41:
+			m.Type = "VOICE"
+			m.Text = ""
+			m.Attachments = []map[string]any{
+				{"id": "mxc://x/voice41", "type": "audio", "isVoiceNote": true,
+					"transcription": map[string]any{"transcription": "call me back tomorrow", "engine": "test"}},
+			}
+		case 42:
+			m.Mentions = []string{"@signal_bob:beeper.local", "@room"}
+		}
+		ch.Msgs = append(ch.Msgs, m)
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	return ch
+}
+
+func newTestImporter(t *testing.T, f *fakeBeeper) (*Importer, *store.Store, func()) {
+	t.Helper()
+	srv := f.server()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, NewClient(srv.URL, testToken, 10000))
+	return imp, st, srv.Close
+}
+
+func TestImportBackfillEndToEnd(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	assert.EqualValues(1, sum.ChatsProcessed)
+	assert.EqualValues(44, sum.MessagesProcessed, "43 persisted + 1 deletion tombstone; hidden events are not counted")
+	assert.EqualValues(43, sum.MessagesAdded)
+	assert.EqualValues(0, sum.Errors)
+
+	var msgCount int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&msgCount))
+	assert.Equal(43, msgCount)
+
+	// Conversation and its full participant list (admin role preserved).
+	var convID int64
+	var convType string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id, conversation_type FROM conversations WHERE source_conversation_id = ?`,
+	), "!e2e:beeper.local").Scan(&convID, &convType))
+	assert.Equal("group_chat", convType)
+	var partCount, adminCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ?`), convID).Scan(&partCount))
+	assert.Equal(3, partCount)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ? AND role='admin'`), convID).Scan(&adminCount))
+	assert.Equal(1, adminCount)
+
+	// Phone participant deduped by E.164, sender attribution set.
+	var alicePID int64
+	require.NoError(st.DB().QueryRow(
+		`SELECT id FROM participants WHERE phone_number = '+15550100010'`).Scan(&alicePID))
+	var senderCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE sender_id = ? AND message_type='beeper'`), alicePID).Scan(&senderCount))
+	assert.Equal(43, senderCount)
+
+	// Reply linked to its parent.
+	var parentID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "m5").Scan(&parentID))
+	var linkedParent sql.NullInt64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT reply_to_message_id FROM messages WHERE source_message_id = ?`), "m20").Scan(&linkedParent))
+	require.True(linkedParent.Valid)
+	assert.Equal(parentID, linkedParent.Int64)
+
+	// Embedded reaction persisted.
+	var reactionValue string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT r.reaction_value FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ?`), "m10").Scan(&reactionValue))
+	assert.Equal("👍", reactionValue)
+
+	// Edit flag set.
+	var isEdited bool
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT is_edited FROM messages WHERE source_message_id = ?`), "m40").Scan(&isEdited))
+	assert.True(isEdited)
+
+	// Voice transcription is searchable (body + FTS).
+	var voiceBody string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT b.body_text FROM message_bodies b
+		JOIN messages m ON m.id = b.message_id
+		WHERE m.source_message_id = ?`), "m41").Scan(&voiceBody))
+	assert.Contains(voiceBody, "[voice message]")
+	assert.Contains(voiceBody, "call me back tomorrow")
+
+	// Mentions become mention recipient rows; @room is skipped; no from/to rows.
+	var mentionCount, fromToCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'mention'`), "m42").Scan(&mentionCount))
+	assert.Equal(1, mentionCount)
+	require.NoError(st.DB().QueryRow(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.message_type = 'beeper' AND mr.recipient_type IN ('from','to')`).Scan(&fromToCount))
+	assert.Zero(fromToCount)
+
+	// Raw JSON archived with the beeper_json format tag.
+	var rawFormat string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mr.raw_format FROM message_raw mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ?`), "m10").Scan(&rawFormat))
+	assert.Equal("beeper_json", rawFormat)
+
+	// Sync state persisted: backfill complete, incremental cursor primed, anchor set.
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	require.True(run.CursorAfter.Valid)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	cs := state.Chats["!e2e:beeper.local"]
+	require.NotNil(cs)
+	assert.True(cs.Done)
+	assert.NotEmpty(cs.Newest)
+	require.NotEmpty(state.Anchors)
+	assert.NotEmpty(state.ListWatermark)
+
+	// Conversation stats recomputed.
+	var statCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT message_count FROM conversations WHERE id = ?`), convID).Scan(&statCount))
+	assert.Equal(43, statCount)
+
+	// The completed run persists its final counters for sync diagnostics
+	// (mid-run checkpoints are throttled and may never have fired).
+	var processed, added int64
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT messages_processed, messages_added FROM sync_runs
+		WHERE source_id = ? AND status = 'completed' ORDER BY id DESC LIMIT 1`), src.ID).
+		Scan(&processed, &added))
+	assert.EqualValues(44, processed)
+	assert.EqualValues(43, added)
+}
+
+func TestImportSecondRunIncremental(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// Three new messages arrive.
+	now := time.Now().UTC().Truncate(time.Second)
+	for i := range 3 {
+		f.appendMsg("!e2e:beeper.local", fakeMsg{
+			ID: "new" + strconv.Itoa(i), SortKey: 100 + i,
+			Timestamp: now.Add(time.Duration(i-3) * time.Minute),
+			Text:      "fresh " + strconv.Itoa(i),
+			SenderID:  "@signal_bob:beeper.local", SenderName: "Bob",
+		})
+	}
+
+	f.resetRequests()
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	// The reconcile pass may re-upsert recent messages, so MessagesAdded can
+	// exceed 3; the DB count is the duplicate-free ground truth.
+	assert.GreaterOrEqual(sum.MessagesAdded, int64(3))
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(46, total, "no duplicates on re-run")
+
+	// The second run must be cursor-driven: chat discovery filtered by
+	// activity, message fetches either direction=after (incremental) or the
+	// cursor-less head page (reconcile) — never a direction=before backfill.
+	var sawActivityFilter bool
+	for _, req := range f.requests() {
+		if strings.HasPrefix(req, "/v1/chats/search") {
+			sawActivityFilter = sawActivityFilter || strings.Contains(req, "lastActivityAfter=")
+		}
+		if strings.Contains(req, "/messages?") {
+			assert.NotContains(req, "direction=before", "second run must not re-backfill: %s", req)
+		}
+	}
+	assert.True(sawActivityFilter, "second run must filter chat discovery by lastActivityAfter")
+}
+
+func TestImportResumeAfterLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	base := time.Now().Add(-60 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!big:beeper.local", AccountID: "signal", Network: "Signal", Title: "Big", Type: "single",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+		},
+	}
+	for i := range 100 {
+		m := fakeMsg{
+			ID: "b" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "bulk " + strconv.Itoa(i),
+			SenderID:  "@signal_ann:beeper.local", SenderName: "Ann",
+		}
+		if i == 99 {
+			m.LinkedMessageID = "b5" // parent only reached by the resumed run
+		}
+		ch.Msgs = append(ch.Msgs, m)
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	// Run 1: limited — backfill stops early but stays resumable.
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal", Limit: 30})
+	require.NoError(err)
+
+	var afterRun1 int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&afterRun1))
+	require.Less(afterRun1, 100)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotNil(state.Chats["!big:beeper.local"])
+	assert.False(state.Chats["!big:beeper.local"].Done, "limited backfill must stay resumable")
+
+	// Run 2: unlimited — resumes from the stored cursor without refetching.
+	f.resetRequests()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(100, total)
+
+	for _, req := range f.requests() {
+		if strings.Contains(req, "/messages?") && strings.Contains(req, "direction=before") {
+			assert.Contains(req, "cursor=", "resumed backfill must continue from the stored cursor: %s", req)
+		}
+	}
+
+	// Chat now complete.
+	run, err = st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err = LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	assert.True(state.Chats["!big:beeper.local"].Done)
+
+	// The reply pair buffered in run 1 (parent beyond the limit) must have
+	// survived the interruption and linked once the resumed run archived it.
+	var parentID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "b5").Scan(&parentID))
+	var linked sql.NullInt64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT reply_to_message_id FROM messages WHERE source_message_id = ?`), "b99").Scan(&linked))
+	require.True(linked.Valid, "reply pairs must survive a resumed backfill")
+	assert.Equal(parentID, linked.Int64)
+}
+
+func TestImportReactionEventRefreshesTarget(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// Bob reacts to an old message: the network delivers a REACTION event and
+	// the target's embedded reactions[] now include it.
+	ch := f.chat("!e2e:beeper.local")
+	ch.Msgs[5].Reactions = []map[string]any{
+		{"id": "@signal_bob:beeper.local", "reactionKey": "❤️", "participantID": "@signal_bob:beeper.local", "emoji": true},
+	}
+	f.appendMsg("!e2e:beeper.local", fakeMsg{
+		ID: "react1", SortKey: 200, Timestamp: time.Now().UTC().Truncate(time.Second),
+		Type: "REACTION", IsHidden: true, LinkedMessageID: "m5",
+		SenderID: "@signal_bob:beeper.local", SenderName: "Bob",
+	})
+
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	assert.EqualValues(1, sum.ReactionsRefreshed)
+
+	var reactionValue string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT r.reaction_value FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ?`), "m5").Scan(&reactionValue))
+	assert.Equal("❤️", reactionValue)
+
+	// The REACTION event itself must not become a message row.
+	var eventRows int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "react1").Scan(&eventRows))
+	assert.Zero(eventRows)
+}
+
+func TestImportReconcileCatchesRecentDeletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	// Recent chat: all messages inside the reconcile window.
+	base := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!recent:beeper.local", AccountID: "signal", Network: "Signal", Title: "Recent", Type: "single",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+		},
+	}
+	for i := range 5 {
+		ch.Msgs = append(ch.Msgs, fakeMsg{
+			ID: "r" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "recent " + strconv.Itoa(i),
+			SenderID:  "@signal_ann:beeper.local", SenderName: "Ann",
+		})
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// The sender deletes r2 in place; the chat sees new activity so the next
+	// run visits it and the reconcile pass observes the tombstone.
+	f.chat("!recent:beeper.local").Msgs[2].IsDeleted = true
+	f.appendMsg("!recent:beeper.local", fakeMsg{
+		ID: "r5", SortKey: 5, Timestamp: time.Now().UTC().Truncate(time.Second),
+		Text: "newest", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+	})
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var deletedAt sql.NullTime
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT deleted_from_source_at FROM messages WHERE source_message_id = ?`), "r2").Scan(&deletedAt))
+	assert.True(deletedAt.Valid, "reconcile pass must tombstone recent deletions")
+
+	// The archived content survives deletion — that is the point of the archive.
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT b.body_text FROM message_bodies b
+		JOIN messages m ON m.id = b.message_id
+		WHERE m.source_message_id = ?`), "r2").Scan(&body))
+	assert.Equal("recent 2", body)
+}
+
+func TestImportReactionTargetTransientErrorRetries(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// A reaction arrives for an old message, but fetching the target fails
+	// transiently: the cursor must NOT advance past the event, or the
+	// reaction would be lost forever (target is outside the reconcile window).
+	ch := f.chat("!e2e:beeper.local")
+	ch.Msgs[5].Reactions = []map[string]any{
+		{"id": "@signal_bob:beeper.local", "reactionKey": "🔥", "participantID": "@signal_bob:beeper.local", "emoji": true},
+	}
+	f.appendMsg("!e2e:beeper.local", fakeMsg{
+		ID: "react-t", SortKey: 300, Timestamp: time.Now().UTC().Truncate(time.Second),
+		Type: "REACTION", IsHidden: true, LinkedMessageID: "m5",
+		SenderID: "@signal_bob:beeper.local", SenderName: "Bob",
+	})
+	f.setMessageGetFailure("m5", true)
+
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	assert.Positive(sum.FetchErrors, "transient target failure must be recorded as a fetch error")
+
+	// Healed: the next run re-delivers the reaction event and archives it.
+	f.setMessageGetFailure("m5", false)
+	sum, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	assert.EqualValues(1, sum.ReactionsRefreshed)
+
+	var reactionValue string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT r.reaction_value FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ?`), "m5").Scan(&reactionValue))
+	assert.Equal("🔥", reactionValue)
+}
+
+func TestImportTruncatedParticipantsFetchesDetail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	base := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!grp:beeper.local", AccountID: "signal", Network: "Signal", Title: "Grp", Type: "group",
+		ParticipantsTruncated: true,
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+			{"id": "@signal_bea:beeper.local", "fullName": "Bea"},
+		},
+		Msgs: []fakeMsg{{
+			ID: "g0", SortKey: 0, Timestamp: base, Text: "hi",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+		}},
+		LastActivity: base,
+	}
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var convID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM conversations WHERE source_conversation_id = ?`), "!grp:beeper.local").Scan(&convID))
+	var partCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ?`), convID).Scan(&partCount))
+	assert.Equal(3, partCount, "truncated listing must trigger a full-detail fetch")
+}
+
+func TestImportFullRepairsWithoutDuplicates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal", Full: true})
+	require.NoError(err)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(43, total, "--full re-walk must upsert in place")
+}
+
+func TestImportEmptyChatPicksUpLaterMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(&fakeChat{
+		ID: "!empty:beeper.local", AccountID: "signal", Network: "Signal", Title: "Empty", Type: "single",
+		Participants: []map[string]any{{"id": "@me:beeper.local", "isSelf": true}},
+		LastActivity: time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second),
+	})
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	require.Zero(total)
+
+	// The chat's first-ever message arrives after the empty backfill.
+	f.appendMsg("!empty:beeper.local", fakeMsg{
+		ID: "first", SortKey: 1, Timestamp: time.Now().UTC().Truncate(time.Second),
+		Text: "hello at last", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+	})
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(1, total, "a chat that was empty at backfill must still pick up later messages")
+}
+
+func TestImportDegenerateTailPagination(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// The live API never reports hasMore=false walking backward; past the
+	// oldest message it re-serves the tail under a synthetic decrementing
+	// cursor. The backfill must still terminate, mark the chat done, and not
+	// double-process the tail.
+	f := newFakeBeeper(t)
+	base := time.Now().Add(-60 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!tail:beeper.local", AccountID: "signal", Network: "Signal", Title: "Tail", Type: "single",
+		TailCountdown: true,
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+		},
+	}
+	for i := range 45 {
+		ch.Msgs = append(ch.Msgs, fakeMsg{
+			ID: "t" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "tail " + strconv.Itoa(i),
+			SenderID:  "@signal_ann:beeper.local", SenderName: "Ann",
+		})
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	assert.EqualValues(45, sum.MessagesProcessed, "tail re-serves must not be re-processed")
+	assert.EqualValues(45, sum.MessagesAdded)
+
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='beeper'`).Scan(&total))
+	assert.Equal(45, total)
+
+	// Terminates promptly: 3 real pages + 1 degenerate page.
+	msgRequests := 0
+	for _, req := range f.requests() {
+		if strings.Contains(req, "/messages") && !strings.Contains(req, "/messages/") {
+			msgRequests++
+		}
+	}
+	assert.LessOrEqual(msgRequests, 5, "degenerate tail must terminate the walk quickly")
+
+	// The chat is complete despite hasMore never going false.
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotNil(state.Chats["!tail:beeper.local"])
+	assert.True(state.Chats["!tail:beeper.local"].Done)
+}
+
+func TestBackfillCheckpointCarriesPendingReplies(t *testing.T) {
+	require := require.New(t)
+
+	// A mid-chat checkpoint advances the resume cursor past pages whose reply
+	// pairs are still only in memory; the checkpoint must persist those pairs
+	// too, or a hard interruption loses the links permanently.
+	oldInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = oldInterval })
+
+	f := newFakeBeeper(t)
+	base := time.Now().Add(-90 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!ckpt:beeper.local", AccountID: "signal", Network: "Signal", Title: "Ckpt", Type: "single",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+		},
+	}
+	// >25 pages so a mid-chat checkpoint fires; the newest message replies to
+	// a parent near the beginning of history, far beyond the interrupt point.
+	for i := range 600 {
+		m := fakeMsg{
+			ID: "c" + strconv.Itoa(i), SortKey: i,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      "ckpt " + strconv.Itoa(i),
+			SenderID:  "@signal_ann:beeper.local", SenderName: "Ann",
+		}
+		if i == 599 {
+			m.LinkedMessageID = "c5"
+		}
+		ch.Msgs = append(ch.Msgs, m)
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f.cancelAfterPages = 27 // past the 25-page checkpoint, before history ends
+	f.cancelFn = cancel
+
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	// The interrupt can land on either side of a page delivery: as a
+	// context-cancel (run fails; state lives in the run's checkpoint) or as a
+	// fetch error (run completes; state lives in cursor_after). The invariant
+	// under test holds for both: any persisted cursor that advanced past the
+	// reply message must carry its pending pair.
+	_, err := imp.Import(ctx, ImportOptions{AccountID: "signal"})
+	src, serr := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(serr)
+	var blob string
+	if err != nil {
+		require.ErrorIs(err, context.Canceled)
+		cp, cerr := st.GetLatestCheckpointedSync(src.ID)
+		require.NoError(cerr)
+		require.True(cp.CursorBefore.Valid)
+		blob = cp.CursorBefore.String
+	} else {
+		run, rerr := st.GetLastSuccessfulSync(src.ID)
+		require.NoError(rerr)
+		require.True(run.CursorAfter.Valid)
+		blob = run.CursorAfter.String
+	}
+	state, err := LoadSyncState(blob)
+	require.NoError(err)
+	cs := state.Chats["!ckpt:beeper.local"]
+	require.NotNil(cs)
+	require.NotEmpty(cs.Oldest, "persisted state must carry the advanced cursor")
+	require.False(cs.Done)
+	require.Equal([][2]string{{"c599", "c5"}}, cs.PendingReplies,
+		"persisted state must carry the reply pairs its cursor has walked past")
+
+	// The resumed run completes the chat and links the pair.
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	var parentID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "c5").Scan(&parentID))
+	var linked sql.NullInt64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT reply_to_message_id FROM messages WHERE source_message_id = ?`), "c599").Scan(&linked))
+	require.True(linked.Valid)
+	require.Equal(parentID, linked.Int64)
+}
+
+func TestImportUnfinishedChatGoneMarksDone(t *testing.T) {
+	require := require.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat()) // 45 messages: a Limit run leaves it unfinished
+	base := time.Now().Add(-20 * 24 * time.Hour).UTC().Truncate(time.Second)
+	f.addChat(&fakeChat{
+		ID: "!stays:beeper.local", AccountID: "signal", Network: "Signal", Title: "Stays", Type: "single",
+		Participants: []map[string]any{{"id": "@me:beeper.local", "isSelf": true}},
+		Msgs: []fakeMsg{{ID: "s0", SortKey: 0, Timestamp: base, Text: "hi",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann"}},
+		LastActivity: base,
+	})
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal", Limit: 10})
+	require.NoError(err)
+
+	// The unfinished chat disappears from Beeper (left/deleted) while the
+	// other chat survives. Discovery must mark the gone chat Done — keeping
+	// the archived rows — instead of erroring forever or pinning the
+	// watermark.
+	f.mu.Lock()
+	f.chats = f.chats[1:] // drop !e2e, keep !stays
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotNil(state.Chats["!e2e:beeper.local"])
+	require.True(state.Chats["!e2e:beeper.local"].Done, "a gone chat must stop being re-probed")
+
+	// Archived rows survive.
+	var count int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&count))
+	require.Positive(count)
+}
+
+func TestImportIncrementalStuckCursorTerminates(t *testing.T) {
+	require := require.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	var before int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&before))
+
+	// The API misbehaves: direction=after re-serves the head page under a
+	// non-advancing cursor. The incremental walk must terminate (mirroring
+	// the backfill's degenerate-tail defense) without duplicating rows.
+	f.chat("!e2e:beeper.local").StuckHead = true
+	f.resetRequests()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var after int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&after))
+	require.Equal(before, after, "re-served pages must not duplicate rows")
+	require.Less(len(f.requests()), 70, "the walk must terminate promptly, not spin")
+}
+
+func TestImportWatermarkHeldOnFetchError(t *testing.T) {
+	require := require.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	base := time.Now().Add(-20 * 24 * time.Hour).UTC().Truncate(time.Second)
+	f.addChat(&fakeChat{
+		ID: "!other:beeper.local", AccountID: "signal", Network: "Signal", Title: "Other", Type: "single",
+		Participants: []map[string]any{{"id": "@me:beeper.local", "isSelf": true}},
+		Msgs: []fakeMsg{{ID: "o0", SortKey: 0, Timestamp: base, Text: "hi",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann"}},
+		LastActivity: base,
+	})
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// New activity in both chats — the failing chat's message is missed this
+	// run, and the healthy chat's much newer activity would (if the watermark
+	// advanced) push the failing chat outside the discovery overlap forever.
+	now := time.Now().UTC().Truncate(time.Second)
+	f.appendMsg("!e2e:beeper.local", fakeMsg{ID: "b99", SortKey: 99, Timestamp: now.Add(-3 * time.Hour),
+		Text: "missed me?", SenderID: "@signal_ann:beeper.local", SenderName: "Ann"})
+	f.appendMsg("!other:beeper.local", fakeMsg{ID: "o1", SortKey: 1, Timestamp: now,
+		Text: "recent", SenderID: "@signal_ann:beeper.local", SenderName: "Ann"})
+	f.setMessageListFailure("!e2e:beeper.local", true)
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err, "fetch errors are per-chat, not run-fatal")
+
+	// Healed: the held-back watermark keeps the chat discoverable and the
+	// missed message is archived.
+	f.setMessageListFailure("!e2e:beeper.local", false)
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	var count int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_id = ? AND source_message_id = 'b99'`), src.ID).Scan(&count))
+	require.Equal(1, count, "the missed message must be archived once the fetch heals")
+}

--- a/internal/beeper/importer_test.go
+++ b/internal/beeper/importer_test.go
@@ -253,6 +253,53 @@ func TestImportSecondRunIncremental(t *testing.T) {
 	assert.True(sawActivityFilter, "second run must filter chat discovery by lastActivityAfter")
 }
 
+func TestImportLimitIsSharedAcrossIncrementalAndReconcile(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(e2eChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for i := range 45 {
+		f.appendMsg("!e2e:beeper.local", fakeMsg{
+			ID: "limited-new-" + strconv.Itoa(i), SortKey: 100 + i,
+			Timestamp: now.Add(time.Duration(i) * time.Second), Text: "limited incremental",
+			SenderID: "@signal_bob:beeper.local", SenderName: "Bob",
+		})
+	}
+
+	f.resetRequests()
+	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal", Limit: 20})
+	require.NoError(err)
+	assert.EqualValues(20, sum.MessagesProcessed,
+		"one per-chat budget must cover incremental and reconciliation work")
+
+	messageLists := 0
+	for _, req := range f.requests() {
+		if strings.Contains(req, "/messages?") && !strings.Contains(req, "/messages/") {
+			messageLists++
+			assert.Contains(req, "direction=after", "the limited run must stop before reconciliation: %s", req)
+		}
+	}
+	assert.Equal(1, messageLists, "the limit must stop before fetching another page")
+
+	var limitedTotal int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type = 'beeper'`).Scan(&limitedTotal))
+	assert.Equal(63, limitedTotal, "the first incremental page is archived without skipping later pages")
+
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+	var finalTotal int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type = 'beeper'`).Scan(&finalTotal))
+	assert.Equal(88, finalTotal, "the next run must resume the pages left by the limit")
+}
+
 func TestImportResumeAfterLimit(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/beeper/importer_test.go
+++ b/internal/beeper/importer_test.go
@@ -431,6 +431,54 @@ func TestImportReconcileCatchesRecentDeletion(t *testing.T) {
 	assert.Equal("recent 2", body)
 }
 
+func TestImportReconcileVisitsRecentChatWithoutNewActivity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	participants := []map[string]any{
+		{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+		{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+	}
+	f.addChat(&fakeChat{
+		ID: "!watermark:beeper.local", AccountID: "signal", Network: "Signal", Title: "Watermark", Type: "single",
+		Participants: participants,
+		Msgs: []fakeMsg{{
+			ID: "w0", SortKey: 0, Timestamp: now, Text: "sets watermark",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+		}},
+		LastActivity: now,
+	})
+	recentActivity := now.Add(-12 * time.Hour)
+	f.addChat(&fakeChat{
+		ID: "!recent-idle:beeper.local", AccountID: "signal", Network: "Signal", Title: "Recent Idle", Type: "single",
+		Participants: participants,
+		Msgs: []fakeMsg{{
+			ID: "ri0", SortKey: 0, Timestamp: recentActivity, Text: "deleted in place",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+		}},
+		LastActivity: recentActivity,
+	})
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// The recent chat changes in place without advancing LastActivity. It is
+	// older than the one-hour watermark overlap but still inside the promised
+	// reconciliation window, so the next run must enumerate and revisit it.
+	f.chat("!recent-idle:beeper.local").Msgs[0].IsDeleted = true
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	var deletedAt sql.NullTime
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT deleted_from_source_at FROM messages WHERE source_message_id = ?`), "ri0").Scan(&deletedAt))
+	assert.True(deletedAt.Valid, "recent inactive chat must be reconciled despite the newer global watermark")
+}
+
 func TestImportReactionTargetTransientErrorRetries(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/beeper/importer_test.go
+++ b/internal/beeper/importer_test.go
@@ -506,7 +506,7 @@ func TestImportReactionTargetTransientErrorRetries(t *testing.T) {
 	f.setMessageGetFailure("m5", true)
 
 	sum, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
-	require.NoError(err)
+	require.ErrorContains(err, "partial Beeper sync")
 	assert.Positive(sum.FetchErrors, "transient target failure must be recorded as a fetch error")
 
 	// Healed: the next run re-delivers the reaction event and archives it.
@@ -914,7 +914,21 @@ func TestImportWatermarkHeldOnFetchError(t *testing.T) {
 		Text: "recent", SenderID: "@signal_ann:beeper.local", SenderName: "Ann"})
 	f.setMessageListFailure("!e2e:beeper.local", true)
 	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
-	require.NoError(err, "fetch errors are per-chat, not run-fatal")
+	require.ErrorContains(err, "partial Beeper sync")
+
+	// The failure is reported only after the healthy chat is processed and
+	// the resumable state is checkpointed. Monitoring sees a failed run while
+	// successful work from the same attempt remains archived.
+	var healthyCount int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = 'o1'`).Scan(&healthyCount))
+	require.Equal(1, healthyCount, "healthy chats must continue after another chat fails")
+	var status string
+	var cursorBefore sql.NullString
+	require.NoError(st.DB().QueryRow(`
+		SELECT status, cursor_before FROM sync_runs ORDER BY id DESC LIMIT 1`).Scan(&status, &cursorBefore))
+	require.Equal(store.SyncStatusFailed, status)
+	require.True(cursorBefore.Valid, "partial progress must remain checkpointed for retry")
 
 	// Healed: the held-back watermark keeps the chat discoverable and the
 	// missed message is archived.

--- a/internal/beeper/importer_test.go
+++ b/internal/beeper/importer_test.go
@@ -559,6 +559,63 @@ func TestImportTruncatedParticipantsFetchesDetail(t *testing.T) {
 	assert.Equal(3, partCount, "truncated listing must trigger a full-detail fetch")
 }
 
+func TestImportFullReconcilesConversationParticipants(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	base := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	ch := &fakeChat{
+		ID: "!membership:beeper.local", AccountID: "signal", Network: "Signal", Title: "Membership", Type: "group",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+			{"id": "@signal_bea:beeper.local", "fullName": "Bea", "isAdmin": true},
+		},
+		Msgs: []fakeMsg{{
+			ID: "membership-0", SortKey: 0, Timestamp: base, Text: "hello",
+			SenderID: "@signal_bea:beeper.local", SenderName: "Bea",
+		}},
+		LastActivity: base,
+	}
+	f.addChat(ch)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal"})
+	require.NoError(err)
+
+	// Bea leaves and Ann becomes an admin without any new message activity.
+	// A full sync receives a complete membership snapshot and must make the
+	// stored membership exactly match it.
+	ch.Participants = []map[string]any{
+		{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+		{"id": "@signal_ann:beeper.local", "fullName": "Ann", "isAdmin": true},
+	}
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal", Full: true})
+	require.NoError(err)
+
+	var convID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM conversations WHERE source_conversation_id = ?`), ch.ID).Scan(&convID))
+	var memberCount, departedCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ?`), convID).Scan(&memberCount))
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversation_participants cp
+		JOIN participants p ON p.id = cp.participant_id
+		WHERE cp.conversation_id = ? AND p.display_name = 'Bea'`), convID).Scan(&departedCount))
+	assert.Equal(2, memberCount)
+	assert.Zero(departedCount, "departed participants must be removed")
+
+	var annRole string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT cp.role FROM conversation_participants cp
+		JOIN participants p ON p.id = cp.participant_id
+		WHERE cp.conversation_id = ? AND p.display_name = 'Ann'`), convID).Scan(&annRole))
+	assert.Equal("admin", annRole, "role changes must replace the stored role")
+}
+
 func TestImportFullRepairsWithoutDuplicates(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/beeper/mapping.go
+++ b/internal/beeper/mapping.go
@@ -1,0 +1,101 @@
+package beeper
+
+import (
+	"database/sql"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// messageType is the msgvault message_type for all Beeper-archived messages.
+// The originating network (WhatsApp, Signal, …) is distinguished by the
+// per-account source, not by message_type: Beeper's network set is open-ended,
+// while message_type values live in fixed lists across the query layer.
+const messageType = "beeper"
+
+func snippet(text string) string {
+	r := []rune(text)
+	if len(r) > 100 {
+		return string(r[:100])
+	}
+	return text
+}
+
+// placeholderBody synthesizes a searchable body line for messages that carry
+// no text (media, stickers, locations).
+func placeholderBody(m *Message) string {
+	switch m.Type {
+	case "IMAGE":
+		return "[image]"
+	case "VIDEO":
+		return "[video]"
+	case "VOICE":
+		return "[voice message]"
+	case "AUDIO":
+		return "[audio]"
+	case "STICKER":
+		return "[sticker]"
+	case "LOCATION":
+		return "[location]"
+	case "FILE":
+		for _, att := range m.Attachments {
+			if att.FileName != "" {
+				return "[file: " + att.FileName + "]"
+			}
+		}
+		return "[file]"
+	default:
+		return ""
+	}
+}
+
+// bodyText renders the plain-text body: the message text (or a placeholder
+// for text-less media), plus any voice-note transcriptions so they are
+// visible to FTS and embeddings.
+func bodyText(m *Message) string {
+	var parts []string
+	if text := strings.TrimSpace(m.Text); text != "" {
+		parts = append(parts, text)
+	} else if ph := placeholderBody(m); ph != "" {
+		parts = append(parts, ph)
+	}
+	for _, att := range m.Attachments {
+		if att.Transcription != nil && strings.TrimSpace(att.Transcription.Transcription) != "" {
+			parts = append(parts, "🎤 transcript: "+strings.TrimSpace(att.Transcription.Transcription))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// mapMessage converts a Beeper API Message into a store.Message plus the
+// plain-text body. conversationID and sourceID are internal DB IDs. The
+// message's own numeric id is the source_message_id (unique per installation;
+// guarded by the SyncState anchor probe).
+func mapMessage(m *Message, conversationID, sourceID int64) (store.Message, string) {
+	text := bodyText(m)
+	msg := store.Message{
+		ConversationID:  conversationID,
+		SourceID:        sourceID,
+		SourceMessageID: m.ID,
+		MessageType:     messageType,
+		SentAt:          sql.NullTime{Time: m.Timestamp, Valid: !m.Timestamp.IsZero()},
+		ReceivedAt:      sql.NullTime{Time: m.Timestamp, Valid: !m.Timestamp.IsZero()},
+		IsFromMe:        m.IsSender,
+		Snippet:         sql.NullString{String: snippet(text), Valid: text != ""},
+		HasAttachments:  len(m.Attachments) > 0,
+		AttachmentCount: len(m.Attachments),
+	}
+	return msg, text
+}
+
+// chatTypeSingle is the Beeper chat type for direct messages (vs "group").
+const chatTypeSingle = "single"
+
+// conversationType maps a Beeper chat type to the msgvault conversation type:
+// "single" becomes "direct_chat"; everything else becomes "group_chat".
+func conversationType(chatType string) string {
+	if chatType == chatTypeSingle {
+		return "direct_chat"
+	}
+	return "group_chat"
+}

--- a/internal/beeper/mapping_test.go
+++ b/internal/beeper/mapping_test.go
@@ -1,0 +1,82 @@
+package beeper
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBodyText(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  Message
+		want string
+	}{
+		{"plain text", Message{Type: "TEXT", Text: "hello"}, "hello"},
+		{"image placeholder", Message{Type: "IMAGE"}, "[image]"},
+		{"video placeholder", Message{Type: "VIDEO"}, "[video]"},
+		{"voice placeholder", Message{Type: "VOICE"}, "[voice message]"},
+		{"sticker placeholder", Message{Type: "STICKER"}, "[sticker]"},
+		{"location placeholder", Message{Type: "LOCATION"}, "[location]"},
+		{"location with text keeps text", Message{Type: "LOCATION", Text: "123 Main St"}, "123 Main St"},
+		{"file with name", Message{Type: "FILE", Attachments: []Attachment{{FileName: "report.pdf"}}}, "[file: report.pdf]"},
+		{"file without name", Message{Type: "FILE"}, "[file]"},
+		{"media with caption keeps caption", Message{Type: "IMAGE", Text: "look at this"}, "look at this"},
+		{
+			"voice transcription appended",
+			Message{Type: "VOICE", Attachments: []Attachment{{IsVoiceNote: true, Transcription: &Transcription{Transcription: "call me back"}}}},
+			"[voice message]\n🎤 transcript: call me back",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bodyText(&tt.msg))
+		})
+	}
+}
+
+func TestMapMessage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ts := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	m := Message{
+		ID:        "12345",
+		Timestamp: ts,
+		Type:      "TEXT",
+		Text:      "hello world",
+		IsSender:  true,
+		Attachments: []Attachment{
+			{FileName: "a.png"}, {FileName: "b.png"},
+		},
+	}
+	msg, text := mapMessage(&m, 7, 3)
+	assert.Equal(int64(7), msg.ConversationID)
+	assert.Equal(int64(3), msg.SourceID)
+	assert.Equal("12345", msg.SourceMessageID)
+	assert.Equal("beeper", msg.MessageType)
+	assert.True(msg.IsFromMe)
+	require.True(msg.SentAt.Valid)
+	assert.True(msg.SentAt.Time.Equal(ts))
+	require.True(msg.ReceivedAt.Valid)
+	assert.True(msg.HasAttachments)
+	assert.Equal(2, msg.AttachmentCount)
+	assert.Equal("hello world", text)
+	assert.Equal("hello world", msg.Snippet.String)
+	assert.False(msg.Subject.Valid, "chat messages have no subject")
+}
+
+func TestMapMessageSnippetTruncation(t *testing.T) {
+	long := strings.Repeat("é", 150)
+	msg, _ := mapMessage(&Message{ID: "1", Timestamp: time.Now(), Text: long}, 1, 1)
+	assert.Len(t, []rune(msg.Snippet.String), 100)
+}
+
+func TestConversationType(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("direct_chat", conversationType("single"))
+	assert.Equal("group_chat", conversationType("group"))
+	assert.Equal("group_chat", conversationType("anything-else"))
+}

--- a/internal/beeper/media.go
+++ b/internal/beeper/media.go
@@ -266,6 +266,10 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 				sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending))
 		}
 	}
+	// The initial checkpoint carries resume state, but its counters predate
+	// all media work. Persist the final summary before completing the run so
+	// diagnostics and monitoring agree with the returned result.
+	imp.checkpointNow(syncID, state, sum)
 	if err = imp.store.CompleteSync(syncID, stateBlob); err != nil {
 		return sum, err
 	}

--- a/internal/beeper/media.go
+++ b/internal/beeper/media.go
@@ -1,0 +1,274 @@
+package beeper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// defaultMaxMediaBytes caps individual attachment downloads (config
+// max_media_mb overrides).
+const defaultMaxMediaBytes = int64(100 << 20)
+
+// beeperAttachmentID namespaces Beeper-managed attachment rows in
+// attachments.source_attachment_id.
+func beeperAttachmentID(assetURL string) string {
+	return "beeper:" + assetURL
+}
+
+// mediaTypeOf maps a Beeper attachment to msgvault's attachments.media_type.
+func mediaTypeOf(att *Attachment) string {
+	switch {
+	case att.IsSticker:
+		return "sticker"
+	case att.IsGif:
+		return "gif"
+	case att.IsVoiceNote:
+		return "voice_note"
+	}
+	switch att.Type {
+	case "img":
+		return "image"
+	case "video":
+		return "video"
+	case "audio":
+		return "audio"
+	default:
+		return "document"
+	}
+}
+
+// assetRef returns the fetchable reference of an attachment (the mxc:// style
+// asset ID, falling back to srcURL), or "" when there is nothing to fetch.
+func assetRef(att *Attachment) string {
+	if att.ID != "" {
+		return att.ID
+	}
+	return att.SrcURL
+}
+
+// declaredSize returns the API-reported attachment size clamped to a sane
+// non-negative int (the field arrives as float64).
+func declaredSize(att *Attachment) int {
+	if att.FileSize <= 0 || att.FileSize > float64(1<<62) {
+		return 0
+	}
+	return int(int64(att.FileSize))
+}
+
+// persistAttachments downloads a message's media into content-addressed
+// storage and replaces the message's Beeper attachment rows. Media already
+// downloaded for this message (matched by source_attachment_id) is kept
+// as-is, so re-persisting a message never re-fetches its attachments. Failed
+// or over-cap downloads leave a pending marker row (the asset URL in
+// storage_path, no content hash) so BackfillMedia can retry them; the message
+// itself is always archived regardless.
+func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID int64, m *Message, opts ImportOptions, sum *ImportSummary) {
+	existing, err := imp.store.MessageBeeperAttachments(messageID)
+	if err != nil {
+		sum.Errors++
+		return
+	}
+	// Media removed at the source (e.g. an edit) falls through with zero
+	// refs: the replace below clears the stale rows, including pending
+	// markers that BackfillMedia would otherwise revisit forever.
+	if len(m.Attachments) == 0 && len(existing) == 0 {
+		return
+	}
+	maxBytes := opts.MaxMediaBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxMediaBytes
+	}
+	refs := make([]store.AttachmentRef, 0, len(m.Attachments))
+	for i := range m.Attachments {
+		att := &m.Attachments[i]
+		ref := assetRef(att)
+		if ref == "" {
+			continue
+		}
+		sourceAttID := beeperAttachmentID(ref)
+		if prev, ok := existing[sourceAttID]; ok && prev.ContentHash != "" {
+			refs = append(refs, prev)
+			continue
+		}
+		marker := store.AttachmentRef{
+			Filename:           att.FileName,
+			MimeType:           att.MimeType,
+			StoragePath:        ref,
+			Size:               declaredSize(att),
+			SourceAttachmentID: sourceAttID,
+		}
+		// Every failure leaves the marker as a pending row (BackfillMedia
+		// retries it); only unexpected failures also count as errors.
+		pend := func(status, kind string, err error) {
+			imp.recordItem(syncID, m.ID, "attachment", status, kind, err)
+			refs = append(refs, marker)
+			sum.AttachmentsPending++
+			if status == store.SyncRunItemStatusError {
+				sum.Errors++
+			}
+		}
+		if att.FileSize > 0 && int64(att.FileSize) > maxBytes {
+			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large",
+				fmt.Errorf("attachment %s is %d bytes (cap %d)", ref, int64(att.FileSize), maxBytes))
+			continue
+		}
+		data, err := imp.client.GetAssetBytes(ctx, ref, maxBytes)
+		if err == nil && len(data) == 0 {
+			err = errors.New("empty asset response")
+		}
+		if errors.Is(err, ErrAssetTooLarge) {
+			// The declared fileSize was absent or wrong; the capped reader
+			// caught it. Same outcome as the declared-size check above.
+			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large", err)
+			continue
+		}
+		if err != nil {
+			pend(store.SyncRunItemStatusError, "beeper_media_error", err)
+			continue
+		}
+		ma := &mime.Attachment{Filename: att.FileName, ContentType: att.MimeType, Content: data}
+		storagePath, serr := export.StoreAttachmentFile(opts.AttachmentsDir, ma)
+		if serr != nil || storagePath == "" {
+			pend(store.SyncRunItemStatusError, "beeper_media_error", serr)
+			continue
+		}
+		stored := store.AttachmentRef{
+			Filename:           att.FileName,
+			MimeType:           att.MimeType,
+			StoragePath:        storagePath,
+			ContentHash:        ma.ContentHash,
+			Size:               len(data),
+			SourceAttachmentID: sourceAttID,
+			MediaType:          mediaTypeOf(att),
+			DurationMS:         int64(att.Duration * 1000),
+		}
+		if att.Size != nil {
+			stored.Width = int64(att.Size.Width)
+			stored.Height = int64(att.Size.Height)
+		}
+		refs = append(refs, stored)
+		sum.AttachmentsDownloaded++
+	}
+	if err := imp.store.ReplaceMessageBeeperAttachments(messageID, refs); err != nil {
+		sum.Errors++
+		return
+	}
+	if err := imp.store.RecomputeMessageAttachmentStats(messageID); err != nil {
+		sum.Errors++
+	}
+}
+
+// clearPendingMarkers removes a message's pending Beeper markers while
+// preserving its downloaded (content-hashed) attachment rows.
+func (imp *Importer) clearPendingMarkers(messageID int64) error {
+	existing, err := imp.store.MessageBeeperAttachments(messageID)
+	if err != nil {
+		return err
+	}
+	keep := make([]store.AttachmentRef, 0, len(existing))
+	for _, ref := range existing {
+		if ref.ContentHash != "" {
+			keep = append(keep, ref)
+		}
+	}
+	if err := imp.store.ReplaceMessageBeeperAttachments(messageID, keep); err != nil {
+		return err
+	}
+	return imp.store.RecomputeMessageAttachmentStats(messageID)
+}
+
+// BackfillMedia retries pending Beeper attachment downloads for one account:
+// every message that still has a pending marker is re-fetched from the API
+// and its attachments re-persisted. Idempotent (content-addressed storage,
+// replace-by-prefix rows).
+func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
+	start := time.Now()
+	if opts.AttachmentsDir == "" {
+		return nil, errors.New("attachments dir required")
+	}
+	src, err := imp.store.GetOrCreateSource(sourceTypeBeeper, opts.AccountID)
+	if err != nil {
+		return nil, err
+	}
+	sum := &ImportSummary{SourceID: src.ID}
+	// This run's sync_runs row becomes the source's newest completed run, and
+	// Import loads its cursor_after as the resume baseline — so carry the
+	// existing sync state forward verbatim or the next sync would restart
+	// from scratch.
+	state := imp.loadResumeState(src.ID)
+	syncID, err := imp.store.StartSync(src.ID, "beeper_media")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = imp.store.FailSync(syncID, err.Error())
+		}
+	}()
+	// Preserve the carried-forward state even if this run is interrupted.
+	imp.checkpointNow(syncID, state, sum)
+
+	// This pass trusts stored message IDs, which are only unique per Beeper
+	// installation — the same guard the main sync runs applies here, or a
+	// reinstall could attach some other message's media to archived rows.
+	if err = imp.verifyAnchors(ctx, syncID, src.ID, state); err != nil {
+		return sum, err
+	}
+	// This run's state becomes the newest completed baseline: like the main
+	// sync, never persist it with the reinstall guard weakened.
+	imp.rearmAnchors(ctx, nil, state)
+	stateBlob, merr := state.Marshal()
+	if merr != nil {
+		err = merr
+		return sum, err
+	}
+
+	var pending []store.BeeperPendingAttachmentMessage
+	pending, err = imp.store.ListBeeperPendingAttachmentMessages(src.ID)
+	if err != nil {
+		return sum, err
+	}
+	for _, item := range pending {
+		if err = ctx.Err(); err != nil {
+			return sum, err
+		}
+		m, gerr := imp.client.GetMessage(ctx, item.ChatID, item.SourceMessageID)
+		if errors.Is(gerr, ErrNotFound) {
+			// The source message is permanently gone; its pending media can
+			// never be fetched. Clear the markers — but keep the message's
+			// already-downloaded rows, which remain valid archived media.
+			imp.recordItem(syncID, item.SourceMessageID, "attachment", store.SyncRunItemStatusSkipped, "beeper_media_source_gone", gerr)
+			if rerr := imp.clearPendingMarkers(item.MessageID); rerr != nil {
+				sum.Errors++
+			}
+			continue
+		}
+		if gerr != nil {
+			// Transient failure (outage, auth): the marker stays — count it
+			// still pending so the summary cannot claim a clean state — and
+			// the run reports the error.
+			imp.recordItem(syncID, item.SourceMessageID, "attachment", store.SyncRunItemStatusError, "beeper_media_error", gerr)
+			sum.AttachmentsPending++
+			sum.FetchErrors++
+			sum.Errors++
+			continue
+		}
+		imp.persistAttachments(ctx, syncID, item.MessageID, m, opts, sum)
+		sum.MessagesProcessed++
+		if opts.Progress != nil && sum.MessagesProcessed%100 == 0 {
+			opts.Progress(fmt.Sprintf("media backfill: %d messages, %d downloaded, %d still pending",
+				sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending))
+		}
+	}
+	if err = imp.store.CompleteSync(syncID, stateBlob); err != nil {
+		return sum, err
+	}
+	sum.Duration = time.Since(start)
+	return sum, nil
+}

--- a/internal/beeper/media_test.go
+++ b/internal/beeper/media_test.go
@@ -1,0 +1,540 @@
+package beeper
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mediaChat builds a chat with one image message whose asset may or may not
+// be present on the fake server.
+func mediaChat() *fakeChat {
+	base := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+	return &fakeChat{
+		ID: "!media:beeper.local", AccountID: "signal", Network: "Signal", Title: "Media", Type: "single",
+		Participants: []map[string]any{
+			{"id": "@me:beeper.local", "fullName": "Test User", "isSelf": true},
+			{"id": "@signal_ann:beeper.local", "fullName": "Ann"},
+		},
+		Msgs: []fakeMsg{{
+			ID: "p0", SortKey: 0, Timestamp: base, Type: "IMAGE",
+			SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+			Attachments: []map[string]any{{
+				"id": "mxc://beeper.local/photo1", "type": "img", "mimeType": "image/png",
+				"fileName": "photo.png", "fileSize": 11,
+				"size": map[string]any{"width": 640, "height": 480},
+			}},
+		}},
+		LastActivity: base,
+	}
+}
+
+// addFillerMessages appends plain text messages that persist at the source,
+// so verification sampling can distinguish single-message churn from a wipe.
+func addFillerMessages(ch *fakeChat, n int) {
+	last := ch.Msgs[len(ch.Msgs)-1]
+	for i := range n {
+		ch.Msgs = append(ch.Msgs, fakeMsg{
+			ID: "fill" + strconv.Itoa(i), SortKey: last.SortKey + 1 + i,
+			Timestamp: last.Timestamp.Add(time.Duration(i+1) * time.Minute),
+			Text:      "filler", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+		})
+	}
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+}
+
+func mediaImportOptions(t *testing.T) ImportOptions {
+	t.Helper()
+	return ImportOptions{AccountID: "signal", AttachmentsDir: t.TempDir()}
+}
+
+func TestImportDownloadsAttachment(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	f.setAsset("mxc://beeper.local/photo1", []byte("hello bytes"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, sum.AttachmentsDownloaded)
+	assert.EqualValues(0, sum.AttachmentsPending)
+
+	var filename, mimeType, storagePath, contentHash, mediaType string
+	var width, height int64
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT a.filename, a.mime_type, a.storage_path, a.content_hash, a.media_type, a.width, a.height
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "p0").
+		Scan(&filename, &mimeType, &storagePath, &contentHash, &mediaType, &width, &height))
+	assert.Equal("photo.png", filename)
+	assert.Equal("image/png", mimeType)
+	assert.NotEmpty(contentHash)
+	assert.Equal("image", mediaType)
+	assert.EqualValues(640, width)
+	assert.EqualValues(480, height)
+
+	// Bytes are content-addressed on disk.
+	data, err := os.ReadFile(filepath.Join(opts.AttachmentsDir, filepath.FromSlash(storagePath)))
+	require.NoError(err)
+	assert.Equal("hello bytes", string(data))
+
+	// Re-running does not duplicate rows — and does not re-download media the
+	// message already has (re-persists must reuse the stored attachment).
+	f.resetRequests()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal", AttachmentsDir: opts.AttachmentsDir, Full: true})
+	require.NoError(err)
+	var attCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "p0").Scan(&attCount))
+	assert.Equal(1, attCount)
+	for _, req := range f.requests() {
+		assert.NotContains(req, "/v1/assets/serve", "already-stored media must not be re-fetched: %s", req)
+	}
+
+	// Metadata folded into the attachment row survives the re-persist.
+	var keptMediaType string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT a.media_type FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "p0").Scan(&keptMediaType))
+	assert.Equal("image", keptMediaType)
+}
+
+func TestImportMediaFailureLeavesMarkerAndBackfillRepairs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	// Asset intentionally missing: download fails, message still archives.
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(0, sum.AttachmentsDownloaded)
+	assert.EqualValues(1, sum.AttachmentsPending)
+
+	var msgCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "p0").Scan(&msgCount))
+	require.Equal(1, msgCount, "message archives even when its media fails")
+
+	// Marker row: asset URL in storage_path, no hash, prefixed source id.
+	var storagePath, sourceAttID string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT a.storage_path, a.source_attachment_id
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "p0").Scan(&storagePath, &sourceAttID))
+	assert.Equal("mxc://beeper.local/photo1", storagePath)
+	assert.Equal("beeper:mxc://beeper.local/photo1", sourceAttID)
+
+	// Error recorded per item.
+	var itemCount int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM sync_run_items WHERE error_kind = 'beeper_media_error'`).Scan(&itemCount))
+	assert.Equal(1, itemCount)
+
+	// The asset becomes available; backfill repairs the marker.
+	f.setAsset("mxc://beeper.local/photo1", []byte("late bytes"))
+	bsum, err := imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	assert.EqualValues(1, bsum.AttachmentsDownloaded)
+	assert.EqualValues(0, bsum.AttachmentsPending)
+
+	var attCount int
+	var contentHash string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*), MAX(COALESCE(a.content_hash, ''))
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "p0").Scan(&attCount, &contentHash))
+	assert.Equal(1, attCount, "marker replaced, not duplicated")
+	assert.NotEmpty(contentHash)
+
+	// Nothing pending anymore: a second backfill visits no messages.
+	bsum, err = imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	assert.EqualValues(0, bsum.MessagesProcessed)
+
+	// The media run must carry the sync state forward: a following sync-beeper
+	// still sees completed chats and the anchor, not an empty baseline.
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	require.True(run.CursorAfter.Valid)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	assert.NotEmpty(state.Chats, "backfill-beeper-media must not clobber the sync baseline")
+	assert.NotEmpty(state.Anchors)
+	f.resetRequests()
+	_, err = imp.Import(context.Background(), ImportOptions{AccountID: "signal", AttachmentsDir: opts.AttachmentsDir})
+	require.NoError(err)
+	for _, req := range f.requests() {
+		assert.NotContains(req, "direction=before", "sync after media backfill must stay incremental: %s", req)
+	}
+}
+
+func TestImportMediaSizeCap(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	ch := mediaChat()
+	ch.Msgs[0].Attachments[0]["id"] = "mxc://beeper.local/huge1"
+	ch.Msgs[0].Attachments[0]["fileSize"] = 10 << 20
+	f.addChat(ch)
+	f.setAsset("mxc://beeper.local/huge1", []byte("would be huge"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	opts.MaxMediaBytes = 1 << 20 // 1 MB cap; declared size is 10 MB
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(0, sum.AttachmentsDownloaded)
+	assert.EqualValues(1, sum.AttachmentsPending)
+	assert.EqualValues(0, sum.Errors, "over-cap is a skip, not an error")
+
+	var itemCount int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM sync_run_items WHERE error_kind = 'beeper_media_too_large'`).Scan(&itemCount))
+	assert.Equal(1, itemCount)
+}
+
+func TestImportMediaSizeCapUndeclaredSize(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// fileSize is untrusted metadata: with none declared, the cap must still
+	// hold at download time (bounded reader), not after buffering the body.
+	f := newFakeBeeper(t)
+	ch := mediaChat()
+	delete(ch.Msgs[0].Attachments[0], "fileSize")
+	f.addChat(ch)
+	f.setAsset("mxc://beeper.local/photo1", make([]byte, 2<<20)) // 2 MiB body
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	opts.MaxMediaBytes = 1 << 20 // 1 MiB cap
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(0, sum.AttachmentsDownloaded)
+	assert.EqualValues(1, sum.AttachmentsPending)
+	assert.EqualValues(0, sum.Errors, "over-cap is a skip, not an error")
+
+	var itemCount int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM sync_run_items WHERE error_kind = 'beeper_media_too_large'`).Scan(&itemCount))
+	assert.Equal(1, itemCount)
+}
+
+func TestImportNoMediaSkipsDownloadsEntirely(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	f.setAsset("mxc://beeper.local/photo1", []byte("bytes"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	opts.NoMedia = true
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(0, sum.AttachmentsDownloaded)
+	assert.EqualValues(0, sum.AttachmentsPending)
+
+	var attCount int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM attachments`).Scan(&attCount))
+	assert.Zero(attCount, "no rows, not even markers, when media is disabled")
+
+	// Message metadata still reflects the attachment.
+	var hasAtt bool
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT has_attachments FROM messages WHERE source_message_id = ?`), "p0").Scan(&hasAtt))
+	assert.True(hasAtt)
+}
+
+func TestImportClearsAttachmentsRemovedAtSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	f.setAsset("mxc://beeper.local/photo1", []byte("bytes"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var attCount int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM attachments`).Scan(&attCount))
+	require.Equal(1, attCount)
+
+	// The sender redacts the media: the re-persisted message has no
+	// attachments, so the stale row must be cleared, not kept forever.
+	f.chat("!media:beeper.local").Msgs[0].Attachments = nil
+	_, err = imp.Import(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir, Full: true,
+	})
+	require.NoError(err)
+
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM attachments`).Scan(&attCount))
+	assert.Zero(attCount, "attachments removed at the source must be cleared")
+	var hasAtt bool
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT has_attachments FROM messages WHERE source_message_id = ?`), "p0").Scan(&hasAtt))
+	assert.False(hasAtt)
+}
+
+func TestBackfillMediaClearsMarkerWhenAttachmentGone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	// Asset missing: the sync leaves a pending marker.
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Before the retry, the message loses its attachment at the source; the
+	// marker must be cleared or BackfillMedia would revisit it forever.
+	f.chat("!media:beeper.local").Msgs[0].Attachments = nil
+	bsum, err := imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	require.EqualValues(1, bsum.MessagesProcessed)
+
+	var attCount int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM attachments`).Scan(&attCount))
+	assert.Zero(attCount)
+
+	bsum, err = imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	assert.EqualValues(0, bsum.MessagesProcessed, "cleared marker must not be revisited")
+}
+
+func TestBackfillMediaTransientFetchErrorKeepsMarker(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	ch := mediaChat()
+	// A newer plain message so the sync anchors on it, keeping the anchor
+	// distinct from the message whose fetch this test makes fail.
+	ch.Msgs = append(ch.Msgs, fakeMsg{
+		ID: "p1", SortKey: 1, Timestamp: ch.Msgs[0].Timestamp.Add(time.Minute),
+		Text: "anchor me", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+	})
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+	// Asset missing: the sync leaves a pending marker.
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The retry hits a transient failure fetching the message: the run must
+	// surface the error (not report clean counts) and keep the marker.
+	f.setMessageGetFailure("p0", true)
+	bsum, err := imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	assert.Positive(bsum.Errors, "transient fetch failures must be reported")
+	assert.EqualValues(0, bsum.AttachmentsDownloaded)
+
+	var markers int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM attachments WHERE content_hash IS NULL OR content_hash = ''`).Scan(&markers))
+	require.Equal(1, markers, "marker must survive a transient failure")
+
+	// Healed: the asset appears and the retry succeeds.
+	f.setMessageGetFailure("p0", false)
+	f.setAsset("mxc://beeper.local/photo1", []byte("finally"))
+	bsum, err = imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	assert.EqualValues(1, bsum.AttachmentsDownloaded)
+	assert.EqualValues(0, bsum.Errors)
+}
+
+func TestBackfillMediaVerifiesAnchorFirst(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	// Asset missing: the sync leaves a pending marker.
+	imp, _, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Simulate a reinstall re-assigning message IDs: the backfill trusts
+	// stored IDs, so it must abort like the main sync instead of attaching
+	// some other message's media to archived rows.
+	ch := f.chat("!media:beeper.local")
+	for i := range ch.Msgs {
+		ch.Msgs[i].Timestamp = ch.Msgs[i].Timestamp.Add(time.Hour)
+	}
+	f.setAsset("mxc://beeper.local/photo1", []byte("wrong install"))
+	f.resetRequests()
+
+	_, err = imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "re-assigned")
+	for _, req := range f.requests() {
+		assert.NotContains(req, "/v1/assets/serve", "no media may be fetched after an anchor mismatch: %s", req)
+	}
+}
+
+func TestBackfillMediaGoneMessageKeepsDownloadedRows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	ch := mediaChat()
+	// Two attachments on one message: one downloadable, one missing.
+	ch.Msgs[0].Attachments = append(ch.Msgs[0].Attachments, map[string]any{
+		"id": "mxc://beeper.local/photo2", "type": "img", "mimeType": "image/png", "fileName": "gone.png",
+	})
+	addFillerMessages(ch, 5)
+	f.addChat(ch)
+	f.setAsset("mxc://beeper.local/photo1", []byte("archived bytes"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.EqualValues(1, sum.AttachmentsDownloaded)
+	require.EqualValues(1, sum.AttachmentsPending)
+
+	// The source message disappears before the retry (other messages
+	// remain): only the pending marker may be cleared — the downloaded
+	// attachment is archived media — and a gone message is expected churn,
+	// not an error.
+	chat := f.chat("!media:beeper.local")
+	chat.Msgs = chat.Msgs[1:] // drop p0, keep fillers
+	bsum, err := imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	assert.EqualValues(0, bsum.Errors)
+
+	var downloaded, markers int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM attachments WHERE content_hash IS NOT NULL AND content_hash != ''`).Scan(&downloaded))
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM attachments WHERE content_hash IS NULL OR content_hash = ''`).Scan(&markers))
+	assert.Equal(1, downloaded, "downloaded media must survive the marker cleanup")
+	assert.Zero(markers)
+
+	// The cleared marker must not be revisited by later backfills.
+	bsum, err = imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+	assert.EqualValues(0, bsum.MessagesProcessed)
+}
+
+func TestBackfillMediaRearmsLostAnchor(t *testing.T) {
+	require := require.New(t)
+
+	f := newFakeBeeper(t)
+	ch := mediaChat()
+	// A newer plain message becomes the anchor, distinct from the media message.
+	ch.Msgs = append(ch.Msgs, fakeMsg{
+		ID: "p1", SortKey: 1, Timestamp: ch.Msgs[0].Timestamp.Add(time.Minute),
+		Text: "anchor me", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+	})
+	ch.LastActivity = ch.Msgs[len(ch.Msgs)-1].Timestamp
+	f.addChat(ch)
+	f.setAsset("mxc://beeper.local/photo1", []byte("bytes"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The anchor message is deleted (chat alive). The media run soft-clears
+	// it and — becoming the newest completed baseline — must re-arm before
+	// persisting, or every later run would start unguarded.
+	chat := f.chat("!media:beeper.local")
+	chat.Msgs = chat.Msgs[:1] // drop p1, keep p0
+	_, err = imp.BackfillMedia(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+	})
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	require.NotEmpty(state.Anchors, "media runs must not persist a disarmed reinstall guard")
+	require.Equal("p0", state.Anchors[0].MessageID)
+}
+
+func TestMediaTypeOf(t *testing.T) {
+	assert := assert.New(t)
+	cases := []struct {
+		name string
+		att  Attachment
+		want string
+	}{
+		{"image", Attachment{Type: "img"}, "image"},
+		{"video", Attachment{Type: "video"}, "video"},
+		{"audio", Attachment{Type: "audio"}, "audio"},
+		{"unknown type", Attachment{Type: "something"}, "document"},
+		// Flags outrank the base type: a sticker served as img is a sticker.
+		{"sticker wins over img", Attachment{Type: "img", IsSticker: true}, "sticker"},
+		{"gif wins over video", Attachment{Type: "video", IsGif: true}, "gif"},
+		{"voice note wins over audio", Attachment{Type: "audio", IsVoiceNote: true}, "voice_note"},
+	}
+	for _, tc := range cases {
+		assert.Equal(tc.want, mediaTypeOf(&tc.att), tc.name)
+	}
+
+	assert.Equal("mxc://x/1", assetRef(&Attachment{ID: "mxc://x/1", SrcURL: "http://y"}))
+	assert.Equal("http://y", assetRef(&Attachment{SrcURL: "http://y"}), "srcURL is the fallback when the asset ID is empty")
+	assert.Empty(assetRef(&Attachment{}))
+}

--- a/internal/beeper/media_test.go
+++ b/internal/beeper/media_test.go
@@ -374,6 +374,15 @@ func TestBackfillMediaTransientFetchErrorKeepsMarker(t *testing.T) {
 	assert.Positive(bsum.Errors, "transient fetch failures must be reported")
 	assert.EqualValues(0, bsum.AttachmentsDownloaded)
 
+	src, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(err)
+	assert.Equal(bsum.MessagesProcessed, run.MessagesProcessed,
+		"completed run must persist the returned processed count")
+	assert.Equal(bsum.Errors, run.ErrorsCount,
+		"completed run must persist the returned error count")
+
 	var markers int
 	require.NoError(st.DB().QueryRow(
 		`SELECT COUNT(*) FROM attachments WHERE content_hash IS NULL OR content_hash = ''`).Scan(&markers))

--- a/internal/beeper/participants.go
+++ b/internal/beeper/participants.go
@@ -1,0 +1,149 @@
+package beeper
+
+import (
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// participantIdentifierType namespaces Beeper user IDs in
+// participant_identifiers. The IDs are Beeper-local Matrix-style IDs
+// (@x:beeper.local), not federated Matrix IDs.
+const participantIdentifierType = "beeper"
+
+// participantResolver resolves Beeper users to msgvault participant IDs,
+// cached per run by Beeper user ID.
+//
+// Resolution ladder (exclusive — EnsureParticipantByIdentifier creates a new
+// participant for unseen identifiers, so calling two rungs for one person
+// would fork them):
+//  1. E.164 phone number → EnsureParticipantByPhone, deduping people across
+//     Beeper and native SMS/WhatsApp archives.
+//  2. Email → EnsureParticipant, deduping against mail archives.
+//  3. Beeper user ID → EnsureParticipantByIdentifier("beeper", …).
+//
+// Phone/email are only present on chat participant entries, so the resolver
+// is seeded from each chat's participant list; message senders then hit the
+// cache by user ID. Rich (phone/email) resolutions and bare-ID fallbacks are
+// cached separately: a fallback cached in one chat must not block a later
+// chat's richer metadata from deduping the person across archives.
+// richEntry is a cached phone/email-based resolution. Email entries stay
+// upgradeable: phone outranks email in the ladder, so a user first seen with
+// only an email must still dedupe by phone when one appears later.
+type richEntry struct {
+	pid     int64
+	byPhone bool
+}
+
+type participantResolver struct {
+	store    *store.Store
+	rich     map[string]richEntry // phone/email-based resolutions
+	fallback map[string]int64     // bare-ID fallbacks; upgraded when metadata appears
+}
+
+func newParticipantResolver(s *store.Store) *participantResolver {
+	return &participantResolver{store: s, rich: map[string]richEntry{}, fallback: map[string]int64{}}
+}
+
+func (r *participantResolver) resolveUser(u *User) (int64, error) {
+	if u == nil || u.ID == "" {
+		return 0, nil
+	}
+	hasPhone := strings.HasPrefix(u.PhoneNumber, "+")
+	if e, ok := r.rich[u.ID]; ok && (e.byPhone || !hasPhone) {
+		return e.pid, nil
+	}
+	switch {
+	case hasPhone:
+		pid, err := r.store.EnsureParticipantByPhone(u.PhoneNumber, u.FullName, participantIdentifierType)
+		if err != nil {
+			return 0, err
+		}
+		// Upgrading an earlier email-based resolution: both rows are the
+		// same Beeper user, so fold the email participant's history into the
+		// phone one (which dedupes with SMS/WhatsApp archives).
+		if e, ok := r.rich[u.ID]; ok && e.pid != pid {
+			if err := r.store.MergeParticipants(e.pid, pid); err != nil {
+				return 0, err
+			}
+		}
+		return pid, r.recordRich(u.ID, pid, true)
+	case strings.Contains(u.Email, "@"):
+		// Never downgrade: if a prior run already resolved this Beeper user
+		// by phone, an email-only sighting must keep pointing at that
+		// participant instead of re-pointing the identifier to a weaker row.
+		prev, hasPhone, err := r.store.ParticipantByIdentifier(participantIdentifierType, u.ID)
+		if err != nil {
+			return 0, err
+		}
+		if prev != 0 && hasPhone {
+			r.rich[u.ID] = richEntry{pid: prev, byPhone: true}
+			delete(r.fallback, u.ID)
+			return prev, nil
+		}
+		pid, err := r.byEmail(u.Email, u.FullName)
+		if err != nil {
+			return 0, err
+		}
+		return pid, r.recordRich(u.ID, pid, false)
+	default:
+		return r.resolveID(u.ID, u.FullName)
+	}
+}
+
+// recordRich caches a phone/email-based resolution and persists the Beeper
+// user ID as an identifier of that participant, so later runs (fresh caches)
+// resolve bare sender IDs to the same person. When a weak (bare-ID-only)
+// participant already owns the identifier, its history — messages, reactions,
+// membership — is merged into the rich participant rather than left split.
+func (r *participantResolver) recordRich(userID string, pid int64, byPhone bool) error {
+	prev, hasPhone, err := r.store.ParticipantByIdentifier(participantIdentifierType, userID)
+	if err != nil {
+		return err
+	}
+	// A prior owner without a phone — a bare-ID fallback or an email-only
+	// resolution — is the same Beeper user seen with weaker metadata: fold
+	// its history into this resolution. A phone-bearing owner whose number
+	// differs is left un-merged (conservative: numbers can be recycled).
+	if prev != 0 && prev != pid && !hasPhone {
+		if err := r.store.MergeParticipants(prev, pid); err != nil {
+			return err
+		}
+	}
+	if err := r.store.SetParticipantIdentifier(pid, participantIdentifierType, userID); err != nil {
+		return err
+	}
+	r.rich[userID] = richEntry{pid: pid, byPhone: byPhone}
+	delete(r.fallback, userID)
+	return nil
+}
+
+// resolveID resolves a bare Beeper user ID (message sender, mention, reactor)
+// with an optional display name. Cache misses fall through to rung 3 of the
+// ladder since no phone/email is available on bare IDs.
+func (r *participantResolver) resolveID(userID, displayName string) (int64, error) {
+	if userID == "" {
+		return 0, nil
+	}
+	if e, ok := r.rich[userID]; ok {
+		return e.pid, nil
+	}
+	if pid, ok := r.fallback[userID]; ok {
+		return pid, nil
+	}
+	pid, err := r.store.EnsureParticipantByIdentifier(participantIdentifierType, userID, displayName)
+	if err != nil {
+		return 0, err
+	}
+	r.fallback[userID] = pid
+	return pid, nil
+}
+
+func (r *participantResolver) byEmail(email, displayName string) (int64, error) {
+	email = strings.ToLower(email)
+	domain := ""
+	if at := strings.LastIndex(email, "@"); at >= 0 {
+		domain = email[at+1:]
+	}
+	return r.store.EnsureParticipant(email, displayName, domain)
+}

--- a/internal/beeper/participants_test.go
+++ b/internal/beeper/participants_test.go
@@ -1,0 +1,410 @@
+package beeper
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestResolveUserPhoneRungDedupesAcrossSources(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// A native SMS/WhatsApp import already created this person by phone.
+	existing, err := st.EnsureParticipantByPhone("+15550100001", "Alice Native", "whatsapp")
+	require.NoError(err)
+
+	pid, err := r.resolveUser(&User{
+		ID:          "@15550100001:local-whatsapp.localhost",
+		PhoneNumber: "+15550100001",
+		FullName:    "Alice",
+	})
+	require.NoError(err)
+	assert.Equal(existing, pid, "phone rung must dedupe with native imports")
+}
+
+func TestResolveUserEmailRung(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	existing, err := st.EnsureParticipant("bob@example.com", "Bob Mail", "example.com")
+	require.NoError(err)
+
+	pid, err := r.resolveUser(&User{
+		ID:       "@linkedin_bob:beeper.local",
+		Email:    "Bob@Example.com",
+		FullName: "Bob",
+	})
+	require.NoError(err)
+	assert.Equal(existing, pid, "email rung must lowercase and dedupe with mail archives")
+}
+
+func TestResolveUserIdentifierFallback(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	pid, err := r.resolveUser(&User{ID: "@signal_uuid:beeper.local", FullName: "Carol"})
+	require.NoError(err)
+	require.NotZero(pid)
+
+	var identifierType, identifierValue string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT identifier_type, identifier_value FROM participant_identifiers WHERE participant_id = ?`), pid,
+	).Scan(&identifierType, &identifierValue))
+	assert.Equal("beeper", identifierType)
+	assert.Equal("@signal_uuid:beeper.local", identifierValue)
+}
+
+func TestResolveUserLadderIsExclusive(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// A phone-resolvable user resolves through the phone rung (phone wins
+	// over email), and the Beeper user ID is persisted as an identifier of
+	// that same participant so later runs cannot fork the person.
+	pid, err := r.resolveUser(&User{
+		ID:          "@15550100002:local-whatsapp.localhost",
+		PhoneNumber: "+15550100002",
+		Email:       "dave@example.com", // phone wins over email
+		FullName:    "Dave",
+	})
+	require.NoError(err)
+	require.NotZero(pid)
+
+	var matrixIDOwner int64
+	require.NoError(st.DB().QueryRow(
+		`SELECT participant_id FROM participant_identifiers WHERE identifier_value = '@15550100002:local-whatsapp.localhost'`,
+	).Scan(&matrixIDOwner))
+	assert.Equal(pid, matrixIDOwner, "the Beeper user ID must map to the phone participant, not a fork")
+
+	var phone string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT phone_number FROM participants WHERE id = ?`), pid,
+	).Scan(&phone))
+	assert.Equal("+15550100002", phone)
+
+	// The phone rung records the phone under the beeper identifier namespace.
+	var phoneIdentRows int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM participant_identifiers WHERE participant_id = ? AND identifier_type = 'beeper' AND identifier_value = '+15550100002'`), pid,
+	).Scan(&phoneIdentRows))
+	assert.Equal(1, phoneIdentRows)
+}
+
+func TestResolveUserCache(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	u := &User{ID: "@x:beeper.local", FullName: "X"}
+	first, err := r.resolveUser(u)
+	require.NoError(err)
+	second, err := r.resolveUser(u)
+	require.NoError(err)
+	assert.Equal(first, second)
+}
+
+func TestResolveIDHitsSeededCache(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// Seeding from the chat participant list (phone rung)…
+	seeded, err := r.resolveUser(&User{
+		ID:          "@15550100003:local-whatsapp.localhost",
+		PhoneNumber: "+15550100003",
+		FullName:    "Eve",
+	})
+	require.NoError(err)
+
+	// …means a later bare sender ID resolves to the same person, not a fork.
+	pid, err := r.resolveID("@15550100003:local-whatsapp.localhost", "Eve")
+	require.NoError(err)
+	assert.Equal(seeded, pid)
+}
+
+func TestResolveUserUpgradesBareIDFallback(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// A departed member is first seen as a bare sender ID (fallback rung)…
+	weak, err := r.resolveID("@15550100004:local-whatsapp.localhost", "Fay")
+	require.NoError(err)
+	require.NotZero(weak)
+
+	// …but the same user appears later in another chat's participant list
+	// with a phone number. The richer metadata must win (deduping across
+	// archives), not be blocked by the cached fallback.
+	native, err := st.EnsureParticipantByPhone("+15550100004", "Fay Native", "imessage")
+	require.NoError(err)
+
+	rich, err := r.resolveUser(&User{
+		ID:          "@15550100004:local-whatsapp.localhost",
+		PhoneNumber: "+15550100004",
+		FullName:    "Fay",
+	})
+	require.NoError(err)
+	assert.Equal(native, rich, "phone metadata must dedupe with the native archive")
+	assert.NotEqual(weak, rich)
+
+	// Subsequent bare-ID lookups now resolve to the upgraded participant.
+	again, err := r.resolveID("@15550100004:local-whatsapp.localhost", "Fay")
+	require.NoError(err)
+	assert.Equal(rich, again)
+}
+
+func TestRichResolutionPersistsAcrossRuns(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	// Run 1 sees the user with a phone number in a chat's member list.
+	r1 := newParticipantResolver(st)
+	rich, err := r1.resolveUser(&User{
+		ID:          "@15550100005:local-whatsapp.localhost",
+		PhoneNumber: "+15550100005",
+		FullName:    "Gil",
+	})
+	require.NoError(err)
+
+	// Run 2 (fresh cache) sees the same user only as a bare sender ID (they
+	// left the group): the persisted identifier must unify, not fork.
+	r2 := newParticipantResolver(st)
+	pid, err := r2.resolveID("@15550100005:local-whatsapp.localhost", "Gil")
+	require.NoError(err)
+	assert.Equal(rich, pid, "bare-ID resolution in a later run must find the rich participant")
+
+	// And the reverse order: a weak participant from run 1 is re-pointed
+	// when run 2 learns the phone number.
+	r3 := newParticipantResolver(st)
+	weak, err := r3.resolveID("@15550100006:beeper.local", "Hana")
+	require.NoError(err)
+	r4 := newParticipantResolver(st)
+	native, err := st.EnsureParticipantByPhone("+15550100006", "Hana Native", "imessage")
+	require.NoError(err)
+	upgraded, err := r4.resolveUser(&User{
+		ID:          "@15550100006:beeper.local",
+		PhoneNumber: "+15550100006",
+		FullName:    "Hana",
+	})
+	require.NoError(err)
+	assert.Equal(native, upgraded)
+	assert.NotEqual(weak, upgraded)
+	r5 := newParticipantResolver(st)
+	pid, err = r5.resolveID("@15550100006:beeper.local", "Hana")
+	require.NoError(err)
+	assert.Equal(native, pid, "the identifier row must be re-pointed at the rich participant")
+}
+
+func TestRichUpgradeMergesWeakHistory(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	// Run 1: the user is only seen as a bare sender ID; messages, a reaction,
+	// a mention, and membership are written under the weak participant.
+	r1 := newParticipantResolver(st)
+	weak, err := r1.resolveID("@15550100007:beeper.local", "Ida")
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("beeper", "merge-test")
+	require.NoError(err)
+	convID, err := st.EnsureConversationWithType(src.ID, "!merge:beeper.local", "direct_chat", "Merge")
+	require.NoError(err)
+	require.NoError(st.EnsureConversationParticipant(convID, weak, "member"))
+	msgID, err := st.UpsertMessage(&store.Message{
+		ConversationID: convID, SourceID: src.ID, SourceMessageID: "mm1",
+		MessageType: "beeper", SentAt: sql.NullTime{Time: time.Now(), Valid: true},
+		SenderID: sql.NullInt64{Int64: weak, Valid: true},
+	})
+	require.NoError(err)
+	require.NoError(st.UpsertReaction(msgID, weak, "emoji", "👍", time.Now()))
+	require.NoError(st.ReplaceMessageRecipients(msgID, "mention", []int64{weak}, []string{""}))
+
+	// Run 2: the same user appears with a phone number. The weak history must
+	// fold into the rich participant, not stay split.
+	r2 := newParticipantResolver(st)
+	rich, err := r2.resolveUser(&User{
+		ID:          "@15550100007:beeper.local",
+		PhoneNumber: "+15550100007",
+		FullName:    "Ida",
+	})
+	require.NoError(err)
+	require.NotEqual(weak, rich)
+
+	var senderID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT sender_id FROM messages WHERE id = ?`), msgID).Scan(&senderID))
+	assert.Equal(rich, senderID, "messages must move to the rich participant")
+
+	var reactionOwner int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT participant_id FROM reactions WHERE message_id = ?`), msgID).Scan(&reactionOwner))
+	assert.Equal(rich, reactionOwner)
+
+	var mentionOwner int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT participant_id FROM message_recipients WHERE message_id = ? AND recipient_type = 'mention'`), msgID).Scan(&mentionOwner))
+	assert.Equal(rich, mentionOwner)
+
+	var memberOwner int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT participant_id FROM conversation_participants WHERE conversation_id = ?`), convID).Scan(&memberOwner))
+	assert.Equal(rich, memberOwner)
+
+	var weakRows int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM participants WHERE id = ?`), weak).Scan(&weakRows))
+	assert.Zero(weakRows, "the weak participant row must be deleted after the merge")
+}
+
+func TestPhoneUpgradesEmailResolution(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+
+	// First seen with only an email (e.g. a LinkedIn chat)…
+	emailPID, err := r.resolveUser(&User{
+		ID:       "@15550100008:beeper.local",
+		Email:    "kim@example.com",
+		FullName: "Kim",
+	})
+	require.NoError(err)
+
+	// …later seen with an E.164 phone. Phone outranks email in the ladder:
+	// the cached email resolution must not block deduping with the native
+	// SMS archive, and the email participant's history folds into it.
+	native, err := st.EnsureParticipantByPhone("+15550100008", "Kim Native", "imessage")
+	require.NoError(err)
+	phonePID, err := r.resolveUser(&User{
+		ID:          "@15550100008:beeper.local",
+		PhoneNumber: "+15550100008",
+		Email:       "kim@example.com",
+		FullName:    "Kim",
+	})
+	require.NoError(err)
+	assert.Equal(native, phonePID, "phone metadata must dedupe with the native archive")
+	assert.NotEqual(emailPID, phonePID)
+
+	// The merge preserved the email on the surviving participant.
+	var email string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COALESCE(email_address, '') FROM participants WHERE id = ?`), phonePID).Scan(&email))
+	assert.Equal("kim@example.com", email)
+
+	// Cache and identifier now both point at the phone participant.
+	again, err := r.resolveUser(&User{ID: "@15550100008:beeper.local", Email: "kim@example.com"})
+	require.NoError(err)
+	assert.Equal(phonePID, again)
+	pid, err := r.resolveID("@15550100008:beeper.local", "Kim")
+	require.NoError(err)
+	assert.Equal(phonePID, pid)
+}
+
+func TestResolveIDEmpty(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	r := newParticipantResolver(st)
+	pid, err := r.resolveID("", "nobody")
+	require.NoError(err)
+	assert.Zero(pid)
+}
+
+func TestPhoneUpgradesEmailResolutionAcrossRuns(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	// Run 1 sees the user with only an email; the Beeper ID lands on the
+	// email participant.
+	r1 := newParticipantResolver(st)
+	emailPID, err := r1.resolveUser(&User{
+		ID:       "@15550100013:beeper.local",
+		Email:    "mia@example.com",
+		FullName: "Mia",
+	})
+	require.NoError(err)
+
+	// Run 2 (fresh cache) sees a phone: the email participant is the same
+	// Beeper user with weaker metadata — its history must fold into the
+	// phone-deduped participant, not stay split.
+	r2 := newParticipantResolver(st)
+	phonePID, err := r2.resolveUser(&User{
+		ID:          "@15550100013:beeper.local",
+		PhoneNumber: "+15550100013",
+		FullName:    "Mia",
+	})
+	require.NoError(err)
+	require.NotEqual(emailPID, phonePID)
+
+	var gone int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM participants WHERE id = ?`), emailPID).Scan(&gone))
+	assert.Zero(gone, "the email participant must be merged away")
+	var email string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COALESCE(email_address, '') FROM participants WHERE id = ?`), phonePID).Scan(&email))
+	assert.Equal("mia@example.com", email, "the merge preserves the email")
+
+	// And the reverse across runs: an email-only sighting must not downgrade
+	// a phone-resolved identity.
+	r3 := newParticipantResolver(st)
+	again, err := r3.resolveUser(&User{
+		ID:       "@15550100013:beeper.local",
+		Email:    "mia@example.com",
+		FullName: "Mia",
+	})
+	require.NoError(err)
+	assert.Equal(phonePID, again, "email-only sightings keep the phone participant")
+}
+
+func TestRichUpgradeDoesNotAbsorbContactOwner(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	// The Beeper user ID is already owned by a participant with its own
+	// contact metadata (e.g. the person's old number from another archive).
+	owner, err := st.EnsureParticipantByPhone("+15550100011", "Lea Old", "imessage")
+	require.NoError(err)
+	require.NoError(st.SetParticipantIdentifier(owner, "beeper", "@lea:beeper.local"))
+
+	// Resolving the same Beeper ID with a different phone must re-point the
+	// identifier, but never destructively merge a contact-bearing row.
+	r := newParticipantResolver(st)
+	pid, err := r.resolveUser(&User{
+		ID:          "@lea:beeper.local",
+		PhoneNumber: "+15550100012",
+		FullName:    "Lea",
+	})
+	require.NoError(err)
+	require.NotEqual(owner, pid)
+
+	var oldPhone string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COALESCE(phone_number, '') FROM participants WHERE id = ?`), owner).Scan(&oldPhone))
+	assert.Equal("+15550100011", oldPhone, "the previous owner must survive un-merged")
+
+	again, err := r.resolveID("@lea:beeper.local", "Lea")
+	require.NoError(err)
+	assert.Equal(pid, again, "the identifier now points at the new resolution")
+}

--- a/internal/beeper/participants_test.go
+++ b/internal/beeper/participants_test.go
@@ -304,11 +304,14 @@ func TestPhoneUpgradesEmailResolution(t *testing.T) {
 	assert.Equal(native, phonePID, "phone metadata must dedupe with the native archive")
 	assert.NotEqual(emailPID, phonePID)
 
-	// The merge preserved the email on the surviving participant.
-	var email string
+	// The merge preserved the email and its analytics domain on the surviving
+	// participant.
+	var email, domain string
 	require.NoError(st.DB().QueryRow(st.Rebind(
-		`SELECT COALESCE(email_address, '') FROM participants WHERE id = ?`), phonePID).Scan(&email))
+		`SELECT COALESCE(email_address, ''), COALESCE(domain, '') FROM participants WHERE id = ?`), phonePID).
+		Scan(&email, &domain))
 	assert.Equal("kim@example.com", email)
+	assert.Equal("example.com", domain)
 
 	// Cache and identifier now both point at the phone participant.
 	again, err := r.resolveUser(&User{ID: "@15550100008:beeper.local", Email: "kim@example.com"})

--- a/internal/beeper/syncstate.go
+++ b/internal/beeper/syncstate.go
@@ -1,0 +1,112 @@
+package beeper
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ChatState tracks one chat's sync progress.
+//
+// Newest is the cursor to resume incremental fetches from (direction=after).
+// Oldest is the backfill resume point (direction=before); it advances as the
+// backfill walks toward the beginning of history. Done means the backfill
+// reached the beginning of the chat's locally-available history.
+type ChatState struct {
+	Newest string `json:"newest,omitempty"`
+	Oldest string `json:"oldest,omitempty"`
+	Done   bool   `json:"done,omitempty"`
+	// PendingReplies holds [child, parent] source-message-ID pairs whose
+	// parents were not yet archived when the walk stopped (backfill walks
+	// newest→oldest); they are linked once the backfill completes.
+	PendingReplies [][2]string `json:"pending_replies,omitempty"`
+}
+
+// AnchorProbe fingerprints the Beeper installation's message-ID space.
+// Message IDs are only unique per installation; a reinstall or re-index could
+// re-assign them, which would silently corrupt incremental dedup. Each run
+// re-fetches the anchor message and aborts on mismatch instead.
+type AnchorProbe struct {
+	ChatID    string    `json:"chat_id"`
+	MessageID string    `json:"message_id"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// SyncState holds per-chat incremental cursors for one Beeper account source,
+// persisted as JSON in sync_runs.cursor_after (and checkpointed mid-run in
+// cursor_before).
+type SyncState struct {
+	Chats map[string]*ChatState `json:"chats"` // key = chat ID (Matrix room ID)
+	// Anchors fingerprint the installation across several distinct chats (see
+	// AnchorProbe): ordinary churn can delete any one anchor's chat, so a
+	// reinstall is only concluded when no anchor survives.
+	Anchors []AnchorProbe `json:"anchors,omitempty"`
+	// ListWatermark is the max chat lastActivity observed (RFC3339); the next
+	// incremental run enumerates only chats active after it.
+	ListWatermark string `json:"list_watermark,omitempty"`
+}
+
+func NewSyncState() *SyncState {
+	return &SyncState{Chats: map[string]*ChatState{}}
+}
+
+func LoadSyncState(blob string) (*SyncState, error) {
+	s := NewSyncState()
+	if blob == "" {
+		return s, nil
+	}
+	if err := json.Unmarshal([]byte(blob), s); err != nil {
+		return nil, err
+	}
+	if s.Chats == nil {
+		s.Chats = map[string]*ChatState{}
+	}
+	return s, nil
+}
+
+func (s *SyncState) Marshal() (string, error) {
+	b, err := json.Marshal(s)
+	return string(b), err
+}
+
+// EnsureChat returns the (created-if-missing) state for chatID.
+func (s *SyncState) EnsureChat(chatID string) *ChatState {
+	cs, ok := s.Chats[chatID]
+	if !ok {
+		cs = &ChatState{}
+		s.Chats[chatID] = cs
+	}
+	return cs
+}
+
+// Merge incorporates cursors from other into s. Cursors are opaque API tokens
+// that cannot be compared by value; like the Teams deltaLink merge, we prefer
+// other's non-empty values wholesale on the assumption that other represents a
+// more recent (checkpoint) run whose cursors are at least as advanced. Done
+// flags are OR'd. The later ListWatermark wins (RFC3339 is order-comparable).
+func (s *SyncState) Merge(other *SyncState) {
+	if other == nil {
+		return
+	}
+	for chatID, ocs := range other.Chats {
+		if ocs == nil {
+			continue
+		}
+		cs := s.EnsureChat(chatID)
+		if ocs.Newest != "" {
+			cs.Newest = ocs.Newest
+		}
+		if ocs.Oldest != "" {
+			cs.Oldest = ocs.Oldest
+		}
+		if len(ocs.PendingReplies) > 0 {
+			cs.PendingReplies = ocs.PendingReplies
+		}
+		cs.Done = cs.Done || ocs.Done
+	}
+	if len(s.Anchors) == 0 {
+		s.Anchors = other.Anchors
+	}
+	if other.ListWatermark > s.ListWatermark {
+		s.ListWatermark = other.ListWatermark
+	}
+}

--- a/internal/beeper/syncstate_test.go
+++ b/internal/beeper/syncstate_test.go
@@ -1,0 +1,93 @@
+package beeper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncStateRoundTrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	s := NewSyncState()
+	s.EnsureChat("!a:x").Newest = "100"
+	s.EnsureChat("!a:x").Oldest = "5"
+	s.EnsureChat("!b:x").Done = true
+	s.Anchors = []AnchorProbe{{ChatID: "!a:x", MessageID: "42", Timestamp: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}}
+	s.ListWatermark = "2026-01-02T03:04:05Z"
+
+	blob, err := s.Marshal()
+	require.NoError(err)
+
+	got, err := LoadSyncState(blob)
+	require.NoError(err)
+	assert.Equal(s.Chats["!a:x"], got.Chats["!a:x"])
+	assert.Equal(s.Chats["!b:x"], got.Chats["!b:x"])
+	require.Len(got.Anchors, 1)
+	assert.Equal("42", got.Anchors[0].MessageID)
+	assert.True(got.Anchors[0].Timestamp.Equal(s.Anchors[0].Timestamp))
+	assert.Equal(s.ListWatermark, got.ListWatermark)
+}
+
+func TestLoadSyncStateEmpty(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	s, err := LoadSyncState("")
+	require.NoError(err)
+	require.NotNil(s.Chats)
+	assert.Empty(s.Chats)
+	assert.Empty(s.Anchors)
+}
+
+func TestLoadSyncStateInvalid(t *testing.T) {
+	_, err := LoadSyncState("{not json")
+	require.Error(t, err)
+}
+
+func TestSyncStateMerge(t *testing.T) {
+	assert := assert.New(t)
+	base := NewSyncState()
+	base.EnsureChat("!a:x").Newest = "10"
+	base.EnsureChat("!a:x").Oldest = "5"
+	base.EnsureChat("!keep:x").Newest = "77"
+	base.ListWatermark = "2026-01-01T00:00:00Z"
+	base.Anchors = []AnchorProbe{{ChatID: "!a:x", MessageID: "1"}}
+
+	// Checkpoint from an interrupted, more advanced run.
+	cp := NewSyncState()
+	cp.EnsureChat("!a:x").Newest = "20"
+	cp.EnsureChat("!a:x").Done = true
+	cp.EnsureChat("!new:x").Oldest = "3"
+	cp.ListWatermark = "2026-02-01T00:00:00Z"
+	cp.Anchors = []AnchorProbe{{ChatID: "!other:x", MessageID: "9"}}
+
+	base.Merge(cp)
+
+	assert.Equal("20", base.Chats["!a:x"].Newest, "checkpoint cursor wins")
+	assert.Equal("5", base.Chats["!a:x"].Oldest, "empty checkpoint field keeps baseline")
+	assert.True(base.Chats["!a:x"].Done, "done flags OR")
+	assert.Equal("77", base.Chats["!keep:x"].Newest, "untouched chats survive")
+	assert.Equal("3", base.Chats["!new:x"].Oldest, "new chats copied")
+	assert.Equal("2026-02-01T00:00:00Z", base.ListWatermark, "later watermark wins")
+	assert.Equal("1", base.Anchors[0].MessageID, "existing anchors are never replaced")
+}
+
+func TestSyncStateMergeNil(t *testing.T) {
+	base := NewSyncState()
+	base.EnsureChat("!a:x").Newest = "10"
+	base.Merge(nil)
+	assert.Equal(t, "10", base.Chats["!a:x"].Newest)
+}
+
+func TestSyncStateMergeFillsAnchor(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	base := NewSyncState()
+	cp := NewSyncState()
+	cp.Anchors = []AnchorProbe{{ChatID: "!a:x", MessageID: "9"}}
+	base.Merge(cp)
+	require.NotEmpty(base.Anchors)
+	assert.Equal("9", base.Anchors[0].MessageID)
+}

--- a/internal/beeper/token.go
+++ b/internal/beeper/token.go
@@ -1,0 +1,87 @@
+package beeper
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/msgvault/internal/fileutil"
+)
+
+// tokenFile stores the Beeper Desktop access token. There is a single Beeper
+// Desktop per machine (loopback-only API), so the file is a singleton rather
+// than per-identifier.
+type tokenFile struct {
+	AccessToken string `json:"access_token"`
+}
+
+// tokenPath returns the path of the Beeper Desktop token file.
+func tokenPath(tokensDir string) string {
+	return filepath.Join(tokensDir, "beeper.json")
+}
+
+// SaveToken saves the Beeper Desktop access token. Uses atomic temp-file +
+// rename to avoid partial writes, and fileutil.Secure* helpers for Windows
+// DACL hardening.
+func SaveToken(tokensDir, token string) error {
+	if err := fileutil.SecureMkdirAll(tokensDir, 0700); err != nil {
+		return fmt.Errorf("create tokens dir: %w", err)
+	}
+	data, err := json.Marshal(tokenFile{AccessToken: token}) //nolint:gosec // serialized to a 0600 file on the user's own machine
+	if err != nil {
+		return err
+	}
+	path := tokenPath(tokensDir)
+
+	tmpFile, err := os.CreateTemp(tokensDir, ".beeper-token-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp token file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp token file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp token file: %w", err)
+	}
+	if err := fileutil.SecureChmod(tmpPath, 0600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp token file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename temp token file: %w", err)
+	}
+	return nil
+}
+
+// LoadToken loads the Beeper Desktop access token.
+func LoadToken(tokensDir string) (string, error) {
+	data, err := os.ReadFile(tokenPath(tokensDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.New("no Beeper Desktop token found (run 'add-beeper' first)")
+		}
+		return "", fmt.Errorf("read beeper token: %w", err)
+	}
+	var tf tokenFile
+	if err := json.Unmarshal(data, &tf); err != nil {
+		return "", fmt.Errorf("parse beeper token: %w", err)
+	}
+	return tf.AccessToken, nil
+}
+
+// DeleteToken removes the Beeper Desktop token file. Missing file is not an error.
+func DeleteToken(tokensDir string) error {
+	err := os.Remove(tokenPath(tokensDir))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/beeper/token_test.go
+++ b/internal/beeper/token_test.go
@@ -1,0 +1,41 @@
+package beeper
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenRoundTrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+
+	_, err := LoadToken(dir)
+	require.Error(err)
+	assert.Contains(err.Error(), "add-beeper")
+
+	require.NoError(SaveToken(dir, "secret-token"))
+
+	got, err := LoadToken(dir)
+	require.NoError(err)
+	assert.Equal("secret-token", got)
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(tokenPath(dir))
+		require.NoError(err)
+		assert.Equal(os.FileMode(0600), info.Mode().Perm())
+	}
+
+	// Overwrite is atomic and replaces the value.
+	require.NoError(SaveToken(dir, "rotated"))
+	got, err = LoadToken(dir)
+	require.NoError(err)
+	assert.Equal("rotated", got)
+
+	require.NoError(DeleteToken(dir))
+	require.NoError(DeleteToken(dir), "double delete is not an error")
+}

--- a/internal/beeper/types.go
+++ b/internal/beeper/types.go
@@ -1,0 +1,190 @@
+package beeper
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ---- Beeper Desktop API objects (see /v1/spec, "Beeper Client API") ----
+
+// Account is a chat account connected to Beeper Desktop (one per network login).
+type Account struct {
+	AccountID string `json:"accountID"`
+	Network   string `json:"network"` // human-friendly name; may be empty
+	User      User   `json:"user"`
+}
+
+// User identifies a person on a network. Only fields the importer consumes
+// are modelled; the archived raw JSON preserves everything else.
+type User struct {
+	ID          string `json:"id"` // Matrix-style user ID, e.g. "@signal_<uuid>:beeper.local"
+	Username    string `json:"username"`
+	PhoneNumber string `json:"phoneNumber"` // E.164 when present
+	Email       string `json:"email"`
+	FullName    string `json:"fullName"`
+	IsSelf      bool   `json:"isSelf"`
+}
+
+// Participant is a chat member: a User plus membership metadata.
+type Participant struct {
+	User
+
+	IsAdmin bool `json:"isAdmin"`
+}
+
+// ChatParticipants wraps the (possibly truncated) participant list of a chat.
+type ChatParticipants struct {
+	Items   []Participant `json:"items"`
+	HasMore bool          `json:"hasMore"`
+	Total   int           `json:"total"`
+}
+
+// Chat is a conversation on one account.
+type Chat struct {
+	ID           string           `json:"id"` // Matrix room ID, globally unique
+	AccountID    string           `json:"accountID"`
+	Network      string           `json:"network"`
+	Title        string           `json:"title"`
+	Type         string           `json:"type"` // "single" | "group"
+	Participants ChatParticipants `json:"participants"`
+	LastActivity time.Time        `json:"lastActivity"`
+}
+
+// Reaction is one participant's reaction to a message.
+type Reaction struct {
+	ID            string `json:"id"`
+	ReactionKey   string `json:"reactionKey"`
+	ParticipantID string `json:"participantID"`
+	Emoji         bool   `json:"emoji"`
+}
+
+// Transcription is an attachment transcription (voice notes).
+type Transcription struct {
+	Transcription string `json:"transcription"`
+}
+
+// Attachment is a media attachment on a message. The id is typically an
+// mxc:// URL fetchable via GET /v1/assets/serve?url=.
+type Attachment struct {
+	ID            string         `json:"id"`
+	Type          string         `json:"type"` // unknown | img | video | audio
+	SrcURL        string         `json:"srcURL"`
+	MimeType      string         `json:"mimeType"`
+	FileName      string         `json:"fileName"`
+	FileSize      float64        `json:"fileSize"`
+	IsGif         bool           `json:"isGif"`
+	IsSticker     bool           `json:"isSticker"`
+	IsVoiceNote   bool           `json:"isVoiceNote"`
+	Duration      float64        `json:"duration"` // seconds
+	Transcription *Transcription `json:"transcription"`
+	Size          *struct {
+		Width  float64 `json:"width"`
+		Height float64 `json:"height"`
+	} `json:"size"`
+}
+
+// Message is one message event. type distinguishes regular content
+// (TEXT/NOTICE/media types/LOCATION) from REACTION events.
+type Message struct {
+	ID              string       `json:"id"` // numeric string, unique per installation
+	ChatID          string       `json:"chatID"`
+	AccountID       string       `json:"accountID"`
+	SenderID        string       `json:"senderID"`
+	SenderName      string       `json:"senderName"`
+	Timestamp       time.Time    `json:"timestamp"`
+	SortKey         string       `json:"sortKey"`
+	Type            string       `json:"type"`
+	Text            string       `json:"text"`
+	EditedTimestamp *time.Time   `json:"editedTimestamp"`
+	IsSender        bool         `json:"isSender"`
+	IsHidden        bool         `json:"isHidden"`
+	IsDeleted       bool         `json:"isDeleted"`
+	Attachments     []Attachment `json:"attachments"`
+	LinkedMessageID string       `json:"linkedMessageID"` // reply target (or reaction target for REACTION events)
+	Mentions        []string     `json:"mentions"`        // mentioned user IDs or "@room"; null for legacy messages
+	Reactions       []Reaction   `json:"reactions"`
+	// Raw holds the exact original JSON for this message, captured during decode
+	// (see UnmarshalJSON). It is archived verbatim so no API field is lost to
+	// our partial struct modelling.
+	Raw json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON decodes a Message while retaining the exact original bytes in
+// Raw, so the archived raw blob is lossless even for fields we do not model.
+func (m *Message) UnmarshalJSON(b []byte) error {
+	type alias Message // avoid recursion into this method
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*m = Message(a)
+	m.Raw = append(json.RawMessage(nil), b...)
+	return nil
+}
+
+// ListMessagesOutput is the page envelope of GET /v1/chats/{chatID}/messages.
+// Cursors are opaque; direction=before pages older, direction=after newer.
+type ListMessagesOutput struct {
+	Items        []Message `json:"items"`
+	HasMore      bool      `json:"hasMore"`
+	OldestCursor string    `json:"oldestCursor"`
+	NewestCursor string    `json:"newestCursor"`
+}
+
+// SearchChatsOutput is the page envelope of GET /v1/chats/search.
+type SearchChatsOutput struct {
+	Items        []Chat `json:"items"`
+	HasMore      bool   `json:"hasMore"`
+	OldestCursor string `json:"oldestCursor"`
+	NewestCursor string `json:"newestCursor"`
+}
+
+// ---- Importer options/summary ----
+
+// ImportOptions configures one Import run for a single Beeper account
+// (= one msgvault source).
+type ImportOptions struct {
+	// AccountID is the Beeper account to sync (e.g. "whatsapp", "signal").
+	// It doubles as the msgvault source identifier.
+	AccountID string
+	// Limit caps the number of messages processed per chat (0 = no limit).
+	// A limited backfill leaves the chat resumable, not complete.
+	Limit int
+	// Full ignores the prior sync cursor and any interrupted checkpoint so
+	// every chat is re-walked and every message re-persisted (repair path).
+	Full bool
+	// AttachmentsDir is the content-addressed attachment store root. Empty
+	// disables media download (as does NoMedia).
+	AttachmentsDir string
+	// NoMedia skips attachment downloads entirely (no pending markers are
+	// written; a later --full run re-persists messages and downloads then).
+	NoMedia bool
+	// MaxMediaBytes caps individual attachment downloads (0 = 100 MB).
+	// Over-cap attachments leave a pending marker.
+	MaxMediaBytes int64
+	// Progress, if non-nil, is called after each chat with a human-readable
+	// status line. Safe to leave nil (silent mode).
+	Progress func(msg string) `json:"-"`
+}
+
+type ImportSummary struct {
+	Duration          time.Duration
+	SourceID          int64
+	ChatsProcessed    int64
+	MessagesProcessed int64
+	// MessagesAdded counts messages persisted (upserted) this run, including
+	// re-persisted messages on --full and reconcile passes — not strictly
+	// new rows.
+	MessagesAdded      int64
+	ReactionsRefreshed int64
+	// AttachmentsDownloaded counts media stored this run;
+	// AttachmentsPending counts failed/deferred downloads that left a
+	// retry marker (see backfill-beeper-media).
+	AttachmentsDownloaded int64
+	AttachmentsPending    int64
+	// FetchErrors counts Beeper API fetch failures (a subset of Errors). Any
+	// fetch failure keeps the discovery watermark from advancing so the
+	// affected chats are re-visited next run.
+	FetchErrors int64
+	Errors      int64
+}

--- a/internal/clirun/env.go
+++ b/internal/clirun/env.go
@@ -3,12 +3,16 @@ package clirun
 // EnvIMAPPassword names the env var used to pass an IMAP password to a daemon-owned CLI subprocess.
 const EnvIMAPPassword = "MSGVAULT_IMAP_PASSWORD" // #nosec G101 -- environment variable name, not a credential value
 
+// EnvBeeperToken names the env var used to pass a Beeper Desktop access token
+// to a daemon-owned CLI subprocess.
+const EnvBeeperToken = "MSGVAULT_BEEPER_TOKEN" // #nosec G101 -- environment variable name, not a credential value
+
 // EnvRemoteDeleteOptIn names the env var that opts into executing staged remote deletions.
 const EnvRemoteDeleteOptIn = "MSGVAULT_ENABLE_REMOTE_DELETE"
 
 func EnvAllowed(name string) bool {
 	switch name {
-	case EnvIMAPPassword, EnvRemoteDeleteOptIn:
+	case EnvIMAPPassword, EnvBeeperToken, EnvRemoteDeleteOptIn:
 		return true
 	default:
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -189,6 +190,7 @@ type Config struct {
 	Accounts    []AccountSchedule `toml:"accounts"`
 	SynctechSMS SynctechSMSConfig `toml:"synctech_sms"`
 	GCal        []GCalSource      `toml:"gcal"`
+	Beeper      BeeperConfig      `toml:"beeper"`
 	Backup      BackupConfig      `toml:"backup"`
 
 	// Computed paths (not from config file)
@@ -666,6 +668,57 @@ func (c *Config) GetAccountSchedule(email string) *AccountSchedule {
 		}
 	}
 	return nil
+}
+
+// BeeperConfig configures the Beeper Desktop archive source ([beeper] table).
+// A single block, not a slice: the Beeper Desktop API is loopback-only, so
+// there is exactly one instance per machine and the daemon must be co-located
+// with it.
+type BeeperConfig struct {
+	// URL is the Beeper Desktop API base URL. Empty means the default
+	// loopback address (http://localhost:23373).
+	URL string `toml:"url"`
+	// Enabled gates the daemon scheduler job.
+	Enabled bool `toml:"enabled"`
+	// Schedule is a 5-field cron expression; empty = not daemon-scheduled.
+	Schedule string `toml:"schedule"`
+	// Accounts is an accountID include filter (empty = sync all accounts).
+	Accounts []string `toml:"accounts"`
+	// ExcludeAccounts skips specific accountIDs — e.g. ["whatsapp"] when the
+	// native import-whatsapp path already archives that network.
+	ExcludeAccounts []string `toml:"exclude_accounts"`
+	// RateLimitQPS bounds request rate against the local Beeper Desktop app
+	// (0 = default 20).
+	RateLimitQPS float64 `toml:"rate_limit_qps"`
+	// Media toggles attachment download (nil/absent = enabled).
+	Media *bool `toml:"media"`
+	// MaxMediaMB caps individual attachment downloads in MiB (0 = 100).
+	MaxMediaMB int `toml:"max_media_mb"`
+}
+
+// MediaEnabled reports whether attachment download is on (default true).
+func (b BeeperConfig) MediaEnabled() bool {
+	return b.Media == nil || *b.Media
+}
+
+// MaxMediaBytes returns the per-attachment download cap in bytes.
+func (b BeeperConfig) MaxMediaBytes() int64 {
+	if b.MaxMediaMB > 0 {
+		return int64(b.MaxMediaMB) << 20
+	}
+	return 100 << 20
+}
+
+// AccountIncluded reports whether a Beeper accountID passes the
+// include/exclude filters.
+func (b BeeperConfig) AccountIncluded(accountID string) bool {
+	if slices.Contains(b.ExcludeAccounts, accountID) {
+		return false
+	}
+	if len(b.Accounts) == 0 {
+		return true
+	}
+	return slices.Contains(b.Accounts, accountID)
 }
 
 // GCalSource is one configured Google Calendar sync target. Each entry is a

--- a/internal/config/config_beeper_test.go
+++ b/internal/config/config_beeper_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBeeperConfig(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	t.Setenv("MSGVAULT_HOME", tmpDir)
+
+	configContent := `
+[beeper]
+url = "http://localhost:9999"
+enabled = true
+schedule = "*/30 * * * *"
+accounts = ["signal", "telegram"]
+exclude_accounts = ["whatsapp"]
+rate_limit_qps = 10
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	require.NoError(os.WriteFile(configPath, []byte(configContent), 0644))
+
+	cfg, err := Load(configPath, "")
+	require.NoError(err)
+
+	assert.Equal("http://localhost:9999", cfg.Beeper.URL)
+	assert.Equal("http://localhost:9999", cfg.Beeper.URL)
+	assert.True(cfg.Beeper.Enabled)
+	assert.Equal("*/30 * * * *", cfg.Beeper.Schedule)
+	assert.Equal([]string{"signal", "telegram"}, cfg.Beeper.Accounts)
+	assert.Equal([]string{"whatsapp"}, cfg.Beeper.ExcludeAccounts)
+	assert.InEpsilon(10.0, cfg.Beeper.RateLimitQPS, 0.001)
+}
+
+func TestBeeperConfigDefaults(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	t.Setenv("MSGVAULT_HOME", tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.toml")
+	require.NoError(os.WriteFile(configPath, []byte(""), 0644))
+
+	cfg, err := Load(configPath, "")
+	require.NoError(err)
+
+	assert.Empty(cfg.Beeper.URL, "empty URL selects the client loopback default")
+	assert.False(cfg.Beeper.Enabled)
+	assert.Empty(cfg.Beeper.Schedule)
+	assert.True(cfg.Beeper.MediaEnabled(), "media defaults on")
+	assert.Equal(int64(100<<20), cfg.Beeper.MaxMediaBytes(), "default 100 MiB cap")
+}
+
+func TestBeeperMediaConfig(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	t.Setenv("MSGVAULT_HOME", tmpDir)
+
+	configContent := `
+[beeper]
+media = false
+max_media_mb = 5
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	require.NoError(os.WriteFile(configPath, []byte(configContent), 0644))
+
+	cfg, err := Load(configPath, "")
+	require.NoError(err)
+	assert.False(cfg.Beeper.MediaEnabled())
+	assert.Equal(int64(5<<20), cfg.Beeper.MaxMediaBytes())
+}
+
+func TestBeeperAccountIncluded(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       BeeperConfig
+		accountID string
+		want      bool
+	}{
+		{"no filters includes all", BeeperConfig{}, "signal", true},
+		{"include list match", BeeperConfig{Accounts: []string{"signal"}}, "signal", true},
+		{"include list miss", BeeperConfig{Accounts: []string{"signal"}}, "telegram", false},
+		{"exclude wins", BeeperConfig{ExcludeAccounts: []string{"whatsapp"}}, "whatsapp", false},
+		{"exclude beats include", BeeperConfig{Accounts: []string{"whatsapp"}, ExcludeAccounts: []string{"whatsapp"}}, "whatsapp", false},
+		{"exclude other passes", BeeperConfig{ExcludeAccounts: []string{"whatsapp"}}, "signal", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.AccountIncluded(tt.accountID))
+		})
+	}
+}

--- a/internal/query/duckdb_text.go
+++ b/internal/query/duckdb_text.go
@@ -14,7 +14,7 @@ var _ TextEngine = (*DuckDBEngine)(nil)
 
 // textTypeFilter returns a SQL condition restricting to text message types.
 func textTypeFilter() string {
-	return "msg.message_type IN ('whatsapp','imessage','sms','mms','google_voice_text','teams')"
+	return "msg.message_type IN (" + TextMessageTypeSQLList + ")"
 }
 
 // textSenderJoin resolves the sending participant (p_sender) for each text
@@ -465,11 +465,11 @@ func (e *DuckDBEngine) TextSearch(
 		LEFT JOIN participants p ON p.id = m.sender_id
 		LEFT JOIN conversations c ON c.id = m.conversation_id
 		WHERE messages_fts MATCH ?
-		  AND m.message_type IN ('whatsapp','imessage','sms','mms','google_voice_text','teams')
+		  AND %s
 		  AND %s
 		ORDER BY m.sent_at DESC
 		LIMIT ? OFFSET ?
-	`, store.LiveMessagesWhere("m", true))
+	`, textMsgTypeFilter(), store.LiveMessagesWhere("m", true))
 
 	rows, err := e.sqliteDB.QueryContext(ctx, sqlQuery,
 		match, limit, offset)

--- a/internal/query/sqlite_text.go
+++ b/internal/query/sqlite_text.go
@@ -44,13 +44,13 @@ func parseSQLiteTimestamp(s string) (time.Time, error) {
 // textMsgTypeFilter returns a SQL condition restricting to text message types.
 // Uses the m. table alias used in text query methods.
 func textMsgTypeFilter() string {
-	return "m.message_type IN ('whatsapp','imessage','sms','mms','google_voice_text','teams')"
+	return "m.message_type IN (" + TextMessageTypeSQLList + ")"
 }
 
 // textMsgTypeFilterAlias returns a SQL condition restricting to text message types
 // using the given table alias.
 func textMsgTypeFilterAlias(alias string) string {
-	return alias + ".message_type IN ('whatsapp','imessage','sms','mms','google_voice_text','teams')"
+	return alias + ".message_type IN (" + TextMessageTypeSQLList + ")"
 }
 
 func sqliteDirection(d SortDirection) string {
@@ -466,11 +466,11 @@ func (e *SQLiteEngine) TextSearch(
 		LEFT JOIN participants p ON p.id = m.sender_id
 		LEFT JOIN conversations c ON c.id = m.conversation_id
 		WHERE fts.messages_fts MATCH ?
-		  AND m.message_type IN ('whatsapp','imessage','sms','mms','google_voice_text','teams')
+		  AND %s
 		  AND %s
 		ORDER BY m.sent_at DESC
 		LIMIT ? OFFSET ?
-	`, store.LiveMessagesWhere("m", true))
+	`, textMsgTypeFilter(), store.LiveMessagesWhere("m", true))
 
 	rows, err := e.db.QueryContext(ctx, sqlQuery, match, limit, offset)
 	if err != nil {

--- a/internal/query/text_models.go
+++ b/internal/query/text_models.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"slices"
+	"strings"
 	"time"
 )
 
@@ -115,8 +116,14 @@ const messageTypeSMS = "sms"
 
 // TextMessageTypes lists the message_type values included in Texts mode.
 var TextMessageTypes = []string{
-	"whatsapp", "imessage", messageTypeSMS, "mms", "google_voice_text", "teams",
+	"whatsapp", "imessage", messageTypeSMS, "mms", "google_voice_text", "teams", "beeper",
 }
+
+// TextMessageTypeSQLList renders TextMessageTypes as a quoted SQL IN-list
+// ("'whatsapp','imessage',...") so filters derive from the one canonical
+// slice instead of hand-maintained literals. Values are trusted package
+// constants, never user input.
+var TextMessageTypeSQLList = "'" + strings.Join(TextMessageTypes, "','") + "'"
 
 // textSortFieldToSortField converts a TextSortField to the generic SortField
 // used by aggregate queries. TextSortByLastMessage has no direct equivalent
@@ -154,6 +161,7 @@ var KnownMessageTypes = []string{
 	"google_voice_text",
 	"google_voice_call",
 	"google_voice_voicemail",
+	"beeper",
 }
 
 // IsKnownMessageType reports whether mt is a message_type value that msgvault

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2132,6 +2132,32 @@ func (s *Store) EnsureConversationParticipant(conversationID, participantID int6
 	return err
 }
 
+// ConversationParticipantRef identifies one current member of a conversation.
+type ConversationParticipantRef struct {
+	ParticipantID int64
+	Role          string
+}
+
+// ReplaceConversationParticipants atomically replaces a conversation's
+// membership with a complete source snapshot.
+func (s *Store) ReplaceConversationParticipants(conversationID int64, participants []ConversationParticipantRef) error {
+	return s.withTx(func(tx *loggedTx) error {
+		if _, err := tx.Exec(`DELETE FROM conversation_participants WHERE conversation_id = ?`, conversationID); err != nil {
+			return err
+		}
+		for _, participant := range participants {
+			if participant.ParticipantID == 0 {
+				continue
+			}
+			if _, err := tx.Exec(s.dialect.InsertOrIgnore(fmt.Sprintf(`INSERT OR IGNORE INTO conversation_participants (conversation_id, participant_id, role, joined_at)
+				VALUES (?, ?, ?, %s)`, s.dialect.Now())), conversationID, participant.ParticipantID, participant.Role); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // UpsertReaction inserts or ignores a reaction.
 func (s *Store) UpsertReaction(messageID, participantID int64, reactionType, reactionValue string, createdAt time.Time) error {
 	_, err := s.db.Exec(s.dialect.InsertOrIgnore(`INSERT OR IGNORE INTO reactions (message_id, participant_id, reaction_type, reaction_value, created_at)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -969,6 +969,14 @@ func (s *Store) SetReplyTo(sourceID int64, childSourceMessageID, parentSourceMes
 	return err
 }
 
+// SetMessageEdited marks a message as edited at the source. UpsertMessage
+// does not write is_edited, so importers that observe an edit flag call this
+// after upserting.
+func (s *Store) SetMessageEdited(messageID int64) error {
+	_, err := s.db.Exec(`UPDATE messages SET is_edited = TRUE WHERE id = ?`, messageID)
+	return err
+}
+
 // MarkMessageDeleted marks a message as deleted from the source.
 func (s *Store) MarkMessageDeleted(sourceID int64, sourceMessageID string) error {
 	_, err := s.db.Exec(fmt.Sprintf(`
@@ -1630,6 +1638,109 @@ func (s *Store) EnsureParticipantByPhone(phone, displayName, identifierType stri
 	return id, nil
 }
 
+// MergeParticipants repoints every reference from the old participant to the
+// new one — messages, reactions, recipients, conversation membership, and
+// identifiers — deduplicating where unique constraints would collide, then
+// deletes the old participant row. Used when an importer discovers that two
+// participant rows are the same person.
+func (s *Store) MergeParticipants(oldID, newID int64) error {
+	if oldID == newID || oldID == 0 || newID == 0 {
+		return nil
+	}
+	return s.withTx(func(tx *loggedTx) error {
+		// The merge must not lose contact metadata: fill gaps on the survivor
+		// from the absorbed row. Both columns are UNIQUE, so the absorbed row
+		// must release each value before the survivor can take it.
+		var oldEmail, oldPhone sql.NullString
+		if err := tx.QueryRow(`SELECT NULLIF(email_address, ''), NULLIF(phone_number, '') FROM participants WHERE id = ?`, oldID).
+			Scan(&oldEmail, &oldPhone); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`UPDATE participants SET email_address = NULL, phone_number = NULL WHERE id = ?`, oldID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`
+			UPDATE participants SET
+				email_address = COALESCE(NULLIF(email_address, ''), ?),
+				phone_number  = COALESCE(NULLIF(phone_number, ''), ?)
+			WHERE id = ?`, oldEmail, oldPhone, newID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`UPDATE messages SET sender_id = ? WHERE sender_id = ?`, newID, oldID); err != nil {
+			return err
+		}
+		// Drop old rows that would collide with an existing row of the new
+		// participant, then repoint the remainder.
+		if _, err := tx.Exec(`
+			DELETE FROM reactions WHERE participant_id = ? AND EXISTS (
+				SELECT 1 FROM reactions r2 WHERE r2.message_id = reactions.message_id
+				  AND r2.participant_id = ? AND r2.reaction_type = reactions.reaction_type
+				  AND r2.reaction_value = reactions.reaction_value)`, oldID, newID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`UPDATE reactions SET participant_id = ? WHERE participant_id = ?`, newID, oldID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`
+			DELETE FROM message_recipients WHERE participant_id = ? AND EXISTS (
+				SELECT 1 FROM message_recipients m2 WHERE m2.message_id = message_recipients.message_id
+				  AND m2.participant_id = ? AND m2.recipient_type = message_recipients.recipient_type)`, oldID, newID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`UPDATE message_recipients SET participant_id = ? WHERE participant_id = ?`, newID, oldID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`
+			DELETE FROM conversation_participants WHERE participant_id = ? AND EXISTS (
+				SELECT 1 FROM conversation_participants c2 WHERE c2.conversation_id = conversation_participants.conversation_id
+				  AND c2.participant_id = ?)`, oldID, newID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`UPDATE conversation_participants SET participant_id = ? WHERE participant_id = ?`, newID, oldID); err != nil {
+			return err
+		}
+		// Identifier values are globally unique, so a plain repoint suffices.
+		if _, err := tx.Exec(`UPDATE participant_identifiers SET participant_id = ? WHERE participant_id = ?`, newID, oldID); err != nil {
+			return err
+		}
+		_, err := tx.Exec(`DELETE FROM participants WHERE id = ?`, oldID)
+		return err
+	})
+}
+
+// ParticipantByIdentifier returns the participant an identifier points at,
+// with whether that participant carries a phone number (0 if none).
+func (s *Store) ParticipantByIdentifier(identifierType, identifierValue string) (id int64, hasPhone bool, err error) {
+	err = s.db.QueryRow(`
+		SELECT p.id, COALESCE(p.phone_number, '') != ''
+		FROM participant_identifiers pi
+		JOIN participants p ON p.id = pi.participant_id
+		WHERE pi.identifier_type = ? AND pi.identifier_value = ?
+	`, identifierType, identifierValue).Scan(&id, &hasPhone)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	return id, hasPhone, err
+}
+
+// SetParticipantIdentifier points identifier (type, value) at participantID,
+// creating the row or re-pointing an existing one (idempotent). Importers use
+// it to persist alternate identifiers on an already-resolved participant so
+// later runs unify instead of forking a new participant.
+func (s *Store) SetParticipantIdentifier(participantID int64, identifierType, identifierValue string) error {
+	identifierType = strings.TrimSpace(identifierType)
+	identifierValue = strings.TrimSpace(identifierValue)
+	if identifierType == "" || identifierValue == "" {
+		return errors.New("identifier type and value are required")
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO participant_identifiers (participant_id, identifier_type, identifier_value, is_primary)
+		VALUES (?, ?, ?, FALSE)
+		ON CONFLICT (identifier_type, identifier_value) DO UPDATE SET participant_id = excluded.participant_id
+	`, participantID, identifierType, identifierValue)
+	return err
+}
+
 func (s *Store) EnsureParticipantByIdentifier(identifierType, identifierValue, displayName string) (int64, error) {
 	identifierType = strings.TrimSpace(identifierType)
 	identifierValue = strings.TrimSpace(identifierValue)
@@ -2200,6 +2311,45 @@ type AttachmentRef struct {
 	ContentHash        string
 	Size               int
 	SourceAttachmentID string
+	// Optional media metadata; zero values are stored as NULL.
+	MediaType  string
+	Width      int64
+	Height     int64
+	DurationMS int64
+}
+
+// replaceMessageAttachmentsWhere atomically deletes a message's attachment
+// rows matching deleteWhere and inserts refs. Refs with an empty StoragePath
+// (and, when requireHash is set, an empty ContentHash) are skipped.
+func (s *Store) replaceMessageAttachmentsWhere(messageID int64, deleteWhere string, requireHash bool, refs []AttachmentRef) error {
+	return s.withTx(func(tx *loggedTx) error {
+		if _, err := tx.Exec(`DELETE FROM attachments WHERE message_id = ? AND (`+deleteWhere+`)`, messageID); err != nil {
+			return err
+		}
+		for _, ref := range refs {
+			if ref.StoragePath == "" || (requireHash && ref.ContentHash == "") {
+				continue
+			}
+			if _, err := tx.Exec(fmt.Sprintf(`
+				INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, source_attachment_id,
+					media_type, width, height, duration_ms, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s)
+				ON CONFLICT (message_id, content_hash) WHERE content_hash IS NOT NULL AND content_hash != '' DO NOTHING
+			`, s.dialect.Now()), messageID, ref.Filename, ref.MimeType, ref.StoragePath, ref.ContentHash, int64(ref.Size), ref.SourceAttachmentID,
+				nullIfEmpty(ref.MediaType), nullIfZero(ref.Width), nullIfZero(ref.Height), nullIfZero(ref.DurationMS)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func nullIfEmpty(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: s != ""}
+}
+
+func nullIfZero(n int64) sql.NullInt64 {
+	return sql.NullInt64{Int64: n, Valid: n != 0}
 }
 
 // ReplaceMessageInlineAttachments replaces Teams-managed inline media rows for
@@ -2207,66 +2357,136 @@ type AttachmentRef struct {
 // scheme and legacy unmarked Teams inline rows produced before that marker was
 // added, while leaving URL-backed reference/recording attachments untouched.
 func (s *Store) ReplaceMessageInlineAttachments(messageID int64, refs []AttachmentRef) error {
-	return s.withTx(func(tx *loggedTx) error {
-		if _, err := tx.Exec(`
-			DELETE FROM attachments
-			WHERE message_id = ?
-			  AND (
-			    source_attachment_id LIKE 'teams:inline:%'
-			    OR (
-			      (source_attachment_id IS NULL OR source_attachment_id = '')
-			      AND storage_path != ''
-			      AND storage_path NOT LIKE 'http://%'
-			      AND storage_path NOT LIKE 'https://%'
-			      AND content_hash IS NOT NULL
-			      AND content_hash != ''
-			      AND COALESCE(filename, '') = ''
-			      AND COALESCE(mime_type, '') = ''
-			    )
-			  )
-		`, messageID); err != nil {
-			return err
+	return s.replaceMessageAttachmentsWhere(messageID, `
+		source_attachment_id LIKE 'teams:inline:%'
+		OR (
+		  (source_attachment_id IS NULL OR source_attachment_id = '')
+		  AND storage_path != ''
+		  AND storage_path NOT LIKE 'http://%'
+		  AND storage_path NOT LIKE 'https://%'
+		  AND content_hash IS NOT NULL
+		  AND content_hash != ''
+		  AND COALESCE(filename, '') = ''
+		  AND COALESCE(mime_type, '') = ''
+		)`, true, refs)
+}
+
+// ReplaceMessageBeeperAttachments replaces Beeper-managed attachment rows for
+// a message (rows whose source_attachment_id carries the "beeper:" prefix).
+// Rows with a content hash are downloaded media; rows without one are
+// pending-download markers whose storage_path holds the source asset URL, so
+// a later retry pass can find and repair them.
+func (s *Store) ReplaceMessageBeeperAttachments(messageID int64, refs []AttachmentRef) error {
+	return s.replaceMessageAttachmentsWhere(messageID, `source_attachment_id LIKE 'beeper:%'`, false, refs)
+}
+
+// MessageBeeperAttachments returns the message's existing Beeper-managed
+// attachment rows keyed by source_attachment_id, so re-persisting a message
+// can keep already-downloaded media without re-fetching it.
+func (s *Store) MessageBeeperAttachments(messageID int64) (map[string]AttachmentRef, error) {
+	rows, err := s.db.Query(`
+		SELECT COALESCE(filename, ''), COALESCE(mime_type, ''), storage_path, COALESCE(content_hash, ''), size, source_attachment_id,
+		       COALESCE(media_type, ''), COALESCE(width, 0), COALESCE(height, 0), COALESCE(duration_ms, 0)
+		FROM attachments
+		WHERE message_id = ? AND source_attachment_id LIKE 'beeper:%'
+	`, messageID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := map[string]AttachmentRef{}
+	for rows.Next() {
+		var ref AttachmentRef
+		var size int64
+		if err := rows.Scan(&ref.Filename, &ref.MimeType, &ref.StoragePath, &ref.ContentHash, &size, &ref.SourceAttachmentID,
+			&ref.MediaType, &ref.Width, &ref.Height, &ref.DurationMS); err != nil {
+			return nil, err
 		}
-		for _, ref := range refs {
-			if ref.StoragePath == "" || ref.ContentHash == "" {
-				continue
-			}
-			if _, err := tx.Exec(fmt.Sprintf(`
-				INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, source_attachment_id, created_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, %s)
-				ON CONFLICT (message_id, content_hash) WHERE content_hash IS NOT NULL AND content_hash != '' DO NOTHING
-			`, s.dialect.Now()), messageID, ref.Filename, ref.MimeType, ref.StoragePath, ref.ContentHash, int64(ref.Size), ref.SourceAttachmentID); err != nil {
-				return err
-			}
+		ref.Size = int(size)
+		out[ref.SourceAttachmentID] = ref
+	}
+	return out, rows.Err()
+}
+
+// SourceMessageRef locates an archived message at its source: the source
+// message ID, its conversation's source ID, and the archived timestamp.
+type SourceMessageRef struct {
+	SourceMessageID string
+	ChatID          string // conversations.source_conversation_id
+	SentAt          time.Time
+}
+
+// ListRecentMessagesForSource returns refs of the source's most recently
+// archived, non-tombstoned messages, for verifying that stored IDs still
+// resolve to the same content at the source.
+func (s *Store) ListRecentMessagesForSource(sourceID int64, limit int) ([]SourceMessageRef, error) {
+	rows, err := s.db.Query(`
+		SELECT m.source_message_id, c.source_conversation_id, m.sent_at
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		WHERE m.source_id = ? AND m.sent_at IS NOT NULL AND m.deleted_from_source_at IS NULL
+		ORDER BY m.sent_at DESC, m.id DESC
+		LIMIT ?
+	`, sourceID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []SourceMessageRef
+	for rows.Next() {
+		var ref SourceMessageRef
+		if err := rows.Scan(&ref.SourceMessageID, &ref.ChatID, &ref.SentAt); err != nil {
+			return nil, err
 		}
-		return nil
-	})
+		out = append(out, ref)
+	}
+	return out, rows.Err()
+}
+
+// BeeperPendingAttachmentMessage identifies a message with at least one
+// pending (not yet downloaded) Beeper attachment marker.
+type BeeperPendingAttachmentMessage struct {
+	MessageID       int64
+	SourceMessageID string
+	ChatID          string // conversations.source_conversation_id
+}
+
+// ListBeeperPendingAttachmentMessages returns the messages of a beeper
+// source that still have pending attachment markers, so a retry pass can
+// re-fetch their media. Buffered (not a cursor callback): callers do slow
+// network and write work per item, which must not hold a read cursor open.
+func (s *Store) ListBeeperPendingAttachmentMessages(sourceID int64) ([]BeeperPendingAttachmentMessage, error) {
+	rows, err := s.db.Query(`
+		SELECT m.id, m.source_message_id, c.source_conversation_id
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		WHERE m.source_id = ?
+		  AND EXISTS (
+		    SELECT 1 FROM attachments a
+		    WHERE a.message_id = m.id
+		      AND a.source_attachment_id LIKE 'beeper:%'
+		      AND (a.content_hash IS NULL OR a.content_hash = '')
+		  )
+	`, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var items []BeeperPendingAttachmentMessage
+	for rows.Next() {
+		var item BeeperPendingAttachmentMessage
+		if err := rows.Scan(&item.MessageID, &item.SourceMessageID, &item.ChatID); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
 }
 
 // ReplaceMessageLinkAttachments replaces URL-backed attachment rows for a message.
 // It intentionally leaves content-addressed local attachment paths (for example
 // downloaded inline media) untouched.
 func (s *Store) ReplaceMessageLinkAttachments(messageID int64, refs []AttachmentRef) error {
-	return s.withTx(func(tx *loggedTx) error {
-		if _, err := tx.Exec(`
-			DELETE FROM attachments
-			WHERE message_id = ?
-			  AND (storage_path LIKE 'http://%' OR storage_path LIKE 'https://%')
-		`, messageID); err != nil {
-			return err
-		}
-		for _, ref := range refs {
-			if ref.StoragePath == "" {
-				continue
-			}
-			if _, err := tx.Exec(fmt.Sprintf(`
-				INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, source_attachment_id, created_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, %s)
-				ON CONFLICT (message_id, content_hash) WHERE content_hash IS NOT NULL AND content_hash != '' DO NOTHING
-			`, s.dialect.Now()), messageID, ref.Filename, ref.MimeType, ref.StoragePath, ref.ContentHash, int64(ref.Size), ref.SourceAttachmentID); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+	return s.replaceMessageAttachmentsWhere(messageID,
+		`storage_path LIKE 'http://%' OR storage_path LIKE 'https://%'`, false, refs)
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -1649,11 +1649,12 @@ func (s *Store) MergeParticipants(oldID, newID int64) error {
 	}
 	return s.withTx(func(tx *loggedTx) error {
 		// The merge must not lose contact metadata: fill gaps on the survivor
-		// from the absorbed row. Both columns are UNIQUE, so the absorbed row
-		// must release each value before the survivor can take it.
-		var oldEmail, oldPhone sql.NullString
-		if err := tx.QueryRow(`SELECT NULLIF(email_address, ''), NULLIF(phone_number, '') FROM participants WHERE id = ?`, oldID).
-			Scan(&oldEmail, &oldPhone); err != nil {
+		// from the absorbed row, carrying the email's analytics domain with it.
+		// Email and phone are UNIQUE, so the absorbed row must release each
+		// value before the survivor can take it.
+		var oldEmail, oldDomain, oldPhone sql.NullString
+		if err := tx.QueryRow(`SELECT NULLIF(email_address, ''), NULLIF(domain, ''), NULLIF(phone_number, '') FROM participants WHERE id = ?`, oldID).
+			Scan(&oldEmail, &oldDomain, &oldPhone); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(`UPDATE participants SET email_address = NULL, phone_number = NULL WHERE id = ?`, oldID); err != nil {
@@ -1662,8 +1663,9 @@ func (s *Store) MergeParticipants(oldID, newID int64) error {
 		if _, err := tx.Exec(`
 			UPDATE participants SET
 				email_address = COALESCE(NULLIF(email_address, ''), ?),
+				domain        = COALESCE(NULLIF(domain, ''), ?),
 				phone_number  = COALESCE(NULLIF(phone_number, ''), ?)
-			WHERE id = ?`, oldEmail, oldPhone, newID); err != nil {
+			WHERE id = ?`, oldEmail, oldDomain, oldPhone, newID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(`UPDATE messages SET sender_id = ? WHERE sender_id = ?`, newID, oldID); err != nil {

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -544,7 +544,7 @@ func (s *Store) GetLastSuccessfulSync(sourceID int64) (*SyncRun, error) {
 		       error_message, cursor_before, cursor_after
 		FROM sync_runs
 		WHERE source_id = ? AND status = 'completed'
-		ORDER BY completed_at DESC
+		ORDER BY completed_at DESC, id DESC
 		LIMIT 1
 	`, sourceID)
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -572,7 +572,7 @@ func (m Model) messageListView() string {
 		// Format subject with indicators (rune-aware)
 		// For chat messages without a subject, show snippet or group title
 		subject := textutil.SanitizeTerminal(msg.Subject)
-		if subject == "" && msg.MessageType == "whatsapp" {
+		if subject == "" && query.IsTextMessageType(msg.MessageType) {
 			title := textutil.SanitizeTerminal(msg.ConversationTitle)
 			snippet := textutil.SanitizeTerminal(msg.Snippet)
 			if title != "" {
@@ -924,7 +924,7 @@ func (m Model) threadView() string {
 		}
 		if msg.Subject != "" {
 			fromSubject = truncateRunes(fromSubject, 18) + ": " + textutil.SanitizeTerminal(msg.Subject)
-		} else if msg.MessageType == "whatsapp" && msg.Snippet != "" {
+		} else if query.IsTextMessageType(msg.MessageType) && msg.Snippet != "" {
 			fromSubject = truncateRunes(fromSubject, 18) + ": " + textutil.SanitizeTerminal(msg.Snippet)
 		}
 		if msg.DeletedAt != nil {


### PR DESCRIPTION
Archives every chat network bridged through [Beeper Desktop](https://developers.beeper.com/desktop-api) — WhatsApp, Signal, Telegram, Instagram, LinkedIn, X, Facebook, Matrix — via its local REST API. Supersedes #455 as a single consolidated PR.

## Usage

```bash
msgvault add-beeper       # access token from Beeper Desktop → Settings → Developer
msgvault sync-beeper      # first run backfills full history; later runs are incremental
```

Each connected network account becomes its own source (`signal`, `whatsapp`, …), so networks stay separately filterable in the TUI and search; all rows share `message_type = "beeper"`.

## What's stored

Message text with FTS (voice-note transcriptions included), reactions, replies, mentions, group membership, deletion tombstones (archived content survives network deletions), media in the content-addressed attachment store, and the verbatim API JSON per message (`raw_format = beeper_json`).

## Behavior notes

- The client is GET-only by construction — the archiver can never write to Beeper.
- Backfills checkpoint continuously and resume after interruption; `--full` re-fetches and upserts in place.
- The live API's pagination quirks (`hasMore` never goes false; re-served pages at history edges) are handled and regression-tested against recorded behavior.
- Beeper message IDs are only unique per installation: an anchor probe fails fast after a reinstall/re-index instead of silently duplicating the archive.
- `[beeper]` config covers daemon scheduling, per-network include/exclude (e.g. exclude `whatsapp` when using the native importer), and a media size cap; `backfill-beeper-media` retries failed downloads.

## Store/query changes

- `SetMessageEdited` helper (nothing wrote `is_edited` before) and a same-second tiebreak in `GetLastSuccessfulSync`.
- The three attachment-replace methods now share one helper; media metadata lands in the insert.
- Texts-mode SQL type filters derive from `TextMessageTypes` instead of five hand-maintained literals, and the TUI snippet fallback applies to all text types (was WhatsApp-only).

Verified against a live Beeper Desktop with 8 accounts: full backfill, incremental re-runs, media download, interrupt/resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
