### PR TITLE
feat: serve attachment content via GET /api/v1/attachments/{hash}

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2705,6 +2705,66 @@ paths:
       summary: Get nested aggregate rows
       tags:
         - API
+  /api/v1/attachments/{hash}/content:
+    get:
+      operationId: getAttachmentContent
+      parameters:
+        - description: Attachment SHA-256 content hash
+          in: path
+          name: hash
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Download attachment content by SHA-256 hash
+      tags:
+        - API
   /api/v1/attachments/{id}:
     get:
       operationId: getAttachment

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2718,7 +2718,7 @@ paths:
       responses:
         "200":
           content:
-            application/octet-stream:
+            "*/*":
               schema:
                 contentMediaType: application/octet-stream
                 format: binary

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,6 +18,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/daemonclient"
+	msgexport "go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/fileutil"
 	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/query"
@@ -2530,6 +2532,87 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, AttachmentInfo(*att))
+}
+
+// handleGetAttachmentContent streams a stored attachment's raw bytes by its
+// SHA-256 content hash. The /content suffix keeps this binary response distinct
+// from GET /attachments/{id}, which returns attachment metadata as JSON.
+func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Request) {
+	if s.engine == nil {
+		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
+		return
+	}
+
+	hash := r.PathValue("hash")
+
+	// StoragePath validates the hash is exactly 64 hex characters, which also
+	// guards against path traversal before we touch the filesystem.
+	path, err := msgexport.StoragePath(s.cfg.AttachmentsDir(), hash)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_hash", "Attachment hash must be a 64-character hex SHA-256")
+		return
+	}
+
+	att, err := s.engine.GetAttachmentByHash(r.Context(), hash)
+	if err != nil {
+		s.logger.Error("failed to look up attachment by hash", "error", err, "hash", hash)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to look up attachment")
+		return
+	}
+	if att == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		return
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			writeError(w, http.StatusNotFound, "not_found", "Attachment content not available")
+			return
+		}
+		s.logger.Error("failed to open attachment file", "error", err, "hash", hash)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to open attachment")
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		s.logger.Error("failed to stat attachment file", "error", err, "hash", hash)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read attachment")
+		return
+	}
+
+	contentType := att.MimeType
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", contentDisposition(att.Filename))
+	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	if _, err := io.Copy(w, f); err != nil {
+		// Status and headers are already committed, so only logging is possible.
+		s.logger.Error("failed to stream attachment", "error", err, "hash", hash)
+	}
+}
+
+func contentDisposition(filename string) string {
+	if filename == "" {
+		return "attachment"
+	}
+	ascii := strings.Map(func(r rune) rune {
+		if r < 0x20 || r >= 0x7f || r == '"' || r == '\\' {
+			return '_'
+		}
+		return r
+	}, filename)
+	value := fmt.Sprintf("attachment; filename=%q", ascii)
+	if ascii != filename {
+		value += "; filename*=UTF-8''" + url.PathEscape(filename)
+	}
+	return value
 }
 
 func (s *Server) handleSearchByDomains(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2545,10 +2545,7 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 
 	hash := r.PathValue("hash")
 
-	// StoragePath validates the hash is exactly 64 hex characters, which also
-	// guards against path traversal before we touch the filesystem.
-	path, err := msgexport.StoragePath(s.cfg.AttachmentsDir(), hash)
-	if err != nil {
+	if err := msgexport.ValidateContentHash(hash); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_hash", "Attachment hash must be a 64-character hex SHA-256")
 		return
 	}
@@ -2564,24 +2561,38 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	f, err := os.Open(path)
+	var content io.ReadCloser
+	var contentLength int64
+	if s.blobStore != nil {
+		content, contentLength, err = s.blobStore.Open(hash)
+	} else {
+		var path string
+		path, err = msgexport.StoragePath(s.cfg.AttachmentsDir(), hash)
+		if err == nil {
+			var f *os.File
+			f, err = os.Open(path)
+			if err == nil {
+				var info os.FileInfo
+				info, err = f.Stat()
+				if err == nil {
+					content = f
+					contentLength = info.Size()
+				} else {
+					_ = f.Close()
+				}
+			}
+		}
+	}
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			writeError(w, http.StatusNotFound, "not_found", "Attachment content not available")
 			return
 		}
-		s.logger.Error("failed to open attachment file", "error", err, "hash", hash)
+		s.logger.Error("failed to open attachment content", "error", err, "hash", hash)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to open attachment")
 		return
 	}
-	defer func() { _ = f.Close() }()
-
-	info, err := f.Stat()
-	if err != nil {
-		s.logger.Error("failed to stat attachment file", "error", err, "hash", hash)
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read attachment")
-		return
-	}
+	defer func() { _ = content.Close() }()
 
 	contentType := att.MimeType
 	if contentType == "" {
@@ -2589,10 +2600,10 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 	}
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Disposition", contentDisposition(att.Filename))
-	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
+	w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
-	if _, err := io.Copy(w, f); err != nil {
+	if _, err := io.Copy(w, content); err != nil {
 		// Status and headers are already committed, so only logging is possible.
 		s.logger.Error("failed to stream attachment", "error", err, "hash", hash)
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2531,7 +2531,14 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, AttachmentInfo(*att))
+	writeJSON(w, http.StatusOK, AttachmentInfo{
+		ID:          att.ID,
+		Filename:    att.Filename,
+		MimeType:    att.MimeType,
+		Size:        att.Size,
+		ContentHash: att.ContentHash,
+		URL:         att.URL,
+	})
 }
 
 // handleGetAttachmentContent streams a stored attachment's raw bytes by its
@@ -2565,23 +2572,11 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 	var contentLength int64
 	if s.blobStore != nil {
 		content, contentLength, err = s.blobStore.Open(hash)
-	} else {
-		var path string
-		path, err = msgexport.StoragePath(s.cfg.AttachmentsDir(), hash)
-		if err == nil {
-			var f *os.File
-			f, err = os.Open(path)
-			if err == nil {
-				var info os.FileInfo
-				info, err = f.Stat()
-				if err == nil {
-					content = f
-					contentLength = info.Size()
-				} else {
-					_ = f.Close()
-				}
-			}
-		}
+	}
+	if s.blobStore == nil || errors.Is(err, os.ErrNotExist) {
+		content, contentLength, err = openLooseAttachmentContent(
+			s.cfg.AttachmentsDir(), hash, att.StoragePath,
+		)
 	}
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -2607,6 +2602,61 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 		// Status and headers are already committed, so only logging is possible.
 		s.logger.Error("failed to stream attachment", "error", err, "hash", hash)
 	}
