### PR TITLE
Fix daemon discovery for symlinked home directories

### DIFF
--- a/cmd/msgvault/cmd/daemon_runtime.go
+++ b/cmd/msgvault/cmd/daemon_runtime.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -43,6 +44,14 @@ type DaemonRuntime struct {
 }
 
 func daemonRuntimeStore(dataDir string) daemon.RuntimeStore {
+	// RuntimeStore rejects a symlink as its directory even when the target is
+	// a private directory owned by the current user. Resolve existing data-dir
+	// symlinks so supported MSGVAULT_HOME layouts keep working while the store
+	// still validates the canonical target. Leave unresolved paths unchanged so
+	// RuntimeStore preserves its existing errors for dangling or invalid paths.
+	if resolved, err := filepath.EvalSymlinks(dataDir); err == nil {
+		dataDir = resolved
+	}
 	return daemon.RuntimeStore{Dir: dataDir}
 }
 

--- a/cmd/msgvault/cmd/daemon_runtime_test.go
+++ b/cmd/msgvault/cmd/daemon_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -38,6 +39,27 @@ func TestWriteDaemonRuntimePublishesKitRecord(t *testing.T) {
 	assert.Equal(api.APISchemaVersion, rec.Metadata[runtimeAPISchemaVersion], "api schema metadata")
 	assert.Equal(daemonAPIKeyFingerprint("test-api-key"), rec.Metadata[runtimeAuthFingerprint], "api key fingerprint metadata")
 	assert.Equal(shutdownToken, rec.Metadata[runtimeShutdownToken], "shutdown token metadata")
+}
+
+func TestWriteDaemonRuntimeAcceptsSymlinkedDataDir(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	parentDir := t.TempDir()
+	realDataDir := filepath.Join(parentDir, "real")
+	linkedDataDir := filepath.Join(parentDir, "linked")
+	require.NoError(os.Mkdir(realDataDir, 0o700), "create real data directory")
+	if err := os.Symlink(realDataDir, linkedDataDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	path, _, err := writeDaemonRuntime(linkedDataDir, "127.0.0.1", 8123, "v-test", "")
+	require.NoError(err, "writeDaemonRuntime through symlink")
+	t.Cleanup(func() { removeDaemonRuntime(linkedDataDir) })
+
+	rec, err := daemonRuntimeStore(linkedDataDir).Read(path)
+	require.NoError(err, "read runtime record through symlink")
+	assert.Equal(os.Getpid(), rec.PID, "pid")
+	assert.Equal(daemonService, rec.Service, "service")
 }
 
 func TestFindDaemonRuntimeRequiresLiveMsgvaultPing(t *testing.T) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,12 @@ All notable changes to msgvault, grouped by release.
 - PostgreSQL full-text indexes use a versioned field layout so stale indexes
   are detected and must be backfilled before body-only search.
 
+**Bug fixes**
+
+- Local daemon discovery works when the msgvault home or configured data
+  directory is a symlink, restoring the path layouts supported before 0.17.0
+  while retaining ownership and permission checks on the resolved directory.
+
 ---
 
 ## 0.17.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -432,6 +432,10 @@ export MSGVAULT_HOME=/mnt/data/msgvault
 
 Both options are equivalent: `config.toml` is loaded from the specified directory, and all data (database, tokens, attachments) is stored there. The `--home` flag takes priority over `MSGVAULT_HOME`.
 
+The home or `[data].data_dir` directory may be a symlink to an existing
+directory. Local daemon bookkeeping resolves the symlink and applies its
+ownership and permission checks to the target directory.
+
 ## Environment Variables
 
 | Variable | Description |


### PR DESCRIPTION
msgvault 0.17.0 moved local archive commands behind daemon runtime discovery. The runtime store then rejected an effective home or data directory whose final component was a symlink, breaking layouts supported by earlier releases and preventing both lifecycle and archive commands from running.

Resolve existing data-directory aliases before constructing the runtime store. The hardened store still checks ownership and permissions on the canonical target, while dangling or invalid paths retain their existing errors.

Regression coverage exercises real runtime record write/read behavior through a symlink, and the configuration reference now documents the supported layout.