### PR TITLE
feat(o365): allow users to configure redirect_uri alongside client_id

### DIFF
--- a/cmd/msgvault/cmd/add_teams.go
+++ b/cmd/msgvault/cmd/add_teams.go
@@ -40,6 +40,7 @@ func preflightAddTeamsAuthorize(cmd *cobra.Command, email string) error {
 	mgr := microsoft.NewGraphManager(
 		cfg.Microsoft.ClientID,
 		microsoftTenantID(teamsTenantID),
+		cfg.Microsoft.EffectiveRedirectURI(),
 		cfg.TokensDir(),
 		logger,
 	)
@@ -93,6 +94,7 @@ func runAddTeamsLocal(cmd *cobra.Command, args []string) error {
 		mgr := microsoft.NewGraphManager(
 			cfg.Microsoft.ClientID,
 			microsoftTenantID(teamsTenantID),
+			cfg.Microsoft.EffectiveRedirectURI(),
 			cfg.TokensDir(),
 			logger,
 		)

--- a/cmd/msgvault/cmd/addo365.go
+++ b/cmd/msgvault/cmd/addo365.go
@@ -43,6 +43,7 @@ func preflightAddO365Authorize(cmd *cobra.Command, email string) error {
 	msMgr := microsoft.NewManager(
 		cfg.Microsoft.ClientID,
 		microsoftTenantID(o365TenantID),
+		cfg.Microsoft.EffectiveRedirectURI(),
 		cfg.TokensDir(),
 		logger,
 	)
@@ -91,6 +92,7 @@ func runAddO365Local(cmd *cobra.Command, args []string) error {
 	msMgr := microsoft.NewManager(
 		cfg.Microsoft.ClientID,
 		microsoftTenantID(o365TenantID),
+		cfg.Microsoft.EffectiveRedirectURI(),
 		cfg.TokensDir(),
 		logger,
 	)

--- a/cmd/msgvault/cmd/backfill_teams_media.go
+++ b/cmd/msgvault/cmd/backfill_teams_media.go
@@ -58,6 +58,7 @@ Examples:
 		mgr := microsoft.NewGraphManager(
 			cfg.Microsoft.ClientID,
 			cfg.Microsoft.EffectiveTenantID(),
+			cfg.Microsoft.EffectiveRedirectURI(),
 			cfg.TokensDir(),
 			logger,
 		)

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -279,6 +279,7 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 		graphMgr := microsoft.NewGraphManager(
 			cfg.Microsoft.ClientID,
 			cfg.Microsoft.EffectiveTenantID(),
+			cfg.Microsoft.EffectiveRedirectURI(),
 			cfg.TokensDir(),
 			logger,
 		)
@@ -322,6 +323,7 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 					msMgr := microsoft.NewManager(
 						cfg.Microsoft.ClientID,
 						cfg.Microsoft.EffectiveTenantID(),
+						cfg.Microsoft.EffectiveRedirectURI(),
 						cfg.TokensDir(),
 						logger,
 					)

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -982,7 +982,7 @@ func TestRemoveAccountCmd_TeamsRemovesGraphToken(t *testing.T) {
 	require.NoError(err, "create source")
 	_ = s.Close()
 
-	mgr := microsoft.NewGraphManager("client-id", "", tokensDir, nil)
+	mgr := microsoft.NewGraphManager("client-id", "", "", tokensDir, nil)
 	tokenPath := mgr.TokenPath("tok@example.com")
 	require.NoError(os.WriteFile(tokenPath, []byte(`{}`), 0600), "write teams token")
 

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1579,7 +1579,7 @@ func runScheduledTeamsSync(ctx context.Context, src *store.Source, s *store.Stor
 		return fmt.Errorf("post-source-create migrations: %w", err)
 	}
 
-	mgr := microsoft.NewGraphManager(cfg.Microsoft.ClientID, cfg.Microsoft.EffectiveTenantID(), cfg.TokensDir(), logger)
+	mgr := microsoft.NewGraphManager(cfg.Microsoft.ClientID, cfg.Microsoft.EffectiveTenantID(), cfg.Microsoft.EffectiveRedirectURI(), cfg.TokensDir(), logger)
 	tokenFn, err := mgr.TokenSource(ctx, email)
 	if err != nil {
 		return err

--- a/cmd/msgvault/cmd/sync_teams.go
+++ b/cmd/msgvault/cmd/sync_teams.go
@@ -63,6 +63,7 @@ Examples:
 		mgr := microsoft.NewGraphManager(
 			cfg.Microsoft.ClientID,
 			cfg.Microsoft.EffectiveTenantID(),
+			cfg.Microsoft.EffectiveRedirectURI(),
 			cfg.TokensDir(),
 			logger,
 		)

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -309,6 +309,7 @@ func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(str
 			msMgr := microsoft.NewManager(
 				cfg.Microsoft.ClientID,
 				cfg.Microsoft.EffectiveTenantID(),
+				cfg.Microsoft.EffectiveRedirectURI(),
 				cfg.TokensDir(),
 				logger,
 			)
@@ -773,6 +774,7 @@ func imapSkipReason(src *store.Source) (string, error) {
 		msMgr := microsoft.NewManager(
 			cfg.Microsoft.ClientID,
 			cfg.Microsoft.EffectiveTenantID(),
+			cfg.Microsoft.EffectiveRedirectURI(),
 			cfg.TokensDir(),
 			logger,
 		)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ client_secrets = "/path/to/acme_workspace_secret.json"
 [microsoft]
 # Azure AD app registration client ID (required for M365)
 client_id = "your-azure-app-client-id"
+# redirect_uri = "http://localhost:8089/callback/microsoft"  # default
 # tenant_id = "your-tenant-id"   # optional, default "common"
 
 [discord]
@@ -186,6 +187,7 @@ sync. Required only if you use `add-o365`, `add-teams`, or `sync-teams`.
 | Key | Default | Description |
 |---|---|---|
 | `client_id` | — | Azure AD Application (client) ID (required) |
+| `redirect_uri` | `http://localhost:8089/callback/microsoft` | OAuth redirect URI registered in the Azure AD app |
 | `tenant_id` | `common` | Azure AD tenant ID; `common` allows both personal and org accounts |
 
 See [OAuth Setup: Microsoft 365](/guides/oauth-setup/#microsoft-365-outlook-hotmail) for app registration steps. Teams uses the same `client_id` but requests Microsoft Graph scopes and stores tokens under `tokens/teams_<email>.json`; Outlook/Hotmail IMAP OAuth uses `tokens/microsoft_<email>.json`.

--- a/docs/guides/oauth-setup.md
+++ b/docs/guides/oauth-setup.md
@@ -255,11 +255,12 @@ You need to register an application in Microsoft Entra (Azure AD) before using `
 2. Set the fields:
    - **Name:** `msgvault`
    - **Supported account types:** "Accounts in any organizational directory and personal Microsoft accounts"
-   - **Redirect URI:** Platform = **Mobile and desktop applications**, URI = `http://localhost:8089/callback/microsoft`
+    - **Redirect URI:** Platform = **Mobile and desktop applications**, URI = your `redirect_uri` from `config.toml` (default: `http://localhost:8089/callback/microsoft`)
 3. Click **Register**
 4. Under **API permissions**, click **Add a permission > APIs my organization uses**, search for **Office 365 Exchange Online**, select **Delegated permissions**, then add `IMAP.AccessAsUser.All`
 5. Under **Authentication**, enable **Allow public client flows** (required for PKCE)
-6. Copy the **Application (client) ID** from the app's Overview page
+6. If you will use a custom `redirect_uri` in `config.toml`, make sure the Redirect URI in the app registration matches it exactly — including scheme, host, port, and path. For `https://localhost/` on a privileged port (e.g. 443), register that exact URI.
+7. Copy the **Application (client) ID** from the app's Overview page
 
 ### Configure msgvault
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,8 +340,18 @@ func (o *OAuthConfig) HasAnyConfig() bool {
 
 // MicrosoftConfig holds Microsoft 365 / Azure AD OAuth configuration.
 type MicrosoftConfig struct {
-	ClientID string `toml:"client_id"`
-	TenantID string `toml:"tenant_id"`
+	ClientID    string `toml:"client_id"`
+	TenantID    string `toml:"tenant_id"`
+	RedirectURI string `toml:"redirect_uri"`
+}
+
+// EffectiveRedirectURI returns the redirect URI, defaulting to the
+// standard OAuth callback URI for local development.
+func (c *MicrosoftConfig) EffectiveRedirectURI() string {
+	if c.RedirectURI != "" {
+		return c.RedirectURI
+	}
+	return "http://localhost:8089/callback/microsoft"
 }
 
 // EffectiveTenantID returns the tenant ID, defaulting to "common"

--- a/internal/microsoft/graph_oauth.go
+++ b/internal/microsoft/graph_oauth.go
@@ -45,10 +45,11 @@ func GraphScopes() []string {
 // internal *Manager delegate; only token storage (filename prefix) and the
 // scope set differ. This keeps Manager's external behavior unchanged.
 type GraphManager struct {
-	clientID  string
-	tenantID  string
-	tokensDir string
-	logger    *slog.Logger
+	clientID    string
+	tenantID    string
+	redirectURI string
+	tokensDir   string
+	logger      *slog.Logger
 
 	// Test hooks, mirrored onto the internal delegate. See Manager.
 	browserFlowFn   func(ctx context.Context, email string, scopes []string) (*oauth2.Token, string, error)
@@ -57,7 +58,7 @@ type GraphManager struct {
 
 // NewGraphManager constructs a GraphManager. An empty tenantID defaults to the
 // multi-tenant "common" endpoint; a nil logger defaults to slog.Default().
-func NewGraphManager(clientID, tenantID, tokensDir string, logger *slog.Logger) *GraphManager {
+func NewGraphManager(clientID, tenantID, redirectURI, tokensDir string, logger *slog.Logger) *GraphManager {
 	if tenantID == "" {
 		tenantID = DefaultTenant
 	}
@@ -65,10 +66,11 @@ func NewGraphManager(clientID, tenantID, tokensDir string, logger *slog.Logger) 
 		logger = slog.Default()
 	}
 	return &GraphManager{
-		clientID:  clientID,
-		tenantID:  tenantID,
-		tokensDir: tokensDir,
-		logger:    logger,
+		clientID:    clientID,
+		tenantID:    tenantID,
+		redirectURI: redirectURI,
+		tokensDir:   tokensDir,
+		logger:      logger,
 	}
 }
 
@@ -79,6 +81,7 @@ func (m *GraphManager) delegate() *Manager {
 	return &Manager{
 		clientID:        m.clientID,
 		tenantID:        m.tenantID,
+		redirectURI:     m.redirectURI,
 		tokensDir:       m.tokensDir,
 		logger:          m.logger,
 		browserFlowFn:   m.browserFlowFn,

--- a/internal/microsoft/graph_oauth_test.go
+++ b/internal/microsoft/graph_oauth_test.go
@@ -31,7 +31,7 @@ func TestGraphScopes(t *testing.T) {
 }
 
 func TestNewGraphManager_DefaultsTenant(t *testing.T) {
-	m := NewGraphManager("client", "", "tmp/tokens", nil)
+	m := NewGraphManager("client", "", "", "tmp/tokens", nil)
 	assert.Equal(t, DefaultTenant, m.tenantID, "tenantID should default to common")
 	require.NotNil(t, m.logger, "logger should default")
 }
@@ -40,7 +40,7 @@ func TestGraphManager_SaveLoadHasToken(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	dir := t.TempDir()
-	m := NewGraphManager("client", "common", dir, slog.Default())
+	m := NewGraphManager("client", "common", "", dir, slog.Default())
 
 	assert.False(m.HasToken("user@example.com"), "HasToken false before save")
 
@@ -66,7 +66,7 @@ func TestGraphManager_Authorize_PersistsGraphToken(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	dir := t.TempDir()
-	m := NewGraphManager("test-client", "common", dir, slog.Default())
+	m := NewGraphManager("test-client", "common", "", dir, slog.Default())
 	m.verifyIDTokenFn = testVerifyFn
 
 	var gotScopes []string
@@ -93,7 +93,7 @@ func TestGraphManager_Authorize_PersistsGraphToken(t *testing.T) {
 
 func TestGraphManager_Authorize_Mismatch(t *testing.T) {
 	dir := t.TempDir()
-	m := NewGraphManager("test-client", "common", dir, slog.Default())
+	m := NewGraphManager("test-client", "common", "", dir, slog.Default())
 	m.verifyIDTokenFn = testVerifyFn
 	m.browserFlowFn = func(_ context.Context, _ string, _ []string) (*oauth2.Token, string, error) {
 		idToken := makeIDToken(t, map[string]any{"email": "other@example.com"})
@@ -109,7 +109,7 @@ func TestGraphManager_Authorize_Mismatch(t *testing.T) {
 
 func TestGraphManager_TokenSource_NoIMAPValidation(t *testing.T) {
 	dir := t.TempDir()
-	m := NewGraphManager("test-client", "common", dir, slog.Default())
+	m := NewGraphManager("test-client", "common", "", dir, slog.Default())
 
 	// Save a Graph token. There is no IMAP scope; the IMAP Manager would
 	// reject this, but GraphManager must accept it.
@@ -124,7 +124,7 @@ func TestGraphManager_TokenSource_NoIMAPValidation(t *testing.T) {
 func TestGraphManager_TokenSource_StaleGraphScopesReturnsError(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()
-	m := NewGraphManager("test-client", "common", dir, slog.Default())
+	m := NewGraphManager("test-client", "common", "", dir, slog.Default())
 
 	token := &oauth2.Token{AccessToken: "graph-access", RefreshToken: "graph-refresh", TokenType: "Bearer"}
 	oldScopes := []string{
@@ -147,7 +147,7 @@ func TestGraphManager_TokenSource_StaleGraphScopesReturnsError(t *testing.T) {
 }
 
 func TestGraphManager_TokenSource_MissingToken(t *testing.T) {
-	m := NewGraphManager("test-client", "common", t.TempDir(), slog.Default())
+	m := NewGraphManager("test-client", "common", "", t.TempDir(), slog.Default())
 	_, err := m.TokenSource(t.Context(), "nobody@example.com")
 	require.Error(t, err, "expected error for missing token")
 	assert.ErrorContains(t, err, "no valid token")
@@ -155,7 +155,7 @@ func TestGraphManager_TokenSource_MissingToken(t *testing.T) {
 
 func TestGraphManager_TokenSource_Concurrent(t *testing.T) {
 	dir := t.TempDir()
-	m := NewGraphManager("test-client", "common", dir, slog.Default())
+	m := NewGraphManager("test-client", "common", "", dir, slog.Default())
 	token := &oauth2.Token{AccessToken: "graph-access", RefreshToken: "graph-refresh", TokenType: "Bearer"}
 	require.NoError(t, m.saveToken("user@company.com", token, GraphScopes(), "org-tid"))
 

--- a/internal/microsoft/oauth.go
+++ b/internal/microsoft/oauth.go
@@ -1,14 +1,20 @@
 package microsoft
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -16,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -37,9 +44,6 @@ const (
 	// MicrosoftConsumerTenantID is the fixed tenant ID for all personal
 	// Microsoft accounts (outlook.com, hotmail.com, live.com, etc.).
 	MicrosoftConsumerTenantID = "9188040d-6c67-4c5b-b112-36a304b66dad"
-
-	redirectPort = "8089"
-	callbackPath = "/callback/microsoft"
 
 	// scopeOfflineAccess is the OAuth scope requesting a refresh token.
 	scopeOfflineAccess = "offline_access"
@@ -105,10 +109,11 @@ func (e *TokenMismatchError) Error() string {
 }
 
 type Manager struct {
-	clientID  string
-	tenantID  string
-	tokensDir string
-	logger    *slog.Logger
+	clientID    string
+	tenantID    string
+	redirectURI string
+	tokensDir   string
+	logger      *slog.Logger
 
 	// browserFlowFn overrides browserFlow for testing. Returns (token, nonce, error).
 	browserFlowFn func(ctx context.Context, email string, scopes []string) (*oauth2.Token, string, error)
@@ -116,7 +121,7 @@ type Manager struct {
 	verifyIDTokenFn func(ctx context.Context, rawIDToken string) (*idTokenClaims, error)
 }
 
-func NewManager(clientID, tenantID, tokensDir string, logger *slog.Logger) *Manager {
+func NewManager(clientID, tenantID, redirectURI, tokensDir string, logger *slog.Logger) *Manager {
 	if tenantID == "" {
 		tenantID = DefaultTenant
 	}
@@ -124,10 +129,11 @@ func NewManager(clientID, tenantID, tokensDir string, logger *slog.Logger) *Mana
 		logger = slog.Default()
 	}
 	return &Manager{
-		clientID:  clientID,
-		tenantID:  tenantID,
-		tokensDir: tokensDir,
-		logger:    logger,
+		clientID:    clientID,
+		tenantID:    tenantID,
+		redirectURI: redirectURI,
+		tokensDir:   tokensDir,
+		logger:      logger,
 	}
 }
 
@@ -142,7 +148,7 @@ func (m *Manager) oauthConfigWithTenant(tenantID string, scopes []string) *oauth
 			AuthURL:  fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize", tenantID),
 			TokenURL: fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID),
 		},
-		RedirectURL: "http://localhost:" + redirectPort + callbackPath,
+		RedirectURL: m.redirectURI,
 		Scopes:      scopes,
 	}
 }
@@ -339,14 +345,22 @@ func (m *Manager) IMAPHost(email string) (string, error) {
 }
 
 func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string) (*oauth2.Token, string, error) {
-	// Bound the entire browser flow to 5 minutes. This prevents port 8089
+	// Bound the entire browser flow to 5 minutes. This prevents the port
 	// from staying bound indefinitely if the user abandons authorization.
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
+	scheme, host, redirectPort, callbackPath, err := redirectURIParts(m.redirectURI)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse redirect URI: %w", err)
+	}
+
 	// Bind the listener before constructing the auth URL so that the redirect
 	// URI embedded in the authorization request matches exactly. Failing fast
 	// here produces a clear error instead of a silent hang.
+	if err := checkBindPort(redirectPort); err != nil {
+		return nil, "", fmt.Errorf("cannot bind to port %s: %w", redirectPort, err)
+	}
 	lc := &net.ListenConfig{}
 	ln, err := lc.Listen(ctx, "tcp", "localhost:"+redirectPort)
 	if err != nil {
@@ -355,6 +369,18 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 			redirectPort, err,
 		)
 	}
+
+	if scheme == "https" {
+		certCert, err := generateSelfSignedCert([]string{host})
+		if err != nil {
+			return nil, "", fmt.Errorf("generate self-signed TLS cert: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, "\nThis is a self-signed certificate for localhost.\n\n    Your browser will show a certificate warning on https://localhost\n    — click \"Advanced\" → \"Accept the risk and continue\" to proceed.")
+		tlsCfg := &tls.Config{Certificates: []tls.Certificate{certCert}, MinVersion: tls.VersionTLS12}
+		ln = tls.NewListener(ln, tlsCfg)
+	}
+
+	defer ln.Close()
 
 	cfg := m.oauthConfig(scopes)
 
@@ -451,6 +477,8 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 
 	fmt.Printf("Opening browser for Microsoft authorization...\n")
 	fmt.Printf("If browser doesn't open, visit:\n%s\n\n", redactAuthURL(authURL))
+	// Note: browser will show a self-signed cert warning on https://localhost —
+	// the user must click "Advanced" → "Accept the risk and continue".
 	if err := openBrowser(ctx, authURL); err != nil {
 		m.logger.Warn("failed to open browser", "error", err)
 	}
@@ -470,6 +498,50 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 		return nil, "", ctx.Err()
 	}
 }
+
+// generateSelfSignedCert creates a self-signed TLS certificate for the given hosts.
+func generateSelfSignedCert(hosts []string) (tls.Certificate, error) {
+	var buf bytes.Buffer
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate key: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		NotBefore:    time.Now().Add(-24 * time.Hour),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	if len(hosts) == 0 {
+		template.DNSNames = []string{"localhost"}
+	} else {
+		template.DNSNames = hosts
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("create certificate: %w", err)
+	}
+
+	if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		return tls.Certificate{}, fmt.Errorf("encode cert: %w", err)
+	}
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("marshal key: %w", err)
+	}
+	if err := pem.Encode(&buf, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}); err != nil {
+		return tls.Certificate{}, fmt.Errorf("encode key: %w", err)
+	}
+
+	return tls.X509KeyPair(buf.Bytes(), buf.Bytes())
+}
+
 
 // resolveTokenEmail verifies the ID token and validates the authenticated
 // email matches the expected address. Uses OIDC signature/issuer/audience
@@ -788,5 +860,52 @@ func openBrowser(ctx context.Context, rawURL string) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start browser command: %w", err)
 	}
+	return nil
+}
+
+// redirectURIParts parses a redirect URL string and returns its scheme,
+// host, port, and path components. Returns the port as "443" for
+// https:// URLs with no explicit port, and "80" for http:// URLs with
+// no explicit port so callers can decide whether TLS is needed.
+func redirectURIParts(rawURL string) (scheme, host, redirectPort, path string, err error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("parse URL %q: %w", rawURL, err)
+	}
+	scheme = parsed.Scheme
+	host = parsed.Hostname()
+	redirectPort = parsed.Port()
+	if redirectPort == "" {
+		if scheme == "https" {
+			redirectPort = "443"
+		} else {
+			redirectPort = "80"
+		}
+	}
+	if scheme != "https" && scheme != "http" {
+		return "", "", "", "", fmt.Errorf("redirect URL scheme %q not supported (only http and https)", scheme)
+	}
+	path = parsed.Path
+	if path == "" {
+		path = "/"
+	}
+	return scheme, host, redirectPort, path, nil
+}
+
+// checkBindPort verifies that the process can bind to port.
+func checkBindPort(port string) error {
+	ln, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		// If we're trying to bind a privileged port (< 1024) without the
+		// cap_net_bind_service capability, provide a clear hint.
+		p, _ := strconv.Atoi(port)
+		if p > 0 && p < 1024 {
+			return fmt.Errorf("cannot bind to privileged port %s: %w\n\n"+
+				"Fix by granting the capability to the binary:\n"+
+				"  sudo setcap 'cap_net_bind_service=+ep' \"$(which msgvault)\"", port, err)
+		}
+		return fmt.Errorf("cannot bind to port %s: %w", port, err)
+	}
+	_ = ln.Close()
 	return nil
 }

--- a/internal/microsoft/oauth.go
+++ b/internal/microsoft/oauth.go
@@ -361,8 +361,24 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 	if err := checkBindPort(redirectPort); err != nil {
 		return nil, "", fmt.Errorf("cannot bind to port %s: %w", redirectPort, err)
 	}
+
+	bindHost := "localhost"
+	if host == "localhost" || host == "" {
+		bindHost = "localhost"
+	} else if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		// Allow 127.x.x.x, ::1 — use the configured loopback address so the
+		// bind address matches the redirect URI (browser sends callback to
+		// 127.0.0.1, server listens on 127.0.0.1, etc.).
+		bindHost = host
+	} else {
+		return nil, "", fmt.Errorf(
+			"redirect URI host %q must be localhost or a loopback address", host,
+		)
+	}
+	bindAddr := net.JoinHostPort(bindHost, redirectPort)
+
 	lc := &net.ListenConfig{}
-	ln, err := lc.Listen(ctx, "tcp", "localhost:"+redirectPort)
+	ln, err := lc.Listen(ctx, "tcp4", bindAddr)
 	if err != nil {
 		return nil, "", fmt.Errorf(
 			"port %s is already in use — ensure no other process is using it and retry: %w",

--- a/internal/microsoft/oauth.go
+++ b/internal/microsoft/oauth.go
@@ -358,9 +358,6 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 	// Bind the listener before constructing the auth URL so that the redirect
 	// URI embedded in the authorization request matches exactly. Failing fast
 	// here produces a clear error instead of a silent hang.
-	if err := checkBindPort(redirectPort); err != nil {
-		return nil, "", fmt.Errorf("cannot bind to port %s: %w", redirectPort, err)
-	}
 
 	bindHost := "localhost"
 	if host == "localhost" || host == "" {
@@ -378,12 +375,23 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 	bindAddr := net.JoinHostPort(bindHost, redirectPort)
 
 	lc := &net.ListenConfig{}
-	ln, err := lc.Listen(ctx, "tcp4", bindAddr)
+	ln, err := lc.Listen(ctx, "tcp", bindAddr)
 	if err != nil {
-		return nil, "", fmt.Errorf(
-			"port %s is already in use — ensure no other process is using it and retry: %w",
-			redirectPort, err,
-		)
+		p, perr := strconv.Atoi(redirectPort)
+		switch {
+		case perr == nil && p > 0 && p < 1024:
+			return nil, "", fmt.Errorf(
+				"cannot bind to privileged port %d: %w\n\n"+
+					"Fix by granting the capability to the binary:\n"+
+					"  sudo setcap 'cap_net_bind_service=+ep' \"$(which msgvault)\"",
+				p, err,
+			)
+		default:
+			return nil, "", fmt.Errorf(
+				"port %s is already in use — ensure no other process is using it and retry: %w",
+				redirectPort, err,
+			)
+		}
 	}
 
 	if scheme == "https" {
@@ -906,22 +914,4 @@ func redirectURIParts(rawURL string) (scheme, host, redirectPort, path string, e
 		path = "/"
 	}
 	return scheme, host, redirectPort, path, nil
-}
-
-// checkBindPort verifies that the process can bind to port.
-func checkBindPort(port string) error {
-	ln, err := net.Listen("tcp", ":"+port)
-	if err != nil {
-		// If we're trying to bind a privileged port (< 1024) without the
-		// cap_net_bind_service capability, provide a clear hint.
-		p, _ := strconv.Atoi(port)
-		if p > 0 && p < 1024 {
-			return fmt.Errorf("cannot bind to privileged port %s: %w\n\n"+
-				"Fix by granting the capability to the binary:\n"+
-				"  sudo setcap 'cap_net_bind_service=+ep' \"$(which msgvault)\"", port, err)
-		}
-		return fmt.Errorf("cannot bind to port %s: %w", port, err)
-	}
-	_ = ln.Close()
-	return nil
 }

--- a/internal/microsoft/oauth.go
+++ b/internal/microsoft/oauth.go
@@ -359,15 +359,17 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 	// URI embedded in the authorization request matches exactly. Failing fast
 	// here produces a clear error instead of a silent hang.
 
-	bindHost := "localhost"
-	if host == "localhost" || host == "" {
+	ip := net.ParseIP(host)
+	var bindHost string
+	switch {
+	case host == "localhost" || host == "":
 		bindHost = "localhost"
-	} else if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+	case ip != nil && ip.IsLoopback():
 		// Allow 127.x.x.x, ::1 — use the configured loopback address so the
 		// bind address matches the redirect URI (browser sends callback to
 		// 127.0.0.1, server listens on 127.0.0.1, etc.).
 		bindHost = host
-	} else {
+	default:
 		return nil, "", fmt.Errorf(
 			"redirect URI host %q must be localhost or a loopback address", host,
 		)
@@ -404,7 +406,7 @@ func (m *Manager) browserFlow(ctx context.Context, email string, scopes []string
 		ln = tls.NewListener(ln, tlsCfg)
 	}
 
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	cfg := m.oauthConfig(scopes)
 
@@ -536,7 +538,7 @@ func generateSelfSignedCert(hosts []string) (tls.Certificate, error) {
 		SerialNumber: big.NewInt(time.Now().UnixNano()),
 		NotBefore:    time.Now().Add(-24 * time.Hour),
 		NotAfter:     time.Now().Add(1 * time.Hour),
-		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 	}
@@ -563,9 +565,12 @@ func generateSelfSignedCert(hosts []string) (tls.Certificate, error) {
 		return tls.Certificate{}, fmt.Errorf("encode key: %w", err)
 	}
 
-	return tls.X509KeyPair(buf.Bytes(), buf.Bytes())
+	cert, err := tls.X509KeyPair(buf.Bytes(), buf.Bytes())
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("parse generated certificate and key: %w", err)
+	}
+	return cert, nil
 }
-
 
 // resolveTokenEmail verifies the ID token and validates the authenticated
 // email matches the expected address. Uses OIDC signature/issuer/audience


### PR DESCRIPTION
The OAuth redirect URI is tied to the client ID at the provider — the callback URI registered in the app must match what msgvault sends. This adds a redirect_uri config field so users can specify their own and use it with any client ID, without relying on a hardcoded redirect port/path.

Also supports localhost URIs on privileged ports (e.g. Thunderbird's https://localhost/ on port 443). https redirects use a self-signed certificate so the OAuth flow works end-to-end for local testing.