### PR TITLE
Bump Go to 1.26.5 (go.mod + nix pin)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 # Pin by digest for reproducibility; update periodically
-FROM golang:1.26-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS builder
+FROM golang:1.26-bookworm@sha256:18aedc16aa19b3fd7ded7245fc14b109e054d65d22ed53c355c899582bbb2113 AS builder
 
 # Install build dependencies for CGO (SQLite, DuckDB)
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/flake.nix
+++ b/flake.nix
@@ -20,14 +20,14 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        # Pin Go 1.26.4 until nixpkgs-unstable ships it.
+        # Pin Go 1.26.5 until nixpkgs-unstable ships it.
         # Scoped to msgvault only — do NOT export via overlay, that would
         # invalidate every Go derivation in the transitive closure.
         goPinned = pkgs.go_1_26.overrideAttrs (_: rec {
-          version = "1.26.4";
+          version = "1.26.5";
           src = pkgs.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+            hash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
           };
         });
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/msgvault
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
go1.26.5 fixes GO-2026-5856 (crypto/tls) and GO-2026-4970 (os), which govulncheck now flags on every branch — CI's test job fails at the vulnerability gate repo-wide. The nix flake pins the Go source tarball by hash, so it moves together with the go directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)