### PR TITLE
feat: Slack workspace archiving (user-token Web API sync)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ make lint                     # Run linter
 ./msgvault sync-teams you@tenant.com         # Sync Teams chats + channels
 ./msgvault sync-teams you@tenant.com --no-channels --limit 50
 
+# Slack (user token from your own internal app)
+./msgvault add-slack                         # Register a workspace (prompts for xoxp token)
+./msgvault sync-slack                        # Sync channels, group DMs, DMs
+./msgvault sync-slack --full                 # Repair: re-fetch + upsert in place
+
 # Daemon mode (NAS/server deployment)
 ./msgvault serve                                      # Start HTTP API + scheduled syncs
 

--- a/cmd/msgvault/cmd/add_slack.go
+++ b/cmd/msgvault/cmd/add_slack.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/clirun"
+	"go.kenn.io/msgvault/internal/slack"
+)
+
+var (
+	addSlackTokenFile         string
+	noDefaultIdentityAddSlack bool
+)
+
+func newAddSlackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-slack",
+		Short: "Add a Slack workspace as an archive source",
+		Long: `Add a Slack workspace as an archive source.
+
+Archives your own view of the workspace — public/private channels you are a
+member of, group DMs, and 1:1 DMs — via the Slack Web API.
+
+Requires a user token (xoxp-...) from an internal Slack app you create:
+
+  1. https://api.slack.com/apps > Create New App > From scratch, in your
+     workspace.
+  2. OAuth & Permissions > User Token Scopes, add:
+       channels:history groups:history im:history mpim:history
+       channels:read groups:read im:read mpim:read
+       users:read users:read.email files:read reactions:read team:read
+  3. Install to Workspace, then copy the "User OAuth Token".
+
+Internal apps you create yourself are not subject to Slack's non-Marketplace
+rate limits, so backfills run at full speed.
+
+Provide the token via --token-file, the MSGVAULT_SLACK_TOKEN environment
+variable, or the interactive prompt.
+
+Examples:
+  msgvault add-slack
+  msgvault add-slack --token-file ~/slack-token.txt
+  MSGVAULT_SLACK_TOKEN="xoxp-..." msgvault add-slack`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				token, err := readAddSlackToken(cmd)
+				if err != nil {
+					return err
+				}
+				return runDaemonCLICommandHTTPFromCobraWithEnv(cmd, args, map[string]string{
+					clirun.EnvSlackToken: token,
+				})
+			}
+
+			token := os.Getenv(clirun.EnvSlackToken)
+			if token == "" {
+				return errors.New("missing Slack token in daemon subprocess (set MSGVAULT_SLACK_TOKEN)")
+			}
+			auth, err := slack.NewClient("", token).AuthTest(cmd.Context())
+			if err != nil {
+				return err
+			}
+			teamDomain := strings.TrimSuffix(strings.TrimPrefix(auth.URL, "https://"), ".slack.com/")
+			if err := slack.SaveToken(cfg.TokensDir(), auth.TeamID, teamDomain, auth.UserID, token); err != nil {
+				return fmt.Errorf("save slack token: %w", err)
+			}
+
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			identifier := auth.TeamID + ":" + auth.UserID
+			source, err := s.GetOrCreateSource(sourceTypeSlack, identifier)
+			if err != nil {
+				return fmt.Errorf("create source for %s: %w", identifier, err)
+			}
+			displayName := "Slack " + auth.Team
+			if err := s.UpdateSourceDisplayName(source.ID, displayName); err != nil {
+				return fmt.Errorf("set display name for %s: %w", identifier, err)
+			}
+			if !noDefaultIdentityAddSlack {
+				confirmDefaultIdentity(cmd.OutOrStdout(), s, source.ID,
+					identifier, auth.UserID, "account-identifier")
+			}
+			if err := runPostSourceCreateMigrations(s); err != nil {
+				return fmt.Errorf("post-source-create migrations: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added Slack workspace %s (%s) as %s\n", auth.Team, auth.TeamID, identifier)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nYou can now run:")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  msgvault sync-slack %s\n", auth.TeamID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&addSlackTokenFile, "token-file", "", "read the Slack user token from this file")
+	cmd.Flags().BoolVar(&noDefaultIdentityAddSlack, "no-default-identity", false, noDefaultIdentityHelp)
+	return cmd
+}
+
+// readAddSlackToken resolves the user token: env var, then --token-file,
+// then interactive masked prompt / piped stdin.
+func readAddSlackToken(cmd *cobra.Command) (string, error) {
+	if envToken := os.Getenv(clirun.EnvSlackToken); envToken != "" {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Using token from %s environment variable\n", clirun.EnvSlackToken); err != nil {
+			return "", fmt.Errorf("write token source notice: %w", err)
+		}
+		return envToken, nil
+	}
+	if addSlackTokenFile != "" {
+		data, err := os.ReadFile(addSlackTokenFile)
+		if err != nil {
+			return "", fmt.Errorf("read token file: %w", err)
+		}
+		token := strings.TrimSpace(string(data))
+		if token == "" {
+			return "", fmt.Errorf("token file %s is empty", addSlackTokenFile)
+		}
+		return token, nil
+	}
+
+	prompt := "Slack user token (xoxp-..., from your app's OAuth & Permissions page):"
+	method, promptOut := choosePasswordStrategy(
+		isatty.IsTerminal(os.Stdin.Fd()),
+		isatty.IsCygwinTerminal(os.Stdin.Fd()),
+		isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd()),
+		isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()),
+	)
+	switch method {
+	case passwordInteractive:
+		return readPasswordInteractive(prompt, promptOut)
+	case passwordNoPrompt:
+		return "", errors.New("cannot read token: no terminal available for prompt (try --token-file, piping the token via stdin, or setting MSGVAULT_SLACK_TOKEN)")
+	case passwordPipe:
+		return readPasswordFromPipe(os.Stdin)
+	default:
+		return "", errors.New("cannot determine token input method")
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(newAddSlackCmd())
+}

--- a/cmd/msgvault/cmd/attachment_maintenance.go
+++ b/cmd/msgvault/cmd/attachment_maintenance.go
@@ -297,6 +297,7 @@ func attachmentProducingCommand(args []string) bool {
 	}
 	switch args[0] {
 	case "backfill-beeper-media",
+		"backfill-slack-media",
 		"backfill-teams-media",
 		"import",
 		"import-emlx",
@@ -308,6 +309,7 @@ func attachmentProducingCommand(args []string) bool {
 		"import-synctech-sms",
 		"import-whatsapp",
 		"sync-beeper",
+		"sync-slack",
 		"sync-synctech-sms",
 		"sync-teams":
 		return true

--- a/cmd/msgvault/cmd/attachment_maintenance_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_test.go
@@ -482,6 +482,7 @@ func TestAutomaticRepackLogsCommittedSiblingProgressBeforeAggregateWarning(t *te
 func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 	allowlisted := []string{
 		"backfill-beeper-media",
+		"backfill-slack-media",
 		"backfill-teams-media",
 		"import",
 		"import-emlx",
@@ -493,6 +494,7 @@ func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 		"import-synctech-sms",
 		"import-whatsapp",
 		"sync-beeper",
+		"sync-slack",
 		"sync-synctech-sms",
 		"sync-teams",
 	}

--- a/cmd/msgvault/cmd/backfill_slack_media.go
+++ b/cmd/msgvault/cmd/backfill_slack_media.go
@@ -56,7 +56,7 @@ Examples:
 					runErrors = append(runErrors, src.Identifier+": malformed slack identifier")
 					continue
 				}
-				token, terr := slack.LoadToken(cfg.TokensDir(), teamID)
+				token, terr := slack.LoadToken(cfg.TokensDir(), teamID, userID)
 				if terr != nil {
 					runErrors = append(runErrors, fmt.Sprintf("%s: %v", teamID, terr))
 					continue

--- a/cmd/msgvault/cmd/backfill_slack_media.go
+++ b/cmd/msgvault/cmd/backfill_slack_media.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/slack"
+)
+
+func newBackfillSlackMediaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backfill-slack-media [team-id]",
+		Short: "Retry pending Slack file downloads",
+		Long: `Retry pending Slack file downloads.
+
+Files that failed to download during sync (outages, size caps since raised)
+leave pending markers. This command re-reads the archived message JSON and
+retries the downloads. Idempotent: already-downloaded files are never
+re-fetched.
+
+Examples:
+  msgvault backfill-slack-media
+  msgvault backfill-slack-media T0123456789`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+
+			flagTeam := ""
+			if len(args) > 0 {
+				flagTeam = args[0]
+			}
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			sources, err := resolveSlackSyncSources(s, flagTeam)
+			if err != nil {
+				return err
+			}
+			ctx, stop := withInterruptCancel(cmd, "\nInterrupted.")
+			defer stop()
+
+			var runErrors []string
+			for _, src := range sources {
+				if ctx.Err() != nil {
+					break
+				}
+				teamID, userID, ok := splitSlackIdentifier(src.Identifier)
+				if !ok {
+					runErrors = append(runErrors, fmt.Sprintf("%s: malformed slack identifier", src.Identifier))
+					continue
+				}
+				token, terr := slack.LoadToken(cfg.TokensDir(), teamID)
+				if terr != nil {
+					runErrors = append(runErrors, fmt.Sprintf("%s: %v", teamID, terr))
+					continue
+				}
+				imp := slack.NewImporter(s, slack.NewClient("", token), teamID)
+				sum, berr := imp.BackfillMedia(ctx, slackImportOptions(teamID, userID))
+				if ctx.Err() != nil {
+					break
+				}
+				if berr != nil {
+					runErrors = append(runErrors, fmt.Sprintf("%s: %v", teamID, berr))
+					continue
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s done in %s: %d messages, %d downloaded, %d still pending\n",
+					teamID, sum.Duration.Round(time.Second), sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending)
+			}
+			if len(runErrors) > 0 {
+				return fmt.Errorf("%d workspace(s) failed: %s", len(runErrors), strings.Join(runErrors, "; "))
+			}
+			if ctx.Err() != nil {
+				return errors.New("interrupted")
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newBackfillSlackMediaCmd())
+}

--- a/cmd/msgvault/cmd/backfill_slack_media.go
+++ b/cmd/msgvault/cmd/backfill_slack_media.go
@@ -53,7 +53,7 @@ Examples:
 				}
 				teamID, userID, ok := splitSlackIdentifier(src.Identifier)
 				if !ok {
-					runErrors = append(runErrors, fmt.Sprintf("%s: malformed slack identifier", src.Identifier))
+					runErrors = append(runErrors, src.Identifier+": malformed slack identifier")
 					continue
 				}
 				token, terr := slack.LoadToken(cfg.TokensDir(), teamID)

--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -9,6 +9,7 @@ const (
 	sourceTypeTeams      = "teams"
 	sourceTypeCalendar   = "gcal"
 	sourceTypeBeeper     = "beeper"
+	sourceTypeSlack      = "slack"
 	sourceTypeGranola    = "granola"
 	sourceTypeCircleback = "circleback"
 )

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -271,8 +271,8 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 			}
 		}
 	case sourceTypeSlack:
-		if teamID, _, ok := splitSlackIdentifier(source.Identifier); ok {
-			if err := slack.DeleteToken(cfg.TokensDir(), teamID); err != nil {
+		if teamID, userID, ok := splitSlackIdentifier(source.Identifier); ok {
+			if err := slack.DeleteToken(cfg.TokensDir(), teamID, userID); err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: could not remove Slack token: %v\n", err,
 				)

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -17,6 +17,7 @@ import (
 	imaplib "go.kenn.io/msgvault/internal/imap"
 	"go.kenn.io/msgvault/internal/microsoft"
 	"go.kenn.io/msgvault/internal/oauth"
+	"go.kenn.io/msgvault/internal/slack"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -266,6 +267,14 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 			if err := beeper.DeleteToken(cfg.TokensDir()); err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: could not remove Beeper token: %v\n", err,
+				)
+			}
+		}
+	case sourceTypeSlack:
+		if teamID, _, ok := splitSlackIdentifier(source.Identifier); ok {
+			if err := slack.DeleteToken(cfg.TokensDir(), teamID); err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not remove Slack token: %v\n", err,
 				)
 			}
 		}

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/msgvault/internal/microsoft"
 	"go.kenn.io/msgvault/internal/oauth"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/slack"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -1043,6 +1044,44 @@ func TestRemoveAccountCmd_CirclebackRemovesToken(t *testing.T) {
 
 	_, err = os.Stat(tokenPath)
 	assert.True(t, os.IsNotExist(err), "token file should be removed for Circleback source")
+}
+
+func TestRemoveAccountCmd_SlackRemovesToken(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/msgvault.db"
+	tokensDir := filepath.Join(tmpDir, "tokens")
+	require.NoError(os.MkdirAll(tokensDir, 0700), "mkdir tokens")
+
+	s, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(s.InitSchema(), "init schema")
+	_, err = s.GetOrCreateSource(sourceTypeSlack, "T01:UME")
+	require.NoError(err, "create source")
+	require.NoError(s.Close(), "close store")
+
+	require.NoError(slack.SaveToken(tokensDir, "T01", "testers", "UME", "xoxp-test"), "write slack token")
+	tokenPath := filepath.Join(tokensDir, "slack_T01.json")
+	_, err = os.Stat(tokenPath)
+	require.NoError(err, "slack token file must exist before removal")
+
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountLocalTestCmd())
+	root.SetArgs([]string{
+		"remove-account", "T01:UME", "--yes", "--type", sourceTypeSlack,
+	})
+
+	require.NoError(root.Execute(), "remove-account")
+
+	_, err = os.Stat(tokenPath)
+	assert.True(t, os.IsNotExist(err), "token file should be removed for Slack source")
 }
 
 func TestRemoveAccountCmd_NonGmailSkipsToken(t *testing.T) {

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -1061,7 +1061,7 @@ func TestRemoveAccountCmd_SlackRemovesToken(t *testing.T) {
 	require.NoError(s.Close(), "close store")
 
 	require.NoError(slack.SaveToken(tokensDir, "T01", "testers", "UME", "xoxp-test"), "write slack token")
-	tokenPath := filepath.Join(tokensDir, "slack_T01.json")
+	tokenPath := filepath.Join(tokensDir, "slack_T01_UME.json")
 	_, err = os.Stat(tokenPath)
 	require.NoError(err, "slack token file must exist before removal")
 

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -292,6 +292,26 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if cfg.Slack.Enabled && cfg.Slack.Schedule == "" {
+		logger.Warn("slack is enabled but has no schedule — the daemon will not sync it; its freshness will eventually go stale",
+			"hint", `set a cron schedule (e.g. "*/30 * * * *") on the [slack] entry`)
+	}
+	if cfg.Slack.Enabled && cfg.Slack.Schedule != "" {
+		if err := sched.AddJob(scheduler.Job{
+			Name:     "slack",
+			Schedule: cfg.Slack.Schedule,
+			Run: func(ctx context.Context) error {
+				return runScheduledSource(ctx, attachmentMaint, true, func(ctx context.Context) error {
+					return runConfiguredSlackSync(ctx, s)
+				})
+			},
+		}); err != nil {
+			logger.Error("failed to schedule slack sync", "error", err)
+		} else {
+			logger.Info("scheduled slack sync", "schedule", cfg.Slack.Schedule)
+		}
+	}
+
 	// Meeting sources (Granola/Circleback) mirror the gcal treatment: warn
 	// when enabled but unscheduled, then register the scheduled ones.
 	for _, src := range cfg.Granola {

--- a/cmd/msgvault/cmd/sync_slack.go
+++ b/cmd/msgvault/cmd/sync_slack.go
@@ -73,7 +73,7 @@ Examples:
 					continue
 				}
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Syncing Slack workspace %s\n", teamID)
-				token, terr := slack.LoadToken(cfg.TokensDir(), teamID)
+				token, terr := slack.LoadToken(cfg.TokensDir(), teamID, userID)
 				if terr != nil {
 					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", teamID, terr))
 					continue
@@ -208,7 +208,7 @@ func runConfiguredSlackSync(ctx context.Context, s *store.Store) error {
 			errs = append(errs, fmt.Errorf("slack %s: malformed identifier", src.Identifier))
 			continue
 		}
-		token, terr := slack.LoadToken(cfg.TokensDir(), teamID)
+		token, terr := slack.LoadToken(cfg.TokensDir(), teamID, userID)
 		if terr != nil {
 			errs = append(errs, fmt.Errorf("slack %s: %w", teamID, terr))
 			continue

--- a/cmd/msgvault/cmd/sync_slack.go
+++ b/cmd/msgvault/cmd/sync_slack.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/slack"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var (
+	syncSlackLimit     int
+	syncSlackFull      bool
+	syncSlackNoThreads bool
+	syncSlackNoMedia   bool
+)
+
+func newSyncSlackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync-slack [team-id]",
+		Short: "Sync Slack conversations (channels, group DMs, DMs)",
+		Long: `Sync Slack conversations for registered workspaces.
+
+The first run backfills each conversation's full history; later runs are
+incremental, fetching only new messages and polling recent threads for late
+replies. Backfills are resumable: re-run after an interruption and the sync
+continues where it stopped.
+
+Requires a workspace added with 'add-slack'. Use --full to ignore stored
+cursors and re-fetch every message; re-fetched messages are upserted in
+place, so this repairs existing rows (and catches old thread replies beyond
+the tracking window) without creating duplicates.
+
+Examples:
+  msgvault sync-slack
+  msgvault sync-slack T0123456789
+  msgvault sync-slack --limit 500
+  msgvault sync-slack --full`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+
+			flagTeam := ""
+			if len(args) > 0 {
+				flagTeam = args[0]
+			}
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			sources, err := resolveSlackSyncSources(s, flagTeam)
+			if err != nil {
+				return err
+			}
+			ctx, stop := withInterruptCancel(cmd, "\nInterrupted. Saving checkpoint...")
+			defer stop()
+
+			var syncErrors []string
+			for _, src := range sources {
+				if ctx.Err() != nil {
+					break
+				}
+				teamID, userID, ok := splitSlackIdentifier(src.Identifier)
+				if !ok {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: malformed slack identifier", src.Identifier))
+					continue
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Syncing Slack workspace %s\n", teamID)
+				token, terr := slack.LoadToken(cfg.TokensDir(), teamID)
+				if terr != nil {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", teamID, terr))
+					continue
+				}
+				imp := slack.NewImporter(s, slack.NewClient("", token), teamID)
+				opts := slackImportOptions(teamID, userID)
+				opts.Limit = syncSlackLimit
+				opts.Full = syncSlackFull
+				opts.NoThreads = syncSlackNoThreads
+				opts.NoMedia = opts.NoMedia || syncSlackNoMedia
+				opts.Progress = func(line string) { _, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+line) }
+				sum, serr := imp.Import(ctx, opts)
+				if ctx.Err() != nil {
+					break
+				}
+				// One broken workspace must not block the others; collect and
+				// keep syncing (multi-account convention).
+				if serr != nil {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", teamID, serr))
+					continue
+				}
+				printSlackSummary(cmd, teamID, sum)
+			}
+
+			// Successful workspaces' messages must reach the analytics cache
+			// regardless of interruptions or per-workspace failures.
+			cacheErr := rebuildCacheAfterWrite(cfg.DatabaseDSN())
+			if ctx.Err() != nil {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nInterrupted — re-run sync-slack to resume.")
+				return cacheErr
+			}
+			if len(syncErrors) > 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nErrors:")
+				for _, e := range syncErrors {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", e)
+				}
+				return errors.Join(
+					fmt.Errorf("%d workspace(s) failed to sync: %s", len(syncErrors), strings.Join(syncErrors, "; ")),
+					cacheErr,
+				)
+			}
+			return cacheErr
+		},
+	}
+	cmd.Flags().IntVar(&syncSlackLimit, "limit", 0, "max messages per conversation this run (0 = no limit; limited backfills resume on the next run)")
+	cmd.Flags().BoolVar(&syncSlackFull, "full", false, "ignore stored cursors and re-fetch every message (repairs/backfills existing rows in place)")
+	cmd.Flags().BoolVar(&syncSlackNoThreads, "no-threads", false, "skip thread reply fetching for this run")
+	cmd.Flags().BoolVar(&syncSlackNoMedia, "no-media", false, "skip file downloads for this run")
+	return cmd
+}
+
+func printSlackSummary(cmd *cobra.Command, teamID string, sum *slack.ImportSummary) {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s done in %s: %d conversations, %d messages",
+		teamID, sum.Duration.Round(time.Second), sum.ConversationsProcessed, sum.MessagesProcessed)
+	if sum.RepliesFetched > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d thread replies", sum.RepliesFetched)
+	}
+	if sum.AttachmentsDownloaded > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d files", sum.AttachmentsDownloaded)
+	}
+	if sum.AttachmentsPending > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media pending (see backfill-slack-media)", sum.AttachmentsPending)
+	}
+	if sum.Errors > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d errors", sum.Errors)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+}
+
+// splitSlackIdentifier parses a slack source identifier ("<team>:<user>").
+func splitSlackIdentifier(identifier string) (teamID, userID string, ok bool) {
+	teamID, userID, ok = strings.Cut(identifier, ":")
+	return teamID, userID, ok && teamID != "" && userID != ""
+}
+
+// resolveSlackSyncSources returns the slack sources to sync: the one for the
+// given team ID, or all registered workspaces.
+func resolveSlackSyncSources(s *store.Store, flagTeam string) ([]*store.Source, error) {
+	sources, err := s.ListSources(sourceTypeSlack)
+	if err != nil {
+		return nil, fmt.Errorf("list slack sources: %w", err)
+	}
+	if flagTeam == "" {
+		if len(sources) == 0 {
+			return nil, errors.New("no Slack workspaces registered (run 'add-slack' first)")
+		}
+		return sources, nil
+	}
+	var out []*store.Source
+	for _, src := range sources {
+		if teamID, _, ok := splitSlackIdentifier(src.Identifier); ok && teamID == flagTeam {
+			out = append(out, src)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("slack workspace %q is not registered (run 'add-slack' first)", flagTeam)
+	}
+	return out, nil
+}
+
+// slackImportOptions builds the config-derived import options shared by the
+// CLI and scheduler paths (flag overlays are applied by the CLI caller).
+func slackImportOptions(teamID, userID string) slack.ImportOptions {
+	return slack.ImportOptions{
+		TeamID:          teamID,
+		UserID:          userID,
+		AttachmentsDir:  cfg.AttachmentsDir(),
+		NoMedia:         !cfg.Slack.MediaEnabled(),
+		MaxMediaBytes:   cfg.Slack.MaxMediaBytes(),
+		ThreadLookback:  cfg.Slack.ThreadLookbackDuration(),
+		IncludeChannels: cfg.Slack.Channels,
+		ExcludeChannels: cfg.Slack.ExcludeChannels,
+	}
+}
+
+// runConfiguredSlackSync is the daemon scheduler entrypoint: an incremental
+// sync of every registered Slack workspace. Per-workspace failures are
+// collected so one broken workspace does not starve the others.
+func runConfiguredSlackSync(ctx context.Context, s *store.Store) error {
+	sources, err := resolveSlackSyncSources(s, "")
+	if err != nil {
+		return err
+	}
+	var errs []error
+	attempted := 0
+	for _, src := range sources {
+		if ctx.Err() != nil {
+			break
+		}
+		teamID, userID, ok := splitSlackIdentifier(src.Identifier)
+		if !ok {
+			errs = append(errs, fmt.Errorf("slack %s: malformed identifier", src.Identifier))
+			continue
+		}
+		token, terr := slack.LoadToken(cfg.TokensDir(), teamID)
+		if terr != nil {
+			errs = append(errs, fmt.Errorf("slack %s: %w", teamID, terr))
+			continue
+		}
+		attempted++
+		imp := slack.NewImporter(s, slack.NewClient("", token), teamID)
+		if _, serr := imp.Import(ctx, slackImportOptions(teamID, userID)); serr != nil {
+			errs = append(errs, fmt.Errorf("slack %s: %w", teamID, serr))
+		}
+	}
+	// Rebuild analytics after any attempt: even a failed or canceled attempt
+	// may have committed messages from healthy conversations.
+	if attempted > 0 {
+		if rerr := rebuildCacheAfterScheduledSync(context.WithoutCancel(ctx), "slack"); rerr != nil {
+			errs = append(errs, rerr)
+		}
+	}
+	if ctx.Err() != nil {
+		errs = append(errs, ctx.Err())
+	}
+	return errors.Join(errs...)
+}
+
+func init() {
+	rootCmd.AddCommand(newSyncSlackCmd())
+}

--- a/cmd/msgvault/cmd/sync_slack.go
+++ b/cmd/msgvault/cmd/sync_slack.go
@@ -69,7 +69,7 @@ Examples:
 				}
 				teamID, userID, ok := splitSlackIdentifier(src.Identifier)
 				if !ok {
-					syncErrors = append(syncErrors, fmt.Sprintf("%s: malformed slack identifier", src.Identifier))
+					syncErrors = append(syncErrors, src.Identifier+": malformed slack identifier")
 					continue
 				}
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Syncing Slack workspace %s\n", teamID)

--- a/cmd/msgvault/cmd/sync_slack_routing_test.go
+++ b/cmd/msgvault/cmd/sync_slack_routing_test.go
@@ -84,7 +84,7 @@ func TestRunConfiguredSlackSyncIsolatesBrokenWorkspaces(t *testing.T) {
 
 	err = runConfiguredSlackSync(context.Background(), st)
 	require.ErrorContains(err, "malformed identifier")
-	require.ErrorContains(err, "no Slack token for workspace T09")
+	require.ErrorContains(err, "no Slack token for UME in workspace T09")
 }
 
 func TestSlackImportOptionsDeriveFromConfig(t *testing.T) {

--- a/cmd/msgvault/cmd/sync_slack_routing_test.go
+++ b/cmd/msgvault/cmd/sync_slack_routing_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/clirun"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestSplitSlackIdentifier(t *testing.T) {
+	tests := []struct {
+		in         string
+		team, user string
+		ok         bool
+	}{
+		{"T01:UME", "T01", "UME", true},
+		{"T01:", "T01", "", false},
+		{":UME", "", "UME", false},
+		{"T01", "T01", "", false},
+		{"", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			team, user, ok := splitSlackIdentifier(tt.in)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.team, team)
+				assert.Equal(t, tt.user, user)
+			}
+		})
+	}
+}
+
+func TestResolveSlackSyncSourcesFiltersByTeam(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	_, err := resolveSlackSyncSources(st, "")
+	require.ErrorContains(err, "no Slack workspaces registered")
+
+	_, err = st.GetOrCreateSource(sourceTypeSlack, "T01:UME")
+	require.NoError(err)
+	_, err = st.GetOrCreateSource(sourceTypeSlack, "T02:UOTHER")
+	require.NoError(err)
+
+	all, err := resolveSlackSyncSources(st, "")
+	require.NoError(err)
+	assert.Len(all, 2)
+
+	one, err := resolveSlackSyncSources(st, "T02")
+	require.NoError(err)
+	require.Len(one, 1)
+	assert.Equal("T02:UOTHER", one[0].Identifier)
+
+	_, err = resolveSlackSyncSources(st, "TYPO")
+	require.ErrorContains(err, `slack workspace "TYPO" is not registered`)
+}
+
+func TestRunConfiguredSlackSyncIsolatesBrokenWorkspaces(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+
+	// One malformed identifier and one workspace whose token file is
+	// missing: the scheduler entrypoint must report both without panicking
+	// or aborting on the first.
+	_, err := st.GetOrCreateSource(sourceTypeSlack, "malformed-no-colon")
+	require.NoError(err)
+	_, err = st.GetOrCreateSource(sourceTypeSlack, "T09:UME")
+	require.NoError(err)
+
+	tmpDir := t.TempDir()
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	err = runConfiguredSlackSync(context.Background(), st)
+	require.ErrorContains(err, "malformed identifier")
+	require.ErrorContains(err, "no Slack token for workspace T09")
+}
+
+func TestSlackImportOptionsDeriveFromConfig(t *testing.T) {
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	media := false
+	cfg = &config.Config{
+		HomeDir: t.TempDir(),
+		Slack: config.SlackConfig{
+			Channels:           []string{"eng"},
+			ExcludeChannels:    []string{"noise"},
+			Media:              &media,
+			MaxMediaMB:         7,
+			ThreadLookbackDays: 3,
+		},
+	}
+
+	opts := slackImportOptions("T01", "UME")
+	assert.Equal(t, "T01", opts.TeamID)
+	assert.Equal(t, "UME", opts.UserID)
+	assert.True(t, opts.NoMedia)
+	assert.Equal(t, int64(7)<<20, opts.MaxMediaBytes)
+	assert.Equal(t, int64(3*24), int64(opts.ThreadLookback.Hours()))
+	assert.Equal(t, []string{"eng"}, opts.IncludeChannels)
+	assert.Equal(t, []string{"noise"}, opts.ExcludeChannels)
+}
+
+func resetSyncSlackRoutingGlobals(t *testing.T) {
+	t.Helper()
+	oldLimit := syncSlackLimit
+	oldFull := syncSlackFull
+	oldNoThreads := syncSlackNoThreads
+	oldNoMedia := syncSlackNoMedia
+	t.Cleanup(func() {
+		syncSlackLimit = oldLimit
+		syncSlackFull = oldFull
+		syncSlackNoThreads = oldNoThreads
+		syncSlackNoMedia = oldNoMedia
+	})
+	syncSlackLimit = 0
+	syncSlackFull = false
+	syncSlackNoThreads = false
+	syncSlackNoMedia = false
+}
+
+func TestSyncSlackCommandUsesDaemonRunner(t *testing.T) {
+	assert := assert.New(t)
+
+	resetSyncSlackRoutingGlobals(t)
+
+	server, requests := newDaemonCLIRunnerTestServer(t, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{
+			"sync-slack",
+			"--full",
+			"--limit=25",
+			"--no-threads",
+			"T0123456789",
+		}, req.Args, "args")
+	}, `{"type":"stdout","data":"Syncing Slack workspace T0123456789\n"}`, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+
+	var stdout bytes.Buffer
+	cmd := newSyncSlackCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"T0123456789",
+		"--full",
+		"--limit", "25",
+		"--no-threads",
+	})
+
+	require.NoError(t, cmd.Execute(), "sync-slack")
+	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
+	assert.Contains(stdout.String(), "Syncing Slack workspace T0123456789")
+}
+
+func TestAddSlackCommandForwardsTokenEnv(t *testing.T) {
+	assert := assert.New(t)
+
+	server, requests := newDaemonCLIRunnerTestServer(t, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{"add-slack"}, req.Args, "args")
+		assert.Equal("xoxp-test-123", req.Env[clirun.EnvSlackToken], "token env forwarded")
+	}, `{"type":"stdout","data":"Added Slack workspace Testers\n"}`, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+	t.Setenv(clirun.EnvSlackToken, "xoxp-test-123")
+
+	var stdout bytes.Buffer
+	cmd := newAddSlackCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{})
+
+	require.NoError(t, cmd.Execute(), "add-slack")
+	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
+	assert.Contains(stdout.String(), "Added Slack workspace Testers")
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -413,6 +413,67 @@ msgvault backfill-beeper-media --account signal
 
 ---
 
