### PR TITLE
docs: promote changelog in navigation

### DIFF
--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -19,6 +19,7 @@ nav = [
   {"CLI Reference" = "cli-reference.md"},
   {"MCP Server" = "usage/chat.md"},
   {"Web Server" = "api-server.md"},
+  {"Changelog" = "changelog.md"},
   {"CLI Usage" = [
     {"Searching" = "usage/searching.md"},
     {"Vector Search" = "usage/vector-search.md"},
@@ -53,7 +54,6 @@ nav = [
   {"Troubleshooting" = "troubleshooting.md"},
   {"Development" = "development.md"},
   {"FAQ" = "faq.md"},
-  {"Changelog" = "changelog.md"},
 ]
 
 [project.extra]


### PR DESCRIPTION
The changelog is a primary way returning users discover recent releases, but it was buried below secondary documentation sections. Move it into the initial standalone navigation block after Web Server so release notes are easier to find while keeping the existing URL unchanged.