### PR TITLE
docs: require explicit roborev requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,13 @@ This file applies to all AI coding agents (Claude Code, Codex, Copilot CLI, etc.
 
 - Project guide: `CLAUDE.md` (this file is authoritative; AGENTS.md inherits its rules).
 
+## Roborev
+
+- Never manually invoke `roborev review` in any form unless the user explicitly
+  asks for it. Never invoke a roborev skill (including `roborev-fix` or
+  `roborev-design-review-branch`) unless the user explicitly asks for that
+  skill.
+
 ## Testing — Use testify
 
 All Go tests use `github.com/stretchr/testify`. New tests and modifications to existing tests MUST use `assert.X` or `require.X` from testify — never `t.Errorf`, `t.Fatalf`, `t.Fatal`, or `t.Error`.


### PR DESCRIPTION
Automated review runs can consume resources and create persistent review state even when review was not part of the requested task. Make both direct `roborev review` invocation and roborev skill activation explicitly user-directed so agents do not treat either as an automatic completion step.