+## add-slack
+
+Register a [Slack workspace](/usage/slack/) as a `slack` source. Requires a
+user token (`xoxp-…`) from an internal Slack app you create (see the usage
+guide for the two-minute setup and scope list). The token is validated with
+`auth.test` and stored at `tokens/slack_<team-id>.json`.
+
+```bash
+msgvault add-slack
+msgvault add-slack --token-file ~/slack-token.txt
+MSGVAULT_SLACK_TOKEN="xoxp-..." msgvault add-slack
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--token-file` | | Read the user token from a file instead of prompting |
+| `--no-default-identity` | `false` | Do not auto-confirm the workspace user ID as the source's "me" identity |
+
+After adding, sync with `msgvault sync-slack`.
+
+---
+
+## sync-slack
+
+Sync Slack conversations — channels you are a member of, group DMs, and 1:1
+DMs — for registered workspaces. The first run backfills full history and is
+resumable; later runs are incremental and poll recent thread roots for late
+replies. Per-workspace failures do not stop the run: remaining workspaces
+still sync and the command exits non-zero listing the failures. The `[slack]`
+config `channels`/`exclude_channels` filters select which channels sync. See
+[Slack](/usage/slack/).
+
+```bash
+msgvault sync-slack
+msgvault sync-slack T0123456789
+msgvault sync-slack --full
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--limit` | `0` | Max messages per conversation this run (0 = no limit; limited backfills resume next run) |
+| `--full` | `false` | Ignore stored cursors and re-fetch every message (repairs rows in place; catches old thread replies and edits) |
+| `--no-threads` | `false` | Skip thread-reply fetching for this run |
+| `--no-media` | `false` | Skip file downloads for this run |
+
+---
+
+## backfill-slack-media
+
+Retry pending Slack file downloads (files that failed or exceeded the size
+cap during `sync-slack`). Idempotent: files are content-addressed and
+already-downloaded ones are never re-fetched. Files hosted outside
+`files.slack.com` are metadata-only link rows and are never downloaded.
+
+```bash
+msgvault backfill-slack-media
+msgvault backfill-slack-media T0123456789
+```
+
+---
+
 ## add-calendar
 
 Authorize read-only Google Calendar access for an account and register its calendars for sync. If the account already has a Gmail token, re-consent bundles Gmail + Calendar so Gmail access is not dropped — keep both checked on the consent screen. The Calendar API must be enabled on the OAuth project. By default only owned/writable calendars are registered.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -418,7 +418,7 @@ msgvault backfill-beeper-media --account signal
 Register a [Slack workspace](/usage/slack/) as a `slack` source. Requires a
 user token (`xoxp-…`) from an internal Slack app you create (see the usage
 guide for the two-minute setup and scope list). The token is validated with
-`auth.test` and stored at `tokens/slack_<team-id>.json`.
+`auth.test` and stored at `tokens/slack_<team-id>_<user-id>.json`.
 
 ```bash
 msgvault add-slack

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -351,7 +351,7 @@ channels = []                     # channel-name include filter (empty = all mem
 exclude_channels = []             # channel names to skip, e.g. ["noise"]
 media = true                      # download shared-file bytes
 max_media_mb = 100                # per-file download cap (MiB)
-thread_lookback_days = 30         # how long thread roots stay tracked for new replies
+thread_lookback_days = 30         # thread tracking + edit-rescan window
 ```
 
 | Key | Default | Description |
@@ -362,7 +362,7 @@ thread_lookback_days = 30         # how long thread roots stay tracked for new r
 | `exclude_channels` | — | Channel names to skip (wins over `channels`) |
 | `media` | `true` | Download shared-file bytes (failed downloads retry via `backfill-slack-media`) |
 | `max_media_mb` | `100` | Per-file download cap in MiB (over-cap files leave a retry marker) |
-| `thread_lookback_days` | `30` | Reply-tracking window for thread roots (older replies need `--full`) |
+| `thread_lookback_days` | `30` | Window for thread-reply tracking, new-thread discovery, and the edit/reaction rescan (older changes need `--full`) |
 
 ### Granola Sources
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -337,6 +337,33 @@ max_media_mb = 100                # per-attachment download cap (MiB)
 | `media` | `true` | Download attachment bytes (failed downloads retry via `backfill-beeper-media`) |
 | `max_media_mb` | `100` | Per-attachment download cap in MiB (over-cap media leaves a retry marker) |
 
+### `[slack]`
+
+Archive [Slack workspaces](/usage/slack/). A single block covers every
+registered workspace (tokens are per-workspace files). Authorize each
+workspace first with `msgvault add-slack`.
+
+```toml
+[slack]
+enabled = true                    # gate for the daemon schedule
+schedule = "*/30 * * * *"         # 5-field cron; empty = manual sync only
+channels = []                     # channel-name include filter (empty = all memberships)
+exclude_channels = []             # channel names to skip, e.g. ["noise"]
+media = true                      # download shared-file bytes
+max_media_mb = 100                # per-file download cap (MiB)
+thread_lookback_days = 30         # how long thread roots stay tracked for new replies
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Whether the daemon schedules Slack sync |
+| `schedule` | — | Cron expression used by `msgvault serve` |
+| `channels` | all | Channel names to sync (include filter; DMs are never filtered) |
+| `exclude_channels` | — | Channel names to skip (wins over `channels`) |
+| `media` | `true` | Download shared-file bytes (failed downloads retry via `backfill-slack-media`) |
+| `max_media_mb` | `100` | Per-file download cap in MiB (over-cap files leave a retry marker) |
+| `thread_lookback_days` | `30` | Reply-tracking window for thread roots (older replies need `--full`) |
+
 ### Granola Sources
 
 Granola meeting-notes sync is configured with top-level `[[granola]]` entries.

--- a/docs/internal/slack-ingestion-design.md
+++ b/docs/internal/slack-ingestion-design.md
@@ -1,9 +1,10 @@
 # Slack Ingestion — Design
 
 Date: 2026-07-18
-Status: Draft — decisions settled, load-bearing items marked LB-* below
-require live validation against a real workspace before implementation
-is declared sound.
+Status: Draft, load-bearing pass complete — LB-1..5 probed live against a
+Slack Developer Program sandbox (team `TesterMsgVault`, 2026-07-18) with
+a seeded 1,100-message channel. LB-3 was falsified and the incremental
+design revised accordingly; verdicts inline below.
 
 ## Goal
 
@@ -155,6 +156,7 @@ Config:
 # max_media_bytes = 52428800       # 50 MiB default, 0 = metadata-only
 # sync_interval = "1h"             # daemon scheduling
 # edit_rescan_window = "168h"      # see Incremental sync
+# thread_lookback = "720h"         # how long a thread root stays tracked for new replies
 ```
 
 ## Incremental sync & checkpointing
@@ -166,6 +168,9 @@ Config:
 type SyncState struct {
     // channelID -> max message ts persisted for that conversation
     Conversations map[string]string `json:"conversations"`
+    // channelID -> rootTs -> max reply ts persisted for that thread.
+    // Pruned to roots younger than thread_lookback (see below).
+    Threads map[string]map[string]string `json:"threads"`
 }
 ```
 
@@ -180,11 +185,26 @@ type SyncState struct {
   data-loss bug roborev hammered on in #398 — a failed replies fetch
   must fail that conversation's cursor advance, not just increment an
   error counter).
-- **Incremental:** `conversations.history` with `oldest=<cursor>`,
-  `inclusive=false`. New thread replies on *old* roots do appear in
-  history as fresh messages carrying `thread_ts`, so threading links
-  resolve even when the root is already archived (LB-3 verifies the
-  parent lookup path).
+- **Incremental (channel level):** `conversations.history` with
+  `oldest=<cursor>`, `inclusive=false` — catches new roots and
+  broadcast replies only.
+- **Incremental (threads) — revised after LB-3 was falsified.** Thread
+  replies do **not** appear in `conversations.history` unless the author
+  chose "also send to channel", and the updated parent is not re-served
+  either (history filters on the parent's original `ts`). Verified
+  mitigation: `conversations.replies` honors `oldest`, and a re-fetched
+  parent carries live `reply_count`/`latest_reply`. Design: track
+  per-root reply cursors in `SyncState.Threads`; each incremental sync
+  calls `conversations.replies` with `oldest=<thread cursor>` for every
+  tracked root, tracking roots for a configurable `thread_lookback`
+  (default 30 days) before pruning. Replies to threads older than the
+  lookback are caught only by `--full` (or the LB-6 search-based
+  discovery fast-follow). Empty replies calls are cheap at internal-app
+  limits (~50 req/min, LB-1), but this bounds per-sync call count to
+  O(active threads), which is why the lookback exists. Implementation
+  gotcha (probe-verified): `conversations.replies` includes the parent
+  itself as the first message — the importer must skip it or rely on
+  upsert idempotency.
 - **Edits & deletes (structural limitation):** history is keyed by
   original `ts`, so an edit or delete of a message older than the cursor
   is invisible to incremental sync. Mitigation: each scheduled sync
@@ -247,32 +267,41 @@ type SyncState struct {
 - Live validation against a real workspace before the PR (Teams
   precedent: it shipped with a ~313k-message live validation note).
 
-## Load-bearing items (to validate live before/while implementing)
+## Load-bearing findings (probed live 2026-07-18, Developer Program
+sandbox, fresh internal app, 1,100-message seeded channel)
 
-- **LB-1 — internal-app rate limits.** Slack's changelog states internal
-  custom apps keep ~50 req/min + up to 999 msgs/req on
-  `conversations.history`; the clampdown targets commercially
-  distributed apps. Probe: page a large channel with `limit=999` on a
-  fresh internal app and confirm granted page size + sustained request
-  rate. If falsified, backfill is still correct, just slow — and the
-  export-ZIP follow-up spec becomes the recommended backfill path.
-- **LB-2 — full-history depth.** Confirm `conversations.history` serves
-  history to the beginning of the channel on a paid plan (Free plan is
-  documented at 90 days). Validate against the oldest known message in
-  a test workspace.
-- **LB-3 — late thread replies.** Confirm a reply to a months-old root
-  appears in incremental `history` (`oldest=<cursor>`) with `thread_ts`
-  set, and that persisting it links to the archived root via
-  `source_message_id` lookup rather than requiring a re-fetch of the
-  root.
-- **LB-4 — non-member public channels.** Check whether a user token can
-  read `conversations.history` of a public channel the user has never
-  joined. If yes, a `[slack] include_unjoined_public = true` option can
-  be a fast follow; if no, v1's membership scope stands.
-- **LB-5 — mpim membership enumeration.** Confirm `users.conversations`
-  with `types=public_channel,private_channel,mpim,im` returns all four
-  kinds under the listed scopes (Slack has historically had quirks with
-  mpim visibility).
+- **LB-1 — internal-app rate limits: VERIFIED.** `conversations.history`
+  with `limit=999` returned full 999-message pages at 42 req/min
+  sustained (12 consecutive calls, no 429). The 2025 clampdown
+  (1 req/min, 15 msgs) does not apply to internal custom apps; the
+  design's backfill performance assumptions hold.
+- **LB-2 — full-history depth: INCONCLUSIVE in sandbox** (all seeded
+  data is same-day, so there is no >90-day boundary to cross). Slack's
+  plan docs state paid plans serve full history via API; treat as
+  docs-verified and confirm during the first real-workspace sync.
+- **LB-3 — late thread replies: FALSIFIED.** A reply to an
+  already-archived root does **not** appear in `conversations.history
+  oldest=<cursor>` (empty page), and the parent is not re-served with
+  updated metadata either. Verified mitigation (see Incremental sync):
+  `conversations.replies` honors `oldest` and returns the late reply;
+  the re-fetched parent carries `reply_count`/`latest_reply`. Design
+  revised to per-root reply cursors with a `thread_lookback` window.
+- **LB-4 — non-member public channels: WORKS.** The user token read
+  `conversations.history` of a public channel after leaving it. A
+  `[slack] include_unjoined_public = true` option is a viable fast
+  follow; v1 still defaults to memberships only.
+- **LB-5 — conversation-type enumeration: PARTIAL.** `users.conversations`
+  returned `public_channel` and `im` correctly; `mpim` untested because
+  the sandbox has no group DM (needs 3+ users). Re-verify in passing on
+  the first workspace that has one; no design impact expected.
+
+Follow-up probe candidates:
+
+- **LB-6 — search-based reply discovery.** `search.messages` (user
+  scope `search:read`) with an `after:<date>` modifier may return new
+  thread replies globally, removing the `thread_lookback` blind spot
+  for replies to old threads. Not yet probed (scope not granted to the
+  probe app); candidate for a fast follow to the incremental design.
 
 ## Out of scope
 

--- a/docs/internal/slack-ingestion-design.md
+++ b/docs/internal/slack-ingestion-design.md
@@ -275,10 +275,11 @@ sandbox, fresh internal app, 1,100-message seeded channel)
   sustained (12 consecutive calls, no 429). The 2025 clampdown
   (1 req/min, 15 msgs) does not apply to internal custom apps; the
   design's backfill performance assumptions hold.
-- **LB-2 — full-history depth: INCONCLUSIVE in sandbox** (all seeded
-  data is same-day, so there is no >90-day boundary to cross). Slack's
-  plan docs state paid plans serve full history via API; treat as
-  docs-verified and confirm during the first real-workspace sync.
+- **LB-2 — full-history depth: VERIFIED** (follow-up probe 2026-07-19
+  against a real paid workspace, single channels:history scope, one
+  channel, timestamps only): `conversations.history` with a `latest`
+  bound served messages 95 days, 2, 5, and 8+ years old. Paid plans
+  serve full history via API; full-depth backfill is sound.
 - **LB-3 — late thread replies: FALSIFIED.** A reply to an
   already-archived root does **not** appear in `conversations.history
   oldest=<cursor>` (empty page), and the parent is not re-served with

--- a/docs/internal/slack-ingestion-design.md
+++ b/docs/internal/slack-ingestion-design.md
@@ -1,0 +1,287 @@
+# Slack Ingestion — Design
+
+Date: 2026-07-18
+Status: Draft — decisions settled, load-bearing items marked LB-* below
+require live validation against a real workspace before implementation
+is declared sound.
+
+## Goal
+
+Sync and store the user's Slack messages — public/private channels the
+user is a member of, group DMs (mpim), and 1:1 DMs — into msgvault so
+they are searchable alongside mail and other chat sources through the
+existing TUI, FTS, and Parquet analytics. Text (with mrkdwn), threads,
+reactions, @mentions, edits, and shared files are preserved.
+
+## Decisions
+
+- **Acquisition: live Web API sync via a user-created internal Slack
+  app** (a "custom app" installed only to the user's own workspace),
+  using a **user token (`xoxp-…`)**, not a bot token. A user token sees
+  exactly what the user sees — private channels, DMs, group DMs —
+  without inviting a bot anywhere. This mirrors the Teams decision
+  (own-data, delegated access, user registers their own app).
+- **Rate-limit posture (load-bearing, verified against Slack docs
+  2026-07-18):** Slack's 2025 rate-limit clampdown
+  (`conversations.history`/`conversations.replies` at 1 req/min,
+  15 messages/req) applies to **commercially distributed non-Marketplace
+  apps**. **Internal custom apps are explicitly exempt** and retain the
+  historical limits (Tier 3, ~50 req/min, up to 999 messages/req).
+  msgvault's "register your own app" model lands in the exempt category.
+  See LB-1 for the live probe that must confirm this before backfill
+  performance claims are made.
+- **Data scope:** conversations the user is a *member* of, enumerated
+  via `users.conversations`. Public channels the user hasn't joined are
+  out of scope for v1 (see LB-4).
+- **Attachments:** download file bytes into content-addressed storage,
+  subject to a configurable size cap (Beeper precedent); files above the
+  cap store filename + permalink + metadata only. Only URLs on
+  `files.slack.com` are ever fetched with the bearer token (see
+  Security).
+- **Slack export ZIP import is out of scope** for this build — separate
+  follow-up spec if wanted (useful for workspaces where app creation is
+  admin-blocked, and for Free-plan workspaces where the API only serves
+  90 days of history).
+- **Edits/deletes are best-effort** (same stance as Teams deletes):
+  Slack history queries are keyed by original message `ts`, so edits and
+  deletions of already-archived messages are only caught by a periodic
+  re-scan window, not by incremental sync. See "Incremental sync".
+
+## Architecture
+
+Parallel to `internal/teams/` and `internal/beeper/` — no new core
+tables, no TUI/query changes beyond registering the new message type.
+
+```
+cmd/msgvault/cmd/add_slack.go        ← token setup + auth.test validation
+cmd/msgvault/cmd/sync_slack.go       ← full + incremental sync
+cmd/msgvault/cmd/backfill_slack_media.go
+        │
+internal/slack/                      ← new package
+   ├── client.go       Web API client (cursor paging, 429 + Retry-After, tier-aware limiter)
+   ├── importer.go     orchestration: enumerate conversations → history/replies → persist
+   ├── mapping.go      Slack message JSON → store.Message (+ body, recipients, reactions)
+   ├── participants.go user-ID → participant resolution (users.list cache, email unification)
+   ├── media.go        files.slack.com downloads → content-addressed store
+   ├── syncstate.go    per-conversation ts cursors in sync_runs.cursor_after
+   ├── token.go        token storage/loading (~/.msgvault/tokens/slack_<team>.json)
+   └── types.go        Slack API DTOs
+        │
+internal/store/…                     ← reused as-is (UpsertMessage,
+                                        EnsureConversationWithType,
+                                        EnsureConversationParticipant,
+                                        RecomputeConversationStats, …)
+```
+
+Per sync run: validate token (`auth.test`) → refresh the users cache
+(`users.list`) → enumerate memberships (`users.conversations`, all four
+types) → per conversation: page `conversations.history` from the saved
+cursor, fetch `conversations.replies` for each thread root, persist
+messages/reactions/mentions/files → advance and flush that
+conversation's cursor → `RecomputeConversationStats` +
+`CompleteSync` with final counts.
+
+## Data model mapping
+
+Reuses the existing generic chat schema — **no new core tables**.
+
+| Slack concept | msgvault storage |
+|---|---|
+| Workspace + user | `sources` row, `source_type = "slack"`, `identifier = "<team_domain>:<user_id>"` (from `auth.test`) |
+| Public/private channel | `conversations`, `conversation_type = "channel"`, `title = "#name"` |
+| Group DM (mpim) | `conversations`, `conversation_type = "group_chat"` |
+| 1:1 DM (im) | `conversations`, `conversation_type = "direct_chat"` |
+| Message | `messages`, `message_type = "slack"`, `source_message_id = "<channel_id>:<ts>"` |
+| Thread reply | `reply_to_message_id` → root (`thread_ts` identifies the root) |
+| Sender | `message_recipients` `"from"`; conversation members via `conversation_participants` |
+| `<@U…>` mention | `message_recipients` `"mention"` (resolved via users cache) |
+| mrkdwn text | `message_bodies.body_text` (mrkdwn → plain text for FTS; raw mrkdwn preserved in `message_raw`) |
+| Reactions | `reactions` table (emoji name; custom emoji stored by name) |
+| File (≤ size cap) | `attachments` (downloaded bytes, content-addressed) |
+| File (> cap) / external | `attachments` row: filename + permalink + metadata, no bytes |
+| Edited message | `UpsertMessage` ON CONFLICT update + `SetMessageEdited` (when the `edited` field is present) |
+| Raw message JSON | `message_raw`, `raw_format = "slack_json"` (verbatim API object, Beeper precedent) |
+
+Registration touch-points: add `"slack"` to `KnownMessageTypes` and
+`TextMessageTypes` (`internal/query/text_models.go`) — TUI Texts mode,
+type filters, and snippet fallback then derive automatically.
+
+Notes:
+
+- **`ts` is the message identity** within a channel (string, e.g.
+  `"1734567890.123456"`); it is unique per channel only, hence the
+  composite `source_message_id`. It is also the timestamp — normalize to
+  UTC (`time.Unix` on the integer part; keep full string for identity).
+- **Identity unification.** `users.list` with `users:read.email` yields
+  `profile.email` for workspace members; store the Slack user ID as a
+  `slack_user_id` identifier on `participants` and dedup against
+  existing mail identities by email — same pattern as Teams' AAD-id →
+  email resolution, giving cross-platform search of one human.
+  Bots (`is_bot`), deactivated users, and Slack Connect guests may lack
+  emails — store id-only, best-effort (Teams precedent).
+- **System subtypes** (`channel_join`, `channel_leave`, etc.) are
+  persisted as messages (they carry history value) but excluded from
+  FTS-noise-sensitive surfaces the same way other importers handle
+  service messages; `bot_message` subtype keeps its `bot_id`/`username`
+  as the sender.
+
+## Auth & permissions
+
+`msgvault add-slack` flow (token-paste model, Beeper precedent — no
+OAuth redirect server needed for an internal app):
+
+1. User creates an app at api.slack.com/apps ("From scratch", their
+   workspace), adds **user token scopes**:
+   `channels:history`, `groups:history`, `im:history`, `mpim:history`
+   (message reads); `channels:read`, `groups:read`, `im:read`,
+   `mpim:read` (conversation enumeration); `users:read`,
+   `users:read.email` (identity resolution); `files:read` (file
+   downloads); `reactions:read`; `team:read`.
+2. "Install to Workspace" → copy the **User OAuth Token** (`xoxp-…`).
+3. `msgvault add-slack` prompts for the token (stdin, not argv),
+   validates with `auth.test`, derives `team_domain`/`team_id`/`user_id`,
+   writes `~/.msgvault/tokens/slack_<team_id>.json` (0600), creates the
+   `sources` row.
+
+Multiple workspaces = multiple `add-slack` runs = multiple sources; the
+TUI account filter (`a`) separates them for free.
+
+Config:
+
+```toml
+[slack]
+# include = ["#eng", "#general"]   # default: all memberships
+# exclude = ["#noise"]
+# max_media_bytes = 52428800       # 50 MiB default, 0 = metadata-only
+# sync_interval = "1h"             # daemon scheduling
+# edit_rescan_window = "168h"      # see Incremental sync
+```
+
+## Incremental sync & checkpointing
+
+**Cursor model** (`internal/slack/syncstate.go`, persisted as JSON in
+`sync_runs.cursor_after`, Teams precedent):
+
+```go
+type SyncState struct {
+    // channelID -> max message ts persisted for that conversation
+    Conversations map[string]string `json:"conversations"`
+}
+```
+
+- **Backfill:** `conversations.history` with cursor pagination
+  (`limit=999` for internal apps), oldest→newest per page batch; for
+  every root with `thread_ts == ts` and `reply_count > 0`, fetch
+  `conversations.replies` (also paginated). The conversation's cursor
+  advances **only after** its messages, replies, raw JSON, and reaction
+  rows have persisted without error; the state is flushed via
+  `UpdateSyncCheckpoint` **after each conversation** so an interrupted
+  backfill resumes mid-stream (Teams precedent, and the exact class of
+  data-loss bug roborev hammered on in #398 — a failed replies fetch
+  must fail that conversation's cursor advance, not just increment an
+  error counter).
+- **Incremental:** `conversations.history` with `oldest=<cursor>`,
+  `inclusive=false`. New thread replies on *old* roots do appear in
+  history as fresh messages carrying `thread_ts`, so threading links
+  resolve even when the root is already archived (LB-3 verifies the
+  parent lookup path).
+- **Edits & deletes (structural limitation):** history is keyed by
+  original `ts`, so an edit or delete of a message older than the cursor
+  is invisible to incremental sync. Mitigation: each scheduled sync
+  re-pages a trailing `edit_rescan_window` (default 7 days) and upserts
+  in place — `UpsertMessage` ON CONFLICT catches edits, and messages
+  present in the archive but absent from the re-scanned window are
+  *not* deleted locally (archive semantics: local copy survives remote
+  deletion, Beeper precedent). Documented as best-effort.
+- **Rate limiting:** honor `Retry-After` on 429 globally; a token-bucket
+  limiter keyed by method tier (Tier 2: `conversations.list`,
+  `users.list`; Tier 3: `history`/`replies`; Tier 4: `auth.test`),
+  matching the Gmail limiter pattern.
+- **Failure accounting:** final `UpdateSyncCheckpoint` with counts +
+  errors before `CompleteSync`, so a partially-failed run never reports
+  clean (roborev finding on #398).
+
+## Security
+
+- **Never fetch a user-controlled URL with the bearer token.** Message
+  and file JSON contain attacker-influenceable URLs. Media downloads are
+  restricted to `url_private` values whose host is exactly
+  `files.slack.com` (scheme https, no redirects followed off-host);
+  anything else is recorded as metadata-only. This is the Slack analogue
+  of the Graph-token-exfiltration finding roborev raised on the Teams PR
+  (crafted hosted-content URL → attacker host).
+- Token file 0600 under `~/.msgvault/tokens/`; token accepted via
+  prompt, never argv (shell history).
+- Client is read-only by construction: the package exposes only GET/
+  read-method calls (`conversations.*` reads, `users.*`, `auth.test`) —
+  no `chat.*` write surface exists in the client (Beeper precedent).
+
+## CLI & daemon integration
+
+- `msgvault add-slack` — token setup (above); `remove-account` gains
+  slack support (token file + source rows), Teams/Beeper precedent.
+- `msgvault sync-slack [<team>]` — full/incremental auto-detected from
+  stored cursors; `--limit N` (conversations), `--full` (ignore cursors,
+  re-fetch + upsert in place), `--no-threads` for scoped first runs.
+- `msgvault backfill-slack-media` — retry failed/over-cap downloads
+  (`--only-incomplete`), Teams/Beeper precedent.
+- `msgvault serve` — scheduled syncs alongside other sources; the
+  daemon's all-source-types-per-identifier behavior (from #398) needs no
+  change since Slack identifiers are team-scoped and won't collide with
+  mail addresses.
+- TUI / FTS / Parquet: no changes beyond the message-type registration —
+  Slack rows flow through the standard `messages` path.
+
+## Testing
+
+- Table-driven testify tests (`assert`/`require`), no `t.Errorf`
+  patterns; synthetic fixtures only (`alice`, `U0ALICE`,
+  `user@example.com`) — no real workspace data.
+- Mapping tests over recorded (synthetic) Slack JSON: message subtypes,
+  threads, edits, reactions, mentions, mrkdwn → text.
+- A fake Slack HTTP server (Beeper's `fake_server_test.go` precedent)
+  driving the full sync → store → search path, including: cursor
+  pagination, 429/Retry-After, mid-backfill interrupt + resume, replies
+  fetch failure ⇒ cursor not advanced, and the files.slack.com host
+  restriction (attempted off-host fetch must not carry the token).
+- Live validation against a real workspace before the PR (Teams
+  precedent: it shipped with a ~313k-message live validation note).
+
+## Load-bearing items (to validate live before/while implementing)
+
+- **LB-1 — internal-app rate limits.** Slack's changelog states internal
+  custom apps keep ~50 req/min + up to 999 msgs/req on
+  `conversations.history`; the clampdown targets commercially
+  distributed apps. Probe: page a large channel with `limit=999` on a
+  fresh internal app and confirm granted page size + sustained request
+  rate. If falsified, backfill is still correct, just slow — and the
+  export-ZIP follow-up spec becomes the recommended backfill path.
+- **LB-2 — full-history depth.** Confirm `conversations.history` serves
+  history to the beginning of the channel on a paid plan (Free plan is
+  documented at 90 days). Validate against the oldest known message in
+  a test workspace.
+- **LB-3 — late thread replies.** Confirm a reply to a months-old root
+  appears in incremental `history` (`oldest=<cursor>`) with `thread_ts`
+  set, and that persisting it links to the archived root via
+  `source_message_id` lookup rather than requiring a re-fetch of the
+  root.
+- **LB-4 — non-member public channels.** Check whether a user token can
+  read `conversations.history` of a public channel the user has never
+  joined. If yes, a `[slack] include_unjoined_public = true` option can
+  be a fast follow; if no, v1's membership scope stands.
+- **LB-5 — mpim membership enumeration.** Confirm `users.conversations`
+  with `types=public_channel,private_channel,mpim,im` returns all four
+  kinds under the listed scopes (Slack has historically had quirks with
+  mpim visibility).
+
+## Out of scope
+
+- Slack export ZIP import (`import-slack-export`) — separate follow-up
+  spec; needed for admin-blocked workspaces and pre-90-day Free-plan
+  history.
+- Session-token acquisition (`xoxc`/`xoxd` browser tokens, slackdump
+  style) — ToS-gray, not something msgvault should ship.
+- Canvases, huddles, clips, workflows, and Slack Connect external-shared
+  channel edge cases beyond what `users.conversations` returns.
+- Custom emoji image download (`emoji.list` mapping) — reactions store
+  the emoji name; image backfill can be a fast follow.

--- a/docs/internal/slack-ingestion-design.md
+++ b/docs/internal/slack-ingestion-design.md
@@ -155,7 +155,7 @@ Config:
 # exclude = ["#noise"]
 # max_media_bytes = 52428800       # 50 MiB default, 0 = metadata-only
 # sync_interval = "1h"             # daemon scheduling
-# edit_rescan_window = "168h"      # see Incremental sync
+# (the edit/discovery rescan shares the thread_lookback window)
 # thread_lookback = "720h"         # how long a thread root stays tracked for new replies
 ```
 

