### PR TITLE
docs: clarify roborev review restriction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,11 @@ This file applies to all AI coding agents (Claude Code, Codex, Copilot CLI, etc.
 
 ## Roborev
 
-- Never manually invoke `roborev review` in any form unless the user explicitly
-  asks for it. Never invoke a roborev skill (including `roborev-fix` or
-  `roborev-design-review-branch`) unless the user explicitly asks for that
-  skill.
+- Never invoke the `roborev review` CLI command in any form unless the user
+  explicitly asks for it. Use all other `roborev` CLI commands normally when
+  they are appropriate for interacting with roborev. Never invoke a roborev
+  skill (including `roborev-fix` or `roborev-design-review-branch`) unless the
+  user explicitly asks for that skill.
 
 ## Testing — Use testify
 


### PR DESCRIPTION
The existing instruction can be read as restricting the roborev CLI generally. Clarify that only the `roborev review` subcommand requires an explicit user request and encourage normal use of every other roborev CLI command; roborev skills remain opt-in.