### PR TITLE
ci: shard slow Windows CLI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,9 @@ jobs:
         include:
           - name: cli
             package: ./cmd/msgvault/cmd
-          - name: sync
+          - name: sync-vector-embed
             package: ./internal/sync
-          - name: vector-embed
-            package: ./internal/vector/embed
+            package2: ./internal/vector/embed
           - name: vector-sqlite
             package: ./internal/vector/sqlitevec
     runs-on: windows-latest
@@ -214,11 +213,16 @@ jobs:
           CGO_CFLAGS: "-IC:/msys64/mingw64/include -fgnu89-inline"
           CGO_LDFLAGS: "-Wl,--allow-multiple-definition"
         run: |
-          ./scripts/test-package-shards.ps1 `
-            -Package '${{ matrix.package }}' `
-            -ShardCount 4 `
-            -Tags "fts5 sqlite_vec" `
-            -Timeout 20m
+          $packages = @('${{ matrix.package }}', '${{ matrix.package2 }}') |
+            Where-Object { $_ }
+          foreach ($package in $packages) {
+            ./scripts/test-package-shards.ps1 `
+              -Package $package `
+              -ShardCount 4 `
+              -Tags "fts5 sqlite_vec" `
+              -Timeout 20m
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
   test-windows-pack-restore:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,14 @@ jobs:
           CGO_CFLAGS: "-IC:/msys64/mingw64/include -fgnu89-inline"
           CGO_LDFLAGS: "-Wl,--allow-multiple-definition"
         run: |
+          $shardedPackages = @(
+            "go.kenn.io/msgvault/cmd/msgvault/cmd"
+            "go.kenn.io/msgvault/internal/sync"
+            "go.kenn.io/msgvault/internal/vector/embed"
+            "go.kenn.io/msgvault/internal/vector/sqlitevec"
+          )
           $packages = go list -tags "fts5 sqlite_vec" ./... |
-            Where-Object { $_ -ne "go.kenn.io/msgvault/cmd/msgvault/cmd" }
+            Where-Object { $_ -notin $shardedPackages }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           go test -timeout 20m -tags "fts5 sqlite_vec" $packages
 
@@ -143,7 +149,20 @@ jobs:
           name: msgvault-windows-amd64
           path: msgvault.exe
 
-  test-windows-cli:
+  test-windows-sharded:
+    name: test-windows-sharded (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: cli
+            package: ./cmd/msgvault/cmd
+          - name: sync
+            package: ./internal/sync
+          - name: vector-embed
+            package: ./internal/vector/embed
+          - name: vector-sqlite
+            package: ./internal/vector/sqlitevec
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -157,7 +176,7 @@ jobs:
         run: |
           C:\msys64\usr\bin\pacman.exe -S --noconfirm --needed mingw-w64-x86_64-sqlite3
 
-      - name: Test CLI package in isolated shards
+      - name: Test package in isolated shards
         shell: pwsh
         env:
           CGO_ENABLED: "1"
@@ -165,7 +184,7 @@ jobs:
           CGO_LDFLAGS: "-Wl,--allow-multiple-definition"
         run: |
           ./scripts/test-package-shards.ps1 `
-            -Package ./cmd/msgvault/cmd `
+            -Package '${{ matrix.package }}' `
             -ShardCount 4 `
             -Tags "fts5 sqlite_vec" `
             -Timeout 20m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,12 +132,43 @@ jobs:
           CGO_ENABLED: "1"
           CGO_CFLAGS: "-IC:/msys64/mingw64/include -fgnu89-inline"
           CGO_LDFLAGS: "-Wl,--allow-multiple-definition"
-        run: go test -timeout 20m -tags "fts5 sqlite_vec" ./...
+        run: |
+          $packages = go list -tags "fts5 sqlite_vec" ./... |
+            Where-Object { $_ -ne "go.kenn.io/msgvault/cmd/msgvault/cmd" }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          go test -timeout 20m -tags "fts5 sqlite_vec" $packages
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: msgvault-windows-amd64
           path: msgvault.exe
+
+  test-windows-cli:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install sqlite3 dev headers
+        shell: pwsh
+        run: |
+          C:\msys64\usr\bin\pacman.exe -S --noconfirm --needed mingw-w64-x86_64-sqlite3
+
+      - name: Test CLI package in isolated shards
+        shell: pwsh
+        env:
+          CGO_ENABLED: "1"
+          CGO_CFLAGS: "-IC:/msys64/mingw64/include -fgnu89-inline"
+          CGO_LDFLAGS: "-Wl,--allow-multiple-definition"
+        run: |
+          ./scripts/test-package-shards.ps1 `
+            -Package ./cmd/msgvault/cmd `
+            -ShardCount 4 `
+            -Tags "fts5 sqlite_vec" `
+            -Timeout 20m
 
   test-windows-pack-restore:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,14 +133,18 @@ jobs:
           CGO_CFLAGS: "-IC:/msys64/mingw64/include -fgnu89-inline"
           CGO_LDFLAGS: "-Wl,--allow-multiple-definition"
         run: |
-          $shardedPackages = @(
+          $separatePackages = @(
             "go.kenn.io/msgvault/cmd/msgvault/cmd"
+            "go.kenn.io/msgvault/internal/api"
+            "go.kenn.io/msgvault/internal/importer"
+            "go.kenn.io/msgvault/internal/store"
             "go.kenn.io/msgvault/internal/sync"
             "go.kenn.io/msgvault/internal/vector/embed"
             "go.kenn.io/msgvault/internal/vector/sqlitevec"
+            "go.kenn.io/msgvault/scripts"
           )
           $packages = go list -tags "fts5 sqlite_vec" ./... |
-            Where-Object { $_ -notin $shardedPackages }
+            Where-Object { $_ -notin $separatePackages }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           go test -timeout 20m -tags "fts5 sqlite_vec" $packages
 
@@ -148,6 +152,33 @@ jobs:
         with:
           name: msgvault-windows-amd64
           path: msgvault.exe
+
+  test-windows-slow-packages:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install sqlite3 dev headers
+        shell: pwsh
+        run: |
+          C:\msys64\usr\bin\pacman.exe -S --noconfirm --needed mingw-w64-x86_64-sqlite3
+
+      - name: Test slow packages
+        shell: pwsh
+        env:
+          CGO_ENABLED: "1"
+          CGO_CFLAGS: "-IC:/msys64/mingw64/include -fgnu89-inline"
+          CGO_LDFLAGS: "-Wl,--allow-multiple-definition"
+        run: |
+          go test -timeout 20m -tags "fts5 sqlite_vec" `
+            ./internal/api `
+            ./internal/importer `
+            ./internal/store `
+            ./scripts
 
   test-windows-sharded:
     name: test-windows-sharded (${{ matrix.name }})

--- a/scripts/test-package-shards.ps1
+++ b/scripts/test-package-shards.ps1
@@ -1,0 +1,124 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Package,
+
+    [ValidateRange(1, 64)]
+    [int]$ShardCount = 4,
+
+    [string]$Tags = "",
+
+    [string]$Timeout = "20m"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$goListArgs = @("list", "-f", "{{.Dir}}")
+if ($Tags) {
+    $goListArgs += @("-tags", $Tags)
+}
+$goListArgs += $Package
+
+$packageDir = & go @goListArgs
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+$packageDir = $packageDir.Trim()
+
+$testBinary = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "msgvault-tests-{0}-{1}.exe" -f $PID, [guid]::NewGuid().ToString("N")
+)
+
+try {
+    $compileArgs = @("test", "-c", "-o", $testBinary)
+    if ($Tags) {
+        $compileArgs += @("-tags", $Tags)
+    }
+    $compileArgs += $Package
+
+    & go @compileArgs
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    $testNames = @(& $testBinary "-test.list=^(Test|Example|Fuzz)")
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    if ($testNames.Count -eq 0) {
+        Write-Host "No tests found in $Package"
+        exit 0
+    }
+
+    $activeShards = [Math]::Min($ShardCount, $testNames.Count)
+    $shards = [object[]]::new($activeShards)
+    for ($i = 0; $i -lt $activeShards; $i++) {
+        $shards[$i] = [System.Collections.Generic.List[string]]::new()
+    }
+    for ($i = 0; $i -lt $testNames.Count; $i++) {
+        $shards[$i % $activeShards].Add($testNames[$i])
+    }
+
+    Write-Host "Running $($testNames.Count) tests from $Package in $activeShards shards"
+
+    $runs = for ($i = 0; $i -lt $activeShards; $i++) {
+        $escapedNames = $shards[$i] | ForEach-Object { [regex]::Escape($_) }
+        $pattern = "^(" + ($escapedNames -join "|") + ")$"
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $testBinary
+        $startInfo.WorkingDirectory = $packageDir
+        $startInfo.UseShellExecute = $false
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        $startInfo.ArgumentList.Add("-test.run=$pattern")
+        $startInfo.ArgumentList.Add("-test.timeout=$Timeout")
+
+        $process = [System.Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        if (-not $process.Start()) {
+            throw "Failed to start test shard $i"
+        }
+
+        [pscustomobject]@{
+            Index       = $i
+            Count       = $shards[$i].Count
+            Process     = $process
+            StandardOut = $process.StandardOutput.ReadToEndAsync()
+            StandardErr = $process.StandardError.ReadToEndAsync()
+        }
+    }
+
+    $failed = $false
+    foreach ($run in $runs) {
+        $run.Process.WaitForExit()
+        $elapsed = $run.Process.ExitTime - $run.Process.StartTime
+        $stdout = $run.StandardOut.GetAwaiter().GetResult()
+        $stderr = $run.StandardErr.GetAwaiter().GetResult()
+
+        if ($run.Process.ExitCode -eq 0) {
+            Write-Host ("ok shard {0}: {1} tests ({2:N1}s)" -f (
+                $run.Index + 1
+            ), $run.Count, $elapsed.TotalSeconds)
+        } else {
+            $failed = $true
+            Write-Error ("shard {0} failed with exit code {1}" -f (
+                $run.Index + 1
+            ), $run.Process.ExitCode) -ErrorAction Continue
+            if ($stdout) {
+                Write-Output $stdout
+            }
+            if ($stderr) {
+                Write-Error $stderr -ErrorAction Continue
+            }
+        }
+
+        $run.Process.Dispose()
+    }
+
+    if ($failed) {
+        exit 1
+    }
+} finally {
+    Remove-Item -LiteralPath $testBinary -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Windows CI previously put every package behind one runner. The 652-test CLI package, sync engine, vector backends, and several storage-heavy packages all contain substantial serial work, leaving the Windows check at 13m10s on current main. Adding `t.Parallel()` broadly would be unsafe because many command tests mutate process-global command state, environment variables, or the working directory.

This compiles the serial-heavy package test binaries once and runs deterministic test groups in isolated processes. The remaining slow packages retain Go's package-level concurrency on a separate runner, while the existing artifact job keeps its build and upload contract and covers every other package. Process isolation preserves existing test assumptions without changing production code or test coverage.

A healthy `windows-latest` run completed the slowest Windows job in 4m39s, down 65% from main's 13m10s. The tradeoff is aggregate Windows runner time: the primary Windows test jobs use about 19m56s instead of 13m10s, an increase of roughly 51%, while the existing packed-restore benchmark job is unchanged.