--- a/docs/usage/slack.md
+++ b/docs/usage/slack.md
@@ -41,8 +41,9 @@ msgvault add-slack
 ```
 
 The command validates the token (`auth.test`), stores it at
-`tokens/slack_<team-id>.json` (0600), and registers the workspace as a
-`slack` source identified by `<team-id>:<user-id>`.
+`tokens/slack_<team-id>_<user-id>.json` (0600), and registers the workspace
+as a `slack` source identified by `<team-id>:<user-id>`. Tokens are keyed by
+workspace *and* user, so two accounts in the same workspace coexist.
 
 Provide the token via the interactive prompt, `--token-file <path>`, or the
 `MSGVAULT_SLACK_TOKEN` environment variable:
@@ -84,12 +85,12 @@ for new replies.
 
 Slack's history API never returns thread replies in the main channel stream
 (unless the author chose "also send to channel"), so msgvault tracks each
-thread root and polls it for new replies. Tracking lasts
-`thread_lookback_days` (default 30); a reply posted to an older thread is
-only picked up by a `--full` run.
-
-Edits and reaction changes are caught within the trailing re-scan window
-(one week); older ones likewise need `--full`. Deleted messages simply
+thread root and polls it for new replies. Each incremental sync also
+re-reads the trailing `thread_lookback_days` window (default 30 days),
+which both catches edits and reaction changes and discovers threads whose
+FIRST reply arrived after the root was archived. Replies or edits landing
+on messages older than the lookback are only picked up by a `--full` run.
+Deleted messages simply
 disappear from Slack — your archived copy is kept (archive semantics; nothing
 is ever deleted locally).
 

--- a/docs/usage/slack.md
+++ b/docs/usage/slack.md
@@ -1,0 +1,126 @@
+---
+title: Slack
+description: Archive your Slack workspaces — channels, group DMs, and DMs — via the Web API.
+---
+
+msgvault archives your own view of a Slack workspace: every public and
+private channel you are a member of, group DMs, and 1:1 DMs, with threads,
+reactions, @mentions, edits, and shared files. Each workspace becomes its own
+msgvault source; all Slack-archived messages share `message_type = slack` for
+search.
+
+Slack sync is strictly read-only: msgvault only calls read methods of the Web
+API and never posts, edits, or marks anything in Slack.
+
+## Prerequisites
+
+A **user token** from an internal Slack app you create yourself (a two-minute,
+one-time setup per workspace):
+
+1. Open [api.slack.com/apps](https://api.slack.com/apps) → **Create New
+   App** → **From scratch**, in your workspace.
+2. Under **OAuth & Permissions → Scopes → User Token Scopes**, add:
+   `channels:history`, `groups:history`, `im:history`, `mpim:history`,
+   `channels:read`, `groups:read`, `im:read`, `mpim:read`,
+   `users:read`, `users:read.email`, `files:read`, `reactions:read`,
+   `team:read`.
+3. Click **Install to Workspace** and copy the **User OAuth Token**
+   (`xoxp-…`).
+
+Because the app is yours and not distributed, it is **not** subject to
+Slack's non-Marketplace rate limits — history backfills run at full page size
+(999 messages per request) rather than the throttled 15.
+
+Some workspaces restrict app creation to admins; if that applies to yours,
+ask an admin to approve the app.
+
+## Add a workspace
+
+```bash
+msgvault add-slack
+```
+
+The command validates the token (`auth.test`), stores it at
+`tokens/slack_<team-id>.json` (0600), and registers the workspace as a
+`slack` source identified by `<team-id>:<user-id>`.
+
+Provide the token via the interactive prompt, `--token-file <path>`, or the
+`MSGVAULT_SLACK_TOKEN` environment variable:
+
+```bash
+MSGVAULT_SLACK_TOKEN="xoxp-..." msgvault add-slack
+msgvault add-slack --token-file ~/slack-token.txt
+```
+
+Repeat for additional workspaces — tokens are per-workspace and sources stay
+separately filterable in the TUI (`a`).
+
+## Sync
+
+```bash
+# First run backfills all history; later runs are incremental.
+msgvault sync-slack
+
+# One workspace only.
+msgvault sync-slack T0123456789
+
+# Repair path: re-fetch everything, upserting in place.
+msgvault sync-slack --full
+```
+
+| Flag | Description |
+|---|---|
+| `--limit N` | Max messages per conversation this run (backfills resume next run) |
+| `--full` | Ignore stored cursors; re-fetch and upsert every message in place |
+| `--no-threads` | Skip thread-reply fetching this run |
+| `--no-media` | Skip file downloads this run |
+
+Backfills are resumable: interrupt with Ctrl-C and the next run continues
+from the last checkpoint. Incremental runs fetch new messages, re-scan the
+trailing week for edits and reaction changes, and poll recent thread roots
+for new replies.
+
+### Threads, edits, and deletions
+
+Slack's history API never returns thread replies in the main channel stream
+(unless the author chose "also send to channel"), so msgvault tracks each
+thread root and polls it for new replies. Tracking lasts
+`thread_lookback_days` (default 30); a reply posted to an older thread is
+only picked up by a `--full` run.
+
+Edits and reaction changes are caught within the trailing re-scan window
+(one week); older ones likewise need `--full`. Deleted messages simply
+disappear from Slack — your archived copy is kept (archive semantics; nothing
+is ever deleted locally).
+
+### Files
+
+Files are downloaded into content-addressed attachment storage, capped at
+`max_media_mb` per file. Files hosted outside `files.slack.com` (external
+links, connected drives) are recorded as metadata + permalink only. Failed
+downloads leave pending markers:
+
+```bash
+msgvault backfill-slack-media
+```
+
+retries them (idempotent; already-downloaded files are never re-fetched).
+
+## Daemon scheduling
+
+```toml
+[slack]
+enabled = true
+schedule = "*/30 * * * *"
+```
+
+The daemon then syncs every registered workspace on the schedule. See
+[Configuration](/configuration/#slack) for the full option list
+(channel include/exclude filters, media caps, thread lookback).
+
+## Identity unification
+
+Workspace members' profile emails (via `users:read.email`) link their Slack
+messages to the same participant as their archived mail, so searching a
+person spans both. Bots, deactivated members, and Slack Connect guests
+without a visible email resolve as Slack-only identities.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -28,6 +28,7 @@ nav = [
     {"Google Calendar" = "usage/calendar.md"},
     {"Microsoft Teams" = "usage/teams.md"},
     {"Beeper" = "usage/beeper.md"},
+    {"Slack" = "usage/slack.md"},
     {"Meeting Transcripts" = "usage/meetings.md"},
     {"Exporting Data" = "usage/exporting.md"},
     {"Analytics & Stats" = "usage/analytics.md"},

--- a/internal/api/cli_allowlist_slack_test.go
+++ b/internal/api/cli_allowlist_slack_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The daemon-only CLI model means a command missing from the run allowlist
+// simply does not work end-to-end, with no compile-time signal — so the
+// Slack commands' presence is asserted explicitly.
+func TestCLIRunCommandAllowedSlackCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"add-slack"},
+		{"sync-slack"},
+		{"sync-slack", "T0123456789", "--full"},
+		{"backfill-slack-media"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			assert.True(t, cliRunCommandAllowed(args), "%v must be runnable via the daemon CLI", args)
+		})
+	}
+	assert.False(t, cliRunCommandAllowed([]string{"slack-not-a-command"}))
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1035,9 +1035,11 @@ func cliRunCommandAllowed(args []string) bool {
 		"add-granola",
 		"add-imap",
 		"add-o365",
+		"add-slack",
 		"add-synctech-sms-drive",
 		"add-teams",
 		"backfill-beeper-media",
+		"backfill-slack-media",
 		"backfill-teams-media",
 		"build-embeddings",
 		"cancel-deletion",
@@ -1064,6 +1066,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"sync-calendar",
 		"sync-circleback",
 		"sync-granola",
+		"sync-slack",
 		"sync-synctech-sms",
 		"sync-teams":
 		return true

--- a/internal/clirun/env.go
+++ b/internal/clirun/env.go
@@ -7,12 +7,16 @@ const EnvIMAPPassword = "MSGVAULT_IMAP_PASSWORD" // #nosec G101 -- environment v
 // to a daemon-owned CLI subprocess.
 const EnvBeeperToken = "MSGVAULT_BEEPER_TOKEN" // #nosec G101 -- environment variable name, not a credential value
 
+// EnvSlackToken names the env var used to pass a Slack user token to a
+// daemon-owned CLI subprocess.
+const EnvSlackToken = "MSGVAULT_SLACK_TOKEN" // #nosec G101 -- environment variable name, not a credential value
+
 // EnvRemoteDeleteOptIn names the env var that opts into executing staged remote deletions.
 const EnvRemoteDeleteOptIn = "MSGVAULT_ENABLE_REMOTE_DELETE"
 
 func EnvAllowed(name string) bool {
 	switch name {
-	case EnvIMAPPassword, EnvBeeperToken, EnvRemoteDeleteOptIn:
+	case EnvIMAPPassword, EnvBeeperToken, EnvSlackToken, EnvRemoteDeleteOptIn:
 		return true
 	default:
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,7 @@ type Config struct {
 	SynctechSMS SynctechSMSConfig  `toml:"synctech_sms"`
 	GCal        []GCalSource       `toml:"gcal"`
 	Beeper      BeeperConfig       `toml:"beeper"`
+	Slack       SlackConfig        `toml:"slack"`
 	Granola     []GranolaSource    `toml:"granola"`
 	Circleback  []CirclebackSource `toml:"circleback"`
 	Backup      BackupConfig       `toml:"backup"`
@@ -701,6 +702,49 @@ type BeeperConfig struct {
 	Media *bool `toml:"media"`
 	// MaxMediaMB caps individual attachment downloads in MiB (0 = 100).
 	MaxMediaMB int `toml:"max_media_mb"`
+}
+
+// SlackConfig configures Slack workspace archive sources ([slack] table).
+// One block covers every registered workspace: tokens are per-workspace
+// files, so no per-workspace config entries are needed.
+type SlackConfig struct {
+	// Enabled gates the daemon scheduler job.
+	Enabled bool `toml:"enabled"`
+	// Schedule is a 5-field cron expression; empty = not daemon-scheduled.
+	Schedule string `toml:"schedule"`
+	// Channels is a channel-name include filter (no "#"; empty = archive
+	// every membership). DMs and group DMs are never filtered.
+	Channels []string `toml:"channels"`
+	// ExcludeChannels skips specific channel names.
+	ExcludeChannels []string `toml:"exclude_channels"`
+	// Media toggles file download (nil/absent = enabled).
+	Media *bool `toml:"media"`
+	// MaxMediaMB caps individual file downloads in MiB (0 = 100).
+	MaxMediaMB int `toml:"max_media_mb"`
+	// ThreadLookbackDays bounds how long a thread root stays tracked for new
+	// replies (0 = 30). Replies to older roots are only caught by --full.
+	ThreadLookbackDays int `toml:"thread_lookback_days"`
+}
+
+// MediaEnabled reports whether file download is on (default true).
+func (s SlackConfig) MediaEnabled() bool {
+	return s.Media == nil || *s.Media
+}
+
+// MaxMediaBytes returns the per-file download cap in bytes (0 = importer default).
+func (s SlackConfig) MaxMediaBytes() int64 {
+	if s.MaxMediaMB > 0 {
+		return int64(s.MaxMediaMB) << 20
+	}
+	return 0
+}
+
+// ThreadLookbackDuration returns the thread tracking window (0 = importer default).
+func (s SlackConfig) ThreadLookbackDuration() time.Duration {
+	if s.ThreadLookbackDays > 0 {
+		return time.Duration(s.ThreadLookbackDays) * 24 * time.Hour
+	}
+	return 0
 }
 
 // MediaEnabled reports whether attachment download is on (default true).

--- a/internal/query/text_models.go
+++ b/internal/query/text_models.go
@@ -119,7 +119,7 @@ const (
 
 // TextMessageTypes lists the message_type values included in Texts mode.
 var TextMessageTypes = []string{
-	"whatsapp", "imessage", messageTypeSMS, "mms", "google_voice_text", "teams", "beeper",
+	"whatsapp", "imessage", messageTypeSMS, "mms", "google_voice_text", "teams", "beeper", "slack",
 }
 
 // TextMessageTypeSQLList renders TextMessageTypes as a quoted SQL IN-list
@@ -166,6 +166,7 @@ var KnownMessageTypes = []string{
 	"google_voice_call",
 	"google_voice_voicemail",
 	"beeper",
+	"slack",
 }
 
 // IsKnownMessageType reports whether mt is a message_type value that msgvault

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -247,6 +247,7 @@ func (c *Client) AllConversations(ctx context.Context, fn func(Conversation) err
 		}
 		var out struct {
 			apiResponse
+
 			Channels []Conversation `json:"channels"`
 		}
 		if err := c.call(ctx, "users.conversations", params, &out); err != nil {
@@ -274,6 +275,7 @@ func (c *Client) AllUsers(ctx context.Context, fn func(User) error) error {
 		}
 		var out struct {
 			apiResponse
+
 			Members []User `json:"members"`
 		}
 		if err := c.call(ctx, "users.list", params, &out); err != nil {
@@ -304,6 +306,7 @@ func (c *Client) AllMembers(ctx context.Context, channelID string, fn func(userI
 		}
 		var out struct {
 			apiResponse
+
 			Members []string `json:"members"`
 		}
 		if err := c.call(ctx, "conversations.members", params, &out); err != nil {
@@ -356,6 +359,7 @@ func (c *Client) HistoryPage(ctx context.Context, p HistoryParams) (*HistoryPage
 	}
 	var out struct {
 		apiResponse
+
 		Messages []Message `json:"messages"`
 		HasMore  bool      `json:"has_more"`
 	}
@@ -383,6 +387,7 @@ func (c *Client) RepliesPage(ctx context.Context, channelID, rootTS, cursor, old
 	}
 	var out struct {
 		apiResponse
+
 		Messages []Message `json:"messages"`
 		HasMore  bool      `json:"has_more"`
 	}

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -1,0 +1,386 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	maxRetries = 8
+	// DefaultBaseURL is the Slack Web API root. Injected so tests can point
+	// at httptest servers.
+	DefaultBaseURL = "https://slack.com/api"
+
+	// historyPageLimit is the page size requested from conversations.history
+	// and conversations.replies. Internal (non-distributed) apps are granted
+	// up to 999; distributed non-Marketplace apps are clamped to 15 — the
+	// client honors whatever the server returns either way.
+	historyPageLimit = 999
+	// listPageLimit is the page size for enumeration methods.
+	listPageLimit = 200
+)
+
+// Web API method tiers (docs.slack.dev/apis/web-api/rate-limits). The
+// limiters run slightly under the published per-minute budgets so scheduled
+// daemon syncs never trip 429 in steady state; 429 + Retry-After remains the
+// authoritative backstop.
+var methodTiers = map[string]int{
+	"auth.test":             4,
+	"users.list":            2,
+	"users.conversations":   3,
+	"conversations.history": 3,
+	"conversations.replies": 3,
+	"conversations.members": 4,
+}
+
+// ErrNotFound reports a channel/thread/user that no longer exists.
+var ErrNotFound = errors.New("not found")
+
+// ErrAssetTooLarge reports a file exceeding the caller's size cap; the cap is
+// enforced while reading so oversized bodies are never fully buffered.
+var ErrAssetTooLarge = errors.New("file exceeds size cap")
+
+// ErrAuth reports a rejected or under-scoped token; callers surface it with
+// re-run-add-slack guidance instead of retrying.
+var ErrAuth = errors.New("slack auth error")
+
+// notFoundAPIErrors are Slack method errors that mean "the thing is gone",
+// not "the request failed".
+var notFoundAPIErrors = map[string]bool{
+	"channel_not_found": true,
+	"thread_not_found":  true,
+	"message_not_found": true,
+	"user_not_found":    true,
+	"file_not_found":    true,
+	"file_deleted":      true,
+}
+
+// authAPIErrors are Slack method errors that mean the token (not the
+// request) is the problem.
+var authAPIErrors = map[string]bool{
+	"invalid_auth":       true,
+	"not_authed":         true,
+	"account_inactive":   true,
+	"token_revoked":      true,
+	"token_expired":      true,
+	"missing_scope":      true,
+	"no_permission":      true,
+	"ekm_access_denied":  true,
+	"org_login_required": true,
+}
+
+// Client is a read-only Slack Web API client: it exposes only read methods
+// by construction, so the archiver can never mutate workspace state.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+	// limiters holds one token bucket per rate tier (see methodTiers).
+	limiters map[int]*rate.Limiter
+	// mediaTransport overrides the file-download transport (tests only; the
+	// API base URL is injectable but file URLs are validated against the real
+	// files.slack.com host).
+	mediaTransport http.RoundTripper
+}
+
+// NewClient creates a Client. baseURL "" means the real Slack API.
+func NewClient(baseURL, token string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	perMinute := func(n float64) *rate.Limiter {
+		return rate.NewLimiter(rate.Limit(n/60), 2)
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 60 * time.Second},
+		limiters: map[int]*rate.Limiter{
+			2: perMinute(18),
+			3: perMinute(45),
+			4: perMinute(90),
+		},
+	}
+}
+
+// call POSTs a Web API method with form params, decoding the JSON body into
+// out (which must embed apiResponse via an ok/error check by the caller).
+// 429 and 5xx are retried with Retry-After / exponential back-off.
+func (c *Client) call(ctx context.Context, method string, params url.Values, out any) error {
+	tier := methodTiers[method]
+	if tier == 0 {
+		tier = 3
+	}
+	reqURL := c.baseURL + "/" + method
+	body := params.Encode()
+	for attempt := range maxRetries {
+		if err := c.limiters[tier].Wait(ctx); err != nil {
+			return fmt.Errorf("wait for slack rate limit: %w", err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return fmt.Errorf("slack %s: %w", method, err)
+		}
+		data, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return fmt.Errorf("slack %s: read body: %w", method, readErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("slack %s: close body: %w", method, closeErr)
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("slack %s: status %d: %s", method, resp.StatusCode, truncate(data, 200))
+		}
+
+		var envelope apiResponse
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("slack %s: decode envelope: %w", method, err)
+		}
+		if !envelope.OK {
+			return apiError(method, &envelope)
+		}
+		if out != nil {
+			if err := json.Unmarshal(data, out); err != nil {
+				return fmt.Errorf("slack %s: decode response: %w", method, err)
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("slack %s: exhausted %d retries", method, maxRetries)
+}
+
+// apiError maps a Slack method-level error string to a typed error.
+func apiError(method string, envelope *apiResponse) error {
+	switch {
+	case notFoundAPIErrors[envelope.Error]:
+		return fmt.Errorf("slack %s: %s: %w", method, envelope.Error, ErrNotFound)
+	case authAPIErrors[envelope.Error]:
+		detail := ""
+		if envelope.Error == "missing_scope" {
+			detail = fmt.Sprintf(" (needs scope %q, token has %q)", envelope.Needed, envelope.Provided)
+		}
+		return fmt.Errorf("slack %s: %s%s: re-run 'msgvault add-slack' with an updated token: %w",
+			method, envelope.Error, detail, ErrAuth)
+	default:
+		return fmt.Errorf("slack %s: %s", method, envelope.Error)
+	}
+}
+
+// retryAfter parses a Retry-After header (seconds) or falls back to
+// exponential back-off capped at 60 s.
+func retryAfter(header string, attempt int) time.Duration {
+	if header != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}
+
+// AuthTest validates the token and identifies its workspace and user.
+func (c *Client) AuthTest(ctx context.Context) (*AuthTestResult, error) {
+	var out struct {
+		apiResponse
+		AuthTestResult
+	}
+	if err := c.call(ctx, "auth.test", url.Values{}, &out); err != nil {
+		return nil, err
+	}
+	return &out.AuthTestResult, nil
+}
+
+// AllConversations pages through the user's conversation memberships of all
+// four types, invoking fn per conversation.
+func (c *Client) AllConversations(ctx context.Context, fn func(Conversation) error) error {
+	cursor := ""
+	for {
+		params := url.Values{
+			"types":            {"public_channel,private_channel,mpim,im"},
+			"limit":            {strconv.Itoa(listPageLimit)},
+			"exclude_archived": {"false"},
+		}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var out struct {
+			apiResponse
+			Channels []Conversation `json:"channels"`
+		}
+		if err := c.call(ctx, "users.conversations", params, &out); err != nil {
+			return err
+		}
+		for i := range out.Channels {
+			if err := fn(out.Channels[i]); err != nil {
+				return err
+			}
+		}
+		cursor = out.Metadata.NextCursor
+		if cursor == "" {
+			return nil
+		}
+	}
+}
+
+// AllUsers pages through the workspace member list, invoking fn per user.
+func (c *Client) AllUsers(ctx context.Context, fn func(User) error) error {
+	cursor := ""
+	for {
+		params := url.Values{"limit": {strconv.Itoa(listPageLimit)}}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var out struct {
+			apiResponse
+			Members []User `json:"members"`
+		}
+		if err := c.call(ctx, "users.list", params, &out); err != nil {
+			return err
+		}
+		for i := range out.Members {
+			if err := fn(out.Members[i]); err != nil {
+				return err
+			}
+		}
+		cursor = out.Metadata.NextCursor
+		if cursor == "" {
+			return nil
+		}
+	}
+}
+
+// AllMembers pages through a conversation's member user IDs.
+func (c *Client) AllMembers(ctx context.Context, channelID string, fn func(userID string) error) error {
+	cursor := ""
+	for {
+		params := url.Values{
+			"channel": {channelID},
+			"limit":   {strconv.Itoa(listPageLimit)},
+		}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var out struct {
+			apiResponse
+			Members []string `json:"members"`
+		}
+		if err := c.call(ctx, "conversations.members", params, &out); err != nil {
+			return err
+		}
+		for _, id := range out.Members {
+			if err := fn(id); err != nil {
+				return err
+			}
+		}
+		cursor = out.Metadata.NextCursor
+		if cursor == "" {
+			return nil
+		}
+	}
+}
+
+// HistoryPage is one page of conversations.history / conversations.replies.
+type HistoryPage struct {
+	Messages   []Message
+	HasMore    bool
+	NextCursor string
+}
+
+// HistoryParams selects a slice of a conversation's history.
+type HistoryParams struct {
+	ChannelID string
+	Cursor    string // opaque page cursor; mutually advancing with Oldest
+	Oldest    string // exclusive lower ts bound ("" = beginning)
+	Latest    string // exclusive upper ts bound ("" = now)
+}
+
+// HistoryPage fetches one page of top-level channel history. Slack pages
+// newest→oldest without a cursor; the importer requests oldest-bounded
+// windows and walks pages via NextCursor.
+func (c *Client) HistoryPage(ctx context.Context, p HistoryParams) (*HistoryPage, error) {
+	params := url.Values{
+		"channel":   {p.ChannelID},
+		"limit":     {strconv.Itoa(historyPageLimit)},
+		"inclusive": {"false"},
+	}
+	if p.Cursor != "" {
+		params.Set("cursor", p.Cursor)
+	}
+	if p.Oldest != "" {
+		params.Set("oldest", p.Oldest)
+	}
+	if p.Latest != "" {
+		params.Set("latest", p.Latest)
+	}
+	var out struct {
+		apiResponse
+		Messages []Message `json:"messages"`
+		HasMore  bool      `json:"has_more"`
+	}
+	if err := c.call(ctx, "conversations.history", params, &out); err != nil {
+		return nil, err
+	}
+	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
+}
+
+// RepliesPage fetches one page of a thread's replies (rootTS = the thread
+// root's ts). The response includes the root itself as the first message of
+// the first page; callers must skip or idempotently re-upsert it.
+func (c *Client) RepliesPage(ctx context.Context, channelID, rootTS, cursor, oldest string) (*HistoryPage, error) {
+	params := url.Values{
+		"channel": {channelID},
+		"ts":      {rootTS},
+		"limit":   {strconv.Itoa(historyPageLimit)},
+	}
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+	if oldest != "" {
+		params.Set("oldest", oldest)
+		params.Set("inclusive", "false")
+	}
+	var out struct {
+		apiResponse
+		Messages []Message `json:"messages"`
+		HasMore  bool      `json:"has_more"`
+	}
+	if err := c.call(ctx, "conversations.replies", params, &out); err != nil {
+		return nil, err
+	}
+	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
+}

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -343,8 +343,12 @@ type HistoryPage struct {
 type HistoryParams struct {
 	ChannelID string
 	Cursor    string // opaque page cursor; mutually advancing with Oldest
-	Oldest    string // exclusive lower ts bound ("" = beginning)
-	Latest    string // exclusive upper ts bound ("" = now)
+	Oldest    string // lower ts bound ("" = beginning)
+	Latest    string // upper ts bound ("" = now)
+	// Inclusive makes the Oldest/Latest bounds inclusive (the edit rescan
+	// must re-read the cursor message itself; default exclusive bounds are
+	// what cursor-advancing walks need).
+	Inclusive bool
 }
 
 // HistoryPage fetches one page of top-level channel history. Slack pages
@@ -354,13 +358,14 @@ func (c *Client) HistoryPage(ctx context.Context, p HistoryParams) (*HistoryPage
 	return c.historyPageWithLimit(ctx, p, historyPageLimit)
 }
 
-// historyPageWithLimit is HistoryPage with an explicit page size (the live
-// throttle probe uses tiny pages; every request costs the same budget).
+// historyPageWithLimit is HistoryPage with an explicit page size (the
+// importer sizes pages to the remaining --limit budget; the live throttle
+// probe uses tiny pages).
 func (c *Client) historyPageWithLimit(ctx context.Context, p HistoryParams, limit int) (*HistoryPage, error) {
 	params := url.Values{
 		"channel":   {p.ChannelID},
 		"limit":     {strconv.Itoa(limit)},
-		"inclusive": {"false"},
+		"inclusive": {strconv.FormatBool(p.Inclusive)},
 	}
 	if p.Cursor != "" {
 		params.Set("cursor", p.Cursor)
@@ -387,10 +392,16 @@ func (c *Client) historyPageWithLimit(ctx context.Context, p HistoryParams, limi
 // root's ts). The response includes the root itself as the first message of
 // the first page; callers must skip or idempotently re-upsert it.
 func (c *Client) RepliesPage(ctx context.Context, channelID, rootTS, cursor, oldest string) (*HistoryPage, error) {
+	return c.repliesPageWithLimit(ctx, channelID, rootTS, cursor, oldest, historyPageLimit)
+}
+
+// repliesPageWithLimit is RepliesPage with an explicit page size (sized to
+// the importer's remaining --limit budget).
+func (c *Client) repliesPageWithLimit(ctx context.Context, channelID, rootTS, cursor, oldest string, limit int) (*HistoryPage, error) {
 	params := url.Values{
 		"channel": {channelID},
 		"ts":      {rootTS},
-		"limit":   {strconv.Itoa(historyPageLimit)},
+		"limit":   {strconv.Itoa(limit)},
 	}
 	if cursor != "" {
 		params.Set("cursor", cursor)

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -134,13 +134,17 @@ func (c *Client) call(ctx context.Context, method string, params url.Values, out
 		if err := c.limiters[tier].Wait(ctx); err != nil {
 			return fmt.Errorf("wait for slack rate limit: %w", err)
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(body))
+		// reqURL is the constant Slack API base (or a test-injected httptest
+		// URL) plus a package-constant method name — no remote or user input
+		// reaches it. gosec's taint analysis flags it via the env-var-driven
+		// live-probe test.
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(body)) // #nosec G704
 		if err != nil {
 			return err
 		}
 		req.Header.Set("Authorization", "Bearer "+c.token)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		resp, err := c.http.Do(req)
+		resp, err := c.http.Do(req) // #nosec G704 -- see reqURL above
 		if err != nil {
 			return fmt.Errorf("slack %s: %w", method, err)
 		}
@@ -343,9 +347,15 @@ type HistoryParams struct {
 // newest→oldest without a cursor; the importer requests oldest-bounded
 // windows and walks pages via NextCursor.
 func (c *Client) HistoryPage(ctx context.Context, p HistoryParams) (*HistoryPage, error) {
+	return c.historyPageWithLimit(ctx, p, historyPageLimit)
+}
+
+// historyPageWithLimit is HistoryPage with an explicit page size (the live
+// throttle probe uses tiny pages; every request costs the same budget).
+func (c *Client) historyPageWithLimit(ctx context.Context, p HistoryParams, limit int) (*HistoryPage, error) {
 	params := url.Values{
 		"channel":   {p.ChannelID},
-		"limit":     {strconv.Itoa(historyPageLimit)},
+		"limit":     {strconv.Itoa(limit)},
 		"inclusive": {"false"},
 	}
 	if p.Cursor != "" {

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -113,6 +113,13 @@ func NewClient(baseURL, token string) *Client {
 	}
 }
 
+// disableRateLimits removes the per-tier pacing (tests only).
+func (c *Client) disableRateLimits() {
+	for tier := range c.limiters {
+		c.limiters[tier] = rate.NewLimiter(rate.Inf, 1)
+	}
+}
+
 // call POSTs a Web API method with form params, decoding the JSON body into
 // out (which must embed apiResponse via an ok/error check by the caller).
 // 429 and 5xx are retried with Retry-After / exponential back-off.

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -124,9 +124,13 @@ func (c *Client) disableRateLimits() {
 // out (which must embed apiResponse via an ok/error check by the caller).
 // 429 and 5xx are retried with Retry-After / exponential back-off.
 func (c *Client) call(ctx context.Context, method string, params url.Values, out any) error {
-	tier := methodTiers[method]
-	if tier == 0 {
-		tier = 3
+	// Strict method allowlist: reqURL is base + method, and the G704
+	// suppressions below rest on method being one of these package
+	// constants. Refusing unknown methods enforces that at runtime instead
+	// of by convention (and no new method can dodge tier classification).
+	tier, ok := methodTiers[method]
+	if !ok {
+		return fmt.Errorf("slack client: method %q is not allowlisted", method)
 	}
 	reqURL := c.baseURL + "/" + method
 	body := params.Encode()
@@ -135,9 +139,9 @@ func (c *Client) call(ctx context.Context, method string, params url.Values, out
 			return fmt.Errorf("wait for slack rate limit: %w", err)
 		}
 		// reqURL is the constant Slack API base (or a test-injected httptest
-		// URL) plus a package-constant method name — no remote or user input
-		// reaches it. gosec's taint analysis flags it via the env-var-driven
-		// live-probe test.
+		// URL) plus an allowlisted package-constant method name (enforced
+		// above) — no remote or user input reaches it. gosec's taint
+		// analysis flags it via the env-var-driven live-probe test.
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(body)) // #nosec G704
 		if err != nil {
 			return err

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -48,6 +48,15 @@ func TestClientErrorMapping(t *testing.T) {
 	require.NotErrorIs(t, err, ErrAuth)
 }
 
+func TestClientRejectsUnallowlistedMethods(t *testing.T) {
+	f := newFakeSlack(t)
+	c := testClient(t, f)
+
+	err := c.call(context.Background(), "chat.postMessage", nil, nil)
+	require.ErrorContains(t, err, "not allowlisted",
+		"the client must refuse methods outside its read-only allowlist before any request is made")
+}
+
 func TestClientPagination(t *testing.T) {
 	f := newFakeSlack(t)
 	f.users = []map[string]any{

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -44,8 +44,8 @@ func TestClientErrorMapping(t *testing.T) {
 		})
 	}
 	err := apiError("conversations.history", &apiResponse{Error: "fatal_error"})
-	assert.NotErrorIs(t, err, ErrNotFound)
-	assert.NotErrorIs(t, err, ErrAuth)
+	require.NotErrorIs(t, err, ErrNotFound)
+	require.NotErrorIs(t, err, ErrAuth)
 }
 
 func TestClientPagination(t *testing.T) {

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -1,0 +1,64 @@
+package slack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testClient(t *testing.T, f *fakeSlack) *Client {
+	t.Helper()
+	srv := f.serve()
+	c := NewClient(srv.URL, "xoxp-test")
+	c.disableRateLimits()
+	return c
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	f := newFakeSlack(t)
+	f.rateLimit429s = 2
+	c := testClient(t, f)
+
+	auth, err := c.AuthTest(context.Background())
+	require.NoError(t, err, "429s with Retry-After must be retried, not surfaced")
+	assert.Equal(t, "T01", auth.TeamID)
+	assert.Equal(t, "UME", auth.UserID)
+}
+
+func TestClientErrorMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiError string
+		want     error
+	}{
+		{"not found", "channel_not_found", ErrNotFound},
+		{"auth", "invalid_auth", ErrAuth},
+		{"missing scope", "missing_scope", ErrAuth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := apiError("conversations.history", &apiResponse{Error: tt.apiError})
+			assert.ErrorIs(t, err, tt.want)
+		})
+	}
+	err := apiError("conversations.history", &apiResponse{Error: "fatal_error"})
+	assert.NotErrorIs(t, err, ErrNotFound)
+	assert.NotErrorIs(t, err, ErrAuth)
+}
+
+func TestClientPagination(t *testing.T) {
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "U1"}, {"id": "U2"}, {"id": "U3"}, {"id": "U4"}, {"id": "U5"},
+	}
+	c := testClient(t, f) // fake pageSize is 3: forces two pages
+
+	var ids []string
+	require.NoError(t, c.AllUsers(context.Background(), func(u User) error {
+		ids = append(ids, u.ID)
+		return nil
+	}))
+	assert.Equal(t, []string{"U1", "U2", "U3", "U4", "U5"}, ids)
+}

--- a/internal/slack/doc.go
+++ b/internal/slack/doc.go
@@ -1,0 +1,18 @@
+// Package slack archives a Slack workspace user's own conversations —
+// public/private channels they are a member of, group DMs, and 1:1 DMs —
+// via the Slack Web API using a user token from a user-created internal
+// (non-distributed) Slack app.
+//
+// Design: docs/internal/slack-ingestion-design.md. The package follows the
+// beeper/teams importer anatomy: a read-only rate-limited client, a
+// per-conversation cursor model persisted in sync_runs.cursor_after, and
+// persistence through the shared store schema (no new core tables).
+//
+// Two properties are load-bearing (probed live 2026-07-18):
+//   - Internal apps are exempt from the 2025 non-Marketplace rate-limit
+//     clampdown: conversations.history serves 999-message pages at Tier 3
+//     rates.
+//   - Thread replies never appear in oldest-filtered conversations.history
+//     (unless broadcast), so incremental sync tracks per-root reply cursors
+//     and re-polls conversations.replies for roots within a lookback window.
+package slack

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -124,6 +125,7 @@ type fakeSlack struct {
 }
 
 func newFakeSlack(t *testing.T) *fakeSlack {
+	t.Helper()
 	return &fakeSlack{
 		t: t, pageSize: 3,
 		failHistory: map[string]bool{}, failReplies: map[string]bool{},
@@ -138,12 +140,7 @@ func (f *fakeSlack) handleGhost(c *fakeConv) {
 }
 
 func (f *fakeSlack) isGhost(id string) bool {
-	for _, g := range f.ghosts {
-		if g == id {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(f.ghosts, id)
 }
 
 func (f *fakeSlack) conv(id string) *fakeConv {
@@ -202,7 +199,9 @@ func (f *fakeSlack) reply(w http.ResponseWriter, body map[string]any) {
 
 func (f *fakeSlack) replyErr(w http.ResponseWriter, apiErr string) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": apiErr})
+	if err := json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": apiErr}); err != nil {
+		f.t.Errorf("encode fake error response: %v", err)
+	}
 }
 
 // page slices items[from:from+pageSize] driven by the "cursor" form value
@@ -267,8 +266,8 @@ func (f *fakeSlack) handleMembers(w http.ResponseWriter, r *http.Request) {
 // (oldest, latest) exclusive ts bounds.
 func visibleHistory(c *fakeConv, oldest, latest string) []fakeMsg {
 	var out []fakeMsg
-	for i := len(c.Msgs) - 1; i >= 0; i-- {
-		m := c.Msgs[i]
+	for _, v := range slices.Backward(c.Msgs) {
+		m := v
 		if oldest != "" && !tsLess(oldest, m.TS) {
 			continue
 		}

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -23,6 +23,9 @@ type fakeMsg struct {
 	Edited    bool
 	Reactions []map[string]any
 	Files     []map[string]any
+	// LegacyAttachments/Blocks emit as "attachments"/"blocks" (bot payloads).
+	LegacyAttachments []map[string]any
+	Blocks            []map[string]any
 	// Replies holds the thread's replies (oldest→newest) when this message
 	// is a root. Reply fakeMsgs must carry ThreadTS = root TS.
 	Replies []fakeMsg
@@ -56,6 +59,12 @@ func (m *fakeMsg) toJSON() map[string]any {
 	}
 	if len(m.Files) > 0 {
 		out["files"] = m.Files
+	}
+	if len(m.LegacyAttachments) > 0 {
+		out["attachments"] = m.LegacyAttachments
+	}
+	if len(m.Blocks) > 0 {
+		out["blocks"] = m.Blocks
 	}
 	return out
 }

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -1,0 +1,328 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// fakeMsg is one message held by the fake Slack server. Channel messages
+// live oldest→newest; ts values are assigned by the test.
+type fakeMsg struct {
+	TS        string
+	ThreadTS  string
+	User      string
+	BotID     string
+	Username  string
+	Subtype   string
+	Text      string
+	Edited    bool
+	Reactions []map[string]any
+	Files     []map[string]any
+	// Replies holds the thread's replies (oldest→newest) when this message
+	// is a root. Reply fakeMsgs must carry ThreadTS = root TS.
+	Replies []fakeMsg
+}
+
+func (m *fakeMsg) toJSON() map[string]any {
+	out := map[string]any{"type": "message", "ts": m.TS, "text": m.Text}
+	if m.User != "" {
+		out["user"] = m.User
+	}
+	if m.BotID != "" {
+		out["bot_id"] = m.BotID
+		out["username"] = m.Username
+	}
+	if m.Subtype != "" {
+		out["subtype"] = m.Subtype
+	}
+	if m.ThreadTS != "" {
+		out["thread_ts"] = m.ThreadTS
+	}
+	if len(m.Replies) > 0 {
+		out["thread_ts"] = m.TS
+		out["reply_count"] = len(m.Replies)
+		out["latest_reply"] = m.Replies[len(m.Replies)-1].TS
+	}
+	if m.Edited {
+		out["edited"] = map[string]any{"user": m.User, "ts": m.TS}
+	}
+	if len(m.Reactions) > 0 {
+		out["reactions"] = m.Reactions
+	}
+	if len(m.Files) > 0 {
+		out["files"] = m.Files
+	}
+	return out
+}
+
+type fakeConv struct {
+	ID      string
+	Name    string
+	Kind    string // "public" | "private" | "mpim" | "im"
+	IMUser  string // peer for im
+	Members []string
+	Msgs    []fakeMsg // top-level messages, oldest → newest
+}
+
+func (c *fakeConv) toJSON() map[string]any {
+	out := map[string]any{"id": c.ID, "name": c.Name, "is_member": true}
+	switch c.Kind {
+	case "im":
+		out["is_im"] = true
+		out["user"] = c.IMUser
+	case "mpim":
+		out["is_mpim"] = true
+		out["is_private"] = true
+	case "private":
+		out["is_channel"] = true
+		out["is_private"] = true
+	default:
+		out["is_channel"] = true
+	}
+	return out
+}
+
+// findRoot returns the root fakeMsg for ts, or nil.
+func (c *fakeConv) findRoot(ts string) *fakeMsg {
+	for i := range c.Msgs {
+		if c.Msgs[i].TS == ts {
+			return &c.Msgs[i]
+		}
+	}
+	return nil
+}
+
+// fakeSlack simulates the Slack Web API surface the importer uses, with
+// cursor pagination semantics matching the real API (newest-first history
+// pages, oldest-exclusive bounds, next_cursor continuation).
+type fakeSlack struct {
+	t        *testing.T
+	pageSize int
+
+	mu    sync.Mutex
+	users []map[string]any
+	convs []*fakeConv
+	// failHistory / failReplies make the named channel / root ts answer a
+	// method error (a non-retryable fetch failure).
+	failHistory map[string]bool
+	failReplies map[string]bool
+	// failHistoryContinuations fails only history requests carrying a page
+	// cursor, emulating a walk that dies partway through a multi-page window.
+	failHistoryContinuations bool
+	// rateLimit429s serves that many 429s (with Retry-After: 0) before
+	// succeeding, per method call sequence.
+	rateLimit429s int
+	// historyCalls counts conversations.history requests.
+	historyCalls int
+}
+
+func newFakeSlack(t *testing.T) *fakeSlack {
+	return &fakeSlack{
+		t: t, pageSize: 3,
+		failHistory: map[string]bool{}, failReplies: map[string]bool{},
+	}
+}
+
+func (f *fakeSlack) conv(id string) *fakeConv {
+	for _, c := range f.convs {
+		if c.ID == id {
+			return c
+		}
+	}
+	return nil
+}
+
+func (f *fakeSlack) serve() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth.test", func(w http.ResponseWriter, r *http.Request) {
+		f.reply(w, map[string]any{
+			"url": "https://testers.slack.com/", "team": "Testers",
+			"user": "me", "team_id": "T01", "user_id": "UME",
+		})
+	})
+	mux.HandleFunc("/users.list", f.handleUsersList)
+	mux.HandleFunc("/users.conversations", f.handleUsersConversations)
+	mux.HandleFunc("/conversations.members", f.handleMembers)
+	mux.HandleFunc("/conversations.history", f.handleHistory)
+	mux.HandleFunc("/conversations.replies", f.handleReplies)
+	// The 429 gate runs before any handler takes f.mu (reply is called with
+	// the mutex held, so it must not lock).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		limited := f.rateLimit429s > 0
+		if limited {
+			f.rateLimit429s--
+		}
+		f.mu.Unlock()
+		if limited {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		mux.ServeHTTP(w, r)
+	}))
+	f.t.Cleanup(srv.Close)
+	return srv
+}
+
+// reply writes a successful envelope. Callers may hold f.mu.
+func (f *fakeSlack) reply(w http.ResponseWriter, body map[string]any) {
+	body["ok"] = true
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		f.t.Errorf("encode fake response: %v", err)
+	}
+}
+
+func (f *fakeSlack) replyErr(w http.ResponseWriter, apiErr string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": apiErr})
+}
+
+// page slices items[from:from+pageSize] driven by the "cursor" form value
+// (a stringified index), returning the slice and the next cursor.
+func (f *fakeSlack) page(r *http.Request, n int) (from, to int, next string) {
+	from = 0
+	if cur := r.FormValue("cursor"); cur != "" {
+		idx, err := strconv.Atoi(cur)
+		if err != nil {
+			f.t.Errorf("bad cursor %q", cur)
+			return 0, 0, ""
+		}
+		from = idx
+	}
+	to = min(from+f.pageSize, n)
+	if to < n {
+		next = strconv.Itoa(to)
+	}
+	return from, to, next
+}
+
+func (f *fakeSlack) handleUsersList(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	from, to, next := f.page(r, len(f.users))
+	f.reply(w, map[string]any{
+		"members":           f.users[from:to],
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (f *fakeSlack) handleUsersConversations(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	channels := make([]map[string]any, 0, len(f.convs))
+	for _, c := range f.convs {
+		channels = append(channels, c.toJSON())
+	}
+	from, to, next := f.page(r, len(channels))
+	f.reply(w, map[string]any{
+		"channels":          channels[from:to],
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (f *fakeSlack) handleMembers(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := f.conv(r.FormValue("channel"))
+	if c == nil {
+		f.replyErr(w, "channel_not_found")
+		return
+	}
+	from, to, next := f.page(r, len(c.Members))
+	f.reply(w, map[string]any{
+		"members":           c.Members[from:to],
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+// visibleHistory returns c's top-level messages newest→oldest within the
+// (oldest, latest) exclusive ts bounds.
+func visibleHistory(c *fakeConv, oldest, latest string) []fakeMsg {
+	var out []fakeMsg
+	for i := len(c.Msgs) - 1; i >= 0; i-- {
+		m := c.Msgs[i]
+		if oldest != "" && !tsLess(oldest, m.TS) {
+			continue
+		}
+		if latest != "" && !tsLess(m.TS, latest) {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func (f *fakeSlack) handleHistory(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.historyCalls++
+	c := f.conv(r.FormValue("channel"))
+	if c == nil {
+		f.replyErr(w, "channel_not_found")
+		return
+	}
+	if f.failHistory[c.ID] {
+		f.replyErr(w, "internal_error")
+		return
+	}
+	if f.failHistoryContinuations && r.FormValue("cursor") != "" {
+		f.replyErr(w, "internal_error")
+		return
+	}
+	visible := visibleHistory(c, r.FormValue("oldest"), r.FormValue("latest"))
+	from, to, next := f.page(r, len(visible))
+	msgs := make([]map[string]any, 0, to-from)
+	for _, m := range visible[from:to] {
+		msgs = append(msgs, m.toJSON())
+	}
+	f.reply(w, map[string]any{
+		"messages":          msgs,
+		"has_more":          next != "",
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (f *fakeSlack) handleReplies(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := f.conv(r.FormValue("channel"))
+	if c == nil {
+		f.replyErr(w, "channel_not_found")
+		return
+	}
+	rootTS := r.FormValue("ts")
+	if f.failReplies[rootTS] {
+		f.replyErr(w, "internal_error")
+		return
+	}
+	root := c.findRoot(rootTS)
+	if root == nil {
+		f.replyErr(w, "thread_not_found")
+		return
+	}
+	oldest := r.FormValue("oldest")
+	// The real API serves the root first, then replies oldest→newest.
+	all := []fakeMsg{*root}
+	for _, reply := range root.Replies {
+		if oldest != "" && !tsLess(oldest, reply.TS) {
+			continue
+		}
+		all = append(all, reply)
+	}
+	from, to, next := f.page(r, len(all))
+	msgs := make([]map[string]any, 0, to-from)
+	for _, m := range all[from:to] {
+		msgs = append(msgs, m.toJSON())
+	}
+	f.reply(w, map[string]any{
+		"messages":          msgs,
+		"has_more":          next != "",
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -213,8 +213,9 @@ func (f *fakeSlack) replyErr(w http.ResponseWriter, apiErr string) {
 	}
 }
 
-// page slices items[from:from+pageSize] driven by the "cursor" form value
-// (a stringified index), returning the slice and the next cursor.
+// page slices items[from:from+size] driven by the "cursor" form value (a
+// stringified index), returning the slice and the next cursor. Like the real
+// API, a "limit" smaller than the server's page size is honored.
 func (f *fakeSlack) page(r *http.Request, n int) (from, to int, next string) {
 	from = 0
 	if cur := r.FormValue("cursor"); cur != "" {
@@ -225,7 +226,13 @@ func (f *fakeSlack) page(r *http.Request, n int) (from, to int, next string) {
 		}
 		from = idx
 	}
-	to = min(from+f.pageSize, n)
+	size := f.pageSize
+	if raw := r.FormValue("limit"); raw != "" {
+		if limit, err := strconv.Atoi(raw); err == nil && limit > 0 && limit < size {
+			size = limit
+		}
+	}
+	to = min(from+size, n)
 	if to < n {
 		next = strconv.Itoa(to)
 	}
@@ -272,15 +279,23 @@ func (f *fakeSlack) handleMembers(w http.ResponseWriter, r *http.Request) {
 }
 
 // visibleHistory returns c's top-level messages newest→oldest within the
-// (oldest, latest) exclusive ts bounds.
-func visibleHistory(c *fakeConv, oldest, latest string) []fakeMsg {
+// (oldest, latest) ts bounds — exclusive by default, inclusive like the real
+// API's inclusive=true when requested.
+func visibleHistory(c *fakeConv, oldest, latest string, inclusive bool) []fakeMsg {
 	var out []fakeMsg
-	for _, v := range slices.Backward(c.Msgs) {
-		m := v
-		if oldest != "" && !tsLess(oldest, m.TS) {
+	for _, m := range slices.Backward(c.Msgs) {
+		switch {
+		case oldest == "":
+		case inclusive && tsLess(m.TS, oldest):
+			continue
+		case !inclusive && !tsLess(oldest, m.TS):
 			continue
 		}
-		if latest != "" && !tsLess(m.TS, latest) {
+		switch {
+		case latest == "":
+		case inclusive && tsLess(latest, m.TS):
+			continue
+		case !inclusive && !tsLess(m.TS, latest):
 			continue
 		}
 		out = append(out, m)
@@ -305,7 +320,7 @@ func (f *fakeSlack) handleHistory(w http.ResponseWriter, r *http.Request) {
 		f.replyErr(w, "internal_error")
 		return
 	}
-	visible := visibleHistory(c, r.FormValue("oldest"), r.FormValue("latest"))
+	visible := visibleHistory(c, r.FormValue("oldest"), r.FormValue("latest"), r.FormValue("inclusive") == "true")
 	from, to, next := f.page(r, len(visible))
 	msgs := make([]map[string]any, 0, to-from)
 	for _, m := range visible[from:to] {

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -113,6 +113,9 @@ type fakeSlack struct {
 	// failHistoryContinuations fails only history requests carrying a page
 	// cursor, emulating a walk that dies partway through a multi-page window.
 	failHistoryContinuations bool
+	// ghosts lists conversation IDs that stay enumerable but 404 on read
+	// (see handleGhost).
+	ghosts []string
 	// rateLimit429s serves that many 429s (with Retry-After: 0) before
 	// succeeding, per method call sequence.
 	rateLimit429s int
@@ -127,7 +130,26 @@ func newFakeSlack(t *testing.T) *fakeSlack {
 	}
 }
 
+// handleGhost keeps c in the users.conversations listing while making its
+// history/members lookups answer channel_not_found, like a conversation the
+// token can enumerate but not read.
+func (f *fakeSlack) handleGhost(c *fakeConv) {
+	f.ghosts = append(f.ghosts, c.ID)
+}
+
+func (f *fakeSlack) isGhost(id string) bool {
+	for _, g := range f.ghosts {
+		if g == id {
+			return true
+		}
+	}
+	return false
+}
+
 func (f *fakeSlack) conv(id string) *fakeConv {
+	if f.isGhost(id) {
+		return nil
+	}
 	for _, c := range f.convs {
 		if c.ID == id {
 			return c

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -292,6 +292,13 @@ func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64,
 // conversation resumable rather than failing the run.
 func (imp *Importer) backfillConversation(ctx context.Context, cc *convScope, state *SyncState, sum *ImportSummary) error {
 	cs := cc.cs
+	// Pin the walk's upper bound BEFORE the first page: page cursors index
+	// into the bounded window, so introducing the bound mid-walk would shift
+	// the window under an already-issued cursor and skip messages. Messages
+	// arriving after the pin are left for the incremental phase.
+	if cs.BackfillLatest == "" {
+		cs.BackfillLatest = fmt.Sprintf("%d.999999", imp.now().Unix())
+	}
 	pages := 0
 	for {
 		if err := ctx.Err(); err != nil {
@@ -319,11 +326,6 @@ func (imp *Importer) backfillConversation(ctx context.Context, cc *convScope, st
 		if cs.Cursor == "" && len(page.Messages) > 0 {
 			cs.Cursor = page.Messages[0].TS
 		}
-		// Pin the walk's upper bound so messages arriving mid-backfill are
-		// left for the incremental phase instead of shifting pagination.
-		if cs.BackfillLatest == "" && len(page.Messages) > 0 {
-			cs.BackfillLatest = page.Messages[0].TS
-		}
 		for i := range page.Messages {
 			if err := imp.processMessage(ctx, cc, &page.Messages[i], sum); err != nil {
 				return err
@@ -344,8 +346,10 @@ func (imp *Importer) backfillConversation(ctx context.Context, cc *convScope, st
 }
 
 // incrementalConversation fetches top-level messages newer than the stored
-// cursor. The cursor advances only after a page has fully persisted, so a
-// failed page is re-fetched next run (upserts make that idempotent).
+// cursor. History pages arrive NEWEST-first, so the ts cursor only advances
+// once every page of the window has persisted — advancing it per page would
+// let an interruption after page one permanently skip the older pages.
+// A retried window is re-fetched in full (upserts make that idempotent).
 func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope, sum *ImportSummary) error {
 	cs := cc.cs
 	pageCursor := ""
@@ -355,7 +359,7 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 			return err
 		}
 		if cc.limitReached() {
-			return nil
+			return nil // cursor not advanced; limited runs re-fetch the window
 		}
 		page, err := imp.client.HistoryPage(ctx, HistoryParams{
 			ChannelID: cc.channelID,
@@ -369,7 +373,7 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
-			return nil // cursor not advanced; next run retries
+			return nil // cursor not advanced; next run retries the window
 		}
 		for i := range page.Messages {
 			m := &page.Messages[i]
@@ -381,9 +385,8 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 			}
 		}
 		cc.budgetUsed += len(page.Messages)
-		// The page persisted cleanly: safe to advance the ts cursor.
-		cs.Cursor = maxTS
 		if !page.HasMore || page.NextCursor == "" {
+			cs.Cursor = maxTS // the whole window persisted cleanly
 			return nil
 		}
 		pageCursor = page.NextCursor

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -1,0 +1,738 @@
+package slack
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const sourceTypeSlack = "slack"
+
+// checkpointMinInterval throttles checkpoint flushes: the state blob is
+// O(conversations + tracked threads) JSON. A variable so tests can disable
+// the throttle.
+var checkpointMinInterval = 15 * time.Second
+
+const (
+	// checkpointPageInterval flushes the sync checkpoint every N pages inside
+	// a single conversation backfill (a busy channel can hold years of pages).
+	checkpointPageInterval = 10
+	// defaultThreadLookback bounds how long a thread root stays tracked for
+	// new replies (see ConvState.Threads).
+	defaultThreadLookback = 30 * 24 * time.Hour
+	// editRescanWindow bounds the head re-walk that catches edits and
+	// reaction changes the ts cursor cannot see (Slack history is keyed by
+	// original ts). Changes older than the window are only repaired by
+	// --full runs (documented limitation).
+	editRescanWindow = 7 * 24 * time.Hour
+	// maxRescanPages caps the edit-rescan walk for pathologically busy channels.
+	maxRescanPages = 10
+)
+
+// convScope carries per-conversation state through the persist call chain.
+type convScope struct {
+	channelID  string
+	convID     int64
+	sourceID   int64
+	syncID     int64
+	opts       ImportOptions
+	cs         *ConvState
+	budgetUsed int
+}
+
+func (cc *convScope) limitReached() bool {
+	return cc.opts.Limit > 0 && cc.budgetUsed >= cc.opts.Limit
+}
+
+// Importer ingests one Slack workspace user's conversations into the
+// msgvault store. One Import run covers one workspace (= one source).
+type Importer struct {
+	store          *store.Store
+	client         *Client
+	res            *participantResolver
+	lastCheckpoint time.Time
+	// now is a clock hook for tests.
+	now func() time.Time
+}
+
+// NewImporter creates an Importer backed by the given store and Slack client.
+func NewImporter(s *store.Store, c *Client, teamID string) *Importer {
+	return &Importer{store: s, client: c, res: newParticipantResolver(s, teamID), now: time.Now}
+}
+
+// loadResumeState rebuilds the sync state for a source: the last successful
+// run's cursor blob merged with the latest interrupted checkpoint.
+func (imp *Importer) loadResumeState(sourceID int64) *SyncState {
+	state := NewSyncState()
+	if prev, err := imp.store.GetLastSuccessfulSync(sourceID); err == nil && prev != nil && prev.CursorAfter.Valid {
+		if s, lerr := LoadSyncState(prev.CursorAfter.String); lerr == nil {
+			state = s
+		}
+	}
+	if cp, err := imp.store.GetLatestCheckpointedSync(sourceID); err == nil && cp != nil && cp.CursorBefore.Valid {
+		if cpState, lerr := LoadSyncState(cp.CursorBefore.String); lerr == nil {
+			state.Merge(cpState)
+		}
+	}
+	return state
+}
+
+// Import runs a backfill-then-incremental sync of the workspace user's
+// conversations. New conversations backfill their full history (resumable
+// across interrupted runs); completed ones fetch only messages newer than
+// the stored cursor, then poll tracked threads for late replies.
+func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
+	start := imp.now()
+	if opts.TeamID == "" || opts.UserID == "" {
+		return nil, errors.New("slack team and user IDs required")
+	}
+	src, err := imp.store.GetOrCreateSource(sourceTypeSlack, opts.TeamID+":"+opts.UserID)
+	if err != nil {
+		return nil, err
+	}
+	sum := &ImportSummary{SourceID: src.ID}
+
+	state := imp.loadResumeState(src.ID)
+	if opts.Full {
+		state = NewSyncState()
+	}
+
+	syncID, err := imp.store.StartSync(src.ID, sourceTypeSlack)
+	if err != nil {
+		return nil, err
+	}
+	// Failures below must ASSIGN to err (never shadow it with :=) so this
+	// defer records them on the run.
+	defer func() {
+		if err != nil {
+			_ = imp.store.FailSync(syncID, err.Error())
+		}
+	}()
+
+	// Persist the merged resume state immediately: if this run fails before
+	// its first checkpoint, the next run must still find the prior progress.
+	imp.checkpointNow(syncID, state, sum)
+
+	// Identity resolution is load-bearing for cross-archive dedup: without
+	// the member cache every sender would resolve as a bare ID, splitting
+	// people from their mail identities.
+	if err = imp.res.loadUsers(ctx, imp.client); err != nil {
+		return sum, fmt.Errorf("refresh slack users: %w", err)
+	}
+
+	var convs []Conversation
+	err = imp.client.AllConversations(ctx, func(c Conversation) error {
+		if includeConversation(&c, &opts) {
+			convs = append(convs, c)
+		}
+		return nil
+	})
+	if err != nil {
+		return sum, fmt.Errorf("enumerate slack conversations: %w", err)
+	}
+
+	total := len(convs)
+	for idx := range convs {
+		c := &convs[idx]
+		if err = ctx.Err(); err != nil {
+			return sum, err
+		}
+		before := sum.MessagesProcessed
+		if serr := imp.syncConversation(ctx, syncID, src.ID, c, opts, state, sum); serr != nil {
+			err = serr
+			return sum, err
+		}
+		sum.ConversationsProcessed++
+		if opts.Progress != nil {
+			opts.Progress(fmt.Sprintf("conversation %d/%d (%s): %d messages",
+				idx+1, total, conversationTitle(c, imp.res.displayName), sum.MessagesProcessed-before))
+		}
+		// Flush checkpoint so an interrupted run resumes from this point.
+		imp.checkpoint(syncID, state, sum)
+	}
+
+	if err = imp.store.RecomputeConversationStats(src.ID); err != nil {
+		return sum, err
+	}
+	// Mid-run checkpoints are throttled, so persist the final counters before
+	// completing (CompleteSync only writes status and cursor).
+	imp.checkpointNow(syncID, state, sum)
+	if sum.FetchErrors > 0 {
+		// Fetch failures are isolated so healthy conversations still sync,
+		// but the run must remain failed and caller-visible; the checkpoint
+		// above preserves all partial progress for the next attempt.
+		sum.Duration = imp.now().Sub(start)
+		err = fmt.Errorf("partial Slack sync: %d fetch error(s)", sum.FetchErrors)
+		return sum, err
+	}
+	blob, _ := state.Marshal()
+	if err = imp.store.CompleteSync(syncID, blob); err != nil {
+		return sum, err
+	}
+	sum.Duration = imp.now().Sub(start)
+	return sum, nil
+}
+
+// includeConversation applies the channel include/exclude name filters.
+// DMs and group DMs are never filtered (the filters exist to skip noisy
+// channels, not people).
+func includeConversation(c *Conversation, opts *ImportOptions) bool {
+	if c.IsIM || c.IsMpim {
+		return true
+	}
+	for _, name := range opts.ExcludeChannels {
+		if name == c.Name {
+			return false
+		}
+	}
+	if len(opts.IncludeChannels) == 0 {
+		return true
+	}
+	for _, name := range opts.IncludeChannels {
+		if name == c.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// syncConversation ensures the conversation row and membership, then
+// backfills or incrementally extends its messages and polls tracked threads.
+func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int64, c *Conversation, opts ImportOptions, state *SyncState, sum *ImportSummary) error {
+	convID, err := imp.store.EnsureConversationWithType(sourceID, c.ID, conversationType(c), conversationTitle(c, imp.res.displayName))
+	if err != nil {
+		return err
+	}
+	if err := imp.ensureMembership(ctx, syncID, convID, c, opts, sum); err != nil {
+		return err
+	}
+
+	cs := state.EnsureConv(c.ID)
+	cc := &convScope{channelID: c.ID, convID: convID, sourceID: sourceID, syncID: syncID, opts: opts, cs: cs}
+
+	if !cs.Done {
+		if err := imp.backfillConversation(ctx, cc, state, sum); err != nil {
+			return err
+		}
+	} else {
+		if err := imp.incrementalConversation(ctx, cc, sum); err != nil {
+			return err
+		}
+		if !cc.limitReached() {
+			if err := imp.rescanHead(ctx, cc, sum); err != nil {
+				return err
+			}
+		}
+	}
+
+	if !opts.NoThreads {
+		if err := imp.syncThreads(ctx, cc, sum); err != nil {
+			return err
+		}
+	}
+	// Prune only after thread polling: roots discovered during a long
+	// backfill must get their one reply fetch even when older than the
+	// lookback.
+	cs.PruneThreads(imp.now().Add(-threadLookback(opts)))
+	return nil
+}
+
+func threadLookback(opts ImportOptions) time.Duration {
+	if opts.ThreadLookback > 0 {
+		return opts.ThreadLookback
+	}
+	return defaultThreadLookback
+}
+
+// ensureMembership records the conversation's member list. Membership fetch
+// failures are counted but not fatal: message archiving must not be blocked
+// by a members listing outage.
+func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64, c *Conversation, opts ImportOptions, sum *ImportSummary) error {
+	var members []store.ConversationParticipantRef
+	add := func(userID string) error {
+		pid, err := imp.res.resolveID(userID)
+		if err != nil {
+			return err
+		}
+		if pid != 0 {
+			members = append(members, store.ConversationParticipantRef{ParticipantID: pid, Role: "member"})
+		}
+		return nil
+	}
+	if c.IsIM {
+		if err := add(c.User); err != nil {
+			return err
+		}
+		if err := add(opts.UserID); err != nil {
+			return err
+		}
+	} else {
+		if err := imp.client.AllMembers(ctx, c.ID, add); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.Errors++
+			return nil
+		}
+	}
+	if err := imp.store.ReplaceConversationParticipants(convID, members); err != nil {
+		return err
+	}
+	return nil
+}
+
+// backfillConversation walks the conversation's full history newest→oldest
+// via cursor pages, resumable from BackfillCursor. The incremental cursor is
+// primed from the newest message of the first page. Fetch errors leave the
+// conversation resumable rather than failing the run.
+func (imp *Importer) backfillConversation(ctx context.Context, cc *convScope, state *SyncState, sum *ImportSummary) error {
+	cs := cc.cs
+	pages := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cc.limitReached() {
+			return nil // resumable: Done stays false
+		}
+		page, err := imp.client.HistoryPage(ctx, HistoryParams{
+			ChannelID: cc.channelID,
+			Cursor:    cs.BackfillCursor,
+			Latest:    cs.BackfillLatest,
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		// Pages arrive newest-first; the very first message of the walk
+		// becomes the incremental cursor once the backfill completes.
+		if cs.Cursor == "" && len(page.Messages) > 0 {
+			cs.Cursor = page.Messages[0].TS
+		}
+		// Pin the walk's upper bound so messages arriving mid-backfill are
+		// left for the incremental phase instead of shifting pagination.
+		if cs.BackfillLatest == "" && len(page.Messages) > 0 {
+			cs.BackfillLatest = page.Messages[0].TS
+		}
+		for i := range page.Messages {
+			if err := imp.processMessage(ctx, cc, &page.Messages[i], sum); err != nil {
+				return err
+			}
+		}
+		cc.budgetUsed += len(page.Messages)
+		if !page.HasMore || page.NextCursor == "" {
+			cs.Done = true
+			cs.BackfillCursor = ""
+			return nil
+		}
+		cs.BackfillCursor = page.NextCursor
+		pages++
+		if pages%checkpointPageInterval == 0 {
+			imp.checkpoint(cc.syncID, state, sum)
+		}
+	}
+}
+
+// incrementalConversation fetches top-level messages newer than the stored
+// cursor. The cursor advances only after a page has fully persisted, so a
+// failed page is re-fetched next run (upserts make that idempotent).
+func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope, sum *ImportSummary) error {
+	cs := cc.cs
+	pageCursor := ""
+	maxTS := cs.Cursor
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cc.limitReached() {
+			return nil
+		}
+		page, err := imp.client.HistoryPage(ctx, HistoryParams{
+			ChannelID: cc.channelID,
+			Cursor:    pageCursor,
+			Oldest:    cs.Cursor,
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil // cursor not advanced; next run retries
+		}
+		for i := range page.Messages {
+			m := &page.Messages[i]
+			if err := imp.processMessage(ctx, cc, m, sum); err != nil {
+				return err
+			}
+			if maxTS == "" || tsLess(maxTS, m.TS) {
+				maxTS = m.TS
+			}
+		}
+		cc.budgetUsed += len(page.Messages)
+		// The page persisted cleanly: safe to advance the ts cursor.
+		cs.Cursor = maxTS
+		if !page.HasMore || page.NextCursor == "" {
+			return nil
+		}
+		pageCursor = page.NextCursor
+	}
+}
+
+// rescanHead re-pages the conversation's trailing edit window, re-upserting
+// messages in place to catch edits and reaction changes (history is keyed by
+// original ts, so the incremental cursor cannot see them). Thread roots
+// re-encountered here refresh their tracking, catching reply activity on
+// recent roots.
+func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportSummary) error {
+	oldest := fmt.Sprintf("%d.000000", imp.now().Add(-editRescanWindow).Unix())
+	if cc.cs.Cursor != "" && tsLess(cc.cs.Cursor, oldest) {
+		// Everything newer than the cursor was just fetched by the
+		// incremental pass; nothing older than it has been archived yet.
+		return nil
+	}
+	pageCursor := ""
+	for range maxRescanPages {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cc.limitReached() {
+			return nil
+		}
+		page, err := imp.client.HistoryPage(ctx, HistoryParams{
+			ChannelID: cc.channelID,
+			Cursor:    pageCursor,
+			Oldest:    oldest,
+			Latest:    cc.cs.Cursor,
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		for i := range page.Messages {
+			if err := imp.processMessage(ctx, cc, &page.Messages[i], sum); err != nil {
+				return err
+			}
+		}
+		if !page.HasMore || page.NextCursor == "" {
+			return nil
+		}
+		pageCursor = page.NextCursor
+	}
+	return nil
+}
+
+// syncThreads polls every tracked thread root for replies newer than its
+// reply cursor. A root's cursor advances only after its replies persisted
+// cleanly; a failed root is retried next run without blocking the others.
+func (imp *Importer) syncThreads(ctx context.Context, cc *convScope, sum *ImportSummary) error {
+	for root, replyCursor := range cc.cs.Threads {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cc.limitReached() {
+			return nil
+		}
+		newCursor, err := imp.syncThread(ctx, cc, root, replyCursor, sum)
+		if err != nil {
+			return err
+		}
+		if newCursor != "" {
+			cc.cs.Threads[root] = newCursor
+		}
+	}
+	return nil
+}
+
+// syncThread fetches one thread's replies newer than replyCursor, returning
+// the advanced cursor ("" = do not advance).
+func (imp *Importer) syncThread(ctx context.Context, cc *convScope, root, replyCursor string, sum *ImportSummary) (string, error) {
+	pageCursor := ""
+	maxTS := replyCursor
+	for {
+		page, err := imp.client.RepliesPage(ctx, cc.channelID, root, pageCursor, replyCursor)
+		if errors.Is(err, ErrNotFound) {
+			// The root was deleted; its archived copy is kept, and there is
+			// nothing left to poll.
+			delete(cc.cs.Threads, root)
+			return "", nil
+		}
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", ctx.Err()
+			}
+			imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, root), "thread", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return "", nil // cursor not advanced; next run retries this thread
+		}
+		for i := range page.Messages {
+			m := &page.Messages[i]
+			// The response includes the root itself; re-upserting it is
+			// harmless (idempotent) and refreshes its edited state.
+			if err := imp.processMessage(ctx, cc, m, sum); err != nil {
+				return "", err
+			}
+			if m.TS != root {
+				sum.RepliesFetched++
+				if maxTS == "" || tsLess(maxTS, m.TS) {
+					maxTS = m.TS
+				}
+			}
+		}
+		cc.budgetUsed += len(page.Messages)
+		if !page.HasMore || page.NextCursor == "" {
+			return maxTS, nil
+		}
+		pageCursor = page.NextCursor
+	}
+}
+
+// processMessage persists one message and its auxiliary rows. Store-level
+// failures are fatal (they indicate DB problems); per-item auxiliary
+// failures (FTS, recipients, reactions) are counted but do not abort the run.
+func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Message, sum *ImportSummary) error {
+	if m.Type != "message" || m.TS == "" {
+		return nil
+	}
+	// Track thread roots for reply polling regardless of persist outcome
+	// details: the reply cursor itself only advances in syncThread.
+	if m.IsThreadRoot() {
+		cc.cs.TrackThread(m.TS, "")
+	}
+
+	msg, text := mapMessage(m, cc.channelID, cc.convID, cc.sourceID, m.User == cc.opts.UserID, imp.res.displayName)
+	var senderPID int64
+	var err error
+	if m.User != "" {
+		senderPID, err = imp.res.resolveID(m.User)
+	} else if m.BotID != "" {
+		senderPID, err = imp.res.resolveBot(m.BotID, m.Username)
+	}
+	if err != nil {
+		return err
+	}
+	if senderPID != 0 {
+		msg.SenderID = sql.NullInt64{Int64: senderPID, Valid: true}
+	}
+	messageID, err := imp.store.UpsertMessage(&msg)
+	if err != nil {
+		return err
+	}
+	if err := imp.store.UpsertMessageBody(messageID, sql.NullString{String: text, Valid: text != ""}, sql.NullString{}); err != nil {
+		return err
+	}
+	// Archive the exact original message JSON (captured at decode time) so
+	// no API field is lost to our partial struct modelling.
+	raw := []byte(m.Raw)
+	if len(raw) == 0 {
+		return fmt.Errorf("slack message %s has no raw JSON archive", msg.SourceMessageID)
+	}
+	if err := imp.store.UpsertMessageRawWithFormat(messageID, raw, "slack_json"); err != nil {
+		return fmt.Errorf("archive slack message raw: %w", err)
+	}
+	if err := imp.store.UpsertFTS(messageID, "", text, imp.res.displayName(m.User), "", ""); err != nil {
+		sum.Errors++
+	}
+	if m.Edited != nil {
+		if err := imp.store.SetMessageEdited(messageID); err != nil {
+			sum.Errors++
+		}
+	}
+
+	imp.persistFiles(ctx, cc.syncID, messageID, m, cc.opts, sum)
+
+	if err := imp.persistMentions(messageID, m, sum); err != nil {
+		return err
+	}
+	if err := imp.persistReactions(messageID, m, sum); err != nil {
+		return err
+	}
+
+	// Thread replies link to their root by source-message-ID lookup. Roots
+	// always reach the archive before or with their replies (history pages
+	// carry roots; the replies response carries the root first), and
+	// SetReplyTo resolves to NULL harmlessly if one is missing.
+	if m.IsThreadReply() {
+		if err := imp.store.SetReplyTo(cc.sourceID, sourceMessageID(cc.channelID, m.TS), sourceMessageID(cc.channelID, m.ThreadTS)); err != nil {
+			sum.Errors++
+		}
+	}
+
+	sum.MessagesProcessed++
+	sum.MessagesAdded++
+	return nil
+}
+
+// persistMentions writes "mention" recipient rows. No from/to rows are
+// written: sender attribution lives in messages.sender_id and membership in
+// conversation_participants (WhatsApp/Beeper precedent).
+func (imp *Importer) persistMentions(messageID int64, m *Message, sum *ImportSummary) error {
+	var ids []int64
+	var names []string
+	for _, uid := range m.MentionedUserIDs() {
+		pid, err := imp.res.resolveID(uid)
+		if err != nil {
+			return err
+		}
+		if pid == 0 {
+			continue
+		}
+		ids = append(ids, pid)
+		names = append(names, imp.res.displayName(uid))
+	}
+	if err := imp.store.ReplaceMessageRecipients(messageID, "mention", ids, names); err != nil {
+		sum.Errors++
+	}
+	return nil
+}
+
+// persistReactions replaces the message's reactions from the embedded
+// aggregates. Slack reactions carry no timestamp; created_at approximates
+// with the target message's timestamp (cosmetic only). The API may truncate
+// a reaction's user list on very popular messages — the archived raw JSON
+// preserves the counts.
+func (imp *Importer) persistReactions(messageID int64, m *Message, sum *ImportSummary) error {
+	var reactions []store.ReactionRef
+	for _, rc := range m.Reactions {
+		for _, uid := range rc.Users {
+			pid, err := imp.res.resolveID(uid)
+			if err != nil {
+				return err
+			}
+			if pid == 0 {
+				continue
+			}
+			reactions = append(reactions, store.ReactionRef{
+				ParticipantID: pid,
+				Type:          "emoji",
+				Value:         rc.Name,
+				CreatedAt:     tsTime(m.TS),
+			})
+		}
+	}
+	if err := imp.store.ReplaceReactions(messageID, reactions); err != nil {
+		sum.Errors++
+	}
+	return nil
+}
+
+// checkpoint persists the sync state mid-run so an interrupted run resumes.
+// Flushes are throttled (see checkpointMinInterval).
+func (imp *Importer) checkpoint(syncID int64, state *SyncState, sum *ImportSummary) {
+	if time.Since(imp.lastCheckpoint) < checkpointMinInterval {
+		return
+	}
+	imp.checkpointNow(syncID, state, sum)
+}
+
+// checkpointNow persists the sync state unconditionally: for the initial
+// resume-state write and the final counters, which must never be skipped.
+func (imp *Importer) checkpointNow(syncID int64, state *SyncState, sum *ImportSummary) {
+	blob, err := state.Marshal()
+	if err != nil {
+		return
+	}
+	if imp.store.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+		PageToken:         blob,
+		MessagesProcessed: int64(sum.MessagesProcessed),
+		MessagesAdded:     int64(sum.MessagesAdded),
+		ErrorsCount:       int64(sum.Errors),
+	}) == nil {
+		imp.lastCheckpoint = time.Now()
+	}
+}
+
+// recordItem records a per-item outcome on the sync run.
+func (imp *Importer) recordItem(syncID int64, sourceMessageID, phase, status, kind string, err error) {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	_ = imp.store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: sourceMessageID,
+		Phase:           phase,
+		Status:          status,
+		ErrorKind:       kind,
+		ErrorMessage:    msg,
+	})
+}
+
+// BackfillMedia retries pending Slack file downloads for one workspace:
+// every message that still has a pending marker is re-read from the archived
+// raw JSON and its files re-persisted. Idempotent (content-addressed
+// storage, replace-by-prefix rows).
+func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
+	start := imp.now()
+	if opts.AttachmentsDir == "" {
+		return nil, errors.New("attachments dir required")
+	}
+	src, err := imp.store.GetOrCreateSource(sourceTypeSlack, opts.TeamID+":"+opts.UserID)
+	if err != nil {
+		return nil, err
+	}
+	sum := &ImportSummary{SourceID: src.ID}
+	// This run's sync_runs row becomes the source's newest completed run and
+	// Import loads its cursor_after as the resume baseline — carry the
+	// existing sync state forward verbatim or the next sync would restart.
+	state := imp.loadResumeState(src.ID)
+	stateBlob, err := state.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	syncID, err := imp.store.StartSync(src.ID, "slack_media")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = imp.store.FailSync(syncID, err.Error())
+		}
+	}()
+	imp.checkpointNow(syncID, state, sum)
+
+	pending, err := imp.store.ListSlackPendingAttachmentMessages(src.ID)
+	if err != nil {
+		return sum, err
+	}
+	for _, item := range pending {
+		if err = ctx.Err(); err != nil {
+			return sum, err
+		}
+		raw, rerr := imp.store.GetMessageRaw(item.MessageID)
+		if rerr != nil || len(raw) == 0 {
+			sum.Errors++
+			continue
+		}
+		var m Message
+		if uerr := m.UnmarshalJSON(raw); uerr != nil {
+			sum.Errors++
+			continue
+		}
+		imp.persistFiles(ctx, syncID, item.MessageID, &m, opts, sum)
+		sum.MessagesProcessed++
+	}
+	imp.checkpointNow(syncID, state, sum)
+	if err = imp.store.CompleteSync(syncID, stateBlob); err != nil {
+		return sum, err
+	}
+	sum.Duration = imp.now().Sub(start)
+	return sum, nil
+}

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -275,6 +275,10 @@ func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64,
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			if errors.Is(err, ErrNotFound) {
+				imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				return nil
+			}
 			imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.Errors++
 			return nil
@@ -315,6 +319,15 @@ func (imp *Importer) backfillConversation(ctx context.Context, cc *convScope, st
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				// Enumerated but unreadable (observed live: a sandbox
+				// provisioning-bot DM). There is nothing to fetch — recording
+				// it as a hard error would wedge every future run into
+				// partial failure.
+				imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				cs.Done = true
+				return nil
 			}
 			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
@@ -370,6 +383,12 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			if errors.Is(err, ErrNotFound) {
+				// The conversation is gone (left/deleted); the archived
+				// messages are kept and there is nothing left to fetch.
+				imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				return nil
+			}
 			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
@@ -422,6 +441,10 @@ func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportS
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				return nil
 			}
 			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -25,12 +25,9 @@ const (
 	// defaultThreadLookback bounds how long a thread root stays tracked for
 	// new replies (see ConvState.Threads).
 	defaultThreadLookback = 30 * 24 * time.Hour
-	// editRescanWindow bounds the head re-walk that catches edits and
-	// reaction changes the ts cursor cannot see (Slack history is keyed by
-	// original ts). Changes older than the window are only repaired by
-	// --full runs (documented limitation).
-	editRescanWindow = 7 * 24 * time.Hour
-	// maxRescanPages caps the edit-rescan walk for pathologically busy channels.
+	// maxRescanPages caps the rescan walk for pathologically busy channels;
+	// conversations busier than maxRescanPages full pages per lookback are
+	// only fully repaired by --full runs (documented limitation).
 	maxRescanPages = 10
 )
 
@@ -368,17 +365,28 @@ func (imp *Importer) backfillConversation(ctx context.Context, cc *convScope, st
 // cursor. History pages arrive NEWEST-first, so the ts cursor only advances
 // once every page of the window has persisted — advancing it per page would
 // let an interruption after page one permanently skip the older pages.
-// A retried window is re-fetched in full (upserts make that idempotent).
+// A window interrupted by --limit or a fetch error checkpoints its page
+// cursor (IncrCursor/IncrMaxTS) instead, so limited runs drain a backlog
+// across runs rather than restarting from the newest page forever.
 func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope, sum *ImportSummary) error {
 	cs := cc.cs
-	pageCursor := ""
-	maxTS := cs.Cursor
+	pageCursor := cs.IncrCursor
+	maxTS := cs.IncrMaxTS
+	if maxTS == "" {
+		maxTS = cs.Cursor
+	}
+	checkpoint := func() {
+		cs.IncrCursor = pageCursor
+		cs.IncrMaxTS = maxTS
+	}
 	for {
 		if err := ctx.Err(); err != nil {
+			checkpoint()
 			return err
 		}
 		if cc.limitReached() {
-			return nil // cursor not advanced; limited runs re-fetch the window
+			checkpoint() // main cursor not advanced; next run resumes mid-window
+			return nil
 		}
 		page, err := imp.client.historyPageWithLimit(ctx, HistoryParams{
 			ChannelID: cc.channelID,
@@ -387,6 +395,7 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 		}, cc.pageBudget())
 		if err != nil {
 			if ctx.Err() != nil {
+				checkpoint()
 				return ctx.Err()
 			}
 			if errors.Is(err, ErrNotFound) {
@@ -398,7 +407,8 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
-			return nil // cursor not advanced; next run retries the window
+			checkpoint() // next run retries from this page
+			return nil
 		}
 		for i := range page.Messages {
 			m := &page.Messages[i]
@@ -412,21 +422,25 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 		cc.budgetUsed += len(page.Messages)
 		if !page.HasMore || page.NextCursor == "" {
 			cs.Cursor = maxTS // the whole window persisted cleanly
+			cs.IncrCursor, cs.IncrMaxTS = "", ""
 			return nil
 		}
 		pageCursor = page.NextCursor
 	}
 }
 
-// rescanHead re-pages the conversation's trailing edit window, re-upserting
-// messages in place to catch edits and reaction changes (history is keyed by
-// original ts, so the incremental cursor cannot see them). Thread roots
-// re-encountered here refresh their tracking, catching reply activity on
-// recent roots. The window's upper bound is the cursor message INCLUSIVE:
-// with the default exclusive bounds, edits to the newest archived message
-// would stay invisible until a newer message moved the cursor past it.
+// rescanHead re-pages the conversation's trailing thread-lookback window,
+// re-upserting messages in place. It serves two purposes the ts cursor
+// cannot (history is keyed by original ts): catching edits and reaction
+// changes, and DISCOVERING newly-created thread roots — a first reply to an
+// older message never appears in cursor-bounded history, but the re-read
+// parent now carries reply_count > 0 and gets tracked for reply polling.
+// The window matches the thread lookback so root discovery covers the whole
+// tracking period. Its upper bound is the cursor message INCLUSIVE: with
+// the default exclusive bounds, edits to the newest archived message would
+// stay invisible until a newer message moved the cursor past it.
 func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportSummary) error {
-	oldest := fmt.Sprintf("%d.000000", imp.now().Add(-editRescanWindow).Unix())
+	oldest := fmt.Sprintf("%d.000000", imp.now().Add(-threadLookback(cc.opts)).Unix())
 	if cc.cs.Cursor != "" && tsLess(cc.cs.Cursor, oldest) {
 		// Everything newer than the cursor was just fetched by the
 		// incremental pass; nothing older than it has been archived yet.
@@ -503,11 +517,17 @@ func (imp *Importer) syncThreads(ctx context.Context, cc *convScope, sum *Import
 
 // syncThread fetches one thread's replies newer than replyCursor, returning
 // the advanced cursor ("" = do not advance) and whether polling completed
-// (false = fetch failure; the root must survive pruning to retry).
+// (false = fetch failure or --limit stop; the root must survive pruning to
+// finish later). Replies arrive OLDEST-first, so unlike history windows the
+// cursor can advance after every fully-persisted page — a --limit stop
+// mid-thread loses no progress.
 func (imp *Importer) syncThread(ctx context.Context, cc *convScope, root, replyCursor string, sum *ImportSummary) (string, bool, error) {
 	pageCursor := ""
 	maxTS := replyCursor
 	for {
+		if cc.limitReached() {
+			return maxTS, false, nil // pages persisted so far are checkpointed by the caller
+		}
 		page, err := imp.client.repliesPageWithLimit(ctx, cc.channelID, root, pageCursor, replyCursor, cc.pageBudget())
 		if errors.Is(err, ErrNotFound) {
 			// The root was deleted; its archived copy is kept, and there is
@@ -517,12 +537,15 @@ func (imp *Importer) syncThread(ctx context.Context, cc *convScope, root, replyC
 		}
 		if err != nil {
 			if ctx.Err() != nil {
-				return "", false, ctx.Err()
+				return maxTS, false, ctx.Err()
 			}
 			imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, root), "thread", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
-			return "", false, nil // cursor not advanced; next run retries this thread
+			// Oldest-first ordering makes the pages persisted before the
+			// failure a contiguous prefix: advancing to them is safe, and
+			// the next run resumes from there.
+			return maxTS, false, nil
 		}
 		for i := range page.Messages {
 			m := &page.Messages[i]

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"go.kenn.io/msgvault/internal/store"
@@ -184,20 +185,13 @@ func includeConversation(c *Conversation, opts *ImportOptions) bool {
 	if c.IsIM || c.IsMpim {
 		return true
 	}
-	for _, name := range opts.ExcludeChannels {
-		if name == c.Name {
-			return false
-		}
+	if slices.Contains(opts.ExcludeChannels, c.Name) {
+		return false
 	}
 	if len(opts.IncludeChannels) == 0 {
 		return true
 	}
-	for _, name := range opts.IncludeChannels {
-		if name == c.Name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(opts.IncludeChannels, c.Name)
 }
 
 // syncConversation ensures the conversation row and membership, then

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -49,6 +49,16 @@ func (cc *convScope) limitReached() bool {
 	return cc.opts.Limit > 0 && cc.budgetUsed >= cc.opts.Limit
 }
 
+// pageBudget sizes API page requests to the remaining --limit budget, so a
+// small limit cannot be overshot by an entire 999-message page.
+func (cc *convScope) pageBudget() int {
+	if cc.opts.Limit <= 0 {
+		return historyPageLimit
+	}
+	remaining := max(cc.opts.Limit-cc.budgetUsed, 1)
+	return min(remaining, historyPageLimit)
+}
+
 // Importer ingests one Slack workspace user's conversations into the
 // msgvault store. One Import run covers one workspace (= one source).
 type Importer struct {
@@ -223,15 +233,17 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 		}
 	}
 
+	// Prune only roots polled this run: skipping pruning entirely under
+	// --no-threads (and for limit-skipped or fetch-failed roots) keeps their
+	// replies reachable by a later incremental sync instead of silently
+	// lost.
 	if !opts.NoThreads {
-		if err := imp.syncThreads(ctx, cc, sum); err != nil {
+		polled, err := imp.syncThreads(ctx, cc, sum)
+		if err != nil {
 			return err
 		}
+		cs.PruneThreads(imp.now().Add(-threadLookback(opts)), polled)
 	}
-	// Prune only after thread polling: roots discovered during a long
-	// backfill must get their one reply fetch even when older than the
-	// lookback.
-	cs.PruneThreads(imp.now().Add(-threadLookback(opts)))
 	return nil
 }
 
@@ -305,11 +317,11 @@ func (imp *Importer) backfillConversation(ctx context.Context, cc *convScope, st
 		if cc.limitReached() {
 			return nil // resumable: Done stays false
 		}
-		page, err := imp.client.HistoryPage(ctx, HistoryParams{
+		page, err := imp.client.historyPageWithLimit(ctx, HistoryParams{
 			ChannelID: cc.channelID,
 			Cursor:    cs.BackfillCursor,
 			Latest:    cs.BackfillLatest,
-		})
+		}, cc.pageBudget())
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -368,11 +380,11 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 		if cc.limitReached() {
 			return nil // cursor not advanced; limited runs re-fetch the window
 		}
-		page, err := imp.client.HistoryPage(ctx, HistoryParams{
+		page, err := imp.client.historyPageWithLimit(ctx, HistoryParams{
 			ChannelID: cc.channelID,
 			Cursor:    pageCursor,
 			Oldest:    cs.Cursor,
-		})
+		}, cc.pageBudget())
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -410,7 +422,9 @@ func (imp *Importer) incrementalConversation(ctx context.Context, cc *convScope,
 // messages in place to catch edits and reaction changes (history is keyed by
 // original ts, so the incremental cursor cannot see them). Thread roots
 // re-encountered here refresh their tracking, catching reply activity on
-// recent roots.
+// recent roots. The window's upper bound is the cursor message INCLUSIVE:
+// with the default exclusive bounds, edits to the newest archived message
+// would stay invisible until a newer message moved the cursor past it.
 func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportSummary) error {
 	oldest := fmt.Sprintf("%d.000000", imp.now().Add(-editRescanWindow).Unix())
 	if cc.cs.Cursor != "" && tsLess(cc.cs.Cursor, oldest) {
@@ -426,12 +440,13 @@ func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportS
 		if cc.limitReached() {
 			return nil
 		}
-		page, err := imp.client.HistoryPage(ctx, HistoryParams{
+		page, err := imp.client.historyPageWithLimit(ctx, HistoryParams{
 			ChannelID: cc.channelID,
 			Cursor:    pageCursor,
 			Oldest:    oldest,
 			Latest:    cc.cs.Cursor,
-		})
+			Inclusive: true,
+		}, cc.pageBudget())
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -461,53 +476,60 @@ func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportS
 // syncThreads polls every tracked thread root for replies newer than its
 // reply cursor. A root's cursor advances only after its replies persisted
 // cleanly; a failed root is retried next run without blocking the others.
-func (imp *Importer) syncThreads(ctx context.Context, cc *convScope, sum *ImportSummary) error {
+// The returned set holds the roots whose polling completed this run — the
+// only ones PruneThreads may drop.
+func (imp *Importer) syncThreads(ctx context.Context, cc *convScope, sum *ImportSummary) (map[string]bool, error) {
+	polled := map[string]bool{}
 	for root, replyCursor := range cc.cs.Threads {
 		if err := ctx.Err(); err != nil {
-			return err
+			return polled, err
 		}
 		if cc.limitReached() {
-			return nil
+			return polled, nil
 		}
-		newCursor, err := imp.syncThread(ctx, cc, root, replyCursor, sum)
+		newCursor, completed, err := imp.syncThread(ctx, cc, root, replyCursor, sum)
 		if err != nil {
-			return err
+			return polled, err
+		}
+		if completed {
+			polled[root] = true
 		}
 		if newCursor != "" {
 			cc.cs.Threads[root] = newCursor
 		}
 	}
-	return nil
+	return polled, nil
 }
 
 // syncThread fetches one thread's replies newer than replyCursor, returning
-// the advanced cursor ("" = do not advance).
-func (imp *Importer) syncThread(ctx context.Context, cc *convScope, root, replyCursor string, sum *ImportSummary) (string, error) {
+// the advanced cursor ("" = do not advance) and whether polling completed
+// (false = fetch failure; the root must survive pruning to retry).
+func (imp *Importer) syncThread(ctx context.Context, cc *convScope, root, replyCursor string, sum *ImportSummary) (string, bool, error) {
 	pageCursor := ""
 	maxTS := replyCursor
 	for {
-		page, err := imp.client.RepliesPage(ctx, cc.channelID, root, pageCursor, replyCursor)
+		page, err := imp.client.repliesPageWithLimit(ctx, cc.channelID, root, pageCursor, replyCursor, cc.pageBudget())
 		if errors.Is(err, ErrNotFound) {
 			// The root was deleted; its archived copy is kept, and there is
 			// nothing left to poll.
 			delete(cc.cs.Threads, root)
-			return "", nil
+			return "", true, nil
 		}
 		if err != nil {
 			if ctx.Err() != nil {
-				return "", ctx.Err()
+				return "", false, ctx.Err()
 			}
 			imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, root), "thread", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
-			return "", nil // cursor not advanced; next run retries this thread
+			return "", false, nil // cursor not advanced; next run retries this thread
 		}
 		for i := range page.Messages {
 			m := &page.Messages[i]
 			// The response includes the root itself; re-upserting it is
 			// harmless (idempotent) and refreshes its edited state.
 			if err := imp.processMessage(ctx, cc, m, sum); err != nil {
-				return "", err
+				return "", false, err
 			}
 			if m.TS != root {
 				sum.RepliesFetched++
@@ -518,7 +540,7 @@ func (imp *Importer) syncThread(ctx context.Context, cc *convScope, root, replyC
 		}
 		cc.budgetUsed += len(page.Messages)
 		if !page.HasMore || page.NextCursor == "" {
-			return maxTS, nil
+			return maxTS, true, nil
 		}
 		pageCursor = page.NextCursor
 	}

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -514,6 +514,110 @@ func TestImportLimitBoundsProcessedMessages(t *testing.T) {
 	assert.Positive(t, total)
 }
 
+func TestImportLimitedRunsDrainIncrementalBacklog(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	// A 9-message backlog against a standing --limit 2: without the
+	// incremental window checkpoint, every limited run restarts from the
+	// newest page and the backlog never drains.
+	f.mu.Lock()
+	general := f.conv("C01")
+	for i := range 9 {
+		general.Msgs = append(general.Msgs, fakeMsg{TS: ts(400 + i), User: "UBOB", Text: "backlog " + strconv.Itoa(i)})
+	}
+	f.mu.Unlock()
+
+	limited := opts
+	limited.Limit = 2
+	limited.NoThreads = true
+	for range 8 {
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(t, err)
+	}
+	for i := range 9 {
+		var n int
+		require.NoError(t, st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(400+i)).Scan(&n))
+		assert.Equal(t, 1, n, "backlog message %d must be drained by repeated limited runs", i)
+	}
+}
+
+func TestImportLimitedRunsDrainLargeThread(t *testing.T) {
+	f, rootTS, _ := oldThreadWorkspace(t)
+	// Grow the ancient thread to 7 replies: several budget-sized pages.
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = nil
+	for i := range 7 {
+		root.Replies = append(root.Replies, fakeMsg{
+			TS: ts(-14390 + i), ThreadTS: rootTS, User: "UME", Text: "reply " + strconv.Itoa(i)})
+	}
+	f.mu.Unlock()
+	imp, opts := testImporter(t, f)
+	st := imp.store
+	opts.ThreadLookback = time.Hour // root is prunable the moment polling completes
+
+	limited := opts
+	limited.Limit = 2
+	// Replies arrive oldest-first, so each limited run persists a bounded
+	// slice and advances the thread cursor; repeated runs drain the whole
+	// thread WITHOUT any single run overshooting the budget mid-thread.
+	countRows := func() int {
+		var n int
+		require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&n))
+		return n
+	}
+	prev := 0
+	for range 10 {
+		_, err := imp.Import(context.Background(), limited)
+		require.NoError(t, err)
+		grown := countRows() - prev
+		assert.LessOrEqual(t, grown, 3, "one --limit 2 run must not archive a whole thread page burst")
+		prev += grown
+	}
+	var replies int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages m
+		WHERE m.source_message_id LIKE ? AND m.source_message_id <> ?`),
+		"C09:%", "C09:"+rootTS).Scan(&replies))
+	assert.GreaterOrEqual(t, replies, 7, "limited runs must drain the thread across runs")
+}
+
+func TestImportDiscoversFirstReplyToOlderMessage(t *testing.T) {
+	f, rootTS, _ := oldThreadWorkspace(t)
+	// The 10-day-old message starts with NO replies: it is archived as a
+	// plain message, not tracked as a thread root.
+	f.mu.Lock()
+	f.conv("C09").findRoot(rootTS).Replies = nil
+	f.mu.Unlock()
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	// First reply arrives long after archiving — outside any short edit
+	// window, inside the 30-day lookback. The lookback-wide rescan must
+	// re-encounter the parent (now reply_count > 0), track it, and fetch.
+	lateReply := ts(200)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = []fakeMsg{{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "first ever reply"}}
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	var n int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	assert.Equal(t, 1, n, "a first reply to an older message must be discovered without --full")
+}
+
 func TestImportGoneConversationIsSkippedNotFatal(t *testing.T) {
 	f := testWorkspace(t)
 	// Enumerated but unreadable: history answers channel_not_found (observed

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -50,6 +50,10 @@ func testWorkspace(t *testing.T) *fakeSlack {
 	general.Msgs[4].User = ""
 	general.Msgs[4].BotID = "B042"
 	general.Msgs[4].Username = "deploybot"
+	general.Msgs[4].Text = ""
+	general.Msgs[4].LegacyAttachments = []map[string]any{
+		{"fallback": "Build #42 failed on main"},
+	}
 	general.Msgs[5].Replies = []fakeMsg{
 		{TS: ts(100), ThreadTS: general.Msgs[5].TS, User: "UBOB", Text: "reply one"},
 		{TS: ts(101), ThreadTS: general.Msgs[5].TS, User: "UME", Text: "reply two"},
@@ -171,6 +175,13 @@ func TestImportEndToEnd(t *testing.T) {
 		SELECT p.display_name FROM messages m JOIN participants p ON p.id = m.sender_id
 		WHERE m.source_message_id = ?`), "C01:"+ts(4)).Scan(&botSender))
 	assert.Equal(t, "deploybot", botSender)
+	// The bot message's content lives in a legacy attachment (empty text);
+	// its fallback must be the searchable body.
+	var botBody string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(4)).Scan(&botBody))
+	assert.Equal(t, "Build #42 failed on main", botBody)
 	var rawFormat string
 	require.NoError(t, st.DB().QueryRow(st.Rebind(`
 		SELECT mr.raw_format FROM message_raw mr JOIN messages m ON m.id = mr.message_id

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -401,6 +401,119 @@ func TestImportLimitLeavesBackfillResumable(t *testing.T) {
 	assert.Equal(t, distinct, total)
 }
 
+// oldThreadWorkspace builds a workspace whose only thread root is ~10 days
+// old: outside BOTH the reply-tracking lookback used by these tests and the
+// 7-day edit-rescan window. That placement is load-bearing — a root inside
+// the rescan window would be re-tracked on the next sync, masking a
+// wrongly-pruned root.
+func oldThreadWorkspace(t *testing.T) (*fakeSlack, string, string) {
+	t.Helper()
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	rootTS, replyTS := ts(-14400), ts(-14390) // ~10 days before tsBase
+	f.convs = []*fakeConv{{
+		ID: "C09", Name: "archive", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{
+			{TS: rootTS, User: "UME", Text: "ancient root",
+				Replies: []fakeMsg{{TS: replyTS, ThreadTS: rootTS, User: "UME", Text: "ancient reply"}}},
+			{TS: ts(0), User: "UME", Text: "recent chatter"},
+		},
+	}}
+	return f, rootTS, replyTS
+}
+
+func TestImportNoThreadsDoesNotPruneUnpolledRoots(t *testing.T) {
+	f, _, replyTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+	opts.ThreadLookback = time.Hour
+
+	noThreads := opts
+	noThreads.NoThreads = true
+	_, err := imp.Import(context.Background(), noThreads)
+	require.NoError(t, err)
+	var n int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+replyTS).Scan(&n))
+	require.Zero(t, n, "sanity: --no-threads must not have fetched replies")
+
+	// Without the polled-roots guard the --no-threads run pruned the root
+	// (older than lookback AND outside the rescan window), losing its
+	// replies to every later incremental sync.
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+replyTS).Scan(&n))
+	assert.Equal(t, 1, n, "the root survived --no-threads unpruned, so its replies are fetched next run")
+}
+
+func TestImportThreadFetchFailureSurvivesPruning(t *testing.T) {
+	f, rootTS, replyTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+	opts.ThreadLookback = time.Hour
+
+	f.failReplies[rootTS] = true
+	_, err := imp.Import(context.Background(), opts)
+	require.Error(t, err)
+
+	f.mu.Lock()
+	delete(f.failReplies, rootTS)
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	var n int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+replyTS).Scan(&n))
+	assert.Equal(t, 1, n, "a fetch-failed root must survive pruning and be retried")
+}
+
+func TestImportRescanCatchesEditToNewestMessage(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	// Edit the NEWEST top-level message (the cursor message) with no newer
+	// traffic: only an inclusive rescan upper bound can see it.
+	f.mu.Lock()
+	general := f.conv("C01")
+	general.Msgs[len(general.Msgs)-1].Text = "hello 7 (edited)"
+	general.Msgs[len(general.Msgs)-1].Edited = true
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	var body string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(7)).Scan(&body))
+	assert.Equal(t, "hello 7 (edited)", body, "edits to the cursor message must be caught by the rescan")
+}
+
+func TestImportLimitBoundsProcessedMessages(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	limited := opts
+	limited.Limit = 1
+	limited.NoThreads = true
+	_, err := imp.Import(context.Background(), limited)
+	require.NoError(t, err)
+
+	// Page requests are sized to the remaining budget, so each conversation
+	// processes at most its limit — not a full server page.
+	var total int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.LessOrEqual(t, total, 4, "--limit 1 must not fetch whole pages per conversation")
+	assert.Positive(t, total)
+}
+
 func TestImportGoneConversationIsSkippedNotFatal(t *testing.T) {
 	f := testWorkspace(t)
 	// Enumerated but unreadable: history answers channel_not_found (observed

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -345,6 +345,27 @@ func TestImportFullReUpsertsInPlace(t *testing.T) {
 	assert.Equal(t, 12, total, "full run must upsert, not duplicate")
 }
 
+func TestImportGoneConversationIsSkippedNotFatal(t *testing.T) {
+	f := testWorkspace(t)
+	// Enumerated but unreadable: history answers channel_not_found (observed
+	// live with a sandbox provisioning-bot DM). The fake 404s any channel it
+	// has no record of, so listing a ghost entry reproduces it exactly.
+	f.convs = append(f.convs, &fakeConv{ID: "D_GONE", Kind: "im", IMUser: "UALICE"})
+	ghost := f.convs[len(f.convs)-1]
+	f.handleGhost(ghost)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err, "a permanently-gone conversation must not fail the run")
+	assert.Zero(t, sum.FetchErrors)
+
+	// Everything else archived normally.
+	var total int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.Equal(t, 12, total)
+}
+
 func TestImportChannelFilters(t *testing.T) {
 	f := testWorkspace(t)
 	imp, opts := testImporter(t, f)

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -1,0 +1,365 @@
+package slack
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// tsBase anchors test message times ~25h in the past: recent enough that
+// thread roots stay inside the 30-day tracking lookback, old enough that
+// offsets up to a few hours never land in the future.
+var tsBase = time.Now().Add(-25 * time.Hour).UTC().Truncate(time.Second)
+
+// ts renders a Slack ts for offset minutes after tsBase.
+func ts(minutes int) string {
+	return strconv.FormatInt(tsBase.Add(time.Duration(minutes)*time.Minute).Unix(), 10) + ".000100"
+}
+
+// testWorkspace builds a fake workspace exercising every persist path:
+// channels with threads, reactions, mentions, edits, bot messages, a group
+// DM, and a 1:1 DM.
+func testWorkspace(t *testing.T) *fakeSlack {
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "real_name": "Test User",
+			"profile": map[string]any{"email": "me@example.com", "display_name": "Me"}},
+		{"id": "UALICE", "name": "alice", "real_name": "Alice Example",
+			"profile": map[string]any{"email": "alice@example.com", "display_name": "Alice"}},
+		{"id": "UBOB", "name": "bob", "real_name": "Bob Example",
+			"profile": map[string]any{}}, // no email: resolves by bare ID
+	}
+	general := &fakeConv{
+		ID: "C01", Name: "general", Kind: "public",
+		Members: []string{"UME", "UALICE", "UBOB"},
+	}
+	for i := range 8 {
+		general.Msgs = append(general.Msgs, fakeMsg{TS: ts(i), User: "UALICE", Text: "hello " + strconv.Itoa(i)})
+	}
+	general.Msgs[1].Text = "ping <@UME> see <https://example.com|the docs>"
+	general.Msgs[2].Reactions = []map[string]any{
+		{"name": "thumbsup", "users": []string{"UME", "UBOB"}, "count": 2},
+	}
+	general.Msgs[3].Edited = true
+	general.Msgs[4].User = ""
+	general.Msgs[4].BotID = "B042"
+	general.Msgs[4].Username = "deploybot"
+	general.Msgs[5].Replies = []fakeMsg{
+		{TS: ts(100), ThreadTS: general.Msgs[5].TS, User: "UBOB", Text: "reply one"},
+		{TS: ts(101), ThreadTS: general.Msgs[5].TS, User: "UME", Text: "reply two"},
+	}
+	f.convs = []*fakeConv{
+		general,
+		{ID: "G01", Name: "mpdm-me--alice--bob-1", Kind: "mpim",
+			Members: []string{"UME", "UALICE", "UBOB"},
+			Msgs:    []fakeMsg{{TS: ts(10), User: "UME", Text: "group hi"}}},
+		{ID: "D01", Kind: "im", IMUser: "UALICE",
+			Msgs: []fakeMsg{{TS: ts(20), User: "UALICE", Text: "dm hi"}}},
+	}
+	return f
+}
+
+func testImporter(t *testing.T, f *fakeSlack) (*Importer, ImportOptions) {
+	t.Helper()
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+	return imp, ImportOptions{TeamID: "T01", UserID: "UME", NoMedia: true}
+}
+
+func TestImportEndToEnd(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Equal(t, 3, sum.ConversationsProcessed)
+	assert.Equal(t, 2, sum.RepliesFetched)
+	assert.Zero(t, sum.FetchErrors)
+
+	// 8 channel + 1 mpim + 1 im top-level, 2 replies, root re-upserted in place.
+	var msgCount int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&msgCount))
+	assert.Equal(t, 12, msgCount)
+
+	// Conversation types and titles.
+	var title, convType string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT title, conversation_type FROM conversations WHERE source_conversation_id = ?`), "C01").
+		Scan(&title, &convType))
+	assert.Equal(t, "#general", title)
+	assert.Equal(t, "channel", convType)
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT title, conversation_type FROM conversations WHERE source_conversation_id = ?`), "D01").
+		Scan(&title, &convType))
+	assert.Equal(t, "Alice", title)
+	assert.Equal(t, "direct_chat", convType)
+
+	// Email-based identity: Alice deduped against mail archives by address.
+	var aliceID int64
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM participants WHERE email_address = ?`), "alice@example.com").Scan(&aliceID))
+
+	// Thread replies linked to their root.
+	var linked int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_message_id = ? AND parent.source_message_id = ?`),
+		"C01:"+ts(100), "C01:"+ts(5)).Scan(&linked))
+	assert.Equal(t, 1, linked)
+
+	// Reactions: two users on message 2.
+	var reactions int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ? AND r.reaction_value = 'thumbsup'`), "C01:"+ts(2)).Scan(&reactions))
+	assert.Equal(t, 2, reactions)
+
+	// Mention row for <@UME>, with mrkdwn rendered in the body.
+	var mentions int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'mention'`), "C01:"+ts(1)).Scan(&mentions))
+	assert.Equal(t, 1, mentions)
+	var body string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(1)).Scan(&body))
+	assert.Equal(t, "ping @Me see the docs (https://example.com)", body)
+
+	// Edited flag, bot sender, raw archive format.
+	var edited bool
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT is_edited FROM messages WHERE source_message_id = ?`), "C01:"+ts(3)).Scan(&edited))
+	assert.True(t, edited)
+	var botSender string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT p.display_name FROM messages m JOIN participants p ON p.id = m.sender_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(4)).Scan(&botSender))
+	assert.Equal(t, "deploybot", botSender)
+	var rawFormat string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT mr.raw_format FROM message_raw mr JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(0)).Scan(&rawFormat))
+	assert.Equal(t, "slack_json", rawFormat)
+
+	// Membership recorded.
+	var members int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversation_participants cp
+		JOIN conversations c ON c.id = cp.conversation_id
+		WHERE c.source_conversation_id = ?`), "C01").Scan(&members))
+	assert.Equal(t, 3, members)
+}
+
+func TestImportIncrementalCatchesNewMessagesAndLateReplies(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	// A new top-level message and a late reply to the (old) thread root.
+	f.mu.Lock()
+	general := f.conv("C01")
+	general.Msgs = append(general.Msgs, fakeMsg{TS: ts(200), User: "UBOB", Text: "fresh news"})
+	root := general.findRoot(ts(5))
+	root.Replies = append(root.Replies, fakeMsg{TS: ts(201), ThreadTS: root.TS, User: "UALICE", Text: "late reply"})
+	f.mu.Unlock()
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sum.RepliesFetched, "only the late reply is new; earlier replies are behind the thread cursor")
+
+	for _, id := range []string{"C01:" + ts(200), "C01:" + ts(201)} {
+		var n int
+		require.NoError(t, st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), id).Scan(&n))
+		assert.Equal(t, 1, n, id)
+	}
+}
+
+func TestImportIncrementalMidWindowFailureDoesNotAdvanceCursor(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	// Five new messages: an incremental window of two pages (fake pageSize 3,
+	// newest-first). Page one serves ts(304)..ts(302); page two dies.
+	f.mu.Lock()
+	general := f.conv("C01")
+	for i := range 5 {
+		general.Msgs = append(general.Msgs, fakeMsg{TS: ts(300 + i), User: "UBOB", Text: "burst " + strconv.Itoa(i)})
+	}
+	f.failHistoryContinuations = true
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(t, err, "a run with fetch errors must not report success")
+
+	// The cursor must not have advanced past the unfetched older page: after
+	// healing, ALL five burst messages are archived exactly once.
+	f.mu.Lock()
+	f.failHistoryContinuations = false
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	for i := range 5 {
+		var n int
+		require.NoError(t, st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(300+i)).Scan(&n))
+		assert.Equal(t, 1, n, "burst message %d", i)
+	}
+}
+
+func TestImportRepliesFailureDoesNotAdvanceThreadCursor(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	f.failReplies[ts(5)] = true
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(t, err, "a run with fetch errors must not report success")
+	assert.Positive(t, sum.FetchErrors)
+
+	// The replies never landed.
+	var n int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(100)).Scan(&n))
+	assert.Zero(t, n)
+
+	// Healed: the next run retries the thread from its unadvanced cursor.
+	f.mu.Lock()
+	delete(f.failReplies, ts(5))
+	f.mu.Unlock()
+	sum, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Equal(t, 2, sum.RepliesFetched)
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(100)).Scan(&n))
+	assert.Equal(t, 1, n)
+}
+
+func TestImportHistoryFailureLeavesConversationResumable(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	f.failHistory["C01"] = true
+	_, err := imp.Import(context.Background(), opts)
+	require.Error(t, err)
+
+	// The healthy conversations still synced.
+	var n int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "D01:"+ts(20)).Scan(&n))
+	assert.Equal(t, 1, n)
+
+	f.mu.Lock()
+	delete(f.failHistory, "C01")
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	var total int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.Equal(t, 12, total)
+}
+
+func TestImportInterruptResumesWithoutDuplicates(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// Cancel partway through the first run: as soon as the first history
+	// page has been served, mid-conversation-walk.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		for {
+			f.mu.Lock()
+			served := f.historyCalls > 0
+			f.mu.Unlock()
+			if served {
+				cancel()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	_, _ = imp.Import(ctx, opts)
+
+	// Resume to completion: every message exactly once.
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	var total, distinct int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(t, 12, total)
+	assert.Equal(t, distinct, total)
+}
+
+func TestImportFullReUpsertsInPlace(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	// An old message is edited at the source; only --full re-walks it.
+	f.mu.Lock()
+	f.conv("C01").Msgs[0].Text = "hello 0 (edited)"
+	f.mu.Unlock()
+
+	full := opts
+	full.Full = true
+	_, err = imp.Import(context.Background(), full)
+	require.NoError(t, err)
+
+	var body string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(0)).Scan(&body))
+	assert.Equal(t, "hello 0 (edited)", body)
+	var total int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.Equal(t, 12, total, "full run must upsert, not duplicate")
+}
+
+func TestImportChannelFilters(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	opts.ExcludeChannels = []string{"general"}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	var n int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversations WHERE source_conversation_id = ?`), "C01").Scan(&n))
+	assert.Zero(t, n, "excluded channel must not be archived")
+	// DMs are never filtered.
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversations WHERE source_conversation_id = ?`), "D01").Scan(&n))
+	assert.Equal(t, 1, n)
+}

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -55,6 +55,9 @@ func testWorkspace(t *testing.T) *fakeSlack {
 	}
 	f.convs = []*fakeConv{
 		general,
+		{ID: "C02", Name: "secrets", Kind: "private",
+			Members: []string{"UME", "UALICE"},
+			Msgs:    []fakeMsg{{TS: ts(30), User: "UALICE", Text: "private hi"}}},
 		{ID: "G01", Name: "mpdm-me--alice--bob-1", Kind: "mpim",
 			Members: []string{"UME", "UALICE", "UBOB"},
 			Msgs:    []fakeMsg{{TS: ts(10), User: "UME", Text: "group hi"}}},
@@ -63,6 +66,11 @@ func testWorkspace(t *testing.T) *fakeSlack {
 	}
 	return f
 }
