### PR TITLE
Fix IMAP fast sync high water marks

### DIFF
--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -74,7 +74,7 @@ func TestSaveIMAPFolderStates_ErrorsBlockPersistence(t *testing.T) {
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
-	assert.Empty(t, loaded, "a run with fetch errors must not advance folder watermarks")
+	assert.Empty(t, loaded, "a run with fetch errors must not advance folder high water marks")
 }
 
 func TestSaveIMAPFolderStates_LimitTruncationBlocksPersistence(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSaveIMAPFolderStates_LimitTruncationBlocksPersistence(t *testing.T) {
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
-	assert.Empty(t, loaded, "a --limit-truncated run must not advance folder watermarks")
+	assert.Empty(t, loaded, "a --limit-truncated run must not advance folder high water marks")
 }
 
 func TestSaveIMAPFolderStates_NonIMAPClientIsNoOp(t *testing.T) {
@@ -160,7 +160,7 @@ func TestIMAPFolderStateSaveOption_PersistsCompletedFolders(t *testing.T) {
 	client.AcknowledgeMessages(ctx, []string{"INBOX|1"})
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
-	assert.Empty(loaded, "partial folder acknowledgement must not persist its watermark")
+	assert.Empty(loaded, "partial folder acknowledgement must not persist its high water mark")
 
 	client.AcknowledgeMessages(ctx, []string{"INBOX|2"})
 	loaded, err = loadIMAPFolderStates(st, src.ID)

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -145,6 +145,37 @@ func TestIMAPFolderStateOptions_ForceRescanBypassesSavedStates(t *testing.T) {
 	assert.NotEmpty(imapFolderStateOptions(st, src, false))
 }
 
+func TestIMAPFolderStateSaveOption_PersistsCompletedFolders(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 1})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(err)
+
+	client := listedIMAPClient(t, addr, imapFolderStateSaveOption(st, src))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client.AcknowledgeMessages(ctx, []string{"INBOX|1"})
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	assert.Empty(loaded, "partial folder acknowledgement must not persist its watermark")
+
+	client.AcknowledgeMessages(ctx, []string{"INBOX|2"})
+	loaded, err = loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	require.Contains(loaded, "INBOX")
+	assert.Equal(uint32(3), loaded["INBOX"].UIDNext)
+	assert.NotContains(loaded, "Archive")
+
+	client.AcknowledgeMessages(ctx, []string{"Archive|1"})
+	loaded, err = loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	require.Contains(loaded, "Archive")
+	assert.Equal(uint32(2), loaded["Archive"].UIDNext)
+}
+
 func TestSaveIMAPFolderStates_StoreRoundTripValues(t *testing.T) {
 	require := require.New(t)
 	st := testutil.NewTestStore(t)

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1417,7 +1417,9 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 // on because IMAP page tokens are numeric offsets that don't survive
 // across processes (see syncfull.go).
 func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store) (*gmail.SyncSummary, error) {
-	apiClient, err := buildAPIClient(ctx, src, nil, nil, imapFolderStateOptions(s, src, false)...)
+	imapOpts := imapFolderStateOptions(s, src, false)
+	imapOpts = append(imapOpts, imapFolderStateSaveOption(s, src))
+	apiClient, err := buildAPIClient(ctx, src, nil, nil, imapOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("build IMAP client: %w", err)
 	}

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -29,7 +29,7 @@ This is faster than a full sync as it only fetches changes since the last sync.
 Requires a prior full sync to establish the history ID baseline.
 
 IMAP accounts use folder-based sync. Unchanged folders are skipped when
-UIDVALIDITY/UIDNEXT watermarks are available.
+UIDVALIDITY/UIDNEXT high water marks are available.
 
 If no email is specified, syncs all accounts that have credentials configured.
 Accounts without tokens or history IDs are skipped.
@@ -171,7 +171,7 @@ func runSyncIncrementalLocal(cmd *cobra.Command, args []string) error {
 		if ctx.Err() != nil {
 			break
 		}
-		fmt.Printf("Note: IMAP account %s uses folder-based sync. Unchanged folders are skipped when watermarks are available.\n\n", src.Identifier)
+		fmt.Printf("Note: IMAP account %s uses folder-based sync. Unchanged folders are skipped when high water marks are available.\n\n", src.Identifier)
 		if err := runFullSync(ctx, s, getOAuthMgr, src); err != nil {
 			syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, err))
 		}

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -28,8 +28,8 @@ var syncIncrementalCmd = &cobra.Command{
 This is faster than a full sync as it only fetches changes since the last sync.
 Requires a prior full sync to establish the history ID baseline.
 
-IMAP accounts do not support incremental sync, so they are automatically
-synced using a full sync instead.
+IMAP accounts use folder-based sync. Unchanged folders are skipped when
+UIDVALIDITY/UIDNEXT watermarks are available.
 
 If no email is specified, syncs all accounts that have credentials configured.
 Accounts without tokens or history IDs are skipped.
@@ -166,12 +166,12 @@ func runSyncIncrementalLocal(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Sync IMAP sources via full sync.
+	// Sync IMAP sources via folder-based full sync.
 	for _, src := range imapTargets {
 		if ctx.Err() != nil {
 			break
 		}
-		fmt.Printf("Note: IMAP account %s does not support incremental sync. Running full sync.\n\n", src.Identifier)
+		fmt.Printf("Note: IMAP account %s uses folder-based sync. Unchanged folders are skipped when watermarks are available.\n\n", src.Identifier)
 		if err := runFullSync(ctx, s, getOAuthMgr, src); err != nil {
 			syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", src.Identifier, err))
 		}

--- a/cmd/msgvault/cmd/sync_test.go
+++ b/cmd/msgvault/cmd/sync_test.go
@@ -163,7 +163,9 @@ func TestSyncCmd_SingleSourceNoAmbiguity(t *testing.T) {
 	root.AddCommand(testCmd)
 	root.SetArgs([]string{"sync", "solo@example.com"})
 
+	getOutput := captureStdout(t)
 	err = root.Execute()
+	output := getOutput()
 	require.Error(err, "expected error (no IMAP config)")
 
 	errMsg := err.Error()
@@ -173,6 +175,10 @@ func TestSyncCmd_SingleSourceNoAmbiguity(t *testing.T) {
 
 	// Should NOT hit legacy fallback (source exists in DB).
 	assert.NotContains(errMsg, "no source found", "should not hit legacy fallback path")
+	assert.Contains(output, "uses folder-based sync",
+		"IMAP note should describe folder-based watermarks; output:\n%s", output)
+	assert.NotContains(output, "does not support incremental sync",
+		"IMAP note should not imply every sync is a full rescan; output:\n%s", output)
 }
 
 // TestSyncCmd_MboxIdentifierDoesNotFallback verifies that an

--- a/cmd/msgvault/cmd/sync_test.go
+++ b/cmd/msgvault/cmd/sync_test.go
@@ -176,7 +176,11 @@ func TestSyncCmd_SingleSourceNoAmbiguity(t *testing.T) {
 	// Should NOT hit legacy fallback (source exists in DB).
 	assert.NotContains(errMsg, "no source found", "should not hit legacy fallback path")
 	assert.Contains(output, "uses folder-based sync",
-		"IMAP note should describe folder-based watermarks; output:\n%s", output)
+		"IMAP note should describe folder-based high water marks; output:\n%s", output)
+	assert.Contains(output, "high water marks",
+		"IMAP note should use the high water mark term; output:\n%s", output)
+	assert.NotContains(output, "watermarks",
+		"IMAP note should say high water marks, not watermarks; output:\n%s", output)
 	assert.NotContains(output, "does not support incremental sync",
 		"IMAP note should not imply every sync is a full rescan; output:\n%s", output)
 }

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -387,7 +387,7 @@ func imapFolderStateSaveOption(s *store.Store, src *store.Source) imaplib.Option
 // saveIMAPFolderStates persists the per-mailbox states observed during
 // listing, but only after a sync that completed cleanly: an
 // interrupted, truncated (--limit), or partly failed run must not
-// advance the watermarks, or the messages it skipped would never be
+// advance the high water marks, or the messages it skipped would never be
 // fetched. Save failures only cost the next run's speedup, so they are
 // logged and swallowed.
 func saveIMAPFolderStates(s *store.Store, src *store.Source, apiClient gmail.API, summary *gmail.SyncSummary, limit int) {
@@ -414,8 +414,8 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	progress := &CLIProgress{}
 
 	// --noresume promises a fresh sync, so it must also bypass the
-	// saved folder watermarks and re-enumerate every mailbox. A clean
-	// completed run still saves fresh watermarks afterwards.
+	// saved folder high water marks and re-enumerate every mailbox. A clean
+	// completed run still saves fresh high water marks afterwards.
 	imapOpts := imapFolderStateOptions(s, src, syncNoResume)
 	if src.SourceType == sourceTypeIMAP {
 		imapOpts = append(imapOpts,

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -366,6 +366,24 @@ func imapFolderStateOptions(s *store.Store, src *store.Source, forceRescan bool)
 	return []imaplib.Option{imaplib.WithFolderStates(states)}
 }
 
+func saveIMAPFolderState(s *store.Store, src *store.Source, mailbox string, st imaplib.FolderState) {
+	err := s.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{{
+		Mailbox:     mailbox,
+		UIDValidity: st.UIDValidity,
+		UIDNext:     st.UIDNext,
+	}})
+	if err != nil {
+		logger.Warn("failed to save IMAP folder state",
+			"source", src.Identifier, "mailbox", mailbox, "error", err)
+	}
+}
+
+func imapFolderStateSaveOption(s *store.Store, src *store.Source) imaplib.Option {
+	return imaplib.WithFolderStateSave(func(mailbox string, st imaplib.FolderState) {
+		saveIMAPFolderState(s, src, mailbox, st)
+	})
+}
+
 // saveIMAPFolderStates persists the per-mailbox states observed during
 // listing, but only after a sync that completed cleanly: an
 // interrupted, truncated (--limit), or partly failed run must not
@@ -387,16 +405,8 @@ func saveIMAPFolderStates(s *store.Store, src *store.Source, apiClient gmail.API
 	if len(observed) == 0 {
 		return
 	}
-	states := make([]store.IMAPFolderState, 0, len(observed))
 	for mailbox, st := range observed {
-		states = append(states, store.IMAPFolderState{
-			Mailbox:     mailbox,
-			UIDValidity: st.UIDValidity,
-			UIDNext:     st.UIDNext,
-		})
-	}
-	if err := s.UpsertIMAPFolderStates(src.ID, states); err != nil {
-		logger.Warn("failed to save IMAP folder states", "source", src.Identifier, "error", err)
+		saveIMAPFolderState(s, src, mailbox, st)
 	}
 }
 
@@ -408,7 +418,10 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	// completed run still saves fresh watermarks afterwards.
 	imapOpts := imapFolderStateOptions(s, src, syncNoResume)
 	if src.SourceType == sourceTypeIMAP {
-		imapOpts = append(imapOpts, imaplib.WithListProgress(progress.OnIMAPListProgress))
+		imapOpts = append(imapOpts,
+			imaplib.WithListProgress(progress.OnIMAPListProgress),
+			imapFolderStateSaveOption(s, src),
+		)
 	}
 	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil, imapOpts...)
 	if err != nil {

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -80,6 +80,11 @@ type Client struct {
 
 	priorFolderStates    map[string]FolderState // saved states from the last completed sync
 	observedFolderStates map[string]FolderState // states captured during this session's listing
+	folderStateSave      func(string, FolderState)
+	pendingFolderStates  map[string]FolderState
+	pendingFolderCounts  map[string]int
+	pendingMessageFolder map[string]string
+	completedFolders     map[string]bool
 
 	// listProgress, when set, is invoked during message-list
 	// enumeration: once with done=0 after the mailbox list is known,
@@ -551,6 +556,8 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			c.messageListCache = []gmailapi.MessageID{}
 			return nil
 		}
+	} else {
+		c.clearFolderAcknowledgements()
 	}
 
 	labelMapComplete := true
@@ -579,9 +586,13 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	listOne := func(mailbox string) bool {
 		var minUID imap.UID
 		var observed *FolderState
+		var trackState FolderState
+		var canTrackFolder bool
 		if trackFolders && c.allMailFolder == "" {
 			if status, ok := folderStatuses[mailbox]; ok {
 				observed = &status
+				trackState = status
+				canTrackFolder = true
 				if prior, ok := c.priorFolderStates[mailbox]; ok &&
 					prior.UIDValidity == status.UIDValidity &&
 					prior.UIDNext <= status.UIDNext {
@@ -596,6 +607,11 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 					minUID = imap.UID(prior.UIDNext)
 				}
 			}
+		} else if trackFolders && c.allMailFolder != "" {
+			if status, ok := folderStatuses[mailbox]; ok {
+				trackState = status
+				canTrackFolder = true
+			}
 		}
 
 		uids, err := c.enumerateMailbox(ctx, mailbox, minUID)
@@ -605,6 +621,9 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		}
 		if observed != nil {
 			c.observedFolderStates[mailbox] = *observed
+		}
+		if canTrackFolder {
+			c.trackFolderMessages(mailbox, trackState, uids)
 		}
 		for _, uid := range uids {
 			messages = append(messages, gmailapi.MessageID{
@@ -638,6 +657,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			}
 		} else {
 			c.observedFolderStates = nil
+			c.clearFolderAcknowledgements()
 		}
 	}
 	if unchangedFolders > 0 {

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -544,9 +545,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		if c.allMailFolder != "" &&
 			len(folderStatuses) == len(allMailboxes) &&
 			unchangedStatuses == len(allMailboxes) {
-			for mailbox, status := range folderStatuses {
-				c.observedFolderStates[mailbox] = status
-			}
+			maps.Copy(c.observedFolderStates, folderStatuses)
 			if c.listProgress != nil {
 				c.listProgress(0, len(allMailboxes), "", 0, 0)
 				c.listProgress(len(allMailboxes), len(allMailboxes), "", 0, unchangedStatuses)
@@ -652,9 +651,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	}
 	if trackFolders && c.allMailFolder != "" {
 		if labelMapComplete && enumerationComplete {
-			for mailbox, status := range folderStatuses {
-				c.observedFolderStates[mailbox] = status
-			}
+			maps.Copy(c.observedFolderStates, folderStatuses)
 		} else {
 			c.observedFolderStates = nil
 			c.clearFolderAcknowledgements()

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -440,12 +440,13 @@ func (c *Client) fetchMailboxMessageIDs(
 // Caller must hold mu.
 func (c *Client) buildLabelMap(
 	ctx context.Context, allMailboxes []string,
-) error {
+) (bool, error) {
 	c.msgIDToLabels = make(map[string][]string)
+	complete := true
 
 	for _, mailbox := range allMailboxes {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return false, ctx.Err()
 		}
 		if mailbox == c.allMailFolder {
 			continue
@@ -453,6 +454,7 @@ func (c *Client) buildLabelMap(
 
 		uids, err := c.enumerateMailbox(ctx, mailbox, 0)
 		if err != nil {
+			complete = false
 			c.logger.Warn("skipping mailbox for label map",
 				"mailbox", mailbox, "error", err)
 			continue
@@ -463,6 +465,7 @@ func (c *Client) buildLabelMap(
 
 		msgIDs, err := c.fetchMailboxMessageIDs(ctx, mailbox, uids)
 		if err != nil {
+			complete = false
 			c.logger.Warn("failed to fetch envelopes for label map",
 				"mailbox", mailbox, "error", err)
 			continue
@@ -475,7 +478,7 @@ func (c *Client) buildLabelMap(
 		c.logger.Debug("built label map for mailbox",
 			"mailbox", mailbox, "messages", len(msgIDs))
 	}
-	return nil
+	return complete, nil
 }
 
 // buildMessageListCache enumerates mailboxes and populates
@@ -502,9 +505,10 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 
 	// Determine which mailboxes to list for canonical message IDs.
 	listMailboxes := allMailboxes
+	isGmailAllMail := false
 	if c.allMailFolder != "" {
-		isGmail := strings.HasPrefix(c.allMailFolder, "[Gmail]/")
-		if isGmail {
+		isGmailAllMail = strings.HasPrefix(c.allMailFolder, "[Gmail]/")
+		if isGmailAllMail {
 			// Gmail's All Mail contains every message except Trash
 			// and Spam. Enumerate those alongside All Mail to catch
 			// messages only in those folders.
@@ -518,44 +522,65 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 					listMailboxes, c.junkMailbox)
 			}
 		}
+	}
+
+	// Folder-state tracking skips unchanged mailboxes via STATUS
+	// UIDVALIDITY/UIDNEXT. Disabled under a date filter because a
+	// filtered run does not fetch everything up to UIDNEXT, so the
+	// watermark would be wrong. When an \All mailbox exists, the label
+	// map still needs full enumeration if anything changed, but a fully
+	// unchanged resync can return immediately.
+	trackFolders := c.since.IsZero() && c.before.IsZero()
+	var folderStatuses map[string]FolderState
+	var unchangedStatuses int
+	if trackFolders {
+		c.observedFolderStates = make(map[string]FolderState, len(allMailboxes))
+		folderStatuses, unchangedStatuses = c.observeFolderStates(ctx, allMailboxes)
+		if c.allMailFolder != "" &&
+			len(folderStatuses) == len(allMailboxes) &&
+			unchangedStatuses == len(allMailboxes) {
+			for mailbox, status := range folderStatuses {
+				c.observedFolderStates[mailbox] = status
+			}
+			if c.listProgress != nil {
+				c.listProgress(0, len(allMailboxes), "", 0, 0)
+				c.listProgress(len(allMailboxes), len(allMailboxes), "", 0, unchangedStatuses)
+			}
+			c.logger.Info("skipped unchanged mailboxes",
+				"unchanged", unchangedStatuses, "total", len(allMailboxes))
+			c.messageListCache = []gmailapi.MessageID{}
+			return nil
+		}
+	}
+
+	labelMapComplete := true
+	if c.allMailFolder != "" {
 		// On non-Gmail servers with \All, enumerate all selectable
 		// mailboxes — \All may not be a superset of every folder.
 		// Enable dedup to handle overlaps regardless of server.
 		c.seenRFC822IDs = make(map[string]bool)
 		c.logger.Info("detected All Mail folder via \\All attribute",
 			"folder", c.allMailFolder,
-			"gmail", isGmail,
+			"gmail", isGmailAllMail,
 			"trash", c.trashMailbox,
 			"junk", c.junkMailbox,
 			"total_mailboxes", len(allMailboxes))
 
-		if err := c.buildLabelMap(ctx, allMailboxes); err != nil {
+		var err error
+		labelMapComplete, err = c.buildLabelMap(ctx, allMailboxes)
+		if err != nil {
 			return err
 		}
-	}
-
-	// Folder-state tracking skips unchanged mailboxes via STATUS
-	// UIDVALIDITY/UIDNEXT. Disabled under a date filter (a filtered
-	// run does not fetch everything up to UIDNEXT, so the watermark
-	// would be wrong) and when an \All mailbox exists (the label map
-	// needs full enumeration of every folder).
-	trackFolders := c.since.IsZero() && c.before.IsZero() && c.allMailFolder == ""
-	if trackFolders {
-		c.observedFolderStates = make(map[string]FolderState, len(listMailboxes))
 	}
 
 	var messages []gmailapi.MessageID
 	var unchangedFolders int
 
-	listOne := func(mailbox string) {
+	listOne := func(mailbox string) bool {
 		var minUID imap.UID
 		var observed *FolderState
-		if trackFolders {
-			status, err := c.statusFolder(ctx, mailbox)
-			if err != nil {
-				c.logger.Warn("STATUS failed, enumerating mailbox fully",
-					"mailbox", mailbox, "error", err)
-			} else {
+		if trackFolders && c.allMailFolder == "" {
+			if status, ok := folderStatuses[mailbox]; ok {
 				observed = &status
 				if prior, ok := c.priorFolderStates[mailbox]; ok &&
 					prior.UIDValidity == status.UIDValidity &&
@@ -565,7 +590,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 						// no new messages possible, skip enumeration.
 						c.observedFolderStates[mailbox] = status
 						unchangedFolders++
-						return
+						return true
 					}
 					// Only new messages need listing.
 					minUID = imap.UID(prior.UIDNext)
@@ -576,7 +601,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		uids, err := c.enumerateMailbox(ctx, mailbox, minUID)
 		if err != nil {
 			c.logger.Warn("skipping mailbox", "mailbox", mailbox, "error", err)
-			return
+			return false
 		}
 		if observed != nil {
 			c.observedFolderStates[mailbox] = *observed
@@ -588,18 +613,31 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			})
 		}
 		c.logger.Debug("listed mailbox", "mailbox", mailbox, "count", len(uids))
+		return true
 	}
 
 	if c.listProgress != nil {
 		c.listProgress(0, len(listMailboxes), "", 0, 0)
 	}
+	enumerationComplete := true
 	for i, mailbox := range listMailboxes {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		listOne(mailbox)
+		if !listOne(mailbox) {
+			enumerationComplete = false
+		}
 		if c.listProgress != nil {
 			c.listProgress(i+1, len(listMailboxes), mailbox, len(messages), unchangedFolders)
+		}
+	}
+	if trackFolders && c.allMailFolder != "" {
+		if labelMapComplete && enumerationComplete {
+			for mailbox, status := range folderStatuses {
+				c.observedFolderStates[mailbox] = status
+			}
+		} else {
+			c.observedFolderStates = nil
 		}
 	}
 	if unchangedFolders > 0 {

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -333,7 +333,7 @@ func addMessageIDsFromHeaderFetchResults(dst map[string]bool, msgs []*imapclient
 
 // enumerateMailbox lists UIDs in a single mailbox. A non-zero minUID
 // restricts the search to UIDs at or above it (new messages since a
-// saved UIDNEXT watermark). It handles network errors with one
+// saved UIDNEXT high water mark). It handles network errors with one
 // reconnect attempt.
 func (c *Client) enumerateMailbox(
 	ctx context.Context, mailbox string, minUID imap.UID,
@@ -532,7 +532,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	// Folder-state tracking skips unchanged mailboxes via STATUS
 	// UIDVALIDITY/UIDNEXT. Disabled under a date filter because a
 	// filtered run does not fetch everything up to UIDNEXT, so the
-	// watermark would be wrong. When an \All mailbox exists, the label
+	// high water mark would be wrong. When an \All mailbox exists, the label
 	// map still needs full enumeration if anything changed, but a fully
 	// unchanged resync can return immediately.
 	trackFolders := c.since.IsZero() && c.before.IsZero()

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -111,6 +111,11 @@ type listProgressCall struct {
 	found, unchanged int
 }
 
+type folderStateSave struct {
+	mailbox string
+	state   FolderState
+}
+
 func TestListMessages_ReportsListProgress(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -205,4 +210,32 @@ func TestListMessages_AllMailboxRecordsFolderStatesForNoopResync(t *testing.T) {
 	assert.Empty(ids, "unchanged folders must not be re-enumerated when an All Mail folder exists")
 	assert.Equal(saved, second.ObservedFolderStates())
 	assert.Nil(second.msgIDToLabels, "a no-op resync must not build the All Mail label map")
+}
+
+func TestAcknowledgeMessagesFlushesFolderStateWhenFolderComplete(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 1})
+
+	var saved []folderStateSave
+	client := newTestClient(t, addr, WithFolderStateSave(func(mailbox string, state FolderState) {
+		saved = append(saved, folderStateSave{mailbox: mailbox, state: state})
+	}))
+	require.Len(listAllMessages(t, client), 3)
+
+	client.AcknowledgeMessages(context.Background(), []string{"INBOX|1"})
+	assert.Empty(saved, "folder state must not be saved until every listed UID in the folder is handled")
+
+	client.AcknowledgeMessages(context.Background(), []string{"INBOX|2"})
+	require.Len(saved, 1)
+	assert.Equal("INBOX", saved[0].mailbox)
+	assert.Equal(client.ObservedFolderStates()["INBOX"], saved[0].state)
+
+	client.AcknowledgeMessages(context.Background(), []string{"Archive|1"})
+	require.Len(saved, 2)
+	assert.Equal("Archive", saved[1].mailbox)
+	assert.Equal(client.ObservedFolderStates()["Archive"], saved[1].state)
+
+	client.AcknowledgeMessages(context.Background(), []string{"INBOX|2"})
+	assert.Len(saved, 2, "duplicate acknowledgements must not save a folder twice")
 }

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -181,3 +181,28 @@ func TestListMessages_DateFilterDisablesFolderTracking(t *testing.T) {
 	assert.Nil(second.ObservedFolderStates(),
 		"date-filtered runs must not record folder states")
 }
+
+func TestListMessages_AllMailboxRecordsFolderStatesForNoopResync(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"All Mail": 2, "Projects": 1})
+
+	first := newTestClient(t, addr)
+	// Seed mailbox discovery as if LIST reported All Mail with \All;
+	// the in-memory server does not retain CreateOptions.SpecialUse.
+	first.mailboxCache = []string{"All Mail", "Projects"}
+	first.allMailFolder = "All Mail"
+	require.Len(listAllMessages(t, first), 3)
+	saved := first.ObservedFolderStates()
+	require.Contains(saved, "All Mail")
+	require.Contains(saved, "Projects")
+	require.NoError(first.Close())
+
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	second.mailboxCache = []string{"All Mail", "Projects"}
+	second.allMailFolder = "All Mail"
+	ids := listAllMessages(t, second)
+	assert.Empty(ids, "unchanged folders must not be re-enumerated when an All Mail folder exists")
+	assert.Equal(saved, second.ObservedFolderStates())
+	assert.Nil(second.msgIDToLabels, "a no-op resync must not build the All Mail label map")
+}

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -22,9 +22,9 @@ type FolderState struct {
 // completed sync. During message listing, mailboxes whose current
 // STATUS matches the saved state are skipped without enumeration, and
 // changed mailboxes are searched only for UIDs at or above the saved
-// UIDNEXT. Ignored when a date filter is active or when the server
-// exposes an \All mailbox (Gmail-style virtual folders need full
-// enumeration for label mapping).
+// UIDNEXT. Ignored when a date filter is active. When the server
+// exposes an \All mailbox, saved states short-circuit fully unchanged
+// resyncs; changed runs still enumerate fully for label mapping.
 func WithFolderStates(states map[string]FolderState) Option {
 	return func(c *Client) { c.priorFolderStates = states }
 }
@@ -33,7 +33,7 @@ func WithFolderStates(states map[string]FolderState) Option {
 // the last message-list enumeration, for persistence after a completed
 // sync. Mailboxes whose STATUS or enumeration failed are absent, so
 // saved state for them is left untouched. Returns nil when folder
-// tracking was disabled (date filter, \All mailbox, or no listing yet).
+// tracking was disabled (date filter or no listing yet).
 func (c *Client) ObservedFolderStates() map[string]FolderState {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -43,6 +43,28 @@ func (c *Client) ObservedFolderStates() map[string]FolderState {
 	states := make(map[string]FolderState, len(c.observedFolderStates))
 	maps.Copy(states, c.observedFolderStates)
 	return states
+}
+
+func (c *Client) observeFolderStates(
+	ctx context.Context, mailboxes []string,
+) (map[string]FolderState, int) {
+	states := make(map[string]FolderState, len(mailboxes))
+	unchanged := 0
+	for _, mailbox := range mailboxes {
+		status, err := c.statusFolder(ctx, mailbox)
+		if err != nil {
+			c.logger.Warn("STATUS failed, enumerating mailbox fully",
+				"mailbox", mailbox, "error", err)
+			continue
+		}
+		states[mailbox] = status
+		if prior, ok := c.priorFolderStates[mailbox]; ok &&
+			prior.UIDValidity == status.UIDValidity &&
+			prior.UIDNext == status.UIDNext {
+			unchanged++
+		}
+	}
+	return states, unchanged
 }
 
 // statusFolder fetches UIDVALIDITY and UIDNEXT for a mailbox via

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -29,6 +29,12 @@ func WithFolderStates(states map[string]FolderState) Option {
 	return func(c *Client) { c.priorFolderStates = states }
 }
 
+// WithFolderStateSave sets a callback that is invoked after all listed
+// messages for a mailbox have been safely handled by the syncer.
+func WithFolderStateSave(fn func(string, FolderState)) Option {
+	return func(c *Client) { c.folderStateSave = fn }
+}
+
 // ObservedFolderStates returns the per-mailbox states captured during
 // the last message-list enumeration, for persistence after a completed
 // sync. Mailboxes whose STATUS or enumeration failed are absent, so
@@ -65,6 +71,71 @@ func (c *Client) observeFolderStates(
 		}
 	}
 	return states, unchanged
+}
+
+func (c *Client) trackFolderMessages(
+	mailbox string, state FolderState, uids []imap.UID,
+) {
+	if c.folderStateSave == nil || len(uids) == 0 {
+		return
+	}
+	if c.pendingFolderStates == nil {
+		c.pendingFolderStates = make(map[string]FolderState)
+		c.pendingFolderCounts = make(map[string]int)
+		c.pendingMessageFolder = make(map[string]string)
+		c.completedFolders = make(map[string]bool)
+	}
+	c.pendingFolderStates[mailbox] = state
+	c.pendingFolderCounts[mailbox] += len(uids)
+	for _, uid := range uids {
+		c.pendingMessageFolder[compositeID(mailbox, uid)] = mailbox
+	}
+}
+
+func (c *Client) clearFolderAcknowledgements() {
+	c.pendingFolderStates = nil
+	c.pendingFolderCounts = nil
+	c.pendingMessageFolder = nil
+	c.completedFolders = nil
+}
+
+// AcknowledgeMessages records message IDs that the syncer safely
+// handled. When every listed message in a folder has been acknowledged,
+// the folder state callback is invoked with that folder's watermark.
+func (c *Client) AcknowledgeMessages(_ context.Context, messageIDs []string) {
+	var completed []struct {
+		mailbox string
+		state   FolderState
+	}
+
+	c.mu.Lock()
+	if c.folderStateSave != nil {
+		for _, id := range messageIDs {
+			mailbox, ok := c.pendingMessageFolder[id]
+			if !ok {
+				continue
+			}
+			delete(c.pendingMessageFolder, id)
+			c.pendingFolderCounts[mailbox]--
+			if c.pendingFolderCounts[mailbox] > 0 || c.completedFolders[mailbox] {
+				continue
+			}
+			c.completedFolders[mailbox] = true
+			completed = append(completed, struct {
+				mailbox string
+				state   FolderState
+			}{mailbox: mailbox, state: c.pendingFolderStates[mailbox]})
+		}
+	}
+	save := c.folderStateSave
+	c.mu.Unlock()
+
+	if save == nil {
+		return
+	}
+	for _, item := range completed {
+		save(item.mailbox, item.state)
+	}
 }
 
 // statusFolder fetches UIDVALIDITY and UIDNEXT for a mailbox via

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -22,7 +22,7 @@ type FolderState struct {
 // completed sync. During message listing, mailboxes whose current
 // STATUS matches the saved state are skipped without enumeration, and
 // changed mailboxes are searched only for UIDs at or above the saved
-// UIDNEXT. Ignored when a date filter is active. When the server
+// UIDNEXT high water mark. Ignored when a date filter is active. When the server
 // exposes an \All mailbox, saved states short-circuit fully unchanged
 // resyncs; changed runs still enumerate fully for label mapping.
 func WithFolderStates(states map[string]FolderState) Option {
@@ -101,7 +101,7 @@ func (c *Client) clearFolderAcknowledgements() {
 
 // AcknowledgeMessages records message IDs that the syncer safely
 // handled. When every listed message in a folder has been acknowledged,
-// the folder state callback is invoked with that folder's watermark.
+// the folder state callback is invoked with that folder's high water mark.
 func (c *Client) AcknowledgeMessages(_ context.Context, messageIDs []string) {
 	var completed []struct {
 		mailbox string

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -65,7 +65,7 @@ type Syncer struct {
 }
 
 type messageAcknowledger interface {
-	AcknowledgeMessages(context.Context, []string)
+	AcknowledgeMessages(ctx context.Context, messageIDs []string)
 }
 
 // New creates a new Syncer.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -64,6 +64,10 @@ type Syncer struct {
 	opts     *Options
 }
 
+type messageAcknowledger interface {
+	AcknowledgeMessages(context.Context, []string)
+}
+
 // New creates a new Syncer.
 func New(client gmail.API, store *store.Store, opts *Options) *Syncer {
 	if opts == nil {
@@ -151,10 +155,11 @@ func (s *Syncer) initSyncState(sourceID int64) (*syncState, error) {
 
 // batchResult holds the result of processing a batch.
 type batchResult struct {
-	processed  int64
-	added      int64
-	skipped    int64
-	oldestDate time.Time
+	processed    int64
+	added        int64
+	skipped      int64
+	oldestDate   time.Time
+	acknowledged []string
 }
 
 // processBatch processes a single batch of messages from a list response.
@@ -184,7 +189,9 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 	for _, id := range messageIDs {
 		if _, exists := existingMap[id]; !exists {
 			newIDs = append(newIDs, id)
+			continue
 		}
+		result.acknowledged = append(result.acknowledged, id)
 	}
 
 	result.processed = int64(len(messageIDs))
@@ -208,6 +215,7 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 					s.logger.Debug("skipping message deleted before fetch", "id", newIDs[i])
 					s.recordSyncItem(syncID, newIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
 					result.skipped++
+					result.acknowledged = append(result.acknowledged, newIDs[i])
 					continue
 				}
 				errMsg := syncItemErrorMessage(fetch.Err, errRawBatchMissing.Error())
@@ -221,6 +229,7 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			// Distinct from []byte{} which is a genuine empty body.
 			if raw.Raw == nil {
 				result.skipped++
+				result.acknowledged = append(result.acknowledged, newIDs[i])
 				continue
 			}
 
@@ -242,6 +251,7 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			if err != nil {
 				if errors.Is(err, errDuplicateRFC822) {
 					result.skipped++
+					result.acknowledged = append(result.acknowledged, newIDs[i])
 					continue
 				}
 				s.logger.Warn("failed to ingest message", "id", raw.ID, "error", err)
@@ -251,6 +261,7 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			}
 
 			result.added++
+			result.acknowledged = append(result.acknowledged, newIDs[i])
 			summary.BytesDownloaded += int64(len(raw.Raw))
 		}
 
@@ -360,6 +371,9 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 
 		state.checkpoint.MessagesProcessed += result.processed
 		state.checkpoint.MessagesAdded += result.added
+		if ack, ok := s.client.(messageAcknowledger); ok && len(result.acknowledged) > 0 {
+			ack.AcknowledgeMessages(ctx, result.acknowledged)
+		}
 
 		// Report current position date before progress (so UI shows consistent state)
 		if !result.oldestDate.IsZero() {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -43,6 +43,15 @@ func (b *batchErrorAPI) GetMessagesRawBatchWithErrors(_ context.Context, _ []str
 	return nil, errors.New("batch fetch unavailable")
 }
 
+type acknowledgingAPI struct {
+	*gmail.MockAPI
+	acknowledged []string
+}
+
+func (a *acknowledgingAPI) AcknowledgeMessages(_ context.Context, messageIDs []string) {
+	a.acknowledged = append(a.acknowledged, messageIDs...)
+}
+
 func TestFullSync_PanicReturnsError(t *testing.T) {
 	env := newTestEnv(t)
 	seedMessages(env, 1, 12345, "msg1")
@@ -189,6 +198,27 @@ func TestFullSyncCanceledKeepsRunResumable(t *testing.T) {
 	assert.Equal("page_1", summary.ResumedFromToken, "resume picks up at the saved page token")
 	assert.Equal(int64(4), summary.MessagesAdded, "resumed summary carries pre-cancellation progress")
 	assertMessageCount(t, env.Store, 4)
+}
+
+func TestFullSyncAcknowledgesOnlySafelyHandledMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+
+	ackClient := &acknowledgingAPI{MockAPI: env.Mock}
+	env.Syncer = New(ackClient, env.Store, DefaultOptions())
+
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.MessagePages = [][]string{{"msg-ok", "msg-fail"}}
+	env.Mock.AddMessage("msg-ok", testMIME(), []string{"INBOX"})
+	env.Mock.GetMessageError["msg-fail"] = errors.New("temporary fetch failure")
+
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "full sync")
+
+	assert.Equal(int64(1), summary.Errors, "errors")
+	assert.Equal([]string{"msg-ok"}, ackClient.acknowledged)
 }
 
 func TestFullSyncWithErrors(t *testing.T) {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -45,6 +45,7 @@ func (b *batchErrorAPI) GetMessagesRawBatchWithErrors(_ context.Context, _ []str
 
 type acknowledgingAPI struct {
 	*gmail.MockAPI
+
 	acknowledged []string
 }
 


### PR DESCRIPTION
## Summary
- Fix IMAP fast sync for servers that expose an `\All` mailbox, including Fastmail.
- Persist IMAP folder high water marks after each folder is fully ingested or safely acknowledged, instead of requiring the entire account sync to finish first.
- Update IMAP sync status/help text and tests to use "high water mark" terminology.

## Root Cause
IMAP folder state tracking was disabled whenever the server advertised an `\All` mailbox. Fastmail exposes that mailbox, so the sync path never persisted per-folder `UIDVALIDITY`/`UIDNEXT` high water marks and every fast sync fell back to a full folder scan.

## Impact
Fastmail and other IMAP accounts can now establish folder high water marks and skip unchanged folders on later syncs. The sync still avoids advancing a folder high water mark after interrupted, truncated, or partly failed folder ingestion.

## Evidence
Before:

```text
Sync complete!
  Duration:      19h6m54s
  Messages:      1485466 found, 561 added, 1484905 skipped
  Downloaded:    74.37 MB
  Rate:          0.0 messages/sec
```

After:

```text
Sync complete!
  Duration:      36s
  Messages:      126 found, 57 added, 69 skipped
  Downloaded:    4.34 MB
  Rate:          1.6 messages/sec
```

## Validation
- `go test -tags "fts5 sqlite_vec" ./cmd/msgvault/cmd -run TestSyncCmd_SingleSourceNoAmbiguity -count=1`
- `go fmt ./...`
- `go vet -tags "fts5 sqlite_vec" ./...`
- `make test`
