### PR TITLE
Update nix flake for v0.18.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
   sqlite,
 }:
 let
-  version = "0.17.1";
+  version = "0.18.0";
 in
 buildGoModule {
   pname = "msgvault";


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-ykrI7CRnfb5jcfaLRXJ0yDrU7GADz2rEJmVq2vUA68E=`
- Updated version to `0.18.0`

Automated update via `scripts/update-nix-flake.sh`.