+
+// totalWorkspaceMessages is the archived-row count for the full test
+// workspace: 8 channel + 1 private + 1 mpim + 1 im top-level, plus 2 thread
+// replies (the root re-upserts in place).
+const totalWorkspaceMessages = 13
 
 func testImporter(t *testing.T, f *fakeSlack) (*Importer, ImportOptions) {
 	t.Helper()
@@ -85,14 +93,13 @@ func TestImportEndToEnd(t *testing.T) {
 
 	sum, err := imp.Import(context.Background(), opts)
 	require.NoError(t, err)
-	assert.Equal(t, 3, sum.ConversationsProcessed)
+	assert.Equal(t, 4, sum.ConversationsProcessed)
 	assert.Equal(t, 2, sum.RepliesFetched)
 	assert.Zero(t, sum.FetchErrors)
 
-	// 8 channel + 1 mpim + 1 im top-level, 2 replies, root re-upserted in place.
 	var msgCount int
 	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&msgCount))
-	assert.Equal(t, 12, msgCount)
+	assert.Equal(t, totalWorkspaceMessages, msgCount)
 
 	// Conversation types and titles.
 	var title, convType string
@@ -106,6 +113,16 @@ func TestImportEndToEnd(t *testing.T) {
 		Scan(&title, &convType))
 	assert.Equal(t, "Alice", title)
 	assert.Equal(t, "direct_chat", convType)
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT title, conversation_type FROM conversations WHERE source_conversation_id = ?`), "C02").
+		Scan(&title, &convType))
+	assert.Equal(t, "#secrets", title, "private channels archive like channels")
+	assert.Equal(t, "channel", convType)
+	var privateMsgs int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages m JOIN conversations c ON c.id = m.conversation_id
+		WHERE c.source_conversation_id = ?`), "C02").Scan(&privateMsgs))
+	assert.Equal(t, 1, privateMsgs)
 
 	// Email-based identity: Alice deduped against mail archives by address.
 	var aliceID int64
