### PR TITLE
fix: make granola sent_at assertions timezone-independent

### DIFF
--- a/internal/granola/importer_test.go
+++ b/internal/granola/importer_test.go
@@ -148,15 +148,17 @@ func TestImport_RoundTrip(t *testing.T) {
 	assert.EqualValues(0, sum.Errors)
 
 	// Message row: type, subject, sent_at from the scheduled start, organizer
-	// bob is not the account holder.
-	var subject, sentAt string
+	// bob is not the account holder. sent_at compares as an instant, not a
+	// rendered string: text renderings follow the session/local timezone and
+	// fail on non-UTC machines.
+	var subject string
+	var sentAt time.Time
 	var fromMe bool
 	require.NoError(st.DB().QueryRow(st.Rebind(
 		`SELECT subject, sent_at, is_from_me FROM messages WHERE source_message_id = ?`),
 		"not_Ab12Cd34Ef56Gh").Scan(&subject, &sentAt, &fromMe))
 	assert.Equal("Quarterly Planning Review", subject)
-	assert.Contains(sentAt, "2026-06-01")
-	assert.Contains(sentAt, "15:00:00")
+	assert.Equal(time.Date(2026, 6, 1, 15, 0, 0, 0, time.UTC), sentAt.UTC())
 	assert.False(fromMe, "organizer bob is not the account identifier")
 
 	// The ad-hoc note: title fallback, owner alice IS the account holder.
@@ -435,10 +437,13 @@ func TestImport_NormalizesSentAtToUTC(t *testing.T) {
 
 	_, err := imp.Import(context.Background(), ImportOptions{Identifier: "alice@example.com"})
 	require.NoError(err)
-	var sentAt string
-	require.NoError(st.DB().QueryRow(`SELECT CAST(sent_at AS TEXT) FROM messages`).Scan(&sentAt))
-	assert.Contains(sentAt, "2026-06-01 20:00:00")
-	assert.NotContains(sentAt, "-05:00")
+	// Instant equality proves the -05:00 source offset was normalized: the
+	// stored value IS 20:00 UTC. Comparing rendered text instead would tie
+	// the assertion to the session/local timezone and fail on non-UTC
+	// machines (PostgreSQL renders timestamptz in the session zone).
+	var sentAt time.Time
+	require.NoError(st.DB().QueryRow(`SELECT sent_at FROM messages`).Scan(&sentAt))
+	assert.Equal(time.Date(2026, 6, 1, 20, 0, 0, 0, time.UTC), sentAt.UTC())
 }
 
 func TestImport_IdempotentAndRefresh(t *testing.T) {


### PR DESCRIPTION
Two granola tests asserted rendered timestamp strings (`CAST(sent_at AS TEXT)` / raw text scan). PostgreSQL renders `timestamptz` in the session timezone, so `make test-pg` fails in `internal/granola` on any non-UTC machine (e.g. Africa/Johannesburg: "2026-06-01 22:00:00+02" does not contain "2026-06-01 20:00:00") even though the stored instant is correct.

Scan into `time.Time` and compare instants in UTC instead — the pattern the rest of the file already uses. Instant equality also states the UTC-normalization intent more directly than the string probes: `15:00:00-05:00` stored **is** `20:00:00Z`.

Verified on SQLite and PostgreSQL from a UTC+2 machine with no TZ/PGTZ pinning.