### PR TITLE
docs: document the 0.18.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # msgvault
 
-[![Go 1.25+](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://go.dev)
+[![Go 1.26+](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go)](https://go.dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/Docs-msgvault.io-blue)](https://msgvault.io)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/fDnmxB8Wkq)
@@ -15,15 +15,18 @@ Archive a lifetime of email. Analytics and search in milliseconds, entirely offl
 
 Your messages are yours. Decades of correspondence, attachments, and history shouldn't be locked behind a web interface or an API. By default, msgvault downloads a complete local copy and then everything runs offline. Search, analytics, and the MCP server all work against your msgvault archive with no mailbox network access required. If you configure a remote deployment, the archive lives on your own server rather than a hosted msgvault service.
 
-Currently supports Gmail, Google Calendar, Microsoft Teams, and IMAP sync, plus
-offline imports from MBOX exports, Apple Mail (.emlx) directories, PST archives,
-and common chat/text export formats.
+Currently supports Gmail, Google Calendar, Microsoft Teams, Granola,
+Circleback, Beeper Desktop, and IMAP sync, plus offline imports from MBOX
+exports, Apple Mail (`.emlx`) directories, PST archives, and common chat/text
+export formats.
 
 ## Features
 
 - **Full Gmail backup**: raw MIME, attachments, labels, and metadata
 - **Google Calendar sync**: archive events, organizers, and attendees; searchable alongside email
 - **Microsoft Teams sync**: archive delegated Graph chats, channels, replies, and inline media with `message_type = teams`
+- **Meeting notes**: sync Granola and Circleback notes and transcripts, then browse them in the TUI
+- **Beeper Desktop sync**: archive chats and media from every network bridged through Beeper's local API
 - **IMAP sync**: archive mail from any standard IMAP server
 - **Incremental backup snapshots**: verifiable `msgvault backup` repositories for the SQLite archive and attachments
 - **MBOX / Apple Mail / PST import**: import email from local export formats
@@ -35,6 +38,8 @@ and common chat/text export formats.
 - **Multi-account**: archive several Gmail and IMAP accounts in a single database
 - **Resumable**: interrupted syncs resume from the last checkpoint
 - **Content-addressed attachments**: deduplicated by SHA-256
+- **Packed attachment storage**: sealed immutable packs reduce filesystem overhead, with pack, repack, and unpack maintenance commands
+- **Agent skills**: install bundled search, attachment, and analytics workflows for Claude Code and Codex
 
 ## Installation
 
@@ -55,7 +60,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://msgvault.io/install.ps1 | iex
 
 The installer detects your OS and architecture, downloads the latest release from [GitHub Releases](https://github.com/kenn-io/msgvault/releases), verifies the SHA-256 checksum, and installs the binary. You can review the script ([bash](https://msgvault.io/install.sh), [PowerShell](https://msgvault.io/install.ps1)) before running, or download a release binary directly from GitHub.
 
-To build from source instead (requires **Go 1.25+** and a C/C++ compiler for CGO and to statically link DuckDB):
+To build from source instead (requires **Go 1.26+** and a C/C++ compiler for CGO and to statically link DuckDB):
 
 ```bash
 git clone https://github.com/kenn-io/msgvault.git
@@ -96,6 +101,9 @@ msgvault tui
 | `sync-calendar NAME\|EMAIL` | Sync Google Calendar events (full first run, then incremental) |
 | `add-teams EMAIL` | Authorize delegated Microsoft Graph access for Teams |
 | `sync-teams EMAIL` | Sync Microsoft Teams chats and channels |
+| `add-granola` / `sync-granola` | Register and sync Granola meeting notes and transcripts |
+| `add-circleback` / `sync-circleback` | Authorize and sync Circleback meetings, notes, and transcripts |
+| `add-beeper` / `sync-beeper` | Register and sync Beeper Desktop chats and media |
 | `backup` | Initialize, create, list, verify, and restore backup snapshots |
 | `pack-attachments` | Migrate all eligible loose attachment files into immutable packs |
 | `repack-attachments` | Reclaim dead space from sparse attachment packs |
@@ -104,6 +112,7 @@ msgvault tui
 | `search QUERY` | Search messages (`--account` and `--message-type` to filter, `--json` for machine output) |
 | `show-message ID` | View full message details (`--json` for machine output) |
 | `mcp` | Start the MCP server for AI assistant integration |
+| `skills install` | Install bundled agent skills for search, attachments, and analytics |
 | `serve` | Run the API/scheduler or manage the background daemon (`start`, `status`, `stop`, `restart`) |
 | `stats` | Show archive statistics |
 | `list-accounts` | List synced email accounts |

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -262,15 +262,60 @@ Full message details including body and attachment metadata.
   "body_html": "<html><body><p>Full HTML body</p></body></html>",
   "attachments": [
     {
+      "id": 987,
       "filename": "q4-plan.pdf",
       "mime_type": "application/pdf",
-      "size_bytes": 204800
+      "size_bytes": 204800,
+      "content_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     }
   ]
 }
 ```
 
 The `cc`, `bcc`, and `body_html` fields are included only when present. `body` is the plain-text body when one exists; for HTML-only messages, it falls back to the HTML body so callers still receive message content.
+
+---
+
+### Attachment metadata {#get-apiv1attachmentsid}
+
+**Endpoint:** `GET /api/v1/attachments/{id}`
+
+Returns metadata for the numeric attachment ID exposed by message details.
+The response includes the SHA-256 `content_hash` used by the content endpoint:
+
+```json
+{
+  "id": 987,
+  "filename": "q4-plan.pdf",
+  "mime_type": "application/pdf",
+  "size_bytes": 204800,
+  "content_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+```
+
+---
+
+### Attachment content by hash {#get-apiv1attachmentshashcontent}
+
+**Endpoint:** `GET /api/v1/attachments/{hash}/content`
+
+Streams the raw bytes of an archived attachment from either loose or packed
+storage. `{hash}` must be the 64-character SHA-256 `content_hash` returned by
+message details or the attachment metadata endpoint.
+
+```bash
+curl -H "X-API-Key: $MSGVAULT_API_KEY" \
+  --output attachment.bin \
+  "http://localhost:8080/api/v1/attachments/$HASH/content"
+```
+
+Successful responses set the archived MIME type as `Content-Type` (falling
+back to `application/octet-stream`), the archived filename in
+`Content-Disposition`, `Content-Length`, and `X-Content-Type-Options: nosniff`.
+An invalid hash returns `400`; a hash with no attachment row, or content that
+is no longer available, returns `404`. The generated Go client's
+`GetAttachmentContent` wrapper verifies the returned bytes against the
+requested hash before returning them.
 
 ---
 
@@ -324,10 +369,11 @@ to `mode=fts` instead.
 | `explain` | 0/1 | `0` | When `1` and `mode=vector|hybrid`, include per-signal scores |
 
 `message_type` uses the same values as local search: `email`,
-`calendar_event`, `teams`, `sms`, `mms`, `whatsapp`, `imessage`,
-`fbmessenger`, `synctech_sms_call`, `google_voice_text`,
-`google_voice_call`, and `google_voice_voicemail`. The query string can also
-carry `message_type:` / `message_type=` operators inside `q`.
+`calendar_event`, `meeting_transcript`, `beeper`, `teams`, `sms`, `mms`,
+`whatsapp`, `imessage`, `fbmessenger`, `synctech_sms_call`,
+`google_voice_text`, `google_voice_call`, and `google_voice_voicemail`. The
+query string can also carry `message_type:` / `message_type=` operators inside
+`q`.
 
 **Response (mode=fts, default):**
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -3,7 +3,16 @@ title: Architecture Overview
 description: Package structure and data flow.
 ---
 
-msgvault syncs your Gmail, Google Calendar, IMAP, Microsoft 365 mail, and Microsoft Teams accounts to a local SQLite database by default and can import local PST/MBOX archives, Apple Mail exports, and chats/texts from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore. PostgreSQL is available as an opt-in backend for new archives. Keyword search, analytics, the TUI, and the MCP server run against the configured archive database, Parquet metadata exports where available, and local attachment files. Optional vector search calls the embedding endpoint configured in `[vector.embeddings]` to build/query semantic vectors, then stores those vectors in `vectors.db` on SQLite or pgvector tables on PostgreSQL.
+msgvault syncs Gmail, Google Calendar, IMAP, Microsoft 365 mail, Microsoft
+Teams, Beeper Desktop, Granola, and Circleback into a local SQLite database by
+default and can import local PST/MBOX archives, Apple Mail exports, and common
+chat/text formats. PostgreSQL is available as an opt-in backend for new
+archives. Keyword search, analytics, the TUI, and the MCP server run against
+the configured archive database, Parquet metadata exports where available,
+and the mixed loose/packed attachment store. Optional vector search calls the
+embedding endpoint configured in `[vector.embeddings]` to build/query semantic
+vectors, then stores those vectors in `vectors.db` on SQLite or pgvector tables
+on PostgreSQL.
 
 <img src="/assets/static/how-it-works.svg" alt="msgvault architecture: Gmail API syncs to SQLite, then offline Parquet analytics, FTS5 search, TUI, and MCP Server" style="width: 100%; max-width: 960px; margin: 1.5rem auto; display: block;" />
 
@@ -18,6 +27,7 @@ msgvault/
 │   ├── query/               # DuckDB/SQL query engines
 │   ├── store/               # SQLite/PostgreSQL database access
 │   ├── backupapp/           # msgvault's App seam for the kit backup engine
+│   ├── attachmentstore/     # Streaming reads from loose files and sealed packs
 │   ├── deletion/            # Deletion staging and manifest
 │   ├── gmail/               # Gmail API client
 │   ├── gcal/                # Google Calendar API client
@@ -38,6 +48,9 @@ msgvault/
 │   ├── synctechsms/         # SMS Backup & Restore import
 │   ├── microsoft/           # Microsoft 365 OAuth
 │   ├── teams/               # Microsoft Teams Graph ingestion
+│   ├── beeper/              # Beeper Desktop client and importer
+│   ├── granola/             # Granola meeting-note client and importer
+│   ├── circleback/          # Circleback MCP/OAuth client and importer
 │   ├── oauth/               # OAuth2 flows (browser + device)
 │   └── mime/                # MIME parsing
 ├── go.mod
@@ -51,6 +64,7 @@ msgvault/
 | `cmd/` | Cobra CLI commands, config loading |
 | `internal/store` | SQLite and PostgreSQL database operations, schema management |
 | `internal/backupapp` | msgvault's `backup.App` implementation (stats, layout, exclusions) over `go.kenn.io/kit`'s backup/pack engine |
+| `internal/attachmentstore` | Daemon-owned streaming reader for loose and packed attachment content |
 | `internal/sync` | Sync orchestration, MIME parsing, checkpoint management |
 | `internal/gcal` / `internal/calsync` | Google Calendar API client and event sync |
 | `internal/imap` | IMAP client, connection management, credential storage |
@@ -73,13 +87,23 @@ msgvault/
 | `internal/synctechsms` | SMS Backup & Restore XML/ZIP parsing and Drive source sync |
 | `internal/microsoft` | Microsoft 365 OAuth flow |
 | `internal/teams` | Microsoft Teams Graph client mapping, sync cursors, and importer |
+| `internal/beeper` | Beeper Desktop local-API client, resumable sync state, media download, and message mapping |
+| `internal/granola` / `internal/circleback` | Meeting-note provider clients, authentication, formatting, and archive ingestion |
 | `internal/mime` | MIME message parsing, charset detection |
 
 ## Design Decisions
 
-- **Local-first by design**: The Gmail API and IMAP servers are only contacted during explicit `sync-full`, `sync`, and deletion commands. Keyword search, analytics, TUI views, and ordinary MCP reads run against local data with no mailbox network access. Optional vector search additionally calls only the embedding endpoint you configure, so a local/self-hosted endpoint keeps semantic search on your own machine or network.
+- **Local-first by design**: Mail, chat, calendar, and meeting providers are
+  contacted only by explicit authorization/registration, sync, media-backfill,
+  and deletion workflows. Keyword search, analytics, TUI views, and ordinary
+  MCP reads run against archived data without contacting those providers.
+  Optional vector search additionally calls only the embedding endpoint you
+  configure, so a local/self-hosted endpoint keeps semantic search on your own
+  machine or network.
 - **SQLite by default, PostgreSQL opt-in**: SQLite is the default system of record. PostgreSQL can be selected with `[data].database_url` for new archives that should live in a server database.
 - **DuckDB + Parquet for default analytics**: On SQLite archives, the TUI runs an embedded DuckDB engine over Parquet metadata exports, delivering aggregate queries hundreds of times faster than SQLite JOINs. The entire analytics cache for hundreds of thousands of messages fits in a few megabytes, making drill-down and re-aggregation feel instant. PostgreSQL archives currently use live SQL for aggregate views.
-- **Content-addressed attachments**: Deduplicated by SHA-256 hash, stored on disk.
+- **Content-addressed attachments**: Deduplicated by SHA-256 hash and stored as
+  loose files or in sealed immutable packs; readers resolve both layouts
+  transparently.
 - **Resumable sync**: Checkpoints allow interrupted syncs to resume without re-downloading.
 - **Token bucket rate limiting**: Respects Gmail API quotas without manual throttling.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -10,7 +10,7 @@ description: Database schema, Parquet analytics cache, content-addressed attachm
 | SQLite | Default system of record | `~/.msgvault/msgvault.db` |
 | PostgreSQL | Optional system of record | `[data].database_url` |
 | Parquet | Analytics cache | `~/.msgvault/analytics/` |
-| Attachments | Content-addressed files | `~/.msgvault/attachments/` |
+| Attachments | Content-addressed loose files and sealed packs | `~/.msgvault/attachments/` |
 | Tokens | OAuth credentials | `~/.msgvault/tokens/` |
 
 ## Archive Database
@@ -183,20 +183,36 @@ Messages are partitioned by year for efficient time-range queries. The entire an
 
 ## Content-Addressed Attachments
 
-Every attachment from every message (PDFs, photos, documents, spreadsheets, archives) is extracted and stored as a plain file on your local filesystem. No more digging through Gmail's web UI or hitting API rate limits to retrieve your own files. Once synced, they are yours to browse, back up, or process however you like.
+Every attachment from every message is identified by its SHA-256 content hash,
+so identical bytes referenced by multiple messages are stored once. New
+content is written as a loose file first; background maintenance and
+`pack-attachments` move eligible loose objects into sealed immutable packs to
+reduce file-count overhead. The archive can remain in a mixed state, and all
+normal readers resolve loose and packed content transparently.
 
-Attachments are deduplicated by SHA-256 hash:
+The attachment root can therefore contain both layouts:
 
 ```
 attachments/
 ├── ab/
-│   └── abcd1234567890...   # full SHA-256 hash as filename
-├── cd/
-│   └── cdef9876543210...
+│   └── abcd1234567890...            # loose object: full SHA-256 name
+├── packs/
+│   └── 01/
+│       └── 01k...mvpack             # sealed immutable pack
 └── ...
 ```
 
-The first two characters of the hash form the subdirectory (sharding). Multiple messages referencing the same attachment share one file.
+Loose objects are sharded by the first two hash characters. Packed-object
+locations and immutable pack totals are recorded in `attachment_pack_index`
+and `attachment_packs`; loose objects have no pack-index row.
+
+Use `pack-attachments` to migrate the eligible loose backlog immediately,
+`repack-attachments` to reclaim dead space after content is removed, and
+`unpack-attachments` to restore cataloged packed objects to loose files before
+downgrading. The last command is local-only and requires the daemon to be
+stopped because it removes production pack files. See the [CLI
+reference](/cli-reference/#pack-attachments) and [Backup](/usage/backup/) guide
+for maintenance and restore behavior.
 
 ## Token Storage
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,8 +30,7 @@ No notable changes yet.
   `msgvault skills uninstall` removes generated copies.
 - MCP search now has explicit `search_metadata`, `search_message_bodies`, and
   `semantic_search_messages` tools. `search_in_message` finds literal matches
-  with raw-body offsets inside one message and, when vector search is enabled,
-  can rank that message's embedded chunks semantically. The former combined
+  with raw-body offsets inside one message. The former combined
   `search_messages` tool remains as a deprecated compatibility wrapper.
 - MCP `list_messages` accepts a `conversation_id` filter for listing one
   conversation or thread.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,47 +7,93 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
+No notable changes yet.
+
+---
+
+## 0.18.0
+<small>2026-07-14</small>
+
 **New features**
 
-- `msgvault skills install` installs agent skills (per the open
-  agent-skills standard) for Claude Code and Codex, teaching coding
-  agents the search, attachment, and analytics CLI workflows.
-  `msgvault skills uninstall` removes them.
-- MCP message search now separates metadata and body search:
-  `search_metadata` searches metadata, `search_message_bodies` performs
-  body-only full-text search with bounded context around each match, and
-  `semantic_search_messages` owns explicit `vector` and `hybrid` modes.
-  The former combined `search_messages` tool remains as a deprecated
-  compatibility wrapper during migration.
+- Granola and Circleback meeting notes, summaries, action items, and
+  transcripts can be synced into the archive and browsed in a new read-only
+  Meetings mode in the TUI. Meeting records are searchable with
+  `message_type:meeting_transcript`, and scheduled sync is supported through
+  `[[granola]]` and `[[circleback]]` configuration.
+- Beeper Desktop chat archiving registers each bridged network as a separate
+  source, incrementally syncs messages, reactions, edits, and deletions, and
+  downloads media into the attachment store. Interrupted history backfills
+  resume, and `backfill-beeper-media` retries pending downloads.
+- `msgvault skills install` installs bundled read-only agent skills for search,
+  attachment, and analytics workflows into Claude Code and Codex;
+  `msgvault skills uninstall` removes generated copies.
+- MCP search now has explicit `search_metadata`, `search_message_bodies`, and
+  `semantic_search_messages` tools. `search_in_message` finds literal matches
+  with raw-body offsets inside one message and, when vector search is enabled,
+  can rank that message's embedded chunks semantically. The former combined
+  `search_messages` tool remains as a deprecated compatibility wrapper.
 - MCP `list_messages` accepts a `conversation_id` filter for listing one
   conversation or thread.
 - The daemon HTTP API schema is now 1.3.0 and supports `scope=body` on deep
   search so daemon-backed clients can require an exact body-only response;
   bounded excerpts are returned in an ID-keyed `body_contexts` companion.
+- `GET /api/v1/attachments/{hash}/content` streams archived attachment bytes
+  by SHA-256 content hash; message details expose the hash needed to call it.
+- Windows users can build natively with `scripts/build.ps1` on AMD64 or ARM64.
+  Releases now include a native Windows ARM64 package with DuckDB analytics and
+  Parquet cache support.
 
 **Improvements**
 
-- Windows releases include a native ARM64 package with full DuckDB analytics
-  and Parquet cache support.
-- Backup restore now installs compatible attachment packs directly instead of
-  recreating every blob as an individual file, substantially reducing file
-  creation overhead on Windows and large archives. Selected content remains
-  SHA-256 verified, incompatible or oversized entries fall back safely to
-  loose files, and `--loose-attachments` preserves the explicit downgrade and
-  recovery path.
-- Metadata and body search scopes are enforced consistently across SQLite,
-  PostgreSQL, DuckDB, and daemon-backed MCP sessions. Metadata result counts
-  and aggregate statistics use the same predicate, and body-search snippets
-  remain bounded, UTF-8-safe, and are selected by each backend's native FTS
-  tokenizer.
+- Attachment storage now supports sealed, immutable content-addressed packs
+  while remaining compatible with loose files. `pack-attachments` migrates
+  eligible loose content, `repack-attachments` reclaims dead pack space, and
+  `unpack-attachments` restores loose files for downgrade or recovery.
+- Backup snapshots now use Kit's pack-based backup engine. Restore installs
+  compatible attachment packs directly by default, still SHA-256 verifies
+  every selected attachment, and falls back to loose files for incompatible or
+  oversized content; `--loose-attachments` forces loose restoration.
+- Attachment exports, backup capture, HTTP downloads, and other consumers
+  stream packed or loose content instead of buffering whole attachments in
+  memory.
+- SQLite's full `PRAGMA integrity_check` is now opt-in during restore through
+  `--integrity-check`; page hashes, content hashes, and manifest-statistics
+  verification remain enabled for every restore.
+- Apple Mail import recognizes `.partial.emlx` files whose bodies are present
+  but attachments have not been cached. A complete `N.emlx` copy takes
+  precedence over `N.partial.emlx` when both exist.
 - PostgreSQL full-text indexes use a versioned field layout so stale indexes
   are detected and must be backfilled before body-only search.
 
 **Bug fixes**
 
+- IMAP folder `UIDVALIDITY` / `UIDNEXT` high water marks are now supported on
+  servers that advertise an `\All` mailbox and are persisted as each folder is
+  safely ingested. Interrupted, limited, or partially failed folders do not
+  advance, so later fast syncs can skip unchanged folders without missing mail.
 - Local daemon discovery works when the msgvault home or configured data
   directory is a symlink, restoring the path layouts supported before 0.17.0
   while retaining ownership and permission checks on the resolved directory.
+- Metadata-only and body-only search scopes are enforced consistently across
+  SQLite, PostgreSQL, DuckDB, and daemon-backed MCP sessions. Counts and
+  aggregate statistics use the same predicates, and body excerpts remain
+  bounded and UTF-8-safe.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for the Kit backup and
+  packed-attachment storage work, agent skills, Apple Mail partial-message
+  import, native Windows builds and ARM64 releases, and symlink-safe daemon
+  discovery.
+- Thanks to [endolith](https://github.com/endolith) for the MCP search tools,
+  in-message search, and consistent metadata/body search scopes.
+- Thanks to [Rob Elkin](https://github.com/robelkin) for attachment retrieval
+  by content hash through the HTTP API and generated Go client.
+- Thanks to [Matthew Sweeney](https://github.com/sweenzor) for Beeper Desktop
+  archiving and Granola/Circleback meeting sync and TUI browsing.
+- Thanks to [Jesse Vincent](https://github.com/obra) for correct IMAP folder
+  high water marks and fast sync on servers with an `\All` mailbox.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -492,6 +492,11 @@ msgvault import-emlx <identifier> <mail-dir>
 
 The mail directory should be an Apple Mail mailbox tree containing `.mbox` or `.imapmbox` directories, each with a `Messages/` subdirectory of `.emlx` files. You can also point directly at a single `.mbox` directory. Labels are derived from directory names.
 
+Apple Mail's `N.partial.emlx` files are also imported: their message body is
+complete even when uncached attachment parts are absent. If both `N.emlx` and
+`N.partial.emlx` exist, the complete `N.emlx` copy wins. The command summary
+reports the number of partial files imported.
+
 | Flag | Default | Description |
 |---|---|---|
 | `--source-type` | `apple-mail` | Source type recorded in database |
@@ -766,6 +771,54 @@ cataloged packs, so overwrite cannot currently make the same guarantee.
 Restoring into the live archive home of a running daemon is refused. See
 [Backup](/usage/backup/) for repository format, scheduling, verification, and
 privacy details.
+
+---
+
+## pack-attachments
+
+Move every eligible loose content-addressed attachment into sealed immutable
+pack files:
+
+```bash
+msgvault pack-attachments
+```
+
+The daemon serializes packing against sync and backup operations. Reads remain
+available from loose, packed, or mixed storage, and the command is safe to
+rerun as new loose content arrives. Bounded packing also runs after successful
+attachment-producing operations and during scheduled maintenance; this command
+processes the complete eligible backlog immediately.
+
+---
+
+## repack-attachments
+
+Reclaim dead bytes from sparse attachment packs:
+
+```bash
+msgvault repack-attachments
+```
+
+Repack always runs through the selected daemon so it can atomically replace
+live blob mappings, retire shared readers, and remove old pack files. It is
+safe to retry after interruption or a Windows file-sharing error.
+
+---
+
+## unpack-attachments
+
+Restore every cataloged packed attachment to a loose file and remove its pack:
+
+```bash
+msgvault daemon stop
+msgvault unpack-attachments
+```
+
+Each object is SHA-256 verified as it is written. This is the downgrade and
+recovery escape hatch because msgvault versions before packed attachment
+support cannot read the packs. The command is local-only and refuses to run
+while a daemon holds pack readers open. With `[remote]` configured, run it on
+the archive host or pass `--local` there to select that host's local archive.
 
 ---
 
@@ -1226,6 +1279,33 @@ msgvault mcp [flags]
 | `--http-allow-insecure` | `false` | Allow non-loopback HTTP binding. The MCP server has no built-in auth; put it behind a trusted network or authenticated reverse proxy. |
 
 See [MCP Server](/usage/chat/) for configuration and tool reference.
+
+---
+
+## skills
+
+Install or remove the bundled msgvault agent skills:
+
+```bash
+msgvault skills install
+msgvault skills uninstall
+```
+
+Install detects Claude Code and Codex from `~/.claude` and `~/.codex`, then
+writes the `msgvault-search`, `msgvault-attachments`, and
+`msgvault-analytics` skills to their user-level skill directories. Existing
+generated copies are updated in place; files without msgvault's generation
+marker are preserved unless `--force` is supplied.
+
+| Install flag | Description |
+|---|---|
+| `--agent claude` / `--agent codex` | Restrict installation to one or more detected agents; repeat or comma-separate values |
+| `--dir <path>` | Install into an explicit skill directory instead of detected agents |
+| `--force` | Overwrite skill files that no longer carry the msgvault generation marker |
+
+`skills uninstall` accepts `--agent` and `--dir` with the same target
+semantics, and removes only generated copies that still carry the marker. See
+[Agent Skills](/guides/agent-skills/) for the workflow and safety model.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: msgvault
-description: Offline email and message archive with full-text search, interactive TUI, backup snapshots, and multi-account support. Sync Gmail, IMAP, Google Calendar, and Microsoft Teams; import PST, MBOX, Apple Mail, WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore.
+description: Offline email, chat, and meeting archive with full-text search, an interactive TUI, backup snapshots, and multi-account support. Sync Gmail, IMAP, Google Calendar, Microsoft Teams, Beeper, Granola, and Circleback.
 ---
 
 # msgvault
@@ -18,10 +18,10 @@ search, and local AI workflows.
   <img src="/assets/generated/tui-senders.svg" alt="msgvault TUI showing the Senders view" loading="eager">
 </figure>
 
-Supports Gmail sync, Google Calendar sync, Microsoft Teams sync, IMAP,
-Microsoft 365 mail, verifiable backup snapshots, PST import, MBOX import,
-Apple Mail import, and chat/text import (WhatsApp, iMessage, Google Voice,
-Facebook Messenger, and SMS Backup & Restore).
+Supports Gmail, Google Calendar, Microsoft Teams, Granola, Circleback, Beeper
+Desktop, IMAP, and Microsoft 365 mail sync; verifiable backup snapshots; PST,
+MBOX, and Apple Mail import; and chat/text import from WhatsApp, iMessage,
+Google Voice, Facebook Messenger, and SMS Backup & Restore.
 
 Read the [Introduction](/introduction/) to learn more about why this project
 was created.
@@ -41,28 +41,29 @@ powershell -ExecutionPolicy ByPass -c "irm https://msgvault.io/install.ps1 | iex
 Then [set up OAuth credentials](/guides/oauth-setup/) and [start
 syncing](/setup/). You can also [build from source](/setup/#build-from-source).
 
-!!! note "New in 0.17.1"
-    HTTP clients can now stage, list, and cancel deletion manifests through the
-    web API; CLI search reports when the full-text index is checking or
-    rebuilding instead of blocking on that work; IMAP sync is more robust on
-    servers with unusual UID or raw-fetch behavior. See the
-    [Changelog](/changelog/) for the full release notes.
+!!! note "New in 0.18.0"
+    Archive Beeper Desktop chats and Granola or Circleback meeting notes;
+    browse meetings in the TUI; install bundled agent skills; retrieve
+    attachments by hash through the HTTP API; and use native Windows ARM64
+    releases. See the [Changelog](/changelog/) for the full release notes.
 
 ## Why msgvault?
 
 Your email and message data is yours. msgvault downloads a complete local copy
 of your email (from Gmail, IMAP, or local archives) and imports chats and texts
 from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup &
-Restore. Keyword search, analytics, the TUI, and the MCP server query local
-SQLite and Parquet files. **Nothing contacts your live mailbox outside sync and
-deletion commands that you run explicitly.** Optional vector search calls only
-the embedding endpoint you configure; use a local or self-hosted endpoint if
-message text must never leave your machine or network.
+Restore, and can sync Beeper chats plus Granola and Circleback meeting notes.
+Keyword search, analytics, the TUI, and the MCP server query your archive.
+**Source services are contacted only by authorization/registration, sync,
+media-backfill, and deletion workflows that you run or schedule explicitly.**
+Optional vector search calls only the embedding endpoint you configure; use a
+local or self-hosted endpoint if message text must never leave your machine or
+network.
 
 Years of PDFs, photos, documents, and spreadsheets buried in your inbox become
-ordinary files on your filesystem, deduplicated and instantly searchable. Your
-data is no longer locked behind a web interface or an API. It's just files on
-disk that you own and control.
+deduplicated content-addressed objects that can be searched and exported by
+hash. Your data is no longer locked behind a provider's web interface or API;
+it lives in an archive on disk that you own and control.
 
 ## Features
 
@@ -78,6 +79,10 @@ disk that you own and control.
   <section>
     <h3>Teams Sync</h3>
     <p>Archive Microsoft Teams chats, channels, replies, link attachments, and inline media through delegated Microsoft Graph. Teams records use <code>message_type = teams</code> so they can be searched and queried separately from email.</p>
+  </section>
+  <section>
+    <h3>Meetings &amp; Beeper</h3>
+    <p>Sync Granola and Circleback notes and transcripts into a dedicated TUI browser, and archive chats and media from networks bridged through Beeper Desktop. Search each source separately by message type.</p>
   </section>
   <section>
     <h3>Backup Snapshots</h3>
@@ -105,7 +110,11 @@ disk that you own and control.
   </section>
   <section>
     <h3>MCP Server</h3>
-    <p>Expose your archive to AI assistants like Claude Desktop via the Model Context Protocol. Search, read, and analyze your messages from any MCP-compatible LLM.</p>
+    <p>Expose your archive to AI assistants through the Model Context Protocol. Search metadata or bodies lexically, run semantic search, and find matches within one message.</p>
+  </section>
+  <section>
+    <h3>Agent Skills</h3>
+    <p>Install bundled read-only skills that teach Claude Code and Codex how to search the archive, retrieve attachments, and run analytics from the terminal.</p>
   </section>
   <section>
     <h3>Web Server</h3>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,8 +24,9 @@ This means:
   over the years.
 
 I started with Gmail but I want all my life's messages in this system,
-including Google Calendar, Microsoft Teams, WhatsApp, iMessage, Google Voice,
-Facebook Messenger, SMS Backup & Restore archives, and old local email
+including Google Calendar, Microsoft Teams, Beeper Desktop chats, Granola and
+Circleback meeting notes, WhatsApp, iMessage, Google Voice, Facebook Messenger,
+SMS Backup & Restore archives, and old local email
 archives.
 
 I suspect I am not the only one who has felt this way. **I hope you

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,6 +18,10 @@ powershell -ExecutionPolicy ByPass -c "irm https://msgvault.io/install.ps1 | iex
 
 The installer detects your OS and architecture, downloads the latest release from [GitHub Releases](https://github.com/kenn-io/msgvault/releases), verifies the SHA-256 checksum, and installs the binary.
 
+Windows releases include native AMD64 and ARM64 packages. On Windows ARM64,
+the PowerShell installer selects the native package when the release provides
+one and falls back to the AMD64 package under emulation for older releases.
+
 !!! tip "Running on a headless server?"
     msgvault works on headless machines (SSH, VPS, NAS, Docker), but OAuth requires a browser for the initial authorization. You'll authorize on your local machine and copy the token file to the server. See [Headless Server Setup](/guides/oauth-setup/#headless-server-setup) for the copy-token workflow, or jump to the [Remote Deployment](/guides/remote-deployment/) guide for a full NAS/server setup with Docker Compose.
 

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -51,7 +51,7 @@ The MCP server exposes the following tools to connected AI clients:
 | `search_metadata` | Search message metadata with a subset of Gmail query syntax (not full Gmail compatibility). Matches subject, snippet, and sender/recipient metadata, not message bodies. | `query` (string, required), `limit` (int), `offset` (int), `account` (string) |
 | `search_message_bodies` | Keyword full-text search inside message bodies. Returns `matches` excerpts (up to 5 per message), ordered newest-first. Backend excerpts may omit `char_offset` and `line`; use `search_in_message` when exact locations are needed. | `query` (string, required), `limit` (int), `offset` (int), `account` (string) |
 | `semantic_search_messages` | Semantic search over preprocessed message subjects and bodies when [vector search](/usage/vector-search/) is configured. Returns scored chunk excerpts; `min_score` filters excerpts, not ranked messages. | `query` (string, required), `mode` (string: `vector`/`hybrid`, default `hybrid`), `explain` (bool), `min_score` (number), `limit` (int), `offset` (int), `account` (string) |
-| `search_in_message` | Find matches within one message body. Keyword mode returns literal occurrences with raw-body offsets and line numbers; vector mode semantically ranks that message's embedded chunks when vector search is configured. | `id` (int, required), `query` (string, required), `mode` (string: `keyword`/`vector`, default `keyword`), `min_score` (number, vector only), `limit` (int), `offset` (int) |
+| `search_in_message` | Find case-insensitive literal matches within one message body, with raw-body offsets and line numbers. | `id` (int, required), `query` (string, required), `limit` (int), `offset` (int) |
 | `find_similar_messages` | Nearest-neighbor search from a seed message's embedding. Requires vector search to be configured and an active index generation. | `message_id` (int, required), `limit` (int), `account` (string), `message_type` (string), `after` (string), `before` (string), `has_attachment` (bool) |
 | `search_by_domains` | Find messages where any participant (`from`, `to`, or `cc`) belongs to one of several domains, regardless of direction. | `domains` (comma-separated string, required), `limit` (int), `offset` (int), `after` (string), `before` (string) |
 | `get_message` | Get message details with windowed body paging | `id` (int, required), `offset` (int), `center_at` (int), `max_chars` (int), `body_format` (string: `auto`/`text`/`html`), `full_body` (bool) |
@@ -102,17 +102,15 @@ Free text in `search_metadata` matches subject, snippet, and sender/recipient me
 
 ### `search_in_message`
 
-Pass a message `id` from any list or search result plus a `query`. The default
-keyword mode performs case-insensitive literal matching in `body_text` and
+Pass a message `id` from any list or search result plus a `query`. The tool
+performs case-insensitive literal matching in `body_text` and
 returns an exact `total`, paginated `data`, and a `char_offset`, `line`, and
 centered `snippet` for every match. Feed `char_offset` to `get_message` as
 `center_at` to read a larger body window around that occurrence.
 
-When vector search is configured, `mode=vector` embeds the query and scores
-only the selected message's stored chunks. Vector matches include `snippet`
-and `score`; `char_offset` and `line` are present only when preprocessing still
-allows a reliable mapping to the raw body. `min_score` filters vector chunks.
-The tool defaults to `limit = 10` in either mode.
+The tool defaults to `limit = 10`. For semantic search across the archive, use
+`semantic_search_messages`; `msgvault mcp` does not expose a vector mode for
+searching within a single message.
 
 ### `aggregate` response
 

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -1,13 +1,13 @@
 ---
 title: MCP Server
-description: Expose your email archive to AI assistants via MCP.
+description: Expose your email, chat, calendar, and meeting archive to AI assistants via MCP.
 ---
 
 The MCP server operates on your msgvault archive through the selected daemon, not your live Gmail account. Without `[remote].url`, `msgvault mcp` starts or reuses the local background daemon; with `[remote].url`, it uses that remote server. The AI cannot send emails, modify labels, or access your Google credentials. Standard read and search operations go through the daemon. If [vector search](/usage/vector-search/) is enabled, semantic and hybrid searches also call the embedding endpoint configured in `[vector.embeddings]`; use a local or self-hosted endpoint if message text must stay on your machine or network. The `stage_deletion` tool asks the selected daemon to save a deletion manifest, and `export_attachment` saves an attachment to a requested path on the MCP server's filesystem. Neither modifies the database, and actual deletion still requires you to run `msgvault delete-staged` from the CLI. You control when data enters the archive (via sync and import commands) and when anything is deleted (via the explicit [deletion workflow](/usage/deletion/)). Compared to giving an AI assistant direct OAuth access to your mailbox, this is a fundamentally smaller attack surface.
 
 ## Setup
 
-The `mcp` command starts a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes your email archive as a set of tools. This lets AI assistants like Claude Desktop search, read, and analyze your messages directly.
+The `mcp` command starts a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes your archive as a set of tools. This lets AI assistants like Claude Desktop search, read, and analyze archived email, chats, calendar events, and meeting notes directly.
 
 ### Claude Desktop Configuration
 
@@ -51,6 +51,7 @@ The MCP server exposes the following tools to connected AI clients:
 | `search_metadata` | Search message metadata with a subset of Gmail query syntax (not full Gmail compatibility). Matches subject, snippet, and sender/recipient metadata, not message bodies. | `query` (string, required), `limit` (int), `offset` (int), `account` (string) |
 | `search_message_bodies` | Keyword full-text search inside message bodies. Returns `matches` excerpts (up to 5 per message), ordered newest-first. Backend excerpts may omit `char_offset` and `line`; use `search_in_message` when exact locations are needed. | `query` (string, required), `limit` (int), `offset` (int), `account` (string) |
 | `semantic_search_messages` | Semantic search over preprocessed message subjects and bodies when [vector search](/usage/vector-search/) is configured. Returns scored chunk excerpts; `min_score` filters excerpts, not ranked messages. | `query` (string, required), `mode` (string: `vector`/`hybrid`, default `hybrid`), `explain` (bool), `min_score` (number), `limit` (int), `offset` (int), `account` (string) |
+| `search_in_message` | Find matches within one message body. Keyword mode returns literal occurrences with raw-body offsets and line numbers; vector mode semantically ranks that message's embedded chunks when vector search is configured. | `id` (int, required), `query` (string, required), `mode` (string: `keyword`/`vector`, default `keyword`), `min_score` (number, vector only), `limit` (int), `offset` (int) |
 | `find_similar_messages` | Nearest-neighbor search from a seed message's embedding. Requires vector search to be configured and an active index generation. | `message_id` (int, required), `limit` (int), `account` (string), `message_type` (string), `after` (string), `before` (string), `has_attachment` (bool) |
 | `search_by_domains` | Find messages where any participant (`from`, `to`, or `cc`) belongs to one of several domains, regardless of direction. | `domains` (comma-separated string, required), `limit` (int), `offset` (int), `after` (string), `before` (string) |
 | `get_message` | Get message details with windowed body paging | `id` (int, required), `offset` (int), `center_at` (int), `max_chars` (int), `body_format` (string: `auto`/`text`/`html`), `full_body` (bool) |
@@ -98,6 +99,20 @@ Supported operators: `from:`, `to:`, `cc:`, `bcc:`, `subject:`, `label:` (or `l:
 Not supported: negation (`-has:attachment`), `OR`, or parentheses grouping.
 
 Free text in `search_metadata` matches subject, snippet, and sender/recipient metadata only. Use `search_message_bodies` for keyword body search or `semantic_search_messages` for vector/hybrid search over preprocessed subject and body content; both require at least one free-text term. Keyword matches literal words; semantic returns ranked messages with scored chunk excerpts. Keyword backend excerpts omit `char_offset` and `line` when the search backend does not provide efficient locations; semantic excerpts also commonly omit them because preprocessing rewrites message text. Use distinctive snippet terms with keyword `search_in_message` when raw-body navigation is needed.
+
+### `search_in_message`
+
+Pass a message `id` from any list or search result plus a `query`. The default
+keyword mode performs case-insensitive literal matching in `body_text` and
+returns an exact `total`, paginated `data`, and a `char_offset`, `line`, and
+centered `snippet` for every match. Feed `char_offset` to `get_message` as
+`center_at` to read a larger body window around that occurrence.
+
+When vector search is configured, `mode=vector` embeds the query and scores
+only the selected message's stored chunks. Vector matches include `snippet`
+and `score`; `char_offset` and `line` are present only when preprocessing still
+allows a reliable mapping to the raw body. `min_score` filters vector chunks.
+The tool defaults to `limit = 10` in either mode.
 
 ### `aggregate` response
 
@@ -170,20 +185,16 @@ msgvault mcp --http 8080
 
 Deprecated in 0.17.0: MCP analytics behavior moved from per-command flags to daemon configuration. Use `[analytics].engine` and `[analytics].auto_build_cache` in `config.toml` so local and remote daemon behavior stays consistent.
 
-## Claude Code Skill
+## Agent Skills
 
-msgvault ships a Claude Code skill for running SQL queries against your archive. The skill uses `msgvault query` with the views documented in [SQL Queries](/usage/querying/), so you can ask Claude Code natural-language questions and it will translate them into SQL.
+For terminal coding agents, msgvault also bundles read-only skills covering
+search, attachment retrieval, and analytics. Install them into detected Claude
+Code and Codex skill directories with:
 
-To enable the skill, add msgvault's skill directory to your Claude Code configuration:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Skill(msgvault:*)"
-    ]
-  }
-}
+```bash
+msgvault skills install
 ```
 
-Once configured, Claude Code can query your archive directly during a conversation, for example: "How many emails did I get from linkedin.com last year?" or "Show my top 20 senders by message count."
+The skills teach agents the CLI; the MCP server exposes structured tool calls.
+They can be used independently or together. See [Agent Skills](/guides/agent-skills/)
+for installation targets, update behavior, and uninstall instructions.

--- a/docs/usage/meetings.md
+++ b/docs/usage/meetings.md
@@ -49,8 +49,8 @@ msgvault sync-circleback work --full
 
 ### Prerequisites
 
-- A [Granola](https://granola.ai) account on a **Business** (or Enterprise)
-  plan — the public API is not available on individual plans.
+- A [Granola](https://granola.ai) account on a **Business** plan — the public
+  API is not available on individual plans.
 - An API key, created in the Granola desktop app under **Settings**. Keys look
   like `grn_…`.
 
@@ -226,9 +226,8 @@ them with `--probe`, then run `--full` after decoder support is updated.
 In addition to the shared fields above: action items (title, assignee,
 status), insights, and tags land in the message metadata and body; the
 meeting recording URL and `recording_url_fetched_at` remain in the archived
-provider metadata. Circleback recording URLs expire after about 24 hours, so
-msgvault does not expose them as durable attachments. Downloading and archiving
-recording media is not yet supported.
+provider metadata. msgvault does not expose recording URLs as durable
+attachments, and downloading or archiving recording media is not supported.
 
 ## Searching
 

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -113,11 +113,12 @@ msgvault search "message_type:teams incident review"
 msgvault search "dinner" --message-type sms --message-type mms
 ```
 
-Valid values are `email`, `calendar_event`, `sms`, `mms`, `whatsapp`,
-`imessage`, `teams`, `fbmessenger`, `synctech_sms_call`, `google_voice_text`,
-`google_voice_call`, and `google_voice_voicemail`. `message_type:email`
-also includes legacy rows whose type is empty because older msgvault versions
-created them before the column existed.
+Valid values are `email`, `calendar_event`, `meeting_transcript`, `beeper`,
+`sms`, `mms`, `whatsapp`, `imessage`, `teams`, `fbmessenger`,
+`synctech_sms_call`, `google_voice_text`, `google_voice_call`, and
+`google_voice_voicemail`. `message_type:email` also includes legacy rows whose
+type is empty because older msgvault versions created them before the column
+existed.
 
 The same message-type scoping is available in HTTP search via the
 `message_type` query parameter. In MCP, include a `message_type:` operator in

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -19,8 +19,7 @@ When vector search is enabled, the `search` command and HTTP
 `mode=hybrid` (BM25 + vector fused with Reciprocal Rank Fusion). The MCP
 equivalent is `semantic_search_messages`. A separate MCP tool,
 `find_similar_messages`, returns nearest-neighbor messages for a
-given seed, and `search_in_message` can rank the embedded chunks within one
-selected message. The vectors and archive stay local, but embedding work is
+given seed. The vectors and archive stay local, but embedding work is
 performed by the endpoint in your config. If that endpoint is hosted
 by a third party, message text and semantic query text are sent there;
 use a local or self-hosted endpoint when you need the workflow to stay
@@ -402,9 +401,8 @@ filtering.
 - `search_message_bodies` performs body-only full-text search and returns
   bounded context around each keyword match. It requires a free-text term
   and does not depend on the vector index.
-- `search_in_message` defaults to literal keyword matches within one message;
-  with vector search enabled, `mode=vector` ranks that message's embedded
-  chunks and returns scored excerpts.
+- `search_in_message` performs literal keyword matching within one message; it
+  does not expose a vector mode through `msgvault mcp`.
 - `find_similar_messages` takes a seed `message_id` and returns
   nearest neighbors (excluding the seed itself). Optional `account`,
   `after`, `before`, `has_attachment` filters.

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -19,7 +19,8 @@ When vector search is enabled, the `search` command and HTTP
 `mode=hybrid` (BM25 + vector fused with Reciprocal Rank Fusion). The MCP
 equivalent is `semantic_search_messages`. A separate MCP tool,
 `find_similar_messages`, returns nearest-neighbor messages for a
-given seed. The vectors and archive stay local, but embedding work is
+given seed, and `search_in_message` can rank the embedded chunks within one
+selected message. The vectors and archive stay local, but embedding work is
 performed by the endpoint in your config. If that endpoint is hosted
 by a third party, message text and semantic query text are sent there;
 use a local or self-hosted endpoint when you need the workflow to stay
@@ -284,8 +285,9 @@ trigger).
 |---|---|
 | Manual `sync-full` / `sync` (Gmail, IMAP) | No. Run `msgvault embeddings build` afterward |
 | Manual `sync-calendar` / `sync-teams` | No. Run `msgvault embeddings build` afterward |
+| Manual `sync-beeper` / `sync-granola` / `sync-circleback` | No. Run `msgvault embeddings build` afterward |
 | Scheduled account syncs in `msgvault serve` (Gmail, IMAP, Teams) | Yes, when `[vector.embed.schedule].run_after_sync = true` |
-| Scheduled `[[gcal]]` calendar syncs in `msgvault serve` | No. Picked up by the embed worker's `[vector.embed.schedule].cron` schedule |
+| Scheduled calendar, Beeper, Granola, and Circleback syncs in `msgvault serve` | No immediate post-sync run. Picked up by the embed worker's `[vector.embed.schedule].cron` schedule |
 | `import-pst`, `import-emlx`, `import-mbox` | No. Re-run `--full-rebuild` after large imports |
 | Chat/text imports (iMessage, WhatsApp, Google Voice, Messenger, SyncTech SMS) | No. Run a full rebuild after importing if you want chats included |
 
@@ -400,6 +402,9 @@ filtering.
 - `search_message_bodies` performs body-only full-text search and returns
   bounded context around each keyword match. It requires a free-text term
   and does not depend on the vector index.
+- `search_in_message` defaults to literal keyword matches within one message;
+  with vector search enabled, `mode=vector` ranks that message's embedded
+  chunks and returns scored excerpts.
 - `find_similar_messages` takes a seed `message_id` and returns
   nearest neighbors (excluding the seed itself). Optional `account`,
   `after`, `before`, `has_attachment` filters.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_name = "msgvault"
 site_url = "https://msgvault.io"
-site_description = "Offline email and message archive with full-text search, interactive TUI, and multi-account support. Import from Gmail, IMAP, PST, MBOX, Apple Mail, WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup & Restore."
+site_description = "Offline email, chat, and meeting archive with full-text search and an interactive TUI. Sync Gmail, IMAP, Teams, Beeper, Granola, and Circleback; import PST, MBOX, Apple Mail, and common chat exports."
 site_author = "Kenn Software LLC"
 copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>. MIT License.'
 docs_dir = "docs"


### PR DESCRIPTION
msgvault 0.18.0 adds several large user-facing surfaces, while the public documentation still described loose-only attachment storage and omitted new REST, MCP, agent-skill, provider, and Windows details. That drift could send users to incorrect routes or maintenance workflows and left the release contributors uncredited.

This publishes source-verified release notes with contributor acknowledgements and refreshes the public setup, architecture, CLI/API/MCP, search, and provider guidance so shipped paths, flags, message types, limitations, and platform support match the implementation. MCP guidance distinguishes archive-wide semantic search from the literal, keyword-only search available within a single message.