### PR TITLE
Enforce metadata/body search scopes with native contexts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -209,6 +209,23 @@ components:
     BackupFreezeEndResponse:
       additionalProperties: true
       type: object
+    BodySearchContext:
+      additionalProperties: true
+      properties:
+        context_snippets:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        context_snippets_truncated:
+          type: boolean
+        message_id:
+          format: int64
+          type: integer
+      required:
+        - message_id
+      type: object
     BuildingSummary:
       additionalProperties: true
       properties:
@@ -1099,6 +1116,12 @@ components:
     DeepSearchResponse:
       additionalProperties: true
       properties:
+        body_contexts:
+          items:
+            $ref: "#/components/schemas/BodySearchContext"
+          type:
+            - array
+            - "null"
         count:
           format: int64
           type: integer

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1118,6 +1118,8 @@ components:
           type: integer
         query:
           type: string
+        scope:
+          type: string
       required:
         - query
         - messages
@@ -2389,7 +2391,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.2.0
+  version: 1.3.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -4654,6 +4656,11 @@ paths:
           required: true
           schema:
             type: string
+        - description: "Exact search scope: body; omit for composite full-text search"
+          in: query
+          name: scope
+          schema:
+            type: string
         - description: Sender email/address filter
           in: query
           name: sender
@@ -4773,7 +4780,7 @@ paths:
           description: Error
       security:
         - apiKey: []
-      summary: Run deep aggregate search
+      summary: Run full-text message search
       tags:
         - API
   /api/v1/search/domains:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,14 +17,16 @@ All notable changes to msgvault, grouped by release.
 - MCP `list_messages` accepts a `conversation_id` filter for listing one
   conversation or thread.
 - The daemon HTTP API schema is now 1.3.0 and supports `scope=body` on deep
-  search so daemon-backed clients can require an exact body-only response.
+  search so daemon-backed clients can require an exact body-only response;
+  bounded excerpts are returned in an ID-keyed `body_contexts` companion.
 
 **Improvements**
 
 - Metadata and body search scopes are enforced consistently across SQLite,
   PostgreSQL, DuckDB, and daemon-backed MCP sessions. Metadata result counts
   and aggregate statistics use the same predicate, and body-search snippets
-  remain bounded and UTF-8-safe.
+  remain bounded, UTF-8-safe, and are selected by each backend's native FTS
+  tokenizer.
 - PostgreSQL full-text indexes use a versioned field layout so stale indexes
   are detected and must be backfilled before body-only search.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,26 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
-No notable changes yet.
+**New features**
+
+- MCP message search now separates metadata and body search:
+  `search_messages` searches metadata when `mode` is omitted, while
+  `search_message_bodies` performs body-only full-text search with bounded
+  context around each match. Explicit `vector` and `hybrid` modes remain on
+  `search_messages` when vector search is configured.
+- MCP `list_messages` accepts a `conversation_id` filter for listing one
+  conversation or thread.
+- The daemon HTTP API schema is now 1.3.0 and supports `scope=body` on deep
+  search so daemon-backed clients can require an exact body-only response.
+
+**Improvements**
+
+- Metadata and body search scopes are enforced consistently across SQLite,
+  PostgreSQL, DuckDB, and daemon-backed MCP sessions. Metadata result counts
+  and aggregate statistics use the same predicate, and body-search snippets
+  remain bounded and UTF-8-safe.
+- PostgreSQL full-text indexes use a versioned field layout so stale indexes
+  are detected and must be backfilled before body-only search.
 
 ---
 

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -81,9 +81,10 @@ cap it at 50. Metadata-only `search_messages` reports an exact `total`.
 When `mode` is omitted, free text matches subject, snippet, sender, and
 recipient metadata, never message bodies. Use `search_message_bodies` for
 body keywords; it accepts operators such as `from:` and `label:` as filters
-but still requires at least one free-text term. When additional body contexts
-are omitted by the five-snippet cap or the 1 MiB per-body context scan limit,
-`context_snippets_truncated` is `true`.
+but still requires at least one free-text term. Context extraction has a fixed
+request-wide work budget; when matches fall outside it, or additional contexts
+are omitted by the five-snippet cap, `context_snippets_truncated` is `true` and
+`context_snippets` may be empty.
 Gmail-only operators such as `list:` are rejected because msgvault does not
 index `List-ID` locally; use Gmail-side validation for those checks.
 To restrict mixed archives to values such as `email`, `calendar_event`,

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -82,7 +82,8 @@ When `mode` is omitted, free text matches subject, snippet, sender, and
 recipient metadata, never message bodies. Use `search_message_bodies` for
 body keywords; it accepts operators such as `from:` and `label:` as filters
 but still requires at least one free-text term. When additional body contexts
-are omitted by the five-snippet cap, `context_snippets_truncated` is `true`.
+are omitted by the five-snippet cap or the 1 MiB per-body context scan limit,
+`context_snippets_truncated` is `true`.
 Gmail-only operators such as `list:` are rejected because msgvault does not
 index `List-ID` locally; use Gmail-side validation for those checks.
 To restrict mixed archives to values such as `email`, `calendar_event`,

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -47,11 +47,12 @@ The MCP server exposes the following tools to connected AI clients:
 
 | Tool | Description | Parameters |
 |---|---|---|
-| `search_messages` | Search with Gmail-like query syntax. When [vector search](/usage/vector-search/) is configured, supports semantic and hybrid modes. | `query` (string, required), `mode` (string: `fts`/`vector`/`hybrid`, default `fts`), `explain` (bool), `limit` (int), `offset` (int), `account` (string) |
+| `search_messages` | With `mode` omitted, search message metadata using Gmail-like query syntax. When [vector search](/usage/vector-search/) is configured, `vector` and `hybrid` modes are also available. | `query` (string, required), `mode` (string: `vector`/`hybrid`, vector configuration only), `explain` (bool, vector configuration only), `limit` (int), `offset` (int), `account` (string) |
+| `search_message_bodies` | Search only message bodies with full-text keywords and return up to five 300-byte context snippets per message. | `query` (string, required), `limit` (int), `offset` (int), `account` (string) |
 | `find_similar_messages` | Nearest-neighbor search from a seed message's embedding. Requires vector search to be configured and an active index generation. | `message_id` (int, required), `limit` (int), `account` (string), `message_type` (string), `after` (string), `before` (string), `has_attachment` (bool) |
 | `search_by_domains` | Find messages where any participant (`from`, `to`, or `cc`) belongs to one of several domains, regardless of direction. | `domains` (comma-separated string, required), `limit` (int), `offset` (int), `after` (string), `before` (string) |
 | `get_message` | Get message details with windowed body paging | `id` (int, required), `offset` (int), `center_at` (int), `max_chars` (int), `body_format` (string: `auto`/`text`/`html`), `full_body` (bool) |
-| `list_messages` | List messages with filters | `from` (string), `to` (string), `label` (string), `after` (string), `before` (string), `has_attachment` (bool), `limit` (int), `offset` (int), `account` (string) |
+| `list_messages` | List messages with filters | `from` (string), `to` (string), `label` (string), `after` (string), `before` (string), `has_attachment` (bool), `conversation_id` (int), `limit` (int), `offset` (int), `account` (string) |
 | `get_attachment` | Get attachment content by ID | `attachment_id` (int) |
 | `export_attachment` | Save attachment to filesystem | `attachment_id` (int), `destination` (string) |
 | `get_stats` | Archive overview statistics. Includes vector index state when configured. | — |
@@ -70,14 +71,20 @@ The MCP server exposes the following tools to connected AI clients:
 }
 ```
 
-Use `offset` and `limit` to request subsequent pages. `search_messages`
-and `list_messages` default to `limit = 20` and cap it at 50. When a
-backend cannot report a full result count, `total` is `-1`; use
-`has_more` as the pagination signal. `list_messages` uses this
-`total = -1` shape because it does not run a separate count query.
+Use `offset` and `limit` to request subsequent pages. `search_messages`,
+`search_message_bodies`, and `list_messages` default to `limit = 20` and
+cap it at 50. Metadata-only `search_messages` reports an exact `total`.
+`search_message_bodies`, vector/hybrid search, and `list_messages` use
+`total = -1`; use `has_more` as their pagination signal.
+
 `search_messages` accepts msgvault's local subset of Gmail-like syntax.
-Gmail-only operators such as `list:` are rejected because msgvault does
-not index `List-ID` locally; use Gmail-side validation for those checks.
+When `mode` is omitted, free text matches subject, snippet, sender, and
+recipient metadata, never message bodies. Use `search_message_bodies` for
+body keywords; it accepts operators such as `from:` and `label:` as filters
+but still requires at least one free-text term. When additional body contexts
+are omitted by the five-snippet cap, `context_snippets_truncated` is `true`.
+Gmail-only operators such as `list:` are rejected because msgvault does not
+index `List-ID` locally; use Gmail-side validation for those checks.
 To restrict mixed archives to values such as `email`, `calendar_event`,
 `teams`, `sms`, or `mms`, include a `message_type:` operator in the query
 (for example `message_type:teams incident review`). `find_similar_messages`
@@ -89,7 +96,17 @@ slice of the body plus `body_length`, `body_returned`, `offset`, and
 `has_more`, so unusually large messages are paged across calls instead of
 being returned in a single response.
 
-`find_similar_messages` is only registered when the server starts with vector search configured. `search_messages` is always available, but `mode=vector` and `mode=hybrid` return `vector_not_enabled` when the server is not configured for vector search. Vector and hybrid queries require at least one free-text term (operator-only queries return `missing_free_text`). They support `offset`/`limit` pagination inside the configured hybrid ranking window; when `[vector.search].max_page_size_hybrid` is positive, an `offset` at or beyond that cap returns `pagination_limit`. Use `mode=fts` for deeper pagination or adjust that config cap.
+`find_similar_messages` is only registered when the server starts with vector
+search configured. `search_messages` is always available: omit `mode` for
+metadata search, or set `mode=vector` or `mode=hybrid` when vector search is
+configured. Explicit `mode=fts` is not accepted by the MCP tool. Vector and
+hybrid queries require at least one free-text term (operator-only queries
+return `missing_free_text`). They support `offset`/`limit` pagination inside
+the configured hybrid ranking window; when
+`[vector.search].max_page_size_hybrid` is positive, an `offset` at or beyond
+that cap returns `pagination_limit`. For deeper non-vector pagination, omit
+`mode` to search metadata or use `search_message_bodies` for body keywords;
+alternatively adjust the vector ranking cap.
 
 In `mode=vector` and `mode=hybrid`, the paginated response also includes
 top-level `mode`, `pool_saturated`, and `generation` fields. When

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -209,8 +209,9 @@ message in your archive, embeds missing rows in batches through your
 configured embedder, and atomically activates the generation once
 coverage reaches zero. During the
 first build, when no active generation exists yet, HTTP and MCP
-vector/hybrid search return `index_building`; use `mode=fts` for the
-interim.
+vector/hybrid search return `index_building`. For interim keyword search,
+use `mode=fts` on the CLI or HTTP API. In MCP, omit `mode` for metadata
+search or use `search_message_bodies` for body keywords.
 
 !!! tip
     You can interrupt and resume. Each invocation of `msgvault embeddings build`
@@ -345,10 +346,11 @@ msgvault search "message_type:teams release planning" --mode vector
 ```
 
 If the active generation is scoped to `teams`, an unscoped vector/hybrid query
-or a query scoped to `email` returns `index_scope_mismatch`. Use `mode=fts` for
-unscoped keyword searches, add the matching message-type filter, or rebuild an
-unscoped generation by clearing `[vector.embed.scope].message_types` and running
-a full rebuild.
+or a query scoped to `email` returns `index_scope_mismatch`. For unscoped
+keyword search, use `mode=fts` on the CLI or HTTP API; in MCP, omit `mode` for
+metadata or use `search_message_bodies` for body keywords. Alternatively, add
+the matching message-type filter or rebuild an unscoped generation by clearing
+`[vector.embed.scope].message_types` and running a full rebuild.
 
 ## Search
 
@@ -381,16 +383,21 @@ candidate page.
 the free text is what gets embedded as the query vector. A query
 that is purely operators (e.g. `from:alice label:IMPORTANT`) is
 rejected; HTTP and MCP return `missing_free_text`. Use `mode=fts` for
-those.
+filter-only CLI or HTTP queries. In MCP, omit `mode` for metadata-only
+filtering.
 
 **MCP tools:**
 
-- `search_messages` accepts `mode` (`fts`/`vector`/`hybrid`) and
-  `explain` arguments. It paginates with `offset` and `limit`; for
-  vector/hybrid modes, pagination is limited to the configured
+- `search_messages` searches metadata when `mode` is omitted and accepts
+  explicit `vector` or `hybrid` modes plus an `explain` argument. It
+  paginates with `offset` and `limit`; for vector/hybrid modes, pagination
+  is limited to the configured
   `[vector.search].max_page_size_hybrid` ranking window when that cap
   is positive. Requests whose `offset` is at or beyond that window
   return `pagination_limit`.
+- `search_message_bodies` performs body-only full-text search and returns
+  bounded context around each keyword match. It requires a free-text term
+  and does not depend on the vector index.
 - `find_similar_messages` takes a seed `message_id` and returns
   nearest neighbors (excluding the seed itself). Optional `account`,
   `after`, `before`, `has_attachment` filters.
@@ -411,25 +418,30 @@ embedding output policy. While the rebuild is in flight,
 `mode=vector` and `mode=hybrid` return `index_stale` (the
 previously-active generation no longer matches the configured
 fingerprint, so search refuses to serve potentially-mismatched
-results). Use `mode=fts` until the new generation activates; it does
-not depend on the vector index. Once `msgvault embeddings build`
-reports the new generation activated, vector and hybrid modes resume.
+results). On the CLI or HTTP API, use `mode=fts` until the new generation
+activates; it does not depend on the vector index. In MCP, omit `mode` for
+metadata search or use `search_message_bodies`. Once `msgvault embeddings
+build` reports the new generation activated, vector and hybrid modes resume.
 
 ## Troubleshooting
 
 Common HTTP/MCP error codes and fixes. The CLI reports equivalent
 conditions as command errors rather than structured codes.
 
+In the table, a non-vector fallback means `mode=fts` for the CLI or HTTP,
+omitted `mode` for MCP metadata search, or `search_message_bodies` for MCP
+body keywords.
+
 | Error | Meaning | Recovery |
 |---|---|---|
 | `vector_not_enabled` | The server or MCP process did not wire a vector backend, usually because `[vector] enabled = false`. | Set `enabled = true`, configure `[vector.embeddings]`, and start with a build that includes the needed backend (`sqlite_vec` or `pgvector`). |
 | `index_stale` | Active generation's fingerprint does not match the current model, dimension, preprocessing policy, `max_input_chars`, or embedding output policy. | Run `msgvault embeddings build --full-rebuild --yes`. |
-| `index_building` | No active generation yet; one is being built. | Finish running `msgvault embeddings build` or wait for the scheduler. Use `mode=fts` for the interim. |
-| `missing_free_text` | `mode=vector` or `mode=hybrid` used with a filter-only query (no free text to embed). | Add free-text terms to `q`, or switch to `mode=fts`. |
-| `index_scope_mismatch` | The active vector generation was built for selected message types and the query is unscoped or asks for a type outside that scope. | Add a compatible `message_type` filter, use `mode=fts`, or rebuild an unscoped generation. |
+| `index_building` | No active generation yet; one is being built. | Finish running `msgvault embeddings build`, wait for the scheduler, or use the appropriate non-vector fallback. |
+| `missing_free_text` | `mode=vector` or `mode=hybrid` used with a filter-only query (no free text to embed). | Add free-text terms to `q`, or use the appropriate non-vector fallback. |
+| `index_scope_mismatch` | The active vector generation was built for selected message types and the query is unscoped or asks for a type outside that scope. | Add a compatible `message_type` filter, use the appropriate non-vector fallback, or rebuild an unscoped generation. |
 | `pagination_unsupported` | HTTP request asked for `page>1` with `mode=vector|hybrid`. | Use `page=1` with a larger `page_size` instead. |
-| `pagination_limit` | MCP `search_messages` asked for an `offset` at or beyond a positive `[vector.search].max_page_size_hybrid` cap in `mode=vector|hybrid`. | Use `mode=fts` for deeper pagination, request an earlier page, or raise/disable the hybrid page-size cap. |
-| `invalid_mode` | `mode=` value other than `fts`, `vector`, `hybrid`. | Pick one of those. |
+| `pagination_limit` | MCP `search_messages` asked for an `offset` at or beyond a positive `[vector.search].max_page_size_hybrid` cap in `mode=vector|hybrid`. | Omit `mode` for metadata search, use `search_message_bodies` for body keywords, request an earlier vector page, or raise/disable the hybrid page-size cap. |
+| `invalid_mode` | The requested mode is not supported by that surface. | Use `fts`, `vector`, or `hybrid` on the CLI or HTTP; use `vector`, `hybrid`, or omitted `mode` in MCP. |
 | `embedding_timeout` | The embedding endpoint did not respond before the request deadline (transient: slow/cold model, network blip). | Retry; if persistent, raise `[vector.embeddings].timeout` or use a faster endpoint. |
 
 For non-429 HTTP 4xx errors, msgvault treats the response as

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -197,13 +197,23 @@ type GmailIDsResponse struct {
 }
 
 type DeepSearchResponse struct {
-	Query    string           `json:"query"`
-	Scope    string           `json:"scope,omitempty"`
-	Messages []MessageSummary `json:"messages"`
-	Count    int              `json:"count"`
-	HasMore  bool             `json:"has_more"`
-	Offset   int              `json:"offset"`
-	Limit    int              `json:"limit"`
+	Query        string              `json:"query"`
+	Scope        string              `json:"scope,omitempty"`
+	Messages     []MessageSummary    `json:"messages"`
+	BodyContexts []BodySearchContext `json:"body_contexts,omitempty"`
+	Count        int                 `json:"count"`
+	HasMore      bool                `json:"has_more"`
+	Offset       int                 `json:"offset"`
+	Limit        int                 `json:"limit"`
+}
+
+// BodySearchContext carries exact body-match excerpts separately from the
+// stable MessageSummary schema used across existing client surfaces.
+type BodySearchContext struct {
+	MessageID       int64    `json:"message_id"`
+	ContextSnippets []string `json:"context_snippets,omitempty"`
+	// ContextSnippetsTruncated reports contexts omitted by response or work caps.
+	ContextSnippetsTruncated bool `json:"context_snippets_truncated,omitempty"`
 }
 
 // MessageSummary represents a message in list responses.
@@ -2274,6 +2284,14 @@ func toMessageSummaryFromQuery(m query.MessageSummary) MessageSummary {
 	}
 }
 
+func toBodySearchContext(m query.MessageSummary) BodySearchContext {
+	return BodySearchContext{
+		MessageID:                m.ID,
+		ContextSnippets:          m.BodyContextSnippets,
+		ContextSnippetsTruncated: m.BodyContextSnippetsTruncated,
+	}
+}
+
 func formatQueryAddresses(addrs []query.Address) []string {
 	if addrs == nil {
 		return []string{}
@@ -2797,6 +2815,10 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		if s.writeIfContextError(w, err) {
 			return
 		}
+		if scope == "body" && errors.Is(err, query.ErrMessageBodySearchInvalidQuery) {
+			writeError(w, http.StatusBadRequest, "invalid_query", err.Error())
+			return
+		}
 		if scope == "body" && (errors.Is(err, query.ErrMessageBodySearchUnavailable) ||
 			errors.Is(err, query.ErrMessageBodySearchIndexStale)) {
 			writeError(w, http.StatusServiceUnavailable, "body_search_index_unavailable", err.Error())
@@ -2816,15 +2838,23 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	for i, m := range messages {
 		summaries[i] = toMessageSummaryFromQuery(m)
 	}
+	var bodyContexts []BodySearchContext
+	if scope == "body" {
+		bodyContexts = make([]BodySearchContext, len(messages))
+		for i, message := range messages {
+			bodyContexts[i] = toBodySearchContext(message)
+		}
+	}
 
 	writeJSON(w, http.StatusOK, DeepSearchResponse{
-		Query:    queryStr,
-		Scope:    scope,
-		Messages: summaries,
-		Count:    len(summaries),
-		HasMore:  hasMore,
-		Offset:   offset,
-		Limit:    limit,
+		Query:        queryStr,
+		Scope:        scope,
+		Messages:     summaries,
+		BodyContexts: bodyContexts,
+		Count:        len(summaries),
+		HasMore:      hasMore,
+		Offset:       offset,
+		Limit:        limit,
 	})
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -198,6 +198,7 @@ type GmailIDsResponse struct {
 
 type DeepSearchResponse struct {
 	Query    string           `json:"query"`
+	Scope    string           `json:"scope,omitempty"`
 	Messages []MessageSummary `json:"messages"`
 	Count    int              `json:"count"`
 	HasMore  bool             `json:"has_more"`
@@ -2716,8 +2717,9 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleDeepSearch performs full-text body search via FTS5.
-// GET /api/v1/search/deep?q=invoice&offset=0&limit=100&source_id=1&hide_deleted=true.
+// handleDeepSearch performs composite full-text search, or exact body-only
+// search when scope=body is requested.
+// GET /api/v1/search/deep?q=invoice&scope=body&offset=0&limit=100&source_id=1&hide_deleted=true.
 func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	if s.engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
@@ -2729,6 +2731,11 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "missing_query", "Query parameter 'q' is required")
 		return
 	}
+	scope := r.URL.Query().Get("scope")
+	if scope != "" && scope != "body" {
+		writeError(w, http.StatusBadRequest, "invalid_scope", "Invalid search scope. Must be 'body' or omitted")
+		return
+	}
 
 	filter, err := parseMessageFilter(r)
 	if err != nil {
@@ -2738,6 +2745,11 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	q := search.Parse(queryStr)
 	if err := q.Err(); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_query", err.Error())
+		return
+	}
+	if scope == "body" && len(q.TextTerms) == 0 {
+		writeError(w, http.StatusBadRequest, "missing_free_text",
+			"Body-scoped search requires at least one free-text term")
 		return
 	}
 
@@ -2769,9 +2781,25 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	merged := query.MergeFilterIntoQuery(q, filter)
 
 	// Fetch one extra row to determine has_more accurately.
-	messages, err := s.engine.Search(r.Context(), merged, limit+1, offset)
+	var messages []query.MessageSummary
+	if scope == "body" {
+		bodySearcher, ok := s.engine.(query.MessageBodySearcher)
+		if !ok {
+			writeError(w, http.StatusNotImplemented, "body_search_unavailable",
+				"Query engine does not support exact message body search")
+			return
+		}
+		messages, err = bodySearcher.SearchMessageBodies(r.Context(), merged, limit+1, offset)
+	} else {
+		messages, err = s.engine.Search(r.Context(), merged, limit+1, offset)
+	}
 	if err != nil {
 		if s.writeIfContextError(w, err) {
+			return
+		}
+		if scope == "body" && (errors.Is(err, query.ErrMessageBodySearchUnavailable) ||
+			errors.Is(err, query.ErrMessageBodySearchIndexStale)) {
+			writeError(w, http.StatusServiceUnavailable, "body_search_index_unavailable", err.Error())
 			return
 		}
 		s.logger.Error("deep search failed", "query", queryStr, "error", err)
@@ -2791,6 +2819,7 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, DeepSearchResponse{
 		Query:    queryStr,
+		Scope:    scope,
 		Messages: summaries,
 		Count:    len(summaries),
 		HasMore:  hasMore,

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4437,7 +4437,12 @@ func TestHandleDeepSearchBodyScope(t *testing.T) {
 			assert.Equal([]string{"bodyneedle"}, q.TextTerms, "body TextTerms")
 			assert.Equal(11, limit, "limit includes has_more probe")
 			assert.Equal(3, offset, "offset")
-			return []query.MessageSummary{{ID: 2, Subject: "body hit"}}, nil
+			return []query.MessageSummary{{
+				ID:                           2,
+				Subject:                      "body hit",
+				BodyContextSnippets:          []string{"exact body context"},
+				BodyContextSnippetsTruncated: true,
+			}}, nil
 		},
 	}
 	srv := newTestServerWithEngine(t, engine)
@@ -4459,6 +4464,17 @@ func TestHandleDeepSearchBodyScope(t *testing.T) {
 	message, ok := messages[0].(map[string]any)
 	require.True(ok, "message response type")
 	assert.InDelta(float64(2), message["id"], 0, "body hit ID")
+	assert.NotContains(message, "context_snippets",
+		"body search must preserve the shared MessageSummary schema")
+	assert.NotContains(message, "context_snippets_truncated")
+	contexts, ok := resp["body_contexts"].([]any)
+	require.True(ok, "body_contexts response type")
+	require.Len(contexts, 1)
+	bodyContext, ok := contexts[0].(map[string]any)
+	require.True(ok, "body context response type")
+	assert.InDelta(float64(2), bodyContext["message_id"], 0, "body context message ID")
+	assert.Equal([]any{"exact body context"}, bodyContext["context_snippets"])
+	assert.Equal(true, bodyContext["context_snippets_truncated"])
 }
 
 func TestHandleDeepSearchScopeValidation(t *testing.T) {
@@ -4485,6 +4501,17 @@ func TestHandleDeepSearchScopeValidation(t *testing.T) {
 			path:       "/api/v1/search/deep?q=needle&scope=body",
 			engine:     struct{ query.Engine }{Engine: &querytest.MockEngine{}},
 			wantStatus: http.StatusNotImplemented,
+		},
+		{
+			name: "body work limit is a client error",
+			path: "/api/v1/search/deep?q=needle&scope=body",
+			engine: &bodySearchTestEngine{
+				MockEngine: &querytest.MockEngine{},
+				searchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+					return nil, fmt.Errorf("%w: supports at most 32 free-text terms", query.ErrMessageBodySearchInvalidQuery)
+				},
+			},
+			wantStatus: http.StatusBadRequest,
 		},
 	}
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4409,6 +4409,146 @@ func TestHandleDeepSearch(t *testing.T) {
 	assert.Equal(t, "agenda", resp["query"], "query")
 }
 
+type bodySearchTestEngine struct {
+	*querytest.MockEngine
+
+	searchMessageBodiesFunc func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
+}
+
+func (e *bodySearchTestEngine) SearchMessageBodies(
+	ctx context.Context, q *search.Query, limit, offset int,
+) ([]query.MessageSummary, error) {
+	return e.searchMessageBodiesFunc(ctx, q, limit, offset)
+}
+
+func TestHandleDeepSearchBodyScope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var genericCalled, bodyCalled bool
+	engine := &bodySearchTestEngine{
+		MockEngine: &querytest.MockEngine{
+			SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+				genericCalled = true
+				return []query.MessageSummary{{ID: 1, Subject: "generic false positive"}}, nil
+			},
+		},
+		searchMessageBodiesFunc: func(_ context.Context, q *search.Query, limit, offset int) ([]query.MessageSummary, error) {
+			bodyCalled = true
+			assert.Equal([]string{"bodyneedle"}, q.TextTerms, "body TextTerms")
+			assert.Equal(11, limit, "limit includes has_more probe")
+			assert.Equal(3, offset, "offset")
+			return []query.MessageSummary{{ID: 2, Subject: "body hit"}}, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/search/deep?q=bodyneedle&scope=body&limit=10&offset=3", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assert.False(genericCalled, "generic Search must not handle scope=body")
+	assert.True(bodyCalled, "SearchMessageBodies must handle scope=body")
+	var resp map[string]any
+	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode response")
+	assert.Equal("body", resp["scope"], "echoed scope")
+	messages, ok := resp["messages"].([]any)
+	require.True(ok, "messages response type")
+	require.Len(messages, 1)
+	message, ok := messages[0].(map[string]any)
+	require.True(ok, "message response type")
+	assert.InDelta(float64(2), message["id"], 0, "body hit ID")
+}
+
+func TestHandleDeepSearchScopeValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		engine     query.Engine
+		wantStatus int
+	}{
+		{
+			name:       "invalid scope",
+			path:       "/api/v1/search/deep?q=needle&scope=metadata",
+			engine:     &querytest.MockEngine{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "body scope requires free text",
+			path:       "/api/v1/search/deep?q=from%3Aalice%40example.com&scope=body",
+			engine:     &bodySearchTestEngine{MockEngine: &querytest.MockEngine{}, searchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) { return nil, nil }},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "body capability unavailable",
+			path:       "/api/v1/search/deep?q=needle&scope=body",
+			engine:     struct{ query.Engine }{Engine: &querytest.MockEngine{}},
+			wantStatus: http.StatusNotImplemented,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServerWithEngine(t, tc.engine)
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code, "status (body: %s)", w.Body.String())
+		})
+	}
+}
+
+func TestHandleDeepSearchBodyReadinessErrorIsActionable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	engine := &bodySearchTestEngine{
+		MockEngine: &querytest.MockEngine{},
+		searchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return nil, fmt.Errorf("%w: run 'msgvault rebuild-fts' or complete the FTS backfill", query.ErrMessageBodySearchIndexStale)
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search/deep?q=needle&scope=body", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(http.StatusServiceUnavailable, w.Code, "status (body: %s)", w.Body.String())
+	var resp ErrorResponse
+	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode error")
+	assert.Equal("body_search_index_unavailable", resp.Error, "error code")
+	assert.Contains(resp.Message, "rebuild-fts", "actionable rebuild guidance")
+	assert.Contains(resp.Message, "backfill", "actionable backfill guidance")
+}
+
+func TestHandleDeepSearchOmittedScopeUsesGenericSearch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var genericCalled bool
+	engine := &bodySearchTestEngine{
+		MockEngine: &querytest.MockEngine{
+			SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+				genericCalled = true
+				return nil, nil
+			},
+		},
+		searchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			assert.Fail("SearchMessageBodies must not handle omitted scope")
+			return nil, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search/deep?q=needle", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assert.True(genericCalled, "generic Search handles omitted scope")
+	var resp map[string]any
+	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode response")
+	assert.NotContains(resp, "scope", "omitted scope stays generic")
+}
+
 func TestHandleDeepSearchMissingQuery(t *testing.T) {
 	engine := &querytest.MockEngine{}
 	srv := newTestServerWithEngine(t, engine)

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -28,9 +28,11 @@ import (
 // major-version compatibility gate stays at 1.
 //
 // 1.3.0: GET /api/v1/search/deep accepts the additive scope=body parameter
-// and echoes that scope in successful body-only responses. Omitted scope keeps
-// the existing composite search contract. Additive (minor bump): the
-// major-version compatibility gate stays at 1.
+// and echoes that scope in successful body-only responses. Those responses
+// carry ID-keyed body_contexts selected by the active FTS backend while the
+// existing messages element schema remains stable. Omitted scope keeps the
+// existing composite search contract.
+// Additive (minor bump): the major-version compatibility gate stays at 1.
 const APISchemaVersion = "1.3.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -26,7 +26,12 @@ import (
 // (list staged manifests by status), and DELETE /api/v1/deletions/{id}
 // (cancel a pending/in-progress manifest). Additive (minor bump): the
 // major-version compatibility gate stays at 1.
-const APISchemaVersion = "1.2.0"
+//
+// 1.3.0: GET /api/v1/search/deep accepts the additive scope=body parameter
+// and echoes that scope in successful body-only responses. Omitted scope keeps
+// the existing composite search contract. Additive (minor bump): the
+// major-version compatibility gate stays at 1.
+const APISchemaVersion = "1.3.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -279,7 +279,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	registerAPIV1RawHumaJSONRoute[FilteredMessagesResponse](apiV1, "searchMessagesByDomains", http.MethodGet, "/search/domains", "Search messages by participant domains", s.handleSearchByDomains)
 	registerAPIV1RawHumaJSONRoute[similarSearchResponse](apiV1, "findSimilarMessages", http.MethodGet, "/search/similar", "Find messages similar to a seed message", s.handleSimilarSearch)
 	registerAPIV1RawHumaJSONRoute[SearchFastResponse](apiV1, "fastSearch", http.MethodGet, "/search/fast", "Run fast aggregate search", s.handleFastSearch)
-	registerAPIV1RawHumaJSONRoute[DeepSearchResponse](apiV1, "deepSearch", http.MethodGet, "/search/deep", "Run deep aggregate search", s.handleDeepSearch)
+	registerAPIV1RawHumaJSONRoute[DeepSearchResponse](apiV1, "deepSearch", http.MethodGet, "/search/deep", "Run full-text message search", s.handleDeepSearch)
 	registerAPIV1RawHumaJSONRoute[TextConversationsResponse](apiV1, "listTextConversations", http.MethodGet, "/text/conversations", "List text conversations", s.handleTextConversations)
 	registerAPIV1RawHumaJSONRoute[AggregateResponse](apiV1, "getTextAggregates", http.MethodGet, "/text/aggregates", "Get text aggregate rows", s.handleTextAggregates)
 	registerAPIV1RawHumaJSONRoute[TextMessagesResponse](apiV1, "listTextConversationMessages", http.MethodGet, "/text/conversations/{id}/messages", "List messages in a text conversation", s.handleTextConversationMessages)
@@ -522,6 +522,7 @@ func rawRouteParameters(operationID string) []*huma.Param {
 	case "deepSearch":
 		return append([]*huma.Param{
 			queryStringParam("q", "Search query", true),
+			queryStringParam("scope", "Exact search scope: body; omit for composite full-text search", false),
 		}, messageFilterParams()...)
 	case "listTextConversations":
 		return textFilterParams()

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -405,10 +405,50 @@ func messageSummariesFromGenerated(msgs []generated.MessageSummary) []query.Mess
 		return nil
 	}
 	result := make([]query.MessageSummary, len(msgs))
-	for i, m := range msgs {
-		result[i] = querySummaryFromAPIMessage(generatedMessageToAPIMessage(m))
+	for i, message := range msgs {
+		result[i] = querySummaryFromAPIMessage(generatedMessageToAPIMessage(message))
 	}
 	return result
+}
+
+func bodySearchSummariesFromGenerated(
+	msgs []generated.MessageSummary,
+	contexts []generated.BodySearchContext,
+) ([]query.MessageSummary, error) {
+	result := messageSummariesFromGenerated(msgs)
+	byID := make(map[int64]int, len(result))
+	for i, message := range result {
+		if _, duplicate := byID[message.ID]; duplicate {
+			return nil, fmt.Errorf("daemon returned duplicate body-search message %d", message.ID)
+		}
+		byID[message.ID] = i
+	}
+	seen := make(map[int64]struct{}, len(contexts))
+	for _, bodyContext := range contexts {
+		index, ok := byID[bodyContext.MessageID]
+		if !ok {
+			return nil, fmt.Errorf("daemon returned body context for unknown message %d", bodyContext.MessageID)
+		}
+		if _, duplicate := seen[bodyContext.MessageID]; duplicate {
+			return nil, fmt.Errorf("daemon returned duplicate body context for message %d", bodyContext.MessageID)
+		}
+		seen[bodyContext.MessageID] = struct{}{}
+		result[index].BodyContextSnippets = bodyContext.ContextSnippets
+		truncated := false
+		if bodyContext.ContextSnippetsTruncated != nil {
+			truncated = *bodyContext.ContextSnippetsTruncated
+		}
+		if len(bodyContext.ContextSnippets) == 0 && !truncated {
+			return nil, fmt.Errorf("daemon returned empty untruncated body context for message %d", bodyContext.MessageID)
+		}
+		result[index].BodyContextSnippetsTruncated = truncated
+	}
+	for _, message := range result {
+		if _, ok := seen[message.ID]; !ok {
+			return nil, fmt.Errorf("daemon omitted body context for message %d", message.ID)
+		}
+	}
+	return result, nil
 }
 
 func queryAttachmentFromGenerated(att *generated.AttachmentInfo) *query.AttachmentInfo {
@@ -791,7 +831,7 @@ func (e *Engine) SearchMessageBodies(ctx context.Context, q *search.Query, limit
 	if resp.JSON200.Scope == nil || *resp.JSON200.Scope != "body" {
 		return nil, errors.New("daemon did not confirm body-only search scope; upgrade the daemon to API schema 1.3.0 or newer")
 	}
-	return messageSummariesFromGenerated(resp.JSON200.Messages), nil
+	return bodySearchSummariesFromGenerated(resp.JSON200.Messages, resp.JSON200.BodyContexts)
 }
 
 // SearchFast searches message metadata only (no body text).

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -32,6 +32,7 @@ type Engine struct {
 // Compile-time check that Engine implements query.Engine.
 var _ query.Engine = (*Engine)(nil)
 var _ query.TextEngine = (*Engine)(nil)
+var _ query.MessageBodySearcher = (*Engine)(nil)
 
 // NewEngine creates a new daemon-backed query engine.
 func NewEngine(cfg Config) (*Engine, error) {
@@ -762,6 +763,33 @@ func (e *Engine) Search(ctx context.Context, q *search.Query, limit, offset int)
 	})
 	if err != nil {
 		return nil, err
+	}
+	return messageSummariesFromGenerated(resp.JSON200.Messages), nil
+}
+
+// SearchMessageBodies requests the daemon's exact body-only search scope and
+// requires the response to echo that scope. Requiring the echo fails closed
+// against older daemons that ignore the additive query parameter and would
+// otherwise return generic composite-search false positives.
+func (e *Engine) SearchMessageBodies(ctx context.Context, q *search.Query, limit, offset int) ([]query.MessageSummary, error) {
+	if q == nil || len(q.TextTerms) == 0 {
+		return nil, errors.New("message body search requires at least one free-text term")
+	}
+	queryStr := buildSearchQueryString(q)
+	queryParams, err := deepSearchQuery(queryStr, q, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	queryParams.Scope = optionalString("body")
+
+	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.DeepSearchResp, error) {
+		return client.DeepSearchWithResponse(ctx, &generated.DeepSearchRequestOptions{Query: queryParams})
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200.Scope == nil || *resp.JSON200.Scope != "body" {
+		return nil, errors.New("daemon did not confirm body-only search scope; upgrade the daemon to API schema 1.3.0 or newer")
 	}
 	return messageSummariesFromGenerated(resp.JSON200.Messages), nil
 }

--- a/internal/daemonclient/engine_adapter_full_test.go
+++ b/internal/daemonclient/engine_adapter_full_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 func TestEngineListMessagesPreservesDeletedAt(t *testing.T) {
@@ -984,6 +985,11 @@ func TestEngineSearchMessageBodiesForwardsAndRequiresScopeEcho(t *testing.T) {
 				"labels":     []string{},
 				"size_bytes": 100,
 			}},
+			"body_contexts": []map[string]any{{
+				"message_id":                 42,
+				"context_snippets":           []string{"exact daemon context"},
+				"context_snippets_truncated": true,
+			}},
 		})
 	})
 	engine := NewEngineAdapter(store)
@@ -995,6 +1001,49 @@ func TestEngineSearchMessageBodiesForwardsAndRequiresScopeEcho(t *testing.T) {
 	require.NoError(t, err, "SearchMessageBodies")
 	require.Len(t, messages, 1)
 	assert.Equal(int64(42), messages[0].ID, "body hit ID")
+	assert.Equal([]string{"exact daemon context"}, messages[0].BodyContextSnippets)
+	assert.True(messages[0].BodyContextSnippetsTruncated)
+}
+
+func TestBodySearchSummariesFromGeneratedRejectsInvalidCompanions(t *testing.T) {
+	truncated := true
+	tests := []struct {
+		name     string
+		contexts []generated.BodySearchContext
+		want     string
+	}{
+		{name: "missing", want: "omitted body context"},
+		{
+			name: "unknown message",
+			contexts: []generated.BodySearchContext{{
+				MessageID: 99, ContextSnippets: []string{"context"},
+			}},
+			want: "unknown message",
+		},
+		{
+			name: "duplicate",
+			contexts: []generated.BodySearchContext{
+				{MessageID: 42, ContextSnippets: []string{"first"}},
+				{MessageID: 42, ContextSnippetsTruncated: &truncated},
+			},
+			want: "duplicate body context",
+		},
+		{
+			name:     "empty and untruncated",
+			contexts: []generated.BodySearchContext{{MessageID: 42}},
+			want:     "empty untruncated body context",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := bodySearchSummariesFromGenerated(
+				[]generated.MessageSummary{{ID: 42}}, tc.contexts,
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
 }
 
 func TestEngineSearchMessageBodiesFailsClosedWithoutScopeEcho(t *testing.T) {

--- a/internal/daemonclient/engine_adapter_full_test.go
+++ b/internal/daemonclient/engine_adapter_full_test.go
@@ -908,6 +908,7 @@ func TestEngineSearchUsesGeneratedClientAdapter(t *testing.T) {
 
 	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal("/api/v1/search/deep", r.URL.Path, "path")
+		assert.Empty(r.URL.Query().Get("scope"), "generic Search must omit scope")
 		gotQuery := r.URL.Query().Get("q")
 		assert.Contains(gotQuery, "lunch", "q should preserve text terms")
 		assert.Contains(gotQuery, "message_type:sms", "q should preserve message type filters")
@@ -958,6 +959,73 @@ func TestEngineSearchUsesGeneratedClientAdapter(t *testing.T) {
 	assert.Equal("alice@example.com", msgs[0].FromEmail)
 	assert.Equal("Alice", msgs[0].FromName)
 	assert.Equal("sms", msgs[0].MessageType)
+}
+
+func TestEngineSearchMessageBodiesForwardsAndRequiresScopeEcho(t *testing.T) {
+	assert := assert.New(t)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/search/deep", r.URL.Path, "path")
+		assert.Equal("body", r.URL.Query().Get("scope"), "scope")
+		assert.Equal("bodyneedle", r.URL.Query().Get("q"), "q")
+		assert.Equal("7", r.URL.Query().Get("source_id"), "source_id")
+		writeJSONResponse(t, w, map[string]any{
+			"query":    "bodyneedle",
+			"scope":    "body",
+			"count":    1,
+			"has_more": false,
+			"offset":   2,
+			"limit":    5,
+			"messages": []map[string]any{{
+				"id":         42,
+				"subject":    "body hit",
+				"from":       "sender@example.com",
+				"sent_at":    "2024-01-15T10:30:00Z",
+				"snippet":    "preview",
+				"labels":     []string{},
+				"size_bytes": 100,
+			}},
+		})
+	})
+	engine := NewEngineAdapter(store)
+
+	messages, err := engine.SearchMessageBodies(context.Background(), &search.Query{
+		TextTerms:  []string{"bodyneedle"},
+		AccountIDs: []int64{7},
+	}, 5, 2)
+	require.NoError(t, err, "SearchMessageBodies")
+	require.Len(t, messages, 1)
+	assert.Equal(int64(42), messages[0].ID, "body hit ID")
+}
+
+func TestEngineSearchMessageBodiesFailsClosedWithoutScopeEcho(t *testing.T) {
+	assert := assert.New(t)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("body", r.URL.Query().Get("scope"), "scope is still sent to old daemon")
+		writeJSONResponse(t, w, map[string]any{
+			"query":    "bodyneedle",
+			"count":    1,
+			"has_more": false,
+			"offset":   0,
+			"limit":    5,
+			"messages": []map[string]any{{
+				"id":         99,
+				"subject":    "generic false positive",
+				"from":       "sender@example.com",
+				"sent_at":    "2024-01-15T10:30:00Z",
+				"snippet":    "preview",
+				"labels":     []string{},
+				"size_bytes": 100,
+			}},
+		})
+	})
+	engine := NewEngineAdapter(store)
+
+	messages, err := engine.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"bodyneedle"}}, 5, 0)
+	require.Error(t, err, "old daemon must not produce generic false positives")
+	assert.Nil(messages, "unconfirmed results must be discarded")
+	assert.Contains(err.Error(), "did not confirm body-only search scope")
+	assert.Contains(err.Error(), "upgrade")
 }
 
 func TestEngineSearchFastWithStatsUsesGeneratedClientAdapter(t *testing.T) {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -29,19 +29,21 @@ const (
 	maxLimit               = 1000
 	maxSearchMessagesLimit = 50
 	defaultSearchLimit     = 20
-	defaultBodyChars       = 2000
-	bodyFormatAuto         = "auto"
-	bodyFormatText         = "text"
-	bodyFormatHTML         = "html"
+	maxContextSnippets     = 5
+	// searchContextChars is the max byte length of each matches[] snippet in
+	// search_message_bodies and search_in_message.
+	searchContextChars = 300
+	defaultBodyChars   = 2000
+	bodyFormatAuto     = "auto"
+	bodyFormatText     = "text"
+	bodyFormatHTML     = "html"
 	// maxBodyChars caps the body slice returned by get_message regardless of what
 	// the caller requests via max_chars. Prevents a single tool call from flooding
 	// the context window; callers page forward using offset.
 	maxBodyChars = 4000
-	// searchContextChars is the max byte length of each snippet in search_in_message.
-	searchContextChars = 300
 	// totalCountUnknown is returned when the backend cannot report a full match
-	// count (body FTS fallback, hybrid/vector ranking depth, or list_messages
-	// without a separate count query). Clients should use has_more for paging.
+	// count (hybrid/vector ranking depth, or list_messages without a separate
+	// count query). Clients should use has_more for paging.
 	totalCountUnknown = -1
 )
 
@@ -311,6 +313,18 @@ func (h *handlers) readAttachmentFile(contentHash string) ([]byte, error) {
 	return data, nil
 }
 
+// searchMessageItem carries a message summary plus body excerpts centered on
+// query terms. Used by search_message_bodies.
+type searchMessageItem struct {
+	query.MessageSummary
+
+	ContextSnippets          []string `json:"context_snippets,omitempty"`
+	ContextSnippetsTruncated bool     `json:"context_snippets_truncated,omitempty"`
+}
+
+// searchMessages searches message metadata only (subject, sender, recipients,
+// labels, dates). Use search_message_bodies for full-body keyword search.
+// Vector and hybrid modes are delegated to searchMessagesHybrid.
 func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
@@ -320,25 +334,21 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 	}
 
 	mode, _ := args["mode"].(string)
-	if mode == "" {
-		mode = searchModeFTS
-	}
 	explain, _ := args["explain"].(bool)
 
 	if mode == searchModeVector || mode == searchModeHybrid {
 		return h.searchMessagesHybrid(ctx, args, queryStr, mode, explain)
 	}
 
-	if mode != searchModeFTS {
+	if mode != "" {
 		return mcp.NewToolResultError(
-			fmt.Sprintf("invalid mode %q: must be %s, %s, or %s", mode, searchModeFTS, searchModeVector, searchModeHybrid),
+			fmt.Sprintf("invalid mode %q: must be %s or %s (or omit for metadata search)", mode, searchModeVector, searchModeHybrid),
 		), nil
 	}
 
 	limit := searchLimitArg(args)
 	offset := limitArg(args, "offset", 0)
 
-	// Look up account filter
 	account, _ := args["account"].(string)
 	sourceID, err := h.getAccountID(ctx, account)
 	if err != nil {
@@ -355,23 +365,9 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 
 	filter := query.MessageFilter{SourceID: sourceID}
 
-	// Try fast search first (metadata only), fall back to full FTS.
 	results, err := h.engine.SearchFast(ctx, q, filter, limit, offset)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
-	}
-
-	// If fast search returns nothing and query has free text, try full FTS.
-	if len(results) == 0 && len(q.TextTerms) > 0 {
-		results, err = h.engine.Search(ctx, q, limit+1, offset)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
-		}
-		hasMore := len(results) > limit
-		if hasMore {
-			results = results[:limit]
-		}
-		return jsonResult(newPaginatedResponseNoTotal(results, offset, hasMore))
 	}
 
 	totalMatched, err := h.engine.SearchFastCount(ctx, q, filter)
@@ -403,6 +399,68 @@ func unsupportedSearchOperatorMessage(q *search.Query) string {
 		strings.Join(names, ", "),
 	)
 }
+
+// searchMessageBodies performs full-text search over message bodies and returns
+// context_snippets — short excerpts centered on each matched term. Requires at
+// least one free-text term; use search_messages for filter-only queries.
+func (h *handlers) searchMessageBodies(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	queryStr, _ := args["query"].(string)
+	if queryStr == "" {
+		return mcp.NewToolResultError("query parameter is required"), nil
+	}
+
+	limit := searchLimitArg(args)
+	offset := limitArg(args, "offset", 0)
+
+	account, _ := args["account"].(string)
+	sourceID, err := h.getAccountID(ctx, account)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	q := search.Parse(queryStr)
+	if msg := unsupportedSearchOperatorMessage(q); msg != "" {
+		return mcp.NewToolResultError(msg), nil
+	}
+	if sourceID != nil {
+		q.AccountIDs = []int64{*sourceID}
+	}
+
+	if len(q.TextTerms) == 0 {
+		return mcp.NewToolResultError("search_message_bodies requires at least one free-text term; use search_messages for filter-only queries"), nil
+	}
+
+	results, err := h.engine.Search(ctx, q, limit+1, offset)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
+	}
+
+	hasMore := len(results) > limit
+	if hasMore {
+		results = results[:limit]
+	}
+
+	data := make([]searchMessageItem, 0, len(results))
+	for _, r := range results {
+		item := searchMessageItem{MessageSummary: r}
+		msg, err := h.engine.GetMessage(ctx, r.ID)
+		if err == nil && msg != nil {
+			snippets := extractContextChar(msg.BodyText, q.TextTerms, searchContextChars)
+			if len(snippets) > maxContextSnippets {
+				item.ContextSnippetsTruncated = true
+				snippets = snippets[:maxContextSnippets]
+			}
+			item.ContextSnippets = snippets
+		}
+		data = append(data, item)
+	}
+
+	return jsonResult(newPaginatedResponseNoTotal(data, offset, hasMore))
+}
+
+// hybridScoreBreakdown exposes fused-score components for debugging.
 
 // hybridScoreBreakdown exposes fused-score components for debugging.
 // All score fields are pointer-typed so "not present in this signal"
@@ -449,7 +507,8 @@ type searchMessagesHybridResponse struct {
 // hybrid engine. Mirrors api/handlers.go handleHybridSearch: returns
 // descriptive errors when the engine is not configured or the index is
 // stale/building, otherwise returns RRF-ranked hits hydrated via
-// engine.GetMessage.
+// GetMessageSummariesByIDs (body omitted — use search_message_bodies or
+// search_in_message for body content).
 func (h *handlers) searchMessagesHybrid(
 	ctx context.Context, args map[string]any,
 	queryStr, mode string, explain bool,
@@ -481,11 +540,11 @@ func (h *handlers) searchMessagesHybrid(
 
 	// mode=vector|hybrid requires at least one free-text term; filter-only
 	// queries have no query vector to rank by. Callers that want pure
-	// structured filtering should use mode=fts instead.
+	// structured filtering should omit mode (metadata search).
 	if freeText == "" {
 		return mcp.NewToolResultError(
 			"missing_free_text: mode=" + mode +
-				" requires at least one free-text term; use mode=fts for filter-only queries",
+				" requires at least one free-text term; omit mode for metadata-only search",
 		), nil
 	}
 
@@ -511,7 +570,7 @@ func (h *handlers) searchMessagesHybrid(
 		if offset >= maxPage {
 			return mcp.NewToolResultError(fmt.Sprintf(
 				"pagination_limit: offset %d exceeds hybrid ranking window (max %d); "+
-					"use mode=fts for deeper pagination",
+					"use search_messages (metadata) or search_message_bodies for deeper pagination",
 				offset, maxPage,
 			)), nil
 		}
@@ -1425,6 +1484,10 @@ func (h *handlers) listMessages(ctx context.Context, req mcp.CallToolRequest) (*
 	if filter.Before, err = getDateArg(args, "before"); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	if v, ok := args["conversation_id"].(float64); ok && v != 0 {
+		v2 := int64(v)
+		filter.ConversationID = &v2
+	}
 
 	results, err := h.engine.ListMessages(ctx, filter)
 	if err != nil {
@@ -1523,7 +1586,11 @@ func (h *handlers) aggregate(ctx context.Context, req mcp.CallToolRequest) (*mcp
 	return jsonResult(rows)
 }
 
-// intArg extracts a non-negative integer from a map, with a default.
+// limitArg extracts a non-negative integer limit from a map, with a default.
+// JSON numbers arrive as float64. Clamps to maxLimit to prevent excessive
+// result sets.
+// intArg extracts a non-negative integer from args without the maxLimit clamp
+// used by limitArg. Suitable for body-text offsets and similar unbounded values.
 func intArg(args map[string]any, key string, def int) int {
 	v, ok := args[key].(float64)
 	if !ok {
@@ -1535,9 +1602,6 @@ func intArg(args map[string]any, key string, def int) int {
 	return int(v)
 }
 
-// limitArg extracts a non-negative integer limit from a map, with a default.
-// JSON numbers arrive as float64. Clamps to maxLimit to prevent excessive
-// result sets.
 func limitArg(args map[string]any, key string, def int) int {
 	v, ok := args[key].(float64)
 	if !ok {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -415,6 +415,14 @@ func (h *handlers) searchMessageBodies(ctx context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError("query parameter is required"), nil
 	}
 
+	q := search.Parse(queryStr)
+	if err := q.Err(); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if msg := unsupportedSearchOperatorMessage(q); msg != "" {
+		return mcp.NewToolResultError(msg), nil
+	}
+
 	limit := searchLimitArg(args)
 	offset := limitArg(args, "offset", 0)
 
@@ -424,10 +432,6 @@ func (h *handlers) searchMessageBodies(ctx context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	q := search.Parse(queryStr)
-	if msg := unsupportedSearchOperatorMessage(q); msg != "" {
-		return mcp.NewToolResultError(msg), nil
-	}
 	if sourceID != nil {
 		q.AccountIDs = []int64{*sourceID}
 	}
@@ -1128,22 +1132,28 @@ func contextBodyLexemes(body string) []contextLexeme {
 }
 
 // extractContextChar returns up to contextChars of body text centered on each
-// normalized FTS token-prefix match, merging overlapping windows.
+// normalized FTS term-group match, merging overlapping windows. Lexemes within
+// one parsed term stay adjacent: all but the final lexeme match exactly and the
+// final lexeme uses prefix semantics, mirroring the body FTS dialects.
 func extractContextChar(body string, terms []string, contextChars int) []string {
 	if body == "" || len(terms) == 0 || contextChars <= 0 {
 		return nil
 	}
 
-	var queryLexemes []string
+	queryGroups := make([][]string, 0, len(terms))
 	for _, term := range terms {
+		var group []string
 		for _, lexeme := range sqldialect.EscapeTSQueryTerm(term) {
 			normalized := normalizeContextLexeme(lexeme)
 			if normalized != "" {
-				queryLexemes = append(queryLexemes, normalized)
+				group = append(group, normalized)
 			}
 		}
+		if len(group) > 0 {
+			queryGroups = append(queryGroups, group)
+		}
 	}
-	if len(queryLexemes) == 0 {
+	if len(queryGroups) == 0 {
 		return nil
 	}
 	bodyLexemes := contextBodyLexemes(body)
@@ -1153,11 +1163,25 @@ func extractContextChar(body string, terms []string, contextChars int) []string 
 	}
 	var spans []span
 
-	for _, queryLexeme := range queryLexemes {
-		for _, bodyLexeme := range bodyLexemes {
-			if strings.HasPrefix(bodyLexeme.normalized, queryLexeme) {
-				matchLen := min(bodyLexeme.end-bodyLexeme.start, contextChars)
-				start, end := contextWindow(len(body), bodyLexeme.start, matchLen, contextChars)
+	for _, group := range queryGroups {
+		for bodyIndex := 0; bodyIndex+len(group) <= len(bodyLexemes); bodyIndex++ {
+			matched := true
+			for groupIndex, queryLexeme := range group {
+				bodyLexeme := bodyLexemes[bodyIndex+groupIndex]
+				if groupIndex == len(group)-1 {
+					matched = strings.HasPrefix(bodyLexeme.normalized, queryLexeme)
+				} else {
+					matched = bodyLexeme.normalized == queryLexeme
+				}
+				if !matched {
+					break
+				}
+			}
+			if matched {
+				first := bodyLexemes[bodyIndex]
+				last := bodyLexemes[bodyIndex+len(group)-1]
+				matchLen := min(last.end-first.start, contextChars)
+				start, end := contextWindow(len(body), first.start, matchLen, contextChars)
 				spans = append(spans, span{start: start, end: end})
 			}
 		}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"container/heap"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -14,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -22,27 +20,14 @@ import (
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
-	"go.kenn.io/msgvault/internal/sqldialect"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/unicode/norm"
 )
 
 const (
 	maxLimit               = 1000
 	maxSearchMessagesLimit = 50
 	defaultSearchLimit     = 20
-	maxContextSnippets     = 5
-	// Context extraction is deliberately resource-bounded. Message bodies are
-	// imported data and can be attacker-controlled; a single search result must
-	// not force unbounded tokenization, normalization, or term comparisons.
-	maxContextScanBytes        = 1 << 20
-	maxContextScanLexemes      = 200_000
-	maxContextMatchComparisons = 1_000_000
-	maxContextQueryBytes       = 32 << 10
-	maxContextQueryLexemes     = 256
-	maxContextLexemeBytes      = 32 << 10
 	// searchContextChars is the max byte length of each matches[] snippet in
 	// search_message_bodies and search_in_message.
 	searchContextChars = 300
@@ -470,32 +455,12 @@ func (h *handlers) searchMessageBodies(ctx context.Context, req mcp.CallToolRequ
 	data := make([]searchMessageItem, 0, len(results))
 	for _, r := range results {
 		item := searchMessageItem{MessageSummary: r}
-		msg, err := h.engine.GetMessage(ctx, r.ID)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: %v", r.ID, err)), nil
+		if len(r.BodyContextSnippets) == 0 && !r.BodyContextSnippetsTruncated {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"body context unavailable for message %d: search backend returned no context", r.ID)), nil
 		}
-		if msg == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: message not found", r.ID)), nil
-		}
-		if msg.BodyText == "" {
-			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: stored body is empty", r.ID)), nil
-		}
-		snippets, contextTruncated, err := extractContextChar(
-			ctx, msg.BodyText, q.TextTerms, searchContextChars, maxContextSnippets,
-		)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: %v", r.ID, err)), nil
-		}
-		item.ContextSnippetsTruncated = contextTruncated
-		if len(snippets) == 0 {
-			// The backend already proved this is an exact body-index hit. If its
-			// tokenizer diverges from the context matcher or the scan budget ends
-			// before the match, preserve the every-hit-context contract with a
-			// bounded body prefix. context_snippets_truncated distinguishes the
-			// resource-limited case.
-			snippets = []string{bodyByteSlice(msg.BodyText, 0, min(len(msg.BodyText), searchContextChars))}
-		}
-		item.ContextSnippets = snippets
+		item.ContextSnippets = r.BodyContextSnippets
+		item.ContextSnippetsTruncated = r.BodyContextSnippetsTruncated
 		data = append(data, item)
 	}
 
@@ -1081,338 +1046,6 @@ func lineNumberAt(body string, byteOffset int) int {
 		byteOffset = len(body)
 	}
 	return 1 + strings.Count(body[:byteOffset], "\n")
-}
-
-type contextLexeme struct {
-	start      int
-	end        int
-	normalized string
-}
-
-type contextSpan struct {
-	start int
-	end   int
-}
-
-type contextSpanHeap []contextSpan
-
-func (h *contextSpanHeap) Len() int { return len(*h) }
-
-func (h *contextSpanHeap) Less(i, j int) bool {
-	if (*h)[i].start == (*h)[j].start {
-		return (*h)[i].end < (*h)[j].end
-	}
-	return (*h)[i].start < (*h)[j].start
-}
-
-func (h *contextSpanHeap) Swap(i, j int) { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
-
-func (h *contextSpanHeap) Push(value any) {
-	span, ok := value.(contextSpan)
-	if !ok {
-		panic(fmt.Sprintf("context span heap received %T", value))
-	}
-	*h = append(*h, span)
-}
-
-func (h *contextSpanHeap) Pop() any {
-	old := *h
-	last := len(old) - 1
-	value := old[last]
-	*h = old[:last]
-	return value
-}
-
-var contextCaseFolder = cases.Fold()
-
-// normalizeContextLexeme applies the case and diacritic folding needed to
-// mirror SQLite FTS5's unicode61 remove_diacritics=1 matching closely enough
-// to locate an indexed token in the original body.
-func normalizeContextLexeme(s string) string {
-	decomposed := norm.NFD.String(s)
-	var folded strings.Builder
-	folded.Grow(len(decomposed))
-	for _, r := range decomposed {
-		if unicode.Is(unicode.Mn, r) {
-			continue
-		}
-		folded.WriteRune(r)
-	}
-	return contextCaseFolder.String(folded.String())
-}
-
-// extractContextChar returns up to contextChars of body text centered on each
-// normalized FTS term-group match, merging overlapping windows. It streams a
-// bounded body prefix instead of materializing every lexeme and match. Lexemes
-// within one parsed term stay adjacent: all but the final lexeme match exactly
-// and the final lexeme uses prefix semantics, mirroring the body FTS dialects.
-// truncated reports omitted contexts caused by either the snippet cap or an
-// extraction safety budget.
-func extractContextChar(
-	ctx context.Context,
-	body string,
-	terms []string,
-	contextChars int,
-	maxSnippets int,
-) (snippets []string, truncated bool, err error) {
-	if err := ctx.Err(); err != nil {
-		return nil, false, err
-	}
-	if body == "" || len(terms) == 0 || contextChars <= 0 {
-		return nil, false, nil
-	}
-	if maxSnippets <= 0 {
-		return nil, true, nil
-	}
-
-	queryGroups := make([][]string, 0, len(terms))
-	queryByteCount := 0
-	queryLexemeCount := 0
-	maxGroupLen := 0
-	for _, term := range terms {
-		if len(term) > maxContextQueryBytes-queryByteCount {
-			truncated = true
-			break
-		}
-		queryByteCount += len(term)
-		lexemes := sqldialect.EscapeTSQueryTerm(term)
-		if queryLexemeCount+len(lexemes) > maxContextQueryLexemes {
-			truncated = true
-			break
-		}
-		group := make([]string, 0, len(lexemes))
-		for _, lexeme := range lexemes {
-			normalized := normalizeContextLexeme(lexeme)
-			if normalized != "" {
-				group = append(group, normalized)
-			}
-		}
-		if len(group) == 0 {
-			continue
-		}
-		queryLexemeCount += len(lexemes)
-		queryGroups = append(queryGroups, group)
-		maxGroupLen = max(maxGroupLen, len(group))
-	}
-	if len(queryGroups) == 0 {
-		return nil, truncated, nil
-	}
-
-	scanEnd := len(body)
-	if scanEnd > maxContextScanBytes {
-		scanEnd = maxContextScanBytes
-		for scanEnd > 0 && !utf8.RuneStart(body[scanEnd]) {
-			scanEnd--
-		}
-		truncated = true
-	}
-
-	queue := make([]contextLexeme, maxGroupLen)
-	queueHead := 0
-	queueLen := 0
-	queueAt := func(index int) contextLexeme {
-		return queue[(queueHead+index)%len(queue)]
-	}
-	queuePush := func(value contextLexeme) {
-		queue[(queueHead+queueLen)%len(queue)] = value
-		queueLen++
-	}
-	queuePop := func() {
-		queueHead = (queueHead + 1) % len(queue)
-		queueLen--
-	}
-
-	pending := contextSpanHeap{}
-	heap.Init(&pending)
-	merged := make([]contextSpan, 0, maxSnippets)
-	appendMerged := func(candidate contextSpan) bool {
-		if len(merged) == 0 {
-			merged = append(merged, candidate)
-			return true
-		}
-		last := &merged[len(merged)-1]
-		unionStart := min(last.start, candidate.start)
-		unionEnd := max(last.end, candidate.end)
-		if candidate.start <= last.end && unionEnd-unionStart <= contextChars {
-			last.start = unionStart
-			last.end = unionEnd
-			return true
-		}
-		if len(merged) >= maxSnippets {
-			truncated = true
-			return false
-		}
-		merged = append(merged, candidate)
-		return true
-	}
-
-	var scanErr error
-	spanLimitReached := false
-	flushPending := func(safeBefore int, final bool) bool {
-		popped := 0
-		for pending.Len() > 0 && (final || pending[0].start < safeBefore) {
-			if popped%256 == 0 {
-				if err := ctx.Err(); err != nil {
-					scanErr = err
-					return false
-				}
-			}
-			value := heap.Pop(&pending)
-			candidate, ok := value.(contextSpan)
-			if !ok {
-				panic(fmt.Sprintf("context span heap returned %T", value))
-			}
-			if !appendMerged(candidate) {
-				spanLimitReached = true
-				return false
-			}
-			popped++
-		}
-		return true
-	}
-
-	comparisonCount := 0
-	workLimitReached := false
-	processStart := func() bool {
-		first := queueAt(0)
-		// A future match starts at or after first.start. Its centered window
-		// cannot move back a full contextChars bytes, so older heap entries are
-		// now globally ordered and safe to merge.
-		if !flushPending(first.start-contextChars, false) {
-			return false
-		}
-		for _, group := range queryGroups {
-			if len(group) > queueLen {
-				continue
-			}
-			matched := true
-			for groupIndex, queryLexeme := range group {
-				if comparisonCount >= maxContextMatchComparisons {
-					truncated = true
-					workLimitReached = true
-					return false
-				}
-				comparisonCount++
-				if comparisonCount%1024 == 0 {
-					if err := ctx.Err(); err != nil {
-						scanErr = err
-						return false
-					}
-				}
-				bodyLexeme := queueAt(groupIndex)
-				if bodyLexeme.normalized == "" {
-					matched = false
-				} else if groupIndex == len(group)-1 {
-					matched = strings.HasPrefix(bodyLexeme.normalized, queryLexeme)
-				} else {
-					matched = bodyLexeme.normalized == queryLexeme
-				}
-				if !matched {
-					break
-				}
-			}
-			if matched {
-				last := queueAt(len(group) - 1)
-				matchLen := min(last.end-first.start, contextChars)
-				start, end := contextWindow(len(body), first.start, matchLen, contextChars)
-				heap.Push(&pending, contextSpan{start: start, end: end})
-			}
-		}
-		return true
-	}
-
-	lexemeCount := 0
-	emitLexeme := func(start, end int) bool {
-		if lexemeCount >= maxContextScanLexemes {
-			truncated = true
-			return false
-		}
-		lexemeCount++
-		normalized := ""
-		if end-start > maxContextLexemeBytes {
-			// Retain an unmatchable placeholder so phrase terms on either side
-			// cannot become falsely adjacent when normalization is skipped.
-			truncated = true
-		} else {
-			normalized = normalizeContextLexeme(body[start:end])
-		}
-		queuePush(contextLexeme{start: start, end: end, normalized: normalized})
-		if queueLen == maxGroupLen {
-			if !processStart() {
-				return false
-			}
-			queuePop()
-		}
-		return true
-	}
-
-	tokenStart := -1
-	stopped := false
-	lastContextCheck := 0
-
-scanLoop:
-	for byteOffset, r := range body[:scanEnd] {
-		if byteOffset-lastContextCheck >= 4096 {
-			if err := ctx.Err(); err != nil {
-				scanErr = err
-				stopped = true
-				break
-			}
-			lastContextCheck = byteOffset
-		}
-		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r):
-			if tokenStart < 0 {
-				tokenStart = byteOffset
-			}
-		case tokenStart >= 0 && unicode.Is(unicode.Mn, r):
-			// Nonspacing marks continue an existing token so decomposed text stays
-			// intact. A leading mark never starts a token by itself.
-		default:
-			if tokenStart >= 0 && !emitLexeme(tokenStart, byteOffset) {
-				stopped = true
-				break scanLoop
-			}
-			tokenStart = -1
-		}
-	}
-	if scanErr != nil {
-		return nil, false, scanErr
-	}
-	if !stopped && tokenStart >= 0 {
-		emitLexeme(tokenStart, scanEnd)
-	}
-	if scanErr != nil {
-		return nil, false, scanErr
-	}
-
-	// Complete starts already captured in the bounded queue. A lexeme limit
-	// may stop tokenization while still leaving useful, fully observed matches.
-	if !spanLimitReached && !workLimitReached {
-		for queueLen > 0 {
-			if !processStart() {
-				break
-			}
-			queuePop()
-		}
-	}
-	if scanErr != nil {
-		return nil, false, scanErr
-	}
-	if !spanLimitReached {
-		flushPending(0, true)
-	}
-	if scanErr != nil {
-		return nil, false, scanErr
-	}
-	if len(merged) == 0 {
-		return nil, truncated, nil
-	}
-	snippets = make([]string, 0, len(merged))
-	for _, candidate := range merged {
-		snippets = append(snippets, bodyByteSlice(body, candidate.start, candidate.end))
-	}
-	return snippets, truncated, nil
 }
 
 type getMessageResponse struct {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -21,8 +22,11 @@ import (
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/sqldialect"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/unicode/norm"
 )
 
 const (
@@ -432,7 +436,11 @@ func (h *handlers) searchMessageBodies(ctx context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError("search_message_bodies requires at least one free-text term; use search_messages for filter-only queries"), nil
 	}
 
-	results, err := h.engine.Search(ctx, q, limit+1, offset)
+	bodySearcher, ok := h.engine.(query.MessageBodySearcher)
+	if !ok {
+		return mcp.NewToolResultError("search_message_bodies is unavailable: the query engine does not support exact body-only search"), nil
+	}
+	results, err := bodySearcher.SearchMessageBodies(ctx, q, limit+1, offset)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
@@ -446,21 +454,32 @@ func (h *handlers) searchMessageBodies(ctx context.Context, req mcp.CallToolRequ
 	for _, r := range results {
 		item := searchMessageItem{MessageSummary: r}
 		msg, err := h.engine.GetMessage(ctx, r.ID)
-		if err == nil && msg != nil {
-			snippets := extractContextChar(msg.BodyText, q.TextTerms, searchContextChars)
-			if len(snippets) > maxContextSnippets {
-				item.ContextSnippetsTruncated = true
-				snippets = snippets[:maxContextSnippets]
-			}
-			item.ContextSnippets = snippets
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: %v", r.ID, err)), nil
 		}
+		if msg == nil {
+			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: message not found", r.ID)), nil
+		}
+		if msg.BodyText == "" {
+			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: stored body is empty", r.ID)), nil
+		}
+		snippets := extractContextChar(msg.BodyText, q.TextTerms, searchContextChars)
+		if len(snippets) == 0 {
+			// The backend already proved this is an exact body-index hit. If its
+			// tokenizer ever diverges from the context matcher, preserve the
+			// every-hit-context contract with a bounded body prefix.
+			snippets = []string{bodyByteSlice(msg.BodyText, 0, min(len(msg.BodyText), searchContextChars))}
+		}
+		if len(snippets) > maxContextSnippets {
+			item.ContextSnippetsTruncated = true
+			snippets = snippets[:maxContextSnippets]
+		}
+		item.ContextSnippets = snippets
 		data = append(data, item)
 	}
 
 	return jsonResult(newPaginatedResponseNoTotal(data, offset, hasMore))
 }
-
-// hybridScoreBreakdown exposes fused-score components for debugging.
 
 // hybridScoreBreakdown exposes fused-score components for debugging.
 // All score fields are pointer-typed so "not present in this signal"
@@ -684,7 +703,7 @@ func (h *handlers) searchMessagesHybridViaSearcher(
 	if freeText == "" {
 		return mcp.NewToolResultError(
 			"missing_free_text: mode=" + mode +
-				" requires at least one free-text term; use mode=fts for filter-only queries",
+				" requires at least one free-text term; omit mode for metadata-only filter queries",
 		), nil
 	}
 
@@ -1048,37 +1067,99 @@ func lineNumberAt(body string, byteOffset int) int {
 	return 1 + strings.Count(body[:byteOffset], "\n")
 }
 
+type contextLexeme struct {
+	start      int
+	end        int
+	normalized string
+}
+
+var contextCaseFolder = cases.Fold()
+
+// normalizeContextLexeme applies the case and diacritic folding needed to
+// mirror SQLite FTS5's unicode61 remove_diacritics=1 matching closely enough
+// to locate an indexed token in the original body.
+func normalizeContextLexeme(s string) string {
+	decomposed := norm.NFD.String(s)
+	var folded strings.Builder
+	folded.Grow(len(decomposed))
+	for _, r := range decomposed {
+		if unicode.Is(unicode.Mn, r) {
+			continue
+		}
+		folded.WriteRune(r)
+	}
+	return contextCaseFolder.String(folded.String())
+}
+
+// contextBodyLexemes tokenizes body text on runes outside letters/digits and
+// attached nonspacing marks, retaining original UTF-8 byte offsets.
+func contextBodyLexemes(body string) []contextLexeme {
+	var lexemes []contextLexeme
+	start := -1
+	flush := func(end int) {
+		if start < 0 {
+			return
+		}
+		normalized := normalizeContextLexeme(body[start:end])
+		if normalized != "" {
+			lexemes = append(lexemes, contextLexeme{
+				start: start, end: end, normalized: normalized,
+			})
+		}
+		start = -1
+	}
+
+	for byteOffset, r := range body {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			if start < 0 {
+				start = byteOffset
+			}
+		case start >= 0 && unicode.Is(unicode.Mn, r):
+			// Nonspacing marks continue an existing token so decomposed text stays
+			// intact for normalization. A leading mark, or a spacing/enclosing
+			// mark, reaches the default branch and never starts a lexeme by itself.
+		default:
+			flush(byteOffset)
+		}
+	}
+	flush(len(body))
+	return lexemes
+}
+
 // extractContextChar returns up to contextChars of body text centered on each
-// case-insensitive term match, merging overlapping windows.
+// normalized FTS token-prefix match, merging overlapping windows.
 func extractContextChar(body string, terms []string, contextChars int) []string {
 	if body == "" || len(terms) == 0 || contextChars <= 0 {
 		return nil
 	}
 
-	lowerBody := strings.ToLower(body)
+	var queryLexemes []string
+	for _, term := range terms {
+		for _, lexeme := range sqldialect.EscapeTSQueryTerm(term) {
+			normalized := normalizeContextLexeme(lexeme)
+			if normalized != "" {
+				queryLexemes = append(queryLexemes, normalized)
+			}
+		}
+	}
+	if len(queryLexemes) == 0 {
+		return nil
+	}
+	bodyLexemes := contextBodyLexemes(body)
 
 	type span struct {
 		start, end int
 	}
 	var spans []span
 
-	for _, term := range terms {
-		if len(term) < 2 {
-			continue
-		}
-		lowerTerm := strings.ToLower(term)
-		termLen := len(term)
-		searchFrom := 0
-		for {
-			idx := strings.Index(lowerBody[searchFrom:], lowerTerm)
-			if idx < 0 {
-				break
+	for _, queryLexeme := range queryLexemes {
+		for _, bodyLexeme := range bodyLexemes {
+			if strings.HasPrefix(bodyLexeme.normalized, queryLexeme) {
+				matchLen := min(bodyLexeme.end-bodyLexeme.start, contextChars)
+				start, end := contextWindow(len(body), bodyLexeme.start, matchLen, contextChars)
+				spans = append(spans, span{start: start, end: end})
 			}
-			pos := searchFrom + idx
-			searchFrom = pos + 1
-
-			start, end := contextWindow(len(body), pos, termLen, contextChars)
-			spans = append(spans, span{start: start, end: end})
 		}
 	}
 
@@ -1096,8 +1177,9 @@ func extractContextChar(body string, terms []string, contextChars int) []string 
 	merged := []span{spans[0]}
 	for _, s := range spans[1:] {
 		last := &merged[len(merged)-1]
-		if s.start <= last.end {
-			last.end = max(last.end, s.end)
+		unionEnd := max(last.end, s.end)
+		if s.start <= last.end && unionEnd-last.start <= contextChars {
+			last.end = unionEnd
 			continue
 		}
 		merged = append(merged, s)

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"container/heap"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -11,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -34,6 +34,15 @@ const (
 	maxSearchMessagesLimit = 50
 	defaultSearchLimit     = 20
 	maxContextSnippets     = 5
+	// Context extraction is deliberately resource-bounded. Message bodies are
+	// imported data and can be attacker-controlled; a single search result must
+	// not force unbounded tokenization, normalization, or term comparisons.
+	maxContextScanBytes        = 1 << 20
+	maxContextScanLexemes      = 200_000
+	maxContextMatchComparisons = 1_000_000
+	maxContextQueryBytes       = 32 << 10
+	maxContextQueryLexemes     = 256
+	maxContextLexemeBytes      = 32 << 10
 	// searchContextChars is the max byte length of each matches[] snippet in
 	// search_message_bodies and search_in_message.
 	searchContextChars = 300
@@ -340,14 +349,22 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 	mode, _ := args["mode"].(string)
 	explain, _ := args["explain"].(bool)
 
-	if mode == searchModeVector || mode == searchModeHybrid {
-		return h.searchMessagesHybrid(ctx, args, queryStr, mode, explain)
-	}
-
-	if mode != "" {
+	if mode != "" && mode != searchModeVector && mode != searchModeHybrid {
 		return mcp.NewToolResultError(
 			fmt.Sprintf("invalid mode %q: must be %s or %s (or omit for metadata search)", mode, searchModeVector, searchModeHybrid),
 		), nil
+	}
+
+	q := search.Parse(queryStr)
+	if err := q.Err(); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if msg := unsupportedSearchOperatorMessage(q); msg != "" {
+		return mcp.NewToolResultError(msg), nil
+	}
+
+	if mode == searchModeVector || mode == searchModeHybrid {
+		return h.searchMessagesHybrid(ctx, args, queryStr, q, mode, explain)
 	}
 
 	limit := searchLimitArg(args)
@@ -359,10 +376,6 @@ func (h *handlers) searchMessages(ctx context.Context, req mcp.CallToolRequest) 
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	q := search.Parse(queryStr)
-	if msg := unsupportedSearchOperatorMessage(q); msg != "" {
-		return mcp.NewToolResultError(msg), nil
-	}
 	if sourceID != nil {
 		q.AccountIDs = []int64{*sourceID}
 	}
@@ -467,16 +480,20 @@ func (h *handlers) searchMessageBodies(ctx context.Context, req mcp.CallToolRequ
 		if msg.BodyText == "" {
 			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: stored body is empty", r.ID)), nil
 		}
-		snippets := extractContextChar(msg.BodyText, q.TextTerms, searchContextChars)
+		snippets, contextTruncated, err := extractContextChar(
+			ctx, msg.BodyText, q.TextTerms, searchContextChars, maxContextSnippets,
+		)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("body context unavailable for message %d: %v", r.ID, err)), nil
+		}
+		item.ContextSnippetsTruncated = contextTruncated
 		if len(snippets) == 0 {
 			// The backend already proved this is an exact body-index hit. If its
-			// tokenizer ever diverges from the context matcher, preserve the
-			// every-hit-context contract with a bounded body prefix.
+			// tokenizer diverges from the context matcher or the scan budget ends
+			// before the match, preserve the every-hit-context contract with a
+			// bounded body prefix. context_snippets_truncated distinguishes the
+			// resource-limited case.
 			snippets = []string{bodyByteSlice(msg.BodyText, 0, min(len(msg.BodyText), searchContextChars))}
-		}
-		if len(snippets) > maxContextSnippets {
-			item.ContextSnippetsTruncated = true
-			snippets = snippets[:maxContextSnippets]
 		}
 		item.ContextSnippets = snippets
 		data = append(data, item)
@@ -534,10 +551,10 @@ type searchMessagesHybridResponse struct {
 // search_in_message for body content).
 func (h *handlers) searchMessagesHybrid(
 	ctx context.Context, args map[string]any,
-	queryStr, mode string, explain bool,
+	queryStr string, parsed *search.Query, mode string, explain bool,
 ) (*mcp.CallToolResult, error) {
 	if h.hybridSearcher != nil {
-		return h.searchMessagesHybridViaSearcher(ctx, args, queryStr, mode, explain)
+		return h.searchMessagesHybridViaSearcher(ctx, args, queryStr, parsed, mode, explain)
 	}
 	if h.hybridEngine == nil {
 		return mcp.NewToolResultError(
@@ -555,10 +572,6 @@ func (h *handlers) searchMessagesHybrid(
 	limit := searchLimitArg(args)
 	offset := limitArg(args, "offset", 0)
 
-	parsed := search.Parse(queryStr)
-	if msg := unsupportedSearchOperatorMessage(parsed); msg != "" {
-		return mcp.NewToolResultError(msg), nil
-	}
 	freeText := strings.Join(parsed.TextTerms, " ")
 
 	// mode=vector|hybrid requires at least one free-text term; filter-only
@@ -696,13 +709,12 @@ func (h *handlers) searchMessagesHybrid(
 
 func (h *handlers) searchMessagesHybridViaSearcher(
 	ctx context.Context, args map[string]any,
-	queryStr, mode string, explain bool,
+	queryStr string, parsed *search.Query, mode string, explain bool,
 ) (*mcp.CallToolResult, error) {
 	limit := searchLimitArg(args)
 	offset := limitArg(args, "offset", 0)
 	requestedEnd := offset + limit
 
-	parsed := search.Parse(queryStr)
 	freeText := strings.Join(parsed.TextTerms, " ")
 	if freeText == "" {
 		return mcp.NewToolResultError(
@@ -1077,6 +1089,40 @@ type contextLexeme struct {
 	normalized string
 }
 
+type contextSpan struct {
+	start int
+	end   int
+}
+
+type contextSpanHeap []contextSpan
+
+func (h *contextSpanHeap) Len() int { return len(*h) }
+
+func (h *contextSpanHeap) Less(i, j int) bool {
+	if (*h)[i].start == (*h)[j].start {
+		return (*h)[i].end < (*h)[j].end
+	}
+	return (*h)[i].start < (*h)[j].start
+}
+
+func (h *contextSpanHeap) Swap(i, j int) { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+
+func (h *contextSpanHeap) Push(value any) {
+	span, ok := value.(contextSpan)
+	if !ok {
+		panic(fmt.Sprintf("context span heap received %T", value))
+	}
+	*h = append(*h, span)
+}
+
+func (h *contextSpanHeap) Pop() any {
+	old := *h
+	last := len(old) - 1
+	value := old[last]
+	*h = old[:last]
+	return value
+}
+
 var contextCaseFolder = cases.Fold()
 
 // normalizeContextLexeme applies the case and diacritic folding needed to
@@ -1095,80 +1141,168 @@ func normalizeContextLexeme(s string) string {
 	return contextCaseFolder.String(folded.String())
 }
 
-// contextBodyLexemes tokenizes body text on runes outside letters/digits and
-// attached nonspacing marks, retaining original UTF-8 byte offsets.
-func contextBodyLexemes(body string) []contextLexeme {
-	var lexemes []contextLexeme
-	start := -1
-	flush := func(end int) {
-		if start < 0 {
-			return
-		}
-		normalized := normalizeContextLexeme(body[start:end])
-		if normalized != "" {
-			lexemes = append(lexemes, contextLexeme{
-				start: start, end: end, normalized: normalized,
-			})
-		}
-		start = -1
-	}
-
-	for byteOffset, r := range body {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r):
-			if start < 0 {
-				start = byteOffset
-			}
-		case start >= 0 && unicode.Is(unicode.Mn, r):
-			// Nonspacing marks continue an existing token so decomposed text stays
-			// intact for normalization. A leading mark, or a spacing/enclosing
-			// mark, reaches the default branch and never starts a lexeme by itself.
-		default:
-			flush(byteOffset)
-		}
-	}
-	flush(len(body))
-	return lexemes
-}
-
 // extractContextChar returns up to contextChars of body text centered on each
-// normalized FTS term-group match, merging overlapping windows. Lexemes within
-// one parsed term stay adjacent: all but the final lexeme match exactly and the
-// final lexeme uses prefix semantics, mirroring the body FTS dialects.
-func extractContextChar(body string, terms []string, contextChars int) []string {
+// normalized FTS term-group match, merging overlapping windows. It streams a
+// bounded body prefix instead of materializing every lexeme and match. Lexemes
+// within one parsed term stay adjacent: all but the final lexeme match exactly
+// and the final lexeme uses prefix semantics, mirroring the body FTS dialects.
+// truncated reports omitted contexts caused by either the snippet cap or an
+// extraction safety budget.
+func extractContextChar(
+	ctx context.Context,
+	body string,
+	terms []string,
+	contextChars int,
+	maxSnippets int,
+) (snippets []string, truncated bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
 	if body == "" || len(terms) == 0 || contextChars <= 0 {
-		return nil
+		return nil, false, nil
+	}
+	if maxSnippets <= 0 {
+		return nil, true, nil
 	}
 
 	queryGroups := make([][]string, 0, len(terms))
+	queryByteCount := 0
+	queryLexemeCount := 0
+	maxGroupLen := 0
 	for _, term := range terms {
-		var group []string
-		for _, lexeme := range sqldialect.EscapeTSQueryTerm(term) {
+		if len(term) > maxContextQueryBytes-queryByteCount {
+			truncated = true
+			break
+		}
+		queryByteCount += len(term)
+		lexemes := sqldialect.EscapeTSQueryTerm(term)
+		if queryLexemeCount+len(lexemes) > maxContextQueryLexemes {
+			truncated = true
+			break
+		}
+		group := make([]string, 0, len(lexemes))
+		for _, lexeme := range lexemes {
 			normalized := normalizeContextLexeme(lexeme)
 			if normalized != "" {
 				group = append(group, normalized)
 			}
 		}
-		if len(group) > 0 {
-			queryGroups = append(queryGroups, group)
+		if len(group) == 0 {
+			continue
 		}
+		queryLexemeCount += len(lexemes)
+		queryGroups = append(queryGroups, group)
+		maxGroupLen = max(maxGroupLen, len(group))
 	}
 	if len(queryGroups) == 0 {
-		return nil
+		return nil, truncated, nil
 	}
-	bodyLexemes := contextBodyLexemes(body)
 
-	type span struct {
-		start, end int
+	scanEnd := len(body)
+	if scanEnd > maxContextScanBytes {
+		scanEnd = maxContextScanBytes
+		for scanEnd > 0 && !utf8.RuneStart(body[scanEnd]) {
+			scanEnd--
+		}
+		truncated = true
 	}
-	var spans []span
 
-	for _, group := range queryGroups {
-		for bodyIndex := 0; bodyIndex+len(group) <= len(bodyLexemes); bodyIndex++ {
+	queue := make([]contextLexeme, maxGroupLen)
+	queueHead := 0
+	queueLen := 0
+	queueAt := func(index int) contextLexeme {
+		return queue[(queueHead+index)%len(queue)]
+	}
+	queuePush := func(value contextLexeme) {
+		queue[(queueHead+queueLen)%len(queue)] = value
+		queueLen++
+	}
+	queuePop := func() {
+		queueHead = (queueHead + 1) % len(queue)
+		queueLen--
+	}
+
+	pending := contextSpanHeap{}
+	heap.Init(&pending)
+	merged := make([]contextSpan, 0, maxSnippets)
+	appendMerged := func(candidate contextSpan) bool {
+		if len(merged) == 0 {
+			merged = append(merged, candidate)
+			return true
+		}
+		last := &merged[len(merged)-1]
+		unionStart := min(last.start, candidate.start)
+		unionEnd := max(last.end, candidate.end)
+		if candidate.start <= last.end && unionEnd-unionStart <= contextChars {
+			last.start = unionStart
+			last.end = unionEnd
+			return true
+		}
+		if len(merged) >= maxSnippets {
+			truncated = true
+			return false
+		}
+		merged = append(merged, candidate)
+		return true
+	}
+
+	var scanErr error
+	spanLimitReached := false
+	flushPending := func(safeBefore int, final bool) bool {
+		popped := 0
+		for pending.Len() > 0 && (final || pending[0].start < safeBefore) {
+			if popped%256 == 0 {
+				if err := ctx.Err(); err != nil {
+					scanErr = err
+					return false
+				}
+			}
+			value := heap.Pop(&pending)
+			candidate, ok := value.(contextSpan)
+			if !ok {
+				panic(fmt.Sprintf("context span heap returned %T", value))
+			}
+			if !appendMerged(candidate) {
+				spanLimitReached = true
+				return false
+			}
+			popped++
+		}
+		return true
+	}
+
+	comparisonCount := 0
+	workLimitReached := false
+	processStart := func() bool {
+		first := queueAt(0)
+		// A future match starts at or after first.start. Its centered window
+		// cannot move back a full contextChars bytes, so older heap entries are
+		// now globally ordered and safe to merge.
+		if !flushPending(first.start-contextChars, false) {
+			return false
+		}
+		for _, group := range queryGroups {
+			if len(group) > queueLen {
+				continue
+			}
 			matched := true
 			for groupIndex, queryLexeme := range group {
-				bodyLexeme := bodyLexemes[bodyIndex+groupIndex]
-				if groupIndex == len(group)-1 {
+				if comparisonCount >= maxContextMatchComparisons {
+					truncated = true
+					workLimitReached = true
+					return false
+				}
+				comparisonCount++
+				if comparisonCount%1024 == 0 {
+					if err := ctx.Err(); err != nil {
+						scanErr = err
+						return false
+					}
+				}
+				bodyLexeme := queueAt(groupIndex)
+				if bodyLexeme.normalized == "" {
+					matched = false
+				} else if groupIndex == len(group)-1 {
 					matched = strings.HasPrefix(bodyLexeme.normalized, queryLexeme)
 				} else {
 					matched = bodyLexeme.normalized == queryLexeme
@@ -1178,42 +1312,107 @@ func extractContextChar(body string, terms []string, contextChars int) []string 
 				}
 			}
 			if matched {
-				first := bodyLexemes[bodyIndex]
-				last := bodyLexemes[bodyIndex+len(group)-1]
+				last := queueAt(len(group) - 1)
 				matchLen := min(last.end-first.start, contextChars)
 				start, end := contextWindow(len(body), first.start, matchLen, contextChars)
-				spans = append(spans, span{start: start, end: end})
+				heap.Push(&pending, contextSpan{start: start, end: end})
 			}
 		}
+		return true
 	}
 
-	if len(spans) == 0 {
-		return nil
-	}
-
-	sort.Slice(spans, func(i, j int) bool {
-		if spans[i].start == spans[j].start {
-			return spans[i].end < spans[j].end
+	lexemeCount := 0
+	emitLexeme := func(start, end int) bool {
+		if lexemeCount >= maxContextScanLexemes {
+			truncated = true
+			return false
 		}
-		return spans[i].start < spans[j].start
-	})
-
-	merged := []span{spans[0]}
-	for _, s := range spans[1:] {
-		last := &merged[len(merged)-1]
-		unionEnd := max(last.end, s.end)
-		if s.start <= last.end && unionEnd-last.start <= contextChars {
-			last.end = unionEnd
-			continue
+		lexemeCount++
+		normalized := ""
+		if end-start > maxContextLexemeBytes {
+			// Retain an unmatchable placeholder so phrase terms on either side
+			// cannot become falsely adjacent when normalization is skipped.
+			truncated = true
+		} else {
+			normalized = normalizeContextLexeme(body[start:end])
 		}
-		merged = append(merged, s)
+		queuePush(contextLexeme{start: start, end: end, normalized: normalized})
+		if queueLen == maxGroupLen {
+			if !processStart() {
+				return false
+			}
+			queuePop()
+		}
+		return true
 	}
 
-	out := make([]string, 0, len(merged))
-	for _, s := range merged {
-		out = append(out, bodyByteSlice(body, s.start, s.end))
+	tokenStart := -1
+	stopped := false
+	lastContextCheck := 0
+
+scanLoop:
+	for byteOffset, r := range body[:scanEnd] {
+		if byteOffset-lastContextCheck >= 4096 {
+			if err := ctx.Err(); err != nil {
+				scanErr = err
+				stopped = true
+				break
+			}
+			lastContextCheck = byteOffset
+		}
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			if tokenStart < 0 {
+				tokenStart = byteOffset
+			}
+		case tokenStart >= 0 && unicode.Is(unicode.Mn, r):
+			// Nonspacing marks continue an existing token so decomposed text stays
+			// intact. A leading mark never starts a token by itself.
+		default:
+			if tokenStart >= 0 && !emitLexeme(tokenStart, byteOffset) {
+				stopped = true
+				break scanLoop
+			}
+			tokenStart = -1
+		}
 	}
-	return out
+	if scanErr != nil {
+		return nil, false, scanErr
+	}
+	if !stopped && tokenStart >= 0 {
+		emitLexeme(tokenStart, scanEnd)
+	}
+	if scanErr != nil {
+		return nil, false, scanErr
+	}
+
+	// Complete starts already captured in the bounded queue. A lexeme limit
+	// may stop tokenization while still leaving useful, fully observed matches.
+	if !spanLimitReached && !workLimitReached {
+		for queueLen > 0 {
+			if !processStart() {
+				break
+			}
+			queuePop()
+		}
+	}
+	if scanErr != nil {
+		return nil, false, scanErr
+	}
+	if !spanLimitReached {
+		flushPending(0, true)
+	}
+	if scanErr != nil {
+		return nil, false, scanErr
+	}
+	if len(merged) == 0 {
+		return nil, truncated, nil
+	}
+	snippets = make([]string, 0, len(merged))
+	for _, candidate := range merged {
+		snippets = append(snippets, bodyByteSlice(body, candidate.start, candidate.end))
+	}
+	return snippets, truncated, nil
 }
 
 type getMessageResponse struct {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,6 +18,7 @@ import (
 // Tool name constants.
 const (
 	ToolSearchMessages      = "search_messages"
+	ToolSearchMessageBodies = "search_message_bodies"
 	ToolGetMessage          = "get_message"
 	ToolGetAttachment       = "get_attachment"
 	ToolExportAttachment    = "export_attachment"
@@ -121,6 +122,7 @@ func newMCPServer(opts ServeOptions) *server.MCPServer {
 
 	vectorAvailable := opts.HybridEngine != nil || opts.HybridSearcher != nil
 	s.AddTool(searchMessagesTool(vectorAvailable), h.searchMessages)
+	s.AddTool(searchMessageBodiesTool(), h.searchMessageBodies)
 	s.AddTool(getMessageTool(), h.getMessage)
 	s.AddTool(getAttachmentTool(), h.getAttachment)
 	s.AddTool(searchInMessageTool(), h.searchInMessage)
@@ -203,10 +205,11 @@ func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr string) e
 func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 	if !vectorAvailable {
 		return mcp.NewTool(ToolSearchMessages,
-			mcp.WithDescription("Search emails using a subset of Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+			mcp.WithDescription("Search email metadata (subject, sender, recipients, labels, dates) using Gmail-like query syntax. "+
+				"Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text (matched against subject/snippet only, not body). "+
 				"Gmail-only operators such as list: are rejected because msgvault does not index List-ID locally. "+
-				"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
-				"(This server is not configured for vector search; only keyword FTS is available.)"),
+				"For full message body keyword search, use search_message_bodies instead. "+
+				"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithString("query",
 				mcp.Required(),
@@ -218,12 +221,15 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 		)
 	}
 	return mcp.NewTool(ToolSearchMessages,
-		mcp.WithDescription("Search emails using a subset of Gmail-like query syntax. Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text. "+
+		mcp.WithDescription("Search email metadata (subject, sender, recipients, labels, dates) using Gmail-like query syntax. "+
+			"Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text (matched against subject/snippet only, not body). "+
 			"Gmail-only operators such as list: are rejected because msgvault does not index List-ID locally. "+
-			"All modes paginate via offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
+			"For full message body keyword search, use search_message_bodies instead. "+
+			"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
+			"Vector search is configured: set mode=vector for pure semantic search or mode=hybrid to fuse BM25 and vector ranking via RRF. "+
+			"Vector/hybrid require free-text terms; filter-only queries must omit mode. "+
 			"total=-1 means the full match count is unknown — use has_more. "+
-			"Vector/hybrid ranking depth is capped by max_page_size_hybrid in config; beyond that use mode=fts. "+
-			"Vector search is configured: set mode=vector for pure semantic search or mode=hybrid to fuse BM25 and vector ranking via RRF. Vector/hybrid modes require free-text terms in the query; filter-only queries must use mode=fts."),
+			"Vector/hybrid ranking depth is capped by max_page_size_hybrid in config."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("query",
 			mcp.Required(),
@@ -231,16 +237,32 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 		),
 		withAccount(),
 		withLimit("20"),
-		mcp.WithNumber("offset",
-			mcp.Description("Number of results to skip for pagination (default 0)."),
-		),
+		withOffset(),
 		mcp.WithString("mode",
-			mcp.Description("Search mode: fts (default, keyword only), vector (semantic only), or hybrid (BM25 + vector fused via RRF)"),
-			mcp.Enum(searchModeFTS, searchModeVector, searchModeHybrid),
+			mcp.Description("Search mode: vector (semantic only) or hybrid (BM25 + vector fused via RRF). Omit for metadata search."),
+			mcp.Enum(searchModeVector, searchModeHybrid),
 		),
 		mcp.WithBoolean("explain",
 			mcp.Description("Include per-signal scores in the response (for debugging or ranking inspection)"),
 		),
+	)
+}
+
+func searchMessageBodiesTool() mcp.Tool {
+	return mcp.NewTool(ToolSearchMessageBodies,
+		mcp.WithDescription("Search message bodies by keyword using full-text search (FTS). Returns messages whose body text contains the search terms, "+
+			"plus context_snippets — short excerpts (up to 5 per message, 300 bytes each) centered on each matched term. "+
+			"Requires at least one free-text term; use search_messages for filter-only queries (from:, label:, etc.). "+
+			"Paginate with offset/limit (default limit 20, max 50). Response: data, returned, offset, has_more. "+
+			"(total is not available for body search; use has_more to detect more pages.)"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("query",
+			mcp.Required(),
+			mcp.Description("Search query with at least one free-text term (e.g. 'quarterly report' or 'from:alice budget')"),
+		),
+		withAccount(),
+		withLimit("20"),
+		withOffset(),
 	)
 }
 
@@ -340,6 +362,9 @@ func listMessagesTool() mcp.Tool {
 		withBefore(),
 		mcp.WithBoolean("has_attachment",
 			mcp.Description("Only messages with attachments"),
+		),
+		mcp.WithNumber("conversation_id",
+			mcp.Description("Filter by conversation/thread ID"),
 		),
 		withLimit("20"),
 		withOffset(),

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -206,7 +206,7 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 	if !vectorAvailable {
 		return mcp.NewTool(ToolSearchMessages,
 			mcp.WithDescription("Search email metadata (subject, sender, recipients, labels, dates) using Gmail-like query syntax. "+
-				"Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text (matched against subject/snippet only, not body). "+
+				"Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text (matched against subject, snippet, sender, and recipient metadata; never body). "+
 				"Gmail-only operators such as list: are rejected because msgvault does not index List-ID locally. "+
 				"For full message body keyword search, use search_message_bodies instead. "+
 				"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more."),
@@ -222,7 +222,7 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 	}
 	return mcp.NewTool(ToolSearchMessages,
 		mcp.WithDescription("Search email metadata (subject, sender, recipients, labels, dates) using Gmail-like query syntax. "+
-			"Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text (matched against subject/snippet only, not body). "+
+			"Supports from:, to:, subject:, label:, has:attachment, before:, after:, and free text (matched against subject, snippet, sender, and recipient metadata; never body). "+
 			"Gmail-only operators such as list: are rejected because msgvault does not index List-ID locally. "+
 			"For full message body keyword search, use search_message_bodies instead. "+
 			"Paginate with offset/limit (default limit 20, max 50). Response: data, total, returned, offset, has_more. "+
@@ -250,7 +250,7 @@ func searchMessagesTool(vectorAvailable bool) mcp.Tool {
 
 func searchMessageBodiesTool() mcp.Tool {
 	return mcp.NewTool(ToolSearchMessageBodies,
-		mcp.WithDescription("Search message bodies by keyword using full-text search (FTS). Returns messages whose body text contains the search terms, "+
+		mcp.WithDescription("Search message bodies by keyword using exact body-only full-text search (FTS). Returns messages whose body text contains the search terms, "+
 			"plus context_snippets — short excerpts (up to 5 per message, 300 bytes each) centered on each matched term. "+
 			"Requires at least one free-text term; use search_messages for filter-only queries (from:, label:, etc.). "+
 			"Paginate with offset/limit (default limit 20, max 50). Response: data, returned, offset, has_more. "+

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -252,6 +252,7 @@ func searchMessageBodiesTool() mcp.Tool {
 	return mcp.NewTool(ToolSearchMessageBodies,
 		mcp.WithDescription("Search message bodies by keyword using exact body-only full-text search (FTS). Returns messages whose body text contains the search terms, "+
 			"plus context_snippets — short excerpts (up to 5 per message, 300 bytes each) centered on each matched term. "+
+			"A hit outside the bounded context-extraction budget has no excerpt and sets context_snippets_truncated=true. "+
 			"Requires at least one free-text term; use search_messages for filter-only queries (from:, label:, etc.). "+
 			"Paginate with offset/limit (default limit 20, max 50). Response: data, returned, offset, has_more. "+
 			"(total is not available for body search; use has_more to detect more pages.)"),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -120,6 +120,17 @@ func newTestHandlers(eng query.Engine) *handlers {
 	return &handlers{engine: eng}
 }
 
+type listAccountsTrackingEngine struct {
+	*querytest.MockEngine
+
+	listAccountsCalled bool
+}
+
+func (e *listAccountsTrackingEngine) ListAccounts(ctx context.Context) ([]query.AccountInfo, error) {
+	e.listAccountsCalled = true
+	return e.MockEngine.ListAccounts(ctx)
+}
+
 // callToolDirect invokes a handler directly with the given arguments and returns the raw result.
 func callToolDirect(t *testing.T, name string, fn toolHandler, args map[string]any) *mcp.CallToolResult {
 	t.Helper()
@@ -288,6 +299,39 @@ func TestSearchMessageBodies(t *testing.T) {
 		r := runToolExpectError(t, "search_message_bodies", h.searchMessageBodies, map[string]any{"query": "from:alice"})
 		txt := resultText(t, r)
 		assert.Contains(t, txt, "free-text term")
+	})
+
+	t.Run("rejects invalid typed operator values", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			query string
+			op    string
+		}{
+			{name: "bad date", query: "needle before:not-a-date", op: "before:"},
+			{name: "bad size", query: "needle larger:5X", op: "larger:"},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				var searchRan bool
+				invalid := &listAccountsTrackingEngine{
+					MockEngine: &querytest.MockEngine{
+						Accounts: []query.AccountInfo{{ID: 1, Identifier: "alice@example.com"}},
+						SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+							searchRan = true
+							return nil, nil
+						},
+					},
+				}
+				r := runToolExpectError(t, "search_message_bodies",
+					newTestHandlers(invalid).searchMessageBodies,
+					map[string]any{"query": tc.query, "account": "alice@example.com"})
+				txt := resultText(t, r)
+				assert.Contains(t, txt, "invalid value")
+				assert.Contains(t, txt, tc.op)
+				assert.False(t, invalid.listAccountsCalled, "invalid query must not resolve account filters")
+				assert.False(t, searchRan, "invalid query must not reach body search")
+			})
+		}
 	})
 
 	t.Run("missing query", func(t *testing.T) {
@@ -499,6 +543,37 @@ func TestSearchMessageBodies_RealEngineFTSNormalizedContext(t *testing.T) {
 			assert.Contains(exact[0], tc.wantContext)
 		})
 	}
+}
+
+func TestSearchMessageBodies_PhraseContextSurvivesSnippetCap(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+
+	gap := strings.Repeat("é ", searchContextChars)
+	body := strings.Repeat("alpha "+gap, maxContextSnippets+1) + "alpha beta marker"
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-phrase-context").
+		WithSubject("ordinary subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	engine := query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())
+	resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
+		newTestHandlers(engine).searchMessageBodies, map[string]any{"query": `"alpha beta"`})
+	require.Len(resp.Data, 1, "phrase hit")
+	assert.Equal(messageID, resp.Data[0].ID, "phrase hit ID")
+	var foundPhrase bool
+	for _, snippet := range resp.Data[0].ContextSnippets {
+		foundPhrase = foundPhrase || strings.Contains(snippet, "alpha beta")
+		assert.LessOrEqual(len(snippet), searchContextChars, "bounded phrase context")
+		assert.True(utf8.ValidString(snippet), "phrase context must be valid UTF-8")
+	}
+	assert.True(foundPhrase, "context snippets must include the matched phrase")
 }
 
 func TestExtractContextChar(t *testing.T) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -22,6 +23,7 @@ import (
 	"go.kenn.io/msgvault/internal/query/querytest"
 	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
 )
@@ -114,7 +116,7 @@ type paginatedListMessages struct {
 }
 
 // newTestHandlers creates a handlers instance with the given mock engine.
-func newTestHandlers(eng *querytest.MockEngine) *handlers {
+func newTestHandlers(eng query.Engine) *handlers {
 	return &handlers{engine: eng}
 }
 
@@ -251,9 +253,18 @@ func TestSearchMessages_NonPositiveLimitUsesDefault(t *testing.T) {
 }
 
 func TestSearchMessageBodies(t *testing.T) {
+	var genericCalled bool
 	eng := &querytest.MockEngine{
-		SearchResults: []query.MessageSummary{
-			testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+		SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			genericCalled = true
+			return []query.MessageSummary{
+				testutil.NewMessageSummary(99).WithSubject("Generic false positive").Build(),
+			}, nil
+		},
+		SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return []query.MessageSummary{
+				testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+			}, nil
 		},
 		Messages: map[int64]*query.MessageDetail{
 			2: testutil.NewMessageDetail(2).WithBodyText("The resistor value should be 5.1k ohms.").BuildPtr(),
@@ -270,6 +281,7 @@ func TestSearchMessageBodies(t *testing.T) {
 		require.NotEmpty(resp.Data[0].ContextSnippets, "context_snippets")
 		assert.Contains(resp.Data[0].ContextSnippets[0], "5.1k")
 		assert.Equal(int64(totalCountUnknown), resp.Total, "total=-1 for FTS")
+		assert.False(genericCalled, "generic Search must not handle search_message_bodies")
 	})
 
 	t.Run("requires free-text term", func(t *testing.T) {
@@ -281,6 +293,212 @@ func TestSearchMessageBodies(t *testing.T) {
 	t.Run("missing query", func(t *testing.T) {
 		runToolExpectError(t, "search_message_bodies", h.searchMessageBodies, map[string]any{})
 	})
+
+	t.Run("fails when a hit cannot provide body context", func(t *testing.T) {
+		broken := &querytest.MockEngine{
+			SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+				return []query.MessageSummary{{ID: 77, Subject: "stale hit"}}, nil
+			},
+			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+				return nil, errors.New("body unavailable")
+			},
+		}
+		brokenHandlers := newTestHandlers(broken)
+		r := runToolExpectError(t, "search_message_bodies", brokenHandlers.searchMessageBodies,
+			map[string]any{"query": "needle"})
+		assert.Contains(t, resultText(t, r), "body context")
+	})
+
+	t.Run("uses bounded fallback context for a nonempty indexed body", func(t *testing.T) {
+		body := strings.Repeat("fallback context ", 30)
+		fallback := &querytest.MockEngine{
+			SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+				return []query.MessageSummary{{ID: 78, Subject: "tokenizer mismatch"}}, nil
+			},
+			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+				return testutil.NewMessageDetail(78).WithBodyText(body).BuildPtr(), nil
+			},
+		}
+		resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
+			newTestHandlers(fallback).searchMessageBodies, map[string]any{"query": "mismatchneedle"})
+		require.Len(t, resp.Data, 1, "fallback hit")
+		require.Len(t, resp.Data[0].ContextSnippets, 1, "fallback context")
+		assert.Equal(t, body[:searchContextChars], resp.Data[0].ContextSnippets[0])
+	})
+
+	t.Run("keeps dense-match context windows bounded and UTF-8 safe", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := strings.Repeat("é a ", 200)
+		dense := &querytest.MockEngine{
+			SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+				return []query.MessageSummary{{ID: 80, Subject: "dense matches"}}, nil
+			},
+			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+				return testutil.NewMessageDetail(80).WithBodyText(body).BuildPtr(), nil
+			},
+		}
+		resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
+			newTestHandlers(dense).searchMessageBodies, map[string]any{"query": "a"})
+		require.Len(resp.Data, 1, "dense-match hit")
+		require.NotEmpty(resp.Data[0].ContextSnippets, "dense-match context")
+		for _, snippet := range resp.Data[0].ContextSnippets {
+			assert.LessOrEqual(len(snippet), searchContextChars, "bounded handler context")
+			assert.True(utf8.ValidString(snippet), "handler context must be valid UTF-8")
+		}
+	})
+
+	t.Run("fails when an indexed hit has an empty stored body", func(t *testing.T) {
+		empty := &querytest.MockEngine{
+			SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+				return []query.MessageSummary{{ID: 79, Subject: "empty body"}}, nil
+			},
+			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+				return testutil.NewMessageDetail(79).WithBodyText("").BuildPtr(), nil
+			},
+		}
+		r := runToolExpectError(t, "search_message_bodies",
+			newTestHandlers(empty).searchMessageBodies, map[string]any{"query": "needle"})
+		assert.Contains(t, resultText(t, r), "stored body is empty")
+	})
+
+	t.Run("fails closed when capability is unavailable", func(t *testing.T) {
+		withoutCapability := struct{ query.Engine }{Engine: &querytest.MockEngine{}}
+		unsupportedHandlers := newTestHandlers(withoutCapability)
+		r := runToolExpectError(t, "search_message_bodies", unsupportedHandlers.searchMessageBodies,
+			map[string]any{"query": "needle"})
+		assert.Contains(t, resultText(t, r), "does not support exact body-only search")
+	})
+}
+
+func TestSearchTools_RealEngineScopeIsolation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-scope-message").
+		WithSubject("metadataonlyterm subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: "bodyonlyterm appears in the body", Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	engine := query.NewSQLiteEngine(f.Store.DB())
+	if f.Store.IsPostgreSQL() {
+		engine = query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
+	}
+	h := newTestHandlers(engine)
+
+	metadata := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages,
+		map[string]any{"query": "bodyonlyterm"})
+	assert.Empty(metadata.Data, "body-only term must not cross into metadata search")
+	assert.Equal(int64(0), metadata.Total, "metadata count")
+
+	bodyMetadata := runTool[paginatedSearchMessages](t, "search_message_bodies", h.searchMessageBodies,
+		map[string]any{"query": "metadataonlyterm"})
+	assert.Empty(bodyMetadata.Data, "metadata-only term must not cross into body search")
+
+	body := runTool[paginatedSearchMessages](t, "search_message_bodies", h.searchMessageBodies,
+		map[string]any{"query": "bodyonlyterm"})
+	require.Len(body.Data, 1, "body hit")
+	assert.Equal(messageID, body.Data[0].ID, "body hit ID")
+	require.NotEmpty(body.Data[0].ContextSnippets, "every hit has body context")
+	assert.Contains(body.Data[0].ContextSnippets[0], "bodyonlyterm")
+}
+
+func TestSearchMessageBodies_RealEngineFTSNormalizedContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		body        string
+		wantContext string
+		reject      string
+		sqliteOnly  bool
+	}{
+		{
+			name:        "punctuation becomes token boundary",
+			query:       "foo-bar",
+			body:        "alpha foo bar omega",
+			wantContext: "foo bar",
+		},
+		{
+			name:        "diacritics fold like unicode61",
+			query:       "cafe",
+			body:        "café notes",
+			wantContext: "café",
+			sqliteOnly:  true,
+		},
+		{
+			name:        "decomposed diacritic continues token",
+			query:       "cafeteria",
+			body:        "cafe\u0301teria notes",
+			wantContext: "cafe\u0301teria",
+			sqliteOnly:  true,
+		},
+		{
+			name:        "full case fold matches Greek final sigma",
+			query:       "σ",
+			body:        "ς notes",
+			wantContext: "ς",
+			sqliteOnly:  true,
+		},
+		{
+			name:        "spacing mark is a token separator",
+			query:       "b",
+			body:        "a\u0903b notes",
+			wantContext: "b notes",
+			sqliteOnly:  true,
+		},
+		{
+			name:        "one-character token prefix ignores interior character",
+			query:       "a",
+			body:        "beta " + strings.Repeat("xxxxx ", 80) + "alpha marker",
+			wantContext: "alpha marker",
+			reject:      "beta",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := storetest.New(t)
+			if tc.sqliteOnly && f.Store.IsPostgreSQL() {
+				t.Skip("unicode61 remove_diacritics regression is SQLite-specific")
+			}
+			messageID := f.NewMessage().
+				WithSourceMessageID("mcp-normalized-context").
+				WithSubject("ordinary subject").
+				WithSnippet("ordinary preview").
+				Create(t, f.Store)
+			require.NoError(f.Store.UpsertMessageBody(messageID,
+				sql.NullString{String: tc.body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+			_, err := f.Store.BackfillFTS(nil)
+			require.NoError(err, "BackfillFTS")
+
+			engine := query.NewSQLiteEngine(f.Store.DB())
+			if f.Store.IsPostgreSQL() {
+				engine = query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
+			}
+			h := newTestHandlers(engine)
+			resp := runTool[paginatedSearchMessages](t, "search_message_bodies", h.searchMessageBodies,
+				map[string]any{"query": tc.query})
+
+			require.Len(resp.Data, 1, "body hit")
+			assert.Equal(messageID, resp.Data[0].ID, "body hit ID")
+			require.Len(resp.Data[0].ContextSnippets, 1, "FTS hit context windows")
+			assert.Contains(resp.Data[0].ContextSnippets[0], tc.wantContext)
+			if tc.reject != "" {
+				assert.NotContains(resp.Data[0].ContextSnippets[0], tc.reject,
+					"context must start from an FTS token-prefix match")
+			}
+			exact := extractContextChar(tc.body, search.Parse(tc.query).TextTerms, searchContextChars)
+			require.NotEmpty(exact, "context matcher must locate the real FTS token without fallback")
+			assert.Contains(exact[0], tc.wantContext)
+		})
+	}
 }
 
 func TestExtractContextChar(t *testing.T) {
@@ -328,7 +546,7 @@ func TestExtractContextChar(t *testing.T) {
 	t.Run("match near end", func(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
-		body := strings.Repeat("a", 500) + "needle"
+		body := strings.Repeat("a", 500) + " needle"
 		snippets := extractContextChar(body, []string{"needle"}, 100)
 		require.Len(snippets, 1)
 		assert.Len(snippets[0], 100)
@@ -345,9 +563,23 @@ func TestExtractContextChar(t *testing.T) {
 		assert.Nil(extractContextChar("", []string{"foo"}, 300))
 	})
 
-	t.Run("short term skipped", func(t *testing.T) {
+	t.Run("one-character term matched", func(t *testing.T) {
+		require := require.New(t)
 		assert := assert.New(t)
-		assert.Nil(extractContextChar("abc", []string{"a"}, 300))
+		snippets := extractContextChar("abc", []string{"a"}, 300)
+		require.Len(snippets, 1)
+		assert.Equal("abc", snippets[0])
+	})
+
+	t.Run("dense overlapping matches stay bounded and UTF-8 safe", func(t *testing.T) {
+		const contextChars = 24
+		body := strings.Repeat("é a ", 40)
+		snippets := extractContextChar(body, []string{"a"}, contextChars)
+		require.NotEmpty(t, snippets)
+		for _, snippet := range snippets {
+			assert.LessOrEqual(t, len(snippet), contextChars, "bounded extractor context")
+			assert.True(t, utf8.ValidString(snippet), "extractor context must be valid UTF-8")
+		}
 	})
 }
 
@@ -420,6 +652,26 @@ func TestSearchMessages_HybridUsesDaemonSearcher(t *testing.T) {
 	assert.Equal(&rrf, resp.Data[0].Score.RRF, "rrf")
 	assert.True(resp.Data[0].Score.SubjectBoosted, "subject boosted")
 	assert.Equal(int64(7), resp.Generation.ID, "generation")
+}
+
+func TestSearchMessages_HybridDaemonFilterOnlyGuidance(t *testing.T) {
+	searcherCalled := false
+	h := &handlers{
+		engine: &querytest.MockEngine{},
+		hybridSearcher: hybridSearcherFunc(func(context.Context, HybridSearchRequest) (*HybridSearchResult, error) {
+			searcherCalled = true
+			return nil, errors.New("unexpected hybrid search")
+		}),
+	}
+
+	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
+		"query": "from:alice@example.com",
+		"mode":  searchModeHybrid,
+	})
+	text := resultText(t, r)
+	assert.Contains(t, text, "omit mode", "filter-only guidance")
+	assert.NotContains(t, text, "mode=fts", "mode=fts is rejected by search_messages")
+	assert.False(t, searcherCalled, "filter-only query must fail before remote search")
 }
 
 // newHybridHandlersForErrorTest wires a real hybrid.Engine around the

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -70,19 +70,18 @@ type attachmentMeta struct {
 }
 
 type paginatedSearchMessages struct {
-	Data     []query.MessageSummary `json:"data"`
-	Total    int64                  `json:"total"`
-	Returned int                    `json:"returned"`
-	Offset   int                    `json:"offset"`
-	HasMore  bool                   `json:"has_more"`
+	Data     []searchMessageRow `json:"data"`
+	Total    int64              `json:"total"`
+	Returned int                `json:"returned"`
+	Offset   int                `json:"offset"`
+	HasMore  bool               `json:"has_more"`
 }
 
-type paginatedListMessages struct {
-	Data     []query.MessageSummary `json:"data"`
-	Total    int64                  `json:"total"`
-	Returned int                    `json:"returned"`
-	Offset   int                    `json:"offset"`
-	HasMore  bool                   `json:"has_more"`
+type searchMessageRow struct {
+	query.MessageSummary
+
+	ContextSnippets          []string `json:"context_snippets"`
+	ContextSnippetsTruncated bool     `json:"context_snippets_truncated"`
 }
 
 type getMessageResp struct {
@@ -104,6 +103,14 @@ type paginatedInMessageMatches struct {
 	Returned int              `json:"returned"`
 	Offset   int              `json:"offset"`
 	HasMore  bool             `json:"has_more"`
+}
+
+type paginatedListMessages struct {
+	Data     []query.MessageSummary `json:"data"`
+	Total    int64                  `json:"total"`
+	Returned int                    `json:"returned"`
+	Offset   int                    `json:"offset"`
+	HasMore  bool                   `json:"has_more"`
 }
 
 // newTestHandlers creates a handlers instance with the given mock engine.
@@ -151,16 +158,23 @@ func runToolExpectError(t *testing.T, name string, fn toolHandler, args map[stri
 func TestSearchMessages(t *testing.T) {
 	eng := &querytest.MockEngine{
 		SearchFastResults: []query.MessageSummary{
-			testutil.NewMessageSummary(1).WithSubject("Hello").WithFromEmail("alice@example.com").WithSourceConversationID("thread-abc").Build(),
+			testutil.NewMessageSummary(1).WithSubject("Hello").WithFromEmail("alice@example.com").WithSourceConversationID("thread-abc").WithConversationID(99).Build(),
+		},
+		SearchFastCountFunc: func(_ context.Context, _ *search.Query, _ query.MessageFilter) (int64, error) {
+			return 1, nil
 		},
 	}
 	h := newTestHandlers(eng)
 
 	t.Run("valid query", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
 		resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{"query": "from:alice"})
-		require.Len(t, resp.Data, 1, "data")
-		assert.Equal(t, "Hello", resp.Data[0].Subject, "subject")
-		assert.Equal(t, "thread-abc", resp.Data[0].SourceConversationID, "SourceConversationID")
+		require.Len(resp.Data, 1, "data")
+		assert.Equal("Hello", resp.Data[0].Subject, "subject")
+		assert.Equal("thread-abc", resp.Data[0].SourceConversationID, "SourceConversationID")
+		assert.Equal(int64(99), resp.Data[0].ConversationID, "conversation_id")
+		assert.Equal(int64(1), resp.Total, "total")
 	})
 
 	t.Run("missing query", func(t *testing.T) {
@@ -175,32 +189,31 @@ func TestSearchMessages(t *testing.T) {
 	})
 }
 
-func TestSearchFallbackToFTS(t *testing.T) {
+// TestSearchMessages_MetadataOnly verifies that search_messages uses only the
+// fast metadata path and never calls the FTS body search engine.
+func TestSearchMessages_MetadataOnly(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
 	eng := &querytest.MockEngine{
-		SearchFastResults: nil, // fast returns nothing
-		SearchFunc: func(_ context.Context, _ *search.Query, limit, offset int) ([]query.MessageSummary, error) {
-			assert.Equal(2, limit, "FTS fallback should fetch one extra row for has_more")
-			assert.Equal(0, offset, "offset")
-			return []query.MessageSummary{
-				testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
-				testutil.NewMessageSummary(3).WithSubject("Second body match").Build(),
-			}, nil
+		SearchFastResults: []query.MessageSummary{
+			testutil.NewMessageSummary(3).WithSubject("Fast only").Build(),
+		},
+		// SearchResults would be returned by FTS body search — we set it to
+		// confirm search_messages never touches it.
+		SearchResults: []query.MessageSummary{
+			testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+		},
+		SearchFastCountFunc: func(_ context.Context, _ *search.Query, _ query.MessageFilter) (int64, error) {
+			return 1, nil
 		},
 	}
 	h := newTestHandlers(eng)
 
-	resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{
-		"query": "important meeting notes",
-		"limit": float64(1),
-	})
-	require.Len(resp.Data, 1, "FTS fallback data")
-	assert.Equal(int64(2), resp.Data[0].ID, "FTS fallback ID")
-	assert.Equal(int64(totalCountUnknown), resp.Total, "FTS fallback total")
-	assert.Equal(1, resp.Returned, "returned")
-	assert.True(resp.HasMore, "has_more")
+	resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{"query": "important meeting notes"})
+	require.Len(resp.Data, 1, "metadata-only results")
+	// Must return the fast result (ID 3), not the FTS result (ID 2).
+	assert.Equal(int64(3), resp.Data[0].ID, "metadata result ID")
 }
 
 func TestSearchMessages_NonPositiveLimitUsesDefault(t *testing.T) {
@@ -235,6 +248,107 @@ func TestSearchMessages_NonPositiveLimitUsesDefault(t *testing.T) {
 			assert.Equal(int64(1), resp.Total, "total")
 		})
 	}
+}
+
+func TestSearchMessageBodies(t *testing.T) {
+	eng := &querytest.MockEngine{
+		SearchResults: []query.MessageSummary{
+			testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+		},
+		Messages: map[int64]*query.MessageDetail{
+			2: testutil.NewMessageDetail(2).WithBodyText("The resistor value should be 5.1k ohms.").BuildPtr(),
+		},
+	}
+	h := newTestHandlers(eng)
+
+	t.Run("returns FTS results with context_snippets", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		resp := runTool[paginatedSearchMessages](t, "search_message_bodies", h.searchMessageBodies, map[string]any{"query": "5.1k ohms"})
+		require.Len(resp.Data, 1, "data")
+		assert.Equal(int64(2), resp.Data[0].ID)
+		require.NotEmpty(resp.Data[0].ContextSnippets, "context_snippets")
+		assert.Contains(resp.Data[0].ContextSnippets[0], "5.1k")
+		assert.Equal(int64(totalCountUnknown), resp.Total, "total=-1 for FTS")
+	})
+
+	t.Run("requires free-text term", func(t *testing.T) {
+		r := runToolExpectError(t, "search_message_bodies", h.searchMessageBodies, map[string]any{"query": "from:alice"})
+		txt := resultText(t, r)
+		assert.Contains(t, txt, "free-text term")
+	})
+
+	t.Run("missing query", func(t *testing.T) {
+		runToolExpectError(t, "search_message_bodies", h.searchMessageBodies, map[string]any{})
+	})
+}
+
+func TestExtractContextChar(t *testing.T) {
+	t.Run("short body", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := "The resistor value should be 5.1k ohms not 10k as previously stated."
+		snippets := extractContextChar(body, []string{"5.1k"}, 200)
+		require.Len(snippets, 1)
+		assert.Contains(snippets[0], "5.1k")
+		assert.LessOrEqual(len(snippets[0]), 200)
+	})
+
+	t.Run("long quoted line", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		quoted := strings.Repeat("> This is quoted history that should not bloat the snippet. ", 40)
+		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
+		snippets := extractContextChar(body, []string{"5.1k"}, 300)
+		require.Len(snippets, 1)
+		assert.Contains(snippets[0], "5.1k")
+		assert.Len(snippets[0], 300)
+		assert.NotContains(snippets[0], strings.Repeat("> This", 10))
+	})
+
+	t.Run("overlapping matches merge", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := "foo bar foo baz"
+		snippets := extractContextChar(body, []string{"foo"}, 20)
+		require.Len(snippets, 1)
+		assert.Equal(body, snippets[0])
+	})
+
+	t.Run("match near start", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := "needle" + strings.Repeat("x", 500)
+		snippets := extractContextChar(body, []string{"needle"}, 100)
+		require.Len(snippets, 1)
+		assert.Len(snippets[0], 100)
+		assert.Equal(body[:100], snippets[0])
+	})
+
+	t.Run("match near end", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		body := strings.Repeat("a", 500) + "needle"
+		snippets := extractContextChar(body, []string{"needle"}, 100)
+		require.Len(snippets, 1)
+		assert.Len(snippets[0], 100)
+		assert.Equal(body[len(body)-100:], snippets[0])
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.Nil(extractContextChar("hello world", []string{"zzz"}, 300))
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.Nil(extractContextChar("", []string{"foo"}, 300))
+	})
+
+	t.Run("short term skipped", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.Nil(extractContextChar("abc", []string{"a"}, 300))
+	})
 }
 
 func TestSearchMessages_HybridModeNotConfigured(t *testing.T) {
@@ -754,80 +868,25 @@ func TestBodyByteSlice(t *testing.T) {
 	})
 }
 
-func TestExtractContextChar(t *testing.T) {
-	t.Run("short body", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := "The resistor value should be 5.1k ohms not 10k as previously stated."
-		snippets := extractContextChar(body, []string{"5.1k"}, 200)
-		require.Len(snippets, 1)
-		assert.Contains(snippets[0], "5.1k")
-		assert.LessOrEqual(len(snippets[0]), 200)
-	})
-
-	t.Run("long quoted line", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		quoted := strings.Repeat("> This is quoted history that should not bloat the snippet. ", 40)
-		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
-		snippets := extractContextChar(body, []string{"5.1k"}, 300)
-		require.Len(snippets, 1)
-		assert.Contains(snippets[0], "5.1k")
-		assert.Len(snippets[0], 300)
-		assert.NotContains(snippets[0], strings.Repeat("> This", 10))
-	})
-
-	t.Run("overlapping matches merge", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := "foo bar foo baz"
-		snippets := extractContextChar(body, []string{"foo"}, 20)
-		require.Len(snippets, 1)
-		assert.Equal(body, snippets[0])
-	})
-
-	t.Run("match near start", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := "needle" + strings.Repeat("x", 500)
-		snippets := extractContextChar(body, []string{"needle"}, 100)
-		require.Len(snippets, 1)
-		assert.Len(snippets[0], 100)
-		assert.Equal(body[:100], snippets[0])
-	})
-
-	t.Run("match near end", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := strings.Repeat("a", 500) + "needle"
-		snippets := extractContextChar(body, []string{"needle"}, 100)
-		require.Len(snippets, 1)
-		assert.Len(snippets[0], 100)
-		assert.Equal(body[len(body)-100:], snippets[0])
-	})
-
-	t.Run("no matches", func(t *testing.T) {
-		assert := assert.New(t)
-		assert.Nil(extractContextChar("hello world", []string{"zzz"}, 300))
-	})
-
-	t.Run("empty body", func(t *testing.T) {
-		assert := assert.New(t)
-		assert.Nil(extractContextChar("", []string{"foo"}, 300))
-	})
-
-	t.Run("short term skipped", func(t *testing.T) {
-		assert := assert.New(t)
-		assert.Nil(extractContextChar("abc", []string{"a"}, 300))
-	})
-}
-
 func TestSearchMessages_UnknownMode(t *testing.T) {
 	h := newTestHandlers(&querytest.MockEngine{})
 
 	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
 		"query": "meeting notes",
 		"mode":  "bogus",
+	})
+	txt := resultText(t, r)
+	assert.Contains(t, txt, "invalid mode", "expected 'invalid mode' error, got: %s")
+}
+
+// TestSearchMessages_FTSModeRejected guards that passing mode=fts to
+// search_messages returns an error directing the caller to search_message_bodies.
+func TestSearchMessages_FTSModeRejected(t *testing.T) {
+	h := newTestHandlers(&querytest.MockEngine{})
+
+	r := runToolExpectError(t, "search_messages", h.searchMessages, map[string]any{
+		"query": "meeting notes",
+		"mode":  searchModeFTS,
 	})
 	txt := resultText(t, r)
 	assert.Contains(t, txt, "invalid mode", "expected 'invalid mode' error, got: %s")
@@ -955,6 +1014,7 @@ func TestGetMessage(t *testing.T) {
 	})
 
 	t.Run("center_at mid-body", func(t *testing.T) {
+		assert := assert.New(t)
 		body := strings.Repeat("a", 1000) + "KEYWORD" + strings.Repeat("z", 1000)
 		matchOffset := 1000
 		eng2 := &querytest.MockEngine{
@@ -968,9 +1028,10 @@ func TestGetMessage(t *testing.T) {
 			"center_at": float64(matchOffset),
 			"max_chars": float64(200),
 		})
-		assert.Contains(t, msg.BodyText, "KEYWORD")
-		assert.LessOrEqual(t, msg.Offset, matchOffset, "window starts before match")
-		assert.LessOrEqual(t, len(msg.BodyText), 200, "respects max_chars")
+		// The window should be centered on the match: KEYWORD must appear inside it.
+		assert.Contains(msg.BodyText, "KEYWORD")
+		assert.LessOrEqual(msg.Offset, matchOffset, "window starts before match")
+		assert.LessOrEqual(len(msg.BodyText), 200, "respects max_chars")
 	})
 
 	t.Run("center_at near start", func(t *testing.T) {
@@ -1261,61 +1322,6 @@ func TestAggregateInvalidDates(t *testing.T) {
 			runToolExpectError(t, "aggregate", h.aggregate, tt.args)
 		})
 	}
-}
-
-func TestSearchInMessage(t *testing.T) {
-	t.Run("reports line and centered snippet", func(t *testing.T) {
-		body := "line one\nline two has the resistor value should be 5.1k ohms\nline three"
-		eng := &querytest.MockEngine{
-			Messages: map[int64]*query.MessageDetail{
-				10: testutil.NewMessageDetail(10).WithBodyText(body).BuildPtr(),
-			},
-		}
-		h := newTestHandlers(eng)
-
-		resp := runTool[paginatedInMessageMatches](t, "search_in_message", h.searchInMessage, map[string]any{
-			"id":    float64(10),
-			"query": "resistor",
-		})
-		require.Len(t, resp.Data, 1, "matches")
-		assert.Equal(t, 2, resp.Data[0].Line, "line")
-		assert.Contains(t, resp.Data[0].Snippet, "resistor")
-	})
-
-	t.Run("long quoted line", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		quoted := strings.Repeat("> quoted history should not bloat the snippet. ", 40)
-		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
-		eng := &querytest.MockEngine{
-			Messages: map[int64]*query.MessageDetail{
-				11: testutil.NewMessageDetail(11).WithBodyText(body).BuildPtr(),
-			},
-		}
-		h := newTestHandlers(eng)
-
-		resp := runTool[paginatedInMessageMatches](t, "search_in_message", h.searchInMessage, map[string]any{
-			"id":    float64(11),
-			"query": "5.1k",
-		})
-		require.Len(resp.Data, 1, "matches")
-		assert.Contains(resp.Data[0].Snippet, "5.1k")
-		assert.LessOrEqual(len(resp.Data[0].Snippet), searchContextChars)
-		assert.NotContains(resp.Data[0].Snippet, strings.Repeat("> quoted", 5))
-	})
-
-	t.Run("nil message without error", func(t *testing.T) {
-		eng := &querytest.MockEngine{
-			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
-				return nil, nil //nolint:nilnil // mirrors Engine.GetMessage not-found contract
-			},
-		}
-		h := newTestHandlers(eng)
-		runToolExpectError(t, "search_in_message", h.searchInMessage, map[string]any{
-			"id":    float64(42),
-			"query": "resistor",
-		})
-	})
 }
 
 // createAttachmentFixture creates a content-addressed file under dir using the given hash.
@@ -1791,6 +1797,9 @@ func TestAccountFilter(t *testing.T) {
 	h := newTestHandlers(eng)
 
 	t.Run("search with valid account", func(t *testing.T) {
+		eng.SearchFastCountFunc = func(_ context.Context, _ *search.Query, _ query.MessageFilter) (int64, error) {
+			return 1, nil
+		}
 		resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{
 			"query":   "test",
 			"account": "alice@gmail.com",
@@ -1841,12 +1850,87 @@ func TestAccountFilter(t *testing.T) {
 
 	t.Run("empty account means no filter", func(t *testing.T) {
 		// Empty string should not filter - return all results
+		eng.SearchFastCountFunc = func(_ context.Context, _ *search.Query, _ query.MessageFilter) (int64, error) {
+			return 1, nil
+		}
 		resp := runTool[paginatedSearchMessages](t, "search_messages", h.searchMessages, map[string]any{
 			"query":   "test",
 			"account": "",
 		})
 		assert.Len(t, resp.Data, 1, "data")
 	})
+}
+
+func TestSearchInMessage(t *testing.T) {
+	t.Run("reports line and centered snippet", func(t *testing.T) {
+		body := "line one\nline two has the resistor value should be 5.1k ohms\nline three"
+		eng := &querytest.MockEngine{
+			Messages: map[int64]*query.MessageDetail{
+				10: testutil.NewMessageDetail(10).WithBodyText(body).BuildPtr(),
+			},
+		}
+		h := newTestHandlers(eng)
+
+		resp := runTool[paginatedInMessageMatches](t, "search_in_message", h.searchInMessage, map[string]any{
+			"id":    float64(10),
+			"query": "resistor",
+		})
+		require.Len(t, resp.Data, 1, "matches")
+		assert.Equal(t, 2, resp.Data[0].Line, "line")
+		assert.Contains(t, resp.Data[0].Snippet, "resistor")
+	})
+
+	t.Run("long quoted line", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		quoted := strings.Repeat("> quoted history should not bloat the snippet. ", 40)
+		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
+		eng := &querytest.MockEngine{
+			Messages: map[int64]*query.MessageDetail{
+				11: testutil.NewMessageDetail(11).WithBodyText(body).BuildPtr(),
+			},
+		}
+		h := newTestHandlers(eng)
+
+		resp := runTool[paginatedInMessageMatches](t, "search_in_message", h.searchInMessage, map[string]any{
+			"id":    float64(11),
+			"query": "5.1k",
+		})
+		require.Len(resp.Data, 1, "matches")
+		assert.Contains(resp.Data[0].Snippet, "5.1k")
+		assert.LessOrEqual(len(resp.Data[0].Snippet), searchContextChars)
+		assert.NotContains(resp.Data[0].Snippet, strings.Repeat("> quoted", 5))
+	})
+
+	t.Run("nil message without error", func(t *testing.T) {
+		eng := &querytest.MockEngine{
+			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+				return nil, nil //nolint:nilnil // mirrors Engine.GetMessage not-found contract
+			},
+		}
+		h := newTestHandlers(eng)
+		runToolExpectError(t, "search_in_message", h.searchInMessage, map[string]any{
+			"id":    float64(42),
+			"query": "resistor",
+		})
+	})
+}
+
+func TestListMessagesConversationID(t *testing.T) {
+	var captured query.MessageFilter
+	eng := &querytest.MockEngine{
+		ListMessagesFunc: func(_ context.Context, f query.MessageFilter) ([]query.MessageSummary, error) {
+			captured = f
+			return nil, nil
+		},
+	}
+	h := newTestHandlers(eng)
+
+	runTool[paginatedListMessages](t, "list_messages", h.listMessages, map[string]any{
+		"conversation_id": float64(42),
+	})
+	require.NotNil(t, captured.ConversationID, "conversation_id filter")
+	assert.Equal(t, int64(42), *captured.ConversationID, "conversation_id value")
 }
 
 // stageDeletionResponse matches the JSON response from stageDeletion.
@@ -2072,6 +2156,8 @@ type fakeBackend struct {
 	searchCalls  int
 	searchGen    vector.GenerationID
 	searchFilter vector.Filter
+	fusedHits    []vector.FusedHit
+	fusedErr     error
 	building     *vector.Generation
 	buildingErr  error
 	stats        map[vector.GenerationID]vector.Stats
@@ -2096,6 +2182,24 @@ func (f *fakeBackend) Search(_ context.Context, gen vector.GenerationID, _ []flo
 	f.searchGen = gen
 	f.searchFilter = filter
 	return f.searchHits, f.searchErr
+}
+func (f *fakeBackend) FusedSearch(_ context.Context, req vector.FusedRequest) ([]vector.FusedHit, bool, error) {
+	if f.fusedErr != nil {
+		return nil, false, f.fusedErr
+	}
+	hits := f.fusedHits
+	if hits == nil {
+		hits = make([]vector.FusedHit, len(f.searchHits))
+		for i, h := range f.searchHits {
+			hits[i] = vector.FusedHit{
+				MessageID:   h.MessageID,
+				VectorScore: h.Score,
+				RRFScore:    h.Score,
+				BM25Score:   math.NaN(),
+			}
+		}
+	}
+	return hits, len(hits) >= req.Limit, nil
 }
 func (f *fakeBackend) CreateGeneration(_ context.Context, _ string, _ int, _ string) (vector.GenerationID, error) {
 	return 0, errors.New("not implemented")
@@ -2123,7 +2227,10 @@ func (f *fakeBackend) Stats(_ context.Context, gen vector.GenerationID) (vector.
 }
 func (f *fakeBackend) Close() error { return nil }
 
-var _ vector.Backend = (*fakeBackend)(nil)
+var (
+	_ vector.Backend       = (*fakeBackend)(nil)
+	_ vector.FusingBackend = (*fakeBackend)(nil)
+)
 
 // similarResponse matches the JSON response shape of find_similar_messages.
 type similarResponse struct {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -79,6 +79,16 @@ type paginatedSearchMessages struct {
 	HasMore  bool               `json:"has_more"`
 }
 
+func withBodySearchContext(
+	message query.MessageSummary,
+	snippets []string,
+	truncated bool,
+) query.MessageSummary {
+	message.BodyContextSnippets = snippets
+	message.BodyContextSnippetsTruncated = truncated
+	return message
+}
+
 type searchMessageRow struct {
 	query.MessageSummary
 
@@ -124,21 +134,6 @@ type listAccountsTrackingEngine struct {
 	*querytest.MockEngine
 
 	listAccountsCalled bool
-}
-
-type cancelAfterErrContext struct {
-	context.Context
-
-	cancelAfter int
-	errCalls    int
-}
-
-func (c *cancelAfterErrContext) Err() error {
-	c.errCalls++
-	if c.errCalls >= c.cancelAfter {
-		return context.Canceled
-	}
-	return nil
 }
 
 func (e *listAccountsTrackingEngine) ListAccounts(ctx context.Context) ([]query.AccountInfo, error) {
@@ -347,7 +342,10 @@ func TestSearchMessageBodies(t *testing.T) {
 		},
 		SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
 			return []query.MessageSummary{
-				testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+				withBodySearchContext(
+					testutil.NewMessageSummary(2).WithSubject("Body match").WithFromEmail("bob@example.com").Build(),
+					[]string{"The resistor value should be 5.1k ohms."}, false,
+				),
 			}, nil
 		},
 		Messages: map[int64]*query.MessageDetail{
@@ -426,21 +424,24 @@ func TestSearchMessageBodies(t *testing.T) {
 		assert.Contains(t, resultText(t, r), "body context")
 	})
 
-	t.Run("uses bounded fallback context for a nonempty indexed body", func(t *testing.T) {
+	t.Run("forwards bounded fallback context from the search backend", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
 		body := strings.Repeat("fallback context ", 30)
 		fallback := &querytest.MockEngine{
 			SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
-				return []query.MessageSummary{{ID: 78, Subject: "tokenizer mismatch"}}, nil
-			},
-			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
-				return testutil.NewMessageDetail(78).WithBodyText(body).BuildPtr(), nil
+				return []query.MessageSummary{withBodySearchContext(
+					query.MessageSummary{ID: 78, Subject: "bounded backend fallback"},
+					[]string{body[:searchContextChars]}, true,
+				)}, nil
 			},
 		}
 		resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
 			newTestHandlers(fallback).searchMessageBodies, map[string]any{"query": "mismatchneedle"})
-		require.Len(t, resp.Data, 1, "fallback hit")
-		require.Len(t, resp.Data[0].ContextSnippets, 1, "fallback context")
-		assert.Equal(t, body[:searchContextChars], resp.Data[0].ContextSnippets[0])
+		require.Len(resp.Data, 1, "fallback hit")
+		require.Len(resp.Data[0].ContextSnippets, 1, "fallback context")
+		assert.Equal(body[:searchContextChars], resp.Data[0].ContextSnippets[0])
+		assert.True(resp.Data[0].ContextSnippetsTruncated)
 	})
 
 	t.Run("keeps dense-match context windows bounded and UTF-8 safe", func(t *testing.T) {
@@ -449,10 +450,10 @@ func TestSearchMessageBodies(t *testing.T) {
 		body := strings.Repeat("é a ", 200)
 		dense := &querytest.MockEngine{
 			SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
-				return []query.MessageSummary{{ID: 80, Subject: "dense matches"}}, nil
-			},
-			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
-				return testutil.NewMessageDetail(80).WithBodyText(body).BuildPtr(), nil
+				return []query.MessageSummary{withBodySearchContext(
+					query.MessageSummary{ID: 80, Subject: "dense matches"},
+					[]string{bodyByteSlice(body, 0, searchContextChars)}, true,
+				)}, nil
 			},
 		}
 		resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
@@ -465,18 +466,15 @@ func TestSearchMessageBodies(t *testing.T) {
 		}
 	})
 
-	t.Run("fails when an indexed hit has an empty stored body", func(t *testing.T) {
+	t.Run("fails when the search backend returns no context", func(t *testing.T) {
 		empty := &querytest.MockEngine{
 			SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
-				return []query.MessageSummary{{ID: 79, Subject: "empty body"}}, nil
-			},
-			GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
-				return testutil.NewMessageDetail(79).WithBodyText("").BuildPtr(), nil
+				return []query.MessageSummary{{ID: 79, Subject: "missing context"}}, nil
 			},
 		}
 		r := runToolExpectError(t, "search_message_bodies",
 			newTestHandlers(empty).searchMessageBodies, map[string]any{"query": "needle"})
-		assert.Contains(t, resultText(t, r), "stored body is empty")
+		assert.Contains(t, resultText(t, r), "returned no context")
 	})
 
 	t.Run("fails closed when capability is unavailable", func(t *testing.T) {
@@ -562,6 +560,12 @@ func TestSearchMessageBodies_RealEngineFTSNormalizedContext(t *testing.T) {
 			sqliteOnly:  true,
 		},
 		{
+			name:        "ASCII case is folded by both backends",
+			query:       "resume",
+			body:        "RESUME notes",
+			wantContext: "RESUME",
+		},
+		{
 			name:        "spacing mark is a token separator",
 			query:       "b",
 			body:        "a\u0903b notes",
@@ -611,20 +615,188 @@ func TestSearchMessageBodies_RealEngineFTSNormalizedContext(t *testing.T) {
 				assert.NotContains(resp.Data[0].ContextSnippets[0], tc.reject,
 					"context must start from an FTS token-prefix match")
 			}
-			exact, _ := extractContextForTest(t, tc.body, search.Parse(tc.query).TextTerms, searchContextChars)
-			require.NotEmpty(exact, "context matcher must locate the real FTS token without fallback")
-			assert.Contains(exact[0], tc.wantContext)
 		})
 	}
 }
 
-func extractContextForTest(t *testing.T, body string, terms []string, contextChars int) ([]string, bool) {
-	t.Helper()
-	snippets, truncated, err := extractContextChar(
-		context.Background(), body, terms, contextChars, maxContextSnippets,
-	)
-	require.NoError(t, err, "extract context")
-	return snippets, truncated
+func TestSearchMessageBodies_PostgreSQLContextIgnoresAccentLookalikes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if !f.Store.IsPostgreSQL() {
+		t.Skip("PostgreSQL simple-dictionary context semantics")
+	}
+
+	accentLookalike := "résumé " + strings.Repeat("padding ", 60)
+	body := strings.Repeat(accentLookalike, query.MessageBodyContextMaxSnippets) + "resume marker"
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-postgres-accent-context").
+		WithSubject("ordinary subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	engine := query.NewEngine(f.Store.DB(), true)
+	resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
+		newTestHandlers(engine).searchMessageBodies, map[string]any{"query": "resume"})
+	require.Len(resp.Data, 1, "body hit")
+	assert.Equal(messageID, resp.Data[0].ID, "body hit ID")
+	require.NotEmpty(resp.Data[0].ContextSnippets, "FTS hit context windows")
+	assert.Condition(func() bool {
+		for _, snippet := range resp.Data[0].ContextSnippets {
+			if strings.Contains(snippet, "resume marker") {
+				return true
+			}
+		}
+		return false
+	}, "context snippets must include the true PostgreSQL simple-dictionary hit")
+}
+
+func TestSearchMessageBodies_PostgreSQLContextUsesParserTokens(t *testing.T) {
+	f := storetest.New(t)
+	if !f.Store.IsPostgreSQL() {
+		t.Skip("PostgreSQL parser-specific body context semantics")
+	}
+
+	tests := []struct {
+		name      string
+		lookalike string
+		query     string
+		marker    string
+	}{
+		{
+			name:      "decomposed combining mark stays inside a word",
+			lookalike: "cafe\u0301teria",
+			query:     "cafe\u0301teria",
+			marker:    "cafe teria marker",
+		},
+		{
+			name:      "host stays one token",
+			lookalike: "foo.bar",
+			query:     `"foo bar"`,
+			marker:    "foo bar marker",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			lookalike := tc.lookalike + " " + strings.Repeat("padding ", 60)
+			body := strings.Repeat(lookalike, query.MessageBodyContextMaxSnippets) + tc.marker
+			messageID := f.NewMessage().
+				WithSourceMessageID("mcp-postgres-parser-"+tc.name).
+				WithSubject("ordinary subject").
+				WithSnippet("ordinary preview").
+				Create(t, f.Store)
+			require.NoError(f.Store.UpsertMessageBody(messageID,
+				sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+			_, err := f.Store.BackfillFTS(nil)
+			require.NoError(err, "BackfillFTS")
+
+			engine := query.NewEngine(f.Store.DB(), true)
+			resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
+				newTestHandlers(engine).searchMessageBodies,
+				map[string]any{"query": tc.query})
+			require.Len(resp.Data, 1, "body hit")
+			assert.Equal(messageID, resp.Data[0].ID, "body hit ID")
+			require.NotEmpty(resp.Data[0].ContextSnippets, "FTS hit context windows")
+			assert.Condition(func() bool {
+				for _, snippet := range resp.Data[0].ContextSnippets {
+					if strings.Contains(snippet, tc.marker) {
+						return true
+					}
+				}
+				return false
+			}, "context snippets must ignore PostgreSQL parser lookalikes")
+		})
+	}
+}
+
+func TestSearchMessageBodies_ContextIgnoresFullFoldExpansionLookalikes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+
+	fullFoldLookalike := "Straße " + strings.Repeat("padding ", 60)
+	body := strings.Repeat(fullFoldLookalike, query.MessageBodyContextMaxSnippets) + "strasse marker"
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-full-fold-context").
+		WithSubject("ordinary subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	engine := query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())
+	resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
+		newTestHandlers(engine).searchMessageBodies, map[string]any{"query": "strasse"})
+	require.Len(resp.Data, 1, "body hit")
+	assert.Equal(messageID, resp.Data[0].ID, "body hit ID")
+	require.NotEmpty(resp.Data[0].ContextSnippets, "FTS hit context windows")
+	assert.Condition(func() bool {
+		for _, snippet := range resp.Data[0].ContextSnippets {
+			if strings.Contains(snippet, "strasse marker") {
+				return true
+			}
+		}
+		return false
+	}, "context snippets must include the true backend FTS hit")
+}
+
+func TestSearchMessageBodies_SQLiteContextPreservesUnicode61Diacritics(t *testing.T) {
+	f := storetest.New(t)
+	if f.Store.IsPostgreSQL() {
+		t.Skip("SQLite unicode61 remove_diacritics=1 compatibility semantics")
+	}
+
+	tests := []struct {
+		name      string
+		lookalike string
+		query     string
+	}{
+		{name: "precomposed multiple Latin marks", lookalike: "ộ", query: "o"},
+		{name: "precomposed non-Latin mark", lookalike: "ά", query: "α"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			lookalike := tc.lookalike + " " + strings.Repeat("padding ", 60)
+			marker := tc.query + " marker"
+			body := strings.Repeat(lookalike, query.MessageBodyContextMaxSnippets) + marker
+			messageID := f.NewMessage().
+				WithSourceMessageID("mcp-sqlite-diacritic-"+tc.name).
+				WithSubject("ordinary subject").
+				WithSnippet("ordinary preview").
+				Create(t, f.Store)
+			require.NoError(f.Store.UpsertMessageBody(messageID,
+				sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+			_, err := f.Store.BackfillFTS(nil)
+			require.NoError(err, "BackfillFTS")
+
+			engine := query.NewEngine(f.Store.DB(), false)
+			resp := runTool[paginatedSearchMessages](t, "search_message_bodies",
+				newTestHandlers(engine).searchMessageBodies, map[string]any{"query": tc.query})
+			require.Len(resp.Data, 1, "body hit")
+			assert.Equal(messageID, resp.Data[0].ID, "body hit ID")
+			require.NotEmpty(resp.Data[0].ContextSnippets, "FTS hit context windows")
+			assert.Condition(func() bool {
+				for _, snippet := range resp.Data[0].ContextSnippets {
+					if strings.Contains(snippet, marker) {
+						return true
+					}
+				}
+				return false
+			}, "context snippets must ignore lookalikes preserved by unicode61")
+		})
+	}
 }
 
 func TestSearchMessageBodies_PhraseContextSurvivesSnippetCap(t *testing.T) {
@@ -633,7 +805,7 @@ func TestSearchMessageBodies_PhraseContextSurvivesSnippetCap(t *testing.T) {
 	f := storetest.New(t)
 
 	gap := strings.Repeat("é ", searchContextChars)
-	body := strings.Repeat("alpha "+gap, maxContextSnippets+1) + "alpha beta marker"
+	body := strings.Repeat("alpha "+gap, query.MessageBodyContextMaxSnippets+1) + "alpha beta marker"
 	messageID := f.NewMessage().
 		WithSourceMessageID("mcp-phrase-context").
 		WithSubject("ordinary subject").
@@ -658,16 +830,43 @@ func TestSearchMessageBodies_PhraseContextSurvivesSnippetCap(t *testing.T) {
 	assert.True(foundPhrase, "context snippets must include the matched phrase")
 }
 
-func TestSearchMessageBodies_ContextExtractionHonorsCancellation(t *testing.T) {
-	messageID := int64(91)
+func TestSearchMessageBodies_WidePhrasePreservesMatchedEndpoint(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+
+	body := "prefix alpha" + strings.Repeat(" ", 400) + "beta marker tail"
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-wide-phrase-context").
+		WithSubject("ordinary subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	response := runTool[paginatedSearchMessages](t, "search_message_bodies",
+		newTestHandlers(query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())).searchMessageBodies,
+		map[string]any{"query": `"alpha beta"`})
+	require.Len(response.Data, 1, "wide phrase hit")
+	require.NotEmpty(response.Data[0].ContextSnippets, "wide phrase endpoint contexts")
+	assert.True(response.Data[0].ContextSnippetsTruncated,
+		"a phrase wider than one snippet must advertise omitted context")
+	assert.Condition(func() bool {
+		for _, snippet := range response.Data[0].ContextSnippets {
+			if strings.Contains(snippet, "alpha") || strings.Contains(snippet, "beta") {
+				return true
+			}
+		}
+		return false
+	}, "context must contain an endpoint from the actual indexed phrase")
+}
+
+func TestSearchMessageBodies_HonorsBackendCancellation(t *testing.T) {
 	engine := &querytest.MockEngine{
-		SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
-			return []query.MessageSummary{testutil.NewMessageSummary(messageID).Build()}, nil
-		},
-		GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
-			return testutil.NewMessageDetail(messageID).
-				WithBodyText(strings.Repeat("hay ", 10_000) + "needle").
-				BuildPtr(), nil
+		SearchMessageBodiesFunc: func(ctx context.Context, _ *search.Query, _, _ int) ([]query.MessageSummary, error) {
+			return nil, ctx.Err()
 		},
 	}
 	h := newTestHandlers(engine)
@@ -679,156 +878,90 @@ func TestSearchMessageBodies_ContextExtractionHonorsCancellation(t *testing.T) {
 
 	result, err := h.searchMessageBodies(ctx, req)
 	require.NoError(t, err, "handler returned error")
-	require.True(t, result.IsError, "canceled extraction must return a tool error")
+	require.True(t, result.IsError, "canceled backend search must return a tool error")
 	assert.Contains(t, resultText(t, result), context.Canceled.Error())
 }
 
-func TestSearchMessageBodies_MarksContextScanBudgetTruncation(t *testing.T) {
+func TestSearchMessageBodies_LongBodyOutsideContextBudgetIsExplicitlyTruncated(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	messageID := int64(92)
-	body := strings.Repeat("hay ", 300_000) + "needle marker"
-	engine := &querytest.MockEngine{
-		SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
-			return []query.MessageSummary{testutil.NewMessageSummary(messageID).Build()}, nil
-		},
-		GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
-			return testutil.NewMessageDetail(messageID).WithBodyText(body).BuildPtr(), nil
-		},
+	f := storetest.New(t)
+	if f.Store.IsPostgreSQL() {
+		t.Skip("SQLite indexes bodies beyond PostgreSQL's bounded tsvector input")
 	}
+	body := strings.Repeat("hay ", 300_000) + "needle marker"
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-context-scan-budget").
+		WithSubject("ordinary subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
 
 	response := runTool[paginatedSearchMessages](t, "search_message_bodies",
-		newTestHandlers(engine).searchMessageBodies, map[string]any{"query": "needle"})
+		newTestHandlers(query.NewEngine(f.Store.DB(), false)).searchMessageBodies,
+		map[string]any{"query": "needle"})
 	require.Len(response.Data, 1, "body hit")
 	assert.True(response.Data[0].ContextSnippetsTruncated,
-		"bodies beyond the context scan budget must advertise omitted context")
-	require.Len(response.Data[0].ContextSnippets, 1, "bounded fallback context")
-	assert.NotContains(response.Data[0].ContextSnippets[0], "needle",
-		"the extractor must not claim an unscanned late match")
-	assert.LessOrEqual(len(response.Data[0].ContextSnippets[0]), searchContextChars)
-	assert.True(utf8.ValidString(response.Data[0].ContextSnippets[0]),
-		"bounded fallback context must be valid UTF-8")
+		"a bounded native fragment from a long body must advertise omitted context")
+	assert.Empty(response.Data[0].ContextSnippets,
+		"a late match outside the request scan budget must not produce an unrelated fallback")
 }
 
-func TestExtractContextChar(t *testing.T) {
-	t.Run("short body", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := "The resistor value should be 5.1k ohms not 10k as previously stated."
-		snippets, _ := extractContextForTest(t, body, []string{"5.1k"}, 200)
-		require.Len(snippets, 1)
-		assert.Contains(snippets[0], "5.1k")
-		assert.LessOrEqual(len(snippets[0]), 200)
-	})
+func TestSearchMessageBodies_SQLiteOversizedLexemeDoesNotEscapeContextBudget(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if f.Store.IsPostgreSQL() {
+		t.Skip("SQLite FTS5 oversized-token regression")
+	}
+	body := strings.Repeat("a", 2<<20)
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-context-oversized-lexeme").
+		WithSubject("ordinary subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
 
-	t.Run("long quoted line", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		quoted := strings.Repeat("> This is quoted history that should not bloat the snippet. ", 40)
-		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
-		snippets, _ := extractContextForTest(t, body, []string{"5.1k"}, 300)
-		require.Len(snippets, 1)
-		assert.Contains(snippets[0], "5.1k")
-		assert.Len(snippets[0], 300)
-		assert.NotContains(snippets[0], strings.Repeat("> This", 10))
-	})
+	response := runTool[paginatedSearchMessages](t, "search_message_bodies",
+		newTestHandlers(query.NewEngine(f.Store.DB(), false)).searchMessageBodies,
+		map[string]any{"query": "a"})
+	require.Len(response.Data, 1, "body hit")
+	assert.True(response.Data[0].ContextSnippetsTruncated)
+	assert.Empty(response.Data[0].ContextSnippets,
+		"a token cut by every bounded chunk must be omitted, not materialized whole")
+}
 
-	t.Run("overlapping matches merge", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := "foo bar foo baz"
-		snippets, _ := extractContextForTest(t, body, []string{"foo"}, 20)
-		require.Len(snippets, 1)
-		assert.Equal(body, snippets[0])
-	})
+func TestSearchMessageBodies_DenseNativeMarkersStayBounded(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	body := strings.Repeat("a ", 3_000) + "marker"
+	messageID := f.NewMessage().
+		WithSourceMessageID("mcp-context-dense-native-markers").
+		WithSubject("ordinary subject").
+		WithSnippet("ordinary preview").
+		Create(t, f.Store)
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
 
-	t.Run("match near start", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := "needle" + strings.Repeat("x", 500)
-		snippets, _ := extractContextForTest(t, body, []string{"needle"}, 100)
-		require.Len(snippets, 1)
-		assert.Len(snippets[0], 100)
-		assert.Equal(body[:100], snippets[0])
-	})
-
-	t.Run("match near end", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		body := strings.Repeat("a", 500) + " needle"
-		snippets, _ := extractContextForTest(t, body, []string{"needle"}, 100)
-		require.Len(snippets, 1)
-		assert.Len(snippets[0], 100)
-		assert.Equal(body[len(body)-100:], snippets[0])
-	})
-
-	t.Run("no matches", func(t *testing.T) {
-		assert := assert.New(t)
-		snippets, truncated := extractContextForTest(t, "hello world", []string{"zzz"}, 300)
-		assert.Nil(snippets)
-		assert.False(truncated, "fully scanned no-match body")
-	})
-
-	t.Run("empty body", func(t *testing.T) {
-		assert := assert.New(t)
-		snippets, _ := extractContextForTest(t, "", []string{"foo"}, 300)
-		assert.Nil(snippets)
-	})
-
-	t.Run("one-character term matched", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		snippets, _ := extractContextForTest(t, "abc", []string{"a"}, 300)
-		require.Len(snippets, 1)
-		assert.Equal("abc", snippets[0])
-	})
-
-	t.Run("dense overlapping matches stay bounded and UTF-8 safe", func(t *testing.T) {
-		const contextChars = 24
-		body := strings.Repeat("é a ", 40)
-		snippets, _ := extractContextForTest(t, body, []string{"a"}, contextChars)
-		require.NotEmpty(t, snippets)
-		for _, snippet := range snippets {
-			assert.LessOrEqual(t, len(snippet), contextChars, "bounded extractor context")
-			assert.True(t, utf8.ValidString(snippet), "extractor context must be valid UTF-8")
-		}
-	})
-
-	t.Run("six separated matches stop at five", func(t *testing.T) {
-		var body strings.Builder
-		for range maxContextSnippets + 1 {
-			body.WriteString("needle ")
-			body.WriteString(strings.Repeat("x", searchContextChars+20))
-			body.WriteByte(' ')
-		}
-		snippets, truncated := extractContextForTest(t, body.String(), []string{"needle"}, searchContextChars)
-		require.Len(t, snippets, maxContextSnippets, "bounded snippets")
-		assert.True(t, truncated, "sixth non-overlapping context must set truncation marker")
-	})
-
-	t.Run("oversized token does not bridge phrase", func(t *testing.T) {
-		body := "alpha " + strings.Repeat("x", maxContextLexemeBytes+1) + " beta"
-		snippets, truncated := extractContextForTest(t, body, []string{"alpha beta"}, searchContextChars)
-		assert.Nil(t, snippets, "oversized placeholder must keep phrase lexemes non-adjacent")
-		assert.True(t, truncated, "skipped token normalization must set truncation marker")
-	})
-
-	t.Run("oversized query lexeme is not normalized", func(t *testing.T) {
-		term := strings.Repeat("a", maxContextQueryBytes+1)
-		snippets, truncated := extractContextForTest(t, "ordinary body", []string{term}, searchContextChars)
-		assert.Nil(t, snippets, "oversized query lexeme must not produce a context")
-		assert.True(t, truncated, "skipped query normalization must set truncation marker")
-	})
-
-	t.Run("checks cancellation during scan", func(t *testing.T) {
-		ctx := &cancelAfterErrContext{Context: context.Background(), cancelAfter: 3}
-		_, _, err := extractContextChar(ctx,
-			strings.Repeat("hay ", 10_000)+"needle", []string{"needle"},
-			searchContextChars, maxContextSnippets)
-		require.ErrorIs(t, err, context.Canceled)
-		assert.GreaterOrEqual(t, ctx.errCalls, ctx.cancelAfter,
-			"extractor must re-check context after entry")
-	})
+	response := runTool[paginatedSearchMessages](t, "search_message_bodies",
+		newTestHandlers(query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())).searchMessageBodies,
+		map[string]any{"query": "a"})
+	require.Len(response.Data, 1, "dense body hit")
+	require.NotEmpty(response.Data[0].ContextSnippets, "dense body context")
+	assert.True(response.Data[0].ContextSnippetsTruncated)
+	for _, snippet := range response.Data[0].ContextSnippets {
+		assert.LessOrEqual(len(snippet), searchContextChars)
+		assert.True(utf8.ValidString(snippet))
+	}
 }
 
 func TestSearchMessages_HybridModeNotConfigured(t *testing.T) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -126,6 +126,21 @@ type listAccountsTrackingEngine struct {
 	listAccountsCalled bool
 }
 
+type cancelAfterErrContext struct {
+	context.Context
+
+	cancelAfter int
+	errCalls    int
+}
+
+func (c *cancelAfterErrContext) Err() error {
+	c.errCalls++
+	if c.errCalls >= c.cancelAfter {
+		return context.Canceled
+	}
+	return nil
+}
+
 func (e *listAccountsTrackingEngine) ListAccounts(ctx context.Context) ([]query.AccountInfo, error) {
 	e.listAccountsCalled = true
 	return e.MockEngine.ListAccounts(ctx)
@@ -200,6 +215,64 @@ func TestSearchMessages(t *testing.T) {
 		assert.Contains(t, txt, "unsupported_search_operator", "expected unsupported-operator error, got: %s")
 		assert.Contains(t, txt, "list:", "expected list operator context, got: %s")
 	})
+}
+
+func TestSearchMessagesRejectsInvalidQueryBeforeDispatch(t *testing.T) {
+	queries := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{name: "invalid typed value", text: "needle before:not-a-date", want: []string{"invalid value", "before:"}},
+		{name: "unsupported operator", text: "needle list:alerts.example.com", want: []string{"unsupported_search_operator", "list:"}},
+	}
+	paths := []string{"metadata", "local hybrid", "daemon hybrid"}
+	for _, queryCase := range queries {
+		for _, path := range paths {
+			t.Run(queryCase.name+"/"+path, func(t *testing.T) {
+				assert := assert.New(t)
+				var backendCalled bool
+				engine := &listAccountsTrackingEngine{MockEngine: &querytest.MockEngine{
+					Accounts: []query.AccountInfo{{ID: 1, Identifier: "alice@example.com"}},
+					SearchFastFunc: func(context.Context, *search.Query, query.MessageFilter, int, int) ([]query.MessageSummary, error) {
+						backendCalled = true
+						return nil, nil
+					},
+				}}
+				h := &handlers{engine: engine}
+				var localBackend *fakeBackend
+				args := map[string]any{
+					"query":   queryCase.text,
+					"account": "alice@example.com",
+				}
+				switch path {
+				case "local hybrid":
+					localBackend = &fakeBackend{}
+					h = newHybridHandlersForErrorTest(localBackend)
+					h.engine = engine
+					args["mode"] = searchModeHybrid
+				case "daemon hybrid":
+					h.hybridSearcher = hybridSearcherFunc(func(context.Context, HybridSearchRequest) (*HybridSearchResult, error) {
+						backendCalled = true
+						return nil, errors.New("unexpected daemon hybrid search")
+					})
+					args["mode"] = searchModeHybrid
+				}
+
+				result := runToolExpectError(t, "search_messages", h.searchMessages, args)
+				text := resultText(t, result)
+				for _, want := range queryCase.want {
+					assert.Contains(text, want)
+				}
+				assert.False(engine.listAccountsCalled, "invalid query must not resolve account filters")
+				assert.False(backendCalled, "invalid query must not reach metadata or daemon search")
+				if localBackend != nil {
+					assert.Zero(localBackend.activeCalls, "invalid query must not resolve a vector generation")
+					assert.Zero(localBackend.fusedCalls, "invalid query must not run local hybrid search")
+				}
+			})
+		}
+	}
 }
 
 // TestSearchMessages_MetadataOnly verifies that search_messages uses only the
@@ -538,11 +611,20 @@ func TestSearchMessageBodies_RealEngineFTSNormalizedContext(t *testing.T) {
 				assert.NotContains(resp.Data[0].ContextSnippets[0], tc.reject,
 					"context must start from an FTS token-prefix match")
 			}
-			exact := extractContextChar(tc.body, search.Parse(tc.query).TextTerms, searchContextChars)
+			exact, _ := extractContextForTest(t, tc.body, search.Parse(tc.query).TextTerms, searchContextChars)
 			require.NotEmpty(exact, "context matcher must locate the real FTS token without fallback")
 			assert.Contains(exact[0], tc.wantContext)
 		})
 	}
+}
+
+func extractContextForTest(t *testing.T, body string, terms []string, contextChars int) ([]string, bool) {
+	t.Helper()
+	snippets, truncated, err := extractContextChar(
+		context.Background(), body, terms, contextChars, maxContextSnippets,
+	)
+	require.NoError(t, err, "extract context")
+	return snippets, truncated
 }
 
 func TestSearchMessageBodies_PhraseContextSurvivesSnippetCap(t *testing.T) {
@@ -576,12 +658,64 @@ func TestSearchMessageBodies_PhraseContextSurvivesSnippetCap(t *testing.T) {
 	assert.True(foundPhrase, "context snippets must include the matched phrase")
 }
 
+func TestSearchMessageBodies_ContextExtractionHonorsCancellation(t *testing.T) {
+	messageID := int64(91)
+	engine := &querytest.MockEngine{
+		SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return []query.MessageSummary{testutil.NewMessageSummary(messageID).Build()}, nil
+		},
+		GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+			return testutil.NewMessageDetail(messageID).
+				WithBodyText(strings.Repeat("hay ", 10_000) + "needle").
+				BuildPtr(), nil
+		},
+	}
+	h := newTestHandlers(engine)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "search_message_bodies"
+	req.Params.Arguments = map[string]any{"query": "needle"}
+
+	result, err := h.searchMessageBodies(ctx, req)
+	require.NoError(t, err, "handler returned error")
+	require.True(t, result.IsError, "canceled extraction must return a tool error")
+	assert.Contains(t, resultText(t, result), context.Canceled.Error())
+}
+
+func TestSearchMessageBodies_MarksContextScanBudgetTruncation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	messageID := int64(92)
+	body := strings.Repeat("hay ", 300_000) + "needle marker"
+	engine := &querytest.MockEngine{
+		SearchMessageBodiesFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			return []query.MessageSummary{testutil.NewMessageSummary(messageID).Build()}, nil
+		},
+		GetMessageFunc: func(context.Context, int64) (*query.MessageDetail, error) {
+			return testutil.NewMessageDetail(messageID).WithBodyText(body).BuildPtr(), nil
+		},
+	}
+
+	response := runTool[paginatedSearchMessages](t, "search_message_bodies",
+		newTestHandlers(engine).searchMessageBodies, map[string]any{"query": "needle"})
+	require.Len(response.Data, 1, "body hit")
+	assert.True(response.Data[0].ContextSnippetsTruncated,
+		"bodies beyond the context scan budget must advertise omitted context")
+	require.Len(response.Data[0].ContextSnippets, 1, "bounded fallback context")
+	assert.NotContains(response.Data[0].ContextSnippets[0], "needle",
+		"the extractor must not claim an unscanned late match")
+	assert.LessOrEqual(len(response.Data[0].ContextSnippets[0]), searchContextChars)
+	assert.True(utf8.ValidString(response.Data[0].ContextSnippets[0]),
+		"bounded fallback context must be valid UTF-8")
+}
+
 func TestExtractContextChar(t *testing.T) {
 	t.Run("short body", func(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
 		body := "The resistor value should be 5.1k ohms not 10k as previously stated."
-		snippets := extractContextChar(body, []string{"5.1k"}, 200)
+		snippets, _ := extractContextForTest(t, body, []string{"5.1k"}, 200)
 		require.Len(snippets, 1)
 		assert.Contains(snippets[0], "5.1k")
 		assert.LessOrEqual(len(snippets[0]), 200)
@@ -592,7 +726,7 @@ func TestExtractContextChar(t *testing.T) {
 		assert := assert.New(t)
 		quoted := strings.Repeat("> This is quoted history that should not bloat the snippet. ", 40)
 		body := "See below:\n" + quoted + "\nThe actual answer is 5.1k ohms."
-		snippets := extractContextChar(body, []string{"5.1k"}, 300)
+		snippets, _ := extractContextForTest(t, body, []string{"5.1k"}, 300)
 		require.Len(snippets, 1)
 		assert.Contains(snippets[0], "5.1k")
 		assert.Len(snippets[0], 300)
@@ -603,7 +737,7 @@ func TestExtractContextChar(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
 		body := "foo bar foo baz"
-		snippets := extractContextChar(body, []string{"foo"}, 20)
+		snippets, _ := extractContextForTest(t, body, []string{"foo"}, 20)
 		require.Len(snippets, 1)
 		assert.Equal(body, snippets[0])
 	})
@@ -612,7 +746,7 @@ func TestExtractContextChar(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
 		body := "needle" + strings.Repeat("x", 500)
-		snippets := extractContextChar(body, []string{"needle"}, 100)
+		snippets, _ := extractContextForTest(t, body, []string{"needle"}, 100)
 		require.Len(snippets, 1)
 		assert.Len(snippets[0], 100)
 		assert.Equal(body[:100], snippets[0])
@@ -622,7 +756,7 @@ func TestExtractContextChar(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
 		body := strings.Repeat("a", 500) + " needle"
-		snippets := extractContextChar(body, []string{"needle"}, 100)
+		snippets, _ := extractContextForTest(t, body, []string{"needle"}, 100)
 		require.Len(snippets, 1)
 		assert.Len(snippets[0], 100)
 		assert.Equal(body[len(body)-100:], snippets[0])
@@ -630,18 +764,21 @@ func TestExtractContextChar(t *testing.T) {
 
 	t.Run("no matches", func(t *testing.T) {
 		assert := assert.New(t)
-		assert.Nil(extractContextChar("hello world", []string{"zzz"}, 300))
+		snippets, truncated := extractContextForTest(t, "hello world", []string{"zzz"}, 300)
+		assert.Nil(snippets)
+		assert.False(truncated, "fully scanned no-match body")
 	})
 
 	t.Run("empty body", func(t *testing.T) {
 		assert := assert.New(t)
-		assert.Nil(extractContextChar("", []string{"foo"}, 300))
+		snippets, _ := extractContextForTest(t, "", []string{"foo"}, 300)
+		assert.Nil(snippets)
 	})
 
 	t.Run("one-character term matched", func(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
-		snippets := extractContextChar("abc", []string{"a"}, 300)
+		snippets, _ := extractContextForTest(t, "abc", []string{"a"}, 300)
 		require.Len(snippets, 1)
 		assert.Equal("abc", snippets[0])
 	})
@@ -649,12 +786,48 @@ func TestExtractContextChar(t *testing.T) {
 	t.Run("dense overlapping matches stay bounded and UTF-8 safe", func(t *testing.T) {
 		const contextChars = 24
 		body := strings.Repeat("é a ", 40)
-		snippets := extractContextChar(body, []string{"a"}, contextChars)
+		snippets, _ := extractContextForTest(t, body, []string{"a"}, contextChars)
 		require.NotEmpty(t, snippets)
 		for _, snippet := range snippets {
 			assert.LessOrEqual(t, len(snippet), contextChars, "bounded extractor context")
 			assert.True(t, utf8.ValidString(snippet), "extractor context must be valid UTF-8")
 		}
+	})
+
+	t.Run("six separated matches stop at five", func(t *testing.T) {
+		var body strings.Builder
+		for range maxContextSnippets + 1 {
+			body.WriteString("needle ")
+			body.WriteString(strings.Repeat("x", searchContextChars+20))
+			body.WriteByte(' ')
+		}
+		snippets, truncated := extractContextForTest(t, body.String(), []string{"needle"}, searchContextChars)
+		require.Len(t, snippets, maxContextSnippets, "bounded snippets")
+		assert.True(t, truncated, "sixth non-overlapping context must set truncation marker")
+	})
+
+	t.Run("oversized token does not bridge phrase", func(t *testing.T) {
+		body := "alpha " + strings.Repeat("x", maxContextLexemeBytes+1) + " beta"
+		snippets, truncated := extractContextForTest(t, body, []string{"alpha beta"}, searchContextChars)
+		assert.Nil(t, snippets, "oversized placeholder must keep phrase lexemes non-adjacent")
+		assert.True(t, truncated, "skipped token normalization must set truncation marker")
+	})
+
+	t.Run("oversized query lexeme is not normalized", func(t *testing.T) {
+		term := strings.Repeat("a", maxContextQueryBytes+1)
+		snippets, truncated := extractContextForTest(t, "ordinary body", []string{term}, searchContextChars)
+		assert.Nil(t, snippets, "oversized query lexeme must not produce a context")
+		assert.True(t, truncated, "skipped query normalization must set truncation marker")
+	})
+
+	t.Run("checks cancellation during scan", func(t *testing.T) {
+		ctx := &cancelAfterErrContext{Context: context.Background(), cancelAfter: 3}
+		_, _, err := extractContextChar(ctx,
+			strings.Repeat("hay ", 10_000)+"needle", []string{"needle"},
+			searchContextChars, maxContextSnippets)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.GreaterOrEqual(t, ctx.errCalls, ctx.cancelAfter,
+			"extractor must re-check context after entry")
 	})
 }
 
@@ -2478,6 +2651,7 @@ type fakeBackend struct {
 	loadCalls    int
 	active       vector.Generation
 	activeErr    error
+	activeCalls  int
 	searchHits   []vector.Hit
 	searchErr    error
 	searchCalls  int
@@ -2485,6 +2659,7 @@ type fakeBackend struct {
 	searchFilter vector.Filter
 	fusedHits    []vector.FusedHit
 	fusedErr     error
+	fusedCalls   int
 	building     *vector.Generation
 	buildingErr  error
 	stats        map[vector.GenerationID]vector.Stats
@@ -2502,6 +2677,7 @@ func (f *fakeBackend) EmbeddedMessageCount(_ context.Context, _ vector.Generatio
 	return 0, errors.New("not implemented")
 }
 func (f *fakeBackend) ActiveGeneration(_ context.Context) (vector.Generation, error) {
+	f.activeCalls++
 	return f.active, f.activeErr
 }
 func (f *fakeBackend) Search(_ context.Context, gen vector.GenerationID, _ []float32, _ int, filter vector.Filter) ([]vector.Hit, error) {
@@ -2511,6 +2687,7 @@ func (f *fakeBackend) Search(_ context.Context, gen vector.GenerationID, _ []flo
 	return f.searchHits, f.searchErr
 }
 func (f *fakeBackend) FusedSearch(_ context.Context, req vector.FusedRequest) ([]vector.FusedHit, bool, error) {
+	f.fusedCalls++
 	if f.fusedErr != nil {
 		return nil, false, f.fusedErr
 	}

--- a/internal/query/body_context.go
+++ b/internal/query/body_context.go
@@ -1,0 +1,1162 @@
+package query
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"go.kenn.io/msgvault/internal/sqldialect"
+	"go.kenn.io/msgvault/internal/sqliteutil"
+)
+
+const (
+	// MessageBodyContextSnippetBytes is the maximum UTF-8 byte length of one
+	// body-search context snippet.
+	MessageBodyContextSnippetBytes = 300
+	// MessageBodyContextMaxSnippets caps contexts returned for one message.
+	MessageBodyContextMaxSnippets = 5
+
+	// Context extraction deliberately has a request-wide budget. Search bodies
+	// are imported data and may be attacker-controlled; multiplying a per-body
+	// allowance by the HTTP result limit would otherwise make one request do
+	// hundreds of megabytes of tokenization work.
+	messageBodyContextRequestScanBytes = 1 * 1024 * 1024
+	messageBodyContextChunkCoreBytes   = 4 * 1024
+	messageBodyContextChunkGuardBytes  = 1 * 1024
+	// PostgreSQL's indexed body input is byte-capped at 700 kB on the
+	// incremental path. Keeping the canonical probe at or below that bound
+	// avoids creating a tsvector larger than the one that produced the hit.
+	messageBodyContextPostgresScanBytes = 700_000
+
+	messageBodyContextMaxQueryTerms     = 32
+	messageBodyContextMaxQueryBytes     = 32 * 1024
+	messageBodyContextMaxQueryLexemes   = 256
+	messageBodyContextMaxMarkers        = 2_048
+	messageBodyContextMaxCandidates     = 2_048
+	messageBodyContextMaxCandidateBytes = 8 * 1024 * 1024
+)
+
+type bodyContextSpan struct {
+	start int
+	end   int
+}
+
+type bodyContextMarkers struct {
+	start    string
+	end      string
+	ellipsis string
+}
+
+type bodyContextSourceState struct {
+	scanTruncated bool
+	chunked       bool
+}
+
+type bodyContextChunk struct {
+	id        int
+	messageID int64
+	body      string
+	start     int
+	end       int
+	coreStart int
+	coreEnd   int
+}
+
+type rawBodyContext struct {
+	messageID int64
+	group     int
+	chunkID   int
+	marked    string
+}
+
+type parsedBodyContext struct {
+	messageID     int64
+	group         int
+	chunkID       int
+	fragmentStart int
+	plain         string
+	spans         []bodyContextSpan
+	truncated     bool
+}
+
+type postgresBodyContextCandidate struct {
+	parsedIndex int
+	query       string
+	fragment    string
+	spans       []bodyContextSpan
+}
+
+type bodyContextGroupKey struct {
+	messageID int64
+	group     int
+}
+
+type messageBodyContextAccumulator struct {
+	snippets  []string
+	seen      map[string]struct{}
+	groups    map[int]struct{}
+	truncated bool
+}
+
+func validateMessageBodyContextQuery(terms []string) error {
+	if len(terms) == 0 {
+		return fmt.Errorf("%w: requires at least one search term", ErrMessageBodySearchInvalidQuery)
+	}
+	if len(terms) > messageBodyContextMaxQueryTerms {
+		return fmt.Errorf("%w: supports at most %d free-text terms",
+			ErrMessageBodySearchInvalidQuery, messageBodyContextMaxQueryTerms)
+	}
+	totalBytes := 0
+	for _, term := range terms {
+		totalBytes += len(term)
+		if len(sqldialect.EscapeTSQueryTerm(term)) > messageBodyContextMaxQueryLexemes {
+			return fmt.Errorf("%w: one term expands beyond the %d-lexeme limit",
+				ErrMessageBodySearchInvalidQuery, messageBodyContextMaxQueryLexemes)
+		}
+	}
+	if totalBytes > messageBodyContextMaxQueryBytes {
+		return fmt.Errorf("%w: free text exceeds the %d-byte limit",
+			ErrMessageBodySearchInvalidQuery, messageBodyContextMaxQueryBytes)
+	}
+	return nil
+}
+
+func (e *SQLiteEngine) searchableBodyContextTerms(
+	ctx context.Context,
+	terms []string,
+) ([]string, error) {
+	switch e.dialect.messageBodyContextBackend() {
+	case messageBodyContextPostgreSQL:
+		searchable := make([]string, 0, len(terms))
+		for _, term := range terms {
+			if _, arg := e.dialect.BuildFTSBodyTerm([]string{term}); arg != "" {
+				searchable = append(searchable, term)
+			}
+		}
+		return searchable, nil
+	case messageBodyContextSQLite:
+		return sqliteSearchableBodyContextTerms(ctx, terms)
+	default:
+		return nil, errors.New("message body context is unavailable for this query dialect")
+	}
+}
+
+// sqliteSearchableBodyContextTerms asks unicode61 itself which term groups
+// contain tokens. A Go Unicode-category prefilter is not equivalent: SQLite's
+// frozen table intentionally treats some code points assigned after Unicode
+// 6.1 as tokens, so host-language classification could silently broaden an
+// AND query by dropping a real group.
+func sqliteSearchableBodyContextTerms(ctx context.Context, terms []string) ([]string, error) {
+	if len(terms) == 0 {
+		return nil, nil
+	}
+	scratch, err := sql.Open(sqliteutil.DriverName(), ":memory:")
+	if err != nil {
+		return nil, fmt.Errorf("open SQLite body-context term probe: %w", err)
+	}
+	scratch.SetMaxOpenConns(1)
+	defer func() { _ = scratch.Close() }()
+	if _, err := scratch.ExecContext(ctx, `CREATE VIRTUAL TABLE term_probe USING fts5(
+		term_id UNINDEXED,
+		body,
+		tokenize='unicode61 remove_diacritics 1'
+	)`); err != nil {
+		return nil, fmt.Errorf("create SQLite body-context term probe: %w", err)
+	}
+
+	values := make([]string, len(terms))
+	args := make([]any, 0, 3*len(terms))
+	for i, term := range terms {
+		values[i] = "(?, ?, ?)"
+		// SQLiteQueryDialect removes embedded '*' before quoting the MATCH
+		// phrase, so probe the same literal text rather than tokenizing '*' as
+		// a separator here.
+		args = append(args, i+1, i, strings.ReplaceAll(term, "*", ""))
+	}
+	if _, err := scratch.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO term_probe(rowid, term_id, body) VALUES %s
+	`, strings.Join(values, ", ")), args...); err != nil {
+		return nil, fmt.Errorf("populate SQLite body-context term probe: %w", err)
+	}
+
+	dialect := SQLiteQueryDialect{}
+	parts := make([]string, len(terms))
+	args = args[:0]
+	for i, term := range terms {
+		_, queryArg := dialect.BuildFTSBodyTerm([]string{term})
+		parts[i] = fmt.Sprintf(`
+			SELECT %d AS term_index
+			FROM term_probe
+			WHERE rowid = ? AND term_probe MATCH ?
+		`, i)
+		args = append(args, i+1, queryArg)
+	}
+	rows, err := scratch.QueryContext(ctx, fmt.Sprintf(`
+		WITH searchable AS (%s)
+		SELECT term_index FROM searchable ORDER BY term_index
+	`, strings.Join(parts, " UNION ALL ")), args...)
+	if err != nil {
+		return nil, fmt.Errorf("probe SQLite body-context terms: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	searchable := make([]string, 0, len(terms))
+	for rows.Next() {
+		var index int
+		if err := rows.Scan(&index); err != nil {
+			return nil, fmt.Errorf("scan SQLite body-context term probe: %w", err)
+		}
+		searchable = append(searchable, terms[index])
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate SQLite body-context term probe: %w", err)
+	}
+	return searchable, nil
+}
+
+// attachMessageBodySearchContexts extracts contexts in a bounded number of
+// set-based operations. Each backend searches bounded, overlapping chunks
+// with its native FTS implementation, so context matching cannot drift from
+// SQLite unicode61 or PostgreSQL's simple text-search configuration.
+func (e *SQLiteEngine) attachMessageBodySearchContexts(
+	ctx context.Context,
+	results []MessageSummary,
+	terms []string,
+) error {
+	if len(results) == 0 {
+		return nil
+	}
+	if err := validateMessageBodyContextQuery(terms); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	markers, err := newBodyContextMarkers()
+	if err != nil {
+		return err
+	}
+	ids := make([]int64, len(results))
+	for i := range results {
+		ids[i] = results[i].ID
+	}
+
+	searchableTerms, err := e.searchableBodyContextTerms(ctx, terms)
+	if err != nil {
+		return err
+	}
+	groupCount := min(len(searchableTerms), MessageBodyContextMaxSnippets)
+	contextTerms := searchableTerms[:groupCount]
+	perBodyScanBytes := max(1, messageBodyContextRequestScanBytes/len(results))
+	if e.dialect.messageBodyContextBackend() == messageBodyContextPostgreSQL {
+		perBodyScanBytes = min(perBodyScanBytes, messageBodyContextPostgresScanBytes)
+	}
+	states, chunks, bodies, err := e.loadBodyContextChunks(ctx, ids, perBodyScanBytes)
+	if err != nil {
+		return err
+	}
+	canonicalMatches, err := e.canonicalBodyContextMatches(ctx, ids, bodies, searchableTerms)
+	if err != nil {
+		return err
+	}
+	// Context output is capped at five groups, but stale-index validation is
+	// not. A legacy index can only be trusted when every searchable AND group
+	// matches a fully scanned canonical body; otherwise a sixth (non-rendered)
+	// term could hide a false index hit.
+	for _, result := range results {
+		state := states[result.ID]
+		if state.scanTruncated {
+			continue
+		}
+		for group := range searchableTerms {
+			key := bodyContextGroupKey{messageID: result.ID, group: group}
+			if _, matchesCanonical := canonicalMatches[key]; !matchesCanonical {
+				return fmt.Errorf(
+					"%w: indexed body for message %d does not match its stored body",
+					ErrMessageBodySearchIndexStale, result.ID,
+				)
+			}
+		}
+	}
+	chunksByID := make(map[int]bodyContextChunk, len(chunks))
+	for _, chunk := range chunks {
+		chunksByID[chunk.id] = chunk
+	}
+
+	var raw []rawBodyContext
+	switch e.dialect.messageBodyContextBackend() {
+	case messageBodyContextSQLite:
+		raw, err = e.sqliteBodyContexts(ctx, chunks, contextTerms, markers)
+	case messageBodyContextPostgreSQL:
+		raw, err = e.postgresBodyContexts(ctx, chunks, contextTerms, markers)
+	default:
+		return errors.New("message body context is unavailable for this query dialect")
+	}
+	if err != nil {
+		return err
+	}
+
+	parsed := make([]parsedBodyContext, 0, len(raw))
+	for _, item := range raw {
+		plain, spans, truncated, parseErr := parseMarkedBodyContext(
+			ctx, item.marked, markers,
+		)
+		if parseErr != nil {
+			return fmt.Errorf("parse message %d body context: %w", item.messageID, parseErr)
+		}
+		chunk, ok := chunksByID[item.chunkID]
+		if !ok {
+			return fmt.Errorf("message %d body context references an unknown chunk", item.messageID)
+		}
+		fragmentStart := bodyContextFragmentStart(
+			chunk, plain, spans, states[item.messageID],
+		)
+		if fragmentStart < 0 {
+			return fmt.Errorf("message %d backend-native body context does not align with its source chunk", item.messageID)
+		}
+		parsed = append(parsed, parsedBodyContext{
+			messageID:     item.messageID,
+			group:         item.group,
+			chunkID:       item.chunkID,
+			fragmentStart: fragmentStart,
+			plain:         plain,
+			spans:         spans,
+			truncated:     truncated || len(plain) < len(chunk.body),
+		})
+	}
+
+	accepted := make(map[int][]bodyContextSpan, len(parsed))
+	uncertainGroups := make(map[bodyContextGroupKey]struct{})
+	for _, result := range results {
+		state := states[result.ID]
+		for group := range contextTerms {
+			key := bodyContextGroupKey{messageID: result.ID, group: group}
+			if state.scanTruncated {
+				uncertainGroups[bodyContextGroupKey{messageID: result.ID, group: group}] = struct{}{}
+			} else if _, matchesCanonical := canonicalMatches[key]; matchesCanonical {
+				uncertainGroups[key] = struct{}{}
+			}
+		}
+	}
+	if e.dialect.messageBodyContextBackend() == messageBodyContextPostgreSQL {
+		var postgresUncertain map[bodyContextGroupKey]struct{}
+		accepted, postgresUncertain, err = e.validatePostgresBodyContextCandidates(
+			ctx, parsed, contextTerms, chunksByID, states,
+		)
+		if err != nil {
+			return err
+		}
+		for key := range postgresUncertain {
+			uncertainGroups[key] = struct{}{}
+		}
+	} else {
+		acceptedGroups := make(map[bodyContextGroupKey]struct{})
+		for i := range parsed {
+			chunk := chunksByID[parsed[i].chunkID]
+			state := states[parsed[i].messageID]
+			var safeSpan *bodyContextSpan
+			for j := range parsed[i].spans {
+				if bodyContextSpanIsSafe(
+					chunk, parsed[i].spanInChunk(parsed[i].spans[j]), state,
+				) {
+					safeSpan = &parsed[i].spans[j]
+					break
+				}
+			}
+			key := bodyContextGroupKey{messageID: parsed[i].messageID, group: parsed[i].group}
+			if safeSpan == nil {
+				uncertainGroups[key] = struct{}{}
+				continue
+			}
+			if _, exists := acceptedGroups[key]; exists {
+				continue
+			}
+			// FTS5 snippet() marks complete phrase instances. One marked span is
+			// sufficient to represent this query-term group and reserves the
+			// remaining response slots for other groups.
+			accepted[i] = []bodyContextSpan{*safeSpan}
+			acceptedGroups[key] = struct{}{}
+		}
+	}
+
+	accumulators := make(map[int64]*messageBodyContextAccumulator, len(results))
+	for _, result := range results {
+		state, ok := states[result.ID]
+		if !ok {
+			return fmt.Errorf("message %d body context source is unavailable", result.ID)
+		}
+		accumulators[result.ID] = &messageBodyContextAccumulator{
+			seen:      make(map[string]struct{}),
+			groups:    make(map[int]struct{}),
+			truncated: state.scanTruncated || state.chunked || len(searchableTerms) > groupCount,
+		}
+	}
+	for i, item := range parsed {
+		spans := accepted[i]
+		if len(spans) == 0 {
+			continue
+		}
+		acc := accumulators[item.messageID]
+		if _, alreadyRepresented := acc.groups[item.group]; alreadyRepresented {
+			continue
+		}
+		acc.groups[item.group] = struct{}{}
+		acc.truncated = acc.truncated || item.truncated
+		snippets, snippetsTruncated := bodyContextSnippets(item.plain, spans)
+		acc.truncated = acc.truncated || snippetsTruncated
+		for _, snippet := range snippets {
+			if _, duplicate := acc.seen[snippet]; duplicate {
+				continue
+			}
+			if len(acc.snippets) >= MessageBodyContextMaxSnippets {
+				acc.truncated = true
+				continue
+			}
+			acc.seen[snippet] = struct{}{}
+			acc.snippets = append(acc.snippets, snippet)
+		}
+	}
+
+	for i := range results {
+		acc := accumulators[results[i].ID]
+		for group := range groupCount {
+			if _, represented := acc.groups[group]; represented {
+				continue
+			}
+			acc.truncated = true
+			key := bodyContextGroupKey{messageID: results[i].ID, group: group}
+			if _, uncertain := uncertainGroups[key]; !uncertain {
+				return fmt.Errorf(
+					"%w: indexed body for message %d does not match its stored body",
+					ErrMessageBodySearchIndexStale, results[i].ID,
+				)
+			}
+		}
+		results[i].BodyContextSnippets = acc.snippets
+		results[i].BodyContextSnippetsTruncated = acc.truncated
+	}
+	return nil
+}
+
+func newBodyContextMarkers() (bodyContextMarkers, error) {
+	var random [8]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return bodyContextMarkers{}, fmt.Errorf("generate body context markers: %w", err)
+	}
+	base := "mv" + hex.EncodeToString(random[:])
+	return bodyContextMarkers{
+		start:    base + "s",
+		end:      base + "e",
+		ellipsis: base + "x",
+	}, nil
+}
+
+func bodyContextIDPlaceholders(ids []int64) (string, []any) {
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	return strings.Join(placeholders, ", "), args
+}
+
+func (e *SQLiteEngine) loadBodyContextChunks(
+	ctx context.Context,
+	ids []int64,
+	scanBytes int,
+) (map[int64]bodyContextSourceState, []bodyContextChunk, map[int64]string, error) {
+	idPlaceholders, idArgs := bodyContextIDPlaceholders(ids)
+	var args []any
+	var querySQL string
+	switch e.dialect.messageBodyContextBackend() {
+	case messageBodyContextSQLite:
+		// SQLite materializes an entire TEXT cell before evaluating substr(),
+		// even when only a tiny prefix is requested. octet_length() is served
+		// from record metadata, so CASE can reject an oversized cell before it
+		// is loaded. Eligible values sum to the request-wide scan budget (plus
+		// one UTF-8 guard per result); oversized values become explicitly
+		// truncated with no misleading fallback context.
+		limit := scanBytes + utf8.UTFMax
+		args = append([]any{limit, limit}, idArgs...)
+		querySQL = fmt.Sprintf(`
+			SELECT mb.message_id,
+				CASE
+					WHEN COALESCE(octet_length(mb.body_text), 0) <= ?
+					THEN CAST(COALESCE(mb.body_text, '') AS BLOB)
+					ELSE X''
+				END,
+				COALESCE(octet_length(mb.body_text), 0) > ?
+			FROM message_bodies mb
+			WHERE mb.message_id IN (%s)
+			ORDER BY mb.message_id
+		`, idPlaceholders)
+	case messageBodyContextPostgreSQL:
+		args = append([]any{scanBytes + utf8.UTFMax}, idArgs...)
+		querySQL = fmt.Sprintf(`
+			SELECT mb.message_id,
+				COALESCE(convert_to(
+					SUBSTRING(COALESCE(mb.body_text, '') FROM 1 FOR ?), 'UTF8'
+				), ''::bytea),
+				FALSE
+			FROM message_bodies mb
+			WHERE mb.message_id IN (%s)
+			ORDER BY mb.message_id
+		`, idPlaceholders)
+	default:
+		return nil, nil, nil, errors.New("message body context is unavailable for this query dialect")
+	}
+	rows, err := e.queryContext(ctx, querySQL, args...)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("load bounded message body prefixes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	states := make(map[int64]bodyContextSourceState, len(ids))
+	bodies := make(map[int64]string, len(ids))
+	chunks := make([]bodyContextChunk, 0)
+	for rows.Next() {
+		var messageID int64
+		var raw []byte
+		var sourceTruncated bool
+		if err := rows.Scan(&messageID, &raw, &sourceTruncated); err != nil {
+			return nil, nil, nil, fmt.Errorf("scan bounded message body prefix: %w", err)
+		}
+		prefix, prefixTruncated, err := validBodyContextPrefix(raw, scanBytes)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("message %d body context: %w", messageID, err)
+		}
+		bodies[messageID] = prefix
+		messageChunks := makeBodyContextChunks(messageID, prefix, len(chunks)+1)
+		states[messageID] = bodyContextSourceState{
+			scanTruncated: sourceTruncated || prefixTruncated,
+			chunked:       len(messageChunks) > 1,
+		}
+		chunks = append(chunks, messageChunks...)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, nil, fmt.Errorf("iterate bounded message body prefixes: %w", err)
+	}
+	return states, chunks, bodies, nil
+}
+
+func validBodyContextPrefix(raw []byte, scanBytes int) (string, bool, error) {
+	cut := min(len(raw), scanBytes)
+	for cut > 0 && cut < len(raw) && !utf8.RuneStart(raw[cut]) {
+		cut--
+	}
+	prefix := raw[:cut]
+	if !utf8.Valid(prefix) {
+		return "", false, errors.New("stored body prefix is not valid UTF-8")
+	}
+	return string(prefix), len(raw) > cut, nil
+}
+
+func (e *SQLiteEngine) canonicalBodyContextMatches(
+	ctx context.Context,
+	ids []int64,
+	bodies map[int64]string,
+	terms []string,
+) (map[bodyContextGroupKey]struct{}, error) {
+	matches := make(map[bodyContextGroupKey]struct{})
+	if len(ids) == 0 || len(terms) == 0 {
+		return matches, nil
+	}
+
+	if e.dialect.messageBodyContextBackend() == messageBodyContextSQLite {
+		scratch, err := sql.Open(sqliteutil.DriverName(), ":memory:")
+		if err != nil {
+			return nil, fmt.Errorf("open SQLite canonical body-context probe: %w", err)
+		}
+		scratch.SetMaxOpenConns(1)
+		defer func() { _ = scratch.Close() }()
+		if _, err := scratch.ExecContext(ctx, `CREATE VIRTUAL TABLE canonical_bodies USING fts5(
+			message_id UNINDEXED,
+			body,
+			tokenize='unicode61 remove_diacritics 1'
+		)`); err != nil {
+			return nil, fmt.Errorf("create SQLite canonical body-context probe: %w", err)
+		}
+		values := make([]string, len(ids))
+		args := make([]any, 0, 3*len(ids))
+		for i, messageID := range ids {
+			values[i] = "(?, ?, ?)"
+			args = append(args, i+1, messageID, bodies[messageID])
+		}
+		if _, err := scratch.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO canonical_bodies(rowid, message_id, body) VALUES %s
+		`, strings.Join(values, ", ")), args...); err != nil {
+			return nil, fmt.Errorf("populate SQLite canonical body-context probe: %w", err)
+		}
+		parts := make([]string, len(terms))
+		args = args[:0]
+		for group, term := range terms {
+			_, queryArg := e.dialect.BuildFTSBodyTerm([]string{term})
+			parts[group] = fmt.Sprintf(`
+				SELECT message_id, %d AS group_id
+				FROM canonical_bodies
+				WHERE canonical_bodies MATCH ?
+			`, group)
+			args = append(args, queryArg)
+		}
+		rows, err := scratch.QueryContext(ctx, strings.Join(parts, " UNION ALL "), args...)
+		if err != nil {
+			return nil, fmt.Errorf("query SQLite canonical body-context probe: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		return scanCanonicalBodyContextMatches(rows)
+	}
+
+	if e.dialect.messageBodyContextBackend() != messageBodyContextPostgreSQL {
+		return nil, errors.New("message body context is unavailable for this query dialect")
+	}
+	sourceValues := make([]string, len(ids))
+	args := make([]any, 0, 2*len(ids)+len(terms))
+	for i, messageID := range ids {
+		sourceValues[i] = "(?::bigint, ?::text)"
+		args = append(args, messageID, bodies[messageID])
+	}
+	queryValues := make([]string, len(terms))
+	for group, term := range terms {
+		_, weightedArg := e.dialect.BuildFTSBodyTerm([]string{term})
+		queryValues[group] = fmt.Sprintf("(%d, to_tsquery('simple', ?))", group)
+		args = append(args, postgresContextTSQuery(weightedArg))
+	}
+	rows, err := e.queryContext(ctx, fmt.Sprintf(`
+		WITH
+		canonical_bodies(message_id, body) AS (VALUES %s),
+		query_groups(group_id, query) AS (VALUES %s)
+		SELECT b.message_id, q.group_id
+		FROM canonical_bodies b
+		CROSS JOIN query_groups q
+		WHERE to_tsvector('simple', b.body) @@ q.query
+	`, strings.Join(sourceValues, ", "), strings.Join(queryValues, ", ")), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query PostgreSQL canonical body-context probe: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanCanonicalBodyContextMatches(rows)
+}
+
+func scanCanonicalBodyContextMatches(rows *sql.Rows) (map[bodyContextGroupKey]struct{}, error) {
+	matches := make(map[bodyContextGroupKey]struct{})
+	for rows.Next() {
+		var key bodyContextGroupKey
+		if err := rows.Scan(&key.messageID, &key.group); err != nil {
+			return nil, fmt.Errorf("scan canonical body-context match: %w", err)
+		}
+		matches[key] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate canonical body-context matches: %w", err)
+	}
+	return matches, nil
+}
+
+func makeBodyContextChunks(messageID int64, body string, firstID int) []bodyContextChunk {
+	chunks := make([]bodyContextChunk, 0, 1+len(body)/messageBodyContextChunkCoreBytes)
+	coreStart := 0
+	for coreStart < len(body) {
+		coreEnd := min(len(body), coreStart+messageBodyContextChunkCoreBytes)
+		for coreEnd > coreStart && coreEnd < len(body) && !utf8.RuneStart(body[coreEnd]) {
+			coreEnd--
+		}
+		if coreEnd == coreStart {
+			_, size := utf8.DecodeRuneInString(body[coreStart:])
+			coreEnd = coreStart + size
+		}
+
+		chunkStart := max(0, coreStart-messageBodyContextChunkGuardBytes)
+		for chunkStart > 0 && !utf8.RuneStart(body[chunkStart]) {
+			chunkStart--
+		}
+		chunkEnd := min(len(body), coreEnd+messageBodyContextChunkGuardBytes)
+		for chunkEnd < len(body) && !utf8.RuneStart(body[chunkEnd]) {
+			chunkEnd++
+		}
+		chunks = append(chunks, bodyContextChunk{
+			id:        firstID + len(chunks),
+			messageID: messageID,
+			body:      body[chunkStart:chunkEnd],
+			start:     chunkStart,
+			end:       chunkEnd,
+			coreStart: coreStart,
+			coreEnd:   coreEnd,
+		})
+		coreStart = coreEnd
+	}
+	return chunks
+}
+
+// bodyContextSpanIsSafe rejects matches manufactured by cutting through a
+// token at a chunk or request-prefix boundary. Each chunk owns match starts in
+// its non-overlapping core; guards provide enough original text on both sides
+// for ordinary snippets and phrases. A match touching an artificial edge is
+// omitted and advertised through the truncation flag instead of being shown as
+// if it came from the indexed body.
+func bodyContextSpanIsSafe(
+	chunk bodyContextChunk,
+	span bodyContextSpan,
+	state bodyContextSourceState,
+) bool {
+	if span.start < 0 || span.end <= span.start || span.end > len(chunk.body) {
+		return false
+	}
+	absoluteStart := chunk.start + span.start
+	if absoluteStart < chunk.coreStart || absoluteStart >= chunk.coreEnd {
+		return false
+	}
+	if span.start == 0 && chunk.start > 0 {
+		return false
+	}
+	if span.end == len(chunk.body) && (chunk.end > chunk.coreEnd || state.scanTruncated) {
+		return false
+	}
+	return true
+}
+
+func (item parsedBodyContext) spanInChunk(span bodyContextSpan) bodyContextSpan {
+	return bodyContextSpan{
+		start: item.fragmentStart + span.start,
+		end:   item.fragmentStart + span.end,
+	}
+}
+
+// bodyContextFragmentStart maps a backend-produced bounded fragment back to
+// its source chunk. Prefer an occurrence whose marked span is owned by the
+// chunk core. Identical repeated fragments have identical tokenizer behavior,
+// so any safe occurrence is equivalent for context purposes.
+func bodyContextFragmentStart(
+	chunk bodyContextChunk,
+	plain string,
+	spans []bodyContextSpan,
+	state bodyContextSourceState,
+) int {
+	if plain == "" || len(spans) == 0 || len(plain) > len(chunk.body) {
+		return -1
+	}
+	first := -1
+	searchFrom := 0
+	outer := bodyContextSpan{start: spans[0].start, end: spans[len(spans)-1].end}
+	for searchFrom <= len(chunk.body)-len(plain) {
+		relative := strings.Index(chunk.body[searchFrom:], plain)
+		if relative < 0 {
+			break
+		}
+		offset := searchFrom + relative
+		if first < 0 {
+			first = offset
+		}
+		if bodyContextSpanIsSafe(chunk, bodyContextSpan{
+			start: offset + outer.start,
+			end:   offset + outer.end,
+		}, state) {
+			return offset
+		}
+		searchFrom = offset + 1
+	}
+	return first
+}
+
+func (e *SQLiteEngine) sqliteBodyContexts(
+	ctx context.Context,
+	chunks []bodyContextChunk,
+	terms []string,
+	markers bodyContextMarkers,
+) ([]rawBodyContext, error) {
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+	scratch, err := sql.Open(sqliteutil.DriverName(), ":memory:")
+	if err != nil {
+		return nil, fmt.Errorf("open SQLite body-context scratch index: %w", err)
+	}
+	scratch.SetMaxOpenConns(1)
+	defer func() { _ = scratch.Close() }()
+	if _, err := scratch.ExecContext(ctx, `CREATE VIRTUAL TABLE body_chunks USING fts5(
+		message_id UNINDEXED,
+		chunk_id UNINDEXED,
+		body,
+		tokenize='unicode61 remove_diacritics 1'
+	)`); err != nil {
+		return nil, fmt.Errorf("create SQLite body-context scratch index: %w", err)
+	}
+
+	values := make([]string, len(chunks))
+	args := make([]any, 0, 4*len(chunks))
+	for i, chunk := range chunks {
+		values[i] = "(?, ?, ?, ?)"
+		args = append(args, chunk.id, chunk.messageID, chunk.id, chunk.body)
+	}
+	if _, err := scratch.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO body_chunks(rowid, message_id, chunk_id, body) VALUES %s
+	`, strings.Join(values, ", ")), args...); err != nil {
+		return nil, fmt.Errorf("populate SQLite body-context scratch index: %w", err)
+	}
+
+	rawParts := make([]string, 0, len(terms))
+	args = args[:0]
+	for group, term := range terms {
+		_, arg := e.dialect.BuildFTSBodyTerm([]string{term})
+		if arg == "" {
+			continue
+		}
+		rawParts = append(rawParts, fmt.Sprintf(`
+			SELECT message_id, %d AS group_id, chunk_id,
+				snippet(body_chunks, 2, ?, ?, ?, 64) AS marked
+			FROM body_chunks
+			WHERE body_chunks MATCH ?
+		`, group))
+		args = append(args, markers.start, markers.end, markers.ellipsis, arg)
+	}
+	if len(rawParts) == 0 {
+		return nil, errors.New("message body context query has no searchable terms")
+	}
+	rows, err := scratch.QueryContext(ctx, fmt.Sprintf(`
+		WITH raw_matches AS (%s)
+		SELECT message_id, group_id, chunk_id, marked
+		FROM raw_matches
+		ORDER BY message_id, group_id, chunk_id
+	`, strings.Join(rawParts, " UNION ALL ")), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query bounded SQLite body contexts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanRawBodyContexts(rows)
+}
+
+func (e *SQLiteEngine) postgresBodyContexts(
+	ctx context.Context,
+	chunks []bodyContextChunk,
+	terms []string,
+	markers bodyContextMarkers,
+) ([]rawBodyContext, error) {
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+	chunkValues := make([]string, len(chunks))
+	args := make([]any, 0, 3*len(chunks)+len(terms)+1)
+	for i, chunk := range chunks {
+		chunkValues[i] = "(?::integer, ?::bigint, ?::text)"
+		args = append(args, chunk.id, chunk.messageID, chunk.body)
+	}
+	queryValues := make([]string, 0, len(terms))
+	for group, term := range terms {
+		_, weightedArg := e.dialect.BuildFTSBodyTerm([]string{term})
+		arg := postgresContextTSQuery(weightedArg)
+		if arg == "" {
+			continue
+		}
+		queryValues = append(queryValues, fmt.Sprintf("(%d, to_tsquery('simple', ?))", group))
+		args = append(args, arg)
+	}
+	if len(queryValues) == 0 {
+		return nil, errors.New("message body context query has no searchable terms")
+	}
+	options := fmt.Sprintf(
+		"StartSel=%s, StopSel=%s, MaxWords=64, MinWords=1, MaxFragments=1, FragmentDelimiter=%s",
+		markers.start, markers.end, markers.ellipsis,
+	)
+	args = append(args, options)
+	rows, err := e.queryContext(ctx, fmt.Sprintf(`
+		WITH
+		chunks(chunk_id, message_id, body) AS (VALUES %s),
+		query_groups(group_id, query) AS (VALUES %s)
+		SELECT c.message_id, q.group_id, c.chunk_id,
+			ts_headline('simple', c.body, q.query, ?) AS marked
+		FROM chunks c
+		CROSS JOIN query_groups q
+		WHERE to_tsvector('simple', c.body) @@ q.query
+		ORDER BY c.message_id, q.group_id, c.chunk_id
+	`, strings.Join(chunkValues, ", "), strings.Join(queryValues, ", ")), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query bounded PostgreSQL body contexts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanRawBodyContexts(rows)
+}
+
+func scanRawBodyContexts(rows *sql.Rows) ([]rawBodyContext, error) {
+	var raw []rawBodyContext
+	for rows.Next() {
+		var item rawBodyContext
+		if err := rows.Scan(&item.messageID, &item.group, &item.chunkID, &item.marked); err != nil {
+			return nil, fmt.Errorf("scan body context: %w", err)
+		}
+		raw = append(raw, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate body contexts: %w", err)
+	}
+	return raw, nil
+}
+
+func (e *SQLiteEngine) validatePostgresBodyContextCandidates(
+	ctx context.Context,
+	parsed []parsedBodyContext,
+	terms []string,
+	chunks map[int]bodyContextChunk,
+	states map[int64]bodyContextSourceState,
+) (map[int][]bodyContextSpan, map[bodyContextGroupKey]struct{}, error) {
+	accepted := make(map[int][]bodyContextSpan, len(parsed))
+	uncertain := make(map[bodyContextGroupKey]struct{})
+	candidates := make([]postgresBodyContextCandidate, 0)
+	totalCandidateBytes := 0
+
+	for parsedIndex, item := range parsed {
+		chunk := chunks[item.chunkID]
+		state := states[item.messageID]
+		key := bodyContextGroupKey{messageID: item.messageID, group: item.group}
+		if item.truncated {
+			uncertain[key] = struct{}{}
+		}
+		lexemeCount := len(sqldialect.EscapeTSQueryTerm(terms[item.group]))
+		if lexemeCount <= 1 {
+			for _, span := range item.spans {
+				if bodyContextSpanIsSafe(chunk, item.spanInChunk(span), state) {
+					accepted[parsedIndex] = []bodyContextSpan{span}
+					break
+				}
+			}
+			if len(accepted[parsedIndex]) == 0 {
+				uncertain[key] = struct{}{}
+			}
+			continue
+		}
+		_, weightedArg := e.dialect.BuildFTSBodyTerm([]string{terms[item.group]})
+		queryArg := postgresContextTSQuery(weightedArg)
+		foundBudget := false
+		for start := range item.spans {
+			for width := 1; width <= lexemeCount && start+width <= len(item.spans); width++ {
+				if len(candidates) >= messageBodyContextMaxCandidates {
+					uncertain[key] = struct{}{}
+					foundBudget = true
+					break
+				}
+				end := start + width
+				fragmentStart := item.spans[start].start
+				fragmentEnd := item.spans[end-1].end
+				if !bodyContextSpanIsSafe(chunk, item.spanInChunk(bodyContextSpan{
+					start: fragmentStart,
+					end:   fragmentEnd,
+				}), state) {
+					uncertain[key] = struct{}{}
+					continue
+				}
+				fragment := item.plain[fragmentStart:fragmentEnd]
+				if totalCandidateBytes+len(fragment) > messageBodyContextMaxCandidateBytes {
+					uncertain[key] = struct{}{}
+					foundBudget = true
+					break
+				}
+				totalCandidateBytes += len(fragment)
+				componentSpans := append([]bodyContextSpan(nil), item.spans[start:end]...)
+				candidates = append(candidates, postgresBodyContextCandidate{
+					parsedIndex: parsedIndex,
+					query:       queryArg,
+					fragment:    fragment,
+					spans:       componentSpans,
+				})
+			}
+			if foundBudget {
+				break
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return accepted, uncertain, nil
+	}
+
+	values := make([]string, len(candidates))
+	args := make([]any, 0, 3*len(candidates))
+	for i, candidate := range candidates {
+		values[i] = "(?::integer, ?::text, ?::text)"
+		args = append(args, i, candidate.fragment, candidate.query)
+	}
+	rows, err := e.queryContext(ctx, fmt.Sprintf(`
+		WITH candidates(candidate_id, fragment, query_text) AS (VALUES %s)
+		SELECT candidate_id
+		FROM candidates
+		WHERE to_tsvector('simple', fragment) @@ to_tsquery('simple', query_text)
+		ORDER BY candidate_id
+	`, strings.Join(values, ", ")), args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate PostgreSQL body-context candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var candidateID int
+		if err := rows.Scan(&candidateID); err != nil {
+			return nil, nil, fmt.Errorf("scan PostgreSQL body-context validation: %w", err)
+		}
+		candidate := candidates[candidateID]
+		if _, alreadyAccepted := accepted[candidate.parsedIndex]; alreadyAccepted {
+			continue
+		}
+		accepted[candidate.parsedIndex] = candidate.spans
+		if len(candidate.fragment) > MessageBodyContextSnippetBytes {
+			parsed[candidate.parsedIndex].truncated = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate PostgreSQL body-context validations: %w", err)
+	}
+	for parsedIndex, item := range parsed {
+		if len(accepted[parsedIndex]) == 0 {
+			uncertain[bodyContextGroupKey{messageID: item.messageID, group: item.group}] = struct{}{}
+		}
+	}
+	return accepted, uncertain, nil
+}
+
+func postgresContextTSQuery(weightedArg string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(weightedArg, ":*D", ":*"), ":D", "")
+}
+
+func parseMarkedBodyContext(
+	ctx context.Context,
+	marked string,
+	markers bodyContextMarkers,
+) (string, []bodyContextSpan, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return "", nil, false, err
+	}
+	truncated := strings.Contains(marked, markers.ellipsis)
+	marked = strings.ReplaceAll(marked, markers.ellipsis, "")
+	var plain strings.Builder
+	plain.Grow(len(marked))
+	spans := make([]bodyContextSpan, 0)
+	cursor := 0
+	for cursor < len(marked) {
+		if len(spans)%256 == 0 {
+			if err := ctx.Err(); err != nil {
+				return "", nil, false, err
+			}
+		}
+		relStart := strings.Index(marked[cursor:], markers.start)
+		if relStart < 0 {
+			plain.WriteString(marked[cursor:])
+			break
+		}
+		markerStart := cursor + relStart
+		plain.WriteString(marked[cursor:markerStart])
+		matchStart := plain.Len()
+		matchTextStart := markerStart + len(markers.start)
+		relEnd := strings.Index(marked[matchTextStart:], markers.end)
+		if relEnd < 0 {
+			return "", nil, false, errors.New("body context has an unterminated match marker")
+		}
+		markerEnd := matchTextStart + relEnd
+		plain.WriteString(marked[matchTextStart:markerEnd])
+		spans = append(spans, bodyContextSpan{start: matchStart, end: plain.Len()})
+		cursor = markerEnd + len(markers.end)
+		if len(spans) >= messageBodyContextMaxMarkers {
+			remainder := strings.ReplaceAll(marked[cursor:], markers.start, "")
+			remainder = strings.ReplaceAll(remainder, markers.end, "")
+			plain.WriteString(remainder)
+			truncated = true
+			break
+		}
+	}
+	if len(spans) == 0 {
+		return "", nil, false, errors.New("backend-native body context contains no match markers")
+	}
+	return plain.String(), spans, truncated, nil
+}
+
+// markedFragmentContext is retained as a focused parser seam for unit tests.
+func markedFragmentContext(
+	ctx context.Context,
+	marked string,
+	startMarker string,
+	endMarker string,
+	ellipsisMarker string,
+) ([]string, bool, error) {
+	plain, spans, truncated, err := parseMarkedBodyContext(ctx, marked, bodyContextMarkers{
+		start: startMarker, end: endMarker, ellipsis: ellipsisMarker,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	snippets, capped := bodyContextSnippets(plain, spans)
+	return snippets, truncated || capped, nil
+}
+
+func bodyContextSnippets(body string, spans []bodyContextSpan) ([]string, bool) {
+	if len(spans) == 0 {
+		return nil, false
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start == spans[j].start {
+			return spans[i].end < spans[j].end
+		}
+		return spans[i].start < spans[j].start
+	})
+	merged := make([]bodyContextSpan, 0, MessageBodyContextMaxSnippets)
+	truncated := false
+	for _, span := range spans {
+		matchLen := span.end - span.start
+		if matchLen > MessageBodyContextSnippetBytes {
+			matchLen = MessageBodyContextSnippetBytes
+			truncated = true
+		}
+		start, end := bodyContextWindow(
+			len(body), span.start, matchLen, MessageBodyContextSnippetBytes,
+		)
+		candidate := bodyContextSpan{start: start, end: end}
+		if len(merged) > 0 {
+			last := &merged[len(merged)-1]
+			unionStart := min(last.start, candidate.start)
+			unionEnd := max(last.end, candidate.end)
+			if candidate.start <= last.end && unionEnd-unionStart <= MessageBodyContextSnippetBytes {
+				last.start = unionStart
+				last.end = unionEnd
+				continue
+			}
+		}
+		if len(merged) >= MessageBodyContextMaxSnippets {
+			truncated = true
+			continue
+		}
+		merged = append(merged, candidate)
+	}
+	snippets := make([]string, 0, len(merged))
+	for _, span := range merged {
+		snippet, adjusted := bodyContextByteSlice(body, span.start, span.end)
+		truncated = truncated || adjusted
+		snippets = append(snippets, snippet)
+	}
+	return snippets, truncated
+}
+
+func bodyContextWindow(bodyLen, pos, matchLen, contextBytes int) (start, end int) {
+	start = pos - (contextBytes-matchLen)/2
+	end = start + contextBytes
+	if start < 0 {
+		start = 0
+		end = min(bodyLen, contextBytes)
+	} else if end > bodyLen {
+		end = bodyLen
+		start = max(0, end-contextBytes)
+	}
+	return start, end
+}
+
+func bodyContextByteSlice(body string, start, end int) (string, bool) {
+	start = max(0, min(start, len(body)))
+	end = max(start, min(end, len(body)))
+	originalStart, originalEnd := start, end
+	for start < end && !utf8.RuneStart(body[start]) {
+		start++
+	}
+	for end > start && end < len(body) && !utf8.RuneStart(body[end]) {
+		end--
+	}
+	return body[start:end], start != originalStart || end != originalEnd
+}

--- a/internal/query/body_context_test.go
+++ b/internal/query/body_context_test.go
@@ -1,0 +1,84 @@
+package query
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkedFragmentContext(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	startMarker := "__start__"
+	endMarker := "__end__"
+	ellipsisMarker := "__ellipsis__"
+	marked := ellipsisMarker + strings.Repeat("quoted history ", 30) +
+		startMarker + "needle" + endMarker + " answer" + ellipsisMarker
+
+	snippets, truncated, err := markedFragmentContext(
+		context.Background(), marked, startMarker, endMarker, ellipsisMarker,
+	)
+	require.NoError(err, "marked fragment context")
+	require.Len(snippets, 1)
+	assert.Contains(snippets[0], "needle")
+	assert.LessOrEqual(len(snippets[0]), MessageBodyContextSnippetBytes)
+	assert.True(utf8.ValidString(snippets[0]))
+	assert.True(truncated, "native ellipses advertise omitted body text")
+}
+
+func TestMarkedFragmentContextHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := markedFragmentContext(ctx, "body", "<s>", "</s>", "...")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBodyContextGuardRejectsArtificialTokenBoundary(t *testing.T) {
+	body := strings.Repeat("x", messageBodyContextChunkCoreBytes+100)
+	chunks := makeBodyContextChunks(1, body, 1)
+	require.GreaterOrEqual(t, len(chunks), 2)
+
+	second := chunks[1]
+	state := bodyContextSourceState{chunked: true}
+	assert.False(t, bodyContextSpanIsSafe(second, bodyContextSpan{
+		start: 0,
+		end:   10,
+	}, state), "a token cut at the left guard cannot become a context match")
+	assert.True(t, bodyContextSpanIsSafe(second, bodyContextSpan{
+		start: second.coreStart - second.start,
+		end:   second.coreStart - second.start + 10,
+	}, state), "an interior match owned by the core is safe")
+}
+
+func TestValidBodyContextPrefixIsRuneSafe(t *testing.T) {
+	prefix, truncated, err := validBodyContextPrefix([]byte("abcéz"), 4)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", prefix)
+	assert.True(t, truncated)
+}
+
+func TestBodyContextSnippetsCapsDistantMatches(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var body strings.Builder
+	spans := make([]bodyContextSpan, 0, MessageBodyContextMaxSnippets+1)
+	for range MessageBodyContextMaxSnippets + 1 {
+		start := body.Len()
+		body.WriteString("needle")
+		spans = append(spans, bodyContextSpan{start: start, end: body.Len()})
+		body.WriteString(strings.Repeat(" padding", MessageBodyContextSnippetBytes))
+	}
+
+	snippets, truncated := bodyContextSnippets(body.String(), spans)
+	require.Len(snippets, MessageBodyContextMaxSnippets)
+	assert.True(truncated)
+	for _, snippet := range snippets {
+		assert.LessOrEqual(len(snippet), MessageBodyContextSnippetBytes)
+		assert.True(utf8.ValidString(snippet))
+	}
+}

--- a/internal/query/dialect.go
+++ b/internal/query/dialect.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"go.kenn.io/msgvault/internal/sqldialect"
+	"go.kenn.io/msgvault/internal/sqliteutil"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -91,6 +92,11 @@ type Dialect interface {
 	// must emit "col = 1"; PostgreSQL has a real BOOLEAN type and rejects
 	// integer comparisons, so the bare column name is the right form.
 	BoolTrueExpr(col string) string
+
+	// UnicodeLowerExpression returns a Unicode-aware lowercasing SQL expression.
+	// SQLite delegates to a deterministic Go scalar registered on every
+	// connection; PostgreSQL uses its collation-aware LOWER implementation.
+	UnicodeLowerExpression(expr string) string
 }
 
 // SQLiteQueryDialect implements Dialect for SQLite.
@@ -99,6 +105,10 @@ type SQLiteQueryDialect struct{}
 func (SQLiteQueryDialect) Rebind(query string) string { return query }
 
 func (SQLiteQueryDialect) BoolTrueExpr(col string) string { return col + " = 1" }
+
+func (SQLiteQueryDialect) UnicodeLowerExpression(expr string) string {
+	return sqliteutil.UnicodeLowerFunction + "(" + expr + ")"
+}
 
 func (SQLiteQueryDialect) TimeTruncExpression(column string, granularity string) string {
 	switch granularity {
@@ -185,6 +195,10 @@ func (PostgreSQLQueryDialect) Rebind(query string) string {
 
 func (PostgreSQLQueryDialect) BoolTrueExpr(col string) string { return col }
 
+func (PostgreSQLQueryDialect) UnicodeLowerExpression(expr string) string {
+	return "LOWER(" + expr + ")"
+}
+
 func (PostgreSQLQueryDialect) TimeTruncExpression(column string, granularity string) string {
 	switch granularity {
 	case "year":
@@ -248,16 +262,30 @@ func (PostgreSQLQueryDialect) BuildFTSTerm(terms []string) (expr string, arg str
 }
 
 func (PostgreSQLQueryDialect) BuildFTSBodyTerm(terms []string) (expr string, arg string) {
-	tsTerms := make([]string, 0, len(terms))
+	termGroups := make([]string, 0, len(terms))
 	for _, term := range terms {
-		for _, lex := range sqldialect.EscapeTSQueryTerm(term) {
-			tsTerms = append(tsTerms, lex+":*D")
+		lexemes := sqldialect.EscapeTSQueryTerm(term)
+		parts := make([]string, len(lexemes))
+		for i, lexeme := range lexemes {
+			suffix := ":D"
+			if i == len(lexemes)-1 {
+				suffix = ":*D"
+			}
+			parts[i] = lexeme + suffix
+		}
+		switch len(parts) {
+		case 0:
+			continue
+		case 1:
+			termGroups = append(termGroups, parts[0])
+		default:
+			termGroups = append(termGroups, "("+strings.Join(parts, " <-> ")+")")
 		}
 	}
-	if len(tsTerms) == 0 {
+	if len(termGroups) == 0 {
 		return "FALSE", ""
 	}
-	return "m.search_fts @@ to_tsquery('simple', ?)", strings.Join(tsTerms, " & ")
+	return "m.search_fts @@ to_tsquery('simple', ?)", strings.Join(termGroups, " & ")
 }
 
 func (PostgreSQLQueryDialect) FTSBodySearchReadinessSQL() string {

--- a/internal/query/dialect.go
+++ b/internal/query/dialect.go
@@ -22,6 +22,13 @@ import (
 	"go.kenn.io/msgvault/internal/store"
 )
 
+type messageBodyContextBackend uint8
+
+const (
+	messageBodyContextSQLite messageBodyContextBackend = iota
+	messageBodyContextPostgreSQL
+)
+
 // Dialect abstracts SQL generation differences for SQLite vs PostgreSQL.
 type Dialect interface {
 	// Rebind converts ? placeholders to the driver's native form.
@@ -97,6 +104,10 @@ type Dialect interface {
 	// SQLite delegates to a deterministic Go scalar registered on every
 	// connection; PostgreSQL uses its collation-aware LOWER implementation.
 	UnicodeLowerExpression(expr string) string
+
+	// messageBodyContextBackend selects the backend-native highlighter used to
+	// extract exact context for body-index hits.
+	messageBodyContextBackend() messageBodyContextBackend
 }
 
 // SQLiteQueryDialect implements Dialect for SQLite.
@@ -108,6 +119,10 @@ func (SQLiteQueryDialect) BoolTrueExpr(col string) string { return col + " = 1" 
 
 func (SQLiteQueryDialect) UnicodeLowerExpression(expr string) string {
 	return sqliteutil.UnicodeLowerFunction + "(" + expr + ")"
+}
+
+func (SQLiteQueryDialect) messageBodyContextBackend() messageBodyContextBackend {
+	return messageBodyContextSQLite
 }
 
 func (SQLiteQueryDialect) TimeTruncExpression(column string, granularity string) string {
@@ -197,6 +212,10 @@ func (PostgreSQLQueryDialect) BoolTrueExpr(col string) string { return col }
 
 func (PostgreSQLQueryDialect) UnicodeLowerExpression(expr string) string {
 	return "LOWER(" + expr + ")"
+}
+
+func (PostgreSQLQueryDialect) messageBodyContextBackend() messageBodyContextBackend {
+	return messageBodyContextPostgreSQL
 }
 
 func (PostgreSQLQueryDialect) TimeTruncExpression(column string, granularity string) string {

--- a/internal/query/dialect.go
+++ b/internal/query/dialect.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"go.kenn.io/msgvault/internal/sqldialect"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 // Dialect abstracts SQL generation differences for SQLite vs PostgreSQL.
@@ -68,6 +69,17 @@ type Dialect interface {
 	// expression and a single argument string. Both SQLite FTS5 and PostgreSQL
 	// tsquery support prefix matching via dialect-appropriate syntax.
 	BuildFTSTerm(terms []string) (expr string, arg string)
+
+	// BuildFTSBodyTerm is the exact-body counterpart to BuildFTSTerm.
+	// SQLite scopes the FTS5 query to its body column; PostgreSQL restricts
+	// tsquery lexemes to weight D in the versioned search_fts layout.
+	BuildFTSBodyTerm(terms []string) (expr string, arg string)
+
+	// FTSBodySearchReadinessSQL returns a query that yields true when the
+	// backend's body-search layout is ready, or "" when no version probe is
+	// needed. PostgreSQL uses messages.indexing_version; SQLite's FTS5 table
+	// has a durable body column and needs no separate version watermark.
+	FTSBodySearchReadinessSQL() string
 
 	// SanitizeFTSQuery converts a raw user search string to a form safe to
 	// pass to FTSSearchExpression. Returns "" if the result is empty after
@@ -130,6 +142,16 @@ func (SQLiteQueryDialect) BuildFTSTerm(terms []string) (expr string, arg string)
 	}
 	return "messages_fts MATCH ?", strings.Join(ftsTerms, " ")
 }
+
+func (d SQLiteQueryDialect) BuildFTSBodyTerm(terms []string) (expr string, arg string) {
+	expr, arg = d.BuildFTSTerm(terms)
+	if arg == "" {
+		return expr, arg
+	}
+	return expr, "body : (" + arg + ")"
+}
+
+func (SQLiteQueryDialect) FTSBodySearchReadinessSQL() string { return "" }
 
 // SanitizeFTSQuery strips FTS5 metacharacters from a single query string
 // and wraps it in quotes for literal phrase interpretation with prefix match.
@@ -223,6 +245,26 @@ func (PostgreSQLQueryDialect) BuildFTSTerm(terms []string) (expr string, arg str
 		return "FALSE", ""
 	}
 	return "m.search_fts @@ to_tsquery('simple', ?)", strings.Join(tsTerms, " & ")
+}
+
+func (PostgreSQLQueryDialect) BuildFTSBodyTerm(terms []string) (expr string, arg string) {
+	tsTerms := make([]string, 0, len(terms))
+	for _, term := range terms {
+		for _, lex := range sqldialect.EscapeTSQueryTerm(term) {
+			tsTerms = append(tsTerms, lex+":*D")
+		}
+	}
+	if len(tsTerms) == 0 {
+		return "FALSE", ""
+	}
+	return "m.search_fts @@ to_tsquery('simple', ?)", strings.Join(tsTerms, " & ")
+}
+
+func (PostgreSQLQueryDialect) FTSBodySearchReadinessSQL() string {
+	return fmt.Sprintf(
+		"SELECT NOT EXISTS (SELECT 1 FROM messages WHERE search_fts IS NULL OR indexing_version IS DISTINCT FROM %d)",
+		store.CurrentFTSIndexingVersion,
+	)
 }
 
 // SanitizeFTSQuery builds a tsquery arg from a single user string using the

--- a/internal/query/dialect_test.go
+++ b/internal/query/dialect_test.go
@@ -94,7 +94,7 @@ func TestBuildFTSBodyTermScopesExactBodyField(t *testing.T) {
 	t.Run("PostgreSQL weight D", func(t *testing.T) {
 		expr, arg := (PostgreSQLQueryDialect{}).BuildFTSBodyTerm([]string{"foo-bar", "baz"})
 		assert.Equal(t, "m.search_fts @@ to_tsquery('simple', ?)", expr)
-		assert.Equal(t, "foo:*D & bar:*D & baz:*D", arg)
+		assert.Equal(t, "(foo:D <-> bar:*D) & baz:*D", arg)
 	})
 
 	t.Run("SQLite body column", func(t *testing.T) {

--- a/internal/query/dialect_test.go
+++ b/internal/query/dialect_test.go
@@ -89,3 +89,17 @@ func TestSQLiteBuildFTSTerm(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildFTSBodyTermScopesExactBodyField(t *testing.T) {
+	t.Run("PostgreSQL weight D", func(t *testing.T) {
+		expr, arg := (PostgreSQLQueryDialect{}).BuildFTSBodyTerm([]string{"foo-bar", "baz"})
+		assert.Equal(t, "m.search_fts @@ to_tsquery('simple', ?)", expr)
+		assert.Equal(t, "foo:*D & bar:*D & baz:*D", arg)
+	})
+
+	t.Run("SQLite body column", func(t *testing.T) {
+		expr, arg := (SQLiteQueryDialect{}).BuildFTSBodyTerm([]string{"foo", "bar"})
+		assert.Equal(t, "messages_fts MATCH ?", expr)
+		assert.Equal(t, `body : ("foo"* "bar"*)`, arg)
+	})
+}

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1981,6 +1981,16 @@ func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offse
 	return results, nil
 }
 
+// SearchMessageBodies delegates to the direct SQLite engine so FTS5 can scope
+// MATCH to the indexed body column. The sqlite_scanner fallback is
+// intentionally unsupported: exact body search must never scan message_bodies.
+func (e *DuckDBEngine) SearchMessageBodies(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
+	if e.sqliteEngine == nil {
+		return nil, fmt.Errorf("%w: a direct SQLite engine is required; reopen the query engine with a SQLite connection", ErrMessageBodySearchUnavailable)
+	}
+	return e.sqliteEngine.SearchMessageBodies(ctx, q, limit, offset)
+}
+
 // SearchByDomains returns message summaries for the given sender domains.
 // It delegates to SQLite because domain search needs JOINs across
 // participants and message_recipients that the Parquet cache doesn't carry.
@@ -2311,7 +2321,7 @@ type ParquetSyncState struct {
 
 // SearchFast searches message metadata in Parquet files (no body text).
 // This is much faster than FTS search for large archives.
-// Searches: subject, sender email/name (case-insensitive).
+// Searches subject, snippet, and sender/recipient metadata (case-insensitive).
 func (e *DuckDBEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
 	release, err := e.acquireQuerySlot(ctx)
 	if err != nil {
@@ -2879,7 +2889,10 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 		args = append(args, filter.TimeRange.Period)
 	}
 
-	// Text search terms - search subject, snippet, and from fields (fast path).
+	// Text search terms - search subject, snippet, and every participant row
+	// without consulting message bodies (fast path). The EXISTS branch includes
+	// all from rows as well as recipients because msg_sender retains only one
+	// display sender for result hydration.
 	// Uses ILIKE for performance on Parquet scans.
 	if len(q.TextTerms) > 0 {
 		for _, term := range q.TextTerms {
@@ -2889,9 +2902,23 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 				COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\' OR
 				COALESCE(ms.from_email, ds.from_email, '') ILIKE ? ESCAPE '\' OR
 				COALESCE(ms.from_name, ds.from_name, '') ILIKE ? ESCAPE '\' OR
-				COALESCE(ms.from_phone, ds.from_phone, '') ILIKE ? ESCAPE '\'
+				COALESCE(ms.from_phone, ds.from_phone, '') ILIKE ? ESCAPE '\' OR
+				EXISTS (
+					SELECT 1
+					FROM mr mr_meta
+					JOIN p p_meta ON p_meta.id = mr_meta.participant_id
+					WHERE mr_meta.message_id = msg.id
+					  AND (
+						COALESCE(p_meta.email_address, '') ILIKE ? ESCAPE '\' OR
+						COALESCE(p_meta.display_name, '') ILIKE ? ESCAPE '\' OR
+						COALESCE(p_meta.phone_number, '') ILIKE ? ESCAPE '\' OR
+						COALESCE(mr_meta.display_name, '') ILIKE ? ESCAPE '\'
+					  )
+				)
 			)`)
-			args = append(args, termPattern, termPattern, termPattern, termPattern, termPattern)
+			for range 9 {
+				args = append(args, termPattern)
+			}
 		}
 	}
 

--- a/internal/query/duckdb_search_scope_test.go
+++ b/internal/query/duckdb_search_scope_test.go
@@ -56,15 +56,19 @@ func TestDuckDBSearchFast_AllFromParticipantsMetadata(t *testing.T) {
 }
 
 func TestDuckDBSearchMessageBodies_DelegatesToDirectSQLite(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	env := newTestEnv(t)
 	env.EnableFTS()
 	engine := &DuckDBEngine{sqliteEngine: env.Engine}
 
 	messages, err := engine.SearchMessageBodies(context.Background(),
 		&search.Query{TextTerms: []string{"body 1"}}, 50, 0)
-	require.NoError(t, err, "SearchMessageBodies")
-	require.Len(t, messages, 1, "body-only hit")
-	assert.Equal(t, int64(1), messages[0].ID, "body-only hit ID")
+	require.NoError(err, "SearchMessageBodies")
+	require.Len(messages, 1, "body-only hit")
+	assert.Equal(int64(1), messages[0].ID, "body-only hit ID")
+	require.NotEmpty(messages[0].BodyContextSnippets, "body-only hit context")
+	assert.Contains(messages[0].BodyContextSnippets[0], "body 1")
 }
 
 func TestDuckDBSearchMessageBodies_RequiresDirectSQLite(t *testing.T) {

--- a/internal/query/duckdb_search_scope_test.go
+++ b/internal/query/duckdb_search_scope_test.go
@@ -1,0 +1,76 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/search"
+)
+
+func TestDuckDBSearchFast_RecipientMetadata(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@example.com")
+	senderID := b.AddParticipant("sender@example.com", "example.com", "Sender")
+	recipientID := b.AddParticipant("recipientneedle@example.com", "example.com", "Recipient Needle")
+	messageID := b.AddMessage(MessageOpt{Subject: "ordinary subject", Snippet: "ordinary preview"})
+	b.AddFrom(messageID, senderID, "Sender")
+	b.AddTo(messageID, recipientID, "Recipient Needle")
+	engine := b.BuildEngine()
+
+	q := &search.Query{TextTerms: []string{"recipientneedle"}}
+	messages, err := engine.SearchFast(context.Background(), q, MessageFilter{}, 50, 0)
+	require.NoError(err, "SearchFast")
+	require.Len(messages, 1, "recipient metadata hit")
+	assert.Equal(messageID, messages[0].ID, "recipient metadata hit ID")
+
+	count, err := engine.SearchFastCount(context.Background(), q, MessageFilter{})
+	require.NoError(err, "SearchFastCount")
+	assert.Equal(int64(len(messages)), count, "result/count agreement")
+}
+
+func TestDuckDBSearchFast_AllFromParticipantsMetadata(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@example.com")
+	primaryFromID := b.AddParticipant("primary@example.com", "example.com", "Primary Sender")
+	secondaryFromID := b.AddParticipant("secondaryneedle@example.com", "example.com", "Secondary Needle")
+	messageID := b.AddMessage(MessageOpt{Subject: "ordinary subject", Snippet: "ordinary preview"})
+	b.AddFrom(messageID, primaryFromID, "Primary Sender")
+	b.AddFrom(messageID, secondaryFromID, "Secondary Needle")
+	engine := b.BuildEngine()
+
+	q := &search.Query{TextTerms: []string{"secondaryneedle"}}
+	messages, err := engine.SearchFast(context.Background(), q, MessageFilter{}, 50, 0)
+	require.NoError(err, "SearchFast")
+	require.Len(messages, 1, "secondary from participant metadata hit")
+	assert.Equal(messageID, messages[0].ID, "secondary from participant hit ID")
+
+	count, err := engine.SearchFastCount(context.Background(), q, MessageFilter{})
+	require.NoError(err, "SearchFastCount")
+	assert.Equal(int64(len(messages)), count, "result/count agreement")
+}
+
+func TestDuckDBSearchMessageBodies_DelegatesToDirectSQLite(t *testing.T) {
+	env := newTestEnv(t)
+	env.EnableFTS()
+	engine := &DuckDBEngine{sqliteEngine: env.Engine}
+
+	messages, err := engine.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"body 1"}}, 50, 0)
+	require.NoError(t, err, "SearchMessageBodies")
+	require.Len(t, messages, 1, "body-only hit")
+	assert.Equal(t, int64(1), messages[0].ID, "body-only hit ID")
+}
+
+func TestDuckDBSearchMessageBodies_RequiresDirectSQLite(t *testing.T) {
+	_, err := (&DuckDBEngine{}).SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"needle"}}, 50, 0)
+	require.Error(t, err, "missing direct SQLite engine")
+	require.ErrorIs(t, err, ErrMessageBodySearchUnavailable)
+	assert.Contains(t, err.Error(), "direct SQLite engine")
+}

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -1126,8 +1126,8 @@ func TestDuckDBEngine_SearchFast(t *testing.T) {
 		{"CaseInsensitive_Lower", "hello", MessageFilter{}, []string{"Hello World", "Re: Hello"}},
 		{"CaseInsensitive_Upper", "HELLO", MessageFilter{}, []string{"Hello World", "Re: Hello"}},
 		{"CaseInsensitive_Mixed", "HeLLo", MessageFilter{}, []string{"Hello World", "Re: Hello"}},
-		{"CaseInsensitive_Sender_Upper", "ALICE", MessageFilter{}, []string{"Hello World", "Re: Hello", "Follow up"}},
-		{"CaseInsensitive_Sender_Lower", "alice", MessageFilter{}, []string{"Hello World", "Re: Hello", "Follow up"}},
+		{"CaseInsensitive_Participant_Upper", "ALICE", MessageFilter{}, []string{"Hello World", "Re: Hello", "Follow up", "Question", "Final"}},
+		{"CaseInsensitive_Participant_Lower", "alice", MessageFilter{}, []string{"Hello World", "Re: Hello", "Follow up", "Question", "Final"}},
 	}
 
 	for _, tt := range tests {

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -2,9 +2,19 @@ package query
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.kenn.io/msgvault/internal/search"
+)
+
+var (
+	// ErrMessageBodySearchUnavailable means the backend cannot execute exact
+	// body-only search without violating the no-body-scan contract.
+	ErrMessageBodySearchUnavailable = errors.New("exact message body search is unavailable")
+	// ErrMessageBodySearchIndexStale means the backend has an FTS index, but
+	// its field layout is not the version required for exact body scoping.
+	ErrMessageBodySearchIndexStale = errors.New("message body search index layout is stale")
 )
 
 // Engine provides query operations for msgvault data.
@@ -46,7 +56,8 @@ type Engine interface {
 
 	// SearchFast searches message metadata only (no body text).
 	// This is much faster for large archives as it queries Parquet files directly.
-	// Searches: subject, sender email/name (case-insensitive).
+	// Free text searches subject, snippet, and sender/recipient metadata
+	// (case-insensitive).
 	// The filter parameter allows contextual search within a drill-down.
 	SearchFast(ctx context.Context, query *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error)
 
@@ -81,6 +92,13 @@ type Engine interface {
 
 	// Close releases any resources held by the engine.
 	Close() error
+}
+
+// MessageBodySearcher is an optional capability for exact full-text search of
+// message bodies. It is deliberately separate from Engine so generic Search
+// retains its composite subject/body/participant semantics.
+type MessageBodySearcher interface {
+	SearchMessageBodies(ctx context.Context, query *search.Query, limit, offset int) ([]MessageSummary, error)
 }
 
 // SearchFastResult holds the combined results of a fast search:

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -15,6 +15,9 @@ var (
 	// ErrMessageBodySearchIndexStale means the backend has an FTS index, but
 	// its field layout is not the version required for exact body scoping.
 	ErrMessageBodySearchIndexStale = errors.New("message body search index layout is stale")
+	// ErrMessageBodySearchInvalidQuery means exact body search rejected a
+	// bounded-work query limit before touching the index.
+	ErrMessageBodySearchInvalidQuery = errors.New("invalid message body search query")
 )
 
 // Engine provides query operations for msgvault data.

--- a/internal/query/models.go
+++ b/internal/query/models.go
@@ -23,27 +23,29 @@ type AggregateRow struct {
 // MessageSummary represents a message in list views.
 // Contains enough information for display without fetching the full body.
 type MessageSummary struct {
-	ID                   int64      `json:"id"`
-	SourceMessageID      string     `json:"source_message_id"`
-	ConversationID       int64      `json:"conversation_id"`
-	SourceConversationID string     `json:"source_conversation_id"` // Gmail Thread ID
-	Subject              string     `json:"subject"`
-	Snippet              string     `json:"snippet"`
-	FromEmail            string     `json:"from_email"`
-	FromName             string     `json:"from_name"`
-	FromPhone            string     `json:"from_phone,omitempty"` // Phone number (for WhatsApp/chat sources)
-	To                   []Address  `json:"to,omitempty"`
-	Cc                   []Address  `json:"cc,omitempty"`
-	Bcc                  []Address  `json:"bcc,omitempty"`
-	SentAt               time.Time  `json:"sent_at"`
-	SizeEstimate         int64      `json:"size_estimate"`
-	HasAttachments       bool       `json:"has_attachments"`
-	AttachmentCount      int        `json:"attachment_count"`
-	Labels               []string   `json:"labels"`
-	DeletedAt            *time.Time `json:"deleted_at,omitempty"`         // When message was deleted from server (nil if not deleted)
-	MessageType          string     `json:"message_type,omitempty"`       // e.g., "email", "whatsapp" — from messages.message_type
-	ConversationTitle    string     `json:"conversation_title,omitempty"` // Group/chat name from conversations.title
-	BodyText             string     `json:"body_text,omitempty"`          // Full body text (only populated for timeline views)
+	ID                           int64      `json:"id"`
+	SourceMessageID              string     `json:"source_message_id"`
+	ConversationID               int64      `json:"conversation_id"`
+	SourceConversationID         string     `json:"source_conversation_id"` // Gmail Thread ID
+	Subject                      string     `json:"subject"`
+	Snippet                      string     `json:"snippet"`
+	FromEmail                    string     `json:"from_email"`
+	FromName                     string     `json:"from_name"`
+	FromPhone                    string     `json:"from_phone,omitempty"` // Phone number (for WhatsApp/chat sources)
+	To                           []Address  `json:"to,omitempty"`
+	Cc                           []Address  `json:"cc,omitempty"`
+	Bcc                          []Address  `json:"bcc,omitempty"`
+	SentAt                       time.Time  `json:"sent_at"`
+	SizeEstimate                 int64      `json:"size_estimate"`
+	HasAttachments               bool       `json:"has_attachments"`
+	AttachmentCount              int        `json:"attachment_count"`
+	Labels                       []string   `json:"labels"`
+	DeletedAt                    *time.Time `json:"deleted_at,omitempty"`         // When message was deleted from server (nil if not deleted)
+	MessageType                  string     `json:"message_type,omitempty"`       // e.g., "email", "whatsapp" — from messages.message_type
+	ConversationTitle            string     `json:"conversation_title,omitempty"` // Group/chat name from conversations.title
+	BodyText                     string     `json:"body_text,omitempty"`          // Full body text (only populated for timeline views)
+	BodyContextSnippets          []string   `json:"-"`
+	BodyContextSnippetsTruncated bool       `json:"-"`
 }
 
 // MessageDetail represents a full message with body and attachments.

--- a/internal/query/pg_compat_test.go
+++ b/internal/query/pg_compat_test.go
@@ -175,6 +175,14 @@ func TestNewEnginePostgresSatisfiesAccountsByGmailIDsResolver(t *testing.T) {
 	assert.Empty(accounts)
 }
 
+func TestNewEnginePostgresSatisfiesMessageBodySearcher(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	eng := query.NewEngine(st.DB(), true)
+
+	_, ok := eng.(query.MessageBodySearcher)
+	require.True(t, ok, "PostgreSQL engine should expose exact message body search")
+}
+
 // TestQueryEngine_CaseInsensitiveSearch_Subject verifies that
 // `subject:` terms passed through query.Engine.Search match
 // case-insensitively on both SQLite and PostgreSQL. SQLite's LIKE is

--- a/internal/query/postgres.go
+++ b/internal/query/postgres.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
+	"go.kenn.io/msgvault/internal/search"
 )
 
 // ErrNotImplemented is a sentinel returned by engine methods that the current
@@ -30,6 +32,8 @@ var ErrNotImplemented = errors.New("query: method not implemented for this engin
 type pgEngine struct {
 	Engine
 }
+
+var _ MessageBodySearcher = (*pgEngine)(nil)
 
 type gmailIDsByMessageIDsResolver interface {
 	GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error)
@@ -60,6 +64,20 @@ func (e *pgEngine) GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string)
 		return nil, ErrNotImplemented
 	}
 	return resolver.GetAccountsByGmailIDs(ctx, gmailIDs)
+}
+
+// SearchMessageBodies forwards exact body-only search through the PostgreSQL
+// wrapper. pgEngine hides optional SQLite-only capabilities by default, so
+// capabilities implemented with PostgreSQL-safe SQL must be promoted
+// explicitly.
+func (e *pgEngine) SearchMessageBodies(
+	ctx context.Context, q *search.Query, limit, offset int,
+) ([]MessageSummary, error) {
+	bodySearcher, ok := e.Engine.(MessageBodySearcher)
+	if !ok {
+		return nil, ErrMessageBodySearchUnavailable
+	}
+	return bodySearcher.SearchMessageBodies(ctx, q, limit, offset)
 }
 
 // NewPostgreSQLEngine creates a query engine backed by PostgreSQL. The engine

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -31,6 +31,7 @@ type MockEngine struct {
 	// Optional overrides — set these to customise behavior per-test.
 	SearchFastFunc               func(context.Context, *search.Query, query.MessageFilter, int, int) ([]query.MessageSummary, error)
 	SearchFunc                   func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
+	SearchMessageBodiesFunc      func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
 	GetMessageFunc               func(context.Context, int64) (*query.MessageDetail, error)
 	GetMessageBySourceIDFunc     func(context.Context, string) (*query.MessageDetail, error)
 	GetTotalStatsFunc            func(context.Context, query.StatsOptions) (*query.TotalStats, error)
@@ -49,6 +50,7 @@ type MockEngine struct {
 
 // Compile-time check.
 var _ query.Engine = (*MockEngine)(nil)
+var _ query.MessageBodySearcher = (*MockEngine)(nil)
 
 func (m *MockEngine) Aggregate(_ context.Context, _ query.ViewType, _ query.AggregateOptions) ([]query.AggregateRow, error) {
 	return m.AggregateRows, nil
@@ -144,6 +146,13 @@ func (m *MockEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error
 func (m *MockEngine) Search(ctx context.Context, q *search.Query, limit, offset int) ([]query.MessageSummary, error) {
 	if m.SearchFunc != nil {
 		return m.SearchFunc(ctx, q, limit, offset)
+	}
+	return m.SearchResults, nil
+}
+
+func (m *MockEngine) SearchMessageBodies(ctx context.Context, q *search.Query, limit, offset int) ([]query.MessageSummary, error) {
+	if m.SearchMessageBodiesFunc != nil {
+		return m.SearchMessageBodiesFunc(ctx, q, limit, offset)
 	}
 	return m.SearchResults, nil
 }

--- a/internal/query/search_scope_test.go
+++ b/internal/query/search_scope_test.go
@@ -126,6 +126,55 @@ func TestSearchFastWithStats_MetadataPredicateConsistency(t *testing.T) {
 	}
 }
 
+func TestSearchFast_MetadataUnicodeCaseFold(t *testing.T) {
+	f := storetest.New(t)
+	ctx := context.Background()
+
+	subjectID := createSearchScopeMessage(t, f, "unicode-metadata-subject",
+		"École newsletter", "ordinary preview", "ordinary body", 0, 0)
+	snippetID := createSearchScopeMessage(t, f, "unicode-metadata-snippet",
+		"ordinary subject", "École preview", "ordinary body", 0, 0)
+	senderID := f.EnsureParticipant("unicode@example.com", "Élodie Example", "example.com")
+	senderMessageID := createSearchScopeMessage(t, f, "unicode-metadata-sender",
+		"ordinary subject", "ordinary preview", "ordinary body", senderID, 0)
+
+	engine := query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())
+	tests := []struct {
+		name    string
+		term    string
+		wantIDs []int64
+	}{
+		{name: "subject and snippet", term: "école", wantIDs: []int64{subjectID, snippetID}},
+		{name: "participant display name", term: "élodie", wantIDs: []int64{senderMessageID}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			q := &search.Query{TextTerms: []string{tc.term}}
+			var gotIDs []int64
+			for offset := range len(tc.wantIDs) {
+				page, err := engine.SearchFast(ctx, q, query.MessageFilter{}, 1, offset)
+				require.NoError(err, "SearchFast page %d", offset)
+				require.Len(page, 1, "SearchFast page %d", offset)
+				gotIDs = append(gotIDs, page[0].ID)
+			}
+			assert.ElementsMatch(tc.wantIDs, gotIDs, "paginated message IDs")
+
+			count, err := engine.SearchFastCount(ctx, q, query.MessageFilter{})
+			require.NoError(err, "SearchFastCount")
+			assert.Equal(int64(len(tc.wantIDs)), count, "total count")
+
+			result, err := engine.SearchFastWithStats(ctx, q, tc.term,
+				query.MessageFilter{}, query.ViewSenders, 1, 0)
+			require.NoError(err, "SearchFastWithStats")
+			require.NotNil(result.Stats, "metadata stats")
+			assert.Equal(count, result.TotalCount, "result total")
+			assert.Equal(count, result.Stats.MessageCount, "stats total")
+		})
+	}
+}
+
 // TestSearchMessageBodies_BodyColumnOnly runs against SQLite by default and
 // PostgreSQL in the test-pg lane. Every non-body FTS field carries the same
 // term in a different message, proving the optional capability scopes the
@@ -151,12 +200,11 @@ func TestSearchMessageBodies_BodyColumnOnly(t *testing.T) {
 	_, err := f.Store.BackfillFTS(nil)
 	require.NoError(err, "BackfillFTS")
 
-	engine := query.NewSQLiteEngine(f.Store.DB())
-	if f.Store.IsPostgreSQL() {
-		engine = query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
-	}
+	engine := query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())
+	bodySearcher, ok := engine.(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
 
-	messages, err := engine.SearchMessageBodies(ctx, &search.Query{TextTerms: []string{"scopeword"}}, 50, 0)
+	messages, err := bodySearcher.SearchMessageBodies(ctx, &search.Query{TextTerms: []string{"scopeword"}}, 50, 0)
 	require.NoError(err, "SearchMessageBodies")
 	require.Len(messages, 1, "body-only hits")
 	assert.Equal(bodyID, messages[0].ID, "body-only hit ID")
@@ -185,13 +233,38 @@ func TestSearchMessageBodies_PostgreSQLRejectsStaleLayout(t *testing.T) {
 	require.NoError(err, "mark layout stale")
 	assert.True(f.Store.NeedsFTSBackfill(), "stale version needs backfill")
 
-	engine := query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
-	_, err = engine.SearchMessageBodies(context.Background(),
+	engine := query.NewEngine(f.Store.DB(), true)
+	bodySearcher, ok := engine.(query.MessageBodySearcher)
+	require.True(ok, "production PostgreSQL engine must expose exact body search")
+	_, err = bodySearcher.SearchMessageBodies(context.Background(),
 		&search.Query{TextTerms: []string{"stalecheck"}}, 50, 0)
 	require.Error(err, "stale body search must fail closed")
 	require.ErrorIs(err, query.ErrMessageBodySearchIndexStale)
 	assert.Contains(err.Error(), "rebuild-fts")
 	assert.Contains(err.Error(), "backfill")
+}
+
+func TestSearchMessageBodies_PhraseGrouping(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	ctx := context.Background()
+
+	adjacentID := createSearchScopeMessage(t, f, "body-phrase-adjacent",
+		"ordinary subject", "ordinary preview", "alpha beta marker", 0, 0)
+	createSearchScopeMessage(t, f, "body-phrase-separated",
+		"ordinary subject", "ordinary preview", "alpha between beta", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	engine := query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())
+	bodySearcher, ok := engine.(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	messages, err := bodySearcher.SearchMessageBodies(ctx,
+		&search.Query{TextTerms: []string{"alpha beta"}}, 50, 0)
+	require.NoError(err, "SearchMessageBodies")
+	require.Len(messages, 1, "phrase body hits")
+	assert.Equal(adjacentID, messages[0].ID, "adjacent phrase hit")
 }
 
 func createSearchScopeMessage(

--- a/internal/query/search_scope_test.go
+++ b/internal/query/search_scope_test.go
@@ -175,6 +175,73 @@ func TestSearchFast_MetadataUnicodeCaseFold(t *testing.T) {
 	}
 }
 
+func TestSearchFast_StructuredMetadataUnicodeCaseFold(t *testing.T) {
+	f := storetest.New(t)
+	ctx := context.Background()
+
+	subjectID := createSearchScopeMessage(t, f, "unicode-structured-subject",
+		"École newsletter", "ordinary preview", "ordinary body", 0, 0)
+	labelMessageID := createSearchScopeMessage(t, f, "unicode-structured-label",
+		"ordinary subject", "ordinary preview", "ordinary body", 0, 0)
+	labels := f.EnsureLabels(map[string]string{"unicode-label": "Étiquette"}, "user")
+	require.NoError(t, f.Store.ReplaceMessageLabels(labelMessageID, []int64{labels["unicode-label"]}),
+		"ReplaceMessageLabels")
+
+	engine := query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL())
+	tests := []struct {
+		name     string
+		query    *search.Query
+		queryStr string
+		groupBy  query.ViewType
+		wantID   int64
+	}{
+		{
+			name:     "subject",
+			query:    &search.Query{SubjectTerms: []string{"école"}},
+			queryStr: "subject:école",
+			groupBy:  query.ViewSenders,
+			wantID:   subjectID,
+		},
+		{
+			name:     "label",
+			query:    &search.Query{Labels: []string{"étiquette"}},
+			queryStr: "label:étiquette",
+			groupBy:  query.ViewLabels,
+			wantID:   labelMessageID,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			messages, err := engine.SearchFast(ctx, tc.query, query.MessageFilter{}, 10, 0)
+			require.NoError(err, "SearchFast")
+			require.Len(messages, 1, "structured metadata hit")
+			assert.Equal(tc.wantID, messages[0].ID, "structured metadata hit ID")
+
+			count, err := engine.SearchFastCount(ctx, tc.query, query.MessageFilter{})
+			require.NoError(err, "SearchFastCount")
+			assert.Equal(int64(1), count, "structured metadata count")
+
+			result, err := engine.SearchFastWithStats(ctx, tc.query, tc.queryStr,
+				query.MessageFilter{}, tc.groupBy, 10, 0)
+			require.NoError(err, "SearchFastWithStats")
+			require.NotNil(result.Stats, "structured metadata stats")
+			assert.Equal(int64(1), result.TotalCount, "structured result total")
+			assert.Equal(int64(1), result.Stats.MessageCount, "structured stats total")
+
+			if tc.groupBy == query.ViewLabels {
+				opts := query.DefaultAggregateOptions()
+				opts.SearchQuery = tc.queryStr
+				rows, err := engine.Aggregate(ctx, query.ViewLabels, opts)
+				require.NoError(err, "Aggregate(ViewLabels)")
+				require.Len(rows, 1, "Unicode label aggregate")
+				assert.Equal("Étiquette", rows[0].Key, "Unicode label aggregate key")
+			}
+		})
+	}
+}
+
 // TestSearchMessageBodies_BodyColumnOnly runs against SQLite by default and
 // PostgreSQL in the test-pg lane. Every non-body FTS field carries the same
 // term in a different message, proving the optional capability scopes the

--- a/internal/query/search_scope_test.go
+++ b/internal/query/search_scope_test.go
@@ -3,6 +3,7 @@ package query_test
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -275,6 +276,8 @@ func TestSearchMessageBodies_BodyColumnOnly(t *testing.T) {
 	require.NoError(err, "SearchMessageBodies")
 	require.Len(messages, 1, "body-only hits")
 	assert.Equal(bodyID, messages[0].ID, "body-only hit ID")
+	require.NotEmpty(messages[0].BodyContextSnippets, "body-only hit context")
+	assert.Contains(messages[0].BodyContextSnippets[0], "scopeword")
 
 	nonBodyIDs := []int64{fromMessageID, toMessageID, ccMessageID}
 	for _, id := range nonBodyIDs {
@@ -311,6 +314,121 @@ func TestSearchMessageBodies_PostgreSQLRejectsStaleLayout(t *testing.T) {
 	assert.Contains(err.Error(), "backfill")
 }
 
+func TestSearchMessageBodies_RejectsCanonicalBodyIndexMismatch(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	messageID := createSearchScopeMessage(t, f, "body-canonical-mismatch",
+		"ordinary subject", "ordinary preview", "oldneedle marker", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	// Simulate a legacy/manual write that predates body-change invalidation.
+	// Search still finds the old index document, but context extraction must
+	// compare it with canonical storage and fail instead of presenting stale text.
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		"UPDATE message_bodies SET body_text = ? WHERE message_id = ?"),
+		"new canonical body", messageID)
+	require.NoError(err, "create body/index mismatch")
+
+	bodySearcher, ok := query.NewEngine(
+		f.Store.DB(), f.Store.IsPostgreSQL(),
+	).(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	_, err = bodySearcher.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"oldneedle"}}, 50, 0)
+	require.Error(err, "body/index mismatch must fail closed")
+	require.ErrorIs(err, query.ErrMessageBodySearchIndexStale)
+}
+
+func TestSearchMessageBodies_ValidatesTermsBeyondSnippetCap(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	messageID := createSearchScopeMessage(t, f, "body-sixth-term-mismatch",
+		"ordinary subject", "ordinary preview", "one two three four five six", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	// The response can render only five term groups, but the sixth term still
+	// participates in the indexed AND query and therefore must be checked
+	// against canonical storage before the hit is trusted.
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		"UPDATE message_bodies SET body_text = ? WHERE message_id = ?"),
+		"one two three four five", messageID)
+	require.NoError(err, "create sixth-term body/index mismatch")
+
+	bodySearcher, ok := query.NewEngine(
+		f.Store.DB(), f.Store.IsPostgreSQL(),
+	).(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	_, err = bodySearcher.SearchMessageBodies(context.Background(), &search.Query{
+		TextTerms: []string{"one", "two", "three", "four", "five", "six"},
+	}, 50, 0)
+	require.Error(err, "a non-rendered query group must not hide a stale hit")
+	require.ErrorIs(err, query.ErrMessageBodySearchIndexStale)
+}
+
+func TestSearchMessageBodies_SQLiteOversizedBodyDoesNotPoisonFollowingHit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if f.Store.IsPostgreSQL() {
+		t.Skip("SQLite octet_length bounded-read regression")
+	}
+
+	oversizedID := createSearchScopeMessage(t, f, "body-context-oversized-first",
+		"ordinary subject", "ordinary preview",
+		"needle "+strings.Repeat("oversized ", 150_000), 0, 0)
+	smallID := createSearchScopeMessage(t, f, "body-context-small-second",
+		"ordinary subject", "ordinary preview", "small needle marker", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	bodySearcher, ok := query.NewEngine(f.Store.DB(), false).(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	messages, err := bodySearcher.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"needle"}}, 50, 0)
+	require.NoError(err, "SearchMessageBodies")
+	require.Len(messages, 2, "body hits")
+
+	byID := make(map[int64]query.MessageSummary, len(messages))
+	for _, message := range messages {
+		byID[message.ID] = message
+	}
+	oversized := byID[oversizedID]
+	assert.Empty(oversized.BodyContextSnippets,
+		"an oversized SQLite cell is skipped before materialization")
+	assert.True(oversized.BodyContextSnippetsTruncated)
+	small := byID[smallID]
+	require.NotEmpty(small.BodyContextSnippets,
+		"an oversized preceding row must not suppress a later bounded row")
+	assert.Contains(small.BodyContextSnippets[0], "needle")
+}
+
+func TestSearchMessageBodies_LimitedHitDoesNotMaskAnotherStaleHit(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	createSearchScopeMessage(t, f, "body-wide-valid-hit",
+		"ordinary subject", "ordinary preview",
+		"needle"+strings.Repeat(" ", 7_000)+"marker", 0, 0)
+	staleID := createSearchScopeMessage(t, f, "body-short-stale-hit",
+		"ordinary subject", "ordinary preview", "needle marker stale", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		"UPDATE message_bodies SET body_text = ? WHERE message_id = ?"),
+		"fresh canonical body", staleID)
+	require.NoError(err, "create second body/index mismatch")
+
+	bodySearcher, ok := query.NewEngine(
+		f.Store.DB(), f.Store.IsPostgreSQL(),
+	).(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	_, err = bodySearcher.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"needle marker"}}, 50, 0)
+	require.Error(err, "a limited valid hit must not excuse a separate stale hit")
+	require.ErrorIs(err, query.ErrMessageBodySearchIndexStale)
+}
+
 func TestSearchMessageBodies_PhraseGrouping(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -332,6 +450,75 @@ func TestSearchMessageBodies_PhraseGrouping(t *testing.T) {
 	require.NoError(err, "SearchMessageBodies")
 	require.Len(messages, 1, "phrase body hits")
 	assert.Equal(adjacentID, messages[0].ID, "adjacent phrase hit")
+}
+
+func TestSearchMessageBodies_IgnoresUnsearchableContextGroups(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := createSearchScopeMessage(t, f, "body-unsearchable-group",
+		"ordinary subject", "ordinary preview", "needle marker", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	bodySearcher, ok := query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL()).(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	messages, err := bodySearcher.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"!!!", "needle"}}, 50, 0)
+	require.NoError(err, "SearchMessageBodies")
+	require.Len(messages, 1, "body hit")
+	assert.Equal(messageID, messages[0].ID)
+	require.NotEmpty(messages[0].BodyContextSnippets)
+	assert.Contains(messages[0].BodyContextSnippets[0], "needle")
+}
+
+func TestSearchMessageBodies_SQLiteUsesNativeTokenizerForTermGroups(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if f.Store.IsPostgreSQL() {
+		t.Skip("SQLite unicode61 term-probe regression")
+	}
+	matchedID := createSearchScopeMessage(t, f, "body-native-term-group",
+		"ordinary subject", "ordinary preview", "🫨 needle marker", 0, 0)
+	createSearchScopeMessage(t, f, "body-without-native-term-group",
+		"ordinary subject", "ordinary preview", "needle only", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	bodySearcher, ok := query.NewEngine(f.Store.DB(), false).(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	messages, err := bodySearcher.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"🫨", "needle"}}, 50, 0)
+	require.NoError(err, "SearchMessageBodies")
+	require.Len(messages, 1, "native tokenizer AND terms")
+	assert.Equal(matchedID, messages[0].ID,
+		"a unicode61 token unknown to Go's letter/digit categories must not be dropped")
+}
+
+func TestSearchMessageBodies_SQLiteTermProbeUsesSanitizedLiteral(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if f.Store.IsPostgreSQL() {
+		t.Skip("SQLite FTS5 embedded-star sanitization regression")
+	}
+	matchedID := createSearchScopeMessage(t, f, "body-sanitized-term-group",
+		"ordinary subject", "ordinary preview", "foobar marker", 0, 0)
+	createSearchScopeMessage(t, f, "body-unsanitized-term-group",
+		"ordinary subject", "ordinary preview", "foo bar marker", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	bodySearcher, ok := query.NewEngine(f.Store.DB(), false).(query.MessageBodySearcher)
+	require.True(ok, "production query engine must expose exact body search")
+	messages, err := bodySearcher.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"foo*bar"}}, 50, 0)
+	require.NoError(err, "SearchMessageBodies")
+	require.Len(messages, 1, "sanitized literal hit")
+	assert.Equal(matchedID, messages[0].ID)
+	require.NotEmpty(messages[0].BodyContextSnippets)
+	assert.Contains(messages[0].BodyContextSnippets[0], "foobar")
 }
 
 func createSearchScopeMessage(

--- a/internal/query/search_scope_test.go
+++ b/internal/query/search_scope_test.go
@@ -1,0 +1,221 @@
+package query_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+// TestSearchFast_MetadataOnly runs against SQLite by default and PostgreSQL in
+// the test-pg lane. It exercises the production query engine and real FTS
+// index so body terms cannot accidentally leak back into the metadata path.
+func TestSearchFast_MetadataOnly(t *testing.T) {
+	rootRequire := require.New(t)
+	rootAssert := assert.New(t)
+	f := storetest.New(t)
+	ctx := context.Background()
+
+	senderID := f.EnsureParticipant("senderneedle@example.com", "Sender Needle", "example.com")
+	recipientID := f.EnsureParticipant("recipientneedle@example.com", "Recipient Needle", "example.com")
+
+	subjectID := createSearchScopeMessage(t, f, "scope-subject", "subjectneedle update", "ordinary preview", "ordinary body", 0, 0)
+	snippetID := createSearchScopeMessage(t, f, "scope-snippet", "ordinary subject", "snippetneedle preview", "ordinary body", 0, 0)
+	senderMessageID := createSearchScopeMessage(t, f, "scope-sender", "ordinary subject", "ordinary preview", "ordinary body", senderID, 0)
+	recipientMessageID := createSearchScopeMessage(t, f, "scope-recipient", "ordinary subject", "ordinary preview", "ordinary body", 0, recipientID)
+	bodyOnlyID := createSearchScopeMessage(t, f, "scope-body", "ordinary subject", "ordinary preview", "bodyneedle appears only in the body", 0, 0)
+
+	_, err := f.Store.BackfillFTS(nil)
+	rootRequire.NoError(err, "BackfillFTS")
+
+	engine := query.NewSQLiteEngine(f.Store.DB())
+	if f.Store.IsPostgreSQL() {
+		engine = query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
+	}
+
+	tests := []struct {
+		name string
+		term string
+		want []int64
+	}{
+		{name: "subject", term: "subjectneedle", want: []int64{subjectID}},
+		{name: "snippet", term: "snippetneedle", want: []int64{snippetID}},
+		{name: "sender", term: "senderneedle", want: []int64{senderMessageID}},
+		{name: "recipient", term: "recipientneedle", want: []int64{recipientMessageID}},
+		{name: "body_only", term: "bodyneedle", want: []int64{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			q := &search.Query{TextTerms: []string{tc.term}}
+			messages, err := engine.SearchFast(ctx, q, query.MessageFilter{}, 50, 0)
+			require.NoError(err, "SearchFast")
+
+			gotIDs := make([]int64, len(messages))
+			for i := range messages {
+				gotIDs[i] = messages[i].ID
+			}
+			assert.ElementsMatch(tc.want, gotIDs, "SearchFast IDs")
+
+			count, err := engine.SearchFastCount(ctx, q, query.MessageFilter{})
+			require.NoError(err, "SearchFastCount")
+			assert.Equal(int64(len(messages)), count, "result/count agreement")
+		})
+	}
+
+	// The generic search contract remains composite and must still find body
+	// text after the metadata-only fast path is corrected.
+	messages, err := engine.Search(ctx, &search.Query{TextTerms: []string{"bodyneedle"}}, 50, 0)
+	rootRequire.NoError(err, "Search")
+	rootRequire.Len(messages, 1, "generic Search body hit")
+	rootAssert.Equal(bodyOnlyID, messages[0].ID, "generic Search body hit ID")
+}
+
+func TestSearchFastWithStats_MetadataPredicateConsistency(t *testing.T) {
+	rootRequire := require.New(t)
+	f := storetest.New(t)
+	ctx := context.Background()
+
+	metadataID := createSearchScopeMessage(t, f, "scope-stats-metadata",
+		"metadatastatneedle subject", "ordinary preview", "ordinary body", 0, 0)
+	createSearchScopeMessage(t, f, "scope-stats-body",
+		"ordinary subject", "ordinary preview", "bodystatneedle appears only in the body", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	rootRequire.NoError(err, "BackfillFTS")
+
+	engine := query.NewSQLiteEngine(f.Store.DB())
+	if f.Store.IsPostgreSQL() {
+		engine = query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
+	}
+
+	tests := []struct {
+		name    string
+		term    string
+		wantIDs []int64
+	}{
+		{name: "body-only term", term: "bodystatneedle", wantIDs: []int64{}},
+		{name: "metadata term", term: "metadatastatneedle", wantIDs: []int64{metadataID}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			result, err := engine.SearchFastWithStats(ctx,
+				&search.Query{TextTerms: []string{tc.term}}, tc.term,
+				query.MessageFilter{}, query.ViewSenders, 50, 0)
+			require.NoError(err, "SearchFastWithStats")
+			require.NotNil(result.Stats, "search stats")
+
+			gotIDs := make([]int64, len(result.Messages))
+			for i := range result.Messages {
+				gotIDs[i] = result.Messages[i].ID
+			}
+			assert.ElementsMatch(tc.wantIDs, gotIDs, "message IDs")
+			assert.Equal(int64(len(tc.wantIDs)), result.TotalCount, "total count")
+			assert.Equal(result.TotalCount, result.Stats.MessageCount,
+				"stats must describe the same metadata-only matches")
+		})
+	}
+}
+
+// TestSearchMessageBodies_BodyColumnOnly runs against SQLite by default and
+// PostgreSQL in the test-pg lane. Every non-body FTS field carries the same
+// term in a different message, proving the optional capability scopes the
+// index to the body column/weight instead of returning composite hits.
+func TestSearchMessageBodies_BodyColumnOnly(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	ctx := context.Background()
+
+	fromID := f.EnsureParticipant("scopeword@example.com", "Scopeword Sender", "example.com")
+	toID := f.EnsureParticipant("scopeword-to@example.com", "Scopeword To", "example.com")
+	ccID := f.EnsureParticipant("scopeword-cc@example.com", "Scopeword Cc", "example.com")
+
+	bodyID := createSearchScopeMessage(t, f, "body-scope-body", "ordinary subject", "ordinary preview", "scopeword appears in the body", 0, 0)
+	createSearchScopeMessage(t, f, "body-scope-subject", "scopeword subject", "ordinary preview", "ordinary body", 0, 0)
+	fromMessageID := createSearchScopeMessage(t, f, "body-scope-from", "ordinary subject", "ordinary preview", "ordinary body", fromID, 0)
+	toMessageID := createSearchScopeMessage(t, f, "body-scope-to", "ordinary subject", "ordinary preview", "ordinary body", 0, toID)
+	ccMessageID := createSearchScopeMessage(t, f, "body-scope-cc", "ordinary subject", "ordinary preview", "ordinary body", 0, 0)
+	require.NoError(f.Store.ReplaceMessageRecipients(
+		ccMessageID, "cc", []int64{ccID}, []string{"Scopeword Cc"}), "ReplaceMessageRecipients(cc)")
+
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	engine := query.NewSQLiteEngine(f.Store.DB())
+	if f.Store.IsPostgreSQL() {
+		engine = query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
+	}
+
+	messages, err := engine.SearchMessageBodies(ctx, &search.Query{TextTerms: []string{"scopeword"}}, 50, 0)
+	require.NoError(err, "SearchMessageBodies")
+	require.Len(messages, 1, "body-only hits")
+	assert.Equal(bodyID, messages[0].ID, "body-only hit ID")
+
+	nonBodyIDs := []int64{fromMessageID, toMessageID, ccMessageID}
+	for _, id := range nonBodyIDs {
+		assert.NotEqual(id, messages[0].ID, "metadata-only FTS field must not cross into body scope")
+	}
+}
+
+func TestSearchMessageBodies_PostgreSQLRejectsStaleLayout(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if !f.Store.IsPostgreSQL() {
+		t.Skip("PostgreSQL indexing_version readiness contract")
+	}
+	messageID := createSearchScopeMessage(t, f, "body-scope-stale", "ordinary subject", "ordinary preview", "stalecheck body", 0, 0)
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+	assert.False(f.Store.NeedsFTSBackfill(), "fresh layout is ready")
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		"UPDATE messages SET indexing_version = ? WHERE id = ?"),
+		store.CurrentFTSIndexingVersion-1, messageID)
+	require.NoError(err, "mark layout stale")
+	assert.True(f.Store.NeedsFTSBackfill(), "stale version needs backfill")
+
+	engine := query.NewEngineWithDialect(f.Store.DB(), query.PostgreSQLQueryDialect{})
+	_, err = engine.SearchMessageBodies(context.Background(),
+		&search.Query{TextTerms: []string{"stalecheck"}}, 50, 0)
+	require.Error(err, "stale body search must fail closed")
+	require.ErrorIs(err, query.ErrMessageBodySearchIndexStale)
+	assert.Contains(err.Error(), "rebuild-fts")
+	assert.Contains(err.Error(), "backfill")
+}
+
+func createSearchScopeMessage(
+	t *testing.T,
+	f *storetest.Fixture,
+	sourceMessageID, subject, snippet, body string,
+	senderID, recipientID int64,
+) int64 {
+	t.Helper()
+
+	messageID := f.NewMessage().
+		WithSourceMessageID(sourceMessageID).
+		WithSubject(subject).
+		WithSnippet(snippet).
+		Create(t, f.Store)
+	require.NoError(t, f.Store.UpsertMessageBody(messageID,
+		sql.NullString{String: body, Valid: true}, sql.NullString{}), "UpsertMessageBody")
+	if senderID != 0 {
+		require.NoError(t, f.Store.ReplaceMessageRecipients(
+			messageID, "from", []int64{senderID}, []string{"Sender Needle"}), "ReplaceMessageRecipients(from)")
+	}
+	if recipientID != 0 {
+		require.NoError(t, f.Store.ReplaceMessageRecipients(
+			messageID, "to", []int64{recipientID}, []string{"Recipient Needle"}), "ReplaceMessageRecipients(to)")
+	}
+	return messageID
+}

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1798,6 +1798,12 @@ func (e *SQLiteEngine) SearchMessageBodies(ctx context.Context, q *search.Query,
 // SearchFast and SearchFastCount. Structured operators retain the generic
 // Search semantics, while free text is deliberately kept off the composite
 // body FTS index.
+func metadataContainsExpression(d Dialect, column string) string {
+	value := d.UnicodeLowerExpression("COALESCE(" + column + ", '')")
+	pattern := d.UnicodeLowerExpression("?")
+	return fmt.Sprintf(`%s LIKE %s ESCAPE '\'`, value, pattern)
+}
+
 func (e *SQLiteEngine) buildMetadataSearchQueryParts(ctx context.Context, q *search.Query) (conditions []string, args []any, ftsJoin string) {
 	structured := *q
 	structured.TextTerms = nil
@@ -1805,19 +1811,19 @@ func (e *SQLiteEngine) buildMetadataSearchQueryParts(ctx context.Context, q *sea
 
 	for _, term := range q.TextTerms {
 		pattern := "%" + escapeSQLiteLike(term) + "%"
-		conditions = append(conditions, `(
-			LOWER(COALESCE(m.subject, '')) LIKE LOWER(?) ESCAPE '\' OR
-			LOWER(COALESCE(m.snippet, '')) LIKE LOWER(?) ESCAPE '\' OR
+		conditions = append(conditions, fmt.Sprintf(`(
+			%s OR
+			%s OR
 			EXISTS (
 				SELECT 1
 				FROM message_recipients mr_meta
 				JOIN participants p_meta ON p_meta.id = mr_meta.participant_id
 				WHERE mr_meta.message_id = m.id
 				  AND (
-					LOWER(COALESCE(p_meta.email_address, '')) LIKE LOWER(?) ESCAPE '\' OR
-					LOWER(COALESCE(p_meta.display_name, '')) LIKE LOWER(?) ESCAPE '\' OR
-					LOWER(COALESCE(p_meta.phone_number, '')) LIKE LOWER(?) ESCAPE '\' OR
-					LOWER(COALESCE(mr_meta.display_name, '')) LIKE LOWER(?) ESCAPE '\'
+					%s OR
+					%s OR
+					%s OR
+					%s
 				  )
 			) OR
 			EXISTS (
@@ -1825,12 +1831,22 @@ func (e *SQLiteEngine) buildMetadataSearchQueryParts(ctx context.Context, q *sea
 				FROM participants p_direct_meta
 				WHERE p_direct_meta.id = m.sender_id
 				  AND (
-					LOWER(COALESCE(p_direct_meta.email_address, '')) LIKE LOWER(?) ESCAPE '\' OR
-					LOWER(COALESCE(p_direct_meta.display_name, '')) LIKE LOWER(?) ESCAPE '\' OR
-					LOWER(COALESCE(p_direct_meta.phone_number, '')) LIKE LOWER(?) ESCAPE '\'
+					%s OR
+					%s OR
+					%s
 				  )
 			)
-		)`)
+		)`,
+			metadataContainsExpression(e.dialect, "m.subject"),
+			metadataContainsExpression(e.dialect, "m.snippet"),
+			metadataContainsExpression(e.dialect, "p_meta.email_address"),
+			metadataContainsExpression(e.dialect, "p_meta.display_name"),
+			metadataContainsExpression(e.dialect, "p_meta.phone_number"),
+			metadataContainsExpression(e.dialect, "mr_meta.display_name"),
+			metadataContainsExpression(e.dialect, "p_direct_meta.email_address"),
+			metadataContainsExpression(e.dialect, "p_direct_meta.display_name"),
+			metadataContainsExpression(e.dialect, "p_direct_meta.phone_number"),
+		))
 		for range 9 {
 			args = append(args, pattern)
 		}

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1757,12 +1757,14 @@ func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offse
 	return e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
 }
 
-// SearchMessageBodies performs exact body-only full-text search. It never
-// reads message_bodies: SQLite scopes MATCH to the FTS5 body column, while
-// PostgreSQL restricts tsquery lexemes to the D-weight body field.
+// SearchMessageBodies performs exact body-only full-text search and uses the
+// active backend's native tokenizer to attach bounded context to every hit.
 func (e *SQLiteEngine) SearchMessageBodies(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
 	if q == nil || len(q.TextTerms) == 0 {
 		return nil, errors.New("message body search requires at least one free-text term")
+	}
+	if err := validateMessageBodyContextQuery(q.TextTerms); err != nil {
+		return nil, err
 	}
 	if !e.hasFTSTable(ctx) {
 		return nil, fmt.Errorf("%w: run 'msgvault rebuild-fts' with an FTS-enabled build", ErrMessageBodySearchUnavailable)
@@ -1788,7 +1790,14 @@ func (e *SQLiteEngine) SearchMessageBodies(ctx context.Context, q *search.Query,
 	if ftsJoin == "" {
 		ftsJoin = e.dialect.FTSJoin()
 	}
-	return e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
+	results, err := e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	if err := e.attachMessageBodySearchContexts(ctx, results, q.TextTerms); err != nil {
+		return nil, fmt.Errorf("extract message body contexts: %w", err)
+	}
+	return results, nil
 }
 
 // buildMetadataSearchQueryParts builds the metadata-only predicate shared by

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -697,8 +697,7 @@ func (e *SQLiteEngine) buildAggregateSearchParts(
 	if groupBy == ViewLabels && len(q.Labels) > 0 {
 		var labelParts []string
 		for _, label := range q.Labels {
-			labelParts = append(labelParts,
-				`LOWER(l.name) LIKE LOWER(?) ESCAPE '\'`)
+			labelParts = append(labelParts, metadataContainsExpression(e.dialect, "l.name"))
 			args = append(args,
 				"%"+escapeSQLiteLike(label)+"%")
 		}
@@ -1664,22 +1663,20 @@ func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Quer
 	// Label filter - case-insensitive substring match using EXISTS
 	// so each label term can match a different row in message_labels.
 	for _, label := range q.Labels {
-		conditions = append(conditions, `EXISTS (
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
 			SELECT 1 FROM message_labels ml_lbl
 			JOIN labels l_lbl ON l_lbl.id = ml_lbl.label_id
 			WHERE ml_lbl.message_id = m.id
-			  AND LOWER(l_lbl.name) LIKE LOWER(?) ESCAPE '\'
-		)`)
+			  AND %s
+		)`, metadataContainsExpression(e.dialect, "l_lbl.name")))
 		args = append(args, "%"+escapeSQLiteLike(label)+"%")
 	}
 
-	// Subject filter. LOWER both sides so PostgreSQL's case-sensitive
-	// LIKE matches the same rows the store API path returns (which
-	// already lowercases). SQLite's LIKE is ASCII-case-insensitive but
-	// the LOWER wrapper still works there.
+	// Subject filter. Use the dialect's Unicode-aware fold on both sides so
+	// SQLite and PostgreSQL retain the same case-insensitive substring contract.
 	if len(q.SubjectTerms) > 0 {
 		for _, term := range q.SubjectTerms {
-			conditions = append(conditions, "LOWER(m.subject) LIKE LOWER(?) ESCAPE '\\'")
+			conditions = append(conditions, metadataContainsExpression(e.dialect, "m.subject"))
 			args = append(args, "%"+escapeSQLiteLike(term)+"%")
 		}
 	}

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1760,11 +1760,90 @@ func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offse
 	return e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
 }
 
-// SearchFast searches using the same FTS5 path as Search but merges
-// MessageFilter context into the query (drill-down filters, hide-deleted, etc.).
+// SearchMessageBodies performs exact body-only full-text search. It never
+// reads message_bodies: SQLite scopes MATCH to the FTS5 body column, while
+// PostgreSQL restricts tsquery lexemes to the D-weight body field.
+func (e *SQLiteEngine) SearchMessageBodies(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
+	if q == nil || len(q.TextTerms) == 0 {
+		return nil, errors.New("message body search requires at least one free-text term")
+	}
+	if !e.hasFTSTable(ctx) {
+		return nil, fmt.Errorf("%w: run 'msgvault rebuild-fts' with an FTS-enabled build", ErrMessageBodySearchUnavailable)
+	}
+	if readinessSQL := e.dialect.FTSBodySearchReadinessSQL(); readinessSQL != "" {
+		var ready bool
+		if err := e.queryRowContext(ctx, readinessSQL).Scan(&ready); err != nil {
+			return nil, fmt.Errorf("check message body search index readiness: %w", err)
+		}
+		if !ready {
+			return nil, fmt.Errorf("%w: run 'msgvault rebuild-fts' or complete the FTS backfill, then retry", ErrMessageBodySearchIndexStale)
+		}
+	}
+
+	structured := *q
+	structured.TextTerms = nil
+	conditions, args, ftsJoin := e.buildSearchQueryParts(ctx, &structured)
+	expr, arg := e.dialect.BuildFTSBodyTerm(q.TextTerms)
+	conditions = append(conditions, expr)
+	if arg != "" {
+		args = append(args, arg)
+	}
+	if ftsJoin == "" {
+		ftsJoin = e.dialect.FTSJoin()
+	}
+	return e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
+}
+
+// buildMetadataSearchQueryParts builds the metadata-only predicate shared by
+// SearchFast and SearchFastCount. Structured operators retain the generic
+// Search semantics, while free text is deliberately kept off the composite
+// body FTS index.
+func (e *SQLiteEngine) buildMetadataSearchQueryParts(ctx context.Context, q *search.Query) (conditions []string, args []any, ftsJoin string) {
+	structured := *q
+	structured.TextTerms = nil
+	conditions, args, ftsJoin = e.buildSearchQueryParts(ctx, &structured)
+
+	for _, term := range q.TextTerms {
+		pattern := "%" + escapeSQLiteLike(term) + "%"
+		conditions = append(conditions, `(
+			LOWER(COALESCE(m.subject, '')) LIKE LOWER(?) ESCAPE '\' OR
+			LOWER(COALESCE(m.snippet, '')) LIKE LOWER(?) ESCAPE '\' OR
+			EXISTS (
+				SELECT 1
+				FROM message_recipients mr_meta
+				JOIN participants p_meta ON p_meta.id = mr_meta.participant_id
+				WHERE mr_meta.message_id = m.id
+				  AND (
+					LOWER(COALESCE(p_meta.email_address, '')) LIKE LOWER(?) ESCAPE '\' OR
+					LOWER(COALESCE(p_meta.display_name, '')) LIKE LOWER(?) ESCAPE '\' OR
+					LOWER(COALESCE(p_meta.phone_number, '')) LIKE LOWER(?) ESCAPE '\' OR
+					LOWER(COALESCE(mr_meta.display_name, '')) LIKE LOWER(?) ESCAPE '\'
+				  )
+			) OR
+			EXISTS (
+				SELECT 1
+				FROM participants p_direct_meta
+				WHERE p_direct_meta.id = m.sender_id
+				  AND (
+					LOWER(COALESCE(p_direct_meta.email_address, '')) LIKE LOWER(?) ESCAPE '\' OR
+					LOWER(COALESCE(p_direct_meta.display_name, '')) LIKE LOWER(?) ESCAPE '\' OR
+					LOWER(COALESCE(p_direct_meta.phone_number, '')) LIKE LOWER(?) ESCAPE '\'
+				  )
+			)
+		)`)
+		for range 9 {
+			args = append(args, pattern)
+		}
+	}
+
+	return conditions, args, ftsJoin
+}
+
+// SearchFast searches message metadata and merges MessageFilter context into
+// the query (drill-down filters, hide-deleted, etc.).
 func (e *SQLiteEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
 	mergedQuery := MergeFilterIntoQuery(q, filter)
-	conditions, args, ftsJoin := e.buildSearchQueryParts(ctx, mergedQuery)
+	conditions, args, ftsJoin := e.buildMetadataSearchQueryParts(ctx, mergedQuery)
 	return e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
 }
 
@@ -2022,8 +2101,11 @@ func timePeriodToBounds(period string) (after, before time.Time, ok bool) {
 // Uses the same query logic as SearchFast to ensure consistent counts.
 func (e *SQLiteEngine) SearchFastCount(ctx context.Context, q *search.Query, filter MessageFilter) (int64, error) {
 	mergedQuery := MergeFilterIntoQuery(q, filter)
-	conditions, args, ftsJoin := e.buildSearchQueryParts(ctx, mergedQuery)
+	conditions, args, ftsJoin := e.buildMetadataSearchQueryParts(ctx, mergedQuery)
+	return e.executeSearchCount(ctx, conditions, args, ftsJoin)
+}
 
+func (e *SQLiteEngine) executeSearchCount(ctx context.Context, conditions []string, args []any, ftsJoin string) (int64, error) {
 	whereClause := strings.Join(conditions, " AND ")
 	if whereClause == "" {
 		whereClause = "1=1"
@@ -2043,31 +2125,93 @@ func (e *SQLiteEngine) SearchFastCount(ctx context.Context, q *search.Query, fil
 	return count, nil
 }
 
-// SearchFastWithStats delegates to SearchFast + SearchFastCount + GetTotalStats.
-// SQLite doesn't benefit from temp table materialization, so we just call the
-// existing methods independently.
+// getMetadataSearchStats computes every aggregate from the same metadata-only
+// predicate used by SearchFast and SearchFastCount. Generic GetTotalStats keeps
+// its composite full-text semantics for its independent public contract.
+func (e *SQLiteEngine) getMetadataSearchStats(ctx context.Context, conditions []string, args []any, ftsJoin string) (*TotalStats, error) {
+	whereClause := strings.Join(conditions, " AND ")
+	if whereClause == "" {
+		whereClause = "1=1"
+	}
+
+	searchMatches := fmt.Sprintf(`
+		SELECT
+			m.id,
+			m.source_id,
+			m.deleted_from_source_at,
+			COALESCE(m.size_estimate, 0) AS size_estimate
+		FROM messages m
+		%s
+		WHERE %s
+	`, ftsJoin, whereClause)
+
+	stats := &TotalStats{}
+	messageStatsQuery := fmt.Sprintf(`
+		WITH search_matches AS (%s)
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(CASE WHEN deleted_from_source_at IS NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN deleted_from_source_at IS NOT NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(size_estimate), 0),
+			COUNT(DISTINCT source_id)
+		FROM search_matches
+	`, searchMatches)
+	if err := e.queryRowContext(ctx, messageStatsQuery, args...).Scan(
+		&stats.MessageCount,
+		&stats.ActiveMessageCount,
+		&stats.SourceDeletedMessageCount,
+		&stats.TotalSize,
+		&stats.AccountCount,
+	); err != nil {
+		return nil, fmt.Errorf("metadata search message stats: %w", err)
+	}
+
+	attachmentStatsQuery := fmt.Sprintf(`
+		WITH search_matches AS (%s)
+		SELECT COUNT(*), COALESCE(SUM(a.size), 0)
+		FROM attachments a
+		JOIN search_matches sm ON sm.id = a.message_id
+	`, searchMatches)
+	if err := e.queryRowContext(ctx, attachmentStatsQuery, args...).Scan(
+		&stats.AttachmentCount,
+		&stats.AttachmentSize,
+	); err != nil {
+		return nil, fmt.Errorf("metadata search attachment stats: %w", err)
+	}
+
+	labelStatsQuery := fmt.Sprintf(`
+		WITH search_matches AS (%s)
+		SELECT COUNT(DISTINCT l.name)
+		FROM labels l
+		JOIN message_labels ml ON ml.label_id = l.id
+		JOIN search_matches sm ON sm.id = ml.message_id
+	`, searchMatches)
+	if err := e.queryRowContext(ctx, labelStatsQuery, args...).Scan(&stats.LabelCount); err != nil {
+		return nil, fmt.Errorf("metadata search label stats: %w", err)
+	}
+
+	return stats, nil
+}
+
+// SearchFastWithStats builds the metadata-only predicate once and reuses it
+// for messages, count, and stats so all three describe the same match set.
 func (e *SQLiteEngine) SearchFastWithStats(ctx context.Context, q *search.Query, queryStr string,
 	filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
-	results, err := e.SearchFast(ctx, q, filter, limit, offset)
+	mergedQuery := MergeFilterIntoQuery(q, filter)
+	conditions, args, ftsJoin := e.buildMetadataSearchQueryParts(ctx, mergedQuery)
+	results, err := e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
 	if err != nil {
 		return nil, err
 	}
 
 	// Best-effort count: don't abort the search if count fails.
-	count, countErr := e.SearchFastCount(ctx, q, filter)
+	count, countErr := e.executeSearchCount(ctx, conditions, args, ftsJoin)
 	if countErr != nil {
 		log.Printf("warning: search count failed (using -1): %v", countErr)
 		count = -1
 	}
 
-	statsOpts := StatsOptions{
-		SourceID:              filter.SourceID,
-		WithAttachmentsOnly:   filter.WithAttachmentsOnly,
-		HideDeletedFromSource: filter.HideDeletedFromSource,
-		SearchQuery:           queryStr,
-		GroupBy:               statsGroupBy,
-	}
-	stats, _ := e.GetTotalStats(ctx, statsOpts)
+	stats, _ := e.getMetadataSearchStats(ctx, conditions, args, ftsJoin)
 
 	return &SearchFastResult{
 		Messages:   results,

--- a/internal/sqliteutil/driver.go
+++ b/internal/sqliteutil/driver.go
@@ -1,0 +1,35 @@
+// Package sqliteutil provides the SQLite driver variant shared by msgvault's
+// production store and tests that exercise SQLite query behavior.
+package sqliteutil
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+const (
+	driverName           = "msgvault_sqlite3"
+	UnicodeLowerFunction = "msgvault_unicode_lower"
+)
+
+var registerDriverOnce sync.Once
+
+// DriverName returns a go-sqlite3 driver whose every connection exposes the
+// deterministic Unicode-aware lowercasing function used by metadata search.
+func DriverName() string {
+	registerDriverOnce.Do(func() {
+		sql.Register(driverName, &sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				if err := conn.RegisterFunc(UnicodeLowerFunction, strings.ToLower, true); err != nil {
+					return fmt.Errorf("register %s: %w", UnicodeLowerFunction, err)
+				}
+				return nil
+			},
+		})
+	})
+	return driverName
+}

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -5,6 +5,11 @@ import (
 	"database/sql"
 )
 
+// CurrentFTSIndexingVersion identifies the PostgreSQL search_fts field-weight
+// layout. Version 2 assigns subject=A, sender=B, recipients=C, and body=D so
+// exact body-only queries can restrict tsquery matches to weight D.
+const CurrentFTSIndexingVersion = 2
+
 // FTSDoc is the set of fields the dialect needs to upsert a message into
 // the full-text search index.
 type FTSDoc struct {

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -85,6 +85,11 @@ type Dialect interface {
 	// a given source. Takes one parameter: source_id.
 	FTSDeleteSQL() string
 
+	// InvalidateFTSForMessage removes or marks stale one message's search
+	// document before its canonical body changes. This prevents a failed
+	// best-effort reindex from leaving an old body searchable as an exact hit.
+	InvalidateFTSForMessage(q querier, messageID int64) error
+
 	// FTSBackfillBatchSQL returns the SQL to populate the search index for a range of message IDs.
 	// Uses two ? placeholders for the ID range: WHERE m.id >= ? AND m.id < ?
 	FTSBackfillBatchSQL() string

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -171,9 +171,10 @@ func (d *PostgreSQLDialect) FTSUpsert(q querier, doc FTSDoc) error {
 		`UPDATE messages SET search_fts =
 			setweight(to_tsvector('simple', LEFT(COALESCE($2, ''), `+charCap+`)), 'A') ||
 			setweight(to_tsvector('simple', LEFT(COALESCE($4, ''), `+charCap+`)), 'B') ||
-			to_tsvector('simple', LEFT(COALESCE($3, ''), `+charCap+`)) ||
-			to_tsvector('simple', LEFT(COALESCE($5, ''), `+charCap+`)) ||
-			to_tsvector('simple', LEFT(COALESCE($6, ''), `+charCap+`))
+			setweight(to_tsvector('simple', LEFT(COALESCE($5, ''), `+charCap+`)), 'C') ||
+			setweight(to_tsvector('simple', LEFT(COALESCE($6, ''), `+charCap+`)), 'C') ||
+			setweight(to_tsvector('simple', LEFT(COALESCE($3, ''), `+charCap+`)), 'D'),
+			indexing_version = `+strconv.Itoa(CurrentFTSIndexingVersion)+`
 		WHERE id = $1`,
 		doc.MessageID, subject, body,
 		fromAddr, toAddrs, ccAddrs,
@@ -191,7 +192,7 @@ func (d *PostgreSQLDialect) FTSUpsert(q querier, doc FTSDoc) error {
 func (d *PostgreSQLDialect) FTSSearchClause() (join, where, orderBy string, orderArgCount int) {
 	return "",
 		"m.search_fts @@ to_tsquery('simple', ?)",
-		"ts_rank(m.search_fts, to_tsquery('simple', ?)) DESC",
+		"ts_rank(ARRAY[0.1, 0.1, 0.4, 1.0]::real[], m.search_fts, to_tsquery('simple', ?)) DESC",
 		1
 }
 
@@ -207,7 +208,6 @@ func (d *PostgreSQLDialect) FTSBackfillBatchSQL() string {
 	charCap := strconv.Itoa(maxFTSBodyChars)
 	return `UPDATE messages m SET search_fts =
 		setweight(to_tsvector('simple', LEFT(COALESCE(m.subject, ''), ` + charCap + `)), 'A') ||
-		to_tsvector('simple', LEFT(COALESCE(src.body_text, ''), ` + charCap + `)) ||
 		setweight(to_tsvector('simple', LEFT(COALESCE(
 			CASE WHEN m.message_type != 'email' AND m.message_type IS NOT NULL AND m.message_type != ''
 			     THEN (SELECT COALESCE(p.phone_number, p.email_address) FROM participants p WHERE p.id = m.sender_id)
@@ -215,8 +215,10 @@ func (d *PostgreSQLDialect) FTSBackfillBatchSQL() string {
 			(SELECT STRING_AGG(p.email_address, ' ') FROM message_recipients mr JOIN participants p ON p.id = mr.participant_id WHERE mr.message_id = m.id AND mr.recipient_type = 'from'),
 			''
 		), ` + charCap + `)), 'B') ||
-		to_tsvector('simple', LEFT(COALESCE((SELECT STRING_AGG(p.email_address, ' ') FROM message_recipients mr JOIN participants p ON p.id = mr.participant_id WHERE mr.message_id = m.id AND mr.recipient_type = 'to'), ''), ` + charCap + `)) ||
-		to_tsvector('simple', LEFT(COALESCE((SELECT STRING_AGG(p.email_address, ' ') FROM message_recipients mr JOIN participants p ON p.id = mr.participant_id WHERE mr.message_id = m.id AND mr.recipient_type = 'cc'), ''), ` + charCap + `))
+		setweight(to_tsvector('simple', LEFT(COALESCE((SELECT STRING_AGG(p.email_address, ' ') FROM message_recipients mr JOIN participants p ON p.id = mr.participant_id WHERE mr.message_id = m.id AND mr.recipient_type = 'to'), ''), ` + charCap + `)), 'C') ||
+		setweight(to_tsvector('simple', LEFT(COALESCE((SELECT STRING_AGG(p.email_address, ' ') FROM message_recipients mr JOIN participants p ON p.id = mr.participant_id WHERE mr.message_id = m.id AND mr.recipient_type = 'cc'), ''), ` + charCap + `)), 'C') ||
+		setweight(to_tsvector('simple', LEFT(COALESCE(src.body_text, ''), ` + charCap + `)), 'D'),
+		indexing_version = ` + strconv.Itoa(CurrentFTSIndexingVersion) + `
 	FROM (
 		SELECT m2.id, mb.body_text
 		FROM messages m2
@@ -234,29 +236,35 @@ func (d *PostgreSQLDialect) FTSAvailable(db *sql.DB) bool {
 	return err == nil && count > 0
 }
 
-// FTSNeedsBackfill reports whether the tsvector column needs population.
-// Probes for the existence of any NULL search_fts row so an interrupted
-// backfill that leaves a low-id row NULL (and later inserts continue normally)
-// still flags the gap — the previous max-vs-max comparison missed that case.
+func postgresFTSNeedsBackfillSQL() string {
+	return fmt.Sprintf(
+		"SELECT EXISTS (SELECT 1 FROM messages WHERE search_fts IS NULL OR indexing_version IS DISTINCT FROM %d)",
+		CurrentFTSIndexingVersion,
+	)
+}
+
+// FTSNeedsBackfill reports whether the tsvector column needs population or
+// uses an obsolete field-weight layout. It probes for a NULL search_fts or an
+// indexing_version other than CurrentFTSIndexingVersion, so both interrupted
+// backfills and durable layout migrations remain visible.
 //
 // Uses EXISTS rather than COUNT(*): a GIN index on search_fts cannot serve an
 // `IS NULL` predicate, so COUNT(*) was a full sequential scan of every message
-// on each startup. EXISTS short-circuits at the first NULL row. The partial
-// btree index idx_messages_search_fts_null (created by EnsureFTSIndex) makes
-// even the false case index-served and self-pruning as backfill completes.
+// on each startup. EXISTS short-circuits at the first NULL row. The versioned
+// partial btree index created by EnsureFTSIndex makes even the false
+// case index-served and self-pruning as backfill completes.
 func (d *PostgreSQLDialect) FTSNeedsBackfill(db *sql.DB) bool {
 	var exists bool
 	if err := db.QueryRow(
-		"SELECT EXISTS (SELECT 1 FROM messages WHERE search_fts IS NULL)",
+		postgresFTSNeedsBackfillSQL(),
 	).Scan(&exists); err != nil {
 		return false
 	}
 	return exists
 }
 
-// FTSNeedsBackfillQuick delegates to FTSNeedsBackfill: the EXISTS probe is
-// already index-served by idx_messages_search_fts_null, so the exact check
-// is as cheap as any approximation would be.
+// FTSNeedsBackfillQuick delegates to FTSNeedsBackfill: the versioned stale-row
+// index makes the exact EXISTS probe as cheap as any approximation would be.
 func (d *PostgreSQLDialect) FTSNeedsBackfillQuick(db *sql.DB) bool {
 	return d.FTSNeedsBackfill(db)
 }
@@ -352,14 +360,13 @@ func (d *PostgreSQLDialect) EnsureFTSIndex(q querier) error {
 	); err != nil {
 		return fmt.Errorf("create messages_search_fts_idx: %w", err)
 	}
-	// Partial btree index that serves the FTSNeedsBackfill probe (a GIN index
-	// on search_fts cannot answer an IS NULL predicate). It only indexes the
-	// rows still awaiting backfill, so it self-prunes to empty as backfill
-	// completes and stays tiny thereafter.
+	// Version the partial-index name as well as its predicate: IF NOT EXISTS
+	// cannot alter the legacy NULL-only index on upgraded databases.
+	staleIndexName := fmt.Sprintf("idx_messages_search_fts_stale_v%d", CurrentFTSIndexingVersion)
 	if _, err := q.Exec(
-		"CREATE INDEX IF NOT EXISTS idx_messages_search_fts_null ON messages (id) WHERE search_fts IS NULL",
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON messages (id) WHERE search_fts IS NULL OR indexing_version IS DISTINCT FROM %d", staleIndexName, CurrentFTSIndexingVersion),
 	); err != nil {
-		return fmt.Errorf("create idx_messages_search_fts_null: %w", err)
+		return fmt.Errorf("create %s: %w", staleIndexName, err)
 	}
 	return nil
 }

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -201,6 +201,14 @@ func (d *PostgreSQLDialect) FTSDeleteSQL() string {
 	return `UPDATE messages SET search_fts = NULL WHERE source_id = $1`
 }
 
+func (d *PostgreSQLDialect) InvalidateFTSForMessage(q querier, messageID int64) error {
+	_, err := q.Exec(
+		"UPDATE messages SET search_fts = NULL, indexing_version = NULL WHERE id = $1",
+		messageID,
+	)
+	return err
+}
+
 // FTSBackfillBatchSQL returns the SQL to populate tsvector for a range of message IDs.
 // Parameters: $1=fromID, $2=toID. Uses LEFT JOIN on message_bodies via a subquery
 // so messages without a body row are still indexed (subject + participants).

--- a/internal/store/dialect_pg_test.go
+++ b/internal/store/dialect_pg_test.go
@@ -1,9 +1,12 @@
 package store
 
 import (
+	"database/sql"
+	"database/sql/driver"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPostgreSQLDialect_Rebind(t *testing.T) {
@@ -102,8 +105,73 @@ func TestPostgreSQLDialect_FTSSearchClause(t *testing.T) {
 	join, where, orderBy, orderArgCount := d.FTSSearchClause()
 	assert.Empty(join, "join (PostgreSQL needs no JOIN)")
 	assert.Equal("m.search_fts @@ to_tsquery('simple', ?)", where)
-	assert.Equal("ts_rank(m.search_fts, to_tsquery('simple', ?)) DESC", orderBy)
+	assert.Equal("ts_rank(ARRAY[0.1, 0.1, 0.4, 1.0]::real[], m.search_fts, to_tsquery('simple', ?)) DESC", orderBy)
 	assert.Equal(1, orderArgCount, "orderArgCount (ts_rank needs query a second time)")
+}
+
+type recordingFTSQuerier struct {
+	query string
+	args  []any
+	all   []string
+}
+
+func (q *recordingFTSQuerier) Exec(query string, args ...any) (sql.Result, error) {
+	q.query = query
+	q.args = args
+	q.all = append(q.all, query)
+	return driver.RowsAffected(1), nil
+}
+
+func (*recordingFTSQuerier) QueryRow(string, ...any) *sql.Row {
+	panic("QueryRow is not used by FTSUpsert")
+}
+
+func TestPostgreSQLDialect_FTSLayoutVersioned(t *testing.T) {
+	assert := assert.New(t)
+	d := &PostgreSQLDialect{}
+	q := &recordingFTSQuerier{}
+	require.NoError(t, d.FTSUpsert(q, FTSDoc{
+		MessageID: 1,
+		Subject:   "subject",
+		Body:      "body",
+		FromAddr:  "from@example.com",
+		ToAddrs:   "to@example.com",
+		CcAddrs:   "cc@example.com",
+	}), "FTSUpsert")
+
+	assert.Contains(q.query, "setweight(to_tsvector('simple', LEFT(COALESCE($2, '')", "subject vector")
+	assert.Contains(q.query, "), 'A')", "subject weight")
+	assert.Contains(q.query, "setweight(to_tsvector('simple', LEFT(COALESCE($4, '')", "sender vector")
+	assert.Contains(q.query, "), 'B')", "sender weight")
+	assert.Contains(q.query, "setweight(to_tsvector('simple', LEFT(COALESCE($5, '')", "to vector")
+	assert.Contains(q.query, "setweight(to_tsvector('simple', LEFT(COALESCE($6, '')", "cc vector")
+	assert.Contains(q.query, "), 'C')", "recipient weight")
+	assert.Contains(q.query, "setweight(to_tsvector('simple', LEFT(COALESCE($3, '')", "body vector")
+	assert.Contains(q.query, "), 'D')", "body weight")
+	assert.Contains(q.query, "indexing_version = 2", "layout version stamp")
+
+	backfill := d.FTSBackfillBatchSQL()
+	assert.Contains(backfill, "setweight(to_tsvector('simple', LEFT(COALESCE(src.body_text, '')", "backfill body vector")
+	assert.Contains(backfill, "), 'D')", "backfill body weight")
+	assert.Contains(backfill, "), 'C')", "backfill recipient weight")
+	assert.Contains(backfill, "indexing_version = 2", "backfill layout version stamp")
+}
+
+func TestPostgreSQLDialect_FTSNeedsBackfillSQLUsesLiteralVersion(t *testing.T) {
+	sql := postgresFTSNeedsBackfillSQL()
+	assert.Contains(t, sql, "indexing_version IS DISTINCT FROM 2")
+	assert.NotContains(t, sql, "$1", "partial-index predicate must remain plan-time provable")
+}
+
+func TestPostgreSQLDialect_EnsureFTSIndexUsesVersionedStalePredicate(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := &PostgreSQLDialect{}
+	q := &recordingFTSQuerier{}
+	require.NoError(d.EnsureFTSIndex(q), "EnsureFTSIndex")
+	require.Len(q.all, 2, "GIN and stale-row indexes")
+	assert.Contains(q.all[1], "idx_messages_search_fts_stale_v2")
+	assert.Contains(q.all[1], "search_fts IS NULL OR indexing_version IS DISTINCT FROM 2")
 }
 
 // TestPostgreSQLDialect_BuildFTSArg covers R3: the tsquery argument

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -10,12 +10,13 @@ import (
 	"unicode"
 
 	"github.com/mattn/go-sqlite3"
+	"go.kenn.io/msgvault/internal/sqliteutil"
 )
 
 // SQLiteDialect implements Dialect for SQLite (the default backend).
 type SQLiteDialect struct{}
 
-func (d *SQLiteDialect) DriverName() string { return "sqlite3" }
+func (d *SQLiteDialect) DriverName() string { return sqliteutil.DriverName() }
 
 // Rebind is a no-op for SQLite — it uses ? placeholders natively.
 func (d *SQLiteDialect) Rebind(query string) string { return query }

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -133,6 +133,17 @@ func (d *SQLiteDialect) FTSDeleteSQL() string {
 	)`
 }
 
+func (d *SQLiteDialect) InvalidateFTSForMessage(q querier, messageID int64) error {
+	_, err := q.Exec("DELETE FROM messages_fts WHERE rowid = ?", messageID)
+	if d.IsNoSuchTableError(err) {
+		// A missing FTS table cannot contain a stale searchable row. Preserve
+		// the existing best-effort indexing contract so canonical message
+		// persistence can continue and a later rebuild can recreate the index.
+		return nil
+	}
+	return err
+}
+
 // FTSBackfillBatchSQL returns the SQL to backfill FTS5 for a range of message IDs.
 // Parameters: fromID(?), toID(?)
 func (d *SQLiteDialect) FTSBackfillBatchSQL() string {

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -96,15 +96,17 @@ func (d *SQLiteDialect) FTSUpsert(q querier, doc FTSDoc) error {
 //
 // The bm25 weights approximate PostgreSQL's setweight field-priority
 // preferences (subject heaviest, then sender, then body / other
-// recipients) for typical email shapes. This is a best-effort SQLite
-// tuning, NOT a strict cross-backend parity guarantee.
+// recipients) for typical email shapes. PostgreSQL assigns recipients
+// weight C and body weight D so body-only search can distinguish them,
+// then supplies explicit rank weights that keep C and D equivalent. This is a
+// best-effort SQLite tuning, NOT a strict cross-backend parity guarantee.
 //
 // Weights are positional over every column declared in messages_fts —
 // UNINDEXED columns count too even though they cannot match — so the
 // leading 1.0 is the placeholder for `message_id UNINDEXED`. The
 // remaining slots map to (subject, body, from_addr, to_addr, cc_addr).
 // PostgreSQL applies setweight 'A'=1.0 to subject and 'B'=0.4 to sender,
-// leaving body and other recipients at default 'D'=0.1 — a 10:4:1 ratio,
+// with explicit C/D rank weights of 0.1 for recipients/body — a 10:4:1 ratio,
 // which bm25 reproduces as 10/1/4/1/1 across (subject, body, from, to,
 // cc). bm25 returns lower (more negative) scores for more relevant rows,
 // so callers ORDER BY this expression ascending (the default).

--- a/internal/store/fts_rowbyrow_fallback_test.go
+++ b/internal/store/fts_rowbyrow_fallback_test.go
@@ -38,13 +38,12 @@ func captureWarnings(t *testing.T) *bytes.Buffer {
 // row in the batch — including ones AFTER the bad one — and (d) BackfillFTS
 // returns no error.
 //
-// The skipped row is NOT left with search_fts NULL: the codebase treats
-// search_fts IS NULL as the sole "needs backfill" signal (FTSNeedsBackfill /
-// idx_messages_search_fts_null), so a permanently-unindexable row left NULL
-// would make backfill re-run forever. The fallback instead marks it with a
-// non-NULL empty tsvector, so it (e) drops out of the needs-backfill probe
-// (NeedsFTSBackfill becomes false) and (f) is correctly unsearchable. This
-// test pins both: the loop-guard and the unsearchability.
+// The skipped row is NOT left with search_fts NULL or an obsolete layout
+// version: either state means "needs backfill", so a permanently-unindexable
+// stale row would make backfill re-run forever. The fallback instead marks it
+// with a non-NULL empty tsvector at the current version, so it (e) drops out of
+// the needs-backfill probe (NeedsFTSBackfill becomes false) and (f) is correctly
+// unsearchable. This test pins both: the loop-guard and the unsearchability.
 //
 // Approach: a test-only injection seam (store.SetBackfillFTSBatchErrHookForTest).
 // A post-cap tsvector overflow is not reliably reproducible — the 600000-char
@@ -110,9 +109,9 @@ func TestPG_BackfillFTS_RowByRowFallbackSkipsBadRow(t *testing.T) {
 	// terminal empty-tsvector UPDATE is not counted as an indexed row).
 	assert.Equal(int64(total-1), n, "every row except the bad one should be indexed")
 
-	// (e) Loop-guard: the skipped row is marked with a non-NULL empty tsvector,
-	// so NO row is left NULL and NeedsFTSBackfill reports false — without this,
-	// the permanently-unindexable row would keep backfill re-running forever.
+	// (e) Loop-guard: the skipped row is marked with a non-NULL empty tsvector
+	// at the current layout version, so NeedsFTSBackfill reports false. Without
+	// both markers, the permanently-unindexable row would keep backfill running.
 	assert.Equal(0, nullSearchFTSCount(t, f.Store),
 		"no row may be left NULL (would make backfill loop forever)")
 	assert.False(f.Store.NeedsFTSBackfill(),
@@ -120,15 +119,18 @@ func TestPG_BackfillFTS_RowByRowFallbackSkipsBadRow(t *testing.T) {
 
 	// The bad row specifically holds the empty tsvector: non-NULL but empty.
 	var (
-		badIsNull bool
-		badFTS    string
+		badIsNull       bool
+		badFTS          string
+		indexingVersion int
 	)
 	require.NoError(f.Store.DB().QueryRow(
-		"SELECT search_fts IS NULL, COALESCE(search_fts::text, '') FROM messages WHERE id = $1",
-		badID).Scan(&badIsNull, &badFTS),
+		"SELECT search_fts IS NULL, COALESCE(search_fts::text, ''), indexing_version FROM messages WHERE id = $1",
+		badID).Scan(&badIsNull, &badFTS, &indexingVersion),
 		"probe bad row")
 	assert.False(badIsNull, "the forced-bad row must be marked non-NULL (terminal)")
 	assert.Empty(badFTS, "the forced-bad row must hold an EMPTY tsvector")
+	assert.Equal(store.CurrentFTSIndexingVersion, indexingVersion,
+		"the forced-bad row must be stamped with the terminal layout version")
 
 	// (c) Good rows BEFORE and AFTER the bad one are indexed and searchable.
 	for i, tok := range tokens {

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -350,13 +350,27 @@ func upsertMessageWith(q querier, d Dialect, msg *Message) (int64, error) {
 
 // UpsertMessageBody stores the body text and HTML for a message in the separate message_bodies table.
 func (s *Store) UpsertMessageBody(messageID int64, bodyText, bodyHTML sql.NullString) error {
-	return upsertMessageBody(s.db, messageID, bodyText, bodyHTML)
+	return upsertMessageBody(s.db, s.dialect, s.fts5Available, messageID, bodyText, bodyHTML)
 }
 
-func upsertMessageBody(q querier, messageID int64, bodyText, bodyHTML sql.NullString) error {
-	bodyChanged, err := messageBodyChanged(q, messageID, bodyText, bodyHTML)
+func upsertMessageBody(
+	q querier,
+	dialect Dialect,
+	ftsAvailable bool,
+	messageID int64,
+	bodyText, bodyHTML sql.NullString,
+) error {
+	embeddingChanged, textChanged, err := messageBodyChanges(q, messageID, bodyText, bodyHTML)
 	if err != nil {
 		return err
+	}
+	if textChanged && ftsAvailable {
+		// Invalidate first. UpsertMessageBody is also used outside a wider
+		// transaction; if the body write then fails, a missing index entry is
+		// recoverable by backfill, while a stale entry could produce a false hit.
+		if err := dialect.InvalidateFTSForMessage(q, messageID); err != nil {
+			return fmt.Errorf("invalidate message FTS document: %w", err)
+		}
 	}
 	_, err = q.Exec(`
 		INSERT INTO message_bodies (message_id, body_text, body_html)
@@ -368,25 +382,31 @@ func upsertMessageBody(q querier, messageID int64, bodyText, bodyHTML sql.NullSt
 	if err != nil {
 		return err
 	}
-	if !bodyChanged {
+	if !embeddingChanged {
 		return nil
 	}
 	_, err = q.Exec(`UPDATE messages SET embed_gen = NULL WHERE id = ? AND embed_gen IS NOT NULL`, messageID)
 	return err
 }
 
-func messageBodyChanged(q querier, messageID int64, bodyText, bodyHTML sql.NullString) (bool, error) {
+func messageBodyChanges(
+	q querier,
+	messageID int64,
+	bodyText, bodyHTML sql.NullString,
+) (embeddingChanged bool, textChanged bool, err error) {
 	var oldText, oldHTML sql.NullString
-	err := q.QueryRow(`
+	err = q.QueryRow(`
 		SELECT body_text, body_html FROM message_bodies WHERE message_id = ?
 	`, messageID).Scan(&oldText, &oldHTML)
 	if errors.Is(err, sql.ErrNoRows) {
-		return embeddingBodyValue(bodyText, bodyHTML) != "", nil
+		return embeddingBodyValue(bodyText, bodyHTML) != "",
+			nullStringValue(bodyText) != "", nil
 	}
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	return embeddingBodyValue(oldText, oldHTML) != embeddingBodyValue(bodyText, bodyHTML), nil
+	return embeddingBodyValue(oldText, oldHTML) != embeddingBodyValue(bodyText, bodyHTML),
+		nullStringValue(oldText) != nullStringValue(bodyText), nil
 }
 
 func embeddingBodyValue(bodyText, bodyHTML sql.NullString) string {
@@ -465,7 +485,9 @@ func (s *Store) PersistMessage(data *MessagePersistData) (int64, error) {
 		}
 		messageID = id
 
-		if err := upsertMessageBody(tx, messageID, data.BodyText, data.BodyHTML); err != nil {
+		if err := upsertMessageBody(
+			tx, s.dialect, s.fts5Available, messageID, data.BodyText, data.BodyHTML,
+		); err != nil {
 			return fmt.Errorf("upsert body: %w", err)
 		}
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -1299,12 +1299,11 @@ func (s *Store) backfillFTSRange(minID, maxID int64, progress func(done, total i
 // tsvector-overflow error; any OTHER per-row error aborts and is returned so a
 // systemic failure cannot be swallowed. Returns the number of rows indexed.
 //
-// A skipped row is NOT left with search_fts NULL: the codebase treats
-// search_fts IS NULL as the sole "needs backfill" signal (FTSNeedsBackfill /
-// idx_messages_search_fts_null), so leaving a permanently-unindexable row NULL
-// would make backfill re-run forever, re-hitting the same overflow each time.
-// Instead the row is marked with a non-NULL empty tsvector: it drops out of the
-// needs-backfill probe and the partial NULL index, and the row is correctly
+// A skipped row is NOT left with search_fts NULL or an obsolete
+// indexing_version: either state means "needs backfill", so leaving a
+// permanently-unindexable row stale would make backfill re-run forever,
+// re-hitting the same overflow each time. Instead the row is marked with a
+// non-NULL empty tsvector at the current layout version; the row is correctly
 // unsearchable (an empty vector matches nothing). This skip write is PG-only —
 // the overflow error is PG-specific (IsFTSValueTooLargeError is always false on
 // SQLite), so the PG-syntax empty-tsvector literal is safe.
@@ -1323,7 +1322,8 @@ func (s *Store) backfillFTSRowByRow(fromID, toID int64) (int64, error) {
 				slog.Int64("message_id", id),
 				slog.Any("error", err))
 			if _, uerr := s.db.Exec(
-				`UPDATE messages SET search_fts = ''::tsvector WHERE id = ?`, id,
+				`UPDATE messages SET search_fts = ''::tsvector, indexing_version = ? WHERE id = ?`,
+				CurrentFTSIndexingVersion, id,
 			); uerr != nil {
 				return indexed, fmt.Errorf("mark FTS-overflow row %d terminal: %w", id, uerr)
 			}

--- a/internal/store/sqlite_unicode_test.go
+++ b/internal/store/sqlite_unicode_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteUnicodeLowerRegisteredOnEveryConnection(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbPath := filepath.Join(t.TempDir(), "unicode-lower.db")
+	st, err := OpenForTest(dbPath)
+	require.NoError(err, "open store")
+	t.Cleanup(func() { _ = st.Close() })
+
+	db := st.DB()
+	db.SetMaxOpenConns(4)
+	conns := make([]*sql.Conn, 0, 4)
+	for range 4 {
+		conn, err := db.Conn(context.Background())
+		require.NoError(err, "acquire pooled connection")
+		conns = append(conns, conn)
+	}
+	t.Cleanup(func() {
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	})
+
+	for i, conn := range conns {
+		var got string
+		err := conn.QueryRowContext(context.Background(),
+			"SELECT msgvault_unicode_lower('ÉCOLE')").Scan(&got)
+		require.NoErrorf(err, "unicode lower on connection %d", i)
+		assert.Equalf("école", got, "unicode lower on connection %d", i)
+	}
+
+	readOnly, err := OpenReadOnly(dbPath)
+	require.NoError(err, "open read-only store")
+	t.Cleanup(func() { _ = readOnly.Close() })
+	var readOnlyGot string
+	err = readOnly.DB().QueryRow("SELECT msgvault_unicode_lower('ÉCOLE')").Scan(&readOnlyGot)
+	require.NoError(err, "unicode lower on read-only connection")
+	assert.Equal("école", readOnlyGot, "unicode lower on read-only connection")
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/mattn/go-sqlite3"
+	"go.kenn.io/msgvault/internal/sqliteutil"
 )
 
 //go:embed schema.sql schema_sqlite.sql schema_pg.sql
@@ -126,7 +127,7 @@ func openSQLite(dbPath, params string) (*Store, error) {
 	}
 
 	dsn := dbPath + params
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open(sqliteutil.DriverName(), dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -214,7 +215,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 	// under SQLITE_OPEN_READONLY. _query_only opens normally (so SQLite
 	// can manage sidecars) but rejects all write SQL at the query layer.
 	dsn := dbPath + "?_query_only=true&_busy_timeout=5000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open(sqliteutil.DriverName(), dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database (read-only): %w", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -798,6 +798,59 @@ func TestStore_UpsertMessageBody(t *testing.T) {
 	assert.False(bodyHTML.Valid, "after update: body_html should be NULL, got %q", bodyHTML.String)
 }
 
+func TestStore_UpsertMessageBodyInvalidatesChangedFTS(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	if !f.Store.FTS5Available() {
+		t.Skip("FTS is unavailable")
+	}
+	messageID := f.CreateMessage("msg-body-fts-invalidation")
+	body := sql.NullString{String: "old indexed body", Valid: true}
+	require.NoError(f.Store.UpsertMessageBody(messageID, body, sql.NullString{}),
+		"store initial body")
+	require.NoError(f.Store.UpsertFTS(
+		messageID, "subject", body.String, "", "", "",
+	), "index initial body")
+
+	// An idempotent body write must not create needless backfill work.
+	require.NoError(f.Store.UpsertMessageBody(messageID, body, sql.NullString{}),
+		"store unchanged body")
+	if f.Store.IsPostgreSQL() {
+		var searchIsNull bool
+		require.NoError(f.Store.DB().QueryRow(
+			"SELECT search_fts IS NULL FROM messages WHERE id = $1", messageID,
+		).Scan(&searchIsNull), "check unchanged PostgreSQL index")
+		assert.False(searchIsNull, "unchanged body must retain its FTS document")
+	} else {
+		var count int
+		require.NoError(f.Store.DB().QueryRow(
+			"SELECT COUNT(*) FROM messages_fts WHERE rowid = ?", messageID,
+		).Scan(&count), "check unchanged SQLite index")
+		assert.Equal(1, count, "unchanged body must retain its FTS document")
+	}
+
+	require.NoError(f.Store.UpsertMessageBody(messageID,
+		sql.NullString{},
+		sql.NullString{String: "<p>old indexed body</p>", Valid: true}),
+		"replace indexed text with equivalent HTML-only body")
+	if f.Store.IsPostgreSQL() {
+		var searchIsNull, versionIsNull bool
+		require.NoError(f.Store.DB().QueryRow(`
+			SELECT search_fts IS NULL, indexing_version IS NULL
+			FROM messages WHERE id = $1
+		`, messageID).Scan(&searchIsNull, &versionIsNull), "check PostgreSQL invalidation")
+		assert.True(searchIsNull, "changed body must clear its old FTS document")
+		assert.True(versionIsNull, "changed body must require a fresh index version")
+	} else {
+		var count int
+		require.NoError(f.Store.DB().QueryRow(
+			"SELECT COUNT(*) FROM messages_fts WHERE rowid = ?", messageID,
+		).Scan(&count), "check SQLite invalidation")
+		assert.Zero(count, "changed body must delete its old FTS document")
+	}
+}
+
 func TestStore_MessageExistsBatch_Empty(t *testing.T) {
 	f := storetest.New(t)
 

--- a/internal/testutil/dbtest/dbtest.go
+++ b/internal/testutil/dbtest/dbtest.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3" // SQLite driver (database/sql)
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/sqliteutil"
 )
 
 // TestDB wraps a *sql.DB with auto-increment counters and builder helpers
@@ -31,7 +31,7 @@ type TestDB struct {
 func NewTestDB(tb testing.TB, schemaPath string) *TestDB {
 	tb.Helper()
 
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open(sqliteutil.DriverName(), ":memory:")
 	require.NoError(tb, err, "open db")
 	tb.Cleanup(func() { _ = db.Close() })
 

--- a/internal/vector/pgvector/fused.go
+++ b/internal/vector/pgvector/fused.go
@@ -25,6 +25,16 @@ var _ vector.FusingBackend = (*Backend)(nil)
 // outer GROUP BY still yields enough distinct messages.
 const fusedANNChunksPerMessage = 8
 
+// postgresFTSRankExpression keeps recipient (C) and body (D) weights equal
+// after the versioned search_fts layout separates those fields. The array is
+// ordered D, C, B, A per PostgreSQL's ts_rank_cd contract.
+func postgresFTSRankExpression(vectorExpr, queryArg string) string {
+	return fmt.Sprintf(
+		"ts_rank_cd(ARRAY[0.1, 0.1, 0.4, 1.0]::real[], %s, to_tsquery('simple', %s), 32)",
+		vectorExpr, queryArg,
+	)
+}
+
 // FusedSearch runs the single-query hybrid CTE against pgvector.
 // Mirrors sqlitevec.FusedSearch (spec §5.3) but built around
 // to_tsquery + ts_rank_cd on the inline messages.search_fts
@@ -132,6 +142,7 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 			// PostgreSQLQueryDialect.BuildFTSTerm's output, never raw text.
 			_, tsArg := query.PostgreSQLQueryDialect{}.BuildFTSTerm(req.FTSTerms)
 			ftsArg := bind(tsArg)
+			ftsRank := postgresFTSRankExpression("m.search_fts", ftsArg)
 			kp1Arg := bind(kPlus1)
 			kArg := bind(req.KPerSignal)
 			// Empty filter: scan messages directly with an inline liveness
@@ -146,12 +157,12 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 			ctes = append(ctes,
 				fmt.Sprintf(`fts_pool AS (
     SELECT m.id AS message_id,
-           ts_rank_cd(m.search_fts, to_tsquery('simple', %s), 32) AS bm25
+           %s AS bm25
       FROM messages m
 %s     WHERE m.search_fts @@ to_tsquery('simple', %s)
 %s     ORDER BY bm25 DESC
      LIMIT %s
-)`, ftsArg, ftsFrom, ftsArg, ftsLive, kp1Arg),
+)`, ftsRank, ftsFrom, ftsArg, ftsLive, kp1Arg),
 				fmt.Sprintf(`fts_ranked AS (
     SELECT message_id, bm25,
            ROW_NUMBER() OVER (ORDER BY bm25 DESC, message_id ASC) AS rnk

--- a/internal/vector/pgvector/fused_sql_test.go
+++ b/internal/vector/pgvector/fused_sql_test.go
@@ -1,0 +1,16 @@
+//go:build pgvector
+
+package pgvector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostgresFTSRankExpression_RecipientAndBodyWeightsMatch(t *testing.T) {
+	assert.Equal(t,
+		"ts_rank_cd(ARRAY[0.1, 0.1, 0.4, 1.0]::real[], m.search_fts, to_tsquery('simple', $1), 32)",
+		postgresFTSRankExpression("m.search_fts", "$1"),
+	)
+}

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -243,7 +243,7 @@ type ClientInterface interface {
 	SearchMessages(ctx context.Context, options *SearchMessagesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchMessagesResponse, error)
 	SearchMessagesWithResponse(ctx context.Context, options *SearchMessagesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchMessagesResp, error)
 
-	// DeepSearch Run deep aggregate search
+	// DeepSearch Run full-text message search
 	DeepSearch(ctx context.Context, options *DeepSearchRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeepSearchResponseJSON, error)
 	DeepSearchWithResponse(ctx context.Context, options *DeepSearchRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeepSearchResp, error)
 
@@ -3546,7 +3546,7 @@ func (c *Client) SearchMessages(ctx context.Context, options *SearchMessagesRequ
 	return responseParser(ctx, resp)
 }
 
-// DeepSearch Run deep aggregate search
+// DeepSearch Run full-text message search
 func (c *Client) DeepSearch(ctx context.Context, options *DeepSearchRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeepSearchResponseJSON, error) {
 	var err error
 	reqParams := runtime.RequestOptionsParameters{

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -3551,7 +3551,7 @@ func (c *Client) SearchMessagesWithResponse(ctx context.Context, options *Search
 	}
 }
 
-// DeepSearch Run deep aggregate search
+// DeepSearch Run full-text message search
 func (c *Client) DeepSearchWithResponse(ctx context.Context, options *DeepSearchRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeepSearchResp, error) {
 	var err error
 	reqParams := runtime.RequestOptionsParameters{

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -420,6 +420,9 @@ type DeepSearchQuery struct {
 	// Q Search query
 	Q string `json:"q" validate:"required"`
 
+	// Scope Exact search scope: body; omit for composite full-text search
+	Scope *string `json:"scope,omitempty"`
+
 	// Sender Sender email/address filter
 	Sender *string `json:"sender,omitempty"`
 

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -900,6 +900,7 @@ type DeepSearchResponse struct {
 	Messages []MessageSummary `json:"messages,omitempty" validate:"required"`
 	Offset   int64            `json:"offset"`
 	Query    string           `json:"query" validate:"required"`
+	Scope    *string          `json:"scope,omitempty"`
 }
 
 func (d DeepSearchResponse) Validate() error {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -175,6 +175,12 @@ func (b BackupFreezeEndRequest) Validate() error {
 
 type BackupFreezeEndResponse = map[string]any
 
+type BodySearchContext struct {
+	ContextSnippets          []string `json:"context_snippets,omitempty"`
+	ContextSnippetsTruncated *bool    `json:"context_snippets_truncated,omitempty"`
+	MessageID                int64    `json:"message_id"`
+}
+
 type BuildingSummary struct {
 	Dimension int64    `json:"dimension"`
 	ID        int64    `json:"id"`
@@ -894,17 +900,25 @@ func (c CreateRequest) Validate() error {
 }
 
 type DeepSearchResponse struct {
-	Count    int64            `json:"count"`
-	HasMore  bool             `json:"has_more"`
-	Limit    int64            `json:"limit"`
-	Messages []MessageSummary `json:"messages,omitempty" validate:"required"`
-	Offset   int64            `json:"offset"`
-	Query    string           `json:"query" validate:"required"`
-	Scope    *string          `json:"scope,omitempty"`
+	BodyContexts []BodySearchContext `json:"body_contexts,omitempty"`
+	Count        int64               `json:"count"`
+	HasMore      bool                `json:"has_more"`
+	Limit        int64               `json:"limit"`
+	Messages     []MessageSummary    `json:"messages,omitempty" validate:"required"`
+	Offset       int64               `json:"offset"`
+	Query        string              `json:"query" validate:"required"`
+	Scope        *string             `json:"scope,omitempty"`
 }
 
 func (d DeepSearchResponse) Validate() error {
 	var errors runtime.ValidationErrors
+	for i, item := range d.BodyContexts {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("BodyContexts[%d]", i), err)
+			}
+		}
+	}
 	for i, item := range d.Messages {
 		if v, ok := any(item).(runtime.Validator); ok {
 			if err := v.Validate(); err != nil {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1041,6 +1041,8 @@ components:
           type: integer
         query:
           type: string
+        scope:
+          type: string
       required:
         - query
         - messages
@@ -2227,7 +2229,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.2.0
+  version: 1.3.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -4492,6 +4494,11 @@ paths:
           required: true
           schema:
             type: string
+        - description: "Exact search scope: body; omit for composite full-text search"
+          in: query
+          name: scope
+          schema:
+            type: string
         - description: Sender email/address filter
           in: query
           name: sender
@@ -4611,7 +4618,7 @@ paths:
           description: Error
       security:
         - apiKey: []
-      summary: Run deep aggregate search
+      summary: Run full-text message search
       tags:
         - API
   /api/v1/search/domains:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -196,6 +196,21 @@ components:
       type: object
     BackupFreezeEndResponse:
       type: object
+    BodySearchContext:
+      properties:
+        context_snippets:
+          items:
+            type: string
+          nullable: true
+          type: array
+        context_snippets_truncated:
+          type: boolean
+        message_id:
+          format: int64
+          type: integer
+      required:
+        - message_id
+      type: object
     BuildingSummary:
       properties:
         dimension:
@@ -1023,6 +1038,11 @@ components:
       type: object
     DeepSearchResponse:
       properties:
+        body_contexts:
+          items:
+            $ref: "#/components/schemas/BodySearchContext"
+          nullable: true
+          type: array
         count:
           format: int64
           type: integer


### PR DESCRIPTION
Split MCP keyword search into explicit metadata and body paths. `search_messages` now searches subjects, snippets, senders, and recipients when mode is omitted while retaining vector and hybrid modes; `search_message_bodies` requires free text and returns up to five bounded, backend-native FTS excerpts per hit, with truncation flagged when request-wide work limits omit context.

Enforce the same scopes across SQLite, PostgreSQL, DuckDB, and daemon-backed clients. PostgreSQL uses a versioned weighted FTS layout and native context selection, and body changes invalidate stale index documents. `/api/v1/search/deep?scope=body` (schema 1.3.0) returns exact body hits plus ID-keyed `body_contexts` without changing the generated `MessageSummary` element type.

Keep metadata results, counts, and statistics aligned for Unicode matching and typed filters; reject unsupported or malformed operators before dispatch; add `conversation_id` to MCP `list_messages`; and update the MCP guides and changelog.