### PR TITLE
import-emlx: import *.partial.emlx files instead of skipping them

### DIFF
--- a/cmd/msgvault/cmd/import_emlx.go
+++ b/cmd/msgvault/cmd/import_emlx.go
@@ -371,6 +371,7 @@ func importAutoAccounts(
 		grandTotal.MessagesAdded += summary.MessagesAdded
 		grandTotal.MessagesUpdated += summary.MessagesUpdated
 		grandTotal.MessagesSkipped += summary.MessagesSkipped
+		grandTotal.PartialFiles += summary.PartialFiles
 		grandTotal.Errors += summary.Errors
 		if summary.HardErrors {
 			grandTotal.HardErrors = true
@@ -445,6 +446,12 @@ func printImportStats(out io.Writer, summary importer.EmlxImportSummary) {
 		"  Skipped (dup):  %d messages\n",
 		summary.MessagesSkipped,
 	)
+	if summary.PartialFiles > 0 {
+		_, _ = fmt.Fprintf(out,
+			"  Partial files:  %d (body imported; attachments not cached by Apple Mail)\n",
+			summary.PartialFiles,
+		)
+	}
 	_, _ = fmt.Fprintf(out,
 		"  Errors:         %d\n",
 		summary.Errors,

--- a/docs/usage/importing.md
+++ b/docs/usage/importing.md
@@ -196,8 +196,8 @@ Both layouts are supported. The importer discovers all `.mbox` and `.imapmbox` d
 
 Apple Mail stores its data at `~/Library/Mail/` on macOS. The auto-discover mode reads `~/Library/Accounts/Accounts4.sqlite` (the macOS accounts database) to map V10 directory GUIDs to email addresses. You can also use a Time Machine backup or a copy of the Mail directory from another machine.
 
-!!! warning
-    The `.partial.emlx` files that Apple Mail creates for incomplete downloads are automatically skipped during import.
+!!! note
+    Apple Mail stores IMAP and Gmail messages whose attachments have not been downloaded as `.partial.emlx` files. The message body in these files is complete, so they are imported normally — only the uncached attachment parts are absent. When both `N.emlx` and `N.partial.emlx` exist for the same message, the fully-downloaded copy is used. The import summary reports how many partial files were imported.
 
 ## Deduplication
 

--- a/internal/emlx/discover.go
+++ b/internal/emlx/discover.go
@@ -222,8 +222,8 @@ func findMessagesDir(mailboxPath string) string {
 	return candidates[0]
 }
 
-// hasEmlxFiles returns true if dir contains at least one
-// non-partial .emlx file.
+// hasEmlxFiles returns true if dir contains at least one .emlx file
+// (including *.partial.emlx).
 func hasEmlxFiles(dir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -290,9 +290,45 @@ func isDigitDir(name string) bool {
 }
 
 func isEmlxFile(name string) bool {
-	lower := strings.ToLower(name)
-	return strings.HasSuffix(lower, ".emlx") &&
-		!strings.HasSuffix(lower, ".partial.emlx")
+	return strings.HasSuffix(strings.ToLower(name), ".emlx")
+}
+
+// IsPartial reports whether name (or path) is a *.partial.emlx file.
+// Apple Mail uses the .partial.emlx form for IMAP/Gmail messages whose
+// body is fully downloaded but whose attachments are not cached locally;
+// the RFC822 payload is complete apart from the attachment parts.
+func IsPartial(name string) bool {
+	return strings.HasSuffix(strings.ToLower(name), ".partial.emlx")
+}
+
+// fullEmlxName returns the non-partial counterpart of a partial name
+// (e.g. "513139.partial.emlx" -> "513139.emlx").
+func fullEmlxName(name string) string {
+	return name[:len(name)-len(".partial.emlx")] + ".emlx"
+}
+
+// selectEmlxNames returns the .emlx file names among entries, skipping
+// a N.partial.emlx when its fully-downloaded N.emlx counterpart exists
+// in the same directory (the full copy supersedes the partial).
+func selectEmlxNames(entries []os.DirEntry) []string {
+	full := make(map[string]bool)
+	for _, e := range entries {
+		if !e.IsDir() && isEmlxFile(e.Name()) && !IsPartial(e.Name()) {
+			full[strings.ToLower(e.Name())] = true
+		}
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !isEmlxFile(e.Name()) {
+			continue
+		}
+		if IsPartial(e.Name()) &&
+			full[strings.ToLower(fullEmlxName(e.Name()))] {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names
 }
 
 func stripMailboxSuffix(name string) string {
@@ -329,10 +365,8 @@ func listEmlxFiles(
 	}
 
 	var files []string
-	for _, e := range entries {
-		if !e.IsDir() && isEmlxFile(e.Name()) {
-			files = append(files, filepath.Join(msgDir, e.Name()))
-		}
+	for _, name := range selectEmlxNames(entries) {
+		files = append(files, filepath.Join(msgDir, name))
 	}
 
 	// Walk numeric partition dirs in Data/ (parent of Messages/).
@@ -375,10 +409,8 @@ func collectPartitionFiles(dir string, files *[]string) {
 			if err != nil {
 				continue
 			}
-			for _, m := range msgs {
-				if !m.IsDir() && isEmlxFile(m.Name()) {
-					*files = append(*files, filepath.Join(msgDir, m.Name()))
-				}
+			for _, n := range selectEmlxNames(msgs) {
+				*files = append(*files, filepath.Join(msgDir, n))
 			}
 		} else if isDigitDir(name) {
 			collectPartitionFiles(filepath.Join(dir, name), files)

--- a/internal/emlx/discover_test.go
+++ b/internal/emlx/discover_test.go
@@ -103,7 +103,7 @@ func TestDiscoverMailboxes_EmptyMailbox(t *testing.T) {
 	require.Empty(t, mailboxes)
 }
 
-func TestDiscoverMailboxes_PartialEmlxSkipped(t *testing.T) {
+func TestDiscoverMailboxes_PartialEmlxIncluded(t *testing.T) {
 	require := require.New(t)
 	root := t.TempDir()
 	mboxDir := filepath.Join(root, "Test.mbox")
@@ -112,8 +112,41 @@ func TestDiscoverMailboxes_PartialEmlxSkipped(t *testing.T) {
 	mailboxes, err := DiscoverMailboxes(mboxDir)
 	require.NoError(err, "DiscoverMailboxes")
 	require.Len(mailboxes, 1)
-	require.Len(mailboxes[0].Files, 1, "partial should be skipped")
+	require.Len(mailboxes[0].Files, 2, "partial should be included")
 	require.Equal("1.emlx", filepath.Base(mailboxes[0].Files[0]))
+	require.Equal("2.partial.emlx", filepath.Base(mailboxes[0].Files[1]))
+}
+
+// A mailbox whose Messages/ directory contains only *.partial.emlx
+// files must still be discovered: for IMAP/Gmail accounts the partial
+// form holds the complete message body (only attachments are uncached).
+func TestDiscoverMailboxes_PartialOnlyMailbox(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	mboxDir := filepath.Join(root, "INBOX.mbox")
+	mkMailbox(t, mboxDir, "513139.partial.emlx")
+
+	mailboxes, err := DiscoverMailboxes(mboxDir)
+	require.NoError(err, "DiscoverMailboxes")
+	require.Len(mailboxes, 1, "partial-only mailbox should be discovered")
+	require.Len(mailboxes[0].Files, 1)
+	require.Equal("513139.partial.emlx", filepath.Base(mailboxes[0].Files[0]))
+}
+
+// When both N.emlx and N.partial.emlx exist in the same directory, the
+// fully-downloaded copy supersedes the partial.
+func TestDiscoverMailboxes_PartialSupersededByFull(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	mboxDir := filepath.Join(root, "Test.mbox")
+	mkMailbox(t, mboxDir, "1.emlx", "1.partial.emlx", "2.partial.emlx")
+
+	mailboxes, err := DiscoverMailboxes(mboxDir)
+	require.NoError(err, "DiscoverMailboxes")
+	require.Len(mailboxes, 1)
+	require.Len(mailboxes[0].Files, 2, "1.partial.emlx superseded by 1.emlx")
+	require.Equal("1.emlx", filepath.Base(mailboxes[0].Files[0]))
+	require.Equal("2.partial.emlx", filepath.Base(mailboxes[0].Files[1]))
 }
 
 func TestDiscoverMailboxes_NotADirectory(t *testing.T) {
@@ -290,7 +323,7 @@ func TestDiscoverMailboxes_V10SingleMailbox(t *testing.T) {
 	assert.Equal(wantSuffix, rel, "MsgDir relative")
 }
 
-func TestDiscoverMailboxes_V10PartialSkipped(t *testing.T) {
+func TestDiscoverMailboxes_V10PartialIncluded(t *testing.T) {
 	require := require.New(t)
 	root := t.TempDir()
 	mboxDir := filepath.Join(root, "Test.mbox")
@@ -301,8 +334,37 @@ func TestDiscoverMailboxes_V10PartialSkipped(t *testing.T) {
 	mailboxes, err := DiscoverMailboxes(mboxDir)
 	require.NoError(err, "DiscoverMailboxes")
 	require.Len(mailboxes, 1)
-	require.Len(mailboxes[0].Files, 1)
+	require.Len(mailboxes[0].Files, 2)
 	assert.Equal(t, "1.emlx", filepath.Base(mailboxes[0].Files[0]))
+	assert.Equal(t, "2.partial.emlx", filepath.Base(mailboxes[0].Files[1]))
+}
+
+// Partition subdirectories follow the same rules: partials are
+// collected, and a partial is superseded by a full copy alongside it.
+func TestDiscoverMailboxes_V10PartitionPartials(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	guid := "9F0F15DD-4CBC-448A-9EBF-C385A47A3A67"
+	mboxDir := filepath.Join(root, "INBOX.mbox")
+
+	partDir := filepath.Join(mboxDir, guid, "Data", "3", "Messages")
+	require.NoError(os.MkdirAll(partDir, 0700), "mkdir %q", partDir)
+	for _, name := range []string{
+		"100.emlx", "100.partial.emlx", "200.partial.emlx",
+	} {
+		path := filepath.Join(partDir, name)
+		require.NoError(os.WriteFile(path, []byte("10\nFrom: x\r\n\r\n"), 0600), "write %q", path)
+	}
+
+	mailboxes, err := DiscoverMailboxes(mboxDir)
+	require.NoError(err, "DiscoverMailboxes")
+	require.Len(mailboxes, 1)
+
+	var names []string
+	for _, f := range mailboxes[0].Files {
+		names = append(names, filepath.Base(f))
+	}
+	require.Equal([]string{"100.emlx", "200.partial.emlx"}, names)
 }
 
 func TestDiscoverMailboxes_MixedLegacyAndV10(t *testing.T) {

--- a/internal/importer/emlx_import.go
+++ b/internal/importer/emlx_import.go
@@ -66,8 +66,13 @@ type EmlxImportSummary struct {
 	MessagesAdded     int64
 	MessagesUpdated   int64
 	MessagesSkipped   int64
-	Errors            int64
-	HardErrors        bool
+
+	// PartialFiles counts *.partial.emlx files parsed. Their bodies are
+	// complete; only attachment parts are uncached by Apple Mail.
+	PartialFiles int64
+
+	Errors     int64
+	HardErrors bool
 }
 
 type emlxCheckpoint struct {
@@ -468,6 +473,10 @@ func ImportEmlxDir(
 					"file", filePath, "error", err,
 				)
 				continue
+			}
+
+			if emlx.IsPartial(filepath.Base(filePath)) {
+				summary.PartialFiles++
 			}
 
 			sum := sha256.Sum256(msg.Raw)

--- a/internal/importer/emlx_import_test.go
+++ b/internal/importer/emlx_import_test.go
@@ -267,23 +267,32 @@ func TestImportEmlxDir_ResumeFromCheckpoint(t *testing.T) {
 	require.Equal(2, msgCount, "msgCount")
 }
 
-func TestImportEmlxDir_PartialEmlxSkipped(t *testing.T) {
+// A .partial.emlx holds a complete message body (only attachments are
+// uncached by Apple Mail), so it must be imported like any other file.
+func TestImportEmlxDir_PartialEmlxImported(t *testing.T) {
+	require := require.New(t)
 	st, tmp := openTestStore(t)
 
 	root := filepath.Join(tmp, "Mail")
 	mboxDir := filepath.Join(root, "Mailboxes", "Test.mbox")
 	msgDir := filepath.Join(mboxDir, "Messages")
-	require.NoError(t, os.MkdirAll(msgDir, 0700), "mkdir")
+	require.NoError(os.MkdirAll(msgDir, 0700), "mkdir")
 
-	raw := email.NewMessage().
+	raw1 := email.NewMessage().
 		From("Alice <alice@example.com>").
 		Subject("Hello").
+		Header("Message-ID", "<msg1@example.com>").
 		Body("hi\n").
 		Bytes()
-	mkEmlx(t, msgDir, "1.emlx", raw)
+	mkEmlx(t, msgDir, "1.emlx", raw1)
 
-	// Create a .partial.emlx file.
-	mkEmlx(t, msgDir, "2.partial.emlx", raw)
+	raw2 := email.NewMessage().
+		From("Bob <bob@example.com>").
+		Subject("Attachments not cached").
+		Header("Message-ID", "<msg2@example.com>").
+		Body("body only\n").
+		Bytes()
+	mkEmlx(t, msgDir, "2.partial.emlx", raw2)
 
 	summary, err := ImportEmlxDir(
 		context.Background(), st, root, EmlxImportOptions{
@@ -292,9 +301,21 @@ func TestImportEmlxDir_PartialEmlxSkipped(t *testing.T) {
 			CheckpointInterval: 1,
 		},
 	)
-	require.NoError(t, err, "ImportEmlxDir")
-	// Only the non-partial file should be imported.
-	require.Equal(t, int64(1), summary.MessagesAdded, "MessagesAdded")
+	require.NoError(err, "ImportEmlxDir")
+	require.Equal(int64(2), summary.MessagesAdded, "MessagesAdded")
+	require.Equal(int64(1), summary.PartialFiles, "PartialFiles")
+
+	var subjects []string
+	rows, err := st.DB().Query(`SELECT subject FROM messages ORDER BY subject`)
+	require.NoError(err, "query subjects")
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var s string
+		require.NoError(rows.Scan(&s), "scan subject")
+		subjects = append(subjects, s)
+	}
+	require.NoError(rows.Err(), "rows error")
+	require.Equal([]string{"Attachments not cached", "Hello"}, subjects)
 }
 
 func TestImportEmlxDir_NoMailboxes(t *testing.T) {


### PR DESCRIPTION
Fixes #457.

- `import-emlx` now discovers and imports `*.partial.emlx` files. Apple Mail uses this form for IMAP/Gmail messages whose attachments are not cached locally; the RFC822 body is complete, so the message imports normally with only the uncached attachment parts absent. Mailboxes containing only partial files are now discovered instead of reporting 0 mailboxes.
- When both `N.emlx` and `N.partial.emlx` exist in the same directory, the fully-downloaded copy supersedes the partial.
- The import summary reports a `Partial files` count when any were imported.
- A partial re-imported later as a full `.emlx` is stored separately (content-hash identity); `msgvault deduplicate` merges such pairs by RFC822 Message-ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)