+}
+
+func openLooseAttachmentContent(attachmentsDir, contentHash, storagePath string) (io.ReadCloser, int64, error) {
+	var path string
+	var err error
+	if storagePath == "" {
+		path, err = msgexport.StoragePath(attachmentsDir, contentHash)
+	} else {
+		path, err = resolveRecordedAttachmentPath(attachmentsDir, storagePath)
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, 0, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, 0, fmt.Errorf("attachment storage path %q is not a regular file", storagePath)
+	}
+	return f, info.Size(), nil
+}
+
+func resolveRecordedAttachmentPath(attachmentsDir, storagePath string) (string, error) {
+	lowerPath := strings.ToLower(storagePath)
+	if strings.HasPrefix(lowerPath, "http://") || strings.HasPrefix(lowerPath, "https://") {
+		return "", errors.New("attachment storage path must be local")
+	}
+	localPath := filepath.Clean(filepath.FromSlash(storagePath))
+	if !filepath.IsLocal(localPath) {
+		return "", fmt.Errorf("attachment storage path %q escapes attachments directory", storagePath)
+	}
+	basePath, err := filepath.Abs(attachmentsDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve attachments directory: %w", err)
+	}
+	basePath, err = filepath.EvalSymlinks(basePath)
+	if err != nil {
+		return "", fmt.Errorf("resolve attachments directory: %w", err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(filepath.Join(basePath, localPath))
+	if err != nil {
+		return "", err
+	}
+	relativePath, err := filepath.Rel(basePath, resolvedPath)
+	if err != nil || !filepath.IsLocal(relativePath) {
+		return "", fmt.Errorf("attachment storage path %q escapes attachments directory", storagePath)
+	}
+	return resolvedPath, nil
 }
 
 func contentDisposition(filename string) string {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2557,16 +2557,17 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	att, err := s.engine.GetAttachmentByHash(r.Context(), hash)
+	attachments, err := s.engine.GetAttachmentsByHash(r.Context(), hash)
 	if err != nil {
 		s.logger.Error("failed to look up attachment by hash", "error", err, "hash", hash)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to look up attachment")
 		return
 	}
-	if att == nil {
+	if len(attachments) == 0 {
 		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
 		return
 	}
+	att := &attachments[0]
 
 	var content io.ReadCloser
 	var contentLength int64
@@ -2574,8 +2575,8 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 		content, contentLength, err = s.blobStore.Open(hash)
 	}
 	if s.blobStore == nil || errors.Is(err, os.ErrNotExist) {
-		content, contentLength, err = openLooseAttachmentContent(
-			s.cfg.AttachmentsDir(), hash, att.StoragePath,
+		content, contentLength, att, err = openLooseAttachmentCandidates(
+			s.cfg.AttachmentsDir(), hash, attachments,
 		)
 	}
 	if err != nil {
@@ -2602,6 +2603,45 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 		// Status and headers are already committed, so only logging is possible.
 		s.logger.Error("failed to stream attachment", "error", err, "hash", hash)
 	}
+}
+
+func openLooseAttachmentCandidates(
+	attachmentsDir string,
+	contentHash string,
+	attachments []query.AttachmentInfo,
+) (io.ReadCloser, int64, *query.AttachmentInfo, error) {
+	content, contentLength, err := openLooseAttachmentContent(attachmentsDir, contentHash, "")
+	if err == nil {
+		return content, contentLength, &attachments[0], nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, 0, nil, err
+	}
+
+	seen := make(map[string]struct{}, len(attachments))
+	var firstPathError error
+	for i := range attachments {
+		storagePath := attachments[i].StoragePath
+		if storagePath == "" {
+			continue
+		}
+		if _, ok := seen[storagePath]; ok {
+			continue
+		}
+		seen[storagePath] = struct{}{}
+
+		content, contentLength, err = openLooseAttachmentContent(attachmentsDir, contentHash, storagePath)
+		if err == nil {
+			return content, contentLength, &attachments[i], nil
+		}
+		if !errors.Is(err, os.ErrNotExist) && firstPathError == nil {
+			firstPathError = err
+		}
+	}
+	if firstPathError != nil {
+		return nil, 0, nil, firstPathError
+	}
+	return nil, 0, nil, os.ErrNotExist
 }
 
 func openLooseAttachmentContent(attachmentsDir, contentHash, storagePath string) (io.ReadCloser, int64, error) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2683,7 +2683,7 @@ func TestCLIAttachmentServesPackedBlob(t *testing.T) {
 		},
 		Logger:    testLogger(),
 		BlobStore: bs,
-		Engine:    query.NewSQLiteEngine(st.DB()),
+		Engine:    query.NewEngine(st.DB(), st.IsPostgreSQL()),
 	})
 
 	t.Run("packed blob returns 200 with body", func(t *testing.T) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -6001,4 +6002,154 @@ func TestHandleGetMessage_EngineUnsupportedFallsBackToStore(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "decode")
 	assert.Equal(t, "Test Subject", resp["subject"], "subject (store path response)")
+}
+
+// newAttachmentTestServer builds a Server whose config points at a temp data
+// dir, so AttachmentsDir() resolves to a writable location for seeding files.
+func newAttachmentTestServer(t *testing.T, engine *querytest.MockEngine) (*Server, *config.Config) {
+	t.Helper()
+	cfg := &config.Config{
+		Server: config.ServerConfig{APIPort: 8080},
+		Data:   config.DataConfig{DataDir: t.TempDir()},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config:    cfg,
+		Store:     &mockStore{},
+		Engine:    engine,
+		Scheduler: newMockScheduler(),
+		Logger:    testLogger(),
+	})
+	return srv, cfg
+}
+
+// seedAttachmentFile writes content to the content-addressed path under the
+// attachments dir (attachmentsDir/<hash[:2]>/<hash>).
+func seedAttachmentFile(t *testing.T, cfg *config.Config, hash string, content []byte) {
+	t.Helper()
+	dir := filepath.Join(cfg.AttachmentsDir(), hash[:2])
+	require.NoError(t, os.MkdirAll(dir, 0o755), "mkdir attachment dir")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, hash), content, 0o644), "write attachment file")
+}
+
+func TestHandleGetAttachmentContent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	hash := strings.Repeat("a1", 32) // 64 hex chars
+	content := []byte("hello attachment world")
+
+	engine := &querytest.MockEngine{
+		AttachmentsByHash: map[string]*query.AttachmentInfo{
+			hash: {ID: 7, Filename: "report.pdf", MimeType: "application/pdf", Size: int64(len(content)), ContentHash: hash},
+		},
+	}
+	srv, cfg := newAttachmentTestServer(t, engine)
+	seedAttachmentFile(t, cfg, hash, content)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+hash+"/content", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assert.Equal("application/pdf", w.Header().Get("Content-Type"), "Content-Type")
+	assert.Equal(`attachment; filename="report.pdf"`, w.Header().Get("Content-Disposition"), "Content-Disposition")
+	assert.Equal(strconv.Itoa(len(content)), w.Header().Get("Content-Length"), "Content-Length")
+	assert.Equal(content, w.Body.Bytes(), "body")
+}
+
+func TestHandleGetAttachmentContent_MissingMimeAndFilename(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	hash := strings.Repeat("bc", 32)
+	content := []byte{0x00, 0x01, 0x02}
+
+	engine := &querytest.MockEngine{
+		AttachmentsByHash: map[string]*query.AttachmentInfo{
+			hash: {ID: 8, Size: int64(len(content)), ContentHash: hash}, // no Filename, no MimeType
+		},
+	}
+	srv, cfg := newAttachmentTestServer(t, engine)
+	seedAttachmentFile(t, cfg, hash, content)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+hash+"/content", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assert.Equal("application/octet-stream", w.Header().Get("Content-Type"), "Content-Type")
+	assert.Equal("attachment", w.Header().Get("Content-Disposition"), "Content-Disposition")
+}
+
+func TestHandleGetAttachmentContent_InvalidHash(t *testing.T) {
+	assert := assert.New(t)
+	srv, _ := newAttachmentTestServer(t, &querytest.MockEngine{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/not-a-valid-hash/content", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(http.StatusBadRequest, w.Code, "status (body: %s)", w.Body.String())
+}
+
+func TestHandleGetAttachmentContent_UnknownHash(t *testing.T) {
+	assert := assert.New(t)
+	// Valid hash shape, but no metadata row for it.
+	srv, _ := newAttachmentTestServer(t, &querytest.MockEngine{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+strings.Repeat("de", 32)+"/content", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(http.StatusNotFound, w.Code, "status (body: %s)", w.Body.String())
+}
+
+func TestHandleGetAttachmentContent_MetadataButFileMissing(t *testing.T) {
+	assert := assert.New(t)
+	hash := strings.Repeat("ef", 32)
+	engine := &querytest.MockEngine{
+		AttachmentsByHash: map[string]*query.AttachmentInfo{
+			hash: {ID: 9, Filename: "gone.bin", MimeType: "application/octet-stream", Size: 10, ContentHash: hash},
+		},
+	}
+	srv, _ := newAttachmentTestServer(t, engine) // note: no seedAttachmentFile
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+hash+"/content", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(http.StatusNotFound, w.Code, "status (body: %s)", w.Body.String())
+}
+
+// TestHandleGetMessage_ExposesAttachmentContentHash verifies the message
+// detail response carries each attachment's content_hash, so a client can
+// discover the hash to pass to GET /api/v1/attachments/{hash}/content.
+func TestHandleGetMessage_ExposesAttachmentContentHash(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	hash := strings.Repeat("ab", 32)
+	engine := &querytest.MockEngine{
+		Messages: map[int64]*query.MessageDetail{
+			1: {
+				ID:             1,
+				Subject:        "With attachment",
+				SentAt:         time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+				HasAttachments: true,
+				Attachments: []query.AttachmentInfo{
+					{ID: 5, Filename: "report.pdf", MimeType: "application/pdf", Size: 1234, ContentHash: hash},
+				},
+			},
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/messages/1", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	var resp struct {
+		Attachments []map[string]any `json:"attachments"`
+	}
+	require.NoError(json.NewDecoder(w.Body).Decode(&resp), "decode")
+	require.Len(resp.Attachments, 1, "attachments")
+	assert.Equal(hash, resp.Attachments[0]["content_hash"], "content_hash")
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2683,15 +2683,7 @@ func TestCLIAttachmentServesPackedBlob(t *testing.T) {
 		},
 		Logger:    testLogger(),
 		BlobStore: bs,
-		Engine: &querytest.MockEngine{AttachmentsByHash: map[string]*query.AttachmentInfo{
-			entry.BlobHash: {
-				ID:          1,
-				Filename:    "packed.bin",
-				MimeType:    "application/octet-stream",
-				Size:        int64(len(content)),
-				ContentHash: entry.BlobHash,
-			},
-		}},
+		Engine:    query.NewSQLiteEngine(st.DB()),
 	})
 
 	t.Run("packed blob returns 200 with body", func(t *testing.T) {
@@ -2718,6 +2710,25 @@ func TestCLIAttachmentServesPackedBlob(t *testing.T) {
 		assert.Equal("application/octet-stream", w.Header().Get("Content-Type"), "Content-Type")
 		assert.Equal(`attachment; filename="packed.bin"`, w.Header().Get("Content-Disposition"), "Content-Disposition")
 		assert.Equal(content, w.Body.Bytes(), "data")
+	})
+
+	t.Run("public content endpoint serves legacy namespaced loose blob", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		hash := "5bc8e75b9fa9867b99fe7498fcb611a46ab49326ff94a96b2a6f68a723f46d91"
+		legacyContent := []byte("legacy namespaced attachment")
+		storagePath := filepath.Join("synctech-sms", hash[:2], hash)
+		require.NoError(st.UpsertAttachment(msgID, "legacy.bin", "application/octet-stream",
+			storagePath, hash, len(legacyContent)), "UpsertAttachment legacy")
+		require.NoError(os.MkdirAll(filepath.Join(attachmentsDir, filepath.Dir(storagePath)), 0o700), "create legacy dir")
+		require.NoError(os.WriteFile(filepath.Join(attachmentsDir, storagePath), legacyContent, 0o600), "write legacy attachment")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+hash+"/content", nil)
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, req)
+
+		assert.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+		assert.Equal(legacyContent, w.Body.Bytes(), "data")
 	})
 
 	t.Run("unknown hash returns 404", func(t *testing.T) {
@@ -6139,6 +6150,20 @@ func TestHandleGetAttachmentContent_MetadataButFileMissing(t *testing.T) {
 	srv.Router().ServeHTTP(w, req)
 
 	assert.Equal(http.StatusNotFound, w.Code, "status (body: %s)", w.Body.String())
+}
+
+func TestResolveRecordedAttachmentPathRejectsUnsafePaths(t *testing.T) {
+	assert := assert.New(t)
+	attachmentsDir := t.TempDir()
+
+	for _, storagePath := range []string{
+		"../outside.bin",
+		filepath.Join(string(filepath.Separator), "absolute.bin"),
+		"https://example.com/attachment.bin",
+	} {
+		_, err := resolveRecordedAttachmentPath(attachmentsDir, storagePath)
+		assert.Error(err, "storage path %q", storagePath)
+	}
 }
 
 // TestHandleGetMessage_ExposesAttachmentContentHash verifies the message

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2731,6 +2731,35 @@ func TestCLIAttachmentServesPackedBlob(t *testing.T) {
 		assert.Equal(legacyContent, w.Body.Bytes(), "data")
 	})
 
+	t.Run("public content endpoint tries every duplicate hash path", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		hash := "80c92207dd517f7edb6479ca8694460ed21ddf969f52e17e2ba7808f706cce74"
+		availableContent := []byte("available duplicate attachment")
+		availablePath := filepath.Join("synctech-sms", hash[:2], hash)
+
+		require.NoError(st.UpsertAttachment(msgID, "missing.bin", "application/x-missing",
+			filepath.Join("missing", hash), hash, len(availableContent)), "UpsertAttachment missing duplicate")
+		availableMsgID, err := st.UpsertMessage(&store.Message{
+			ConversationID: convID, SourceID: src.ID,
+			SourceMessageID: "available-duplicate-message", MessageType: "email",
+		})
+		require.NoError(err, "UpsertMessage available duplicate")
+		require.NoError(st.UpsertAttachment(availableMsgID, "available.bin", "text/plain",
+			availablePath, hash, len(availableContent)), "UpsertAttachment available duplicate")
+		require.NoError(os.MkdirAll(filepath.Join(attachmentsDir, filepath.Dir(availablePath)), 0o700), "create available duplicate dir")
+		require.NoError(os.WriteFile(filepath.Join(attachmentsDir, availablePath), availableContent, 0o600), "write available duplicate")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+hash+"/content", nil)
+		w := httptest.NewRecorder()
+		srv.Router().ServeHTTP(w, req)
+
+		assert.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+		assert.Equal("text/plain", w.Header().Get("Content-Type"), "Content-Type")
+		assert.Equal(`attachment; filename="available.bin"`, w.Header().Get("Content-Disposition"), "Content-Disposition")
+		assert.Equal(availableContent, w.Body.Bytes(), "data")
+	})
+
 	t.Run("unknown hash returns 404", func(t *testing.T) {
 		assert := assert.New(t)
 		unknownHash := "bf0803740e367e2f5e45f0813f62b9c4c09a44e8a649a39970295a9322859048"
@@ -6071,8 +6100,8 @@ func TestHandleGetAttachmentContent(t *testing.T) {
 	content := []byte("hello attachment world")
 
 	engine := &querytest.MockEngine{
-		AttachmentsByHash: map[string]*query.AttachmentInfo{
-			hash: {ID: 7, Filename: "report.pdf", MimeType: "application/pdf", Size: int64(len(content)), ContentHash: hash},
+		AttachmentsByHash: map[string][]query.AttachmentInfo{
+			hash: {{ID: 7, Filename: "report.pdf", MimeType: "application/pdf", Size: int64(len(content)), ContentHash: hash}},
 		},
 	}
 	srv, cfg := newAttachmentTestServer(t, engine)
@@ -6096,8 +6125,8 @@ func TestHandleGetAttachmentContent_MissingMimeAndFilename(t *testing.T) {
 	content := []byte{0x00, 0x01, 0x02}
 
 	engine := &querytest.MockEngine{
-		AttachmentsByHash: map[string]*query.AttachmentInfo{
-			hash: {ID: 8, Size: int64(len(content)), ContentHash: hash}, // no Filename, no MimeType
+		AttachmentsByHash: map[string][]query.AttachmentInfo{
+			hash: {{ID: 8, Size: int64(len(content)), ContentHash: hash}}, // no Filename, no MimeType
 		},
 	}
 	srv, cfg := newAttachmentTestServer(t, engine)
@@ -6139,8 +6168,8 @@ func TestHandleGetAttachmentContent_MetadataButFileMissing(t *testing.T) {
 	assert := assert.New(t)
 	hash := strings.Repeat("ef", 32)
 	engine := &querytest.MockEngine{
-		AttachmentsByHash: map[string]*query.AttachmentInfo{
-			hash: {ID: 9, Filename: "gone.bin", MimeType: "application/octet-stream", Size: 10, ContentHash: hash},
+		AttachmentsByHash: map[string][]query.AttachmentInfo{
+			hash: {{ID: 9, Filename: "gone.bin", MimeType: "application/octet-stream", Size: 10, ContentHash: hash}},
 		},
 	}
 	srv, _ := newAttachmentTestServer(t, engine) // note: no seedAttachmentFile

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2683,6 +2683,15 @@ func TestCLIAttachmentServesPackedBlob(t *testing.T) {
 		},
 		Logger:    testLogger(),
 		BlobStore: bs,
+		Engine: &querytest.MockEngine{AttachmentsByHash: map[string]*query.AttachmentInfo{
+			entry.BlobHash: {
+				ID:          1,
+				Filename:    "packed.bin",
+				MimeType:    "application/octet-stream",
+				Size:        int64(len(content)),
+				ContentHash: entry.BlobHash,
+			},
+		}},
 	})
 
 	t.Run("packed blob returns 200 with body", func(t *testing.T) {
@@ -2695,6 +2704,19 @@ func TestCLIAttachmentServesPackedBlob(t *testing.T) {
 		assert.Equal(http.StatusOK, w.Code, "status")
 		assert.Equal("application/octet-stream", w.Header().Get("Content-Type"), "Content-Type")
 		assert.Equal(entry.BlobHash, w.Header().Get("X-Msgvault-Content-Hash"), "ContentHash")
+		assert.Equal(content, w.Body.Bytes(), "data")
+	})
+
+	t.Run("public content endpoint serves packed blob", func(t *testing.T) {
+		assert := assert.New(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+entry.BlobHash+"/content", nil)
+		w := httptest.NewRecorder()
+
+		srv.Router().ServeHTTP(w, req)
+
+		assert.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+		assert.Equal("application/octet-stream", w.Header().Get("Content-Type"), "Content-Type")
+		assert.Equal(`attachment; filename="packed.bin"`, w.Header().Get("Content-Disposition"), "Content-Disposition")
 		assert.Equal(content, w.Body.Bytes(), "data")
 	})
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -254,6 +254,20 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	registerAPIV1RawHumaJSONRoute[AttachmentInfo](apiV1, "getAttachment", http.MethodGet, "/attachments/{id}", "Get attachment metadata", s.handleGetAttachment)
 	registerAPIV1RawHumaBinaryRoute(
 		apiV1,
+		"getAttachmentContent",
+		http.MethodGet,
+		"/attachments/{hash}/content",
+		"Download attachment content by SHA-256 hash",
+		"application/octet-stream",
+		s.handleGetAttachmentContent,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+	)
+	registerAPIV1RawHumaBinaryRoute(
+		apiV1,
 		"getMessageInlinePart",
 		http.MethodGet,
 		"/messages/{id}/inline",
@@ -351,6 +365,7 @@ func registerAPIV1RawHumaJSONOneOfRoute(
 	registerRawHumaRoute(api, op, handler)
 }
 
+//nolint:unparam // Retain method for symmetry with the other raw-route helpers and future non-GET binary endpoints.
 func registerAPIV1RawHumaBinaryRoute(
 	api huma.API,
 	operationID string,
@@ -458,6 +473,8 @@ func rawRouteParameters(operationID string) []*huma.Param {
 		return []*huma.Param{pathStringParam("id", "Deletion manifest ID")}
 	case "getAttachment":
 		return []*huma.Param{pathIntegerParam("Attachment ID")}
+	case "getAttachmentContent":
+		return []*huma.Param{pathStringParam("hash", "Attachment SHA-256 content hash")}
 	case "getMessageInlinePart":
 		return []*huma.Param{
 			pathIntegerParam("Message ID"),

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -258,7 +258,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 		http.MethodGet,
 		"/attachments/{hash}/content",
 		"Download attachment content by SHA-256 hash",
-		"application/octet-stream",
+		"*/*",
 		s.handleGetAttachmentContent,
 		http.StatusBadRequest,
 		http.StatusUnauthorized,

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -783,6 +783,12 @@ func (e *Engine) GetAttachment(ctx context.Context, id int64) (*query.Attachment
 	return queryAttachmentFromGenerated(resp.JSON200), nil
 }
 
+// GetAttachmentByHash is not exposed through the daemon query adapter. Raw
+// attachment downloads use the daemon client's dedicated binary store path.
+func (e *Engine) GetAttachmentByHash(context.Context, string) (*query.AttachmentInfo, error) {
+	return nil, ErrNotSupported
+}
+
 // Search performs full-text search including message body.
 func (e *Engine) Search(ctx context.Context, q *search.Query, limit, offset int) ([]query.MessageSummary, error) {
 	// Build query string from search.Query

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -783,9 +783,9 @@ func (e *Engine) GetAttachment(ctx context.Context, id int64) (*query.Attachment
 	return queryAttachmentFromGenerated(resp.JSON200), nil
 }
 
-// GetAttachmentByHash is not exposed through the daemon query adapter. Raw
+// GetAttachmentsByHash is not exposed through the daemon query adapter. Raw
 // attachment downloads use the daemon client's dedicated binary store path.
-func (e *Engine) GetAttachmentByHash(context.Context, string) (*query.AttachmentInfo, error) {
+func (e *Engine) GetAttachmentsByHash(context.Context, string) ([]query.AttachmentInfo, error) {
 	return nil, ErrNotSupported
 }
 

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1767,13 +1767,13 @@ func (e *DuckDBEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 	return nil, errors.New("GetAttachment requires SQLite: pass sqliteDB to NewDuckDBEngine")
 }
 
-// GetAttachmentByHash retrieves attachment metadata by content hash.
+// GetAttachmentsByHash retrieves attachment metadata by content hash.
 // Attachments live in SQLite, so delegate to the SQLite engine.
-func (e *DuckDBEngine) GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error) {
+func (e *DuckDBEngine) GetAttachmentsByHash(ctx context.Context, contentHash string) ([]AttachmentInfo, error) {
 	if e.sqliteEngine != nil {
-		return e.sqliteEngine.GetAttachmentByHash(ctx, contentHash)
+		return e.sqliteEngine.GetAttachmentsByHash(ctx, contentHash)
 	}
-	return nil, errors.New("GetAttachmentByHash requires SQLite: pass sqliteDB to NewDuckDBEngine")
+	return nil, errors.New("GetAttachmentsByHash requires SQLite: pass sqliteDB to NewDuckDBEngine")
 }
 
 // GetMessageRaw returns the decompressed raw MIME data for a message.

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1767,6 +1767,15 @@ func (e *DuckDBEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 	return nil, errors.New("GetAttachment requires SQLite: pass sqliteDB to NewDuckDBEngine")
 }
 
+// GetAttachmentByHash retrieves attachment metadata by content hash.
+// Attachments live in SQLite, so delegate to the SQLite engine.
+func (e *DuckDBEngine) GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error) {
+	if e.sqliteEngine != nil {
+		return e.sqliteEngine.GetAttachmentByHash(ctx, contentHash)
+	}
+	return nil, errors.New("GetAttachmentByHash requires SQLite: pass sqliteDB to NewDuckDBEngine")
+}
+
 // GetMessageRaw returns the decompressed raw MIME data for a message.
 func (e *DuckDBEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
 	if e.sqliteDB != nil {

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -41,6 +41,13 @@ type Engine interface {
 	GetMessageBySourceID(ctx context.Context, sourceMessageID string) (*MessageDetail, error)
 	GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error)
 
+	// GetAttachmentByHash returns attachment metadata for the given
+	// content hash. content_hash is not unique — attachments are
+	// de-duplicated by content, so multiple rows may share a hash; any
+	// matching row is returned (filename/mime/size are equivalent across
+	// them). Returns nil, nil when no row matches.
+	GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error)
+
 	// GetMessageRaw returns the decompressed raw MIME data for a message.
 	// Returns nil, nil if no raw data is stored for the given ID.
 	GetMessageRaw(ctx context.Context, id int64) ([]byte, error)

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -41,12 +41,10 @@ type Engine interface {
 	GetMessageBySourceID(ctx context.Context, sourceMessageID string) (*MessageDetail, error)
 	GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error)
 
-	// GetAttachmentByHash returns attachment metadata for the given
-	// content hash. content_hash is not unique — attachments are
-	// de-duplicated by content, so multiple rows may share a hash; any
-	// matching row is returned (filename/mime/size are equivalent across
-	// them). Returns nil, nil when no row matches.
-	GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error)
+	// GetAttachmentsByHash returns every attachment matching the given content
+	// hash in stable ID order. Multiple rows may refer to the same bytes while
+	// retaining different filenames, MIME types, and legacy storage paths.
+	GetAttachmentsByHash(ctx context.Context, contentHash string) ([]AttachmentInfo, error)
 
 	// GetMessageRaw returns the decompressed raw MIME data for a message.
 	// Returns nil, nil if no raw data is stored for the given ID.

--- a/internal/query/models.go
+++ b/internal/query/models.go
@@ -92,6 +92,7 @@ type AttachmentInfo struct {
 	Size        int64
 	ContentHash string
 	URL         string
+	StoragePath string
 }
 
 // ViewType represents the type of aggregate view.

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -18,7 +18,7 @@ type MockEngine struct {
 	ListResults       []query.MessageSummary
 	Messages          map[int64]*query.MessageDetail
 	Attachments       map[int64]*query.AttachmentInfo
-	AttachmentsByHash map[string]*query.AttachmentInfo
+	AttachmentsByHash map[string][]query.AttachmentInfo
 	Stats             *query.TotalStats
 	Accounts          []query.AccountInfo
 	AggregateRows     []query.AggregateRow
@@ -132,13 +132,13 @@ func (m *MockEngine) GetAttachment(_ context.Context, id int64) (*query.Attachme
 	return nil, nil //nolint:nilnil // mirrors Engine.GetAttachment (nil, nil) not-found contract
 }
 
-func (m *MockEngine) GetAttachmentByHash(_ context.Context, contentHash string) (*query.AttachmentInfo, error) {
+func (m *MockEngine) GetAttachmentsByHash(_ context.Context, contentHash string) ([]query.AttachmentInfo, error) {
 	if m.AttachmentsByHash != nil {
-		if a, ok := m.AttachmentsByHash[contentHash]; ok {
-			return a, nil
+		if attachments, ok := m.AttachmentsByHash[contentHash]; ok {
+			return attachments, nil
 		}
 	}
-	return nil, nil //nolint:nilnil // mirrors Engine.GetAttachmentByHash (nil, nil) not-found contract
+	return nil, nil
 }
 
 func (m *MockEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -18,6 +18,7 @@ type MockEngine struct {
 	ListResults       []query.MessageSummary
 	Messages          map[int64]*query.MessageDetail
 	Attachments       map[int64]*query.AttachmentInfo
+	AttachmentsByHash map[string]*query.AttachmentInfo
 	Stats             *query.TotalStats
 	Accounts          []query.AccountInfo
 	AggregateRows     []query.AggregateRow
@@ -129,6 +130,15 @@ func (m *MockEngine) GetAttachment(_ context.Context, id int64) (*query.Attachme
 		}
 	}
 	return nil, nil //nolint:nilnil // mirrors Engine.GetAttachment (nil, nil) not-found contract
+}
+
+func (m *MockEngine) GetAttachmentByHash(_ context.Context, contentHash string) (*query.AttachmentInfo, error) {
+	if m.AttachmentsByHash != nil {
+		if a, ok := m.AttachmentsByHash[contentHash]; ok {
+			return a, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // mirrors Engine.GetAttachmentByHash (nil, nil) not-found contract
 }
 
 func (m *MockEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1048,7 +1048,7 @@ func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 // GetAttachmentByHash retrieves attachment metadata by content hash.
 func (e *SQLiteEngine) GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error) {
 	var att AttachmentInfo
-	err := e.db.QueryRowContext(ctx, `
+	err := e.queryRowContext(ctx, `
 		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, '')
 		FROM attachments
 		WHERE content_hash = ?

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1026,21 +1026,21 @@ func (e *SQLiteEngine) getMessageByQuery(ctx context.Context, whereClause string
 // GetAttachment retrieves attachment metadata by ID.
 func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*AttachmentInfo, error) {
 	var att AttachmentInfo
-	var storagePath string
 	err := e.queryRowContext(ctx, `
 		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, ''), COALESCE(storage_path, '')
 		FROM attachments
 		WHERE id = ?
-	`, id).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash, &storagePath)
+	`, id).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash, &att.StoragePath)
 	if err == sql.ErrNoRows {
 		return nil, nil //nolint:nilnil // Engine.GetAttachment uses (nil, nil) for not-found; callers branch on the nil result
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get attachment: %w", err)
 	}
-	if isURLStoragePath(storagePath) {
-		att.URL = storagePath
+	if isURLStoragePath(att.StoragePath) {
+		att.URL = att.StoragePath
 		att.ContentHash = ""
+		att.StoragePath = ""
 	}
 	return &att, nil
 }
@@ -1049,11 +1049,11 @@ func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 func (e *SQLiteEngine) GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error) {
 	var att AttachmentInfo
 	err := e.queryRowContext(ctx, `
-		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, '')
+		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, ''), COALESCE(storage_path, '')
 		FROM attachments
 		WHERE content_hash = ?
 		LIMIT 1
-	`, contentHash).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash)
+	`, contentHash).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash, &att.StoragePath)
 	if err == sql.ErrNoRows {
 		return nil, nil //nolint:nilnil // Engine.GetAttachmentByHash uses (nil, nil) for not-found; callers branch on the nil result
 	}

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1045,6 +1045,24 @@ func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 	return &att, nil
 }
 
+// GetAttachmentByHash retrieves attachment metadata by content hash.
+func (e *SQLiteEngine) GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error) {
+	var att AttachmentInfo
+	err := e.db.QueryRowContext(ctx, `
+		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, '')
+		FROM attachments
+		WHERE content_hash = ?
+		LIMIT 1
+	`, contentHash).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash)
+	if err == sql.ErrNoRows {
+		return nil, nil //nolint:nilnil // Engine.GetAttachmentByHash uses (nil, nil) for not-found; callers branch on the nil result
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get attachment by hash: %w", err)
+	}
+	return &att, nil
+}
+
 // GetMessageRaw returns the decompressed raw MIME data for a message.
 func (e *SQLiteEngine) GetMessageRaw(ctx context.Context, id int64) ([]byte, error) {
 	return getMessageRawShared(ctx, e.db, e.dialect.Rebind, "", id)

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1045,22 +1045,32 @@ func (e *SQLiteEngine) GetAttachment(ctx context.Context, id int64) (*Attachment
 	return &att, nil
 }
 
-// GetAttachmentByHash retrieves attachment metadata by content hash.
-func (e *SQLiteEngine) GetAttachmentByHash(ctx context.Context, contentHash string) (*AttachmentInfo, error) {
-	var att AttachmentInfo
-	err := e.queryRowContext(ctx, `
+// GetAttachmentsByHash retrieves all attachment metadata matching a content
+// hash in stable ID order.
+func (e *SQLiteEngine) GetAttachmentsByHash(ctx context.Context, contentHash string) ([]AttachmentInfo, error) {
+	rows, err := e.queryContext(ctx, `
 		SELECT id, COALESCE(filename, ''), COALESCE(mime_type, ''), COALESCE(size, 0), COALESCE(content_hash, ''), COALESCE(storage_path, '')
 		FROM attachments
 		WHERE content_hash = ?
-		LIMIT 1
-	`, contentHash).Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash, &att.StoragePath)
-	if err == sql.ErrNoRows {
-		return nil, nil //nolint:nilnil // Engine.GetAttachmentByHash uses (nil, nil) for not-found; callers branch on the nil result
-	}
+		ORDER BY id
+	`, contentHash)
 	if err != nil {
-		return nil, fmt.Errorf("get attachment by hash: %w", err)
+		return nil, fmt.Errorf("get attachments by hash: %w", err)
 	}
-	return &att, nil
+	defer func() { _ = rows.Close() }()
+
+	var attachments []AttachmentInfo
+	for rows.Next() {
+		var att AttachmentInfo
+		if err := rows.Scan(&att.ID, &att.Filename, &att.MimeType, &att.Size, &att.ContentHash, &att.StoragePath); err != nil {
+			return nil, fmt.Errorf("scan attachment by hash: %w", err)
+		}
+		attachments = append(attachments, att)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate attachments by hash: %w", err)
+	}
+	return attachments, nil
 }
 
 // GetMessageRaw returns the decompressed raw MIME data for a message.

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -308,7 +308,7 @@ func TestGetAttachmentClearsURLBackedContentHash(t *testing.T) {
 	assert.Equal("https://sp/recording.mp4", att.URL)
 }
 
-func TestGetAttachmentByHashUsesDialectRebind(t *testing.T) {
+func TestGetAttachmentsByHashUsesDialectRebind(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	env := newTestEnv(t)
@@ -322,9 +322,9 @@ func TestGetAttachmentByHashUsesDialectRebind(t *testing.T) {
 
 	dialect := &rebindRecordingDialect{Dialect: PostgreSQLQueryDialect{}}
 	engine := NewEngineWithDialect(env.DB, dialect)
-	att, err := engine.GetAttachmentByHash(env.Ctx, hash)
-	require.NoError(err, "GetAttachmentByHash")
-	require.NotNil(att, "attachment")
+	attachments, err := engine.GetAttachmentsByHash(env.Ctx, hash)
+	require.NoError(err, "GetAttachmentsByHash")
+	require.Len(attachments, 1, "attachments")
 	require.NotEmpty(dialect.queries, "dialect Rebind calls")
 	assert.Contains(dialect.queries[len(dialect.queries)-1], "content_hash = $1", "rebound query")
 }

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -12,6 +12,18 @@ import (
 	"go.kenn.io/msgvault/internal/testutil/dbtest"
 )
 
+type rebindRecordingDialect struct {
+	Dialect
+
+	queries []string
+}
+
+func (d *rebindRecordingDialect) Rebind(query string) string {
+	rebound := d.Dialect.Rebind(query)
+	d.queries = append(d.queries, rebound)
+	return rebound
+}
+
 // emptyTargets creates an EmptyValueTargets map for testing with the given ViewType(s).
 func emptyTargets(views ...ViewType) map[ViewType]bool {
 	m := make(map[ViewType]bool)
@@ -294,6 +306,27 @@ func TestGetAttachmentClearsURLBackedContentHash(t *testing.T) {
 	require.NotNil(att)
 	assert.Empty(att.ContentHash)
 	assert.Equal("https://sp/recording.mp4", att.URL)
+}
+
+func TestGetAttachmentByHashUsesDialectRebind(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	hash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	_, err := env.DB.Exec(`
+		INSERT INTO attachments (message_id, filename, mime_type, size, content_hash, storage_path)
+		VALUES (1, 'report.pdf', 'application/pdf', 123, ?, '01/report.pdf')
+	`, hash)
+	require.NoError(err, "insert attachment")
+
+	dialect := &rebindRecordingDialect{Dialect: PostgreSQLQueryDialect{}}
+	engine := NewEngineWithDialect(env.DB, dialect)
+	att, err := engine.GetAttachmentByHash(env.Ctx, hash)
+	require.NoError(err, "GetAttachmentByHash")
+	require.NotNil(att, "attachment")
+	require.NotEmpty(dialect.queries, "dialect Rebind calls")
+	assert.Contains(dialect.queries[len(dialect.queries)-1], "content_hash = $1", "rebound query")
 }
 
 func TestGetMessageBySourceID(t *testing.T) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -6,10 +6,36 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/pkg/client/generated"
 )
+
+func TestGeneratedGetAttachmentContentReturnsBinaryBytes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	content := []byte{0x00, 0xff, 0x7b, 0x22, 0x6e, 0x6f, 0x74, 0x2d, 0x6a, 0x73, 0x6f, 0x6e}
+	hash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method, "method")
+		assert.Equal("/api/v1/attachments/"+hash+"/content", r.URL.Path, "path")
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(content)
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := generated.NewDefaultClient(server.URL, runtime.WithHTTPClient(httpClientDoer{client: http.DefaultClient}))
+	require.NoError(err, "NewDefaultClient")
+
+	got, err := c.GetAttachmentContent(context.Background(), &generated.GetAttachmentContentRequestOptions{
+		PathParams: &generated.GetAttachmentContentPath{Hash: hash},
+	})
+	require.NoError(err, "GetAttachmentContent")
+	require.NotNil(got, "response")
+	assert.Equal(content, *got, "content")
+}
 
 func TestNewCreatesTypedClient(t *testing.T) {
 	require := require.New(t)

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -660,22 +660,8 @@ func (c *Client) GetAttachmentContent(ctx context.Context, options *GetAttachmen
 			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
 				runtime.WithStatusCode(resp.StatusCode))
 		}
-		target := new(GetAttachmentContentResponse)
-		// Handle empty response body gracefully
-		if len(bodyBytes) == 0 {
-			return target, nil
-		}
-		if err = json.Unmarshal(bodyBytes, target); err != nil {
-			return nil, &runtime.ResponseDecodeError{
-				StatusCode:    resp.StatusCode,
-				ContentType:   resp.Headers.Get("Content-Type"),
-				ContentLength: len(bodyBytes),
-				TargetType:    "GetAttachmentContentResponse",
-				Body:          bodyBytes,
-				Err:           err,
-			}
-		}
-		return target, nil
+		result := GetAttachmentContentResponse(bodyBytes)
+		return &result, nil
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attachments/{hash}/content")

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -51,6 +51,10 @@ type ClientInterface interface {
 	GetSubAggregates(ctx context.Context, options *GetSubAggregatesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetSubAggregatesResponse, error)
 	GetSubAggregatesWithResponse(ctx context.Context, options *GetSubAggregatesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetSubAggregatesResp, error)
 
+	// GetAttachmentContent Download attachment content by SHA-256 hash
+	GetAttachmentContent(ctx context.Context, options *GetAttachmentContentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentContentResponse, error)
+	GetAttachmentContentWithResponse(ctx context.Context, options *GetAttachmentContentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentContentResp, error)
+
 	// GetAttachment Get attachment metadata
 	GetAttachment(ctx context.Context, options *GetAttachmentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentResponse, error)
 	GetAttachmentWithResponse(ctx context.Context, options *GetAttachmentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentResp, error)
@@ -612,6 +616,69 @@ func (c *Client) GetSubAggregates(ctx context.Context, options *GetSubAggregates
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/aggregates/sub")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// GetAttachmentContent Download attachment content by SHA-256 hash
+func (c *Client) GetAttachmentContent(ctx context.Context, options *GetAttachmentContentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentContentResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attachments/{hash}/content",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetAttachmentContentResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetAttachmentContentErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetAttachmentContentErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetAttachmentContentResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetAttachmentContentResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attachments/{hash}/content")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -138,6 +138,50 @@ func (o *GetSubAggregatesRequestOptions) GetHeader() (map[string]string, error) 
 	return nil, nil
 }
 
+// GetAttachmentContentRequestOptions is the options needed to make a request to GetAttachmentContent.
+type GetAttachmentContentRequestOptions struct {
+	PathParams *GetAttachmentContentPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetAttachmentContentRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetAttachmentContentRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetAttachmentContentRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetAttachmentContentRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetAttachmentContentRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // GetAttachmentRequestOptions is the options needed to make a request to GetAttachment.
 type GetAttachmentRequestOptions struct {
 	PathParams *GetAttachmentPath

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -270,6 +270,119 @@ func (c *Client) GetSubAggregatesWithResponse(ctx context.Context, options *GetS
 	}
 }
 
+// GetAttachmentContent Download attachment content by SHA-256 hash
+func (c *Client) GetAttachmentContentWithResponse(ctx context.Context, options *GetAttachmentContentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentContentResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attachments/{hash}/content",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attachments/{hash}/content")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetAttachmentContentResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		return out, nil
+	case 400:
+		out.JSON400 = new(GetAttachmentContentErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttachmentContentErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 401:
+		out.JSON401 = new(GetAttachmentContentErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON401); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttachmentContentErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(GetAttachmentContentErrorResponseJSON404)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttachmentContentErrorResponseJSON404",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(GetAttachmentContentErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttachmentContentErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(GetAttachmentContentErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttachmentContentErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // GetAttachment Get attachment metadata
 func (c *Client) GetAttachmentWithResponse(ctx context.Context, options *GetAttachmentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentResp, error) {
 	var err error

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -6,6 +6,15 @@ import (
 	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
 )
 
+type GetAttachmentContentPath struct {
+	// Hash Attachment SHA-256 content hash
+	Hash string `json:"hash" validate:"required"`
+}
+
+func (g GetAttachmentContentPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
 type GetAttachmentPath struct {
 	// ID Attachment ID
 	ID int64 `json:"id"`

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -33,7 +33,7 @@ type GetSubAggregatesResponse = AggregateResponse
 
 type GetSubAggregatesErrorResponse = ErrorResponse
 
-type GetAttachmentContentResponse = runtime.File
+type GetAttachmentContentResponse = []byte
 
 type GetAttachmentContentErrorResponse = ErrorResponse
 

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -33,6 +33,18 @@ type GetSubAggregatesResponse = AggregateResponse
 
 type GetSubAggregatesErrorResponse = ErrorResponse
 
+type GetAttachmentContentResponse = runtime.File
+
+type GetAttachmentContentErrorResponse = ErrorResponse
+
+type GetAttachmentContentErrorResponseJSON = ErrorResponse
+
+type GetAttachmentContentErrorResponseJSON404 = ErrorResponse
+
+type GetAttachmentContentErrorResponseJSON500 = ErrorResponse
+
+type GetAttachmentContentErrorResponseJSON503 = ErrorResponse
+
 type GetAttachmentResponse = AttachmentInfo
 
 type GetAttachmentErrorResponse = ErrorResponse
@@ -459,6 +471,17 @@ type GetSubAggregatesResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *GetSubAggregatesResponse
+}
+
+type GetAttachmentContentResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON400      *GetAttachmentContentErrorResponse
+	JSON401      *GetAttachmentContentErrorResponseJSON
+	JSON404      *GetAttachmentContentErrorResponseJSON404
+	JSON500      *GetAttachmentContentErrorResponseJSON500
+	JSON503      *GetAttachmentContentErrorResponseJSON503
 }
 
 type GetAttachmentResp struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2540,6 +2540,66 @@ paths:
       summary: Get nested aggregate rows
       tags:
         - API
+  /api/v1/attachments/{hash}/content:
+    get:
+      operationId: getAttachmentContent
+      parameters:
+        - description: Attachment SHA-256 content hash
+          in: path
+          name: hash
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+                x-contentMediaType: application/octet-stream
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Download attachment content by SHA-256 hash
+      tags:
+        - API
   /api/v1/attachments/{id}:
     get:
       operationId: getAttachment

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2553,7 +2553,7 @@ paths:
       responses:
         "200":
           content:
-            application/octet-stream:
+            "*/*":
               schema:
                 format: binary
                 type: string


### PR DESCRIPTION
## What

Adds `GET /api/v1/attachments/{hash}` — an authenticated endpoint that streams a stored attachment's raw bytes, addressed by its SHA-256 content hash, with the attachment's own `Content-Type` and a download `Content-Disposition` filename.

## Why

The HTTP API had no way to retrieve file-attachment content. `/messages/{id}/inline` serves only inline images (it requires a `cid` and an `image/*` content type), and attachment bytes were otherwise reachable only from the co-located CLI/MCP paths that read the on-disk store directly. A networked client — a remote TUI, or any integration without filesystem access to the attachments directory — had no route to fetch them.

## Usage

```
GET /api/v1/attachments/{sha256-hex}
Authorization: Bearer <api-key>
```

- `200` with the file bytes and `Content-Type` / `Content-Disposition` / `Content-Length` set.
- `400` for a malformed hash (not 64 hex chars; also guards path traversal).
- `404` when the attachment metadata row or its on-disk file is absent (e.g. an account removed with its attachments, or an archive built with `--no-attachments`).

Auth is inherited from the existing `/api/v1` API-key middleware. `content_hash` is not unique (content-addressed dedup), so any matching row supplies the header metadata.