@@ -282,7 +299,7 @@ func TestImportHistoryFailureLeavesConversationResumable(t *testing.T) {
 	require.NoError(t, err)
 	var total int
 	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
-	assert.Equal(t, 12, total)
+	assert.Equal(t, totalWorkspaceMessages, total)
 }
 
 func TestImportInterruptResumesWithoutDuplicates(t *testing.T) {
@@ -313,7 +330,7 @@ func TestImportInterruptResumesWithoutDuplicates(t *testing.T) {
 	var total, distinct int
 	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
 	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
-	assert.Equal(t, 12, total)
+	assert.Equal(t, totalWorkspaceMessages, total)
 	assert.Equal(t, distinct, total)
 }
 
@@ -342,7 +359,34 @@ func TestImportFullReUpsertsInPlace(t *testing.T) {
 	assert.Equal(t, "hello 0 (edited)", body)
 	var total int
 	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
-	assert.Equal(t, 12, total, "full run must upsert, not duplicate")
+	assert.Equal(t, totalWorkspaceMessages, total, "full run must upsert, not duplicate")
+}
+
+func TestImportLimitLeavesBackfillResumable(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// A cap below #general's 8 top-level messages: the first run must stop
+	// early without marking the conversation complete or advancing past
+	// unfetched pages.
+	limited := opts
+	limited.Limit = 4
+	limited.NoThreads = true
+	_, err := imp.Import(context.Background(), limited)
+	require.NoError(t, err)
+	var partial int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&partial))
+	assert.Less(t, partial, totalWorkspaceMessages)
+
+	// An uncapped run completes the backfill: every message exactly once.
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	var total, distinct int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(t, totalWorkspaceMessages, total, "limited first run must not lose messages")
+	assert.Equal(t, distinct, total)
 }
 
 func TestImportGoneConversationIsSkippedNotFatal(t *testing.T) {
@@ -363,7 +407,7 @@ func TestImportGoneConversationIsSkippedNotFatal(t *testing.T) {
 	// Everything else archived normally.
 	var total int
 	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
-	assert.Equal(t, 12, total)
+	assert.Equal(t, totalWorkspaceMessages, total)
 }
 
 func TestImportChannelFilters(t *testing.T) {

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -25,6 +25,7 @@ func ts(minutes int) string {
 // channels with threads, reactions, mentions, edits, bot messages, a group
 // DM, and a 1:1 DM.
 func testWorkspace(t *testing.T) *fakeSlack {
+	t.Helper()
 	f := newFakeSlack(t)
 	f.users = []map[string]any{
 		{"id": "UME", "name": "me", "real_name": "Test User",

--- a/internal/slack/live_429_test.go
+++ b/internal/slack/live_429_test.go
@@ -1,0 +1,84 @@
+package slack
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingTransport records the status codes flowing through the client so
+// the test can prove a real 429 occurred and was absorbed.
+type countingTransport struct {
+	requests   int
+	got429     int
+	retryAfter string
+}
+
+func (ct *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ct.requests++
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err == nil && resp.StatusCode == http.StatusTooManyRequests {
+		ct.got429++
+		ct.retryAfter = resp.Header.Get("Retry-After")
+	}
+	return resp, err
+}
+
+// TestLive429RetryAfter validates the client's throttle handling against the
+// REAL Slack API. It is skipped unless both env vars are set:
+//
+//	MSGVAULT_SLACK_LIVE_TOKEN   user token for a DEV workspace you own
+//	MSGVAULT_SLACK_LIVE_CHANNEL a channel ID with some history
+//
+// With the client's own pacing disabled it requests tiny history pages until
+// Slack throttles (Tier 3 ≈ 50/min), then asserts the throttled call still
+// returned successfully via Retry-After retry. Bounded to maxProbeRequests /
+// probeDeadline; stops at the first observed 429. Run this only against a
+// development workspace.
+func TestLive429RetryAfter(t *testing.T) {
+	token := os.Getenv("MSGVAULT_SLACK_LIVE_TOKEN")
+	channel := os.Getenv("MSGVAULT_SLACK_LIVE_CHANNEL")
+	if token == "" || channel == "" {
+		t.Skip("set MSGVAULT_SLACK_LIVE_TOKEN and MSGVAULT_SLACK_LIVE_CHANNEL to run the live throttle probe")
+	}
+
+	const maxProbeRequests = 500
+	const probeDeadline = 4 * time.Minute
+
+	ct := &countingTransport{}
+	c := NewClient("", token)
+	c.disableRateLimits()
+	c.http.Transport = ct
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeDeadline)
+	defer cancel()
+
+	calls := 0
+	for ct.got429 == 0 && ct.requests < maxProbeRequests {
+		// limit=1 keeps responses tiny; every request still counts against
+		// the per-minute budget.
+		params := HistoryParams{ChannelID: channel}
+		page, err := c.historyPageWithLimit(ctx, params, 1)
+		if ctx.Err() != nil {
+			// Ran out of probe time before Slack throttled (observed live:
+			// enforcement lags the published budget until earlier traffic has
+			// accumulated). Inconclusive, not a failure.
+			t.Skipf("no 429 within %v / %d requests — inconclusive", probeDeadline, ct.requests)
+		}
+		require.NoError(t, err, "call %d must succeed even when throttled mid-way", calls)
+		require.NotNil(t, page)
+		calls++
+	}
+
+	if ct.got429 == 0 {
+		t.Skipf("no 429 within %d requests — workspace budget higher than expected; inconclusive, not a failure", ct.requests)
+	}
+	t.Logf("throttled after %d requests; Retry-After=%q; %d successful calls returned", ct.requests, ct.retryAfter, calls)
+	assert.Positive(t, calls, "the throttled call must have completed via retry")
+	assert.NotEmpty(t, ct.retryAfter, "Slack 429s must carry Retry-After for the backoff to honor")
+}

--- a/internal/slack/mapping.go
+++ b/internal/slack/mapping.go
@@ -24,8 +24,8 @@ var mentionRe = regexp.MustCompile(`<@([UW][A-Z0-9]+)(?:\|[^>]*)?>`)
 // tokenRe matches every <…> mrkdwn token for text rendering.
 var tokenRe = regexp.MustCompile(`<([^<>]+)>`)
 
-// Mentions returns the user IDs mentioned in the message text (deduped, in
-// first-appearance order).
+// MentionedUserIDs returns the user IDs mentioned in the message text
+// (deduped, in first-appearance order).
 func (m *Message) MentionedUserIDs() []string {
 	var ids []string
 	seen := map[string]bool{}

--- a/internal/slack/mapping.go
+++ b/internal/slack/mapping.go
@@ -1,0 +1,153 @@
+package slack
+
+import (
+	"database/sql"
+	"regexp"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// messageType is the msgvault message_type for all Slack-archived messages.
+const messageType = "slack"
+
+// sourceMessageID composes the archive identity of a Slack message. A ts is
+// only unique within its channel, hence the composite key.
+func sourceMessageID(channelID, ts string) string {
+	return channelID + ":" + ts
+}
+
+// mentionRe matches user mentions in raw Slack message text: <@U123>,
+// <@W123> (Enterprise Grid), optionally with a |label suffix.
+var mentionRe = regexp.MustCompile(`<@([UW][A-Z0-9]+)(?:\|[^>]*)?>`)
+
+// tokenRe matches every <…> mrkdwn token for text rendering.
+var tokenRe = regexp.MustCompile(`<([^<>]+)>`)
+
+// Mentions returns the user IDs mentioned in the message text (deduped, in
+// first-appearance order).
+func (m *Message) MentionedUserIDs() []string {
+	var ids []string
+	seen := map[string]bool{}
+	for _, match := range mentionRe.FindAllStringSubmatch(m.Text, -1) {
+		if id := match[1]; !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// renderText converts raw Slack mrkdwn to plain text for FTS and display:
+// mention/channel/link tokens are resolved to readable forms and HTML
+// entities unescaped. lookupName resolves a user ID to a display name (may
+// return "").
+func renderText(raw string, lookupName func(userID string) string) string {
+	text := tokenRe.ReplaceAllStringFunc(raw, func(tok string) string {
+		inner := tok[1 : len(tok)-1]
+		body, label, hasLabel := strings.Cut(inner, "|")
+		switch {
+		case strings.HasPrefix(body, "@"):
+			if hasLabel && label != "" {
+				return "@" + label
+			}
+			if name := lookupName(strings.TrimPrefix(body, "@")); name != "" {
+				return "@" + name
+			}
+			return "@" + strings.TrimPrefix(body, "@")
+		case strings.HasPrefix(body, "#"):
+			if hasLabel && label != "" {
+				return "#" + label
+			}
+			return body
+		case strings.HasPrefix(body, "!"):
+			// Special mentions: <!here>, <!channel>, <!everyone>, <!date^…|fallback>.
+			if hasLabel && label != "" {
+				return label
+			}
+			return "@" + strings.TrimPrefix(body, "!")
+		default:
+			// Link: <url> or <url|label>.
+			if hasLabel && label != "" {
+				return label + " (" + body + ")"
+			}
+			return body
+		}
+	})
+	text = strings.ReplaceAll(text, "&lt;", "<")
+	text = strings.ReplaceAll(text, "&gt;", ">")
+	text = strings.ReplaceAll(text, "&amp;", "&")
+	return text
+}
+
+// placeholderBody synthesizes a searchable body for text-less messages.
+func placeholderBody(m *Message) string {
+	if len(m.Files) > 0 {
+		if m.Files[0].Name != "" {
+			return "[file: " + m.Files[0].Name + "]"
+		}
+		return "[file]"
+	}
+	return ""
+}
+
+func snippet(text string) string {
+	r := []rune(text)
+	if len(r) > 100 {
+		return string(r[:100])
+	}
+	return text
+}
+
+// mapMessage converts a Slack Message into a store.Message plus its rendered
+// plain-text body. isFromMe is decided by the caller (archiving user's ID).
+func mapMessage(m *Message, channelID string, conversationID, storeSourceID int64, isFromMe bool, lookupName func(string) string) (store.Message, string) {
+	text := renderText(m.Text, lookupName)
+	if strings.TrimSpace(text) == "" {
+		text = placeholderBody(m)
+	}
+	t := tsTime(m.TS)
+	msg := store.Message{
+		ConversationID:  conversationID,
+		SourceID:        storeSourceID,
+		SourceMessageID: sourceMessageID(channelID, m.TS),
+		MessageType:     messageType,
+		SentAt:          sql.NullTime{Time: t, Valid: !t.IsZero()},
+		ReceivedAt:      sql.NullTime{Time: t, Valid: !t.IsZero()},
+		IsFromMe:        isFromMe,
+		Snippet:         sql.NullString{String: snippet(text), Valid: text != ""},
+		HasAttachments:  len(m.Files) > 0,
+		AttachmentCount: len(m.Files),
+	}
+	return msg, text
+}
+
+// conversationType maps a Slack conversation to the msgvault conversation
+// type: channels (public/private) → "channel", group DMs → "group_chat",
+// DMs → "direct_chat".
+func conversationType(c *Conversation) string {
+	switch {
+	case c.IsIM:
+		return "direct_chat"
+	case c.IsMpim:
+		return "group_chat"
+	default:
+		return "channel"
+	}
+}
+
+// conversationTitle renders a display title: "#name" for channels, the peer's
+// name for DMs, the member-list name Slack assigns for group DMs.
+func conversationTitle(c *Conversation, lookupName func(string) string) string {
+	switch {
+	case c.IsIM:
+		if name := lookupName(c.User); name != "" {
+			return name
+		}
+		return c.User
+	case c.IsMpim:
+		return c.Name
+	default:
+		return "#" + c.Name
+	}
+}

--- a/internal/slack/mapping.go
+++ b/internal/slack/mapping.go
@@ -91,6 +91,51 @@ func placeholderBody(m *Message) string {
 	return ""
 }
 
+// payloadText extracts searchable text from legacy attachments and Block Kit
+// blocks — where bots and integrations often carry their entire content
+// while the message text stays empty. Per attachment, the mandatory fallback
+// summary wins; otherwise the individual parts are composed. rich_text
+// blocks are skipped (they duplicate the message text field).
+func payloadText(m *Message, lookupName func(string) string) string {
+	var parts []string
+	add := func(s string) {
+		if s = strings.TrimSpace(renderText(s, lookupName)); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	for i := range m.Attachments {
+		a := &m.Attachments[i]
+		if a.Fallback != "" {
+			add(a.Fallback)
+			continue
+		}
+		add(a.Pretext)
+		add(a.Title)
+		add(a.Text)
+		for _, f := range a.Fields {
+			add(strings.TrimSpace(f.Title + ": " + f.Value))
+		}
+		add(a.Footer)
+	}
+	for i := range m.Blocks {
+		b := &m.Blocks[i]
+		switch b.Type {
+		case "section", "header":
+			if b.Text != nil {
+				add(b.Text.Text)
+			}
+			for _, f := range b.Fields {
+				add(f.Text)
+			}
+		case "context":
+			for _, e := range b.Elements {
+				add(e.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 func snippet(text string) string {
 	r := []rune(text)
 	if len(r) > 100 {
@@ -101,9 +146,23 @@ func snippet(text string) string {
 
 // mapMessage converts a Slack Message into a store.Message plus its rendered
 // plain-text body. isFromMe is decided by the caller (archiving user's ID).
+//
+// Legacy-attachment/block text is appended for bot-authored messages and
+// used as the body for text-less ones. User messages WITH text keep only
+// that text: their attachments are link unfurls, and indexing page previews
+// would pollute FTS with content the person never wrote.
 func mapMessage(m *Message, channelID string, conversationID, storeSourceID int64, isFromMe bool, lookupName func(string) string) (store.Message, string) {
-	text := renderText(m.Text, lookupName)
-	if strings.TrimSpace(text) == "" {
+	text := strings.TrimSpace(renderText(m.Text, lookupName))
+	if m.BotID != "" || text == "" {
+		if extra := payloadText(m, lookupName); extra != "" {
+			if text == "" {
+				text = extra
+			} else {
+				text += "\n" + extra
+			}
+		}
+	}
+	if text == "" {
 		text = placeholderBody(m)
 	}
 	t := tsTime(m.TS)

--- a/internal/slack/mapping_test.go
+++ b/internal/slack/mapping_test.go
@@ -1,0 +1,88 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderText(t *testing.T) {
+	names := map[string]string{"UALICE": "Alice"}
+	lookup := func(id string) string { return names[id] }
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain", "hello world", "hello world"},
+		{"mention known", "hi <@UALICE>", "hi @Alice"},
+		{"mention unknown", "hi <@UGONE>", "hi @UGONE"},
+		{"mention labeled", "hi <@UGONE|ghost>", "hi @ghost"},
+		{"channel", "see <#C042|general>", "see #general"},
+		{"special", "<!here> heads up", "@here heads up"},
+		{"link labeled", "read <https://example.com|the docs>", "read the docs (https://example.com)"},
+		{"link bare", "read <https://example.com>", "read https://example.com"},
+		{"entities", "a &lt;b&gt; &amp; c", "a <b> & c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, renderText(tt.in, lookup))
+		})
+	}
+}
+
+func TestMentionedUserIDs(t *testing.T) {
+	m := Message{Text: "<@UALICE> meet <@WBOB|bob>, again <@UALICE>; not <#C1|chan> or <!here>"}
+	assert.Equal(t, []string{"UALICE", "WBOB"}, m.MentionedUserIDs())
+}
+
+func TestTsTimeAndOrdering(t *testing.T) {
+	tm := tsTime("1734567890.123456")
+	assert.Equal(t, time.Date(2024, 12, 19, 0, 24, 50, 123456000, time.UTC), tm)
+	assert.True(t, tsTime("").IsZero())
+	assert.True(t, tsTime("garbage").IsZero())
+
+	// Numeric, not lexical: a 9-digit second count sorts before a 10-digit one.
+	assert.True(t, tsLess("999999999.000001", "1734567890.000001"))
+	assert.False(t, tsLess("1734567890.000002", "1734567890.000001"))
+}
+
+func TestMessageRawCapturedOnDecode(t *testing.T) {
+	blob := `{"type":"message","ts":"1.000001","text":"hi","unmodeled_field":{"kept":true}}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(blob), &m))
+	assert.JSONEq(t, blob, string(m.Raw), "raw archive must preserve fields the struct does not model")
+}
+
+func TestThreadPredicates(t *testing.T) {
+	root := Message{TS: "5.0", ThreadTS: "5.0", ReplyCount: 2}
+	reply := Message{TS: "6.0", ThreadTS: "5.0"}
+	plain := Message{TS: "7.0"}
+	assert.True(t, root.IsThreadRoot())
+	assert.False(t, root.IsThreadReply())
+	assert.True(t, reply.IsThreadReply())
+	assert.False(t, reply.IsThreadRoot())
+	assert.False(t, plain.IsThreadRoot())
+	assert.False(t, plain.IsThreadReply())
+}
+
+func TestConversationTypeAndTitle(t *testing.T) {
+	lookup := func(id string) string {
+		if id == "UALICE" {
+			return "Alice"
+		}
+		return ""
+	}
+	channel := &Conversation{IsChannel: true, Name: "general"}
+	assert.Equal(t, "channel", conversationType(channel))
+	assert.Equal(t, "#general", conversationTitle(channel, lookup))
+
+	im := &Conversation{IsIM: true, User: "UALICE"}
+	assert.Equal(t, "direct_chat", conversationType(im))
+	assert.Equal(t, "Alice", conversationTitle(im, lookup))
+
+	mpim := &Conversation{IsMpim: true, Name: "mpdm-a--b-1"}
+	assert.Equal(t, "group_chat", conversationType(mpim))
+	assert.Equal(t, "mpdm-a--b-1", conversationTitle(mpim, lookup))
+}

--- a/internal/slack/mapping_test.go
+++ b/internal/slack/mapping_test.go
@@ -67,6 +67,88 @@ func TestThreadPredicates(t *testing.T) {
 	assert.False(t, plain.IsThreadReply())
 }
 
+func TestPayloadTextExtraction(t *testing.T) {
+	lookup := func(string) string { return "" }
+
+	t.Run("fallback wins per attachment", func(t *testing.T) {
+		m := Message{Attachments: []LegacyAttachment{
+			{Fallback: "Build #42 failed", Title: "ignored", Text: "ignored too"},
+		}}
+		assert.Equal(t, "Build #42 failed", payloadText(&m, lookup))
+	})
+
+	t.Run("composed parts when no fallback", func(t *testing.T) {
+		m := Message{Attachments: []LegacyAttachment{{
+			Pretext: "Deploy finished",
+			Title:   "api-server v1.2.3",
+			Text:    "all checks green",
+			Fields: []struct {
+				Title string `json:"title"`
+				Value string `json:"value"`
+			}{{Title: "Env", Value: "prod"}},
+			Footer: "deploybot",
+		}}}
+		assert.Equal(t, "Deploy finished\napi-server v1.2.3\nall checks green\nEnv: prod\ndeploybot",
+			payloadText(&m, lookup))
+	})
+
+	t.Run("shape-shifting block elements decode (live regression)", func(t *testing.T) {
+		// Observed live: actions-block buttons carry text as an OBJECT while
+		// context elements carry it as a string; both must decode, and image
+		// elements (no text) must not error.
+		blob := `{"type":"message","ts":"1.000001","bot_id":"B1","blocks":[
+			{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"Approve"}}]},
+			{"type":"context","elements":[{"type":"mrkdwn","text":"requested by alice"},{"type":"image","image_url":"https://x.example/i.png","alt_text":"pic"}]}
+		]}`
+		var m Message
+		require.NoError(t, json.Unmarshal([]byte(blob), &m))
+		assert.Equal(t, "requested by alice", payloadText(&m, lookup),
+			"context text extracted; button labels and images are not content")
+	})
+
+	t.Run("block kit section header context", func(t *testing.T) {
+		m := Message{Blocks: []Block{
+			{Type: "header", Text: &BlockText{Type: "plain_text", Text: "Alert!"}},
+			{Type: "section", Text: &BlockText{Type: "mrkdwn", Text: "disk *full* on <https://host.example|host>"},
+				Fields: []BlockText{{Type: "mrkdwn", Text: "Sev: 1"}}},
+			{Type: "context", Elements: []BlockElement{{Type: "mrkdwn", Text: "triggered 5m ago"}}},
+			{Type: "rich_text"}, // duplicates message text: never extracted
+			{Type: "divider"},
+		}}
+		assert.Equal(t, "Alert!\ndisk *full* on host (https://host.example)\nSev: 1\ntriggered 5m ago",
+			payloadText(&m, lookup))
+	})
+}
+
+func TestMapMessagePayloadRules(t *testing.T) {
+	lookup := func(string) string { return "" }
+	unfurl := []LegacyAttachment{{Fallback: "Some Page Title — example.com"}}
+
+	t.Run("bot message with empty text gets payload body", func(t *testing.T) {
+		m := Message{TS: "1.000001", BotID: "B1", Attachments: unfurl}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "Some Page Title — example.com", text)
+	})
+
+	t.Run("bot message with text appends payload", func(t *testing.T) {
+		m := Message{TS: "1.000001", BotID: "B1", Text: "heads up", Attachments: unfurl}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "heads up\nSome Page Title — example.com", text)
+	})
+
+	t.Run("user message with text ignores unfurl attachments", func(t *testing.T) {
+		m := Message{TS: "1.000001", User: "U1", Text: "check https://example.com", Attachments: unfurl}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "check https://example.com", text)
+	})
+
+	t.Run("files placeholder still applies when no payload", func(t *testing.T) {
+		m := Message{TS: "1.000001", User: "U1", Files: []File{{Name: "a.png"}}}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "[file: a.png]", text)
+	})
+}
+
 func TestConversationTypeAndTitle(t *testing.T) {
 	lookup := func(id string) string {
 		if id == "UALICE" {

--- a/internal/slack/media.go
+++ b/internal/slack/media.go
@@ -1,0 +1,220 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// defaultMaxMediaBytes caps individual file downloads (config max_media_mb
+// overrides).
+const defaultMaxMediaBytes = int64(100 << 20)
+
+// mediaHost is the only host file bytes are ever fetched from with the
+// bearer token. Message JSON is attacker-influenceable (any workspace member
+// authors it), so fetching arbitrary url_private values would hand the token
+// to whatever host the URL names — the Slack analogue of the Graph
+// token-exfiltration finding on the Teams PR. Off-host files are recorded as
+// metadata-only link rows instead.
+const mediaHost = "files.slack.com"
+
+// errOffHost reports a file URL that is not on files.slack.com.
+var errOffHost = errors.New("file URL not on files.slack.com")
+
+// slackAttachmentID namespaces Slack-managed attachment rows in
+// attachments.source_attachment_id.
+func slackAttachmentID(fileID string) string {
+	return "slack:" + fileID
+}
+
+// mediaTypeOf maps a Slack file's mimetype to msgvault's attachments.media_type.
+func mediaTypeOf(f *File) string {
+	switch {
+	case strings.HasPrefix(f.Mimetype, "image/"):
+		return "image"
+	case strings.HasPrefix(f.Mimetype, "video/"):
+		return "video"
+	case strings.HasPrefix(f.Mimetype, "audio/"):
+		return "audio"
+	default:
+		return "document"
+	}
+}
+
+// fetchableURL validates a file's private URL for token-bearing download:
+// https, exactly files.slack.com, no userinfo. Anything else is off-host.
+func fetchableURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "https" || u.User != nil || !strings.EqualFold(u.Host, mediaHost) {
+		return "", fmt.Errorf("%q: %w", rawURL, errOffHost)
+	}
+	return u.String(), nil
+}
+
+// DownloadFile fetches a files.slack.com URL with the bearer token, capped at
+// maxBytes. Redirects are refused entirely: a redirect off-host would carry
+// the token, and same-host redirects do not occur in practice.
+func (c *Client) DownloadFile(ctx context.Context, rawURL string, maxBytes int64) ([]byte, error) {
+	fetchURL, err := fetchableURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	client := &http.Client{
+		Timeout: c.http.Timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return fmt.Errorf("refusing redirect to %s: %w", req.URL.Host, errOffHost)
+		},
+	}
+	if c.mediaTransport != nil {
+		client.Transport = c.mediaTransport
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("slack file GET: status %d", resp.StatusCode)
+	}
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxMediaBytes
+	}
+	if resp.ContentLength > maxBytes {
+		return nil, fmt.Errorf("slack file GET: %d bytes: %w", resp.ContentLength, ErrAssetTooLarge)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("slack file GET: read body: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, ErrAssetTooLarge
+	}
+	return data, nil
+}
+
+// persistFiles downloads a message's files into content-addressed storage
+// and replaces the message's Slack attachment rows. Already-downloaded media
+// (matched by source_attachment_id) is kept without re-fetching. External or
+// off-host files become metadata-only link rows (media_type "link", the
+// permalink as storage path); failed or over-cap downloads leave a pending
+// marker row (no content hash) for BackfillMedia to retry.
+func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, m *Message, opts ImportOptions, sum *ImportSummary) {
+	existing, err := imp.store.MessageSlackAttachments(messageID)
+	if err != nil {
+		sum.Errors++
+		return
+	}
+	if len(m.Files) == 0 && len(existing) == 0 {
+		return
+	}
+	maxBytes := opts.MaxMediaBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxMediaBytes
+	}
+	refs := make([]store.AttachmentRef, 0, len(m.Files))
+	for i := range m.Files {
+		f := &m.Files[i]
+		if f.ID == "" || f.Mode == "tombstone" {
+			continue
+		}
+		sourceAttID := slackAttachmentID(f.ID)
+		if prev, ok := existing[sourceAttID]; ok && prev.ContentHash != "" {
+			refs = append(refs, prev)
+			continue
+		}
+		linkRow := store.AttachmentRef{
+			Filename:           f.Name,
+			MimeType:           f.Mimetype,
+			StoragePath:        f.Permalink,
+			Size:               int(f.Size),
+			SourceAttachmentID: sourceAttID,
+			MediaType:          "link",
+		}
+		pendingRow := linkRow
+		pendingRow.MediaType = ""
+
+		// pend leaves a retryable marker; link records metadata permanently.
+		pend := func(status, kind string, err error) {
+			imp.recordItem(syncID, sourceMessageID("", m.TS), "attachment", status, kind, err)
+			refs = append(refs, pendingRow)
+			sum.AttachmentsPending++
+			if status == store.SyncRunItemStatusError {
+				sum.Errors++
+			}
+		}
+
+		fetchRef := f.URLPrivate
+		if fetchRef == "" {
+			fetchRef = f.URLPrivateDownload
+		}
+		if _, herr := fetchableURL(fetchRef); herr != nil || f.IsExternal {
+			// Off-host / external: never fetched with the token (see mediaHost).
+			refs = append(refs, linkRow)
+			continue
+		}
+		if opts.NoMedia || opts.AttachmentsDir == "" {
+			refs = append(refs, linkRow)
+			continue
+		}
+		if f.Size > 0 && f.Size > maxBytes {
+			pend(store.SyncRunItemStatusSkipped, "slack_media_too_large",
+				fmt.Errorf("file %s is %d bytes (cap %d)", f.ID, f.Size, maxBytes))
+			continue
+		}
+		data, derr := imp.client.DownloadFile(ctx, fetchRef, maxBytes)
+		if errors.Is(derr, ErrAssetTooLarge) {
+			pend(store.SyncRunItemStatusSkipped, "slack_media_too_large", derr)
+			continue
+		}
+		if derr != nil {
+			if ctx.Err() != nil {
+				// Interrupted: keep the pending marker without charging an error.
+				refs = append(refs, pendingRow)
+				sum.AttachmentsPending++
+				continue
+			}
+			pend(store.SyncRunItemStatusError, "slack_media_error", derr)
+			continue
+		}
+		ma := &mime.Attachment{Filename: f.Name, ContentType: f.Mimetype, Content: data}
+		storagePath, serr := export.StoreAttachmentFile(opts.AttachmentsDir, ma)
+		if serr != nil || storagePath == "" {
+			pend(store.SyncRunItemStatusError, "slack_media_error", serr)
+			continue
+		}
+		stored := store.AttachmentRef{
+			Filename:           f.Name,
+			MimeType:           f.Mimetype,
+			StoragePath:        storagePath,
+			ContentHash:        ma.ContentHash,
+			Size:               len(data),
+			SourceAttachmentID: sourceAttID,
+			MediaType:          mediaTypeOf(f),
+		}
+		refs = append(refs, stored)
+		sum.AttachmentsDownloaded++
+	}
+	if err := imp.store.ReplaceMessageSlackAttachments(messageID, refs); err != nil {
+		sum.Errors++
+		return
+	}
+	if err := imp.store.RecomputeMessageAttachmentStats(messageID); err != nil {
+		sum.Errors++
+	}
+}

--- a/internal/slack/media.go
+++ b/internal/slack/media.go
@@ -54,7 +54,7 @@ func mediaTypeOf(f *File) string {
 func fetchableURL(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("parse file URL: %w", err)
 	}
 	if u.Scheme != "https" || u.User != nil || !strings.EqualFold(u.Host, mediaHost) {
 		return "", fmt.Errorf("%q: %w", rawURL, errOffHost)

--- a/internal/slack/media_test.go
+++ b/internal/slack/media_test.go
@@ -1,0 +1,173 @@
+package slack
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestFetchableURLHostRestriction(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		ok   bool
+	}{
+		{"real host", "https://files.slack.com/files-pri/T01-F01/a.png", true},
+		{"case-insensitive host", "https://FILES.SLACK.COM/files-pri/T01-F01/a.png", true},
+		{"attacker host", "https://attacker.example/files-pri/T01-F01/a.png", false},
+		{"subdomain spoof", "https://files.slack.com.attacker.example/a.png", false},
+		{"http downgrade", "http://files.slack.com/a.png", false},
+		{"userinfo trick", "https://files.slack.com@attacker.example/a.png", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := fetchableURL(tt.url)
+			if tt.ok {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+// recordingTransport serves canned bodies for files.slack.com and records
+// every request it sees (it must never see an off-host one).
+type recordingTransport struct {
+	requests []string
+	body     string
+	redirect string // when set, answer 302 to this location
+	status   int
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.requests = append(rt.requests, req.URL.String())
+	if rt.redirect != "" {
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     http.Header{"Location": {rt.redirect}},
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	}
+	status := rt.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode:    status,
+		Body:          io.NopCloser(strings.NewReader(rt.body)),
+		ContentLength: int64(len(rt.body)),
+		Request:       req,
+	}, nil
+}
+
+func TestDownloadFileRefusesOffHostAndRedirects(t *testing.T) {
+	rt := &recordingTransport{body: "bytes"}
+	c := NewClient("", "xoxp-test")
+	c.mediaTransport = rt
+
+	// Off-host: rejected before any request is made.
+	_, err := c.DownloadFile(context.Background(), "https://attacker.example/x", 100)
+	require.ErrorIs(t, err, errOffHost)
+	assert.Empty(t, rt.requests, "the token must never travel to an off-host URL")
+
+	// On-host succeeds.
+	data, err := c.DownloadFile(context.Background(), "https://files.slack.com/files-pri/T01-F01/a.png", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "bytes", string(data))
+	require.Len(t, rt.requests, 1)
+
+	// A redirect — even one a compromised response injects — is refused.
+	rt.redirect = "https://attacker.example/steal"
+	_, err = c.DownloadFile(context.Background(), "https://files.slack.com/files-pri/T01-F02/b.png", 100)
+	require.ErrorIs(t, err, errOffHost)
+	assert.Len(t, rt.requests, 2, "the redirect target must not be followed")
+}
+
+func TestDownloadFileSizeCap(t *testing.T) {
+	rt := &recordingTransport{body: strings.Repeat("x", 64)}
+	c := NewClient("", "xoxp-test")
+	c.mediaTransport = rt
+	_, err := c.DownloadFile(context.Background(), "https://files.slack.com/files-pri/T01-F01/a.png", 10)
+	assert.ErrorIs(t, err, ErrAssetTooLarge)
+}
+
+func TestPersistFilesLinkRowsAndPendingMarkers(t *testing.T) {
+	f := testWorkspace(t)
+	general := f.conv("C01")
+	general.Msgs[6].Files = []map[string]any{
+		{"id": "F_OK", "name": "a.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_OK/a.png",
+			"permalink":   "https://testers.slack.com/files/F_OK"},
+		{"id": "F_EXT", "name": "doc.pdf", "mimetype": "application/pdf", "is_external": true,
+			"url_private": "https://ext.example/doc.pdf",
+			"permalink":   "https://testers.slack.com/files/F_EXT"},
+		{"id": "F_BIG", "name": "video.mp4", "mimetype": "video/mp4", "size": 1 << 40,
+			"url_private": "https://files.slack.com/files-pri/T01-F_BIG/video.mp4",
+			"permalink":   "https://testers.slack.com/files/F_BIG"},
+	}
+
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	client.mediaTransport = &recordingTransport{body: "png01"}
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	opts := ImportOptions{
+		TeamID: "T01", UserID: "UME",
+		AttachmentsDir: t.TempDir(), MaxMediaBytes: 1 << 20,
+	}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT a.source_attachment_id, COALESCE(a.content_hash, ''), COALESCE(a.media_type, '')
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(6))
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	got := map[string][2]string{}
+	for rows.Next() {
+		var id, hash, mediaType string
+		require.NoError(t, rows.Scan(&id, &hash, &mediaType))
+		got[id] = [2]string{hash, mediaType}
+	}
+	require.NoError(t, rows.Err())
+
+	require.Len(t, got, 3)
+	assert.NotEmpty(t, got["slack:F_OK"][0], "on-host file downloads into content-addressed storage")
+	assert.Equal(t, "image", got["slack:F_OK"][1])
+	assert.Empty(t, got["slack:F_EXT"][0])
+	assert.Equal(t, "link", got["slack:F_EXT"][1], "external file records metadata only")
+	assert.Empty(t, got["slack:F_BIG"][0])
+	assert.Empty(t, got["slack:F_BIG"][1], "over-cap file leaves a retryable pending marker")
+
+	// The pending list sees the over-cap marker but not the link row.
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(t, err)
+	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+
+	// Raising the cap and backfilling repairs the pending download (the
+	// declared size in the archived raw JSON no longer exceeds it).
+	opts.MaxMediaBytes = 1 << 50
+	sum, err := imp.BackfillMedia(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sum.AttachmentsDownloaded)
+	pending, err = st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}

--- a/internal/slack/participants.go
+++ b/internal/slack/participants.go
@@ -1,0 +1,149 @@
+package slack
+
+import (
+	"context"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// participantIdentifierType namespaces Slack user IDs in
+// participant_identifiers. IDs are only unique per workspace, so the stored
+// identifier value is "<team_id>:<user_id>".
+const participantIdentifierType = "slack"
+
+// participantResolver resolves Slack user IDs to msgvault participant IDs,
+// seeded once per run from users.list and cached thereafter.
+//
+// Resolution ladder (Beeper precedent, minus the phone rung — Slack profiles
+// carry emails, not reliable E.164 phones):
+//  1. Profile email → EnsureParticipant, deduping the person against mail
+//     archives (and Teams' AAD→email resolutions).
+//  2. Bare Slack user ID → EnsureParticipantByIdentifier("slack", …).
+type participantResolver struct {
+	store  *store.Store
+	teamID string
+	// users caches users.list rows by user ID for display names and titles.
+	users map[string]User
+	// rich caches email-based resolutions; fallback caches bare-ID ones.
+	// Kept separate so a fallback cached before the users refresh cannot
+	// block a later email-based dedup (Beeper precedent).
+	rich     map[string]int64
+	fallback map[string]int64
+}
+
+func newParticipantResolver(s *store.Store, teamID string) *participantResolver {
+	return &participantResolver{
+		store: s, teamID: teamID,
+		users: map[string]User{}, rich: map[string]int64{}, fallback: map[string]int64{},
+	}
+}
+
+// identifierValue namespaces a Slack user ID with its workspace.
+func (r *participantResolver) identifierValue(userID string) string {
+	return r.teamID + ":" + userID
+}
+
+// loadUsers refreshes the workspace member cache. Identity resolution is
+// load-bearing for cross-archive dedup, so callers treat failure as fatal
+// for the run.
+func (r *participantResolver) loadUsers(ctx context.Context, c *Client) error {
+	return c.AllUsers(ctx, func(u User) error {
+		r.users[u.ID] = u
+		return nil
+	})
+}
+
+// displayName returns the best-known name for a user ID ("" when unknown).
+func (r *participantResolver) displayName(userID string) string {
+	if u, ok := r.users[userID]; ok {
+		return u.DisplayName()
+	}
+	return ""
+}
+
+// resolveID resolves a Slack user ID to a participant ID, creating the
+// participant if needed. Unknown IDs (Slack Connect guests, departed users
+// missing from users.list) resolve by bare identifier with no display name.
+func (r *participantResolver) resolveID(userID string) (int64, error) {
+	if userID == "" {
+		return 0, nil
+	}
+	if pid, ok := r.rich[userID]; ok {
+		return pid, nil
+	}
+	if pid, ok := r.fallback[userID]; ok {
+		return pid, nil
+	}
+	u, known := r.users[userID]
+	if known && strings.Contains(u.Profile.Email, "@") && !u.IsBot {
+		pid, err := r.byEmail(u.Profile.Email, u.DisplayName())
+		if err != nil {
+			return 0, err
+		}
+		if err := r.recordRich(userID, pid); err != nil {
+			return 0, err
+		}
+		return pid, nil
+	}
+	name := ""
+	if known {
+		name = u.DisplayName()
+	}
+	pid, err := r.store.EnsureParticipantByIdentifier(participantIdentifierType, r.identifierValue(userID), name)
+	if err != nil {
+		return 0, err
+	}
+	r.fallback[userID] = pid
+	return pid, nil
+}
+
+// recordRich persists the Slack user ID as an identifier of the email-based
+// participant, so later runs resolve bare sightings to the same person. A
+// prior weak (bare-ID) owner is the same Slack user seen with less metadata:
+// its history is merged into the rich participant rather than left split.
+func (r *participantResolver) recordRich(userID string, pid int64) error {
+	value := r.identifierValue(userID)
+	prev, _, err := r.store.ParticipantByIdentifier(participantIdentifierType, value)
+	if err != nil {
+		return err
+	}
+	if prev != 0 && prev != pid {
+		if err := r.store.MergeParticipants(prev, pid); err != nil {
+			return err
+		}
+	}
+	if err := r.store.SetParticipantIdentifier(pid, participantIdentifierType, value); err != nil {
+		return err
+	}
+	r.rich[userID] = pid
+	delete(r.fallback, userID)
+	return nil
+}
+
+// resolveBot resolves a bot sender (bot_id + optional username). Bots never
+// dedup by email; they are namespaced by bot ID.
+func (r *participantResolver) resolveBot(botID, username string) (int64, error) {
+	if botID == "" {
+		return 0, nil
+	}
+	key := "bot:" + botID
+	if pid, ok := r.fallback[key]; ok {
+		return pid, nil
+	}
+	pid, err := r.store.EnsureParticipantByIdentifier(participantIdentifierType, r.identifierValue(key), username)
+	if err != nil {
+		return 0, err
+	}
+	r.fallback[key] = pid
+	return pid, nil
+}
+
+func (r *participantResolver) byEmail(email, displayName string) (int64, error) {
+	email = strings.ToLower(email)
+	domain := ""
+	if at := strings.LastIndex(email, "@"); at >= 0 {
+		domain = email[at+1:]
+	}
+	return r.store.EnsureParticipant(email, displayName, domain)
+}

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -24,6 +24,12 @@ type ConvState struct {
 	BackfillLatest string            `json:"backfill_latest,omitempty"`
 	Done           bool              `json:"done,omitempty"`
 	Threads        map[string]string `json:"threads,omitempty"`
+	// IncrCursor/IncrMaxTS checkpoint a partially-walked incremental window
+	// (interrupted by --limit or a fetch error), so limited runs drain a
+	// backlog across runs instead of restarting from the newest page. The
+	// main Cursor still only advances once the window is exhausted.
+	IncrCursor string `json:"incr_cursor,omitempty"`
+	IncrMaxTS  string `json:"incr_max_ts,omitempty"`
 }
 
 // SyncState holds per-conversation cursors for one Slack source, persisted
@@ -89,6 +95,12 @@ func (s *SyncState) Merge(other *SyncState) {
 		}
 		if ocs.BackfillLatest != "" {
 			cs.BackfillLatest = ocs.BackfillLatest
+		}
+		if ocs.IncrCursor != "" {
+			cs.IncrCursor = ocs.IncrCursor
+		}
+		if ocs.IncrMaxTS != "" && (cs.IncrMaxTS == "" || tsLess(cs.IncrMaxTS, ocs.IncrMaxTS)) {
+			cs.IncrMaxTS = ocs.IncrMaxTS
 		}
 		for root, replyTS := range ocs.Threads {
 			if cur, ok := cs.Threads[root]; !ok || tsLess(cur, replyTS) {

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -110,8 +110,14 @@ func (cs *ConvState) TrackThread(rootTS, replyTS string) {
 
 // PruneThreads drops tracked roots older than cutoff, bounding both the
 // per-sync conversations.replies call count and the checkpoint blob size.
-func (cs *ConvState) PruneThreads(cutoff time.Time) {
+// Only roots whose polling completed this run (polled) are eligible: pruning
+// a root that was skipped (--limit) or whose fetch failed would permanently
+// lose its replies to incremental sync.
+func (cs *ConvState) PruneThreads(cutoff time.Time, polled map[string]bool) {
 	for root := range cs.Threads {
+		if !polled[root] {
+			continue
+		}
 		if t := tsTime(root); !t.IsZero() && t.Before(cutoff) {
 			delete(cs.Threads, root)
 		}

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -1,0 +1,119 @@
+package slack
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ConvState tracks one conversation's sync progress.
+//
+// Cursor is the max top-level message ts persisted; incremental history
+// fetches oldest=Cursor. Backfill is the resumable oldest-ward walk toward
+// the beginning of history: BackfillCursor is the page cursor to resume from
+// and BackfillLatest pins the walk's upper bound so messages arriving during
+// a long backfill cannot shift its pagination. Done means the backfill
+// reached the beginning of history.
+//
+// Threads maps thread-root ts → max reply ts persisted for that root. Roots
+// are tracked while younger than the run's thread lookback, then pruned;
+// replies to pruned roots are only caught by --full runs (see
+// docs/internal/slack-ingestion-design.md, LB-3).
+type ConvState struct {
+	Cursor         string            `json:"cursor,omitempty"`
+	BackfillCursor string            `json:"backfill_cursor,omitempty"`
+	BackfillLatest string            `json:"backfill_latest,omitempty"`
+	Done           bool              `json:"done,omitempty"`
+	Threads        map[string]string `json:"threads,omitempty"`
+}
+
+// SyncState holds per-conversation cursors for one Slack source, persisted
+// as JSON in sync_runs.cursor_after (checkpointed mid-run in cursor_before).
+type SyncState struct {
+	Conversations map[string]*ConvState `json:"conversations"` // key = channel ID
+}
+
+func NewSyncState() *SyncState {
+	return &SyncState{Conversations: map[string]*ConvState{}}
+}
+
+func LoadSyncState(blob string) (*SyncState, error) {
+	s := NewSyncState()
+	if blob == "" {
+		return s, nil
+	}
+	if err := json.Unmarshal([]byte(blob), s); err != nil {
+		return nil, err
+	}
+	if s.Conversations == nil {
+		s.Conversations = map[string]*ConvState{}
+	}
+	return s, nil
+}
+
+func (s *SyncState) Marshal() (string, error) {
+	b, err := json.Marshal(s)
+	return string(b), err
+}
+
+// EnsureConv returns the (created-if-missing) state for channelID.
+func (s *SyncState) EnsureConv(channelID string) *ConvState {
+	cs, ok := s.Conversations[channelID]
+	if !ok {
+		cs = &ConvState{}
+		s.Conversations[channelID] = cs
+	}
+	if cs.Threads == nil {
+		cs.Threads = map[string]string{}
+	}
+	return cs
+}
+
+// Merge incorporates cursors from other (a newer checkpoint) into s. Message
+// ts cursors compare numerically; the more-advanced value wins. Backfill page
+// cursors are opaque, so other's non-empty value wins wholesale (Teams
+// deltaLink precedent). Done flags are OR'd.
+func (s *SyncState) Merge(other *SyncState) {
+	if other == nil {
+		return
+	}
+	for channelID, ocs := range other.Conversations {
+		if ocs == nil {
+			continue
+		}
+		cs := s.EnsureConv(channelID)
+		if ocs.Cursor != "" && (cs.Cursor == "" || tsLess(cs.Cursor, ocs.Cursor)) {
+			cs.Cursor = ocs.Cursor
+		}
+		if ocs.BackfillCursor != "" {
+			cs.BackfillCursor = ocs.BackfillCursor
+		}
+		if ocs.BackfillLatest != "" {
+			cs.BackfillLatest = ocs.BackfillLatest
+		}
+		for root, replyTS := range ocs.Threads {
+			if cur, ok := cs.Threads[root]; !ok || tsLess(cur, replyTS) {
+				cs.Threads[root] = replyTS
+			}
+		}
+		cs.Done = cs.Done || ocs.Done
+	}
+}
+
+// TrackThread starts (or refreshes) reply tracking for a thread root.
+// replyTS is the max reply ts already persisted ("" = none yet).
+func (cs *ConvState) TrackThread(rootTS, replyTS string) {
+	if cur, ok := cs.Threads[rootTS]; ok && (replyTS == "" || tsLess(replyTS, cur)) {
+		return
+	}
+	cs.Threads[rootTS] = replyTS
+}
+
+// PruneThreads drops tracked roots older than cutoff, bounding both the
+// per-sync conversations.replies call count and the checkpoint blob size.
+func (cs *ConvState) PruneThreads(cutoff time.Time) {
+	for root := range cs.Threads {
+		if t := tsTime(root); !t.IsZero() && t.Before(cutoff) {
+			delete(cs.Threads, root)
+		}
+	}
+}

--- a/internal/slack/syncstate_test.go
+++ b/internal/slack/syncstate_test.go
@@ -1,0 +1,74 @@
+package slack
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncStateRoundTrip(t *testing.T) {
+	s := NewSyncState()
+	cs := s.EnsureConv("C01")
+	cs.Cursor = "100.000001"
+	cs.Done = true
+	cs.TrackThread("50.000001", "60.000001")
+
+	blob, err := s.Marshal()
+	require.NoError(t, err)
+	loaded, err := LoadSyncState(blob)
+	require.NoError(t, err)
+	lcs := loaded.EnsureConv("C01")
+	assert.Equal(t, "100.000001", lcs.Cursor)
+	assert.True(t, lcs.Done)
+	assert.Equal(t, "60.000001", lcs.Threads["50.000001"])
+}
+
+func TestSyncStateMergePrefersAdvancedCursors(t *testing.T) {
+	base := NewSyncState()
+	bcs := base.EnsureConv("C01")
+	bcs.Cursor = "100.000001"
+	bcs.TrackThread("50.000001", "60.000001")
+
+	newer := NewSyncState()
+	ncs := newer.EnsureConv("C01")
+	ncs.Cursor = "200.000001"
+	ncs.Done = true
+	ncs.TrackThread("50.000001", "70.000001")
+	newer.EnsureConv("C02").BackfillCursor = "opaque"
+
+	base.Merge(newer)
+	mcs := base.EnsureConv("C01")
+	assert.Equal(t, "200.000001", mcs.Cursor)
+	assert.True(t, mcs.Done)
+	assert.Equal(t, "70.000001", mcs.Threads["50.000001"])
+	assert.Equal(t, "opaque", base.EnsureConv("C02").BackfillCursor)
+
+	// A stale checkpoint must never regress an advanced cursor.
+	stale := NewSyncState()
+	stale.EnsureConv("C01").Cursor = "150.000001"
+	stale.EnsureConv("C01").Threads = map[string]string{"50.000001": "65.000001"}
+	base.Merge(stale)
+	assert.Equal(t, "200.000001", base.EnsureConv("C01").Cursor)
+	assert.Equal(t, "70.000001", base.EnsureConv("C01").Threads["50.000001"])
+}
+
+func TestPruneThreads(t *testing.T) {
+	cs := &ConvState{Threads: map[string]string{}}
+	old := time.Now().Add(-60 * 24 * time.Hour)
+	fresh := time.Now().Add(-time.Hour)
+	oldTS := tsFromTime(old)
+	freshTS := tsFromTime(fresh)
+	cs.TrackThread(oldTS, "")
+	cs.TrackThread(freshTS, "")
+
+	cs.PruneThreads(time.Now().Add(-30 * 24 * time.Hour))
+	assert.NotContains(t, cs.Threads, oldTS)
+	assert.Contains(t, cs.Threads, freshTS)
+}
+
+func tsFromTime(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10) + ".000100"
+}

--- a/internal/slack/syncstate_test.go
+++ b/internal/slack/syncstate_test.go
@@ -57,16 +57,18 @@ func TestSyncStateMergePrefersAdvancedCursors(t *testing.T) {
 
 func TestPruneThreads(t *testing.T) {
 	cs := &ConvState{Threads: map[string]string{}}
-	old := time.Now().Add(-60 * 24 * time.Hour)
-	fresh := time.Now().Add(-time.Hour)
-	oldTS := tsFromTime(old)
-	freshTS := tsFromTime(fresh)
-	cs.TrackThread(oldTS, "")
-	cs.TrackThread(freshTS, "")
+	oldPolled := tsFromTime(time.Now().Add(-60 * 24 * time.Hour))
+	oldSkipped := tsFromTime(time.Now().Add(-59 * 24 * time.Hour))
+	fresh := tsFromTime(time.Now().Add(-time.Hour))
+	cs.TrackThread(oldPolled, "")
+	cs.TrackThread(oldSkipped, "")
+	cs.TrackThread(fresh, "")
 
-	cs.PruneThreads(time.Now().Add(-30 * 24 * time.Hour))
-	assert.NotContains(t, cs.Threads, oldTS)
-	assert.Contains(t, cs.Threads, freshTS)
+	cutoff := time.Now().Add(-30 * 24 * time.Hour)
+	cs.PruneThreads(cutoff, map[string]bool{oldPolled: true, fresh: true})
+	assert.NotContains(t, cs.Threads, oldPolled, "polled roots past the lookback are pruned")
+	assert.Contains(t, cs.Threads, oldSkipped, "unpolled roots must survive pruning or their replies are lost")
+	assert.Contains(t, cs.Threads, fresh, "fresh roots stay tracked")
 }
 
 func tsFromTime(t time.Time) string {

--- a/internal/slack/token.go
+++ b/internal/slack/token.go
@@ -1,0 +1,90 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/msgvault/internal/fileutil"
+)
+
+// tokenFile stores one workspace's user token plus the identity it resolved
+// to at add-slack time. Tokens are per-workspace (unlike Beeper's singleton):
+// multiple workspaces coexist as separate sources.
+type tokenFile struct {
+	AccessToken string `json:"access_token"`
+	TeamID      string `json:"team_id"`
+	TeamDomain  string `json:"team_domain"`
+	UserID      string `json:"user_id"`
+}
+
+// tokenPath returns the token file path for a workspace.
+func tokenPath(tokensDir, teamID string) string {
+	return filepath.Join(tokensDir, "slack_"+teamID+".json")
+}
+
+// SaveToken saves a workspace's user token atomically (temp file + rename)
+// with fileutil.Secure* hardening.
+func SaveToken(tokensDir, teamID, teamDomain, userID, token string) error {
+	if err := fileutil.SecureMkdirAll(tokensDir, 0700); err != nil {
+		return fmt.Errorf("create tokens dir: %w", err)
+	}
+	data, err := json.Marshal(tokenFile{ //nolint:gosec // serialized to a 0600 file on the user's own machine
+		AccessToken: token, TeamID: teamID, TeamDomain: teamDomain, UserID: userID,
+	})
+	if err != nil {
+		return err
+	}
+	path := tokenPath(tokensDir, teamID)
+
+	tmpFile, err := os.CreateTemp(tokensDir, ".slack-token-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp token file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp token file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp token file: %w", err)
+	}
+	if err := fileutil.SecureChmod(tmpPath, 0600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp token file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename temp token file: %w", err)
+	}
+	return nil
+}
+
+// LoadToken loads a workspace's stored token.
+func LoadToken(tokensDir, teamID string) (string, error) {
+	data, err := os.ReadFile(tokenPath(tokensDir, teamID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("no Slack token for workspace %s (run 'add-slack' first)", teamID)
+		}
+		return "", fmt.Errorf("read slack token: %w", err)
+	}
+	var tf tokenFile
+	if err := json.Unmarshal(data, &tf); err != nil {
+		return "", fmt.Errorf("parse slack token: %w", err)
+	}
+	return tf.AccessToken, nil
+}
+
+// DeleteToken removes a workspace's token file. Missing file is not an error.
+func DeleteToken(tokensDir, teamID string) error {
+	err := os.Remove(tokenPath(tokensDir, teamID))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/slack/token.go
+++ b/internal/slack/token.go
@@ -9,9 +9,10 @@ import (
 	"go.kenn.io/msgvault/internal/fileutil"
 )
 
-// tokenFile stores one workspace's user token plus the identity it resolved
-// to at add-slack time. Tokens are per-workspace (unlike Beeper's singleton):
-// multiple workspaces coexist as separate sources.
+// tokenFile stores one workspace user's token plus the identity it resolved
+// to at add-slack time. Tokens are per-workspace-user, matching the source
+// identifier: two users of the same workspace on one machine must not share
+// (or clobber) each other's token.
 type tokenFile struct {
 	AccessToken string `json:"access_token"`
 	TeamID      string `json:"team_id"`
@@ -19,9 +20,9 @@ type tokenFile struct {
 	UserID      string `json:"user_id"`
 }
 
-// tokenPath returns the token file path for a workspace.
-func tokenPath(tokensDir, teamID string) string {
-	return filepath.Join(tokensDir, "slack_"+teamID+".json")
+// tokenPath returns the token file path for a workspace user.
+func tokenPath(tokensDir, teamID, userID string) string {
+	return filepath.Join(tokensDir, "slack_"+teamID+"_"+userID+".json")
 }
 
 // SaveToken saves a workspace's user token atomically (temp file + rename)
@@ -36,7 +37,7 @@ func SaveToken(tokensDir, teamID, teamDomain, userID, token string) error {
 	if err != nil {
 		return err
 	}
-	path := tokenPath(tokensDir, teamID)
+	path := tokenPath(tokensDir, teamID, userID)
 
 	tmpFile, err := os.CreateTemp(tokensDir, ".slack-token-*.tmp")
 	if err != nil {
@@ -64,12 +65,13 @@ func SaveToken(tokensDir, teamID, teamDomain, userID, token string) error {
 	return nil
 }
 
-// LoadToken loads a workspace's stored token.
-func LoadToken(tokensDir, teamID string) (string, error) {
-	data, err := os.ReadFile(tokenPath(tokensDir, teamID))
+// LoadToken loads a workspace user's stored token, validating that the file
+// belongs to the requested identity.
+func LoadToken(tokensDir, teamID, userID string) (string, error) {
+	data, err := os.ReadFile(tokenPath(tokensDir, teamID, userID))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", fmt.Errorf("no Slack token for workspace %s (run 'add-slack' first)", teamID)
+			return "", fmt.Errorf("no Slack token for %s in workspace %s (run 'add-slack' first)", userID, teamID)
 		}
 		return "", fmt.Errorf("read slack token: %w", err)
 	}
@@ -77,12 +79,16 @@ func LoadToken(tokensDir, teamID string) (string, error) {
 	if err := json.Unmarshal(data, &tf); err != nil {
 		return "", fmt.Errorf("parse slack token: %w", err)
 	}
+	if (tf.TeamID != "" && tf.TeamID != teamID) || (tf.UserID != "" && tf.UserID != userID) {
+		return "", fmt.Errorf("slack token file for %s/%s holds identity %s/%s — re-run 'add-slack'",
+			teamID, userID, tf.TeamID, tf.UserID)
+	}
 	return tf.AccessToken, nil
 }
 
-// DeleteToken removes a workspace's token file. Missing file is not an error.
-func DeleteToken(tokensDir, teamID string) error {
-	err := os.Remove(tokenPath(tokensDir, teamID))
+// DeleteToken removes a workspace user's token file. Missing file is not an error.
+func DeleteToken(tokensDir, teamID, userID string) error {
+	err := os.Remove(tokenPath(tokensDir, teamID, userID))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/slack/token_test.go
+++ b/internal/slack/token_test.go
@@ -1,0 +1,48 @@
+package slack
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two users of the same workspace must hold independent tokens: a shared
+// per-team file would be clobbered by the second add-slack, syncing one
+// user's source with the other's token and deleting the survivor's token on
+// remove-account.
+func TestTokensAreIsolatedPerWorkspaceUser(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, SaveToken(dir, "T01", "testers", "UME", "xoxp-me"))
+	require.NoError(t, SaveToken(dir, "T01", "testers", "UOTHER", "xoxp-other"))
+
+	mine, err := LoadToken(dir, "T01", "UME")
+	require.NoError(t, err)
+	other, err := LoadToken(dir, "T01", "UOTHER")
+	require.NoError(t, err)
+	assert.Equal(t, "xoxp-me", mine)
+	assert.Equal(t, "xoxp-other", other)
+
+	require.NoError(t, DeleteToken(dir, "T01", "UOTHER"))
+	mine, err = LoadToken(dir, "T01", "UME")
+	require.NoError(t, err, "removing one user's token must not touch the other's")
+	assert.Equal(t, "xoxp-me", mine)
+	_, err = LoadToken(dir, "T01", "UOTHER")
+	require.ErrorContains(t, err, "run 'add-slack' first")
+}
+
+func TestLoadTokenRejectsIdentityMismatch(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, SaveToken(dir, "T01", "testers", "UME", "xoxp-me"))
+
+	// A token file renamed or copied across identities must not be served.
+	src := tokenPath(dir, "T01", "UME")
+	dst := tokenPath(dir, "T01", "UIMPOSTOR")
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, data, 0o600))
+
+	_, err = LoadToken(dir, "T01", "UIMPOSTOR")
+	require.ErrorContains(t, err, "holds identity")
+}

--- a/internal/slack/types.go
+++ b/internal/slack/types.go
@@ -116,6 +116,73 @@ type Edited struct {
 	TS   string `json:"ts"`
 }
 
+// LegacyAttachment is Slack's pre-Block-Kit rich payload ("secondary
+// attachment"). Bots and integrations often carry their entire content here
+// with an empty message text; user messages get them as link unfurls.
+type LegacyAttachment struct {
+	Fallback string `json:"fallback"` // required plain-text summary
+	Pretext  string `json:"pretext"`
+	Title    string `json:"title"`
+	Text     string `json:"text"`
+	Fields   []struct {
+		Title string `json:"title"`
+		Value string `json:"value"`
+	} `json:"fields"`
+	Footer string `json:"footer"`
+}
+
+// Block is a Block Kit layout block, modelled only deeply enough to extract
+// searchable text: section/header text, section fields, and context
+// elements. rich_text blocks are deliberately not extracted — they duplicate
+// the message's own text field.
+type Block struct {
+	Type     string         `json:"type"`
+	Text     *BlockText     `json:"text"`
+	Fields   []BlockText    `json:"fields"`
+	Elements []BlockElement `json:"elements"`
+}
+
+// BlockText is a Block Kit text object (plain_text or mrkdwn).
+type BlockText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// BlockElement is one entry of a block's elements array. Its text field is
+// shape-shifting across block kinds (observed live): a plain string on
+// context mrkdwn/plain_text elements, a nested text object on actions-block
+// buttons, and absent on rich_text/image elements. All shapes must decode —
+// a strict model here made conversations.history undecodable.
+type BlockElement struct {
+	Type string
+	Text string
+}
+
+// UnmarshalJSON decodes a BlockElement tolerantly (see type comment).
+func (e *BlockElement) UnmarshalJSON(b []byte) error {
+	var probe struct {
+		Type string          `json:"type"`
+		Text json.RawMessage `json:"text"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		return err
+	}
+	e.Type = probe.Type
+	if len(probe.Text) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(probe.Text, &s) == nil {
+		e.Text = s
+		return nil
+	}
+	var bt BlockText
+	if json.Unmarshal(probe.Text, &bt) == nil {
+		e.Text = bt.Text
+	}
+	return nil
+}
+
 // Message is one message from conversations.history / conversations.replies.
 type Message struct {
 	Type        string     `json:"type"`    // "message"
@@ -131,6 +198,10 @@ type Message struct {
 	LatestReply string     `json:"latest_reply"`
 	Reactions   []Reaction `json:"reactions"`
 	Files       []File     `json:"files"`
+	// Attachments are legacy rich payloads; Blocks are Block Kit layout
+	// blocks. Both feed FTS via payloadText (see mapping.go).
+	Attachments []LegacyAttachment `json:"attachments"`
+	Blocks      []Block            `json:"blocks"`
 	// Raw holds the exact original JSON for this message, captured during
 	// decode (see UnmarshalJSON) and archived verbatim so no API field is
 	// lost to our partial struct modelling.

--- a/internal/slack/types.go
+++ b/internal/slack/types.go
@@ -67,6 +67,7 @@ func (u *User) UnmarshalJSON(b []byte) error {
 	type alias User // avoid recursion into this method
 	var a struct {
 		alias
+
 		Profile UserProfile `json:"profile"`
 	}
 	if err := json.Unmarshal(b, &a); err != nil {

--- a/internal/slack/types.go
+++ b/internal/slack/types.go
@@ -1,0 +1,241 @@
+package slack
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// apiResponse is the envelope every Slack Web API method returns.
+type apiResponse struct {
+	OK       bool   `json:"ok"`
+	Error    string `json:"error"`
+	Needed   string `json:"needed"`   // set on missing_scope errors
+	Provided string `json:"provided"` // set on missing_scope errors
+	Metadata struct {
+		NextCursor string `json:"next_cursor"`
+	} `json:"response_metadata"`
+}
+
+// AuthTestResult identifies the token's workspace and user.
+type AuthTestResult struct {
+	URL    string `json:"url"`
+	Team   string `json:"team"`
+	User   string `json:"user"`
+	TeamID string `json:"team_id"`
+	UserID string `json:"user_id"`
+}
+
+// Conversation is one channel/group DM/DM from conversations.list or
+// users.conversations.
+type Conversation struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IsChannel  bool   `json:"is_channel"`
+	IsGroup    bool   `json:"is_group"`
+	IsIM       bool   `json:"is_im"`
+	IsMpim     bool   `json:"is_mpim"`
+	IsPrivate  bool   `json:"is_private"`
+	IsArchived bool   `json:"is_archived"`
+	IsMember   bool   `json:"is_member"`
+	User       string `json:"user"` // IM peer user ID (im only)
+	NumMembers int    `json:"num_members"`
+}
+
+// User is one workspace member from users.list.
+type User struct {
+	ID       string `json:"id"`
+	TeamID   string `json:"team_id"`
+	Name     string `json:"name"` // legacy handle
+	Deleted  bool   `json:"deleted"`
+	IsBot    bool   `json:"is_bot"`
+	Profile  UserProfile
+	RealName string `json:"real_name"`
+}
+
+// UserProfile carries the displayable identity fields of a User.
+type UserProfile struct {
+	Email       string `json:"email"` // requires users:read.email; empty otherwise
+	RealName    string `json:"real_name"`
+	DisplayName string `json:"display_name"`
+	BotID       string `json:"bot_id"`
+}
+
+// UnmarshalJSON flattens the nested profile object into User.
+func (u *User) UnmarshalJSON(b []byte) error {
+	type alias User // avoid recursion into this method
+	var a struct {
+		alias
+		Profile UserProfile `json:"profile"`
+	}
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*u = User(a.alias)
+	u.Profile = a.Profile
+	return nil
+}
+
+// DisplayName returns the best human-readable name for the user.
+func (u *User) DisplayName() string {
+	for _, s := range []string{u.Profile.DisplayName, u.Profile.RealName, u.RealName, u.Name} {
+		if s != "" {
+			return s
+		}
+	}
+	return u.ID
+}
+
+// Reaction is one emoji reaction aggregate on a message.
+type Reaction struct {
+	Name  string   `json:"name"`  // emoji name, e.g. "thumbsup"
+	Users []string `json:"users"` // reacting user IDs (may be truncated by the API)
+	Count int      `json:"count"`
+}
+
+// File is a file shared into a conversation. URLPrivate is only fetched when
+// its host is files.slack.com (see media.go); everything else is recorded as
+// metadata.
+type File struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Mimetype           string `json:"mimetype"`
+	Size               int64  `json:"size"`
+	URLPrivate         string `json:"url_private"`
+	URLPrivateDownload string `json:"url_private_download"`
+	Permalink          string `json:"permalink"`
+	Mode               string `json:"mode"` // "tombstone" when deleted, "external", …
+	IsExternal         bool   `json:"is_external"`
+}
+
+// Edited marks a message as edited.
+type Edited struct {
+	User string `json:"user"`
+	TS   string `json:"ts"`
+}
+
+// Message is one message from conversations.history / conversations.replies.
+type Message struct {
+	Type        string     `json:"type"`    // "message"
+	Subtype     string     `json:"subtype"` // "", "bot_message", "channel_join", "thread_broadcast", …
+	TS          string     `json:"ts"`      // message identity within its channel
+	ThreadTS    string     `json:"thread_ts"`
+	User        string     `json:"user"`
+	BotID       string     `json:"bot_id"`
+	Username    string     `json:"username"` // bot display name
+	Text        string     `json:"text"`
+	Edited      *Edited    `json:"edited"`
+	ReplyCount  int        `json:"reply_count"`
+	LatestReply string     `json:"latest_reply"`
+	Reactions   []Reaction `json:"reactions"`
+	Files       []File     `json:"files"`
+	// Raw holds the exact original JSON for this message, captured during
+	// decode (see UnmarshalJSON) and archived verbatim so no API field is
+	// lost to our partial struct modelling.
+	Raw json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON decodes a Message while retaining the original bytes in Raw.
+func (m *Message) UnmarshalJSON(b []byte) error {
+	type alias Message // avoid recursion into this method
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*m = Message(a)
+	m.Raw = json.RawMessage(strings.Clone(string(b)))
+	return nil
+}
+
+// IsThreadRoot reports whether m is the root of a thread with replies.
+func (m *Message) IsThreadRoot() bool {
+	return m.ThreadTS != "" && m.ThreadTS == m.TS && m.ReplyCount > 0
+}
+
+// IsThreadReply reports whether m is a reply inside a thread (not the root).
+// Broadcast replies ("thread_broadcast") also satisfy this.
+func (m *Message) IsThreadReply() bool {
+	return m.ThreadTS != "" && m.ThreadTS != m.TS
+}
+
+// Time converts a Slack ts string ("1734567890.123456") to UTC time.
+// The zero time is returned for unparseable input.
+func tsTime(ts string) time.Time {
+	if ts == "" {
+		return time.Time{}
+	}
+	sec, frac, _ := strings.Cut(ts, ".")
+	s, err := strconv.ParseInt(sec, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	var ns int64
+	if frac != "" {
+		// Fractional part is microseconds, zero-padded to 6 digits.
+		padded := (frac + "000000")[:6]
+		if us, perr := strconv.ParseInt(padded, 10, 64); perr == nil {
+			ns = us * int64(time.Microsecond)
+		}
+	}
+	return time.Unix(s, ns).UTC()
+}
+
+// tsLess compares two Slack ts strings numerically (seconds, then fraction).
+// String comparison is not safe: second counts can differ in digit length.
+func tsLess(a, b string) bool {
+	at, bt := tsTime(a), tsTime(b)
+	if at.Equal(bt) {
+		return a < b // fall back to lexical for stability
+	}
+	return at.Before(bt)
+}
+
+// ImportOptions configures one Import run.
+type ImportOptions struct {
+	// TeamID is the workspace to sync; with UserID it forms the msgvault
+	// source identifier ("<team_id>:<user_id>").
+	TeamID string
+	// UserID is the archiving user (from auth.test at add-slack time).
+	UserID string
+	// Limit caps messages processed per conversation this run (0 = no
+	// limit). A limited backfill leaves the conversation resumable.
+	Limit int
+	// Full ignores stored cursors: every conversation is re-walked and every
+	// message re-upserted in place (repair path).
+	Full bool
+	// NoThreads skips per-root reply fetching (scoped first runs).
+	NoThreads bool
+	// AttachmentsDir is the content-addressed attachment store root. Empty
+	// disables media download (as does NoMedia).
+	AttachmentsDir string
+	// NoMedia skips file downloads entirely.
+	NoMedia bool
+	// MaxMediaBytes caps individual file downloads (0 = 100 MB).
+	MaxMediaBytes int64
+	// ThreadLookback bounds how long a thread root stays tracked for new
+	// replies (0 = 30 days). Replies to roots older than this are only
+	// caught by --full runs (documented limitation).
+	ThreadLookback time.Duration
+	// IncludeChannels/ExcludeChannels filter by channel name (no "#").
+	// Include empty = all memberships. DMs/group DMs are never filtered.
+	IncludeChannels []string
+	ExcludeChannels []string
+	// Progress, if non-nil, is called after each conversation with a
+	// human-readable status line.
+	Progress func(msg string) `json:"-"`
+}
+
+// ImportSummary reports the outcome of one Import run.
+type ImportSummary struct {
+	SourceID               int64
+	ConversationsProcessed int
+	MessagesProcessed      int
+	MessagesAdded          int
+	RepliesFetched         int
+	AttachmentsDownloaded  int
+	AttachmentsPending     int
+	FetchErrors            int
+	Errors                 int
+	Duration               time.Duration
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2505,12 +2505,19 @@ func (s *Store) ReplaceMessageBeeperAttachments(messageID int64, refs []Attachme
 // attachment rows keyed by source_attachment_id, so re-persisting a message
 // can keep already-downloaded media without re-fetching it.
 func (s *Store) MessageBeeperAttachments(messageID int64) (map[string]AttachmentRef, error) {
+	return s.messageAttachmentsByPrefix(messageID, "beeper:")
+}
+
+// messageAttachmentsByPrefix returns a message's importer-managed attachment
+// rows under the given source_attachment_id prefix, keyed by
+// source_attachment_id. prefix is a trusted package constant, never user input.
+func (s *Store) messageAttachmentsByPrefix(messageID int64, prefix string) (map[string]AttachmentRef, error) {
 	rows, err := s.db.Query(`
 		SELECT COALESCE(filename, ''), COALESCE(mime_type, ''), storage_path, COALESCE(content_hash, ''), size, source_attachment_id,
 		       COALESCE(media_type, ''), COALESCE(width, 0), COALESCE(height, 0), COALESCE(duration_ms, 0)
 		FROM attachments
-		WHERE message_id = ? AND source_attachment_id LIKE 'beeper:%'
-	`, messageID)
+		WHERE message_id = ? AND source_attachment_id LIKE ? || '%'
+	`, messageID, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -2564,19 +2571,25 @@ func (s *Store) ListRecentMessagesForSource(sourceID int64, limit int) ([]Source
 	return out, rows.Err()
 }
 
-// BeeperPendingAttachmentMessage identifies a message with at least one
-// pending (not yet downloaded) Beeper attachment marker.
-type BeeperPendingAttachmentMessage struct {
+// PendingAttachmentMessage identifies a message with at least one pending
+// (not yet downloaded) importer-managed attachment marker.
+type PendingAttachmentMessage struct {
 	MessageID       int64
 	SourceMessageID string
 	ChatID          string // conversations.source_conversation_id
 }
 
-// ListBeeperPendingAttachmentMessages returns the messages of a beeper
-// source that still have pending attachment markers, so a retry pass can
-// re-fetch their media. Buffered (not a cursor callback): callers do slow
-// network and write work per item, which must not hold a read cursor open.
-func (s *Store) ListBeeperPendingAttachmentMessages(sourceID int64) ([]BeeperPendingAttachmentMessage, error) {
+// BeeperPendingAttachmentMessage is the Beeper-era name for
+// PendingAttachmentMessage, kept as an alias for existing callers.
+type BeeperPendingAttachmentMessage = PendingAttachmentMessage
+
+// listPendingAttachmentMessages returns the messages of a source that still
+// have pending attachment markers under the given source_attachment_id
+// prefix, so a retry pass can re-fetch their media. Buffered (not a cursor
+// callback): callers do slow network and write work per item, which must not
+// hold a read cursor open. prefix is a trusted package constant, never user
+// input.
+func (s *Store) listPendingAttachmentMessages(sourceID int64, prefix string) ([]PendingAttachmentMessage, error) {
 	rows, err := s.db.Query(`
 		SELECT m.id, m.source_message_id, c.source_conversation_id
 		FROM messages m
@@ -2585,23 +2598,52 @@ func (s *Store) ListBeeperPendingAttachmentMessages(sourceID int64) ([]BeeperPen
 		  AND EXISTS (
 		    SELECT 1 FROM attachments a
 		    WHERE a.message_id = m.id
-		      AND a.source_attachment_id LIKE 'beeper:%'
+		      AND a.source_attachment_id LIKE ? || '%'
 		      AND (a.content_hash IS NULL OR a.content_hash = '')
+		      AND COALESCE(a.media_type, '') <> 'link'
 		  )
-	`, sourceID)
+	`, sourceID, prefix)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	var items []BeeperPendingAttachmentMessage
+	var items []PendingAttachmentMessage
 	for rows.Next() {
-		var item BeeperPendingAttachmentMessage
+		var item PendingAttachmentMessage
 		if err := rows.Scan(&item.MessageID, &item.SourceMessageID, &item.ChatID); err != nil {
 			return nil, err
 		}
 		items = append(items, item)
 	}
 	return items, rows.Err()
+}
+
+// ListBeeperPendingAttachmentMessages returns the messages of a beeper
+// source that still have pending attachment markers (see
+// listPendingAttachmentMessages).
+func (s *Store) ListBeeperPendingAttachmentMessages(sourceID int64) ([]PendingAttachmentMessage, error) {
+	return s.listPendingAttachmentMessages(sourceID, "beeper:")
+}
+
+// ListSlackPendingAttachmentMessages returns the messages of a slack source
+// that still have pending attachment markers (see
+// listPendingAttachmentMessages). Metadata-only link rows (media_type
+// "link") are deliberate non-downloads, not pending work.
+func (s *Store) ListSlackPendingAttachmentMessages(sourceID int64) ([]PendingAttachmentMessage, error) {
+	return s.listPendingAttachmentMessages(sourceID, "slack:")
+}
+
+// ReplaceMessageSlackAttachments replaces Slack-managed attachment rows for
+// a message (rows whose source_attachment_id carries the "slack:" prefix).
+func (s *Store) ReplaceMessageSlackAttachments(messageID int64, refs []AttachmentRef) error {
+	return s.replaceMessageAttachmentsWhere(messageID, `source_attachment_id LIKE 'slack:%'`, false, refs)
+}
+
+// MessageSlackAttachments returns the message's existing Slack-managed
+// attachment rows keyed by source_attachment_id, so re-persisting a message
+// can keep already-downloaded media without re-fetching it.
+func (s *Store) MessageSlackAttachments(messageID int64) (map[string]AttachmentRef, error) {
+	return s.messageAttachmentsByPrefix(messageID, "slack:")
 }
 
 // ReplaceMessageLinkAttachments replaces URL-backed attachment rows for a message.


### PR DESCRIPTION
Archive your own view of a Slack workspace — public/private channels you're a member of, group DMs, and 1:1 DMs — via the Web API, searchable alongside mail and other chat sources through the existing TUI / FTS / Parquet analytics.

## Usage

```bash
msgvault add-slack     # user token (xoxp-…) from an internal app you create — 2-minute setup, scope list in docs/usage/slack.md
msgvault sync-slack    # first run backfills full history; later runs are incremental
```

Each workspace is its own source (`slack`, identified by `<team-id>:<user-id>`); multiple workspaces coexist and stay separately filterable in the TUI. A `[slack]` config block covers daemon scheduling, channel include/exclude filters, a media size cap, and the thread-tracking window.

## What's stored

Message text with FTS (mrkdwn rendered, mentions resolved to names), threads (root+reply via `reply_to_message_id`), reactions, @mention recipient rows, edits, conversation membership, files in the content-addressed attachment store, and the verbatim API JSON per message (`raw_format = slack_json`). Bot/integration messages that carry their content in legacy `attachments` or Block Kit `blocks` get that text extracted into the searchable body. Members' profile emails unify their Slack identity with their archived mail (Teams AAD-resolution precedent).

## Behavior notes

- Reuses the existing chat schema — no new core tables.
- The client is read-only by construction (a strict method allowlist rejects anything outside the read set) and internal-app rate limits apply (999-message pages; the 2025 non-Marketplace clampdown targets distributed apps only).
- Slack never surfaces thread replies in oldest-filtered channel history, so incremental sync tracks thread roots and polls `conversations.replies` per root for a configurable lookback (default 30 days); older late replies and edits beyond the 7-day rescan window are caught by `--full`.
- Backfills checkpoint per conversation and mid-conversation; cursors only advance after a window fully persists, so interrupted or partially-failed runs resume without loss or duplicates.
- File bytes are fetched only from `files.slack.com` (no redirects followed); external/off-host files are recorded as metadata + permalink. Failed downloads retry via `backfill-slack-media`.
- Conversations that enumerate but 404 on read are skipped, not fatal (observed live: a sandbox Slackbot DM).
- Link unfurls on user messages are not indexed (page previews are content the person never wrote).
- Archived messages survive source deletion (archive semantics).

## Store/query changes

- Slack attachment-row methods share prefix-parameterized helpers with the Beeper ones (`listPendingAttachmentMessages`, `messageAttachmentsByPrefix`); `BeeperPendingAttachmentMessage` is now an alias of the shared `PendingAttachmentMessage`.
- `"slack"` registered in `KnownMessageTypes` / `TextMessageTypes`.

Validated against live workspaces: full backfill (1,100+ message channel), interrupt/resume, incremental re-runs, threads incl. cross-run late replies, reactions (incl. custom emoji), media download into CAS packs, bot payloads, a real 429 absorbed via Retry-After (env-gated live test included), and history depth past 8 years on a paid plan.

Planned follow-up (separate PR): opt-in archiving of unjoined public channels via an explicit config allowlist — reads verified live; kept out of this PR so the consent/config design can be discussed on its own.
