### PR TITLE
feat: Slack workspace archiving (user-token sync + search-based reply sweep)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ make lint                     # Run linter
 ./msgvault sync-teams you@tenant.com         # Sync Teams chats + channels
 ./msgvault sync-teams you@tenant.com --no-channels --limit 50
 
+# Slack (user token from your own internal app)
+./msgvault add-slack                         # Register a workspace (prompts for xoxp token)
+./msgvault sync-slack                        # Sync channels, group DMs, DMs
+./msgvault sync-slack --full                 # Repair: re-fetch + upsert in place
+
 # Daemon mode (NAS/server deployment)
 ./msgvault serve                                      # Start HTTP API + scheduled syncs
 

--- a/cmd/msgvault/cmd/add_slack.go
+++ b/cmd/msgvault/cmd/add_slack.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/clirun"
+	"go.kenn.io/msgvault/internal/slack"
+)
+
+var (
+	addSlackTokenFile         string
+	noDefaultIdentityAddSlack bool
+)
+
+func newAddSlackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-slack",
+		Short: "Add a Slack workspace as an archive source",
+		Long: `Add a Slack workspace as an archive source.
+
+Archives your own view of the workspace — public/private channels you are a
+member of, group DMs, and 1:1 DMs — via the Slack Web API.
+
+Requires a user token (xoxp-...) from an internal Slack app you create:
+
+  1. https://api.slack.com/apps > Create New App > From scratch, in your
+     workspace.
+  2. OAuth & Permissions > User Token Scopes, add:
+       channels:history groups:history im:history mpim:history
+       channels:read groups:read im:read mpim:read
+       users:read users:read.email files:read reactions:read team:read
+       search:read
+  3. Install to Workspace, then copy the "User OAuth Token".
+
+Internal apps you create yourself are not subject to Slack's non-Marketplace
+rate limits, so backfills run at full speed.
+
+Provide the token via --token-file, the MSGVAULT_SLACK_TOKEN environment
+variable, or the interactive prompt.
+
+Examples:
+  msgvault add-slack
+  msgvault add-slack --token-file ~/slack-token.txt
+  MSGVAULT_SLACK_TOKEN="xoxp-..." msgvault add-slack`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				token, err := readAddSlackToken(cmd)
+				if err != nil {
+					return err
+				}
+				return runDaemonCLICommandHTTPFromCobraWithEnv(cmd, args, map[string]string{
+					clirun.EnvSlackToken: token,
+				})
+			}
+
+			token := os.Getenv(clirun.EnvSlackToken)
+			if token == "" {
+				return errors.New("missing Slack token in daemon subprocess (set MSGVAULT_SLACK_TOKEN)")
+			}
+			client := slack.NewClient("", token)
+			auth, err := client.AuthTest(cmd.Context())
+			if err != nil {
+				return err
+			}
+			// The reply sweep needs search:read; catch an under-scoped token
+			// here, where the fix is cheap, not on every future sync.
+			if err := client.ValidateSearchScope(cmd.Context()); err != nil {
+				return err
+			}
+			teamDomain := strings.TrimSuffix(strings.TrimPrefix(auth.URL, "https://"), ".slack.com/")
+			if err := slack.SaveToken(cfg.TokensDir(), auth.TeamID, teamDomain, auth.UserID, token); err != nil {
+				return fmt.Errorf("save slack token: %w", err)
+			}
+
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			identifier := auth.TeamID + ":" + auth.UserID
+			source, err := s.GetOrCreateSource(sourceTypeSlack, identifier)
+			if err != nil {
+				return fmt.Errorf("create source for %s: %w", identifier, err)
+			}
+			displayName := "Slack " + auth.Team
+			if err := s.UpdateSourceDisplayName(source.ID, displayName); err != nil {
+				return fmt.Errorf("set display name for %s: %w", identifier, err)
+			}
+			if !noDefaultIdentityAddSlack {
+				confirmDefaultIdentity(cmd.OutOrStdout(), s, source.ID,
+					identifier, auth.UserID, "account-identifier")
+			}
+			if err := runPostSourceCreateMigrations(s); err != nil {
+				return fmt.Errorf("post-source-create migrations: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added Slack workspace %s (%s) as %s\n", auth.Team, auth.TeamID, identifier)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nYou can now run:")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  msgvault sync-slack %s\n", auth.TeamID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&addSlackTokenFile, "token-file", "", "read the Slack user token from this file")
+	cmd.Flags().BoolVar(&noDefaultIdentityAddSlack, "no-default-identity", false, noDefaultIdentityHelp)
+	return cmd
+}
+
+// readAddSlackToken resolves the user token: env var, then --token-file,
+// then interactive masked prompt / piped stdin.
+func readAddSlackToken(cmd *cobra.Command) (string, error) {
+	if envToken := os.Getenv(clirun.EnvSlackToken); envToken != "" {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Using token from %s environment variable\n", clirun.EnvSlackToken); err != nil {
+			return "", fmt.Errorf("write token source notice: %w", err)
+		}
+		return envToken, nil
+	}
+	if addSlackTokenFile != "" {
+		data, err := os.ReadFile(addSlackTokenFile)
+		if err != nil {
+			return "", fmt.Errorf("read token file: %w", err)
+		}
+		token := strings.TrimSpace(string(data))
+		if token == "" {
+			return "", fmt.Errorf("token file %s is empty", addSlackTokenFile)
+		}
+		return token, nil
+	}
+
+	prompt := "Slack user token (xoxp-..., from your app's OAuth & Permissions page):"
+	method, promptOut := choosePasswordStrategy(
+		isatty.IsTerminal(os.Stdin.Fd()),
+		isatty.IsCygwinTerminal(os.Stdin.Fd()),
+		isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd()),
+		isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()),
+	)
+	switch method {
+	case passwordInteractive:
+		return readPasswordInteractive(prompt, promptOut)
+	case passwordNoPrompt:
+		return "", errors.New("cannot read token: no terminal available for prompt (try --token-file, piping the token via stdin, or setting MSGVAULT_SLACK_TOKEN)")
+	case passwordPipe:
+		return readPasswordFromPipe(os.Stdin)
+	default:
+		return "", errors.New("cannot determine token input method")
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(newAddSlackCmd())
+}

--- a/cmd/msgvault/cmd/add_slack.go
+++ b/cmd/msgvault/cmd/add_slack.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/clirun"
 	"go.kenn.io/msgvault/internal/slack"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 var (
@@ -94,8 +96,7 @@ Examples:
 				return fmt.Errorf("set display name for %s: %w", identifier, err)
 			}
 			if !noDefaultIdentityAddSlack {
-				confirmDefaultIdentity(cmd.OutOrStdout(), s, source.ID,
-					identifier, auth.UserID, "account-identifier")
+				confirmDefaultSlackIdentity(cmd.OutOrStdout(), s, source.ID, auth.TeamID, auth.UserID)
 			}
 			if err := runPostSourceCreateMigrations(s); err != nil {
 				return fmt.Errorf("post-source-create migrations: %w", err)
@@ -110,6 +111,11 @@ Examples:
 	cmd.Flags().StringVar(&addSlackTokenFile, "token-file", "", "read the Slack user token from this file")
 	cmd.Flags().BoolVar(&noDefaultIdentityAddSlack, "no-default-identity", false, noDefaultIdentityHelp)
 	return cmd
+}
+
+func confirmDefaultSlackIdentity(out io.Writer, s *store.Store, sourceID int64, teamID, userID string) {
+	account := teamID + ":" + userID
+	confirmDefaultIdentity(out, s, sourceID, account, account, "account-identifier")
 }
 
 // readAddSlackToken resolves the user token: env var, then --token-file,

--- a/cmd/msgvault/cmd/add_slack.go
+++ b/cmd/msgvault/cmd/add_slack.go
@@ -12,6 +12,7 @@ import (
 	"go.kenn.io/msgvault/internal/clirun"
 	"go.kenn.io/msgvault/internal/slack"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/textutil"
 )
 
 var (
@@ -102,7 +103,7 @@ Examples:
 				return fmt.Errorf("post-source-create migrations: %w", err)
 			}
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added Slack workspace %s (%s) as %s\n", auth.Team, auth.TeamID, identifier)
+			writeAddedSlackWorkspace(cmd.OutOrStdout(), auth.Team, auth.TeamID, identifier)
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nYou can now run:")
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  msgvault sync-slack %s\n", auth.TeamID)
 			return nil
@@ -111,6 +112,11 @@ Examples:
 	cmd.Flags().StringVar(&addSlackTokenFile, "token-file", "", "read the Slack user token from this file")
 	cmd.Flags().BoolVar(&noDefaultIdentityAddSlack, "no-default-identity", false, noDefaultIdentityHelp)
 	return cmd
+}
+
+func writeAddedSlackWorkspace(out io.Writer, team, teamID, identifier string) {
+	_, _ = fmt.Fprintf(out, "Added Slack workspace %s (%s) as %s\n",
+		textutil.SanitizeTerminal(team), teamID, identifier)
 }
 
 func confirmDefaultSlackIdentity(out io.Writer, s *store.Store, sourceID int64, teamID, userID string) {

--- a/cmd/msgvault/cmd/attachment_maintenance.go
+++ b/cmd/msgvault/cmd/attachment_maintenance.go
@@ -301,6 +301,7 @@ func attachmentProducingCommand(args []string) bool {
 	switch args[0] {
 	case "backfill-beeper-media",
 		"backfill-discord-media",
+		"backfill-slack-media",
 		"backfill-teams-media",
 		"import",
 		"import-emlx",
@@ -313,6 +314,7 @@ func attachmentProducingCommand(args []string) bool {
 		"import-whatsapp",
 		"sync-beeper",
 		"sync-discord",
+		"sync-slack",
 		"sync-synctech-sms",
 		"sync-teams":
 		return true

--- a/cmd/msgvault/cmd/attachment_maintenance_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_test.go
@@ -483,6 +483,7 @@ func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 	allowlisted := []string{
 		"backfill-beeper-media",
 		"backfill-discord-media",
+		"backfill-slack-media",
 		"backfill-teams-media",
 		"import",
 		"import-emlx",
@@ -495,6 +496,7 @@ func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 		"import-whatsapp",
 		"sync-beeper",
 		"sync-discord",
+		"sync-slack",
 		"sync-synctech-sms",
 		"sync-teams",
 	}

--- a/cmd/msgvault/cmd/backfill_slack_media.go
+++ b/cmd/msgvault/cmd/backfill_slack_media.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/slack"
+)
+
+func newBackfillSlackMediaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backfill-slack-media [team-id]",
+		Short: "Retry pending Slack file downloads",
+		Long: `Retry pending Slack file downloads.
+
+Files that failed to download during sync (outages, size caps since raised)
+leave pending markers. This command re-reads the archived message JSON and
+retries the downloads. Idempotent: already-downloaded files are never
+re-fetched.
+
+Examples:
+  msgvault backfill-slack-media
+  msgvault backfill-slack-media T0123456789`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+
+			flagTeam := ""
+			if len(args) > 0 {
+				flagTeam = args[0]
+			}
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			sources, err := resolveSlackSyncSources(s, flagTeam)
+			if err != nil {
+				return err
+			}
+			ctx, stop := withInterruptCancel(cmd, "\nInterrupted.")
+			defer stop()
+
+			var runErrors []string
+			for _, src := range sources {
+				if ctx.Err() != nil {
+					break
+				}
+				teamID, userID, ok := splitSlackIdentifier(src.Identifier)
+				if !ok {
+					runErrors = append(runErrors, src.Identifier+": malformed slack identifier")
+					continue
+				}
+				token, terr := slack.LoadToken(cfg.TokensDir(), teamID, userID)
+				if terr != nil {
+					runErrors = append(runErrors, fmt.Sprintf("%s: %v", teamID, terr))
+					continue
+				}
+				imp := slack.NewImporter(s, slack.NewClient("", token), teamID)
+				sum, berr := imp.BackfillMedia(ctx, slackImportOptions(teamID, userID))
+				if ctx.Err() != nil {
+					break
+				}
+				if berr != nil {
+					runErrors = append(runErrors, fmt.Sprintf("%s: %v", teamID, berr))
+					continue
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s done in %s: %d messages, %d downloaded, %d still pending\n",
+					teamID, sum.Duration.Round(time.Second), sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending)
+			}
+			if len(runErrors) > 0 {
+				return fmt.Errorf("%d workspace(s) failed: %s", len(runErrors), strings.Join(runErrors, "; "))
+			}
+			if ctx.Err() != nil {
+				return errors.New("interrupted")
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newBackfillSlackMediaCmd())
+}

--- a/cmd/msgvault/cmd/backfill_slack_media.go
+++ b/cmd/msgvault/cmd/backfill_slack_media.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -46,19 +45,19 @@ Examples:
 			ctx, stop := withInterruptCancel(cmd, "\nInterrupted.")
 			defer stop()
 
-			var runErrors []string
+			var runErrors []error
 			for _, src := range sources {
 				if ctx.Err() != nil {
 					break
 				}
 				teamID, userID, ok := splitSlackIdentifier(src.Identifier)
 				if !ok {
-					runErrors = append(runErrors, src.Identifier+": malformed slack identifier")
+					runErrors = append(runErrors, fmt.Errorf("%s: malformed slack identifier", src.Identifier))
 					continue
 				}
 				token, terr := slack.LoadToken(cfg.TokensDir(), teamID, userID)
 				if terr != nil {
-					runErrors = append(runErrors, fmt.Sprintf("%s: %v", teamID, terr))
+					runErrors = append(runErrors, fmt.Errorf("%s: %w", teamID, terr))
 					continue
 				}
 				imp := slack.NewImporter(s, slack.NewClient("", token), teamID)
@@ -67,22 +66,33 @@ Examples:
 					break
 				}
 				if berr != nil {
-					runErrors = append(runErrors, fmt.Sprintf("%s: %v", teamID, berr))
+					runErrors = append(runErrors, fmt.Errorf("%s: %w", teamID, berr))
 					continue
 				}
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s done in %s: %d messages, %d downloaded, %d still pending\n",
 					teamID, sum.Duration.Round(time.Second), sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending)
 			}
-			if len(runErrors) > 0 {
-				return fmt.Errorf("%d workspace(s) failed: %s", len(runErrors), strings.Join(runErrors, "; "))
-			}
-			if ctx.Err() != nil {
-				return errors.New("interrupted")
-			}
-			return nil
+			return slackMediaBackfillExit(
+				ctx.Err(),
+				runErrors,
+				rebuildCacheAfterWrite(cfg.DatabaseDSN()),
+			)
 		},
 	}
 	return cmd
+}
+
+func slackMediaBackfillExit(ctxErr error, runErrors []error, cacheErr error) error {
+	if ctxErr != nil {
+		return errors.Join(fmt.Errorf("interrupted: %w", ctxErr), cacheErr)
+	}
+	if len(runErrors) > 0 {
+		return errors.Join(
+			fmt.Errorf("%d workspace(s) failed: %w", len(runErrors), errors.Join(runErrors...)),
+			cacheErr,
+		)
+	}
+	return cacheErr
 }
 
 func init() {

--- a/cmd/msgvault/cmd/backfill_slack_media_test.go
+++ b/cmd/msgvault/cmd/backfill_slack_media_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlackMediaBackfillExitPreservesOperationAndCacheErrors(t *testing.T) {
+	operationErr := errors.New("workspace backfill failed")
+	cacheErr := errors.New("cache refresh failed")
+
+	err := slackMediaBackfillExit(nil, []error{operationErr}, cacheErr)
+
+	require.ErrorIs(t, err, operationErr)
+	require.ErrorIs(t, err, cacheErr)
+	require.ErrorContains(t, err, "1 workspace(s) failed")
+}
+
+func TestSlackMediaBackfillExitPreservesInterruptionAndCacheError(t *testing.T) {
+	cacheErr := errors.New("cache refresh failed")
+
+	err := slackMediaBackfillExit(context.Canceled, nil, cacheErr)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, cacheErr)
+	require.ErrorContains(t, err, "interrupted")
+}
+
+func TestSlackMediaBackfillExitReturnsCacheErrorAfterSuccessfulRun(t *testing.T) {
+	cacheErr := errors.New("cache refresh failed")
+
+	err := slackMediaBackfillExit(nil, nil, cacheErr)
+
+	require.ErrorIs(t, err, cacheErr)
+}

--- a/cmd/msgvault/cmd/build_cache_identity_test.go
+++ b/cmd/msgvault/cmd/build_cache_identity_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"database/sql"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,61 @@ import (
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/store"
 )
+
+func TestBuildCache_SlackDefaultIdentityResolvesOwnerParticipant(t *testing.T) {
+	require := require.New(t)
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "msgvault.db")
+	analyticsDir := filepath.Join(tmp, "analytics")
+
+	st, err := store.Open(dbPath)
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	confirmDefaultSlackIdentity(io.Discard, st, src.ID, "T01", "UME")
+	ownerID, err := st.EnsureParticipantByIdentifier("slack", "T01:UME", "Me")
+	require.NoError(err)
+	convID, err := st.EnsureConversationWithType(src.ID, "D01", "direct_chat", "Alice")
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID:  convID,
+		SourceID:        src.ID,
+		SourceMessageID: "D01:123.000100",
+		MessageType:     "slack",
+		SenderID:        sql.NullInt64{Int64: ownerID, Valid: true},
+		SentAt:          sql.NullTime{Time: time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC), Valid: true},
+		ReceivedAt:      sql.NullTime{Time: time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC), Valid: true},
+	})
+	require.NoError(err)
+	require.NoError(st.ReplaceMessageRecipients(messageID, "from", []int64{ownerID}, []string{"Me"}))
+	require.NoError(st.Close())
+
+	result, err := buildCache(dbPath, analyticsDir, false)
+	require.NoError(err)
+	require.False(result.Skipped)
+
+	duckdb, err := sql.Open("duckdb", "")
+	require.NoError(err)
+	defer func() { _ = duckdb.Close() }()
+
+	ownerPattern := filepath.Join(analyticsDir, "owner_participants", "*.parquet")
+	var ownerRows int
+	require.NoError(duckdb.QueryRow(
+		`SELECT COUNT(*) FROM read_parquet(?) WHERE source_id = ? AND participant_id = ?`,
+		ownerPattern, src.ID, ownerID,
+	).Scan(&ownerRows))
+	assert.Equal(t, 1, ownerRows, "the default Slack identity must resolve to its namespaced participant")
+
+	messagePattern := filepath.Join(analyticsDir, "messages", "**", "*.parquet")
+	var isFromMe bool
+	require.NoError(duckdb.QueryRow(
+		`SELECT is_from_me FROM read_parquet(?, hive_partitioning=true) WHERE id = ?`,
+		messagePattern, messageID,
+	).Scan(&isFromMe))
+	assert.True(t, isFromMe, "owner resolution must feed Slack relationship analytics")
+}
 
 // TestBuildCache_DerivesIsFromMeAndIdentityDatasets verifies that:
 //   - messages Parquet gains a derived is_from_me column: true when the

--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -9,6 +9,7 @@ const (
 	sourceTypeTeams      = "teams"
 	sourceTypeCalendar   = "gcal"
 	sourceTypeBeeper     = "beeper"
+	sourceTypeSlack      = "slack"
 	sourceTypeGranola    = "granola"
 	sourceTypeCircleback = "circleback"
 )

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -17,6 +17,7 @@ import (
 	imaplib "go.kenn.io/msgvault/internal/imap"
 	"go.kenn.io/msgvault/internal/microsoft"
 	"go.kenn.io/msgvault/internal/oauth"
+	"go.kenn.io/msgvault/internal/slack"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -303,6 +304,14 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 			if err := beeper.DeleteToken(cfg.TokensDir()); err != nil {
 				fmt.Fprintf(os.Stderr,
 					"Warning: could not remove Beeper token: %v\n", err,
+				)
+			}
+		}
+	case sourceTypeSlack:
+		if teamID, userID, ok := splitSlackIdentifier(source.Identifier); ok {
+			if err := slack.DeleteToken(cfg.TokensDir(), teamID, userID); err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not remove Slack token: %v\n", err,
 				)
 			}
 		}

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -28,6 +28,7 @@ import (
 	"go.kenn.io/msgvault/internal/microsoft"
 	"go.kenn.io/msgvault/internal/oauth"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/slack"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -1238,6 +1239,44 @@ func TestRemoveAccountCmd_CirclebackRemovesToken(t *testing.T) {
 
 	_, err = os.Stat(tokenPath)
 	assert.True(t, os.IsNotExist(err), "token file should be removed for Circleback source")
+}
+
+func TestRemoveAccountCmd_SlackRemovesToken(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/msgvault.db"
+	tokensDir := filepath.Join(tmpDir, "tokens")
+	require.NoError(os.MkdirAll(tokensDir, 0700), "mkdir tokens")
+
+	s, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(s.InitSchema(), "init schema")
+	_, err = s.GetOrCreateSource(sourceTypeSlack, "T01:UME")
+	require.NoError(err, "create source")
+	require.NoError(s.Close(), "close store")
+
+	require.NoError(slack.SaveToken(tokensDir, "T01", "testers", "UME", "xoxp-test"), "write slack token")
+	tokenPath := filepath.Join(tokensDir, "slack_T01_UME.json")
+	_, err = os.Stat(tokenPath)
+	require.NoError(err, "slack token file must exist before removal")
+
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountLocalTestCmd())
+	root.SetArgs([]string{
+		"remove-account", "T01:UME", "--yes", "--type", sourceTypeSlack,
+	})
+
+	require.NoError(root.Execute(), "remove-account")
+
+	_, err = os.Stat(tokenPath)
+	assert.True(t, os.IsNotExist(err), "token file should be removed for Slack source")
 }
 
 func TestRemoveAccountCmd_NonGmailSkipsToken(t *testing.T) {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -344,6 +344,26 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if cfg.Slack.Enabled && cfg.Slack.Schedule == "" {
+		logger.Warn("slack is enabled but has no schedule — the daemon will not sync it; its freshness will eventually go stale",
+			"hint", `set a cron schedule (e.g. "*/30 * * * *") on the [slack] entry`)
+	}
+	if cfg.Slack.Enabled && cfg.Slack.Schedule != "" {
+		if err := sched.AddJob(scheduler.Job{
+			Name:     "slack",
+			Schedule: cfg.Slack.Schedule,
+			Run: func(ctx context.Context) error {
+				return runScheduledSource(ctx, attachmentMaint, true, func(ctx context.Context) error {
+					return runConfiguredSlackSync(ctx, s)
+				})
+			},
+		}); err != nil {
+			logger.Error("failed to schedule slack sync", "error", err)
+		} else {
+			logger.Info("scheduled slack sync", "schedule", cfg.Slack.Schedule)
+		}
+	}
+
 	// Meeting sources (Granola/Circleback) mirror the gcal treatment: warn
 	// when enabled but unscheduled, then register the scheduled ones.
 	for _, src := range cfg.Granola {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -350,7 +350,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	if cfg.Slack.Enabled && cfg.Slack.Schedule != "" {
 		if err := sched.AddJob(scheduler.Job{
-			Name:     "slack",
+			Name:     api.SlackJobName,
 			Schedule: cfg.Slack.Schedule,
 			Run: func(ctx context.Context) error {
 				return runScheduledSource(ctx, attachmentMaint, true, func(ctx context.Context) error {

--- a/cmd/msgvault/cmd/sync_slack.go
+++ b/cmd/msgvault/cmd/sync_slack.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/slack"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var (
+	syncSlackLimit       int
+	syncSlackFull        bool
+	syncSlackNoThreads   bool
+	syncSlackNoMedia     bool
+	syncSlackMaintenance bool
+)
+
+func newSyncSlackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync-slack [team-id]",
+		Short: "Sync Slack conversations (channels, group DMs, DMs)",
+		Long: `Sync Slack conversations for registered workspaces.
+
+The first run backfills each conversation's full history; later runs are
+incremental, fetching only new messages and polling recent threads for late
+replies. Backfills are resumable: re-run after an interruption and the sync
+continues where it stopped.
+
+Requires a workspace added with 'add-slack'. Use --full to start a repair
+session: every message is re-fetched and upserted in place, so existing rows
+are repaired without duplicates. A repair session survives interruptions and
+--limit scoping — subsequent runs of any kind continue it until complete.
+
+Examples:
+  msgvault sync-slack
+  msgvault sync-slack T0123456789
+  msgvault sync-slack --limit 500
+  msgvault sync-slack --full`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+
+			flagTeam := ""
+			if len(args) > 0 {
+				flagTeam = args[0]
+			}
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			sources, err := resolveSlackSyncSources(s, flagTeam)
+			if err != nil {
+				return err
+			}
+			ctx, stop := withInterruptCancel(cmd, "\nInterrupted. Saving checkpoint...")
+			defer stop()
+
+			var syncErrors []string
+			for _, src := range sources {
+				if ctx.Err() != nil {
+					break
+				}
+				teamID, userID, ok := splitSlackIdentifier(src.Identifier)
+				if !ok {
+					syncErrors = append(syncErrors, src.Identifier+": malformed slack identifier")
+					continue
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Syncing Slack workspace %s\n", teamID)
+				token, terr := slack.LoadToken(cfg.TokensDir(), teamID, userID)
+				if terr != nil {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", teamID, terr))
+					continue
+				}
+				imp := slack.NewImporter(s, slack.NewClient("", token), teamID)
+				opts := slackImportOptions(teamID, userID)
+				opts.Limit = syncSlackLimit
+				opts.Full = syncSlackFull
+				opts.NoThreads = syncSlackNoThreads
+				opts.Maintenance = syncSlackMaintenance
+				opts.NoMedia = opts.NoMedia || syncSlackNoMedia
+				opts.Progress = func(line string) { _, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+line) }
+				sum, serr := imp.Import(ctx, opts)
+				if ctx.Err() != nil {
+					break
+				}
+				// One broken workspace must not block the others; collect and
+				// keep syncing (multi-account convention).
+				if serr != nil {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", teamID, serr))
+					continue
+				}
+				printSlackSummary(cmd, teamID, sum)
+			}
+
+			// Successful workspaces' messages must reach the analytics cache
+			// regardless of interruptions or per-workspace failures.
+			cacheErr := rebuildCacheAfterWrite(cfg.DatabaseDSN())
+			if ctx.Err() != nil {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nInterrupted — re-run sync-slack to resume.")
+			} else if len(syncErrors) > 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nErrors:")
+				for _, e := range syncErrors {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", e)
+				}
+			}
+			return slackSyncExit(ctx.Err(), syncErrors, cacheErr)
+		},
+	}
+	cmd.Flags().IntVar(&syncSlackLimit, "limit", 0, "max messages of work per conversation this run, thread replies and a workspace-wide sweep budget included (0 = no limit; every phase resumes next run so standing limited schedules converge; only the maintenance rescan is skipped)")
+	cmd.Flags().BoolVar(&syncSlackFull, "full", false, "start (or continue) a repair session: re-fetch every message, upserting in place; interrupted or --limit-scoped repairs resume across later runs until complete")
+	cmd.Flags().BoolVar(&syncSlackNoThreads, "no-threads", false, "skip thread-reply fetching (backfill inline fetches and the reply sweep) for this run")
+	cmd.Flags().BoolVar(&syncSlackMaintenance, "maintenance", false, "run the maintenance rescan: repair edits and reaction changes on recent messages (archives ignore post-capture mutations by default)")
+	cmd.Flags().BoolVar(&syncSlackNoMedia, "no-media", false, "skip file downloads for this run (files are recorded as pending; backfill-slack-media fetches them later)")
+	return cmd
+}
+
+func printSlackSummary(cmd *cobra.Command, teamID string, sum *slack.ImportSummary) {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s done in %s: %d conversations, %d messages",
+		teamID, sum.Duration.Round(time.Second), sum.ConversationsProcessed, sum.MessagesProcessed)
+	if sum.RepliesFetched > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d thread replies", sum.RepliesFetched)
+	}
+	if sum.AttachmentsDownloaded > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d files", sum.AttachmentsDownloaded)
+	}
+	if sum.AttachmentsPending > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media pending (see backfill-slack-media)", sum.AttachmentsPending)
+	}
+	if sum.Errors > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d errors", sum.Errors)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+}
+
+// splitSlackIdentifier parses a slack source identifier ("<team>:<user>").
+func splitSlackIdentifier(identifier string) (teamID, userID string, ok bool) {
+	teamID, userID, ok = strings.Cut(identifier, ":")
+	return teamID, userID, ok && teamID != "" && userID != ""
+}
+
+// resolveSlackSyncSources returns the slack sources to sync: the one for the
+// given team ID, or all registered workspaces.
+func resolveSlackSyncSources(s *store.Store, flagTeam string) ([]*store.Source, error) {
+	sources, err := s.ListSources(sourceTypeSlack)
+	if err != nil {
+		return nil, fmt.Errorf("list slack sources: %w", err)
+	}
+	if flagTeam == "" {
+		if len(sources) == 0 {
+			return nil, errors.New("no Slack workspaces registered (run 'add-slack' first)")
+		}
+		return sources, nil
+	}
+	var out []*store.Source
+	for _, src := range sources {
+		if teamID, _, ok := splitSlackIdentifier(src.Identifier); ok && teamID == flagTeam {
+			out = append(out, src)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("slack workspace %q is not registered (run 'add-slack' first)", flagTeam)
+	}
+	return out, nil
+}
+
+// slackSyncExit resolves sync-slack's exit error from the run's parts. An
+// interrupted run must NEVER exit clean — schedulers and scripts read exit 0
+// as "sync complete" — even when the cache rebuild succeeded; the sync it
+// summarizes did not.
+func slackSyncExit(ctxErr error, syncErrors []string, cacheErr error) error {
+	if ctxErr != nil {
+		return errors.Join(fmt.Errorf("interrupted: %w", ctxErr), cacheErr)
+	}
+	if len(syncErrors) > 0 {
+		return errors.Join(
+			fmt.Errorf("%d workspace(s) failed to sync: %s", len(syncErrors), strings.Join(syncErrors, "; ")),
+			cacheErr,
+		)
+	}
+	return cacheErr
+}
+
+// slackImportOptions builds the config-derived import options shared by the
+// CLI and scheduler paths (flag overlays are applied by the CLI caller).
+func slackImportOptions(teamID, userID string) slack.ImportOptions {
+	return slack.ImportOptions{
+		TeamID:          teamID,
+		UserID:          userID,
+		AttachmentsDir:  cfg.AttachmentsDir(),
+		NoMedia:         !cfg.Slack.MediaEnabled(),
+		MaxMediaBytes:   cfg.Slack.MaxMediaBytes(),
+		IncludeChannels: cfg.Slack.Channels,
+		ExcludeChannels: cfg.Slack.ExcludeChannels,
+	}
+}
+
+// runConfiguredSlackSync is the daemon scheduler entrypoint: an incremental
+// sync of every registered Slack workspace. Per-workspace failures are
+// collected so one broken workspace does not starve the others.
+func runConfiguredSlackSync(ctx context.Context, s *store.Store) error {
+	sources, err := resolveSlackSyncSources(s, "")
+	if err != nil {
+		return err
+	}
+	var errs []error
+	attempted := 0
+	for _, src := range sources {
+		if ctx.Err() != nil {
+			break
+		}
+		teamID, userID, ok := splitSlackIdentifier(src.Identifier)
+		if !ok {
+			errs = append(errs, fmt.Errorf("slack %s: malformed identifier", src.Identifier))
+			continue
+		}
+		token, terr := slack.LoadToken(cfg.TokensDir(), teamID, userID)
+		if terr != nil {
+			errs = append(errs, fmt.Errorf("slack %s: %w", teamID, terr))
+			continue
+		}
+		attempted++
+		imp := slack.NewImporter(s, slack.NewClient("", token), teamID)
+		if _, serr := imp.Import(ctx, slackImportOptions(teamID, userID)); serr != nil {
+			errs = append(errs, fmt.Errorf("slack %s: %w", teamID, serr))
+		}
+	}
+	// Rebuild analytics after any attempt: even a failed or canceled attempt
+	// may have committed messages from healthy conversations.
+	if attempted > 0 {
+		if rerr := rebuildCacheAfterScheduledSync(context.WithoutCancel(ctx), "slack"); rerr != nil {
+			errs = append(errs, rerr)
+		}
+	}
+	if ctx.Err() != nil {
+		errs = append(errs, ctx.Err())
+	}
+	return errors.Join(errs...)
+}
+
+func init() {
+	rootCmd.AddCommand(newSyncSlackCmd())
+}

--- a/cmd/msgvault/cmd/sync_slack.go
+++ b/cmd/msgvault/cmd/sync_slack.go
@@ -27,9 +27,9 @@ func newSyncSlackCmd() *cobra.Command {
 		Long: `Sync Slack conversations for registered workspaces.
 
 The first run backfills each conversation's full history; later runs are
-incremental, fetching only new messages and polling recent threads for late
-replies. Backfills are resumable: re-run after an interruption and the sync
-continues where it stopped.
+incremental, fetching new messages and discovering late thread replies with
+search plus periodic canonical audits. Backfills and audits are resumable:
+re-run after an interruption and the sync continues where it stopped.
 
 Requires a workspace added with 'add-slack'. Use --full to start a repair
 session: every message is re-fetched and upserted in place, so existing rows

--- a/cmd/msgvault/cmd/sync_slack.go
+++ b/cmd/msgvault/cmd/sync_slack.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/slack"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/textutil"
 )
 
 var (
@@ -86,7 +88,7 @@ Examples:
 				opts.NoThreads = syncSlackNoThreads
 				opts.Maintenance = syncSlackMaintenance
 				opts.NoMedia = opts.NoMedia || syncSlackNoMedia
-				opts.Progress = func(line string) { _, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+line) }
+				opts.Progress = func(line string) { writeSlackProgress(cmd.OutOrStdout(), line) }
 				sum, serr := imp.Import(ctx, opts)
 				if ctx.Err() != nil {
 					break
@@ -120,6 +122,10 @@ Examples:
 	cmd.Flags().BoolVar(&syncSlackMaintenance, "maintenance", false, "run the maintenance rescan: repair edits and reaction changes on recent messages (archives ignore post-capture mutations by default)")
 	cmd.Flags().BoolVar(&syncSlackNoMedia, "no-media", false, "skip file downloads for this run (files are recorded as pending; backfill-slack-media fetches them later)")
 	return cmd
+}
+
+func writeSlackProgress(out io.Writer, line string) {
+	_, _ = fmt.Fprintln(out, "  "+textutil.SanitizeTerminal(line))
 }
 
 func printSlackSummary(cmd *cobra.Command, teamID string, sum *slack.ImportSummary) {

--- a/cmd/msgvault/cmd/sync_slack_routing_test.go
+++ b/cmd/msgvault/cmd/sync_slack_routing_test.go
@@ -111,6 +111,24 @@ func TestSlackImportOptionsDeriveFromConfig(t *testing.T) {
 	assert.Equal([]string{"noise"}, opts.ExcludeChannels)
 }
 
+func TestWriteSlackProgressSanitizesProviderNames(t *testing.T) {
+	var out bytes.Buffer
+	writeSlackProgress(&out,
+		"conversation 1/1 (Testers\x1b]52;c;Y2xpcA==\x07\x1b[31mRed\x1b[0m\nNext): 3 messages")
+
+	assert.Equal(t, "  conversation 1/1 (TestersRed Next): 3 messages\n", out.String())
+	assert.NotContains(t, out.String(), "\x1b")
+}
+
+func TestWriteAddedSlackWorkspaceSanitizesTeamName(t *testing.T) {
+	var out bytes.Buffer
+	writeAddedSlackWorkspace(&out,
+		"Testers\x1b]52;c;Y2xpcA==\x07\x1b[31mRed\x1b[0m\nNext", "T01", "T01:UME")
+
+	assert.Equal(t, "Added Slack workspace TestersRed Next (T01) as T01:UME\n", out.String())
+	assert.NotContains(t, out.String(), "\x1b")
+}
+
 func resetSyncSlackRoutingGlobals(t *testing.T) {
 	t.Helper()
 	oldLimit := syncSlackLimit

--- a/cmd/msgvault/cmd/sync_slack_routing_test.go
+++ b/cmd/msgvault/cmd/sync_slack_routing_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/clirun"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestSplitSlackIdentifier(t *testing.T) {
+	tests := []struct {
+		in         string
+		team, user string
+		ok         bool
+	}{
+		{"T01:UME", "T01", "UME", true},
+		{"T01:", "T01", "", false},
+		{":UME", "", "UME", false},
+		{"T01", "T01", "", false},
+		{"", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			team, user, ok := splitSlackIdentifier(tt.in)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.team, team)
+				assert.Equal(t, tt.user, user)
+			}
+		})
+	}
+}
+
+func TestResolveSlackSyncSourcesFiltersByTeam(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	_, err := resolveSlackSyncSources(st, "")
+	require.ErrorContains(err, "no Slack workspaces registered")
+
+	_, err = st.GetOrCreateSource(sourceTypeSlack, "T01:UME")
+	require.NoError(err)
+	_, err = st.GetOrCreateSource(sourceTypeSlack, "T02:UOTHER")
+	require.NoError(err)
+
+	all, err := resolveSlackSyncSources(st, "")
+	require.NoError(err)
+	assert.Len(all, 2)
+
+	one, err := resolveSlackSyncSources(st, "T02")
+	require.NoError(err)
+	require.Len(one, 1)
+	assert.Equal("T02:UOTHER", one[0].Identifier)
+
+	_, err = resolveSlackSyncSources(st, "TYPO")
+	require.ErrorContains(err, `slack workspace "TYPO" is not registered`)
+}
+
+func TestRunConfiguredSlackSyncIsolatesBrokenWorkspaces(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+
+	// One malformed identifier and one workspace whose token file is
+	// missing: the scheduler entrypoint must report both without panicking
+	// or aborting on the first.
+	_, err := st.GetOrCreateSource(sourceTypeSlack, "malformed-no-colon")
+	require.NoError(err)
+	_, err = st.GetOrCreateSource(sourceTypeSlack, "T09:UME")
+	require.NoError(err)
+
+	tmpDir := t.TempDir()
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+
+	err = runConfiguredSlackSync(context.Background(), st)
+	require.ErrorContains(err, "malformed identifier")
+	require.ErrorContains(err, "no Slack token for UME in workspace T09")
+}
+
+func TestSlackImportOptionsDeriveFromConfig(t *testing.T) {
+	assert := assert.New(t)
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	media := false
+	cfg = &config.Config{
+		HomeDir: t.TempDir(),
+		Slack: config.SlackConfig{
+			Channels:        []string{"eng"},
+			ExcludeChannels: []string{"noise"},
+			Media:           &media,
+			MaxMediaMB:      7,
+		},
+	}
+
+	opts := slackImportOptions("T01", "UME")
+	assert.Equal("T01", opts.TeamID)
+	assert.Equal("UME", opts.UserID)
+	assert.True(opts.NoMedia)
+	assert.Equal(int64(7)<<20, opts.MaxMediaBytes)
+	assert.Equal([]string{"eng"}, opts.IncludeChannels)
+	assert.Equal([]string{"noise"}, opts.ExcludeChannels)
+}
+
+func resetSyncSlackRoutingGlobals(t *testing.T) {
+	t.Helper()
+	oldLimit := syncSlackLimit
+	oldFull := syncSlackFull
+	oldNoThreads := syncSlackNoThreads
+	oldNoMedia := syncSlackNoMedia
+	t.Cleanup(func() {
+		syncSlackLimit = oldLimit
+		syncSlackFull = oldFull
+		syncSlackNoThreads = oldNoThreads
+		syncSlackNoMedia = oldNoMedia
+	})
+	syncSlackLimit = 0
+	syncSlackFull = false
+	syncSlackNoThreads = false
+	syncSlackNoMedia = false
+}
+
+func TestSyncSlackCommandUsesDaemonRunner(t *testing.T) {
+	assert := assert.New(t)
+
+	resetSyncSlackRoutingGlobals(t)
+
+	server, requests := newDaemonCLIRunnerTestServer(t, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{
+			"sync-slack",
+			"--full",
+			"--limit=25",
+			"--no-threads",
+			"T0123456789",
+		}, req.Args, "args")
+	}, `{"type":"stdout","data":"Syncing Slack workspace T0123456789\n"}`, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+
+	var stdout bytes.Buffer
+	cmd := newSyncSlackCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"T0123456789",
+		"--full",
+		"--limit", "25",
+		"--no-threads",
+	})
+
+	require.NoError(t, cmd.Execute(), "sync-slack")
+	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
+	assert.Contains(stdout.String(), "Syncing Slack workspace T0123456789")
+}
+
+func TestAddSlackCommandForwardsTokenEnv(t *testing.T) {
+	assert := assert.New(t)
+
+	server, requests := newDaemonCLIRunnerTestServer(t, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{"add-slack"}, req.Args, "args")
+		assert.Equal("xoxp-test-123", req.Env[clirun.EnvSlackToken], "token env forwarded")
+	}, `{"type":"stdout","data":"Added Slack workspace Testers\n"}`, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+	t.Setenv(clirun.EnvSlackToken, "xoxp-test-123")
+
+	var stdout bytes.Buffer
+	cmd := newAddSlackCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{})
+
+	require.NoError(t, cmd.Execute(), "add-slack")
+	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
+	assert.Contains(stdout.String(), "Added Slack workspace Testers")
+}
+
+func TestSlackSyncExitInterruptedNeverClean(t *testing.T) {
+	require := require.New(t)
+	// Ctrl-C with a clean cache rebuild previously returned nil — exit 0 —
+	// so schedulers and scripts read an incomplete sync as complete.
+	err := slackSyncExit(context.Canceled, nil, nil)
+	require.Error(err, "an interrupted sync must not exit clean")
+	require.ErrorIs(err, context.Canceled)
+
+	err = slackSyncExit(context.Canceled, []string{"T01: boom"}, nil)
+	require.ErrorIs(err, context.Canceled)
+
+	require.NoError(slackSyncExit(nil, nil, nil))
+	require.Error(slackSyncExit(nil, []string{"T01: boom"}, nil))
+	require.Error(slackSyncExit(nil, nil, context.DeadlineExceeded))
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -496,6 +496,70 @@ msgvault backfill-beeper-media --account signal
 
 ---
 
+## add-slack
+
+Register a [Slack workspace](/usage/slack/) as a `slack` source. Requires a
+user token (`xoxp-…`) from an internal Slack app you create (see the usage
+guide for the two-minute setup and scope list). The token is validated with
+`auth.test` plus a `search.messages` probe (thread-reply archiving needs the
+`search:read` scope, so an under-scoped token fails here rather than on
+every future sync) and stored at `tokens/slack_<team-id>_<user-id>.json`.
+
+```bash
+msgvault add-slack
+msgvault add-slack --token-file ~/slack-token.txt
+MSGVAULT_SLACK_TOKEN="xoxp-..." msgvault add-slack
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--token-file` | | Read the user token from a file instead of prompting |
+| `--no-default-identity` | `false` | Do not auto-confirm the workspace user ID as the source's "me" identity |
+
+After adding, sync with `msgvault sync-slack`.
+
+---
+
+## sync-slack
+
+Sync Slack conversations — channels you are a member of, group DMs, and 1:1
+DMs — for registered workspaces. The first run backfills full history and is
+resumable; later runs are incremental and sweep for thread replies created
+since the last run (any thread age). Per-workspace failures do not stop the run: remaining workspaces
+still sync and the command exits non-zero listing the failures. The `[slack]`
+config `channels`/`exclude_channels` filters select which channels sync. See
+[Slack](/usage/slack/).
+
+```bash
+msgvault sync-slack
+msgvault sync-slack T0123456789
+msgvault sync-slack --full
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--limit` | `0` | Max messages of work per conversation this run, thread replies included; the reply sweep gets the same budget workspace-wide (0 = no limit; every phase resumes next run so standing limited schedules converge; only the maintenance rescan is skipped) |
+| `--full` | `false` | Start (or continue) a repair session: re-fetch every message, upserting in place (catches old thread replies and edits). Interrupted or --limit-scoped repairs resume across later runs of any kind until complete |
+| `--no-threads` | `false` | Skip thread-reply fetching for this run (a later threaded run pays the debt automatically) |
+| `--maintenance` | `false` | Repair edits/reaction changes on recent messages (ignored by default after capture) |
+| `--no-media` | `false` | Skip file downloads for this run (files become pending markers; `backfill-slack-media` fetches them later) |
+
+---
+
+## backfill-slack-media
+
+Retry pending Slack file downloads (files that failed or exceeded the size
+cap during `sync-slack`). Idempotent: files are content-addressed and
+already-downloaded ones are never re-fetched. Files hosted outside
+`files.slack.com` are metadata-only link rows and are never downloaded.
+
+```bash
+msgvault backfill-slack-media
+msgvault backfill-slack-media T0123456789
+```
+
+---
+
 ## add-calendar
 
 Authorize read-only Google Calendar access for an account and register its calendars for sync. If the account already has a Gmail token, re-consent bundles Gmail + Calendar so Gmail access is not dropped — keep both checked on the consent screen. The Calendar API must be enabled on the OAuth project. By default only owned/writable calendars are registered.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,6 +439,31 @@ max_media_mb = 100                # per-attachment download cap (MiB)
 | `media` | `true` | Download attachment bytes (failed downloads retry via `backfill-beeper-media`) |
 | `max_media_mb` | `100` | Per-attachment download cap in MiB (over-cap media leaves a retry marker) |
 
+### `[slack]`
+
+Archive [Slack workspaces](/usage/slack/). A single block covers every
+registered workspace (tokens are per-workspace files). Authorize each
+workspace first with `msgvault add-slack`.
+
+```toml
+[slack]
+enabled = true                    # gate for the daemon schedule
+schedule = "*/30 * * * *"         # 5-field cron; empty = manual sync only
+channels = []                     # channel-name include filter (empty = all memberships)
+exclude_channels = []             # channel names to skip, e.g. ["noise"]
+media = true                      # download shared-file bytes
+max_media_mb = 100                # per-file download cap (MiB)
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Whether the daemon schedules Slack sync |
+| `schedule` | — | Cron expression used by `msgvault serve` |
+| `channels` | all | Channel names to sync (include filter; DMs are never filtered) |
+| `exclude_channels` | — | Channel names to skip (wins over `channels`) |
+| `media` | `true` | Download shared-file bytes (failed downloads retry via `backfill-slack-media`) |
+| `max_media_mb` | `100` | Per-file download cap in MiB (over-cap files leave a retry marker) |
+
 ### Granola Sources
 
 Granola meeting-notes sync is configured with top-level `[[granola]]` entries.

--- a/docs/internal/slack-ingestion-design.md
+++ b/docs/internal/slack-ingestion-design.md
@@ -1,0 +1,322 @@
+# Slack Ingestion — Design
+
+> **Partially superseded (2026-07-20):** the thread-lookback polling design
+> below (the LB-3 mitigation: tracked roots, reply cursors, pruning, the
+> automatic rescan) is replaced by the search-based reply sweep — see
+> `slack-reply-sweep-design.md`. Everything else stands.
+
+Date: 2026-07-18
+Status: Draft, load-bearing pass complete — LB-1..5 probed live against a
+Slack Developer Program sandbox (team `TesterMsgVault`, 2026-07-18) with
+a seeded 1,100-message channel. LB-3 was falsified and the incremental
+design revised accordingly; verdicts inline below.
+
+## Goal
+
+Sync and store the user's Slack messages — public/private channels the
+user is a member of, group DMs (mpim), and 1:1 DMs — into msgvault so
+they are searchable alongside mail and other chat sources through the
+existing TUI, FTS, and Parquet analytics. Text (with mrkdwn), threads,
+reactions, @mentions, edits, and shared files are preserved.
+
+## Decisions
+
+- **Acquisition: live Web API sync via a user-created internal Slack
+  app** (a "custom app" installed only to the user's own workspace),
+  using a **user token (`xoxp-…`)**, not a bot token. A user token sees
+  exactly what the user sees — private channels, DMs, group DMs —
+  without inviting a bot anywhere. This mirrors the Teams decision
+  (own-data, delegated access, user registers their own app).
+- **Rate-limit posture (load-bearing, verified against Slack docs
+  2026-07-18):** Slack's 2025 rate-limit clampdown
+  (`conversations.history`/`conversations.replies` at 1 req/min,
+  15 messages/req) applies to **commercially distributed non-Marketplace
+  apps**. **Internal custom apps are explicitly exempt** and retain the
+  historical limits (Tier 3, ~50 req/min, up to 999 messages/req).
+  msgvault's "register your own app" model lands in the exempt category.
+  See LB-1 for the live probe that must confirm this before backfill
+  performance claims are made.
+- **Data scope:** conversations the user is a *member* of, enumerated
+  via `users.conversations`. Public channels the user hasn't joined are
+  out of scope for v1 (see LB-4).
+- **Attachments:** download file bytes into content-addressed storage,
+  subject to a configurable size cap (Beeper precedent); files above the
+  cap store filename + permalink + metadata only. Only URLs on
+  `files.slack.com` are ever fetched with the bearer token (see
+  Security).
+- **Slack export ZIP import is out of scope** for this build — separate
+  follow-up spec if wanted (useful for workspaces where app creation is
+  admin-blocked, and for Free-plan workspaces where the API only serves
+  90 days of history).
+- **Edits/deletes are best-effort** (same stance as Teams deletes):
+  Slack history queries are keyed by original message `ts`, so edits and
+  deletions of already-archived messages are only caught by a periodic
+  re-scan window, not by incremental sync. See "Incremental sync".
+
+## Architecture
+
+Parallel to `internal/teams/` and `internal/beeper/` — no new core
+tables, no TUI/query changes beyond registering the new message type.
+
+```
+cmd/msgvault/cmd/add_slack.go        ← token setup + auth.test validation
+cmd/msgvault/cmd/sync_slack.go       ← full + incremental sync
+cmd/msgvault/cmd/backfill_slack_media.go
+        │
+internal/slack/                      ← new package
+   ├── client.go       Web API client (cursor paging, 429 + Retry-After, tier-aware limiter)
+   ├── importer.go     orchestration: enumerate conversations → history/replies → persist
+   ├── mapping.go      Slack message JSON → store.Message (+ body, recipients, reactions)
+   ├── participants.go user-ID → participant resolution (users.list cache, email unification)
+   ├── media.go        files.slack.com downloads → content-addressed store
+   ├── syncstate.go    per-conversation ts cursors in sync_runs.cursor_after
+   ├── token.go        token storage/loading (~/.msgvault/tokens/slack_<team>.json)
+   └── types.go        Slack API DTOs
+        │
+internal/store/…                     ← reused as-is (UpsertMessage,
+                                        EnsureConversationWithType,
+                                        EnsureConversationParticipant,
+                                        RecomputeConversationStats, …)
+```
+
+Per sync run: validate token (`auth.test`) → refresh the users cache
+(`users.list`) → enumerate memberships (`users.conversations`, all four
+types) → per conversation: page `conversations.history` from the saved
+cursor, fetch `conversations.replies` for each thread root, persist
+messages/reactions/mentions/files → advance and flush that
+conversation's cursor → `RecomputeConversationStats` +
+`CompleteSync` with final counts.
+
+## Data model mapping
+
+Reuses the existing generic chat schema — **no new core tables**.
+
+| Slack concept | msgvault storage |
+|---|---|
+| Workspace + user | `sources` row, `source_type = "slack"`, `identifier = "<team_domain>:<user_id>"` (from `auth.test`) |
+| Public/private channel | `conversations`, `conversation_type = "channel"`, `title = "#name"` |
+| Group DM (mpim) | `conversations`, `conversation_type = "group_chat"` |
+| 1:1 DM (im) | `conversations`, `conversation_type = "direct_chat"` |
+| Message | `messages`, `message_type = "slack"`, `source_message_id = "<channel_id>:<ts>"` |
+| Thread reply | `reply_to_message_id` → root (`thread_ts` identifies the root) |
+| Sender | `message_recipients` `"from"`; conversation members via `conversation_participants` |
+| `<@U…>` mention | `message_recipients` `"mention"` (resolved via users cache) |
+| mrkdwn text | `message_bodies.body_text` (mrkdwn → plain text for FTS; raw mrkdwn preserved in `message_raw`) |
+| Reactions | `reactions` table (emoji name; custom emoji stored by name) |
+| File (≤ size cap) | `attachments` (downloaded bytes, content-addressed) |
+| File (> cap) / external | `attachments` row: filename + permalink + metadata, no bytes |
+| Edited message | `UpsertMessage` ON CONFLICT update + `SetMessageEdited` (when the `edited` field is present) |
+| Raw message JSON | `message_raw`, `raw_format = "slack_json"` (verbatim API object, Beeper precedent) |
+
+Registration touch-points: add `"slack"` to `KnownMessageTypes` and
+`TextMessageTypes` (`internal/query/text_models.go`) — TUI Texts mode,
+type filters, and snippet fallback then derive automatically.
+
+Notes:
+
+- **`ts` is the message identity** within a channel (string, e.g.
+  `"1734567890.123456"`); it is unique per channel only, hence the
+  composite `source_message_id`. It is also the timestamp — normalize to
+  UTC (`time.Unix` on the integer part; keep full string for identity).
+- **Identity unification.** `users.list` with `users:read.email` yields
+  `profile.email` for workspace members; store the Slack user ID as a
+  `slack_user_id` identifier on `participants` and dedup against
+  existing mail identities by email — same pattern as Teams' AAD-id →
+  email resolution, giving cross-platform search of one human.
+  Bots (`is_bot`), deactivated users, and Slack Connect guests may lack
+  emails — store id-only, best-effort (Teams precedent).
+- **System subtypes** (`channel_join`, `channel_leave`, etc.) are
+  persisted as messages (they carry history value) but excluded from
+  FTS-noise-sensitive surfaces the same way other importers handle
+  service messages; `bot_message` subtype keeps its `bot_id`/`username`
+  as the sender.
+
+## Auth & permissions
+
+`msgvault add-slack` flow (token-paste model, Beeper precedent — no
+OAuth redirect server needed for an internal app):
+
+1. User creates an app at api.slack.com/apps ("From scratch", their
+   workspace), adds **user token scopes**:
+   `channels:history`, `groups:history`, `im:history`, `mpim:history`
+   (message reads); `channels:read`, `groups:read`, `im:read`,
+   `mpim:read` (conversation enumeration); `users:read`,
+   `users:read.email` (identity resolution); `files:read` (file
+   downloads); `reactions:read`; `team:read`.
+2. "Install to Workspace" → copy the **User OAuth Token** (`xoxp-…`).
+3. `msgvault add-slack` prompts for the token (stdin, not argv),
+   validates with `auth.test`, derives `team_domain`/`team_id`/`user_id`,
+   writes `~/.msgvault/tokens/slack_<team_id>.json` (0600), creates the
+   `sources` row.
+
+Multiple workspaces = multiple `add-slack` runs = multiple sources; the
+TUI account filter (`a`) separates them for free.
+
+Config:
+
+```toml
+[slack]
+# include = ["#eng", "#general"]   # default: all memberships
+# exclude = ["#noise"]
+# max_media_bytes = 52428800       # 50 MiB default, 0 = metadata-only
+# sync_interval = "1h"             # daemon scheduling
+# (the edit/discovery rescan shares the thread_lookback window)
+# thread_lookback = "720h"         # how long a thread root stays tracked for new replies
+```
+
+## Incremental sync & checkpointing
+
+**Cursor model** (`internal/slack/syncstate.go`, persisted as JSON in
+`sync_runs.cursor_after`, Teams precedent):
+
+```go
+type SyncState struct {
+    // channelID -> max message ts persisted for that conversation
+    Conversations map[string]string `json:"conversations"`
+    // channelID -> rootTs -> max reply ts persisted for that thread.
+    // Pruned to roots younger than thread_lookback (see below).
+    Threads map[string]map[string]string `json:"threads"`
+}
+```
+
+- **Backfill:** `conversations.history` with cursor pagination
+  (`limit=999` for internal apps), oldest→newest per page batch; for
+  every root with `thread_ts == ts` and `reply_count > 0`, fetch
+  `conversations.replies` (also paginated). The conversation's cursor
+  advances **only after** its messages, replies, raw JSON, and reaction
+  rows have persisted without error; the state is flushed via
+  `UpdateSyncCheckpoint` **after each conversation** so an interrupted
+  backfill resumes mid-stream (Teams precedent, and the exact class of
+  data-loss bug roborev hammered on in #398 — a failed replies fetch
+  must fail that conversation's cursor advance, not just increment an
+  error counter).
+- **Incremental (channel level):** `conversations.history` with
+  `oldest=<cursor>`, `inclusive=false` — catches new roots and
+  broadcast replies only.
+- **Incremental (threads) — revised after LB-3 was falsified.** Thread
+  replies do **not** appear in `conversations.history` unless the author
+  chose "also send to channel", and the updated parent is not re-served
+  either (history filters on the parent's original `ts`). Verified
+  mitigation: `conversations.replies` honors `oldest`, and a re-fetched
+  parent carries live `reply_count`/`latest_reply`. Design: track
+  per-root reply cursors in `SyncState.Threads`; each incremental sync
+  calls `conversations.replies` with `oldest=<thread cursor>` for every
+  tracked root, tracking roots for a configurable `thread_lookback`
+  (default 30 days) before pruning. Replies to threads older than the
+  lookback are caught only by `--full` (or the LB-6 search-based
+  discovery fast-follow). Empty replies calls are cheap at internal-app
+  limits (~50 req/min, LB-1), but this bounds per-sync call count to
+  O(active threads), which is why the lookback exists. Implementation
+  gotcha (probe-verified): `conversations.replies` includes the parent
+  itself as the first message — the importer must skip it or rely on
+  upsert idempotency.
+- **Edits & deletes (structural limitation):** history is keyed by
+  original `ts`, so an edit or delete of a message older than the cursor
+  is invisible to incremental sync. Mitigation: each scheduled sync
+  re-pages a trailing `edit_rescan_window` (default 7 days) and upserts
+  in place — `UpsertMessage` ON CONFLICT catches edits, and messages
+  present in the archive but absent from the re-scanned window are
+  *not* deleted locally (archive semantics: local copy survives remote
+  deletion, Beeper precedent). Documented as best-effort.
+- **Rate limiting:** honor `Retry-After` on 429 globally; a token-bucket
+  limiter keyed by method tier (Tier 2: `conversations.list`,
+  `users.list`; Tier 3: `history`/`replies`; Tier 4: `auth.test`),
+  matching the Gmail limiter pattern.
+- **Failure accounting:** final `UpdateSyncCheckpoint` with counts +
+  errors before `CompleteSync`, so a partially-failed run never reports
+  clean (roborev finding on #398).
+
+## Security
+
+- **Never fetch a user-controlled URL with the bearer token.** Message
+  and file JSON contain attacker-influenceable URLs. Media downloads are
+  restricted to `url_private` values whose host is exactly
+  `files.slack.com` (scheme https, no redirects followed off-host);
+  anything else is recorded as metadata-only. This is the Slack analogue
+  of the Graph-token-exfiltration finding roborev raised on the Teams PR
+  (crafted hosted-content URL → attacker host).
+- Token file 0600 under `~/.msgvault/tokens/`; token accepted via
+  prompt, never argv (shell history).
+- Client is read-only by construction: the package exposes only GET/
+  read-method calls (`conversations.*` reads, `users.*`, `auth.test`) —
+  no `chat.*` write surface exists in the client (Beeper precedent).
+
+## CLI & daemon integration
+
+- `msgvault add-slack` — token setup (above); `remove-account` gains
+  slack support (token file + source rows), Teams/Beeper precedent.
+- `msgvault sync-slack [<team>]` — full/incremental auto-detected from
+  stored cursors; `--limit N` (conversations), `--full` (ignore cursors,
+  re-fetch + upsert in place), `--no-threads` for scoped first runs.
+- `msgvault backfill-slack-media` — retry failed/over-cap downloads
+  (`--only-incomplete`), Teams/Beeper precedent.
+- `msgvault serve` — scheduled syncs alongside other sources; the
+  daemon's all-source-types-per-identifier behavior (from #398) needs no
+  change since Slack identifiers are team-scoped and won't collide with
+  mail addresses.
+- TUI / FTS / Parquet: no changes beyond the message-type registration —
+  Slack rows flow through the standard `messages` path.
+
+## Testing
+
+- Table-driven testify tests (`assert`/`require`), no `t.Errorf`
+  patterns; synthetic fixtures only (`alice`, `U0ALICE`,
+  `user@example.com`) — no real workspace data.
+- Mapping tests over recorded (synthetic) Slack JSON: message subtypes,
+  threads, edits, reactions, mentions, mrkdwn → text.
+- A fake Slack HTTP server (Beeper's `fake_server_test.go` precedent)
+  driving the full sync → store → search path, including: cursor
+  pagination, 429/Retry-After, mid-backfill interrupt + resume, replies
+  fetch failure ⇒ cursor not advanced, and the files.slack.com host
+  restriction (attempted off-host fetch must not carry the token).
+- Live validation against a real workspace before the PR (Teams
+  precedent: it shipped with a ~313k-message live validation note).
+
+## Load-bearing findings (probed live 2026-07-18, Developer Program
+sandbox, fresh internal app, 1,100-message seeded channel)
+
+- **LB-1 — internal-app rate limits: VERIFIED.** `conversations.history`
+  with `limit=999` returned full 999-message pages at 42 req/min
+  sustained (12 consecutive calls, no 429). The 2025 clampdown
+  (1 req/min, 15 msgs) does not apply to internal custom apps; the
+  design's backfill performance assumptions hold.
+- **LB-2 — full-history depth: VERIFIED** (follow-up probe 2026-07-19
+  against a real paid workspace, single channels:history scope, one
+  channel, timestamps only): `conversations.history` with a `latest`
+  bound served messages 95 days, 2, 5, and 8+ years old. Paid plans
+  serve full history via API; full-depth backfill is sound.
+- **LB-3 — late thread replies: FALSIFIED.** A reply to an
+  already-archived root does **not** appear in `conversations.history
+  oldest=<cursor>` (empty page), and the parent is not re-served with
+  updated metadata either. Verified mitigation (see Incremental sync):
+  `conversations.replies` honors `oldest` and returns the late reply;
+  the re-fetched parent carries `reply_count`/`latest_reply`. Design
+  revised to per-root reply cursors with a `thread_lookback` window.
+- **LB-4 — non-member public channels: WORKS.** The user token read
+  `conversations.history` of a public channel after leaving it. A
+  `[slack] include_unjoined_public = true` option is a viable fast
+  follow; v1 still defaults to memberships only.
+- **LB-5 — conversation-type enumeration: PARTIAL.** `users.conversations`
+  returned `public_channel` and `im` correctly; `mpim` untested because
+  the sandbox has no group DM (needs 3+ users). Re-verify in passing on
+  the first workspace that has one; no design impact expected.
+
+Follow-up probe candidates:
+
+- **LB-6 — search-based reply discovery.** `search.messages` (user
+  scope `search:read`) with an `after:<date>` modifier may return new
+  thread replies globally, removing the `thread_lookback` blind spot
+  for replies to old threads. Not yet probed (scope not granted to the
+  probe app); candidate for a fast follow to the incremental design.
+
+## Out of scope
+
+- Slack export ZIP import (`import-slack-export`) — separate follow-up
+  spec; needed for admin-blocked workspaces and pre-90-day Free-plan
+  history.
+- Session-token acquisition (`xoxc`/`xoxd` browser tokens, slackdump
+  style) — ToS-gray, not something msgvault should ship.
+- Canvases, huddles, clips, workflows, and Slack Connect external-shared
+  channel edge cases beyond what `users.conversations` returns.
+- Custom emoji image download (`emoji.list` mapping) — reactions store
+  the emoji name; image backfill can be a fast follow.

--- a/docs/internal/slack-reply-sweep-design.md
+++ b/docs/internal/slack-reply-sweep-design.md
@@ -1,10 +1,16 @@
 # Slack Reply Sweep — Design
 
 Date: 2026-07-20
-Status: Probed and decided; supersedes the thread-lookback polling design
+Status: Implemented; supersedes the thread-lookback polling design
 in `slack-ingestion-design.md` (its LB-3 mitigation section). Every
 load-bearing behavior below was verified live against a Slack Developer
 Program sandbox and, where noted, a production workspace.
+
+> **Completeness amendment (2026-07-29):** Slack publishes no upper bound on
+> search indexing delay. The overlap remains the fast path, while a resumable
+> oldest-due canonical conversation/thread audit is recorded once per run
+> and rotates across active conversations, so search is not a permanent
+> single point of omission under continued scheduled syncs.
 
 ## Goal
 
@@ -237,11 +243,13 @@ for incremental sync. Consequences:
   reply_count kept — probed), so every re-read path serves it: the
   window's clock-skew overlap, catch-up and gap re-walks, `--full`,
   and `--maintenance`. The archive's contract is that deleted messages
-  stay archived, so processMessage skips a tombstone whose message
-  already exists — body, raw, and reactions all stand (the tombstone's
+  stay archived, so processMessage skips a tombstone whose complete
+  row-plus-raw snapshot already exists — body, raw, and reactions all stand
+  (the tombstone's
   empty reaction set would otherwise wipe them) — and persists it only
   as a placeholder for a never-archived root, giving orphaned replies
-  a resolvable thread link. The existence probe's store error aborts
+  a resolvable thread link. Both cases mark the row deleted-at-source; a
+  later live reappearance clears that marker. The existence probe's store error aborts
   the run like any other store failure: uncertainty must not read as
   "missing" when that direction overwrites. This resolves the
   previously-open repair-semantics tension in favor of archive
@@ -477,7 +485,8 @@ emptiness-never-clears.
   a truncated day fails the run without certifying past it; an
   excluded-then-re-included channel recovers its gap via the scoped
   sweep; `--limit` bounds thread replies and leaves the page resumable;
-  tombstoned/omitted files keep their archived attachment rows;
+  tombstoned/omitted files keep their archived attachment rows (an omitted
+  pending file becomes terminal metadata rather than disappearing);
   tombstoned ROOTS never overwrite archived originals (overlap, --full,
   --maintenance) and persist as placeholders when never archived;
   a late-indexed reply below a parked entry's resume point merges the

--- a/docs/internal/slack-reply-sweep-design.md
+++ b/docs/internal/slack-reply-sweep-design.md
@@ -1,0 +1,500 @@
+# Slack Reply Sweep — Design
+
+Date: 2026-07-20
+Status: Probed and decided; supersedes the thread-lookback polling design
+in `slack-ingestion-design.md` (its LB-3 mitigation section). Every
+load-bearing behavior below was verified live against a Slack Developer
+Program sandbox and, where noted, a production workspace.
+
+## Goal
+
+Replace lookback-window thread polling with search-driven reply discovery
+for incremental sync. Consequences:
+
+- The 30-day thread blind spot disappears: a reply to a years-old thread
+  is discovered by the next sweep regardless of root age.
+- Per-conversation state shrinks: no tracked-root map, no reply cursors,
+  no pruning rules; one UTC watermark per source replaces all of it.
+- Edits/reactions maintenance becomes explicit-only (`--maintenance`):
+  the periodic rescan loses its thread-discovery role and reverts to a
+  pure repair pass the user runs deliberately.
+
+## Decisions
+
+- **Discovery via `search.messages`** (user scope `search:read`) with the
+  `threads:replies` modifier, which returns thread replies exclusively —
+  verified: not even root messages are included. Day-granular `on:`/
+  `after:` bounds; `sort=timestamp, sort_dir=asc`.
+- `search.messages` is marked legacy (its replacement is
+  `assistant.search.context`), but is preferred here: ~100 results/page
+  at ~20 req/min versus 20/page at ~10 req/min with daily-restriction
+  language. The provider is a small interface so the alternate API can
+  be slotted in if the legacy method is removed; verified: the new API
+  works with a plain user token (no AI-features app flag in practice).
+- **Search is discovery only; `conversations.replies` is the archival
+  fetch.** Search result objects are not native message JSON; archiving
+  them would fork `raw_format`. Instead each hit is a pointer
+  (channel id, reply ts). CORRECTED (probed live, 2026-07-22): a REPLY
+  ts anchor serves ONLY that reply — no bound, limit, or cursor expands
+  it — so full-thread fetches require the ROOT ts. Drain entries anchor
+  at the permalink-parsed root; an unparseable permalink degrades to a
+  solo entry anchored at the reply, which the drain re-anchors to the
+  true root from the fetched reply's own `thread_ts` (rolling its resume
+  point back so the reply re-serves AFTER its parent, keeping the thread
+  link resolvable). Root anchors include the parent even below an
+  `oldest` bound (probed).
+- **Membership boundary is enforced by our filter, not the API.**
+  Verified: search returns hits from public channels the user never
+  joined (both scoped and unscoped queries). Hits are matched against
+  the known conversation set and only `done` conversations are fetched;
+  everything else is dropped. Channel scoping, when needed, must use the
+  immutable `in:<#C…>` ID form (names are mutable/recyclable and were
+  observed unreliable as scopes).
+- **Cursor: a UTC watermark per source plus a certification stamp per
+  conversation.** The watermark (`replies swept before T`) covers the
+  current target set as a whole; each conversation's `SweptThrough`
+  normally tracks it and lags when the conversation missed sweeps
+  (excluded, unreadable, or filtered while the watermark advanced). A
+  conversation re-entering behind the watermark first recovers its gap
+  with a channel-scoped sweep (`in:<#C…>` over just the missed days) —
+  without this, the workspace sweep's floor is already past the gap and
+  those replies are lost permanently. DMs/group DMs (non-`C` IDs, where
+  the `in:` scope form is unprobed) recover through the blunter thread
+  catch-up walk (`ThreadsPending`) instead. Initial `--no-threads` walks
+  flag that debt UNCONDITIONALLY: the flag means "this history was
+  walked without thread coverage", not "threads existed at walk time" —
+  a message can gain its first reply later, and Cursor advances with
+  every window, so no later boundary can be guessed from it. For the
+  same reason, a THREADED initial walk stamps its own `SweptThrough` at
+  completion (its inline drains covered every thread through the pin;
+  a run that dies before its sweep phase must not leave the boundary to
+  a fallback that reads a moved value), and any conversation that still
+  reaches the sweep stamp-less (legacy blobs, pre-stamping states) gets
+  the conservative treatment: flag a catch-up walk, reset its cursors,
+  stamp forward to the sweep's pin. Gone conversations stamp vacuously
+  so they don't churn through that path. Both debt channels are SENIOR
+  to new window work (drain first, then catch-up, then the window):
+  junior catch-up would starve forever under top-level traffic that
+  saturates --limit; a second-chance slot after the walk lets the run
+  that completes an initial backfill pay its debt immediately.
+- **Boundaries are pins; floors overlap.** Stored boundaries (the
+  watermark, the `SweptThrough` stamps, the per-conversation `Cursor`)
+  are the run's own start instant — the pin — never a lagged or
+  forward-rounded value. A boundary means "covered through boundary −
+  margin for sure"; every consumer's floor overlaps back by the lag
+  margin, re-covering the trailing interval into idempotent upserts.
+  The overlap absorbs the two clock uncertainties in the system: search
+  index lag (a reply created just before a sweep may not be indexed yet
+  — the next sweep's floor reaches back behind it) and clock skew
+  between our pin (local clock) and message ts (Slack's clock) on the
+  window walks. Boundaries advance only from fully-searched/walked
+  intervals — never from fetched content — capped at the pin,
+  checkpointed per day (sweeps) or per page (walks), and never rounded
+  forward: a forward-rounded pin claims coverage of instants nothing
+  has covered. Sweep hits above the pin are acted on when the index
+  serves them early (harmless upserts; the next window re-covers them),
+  which is safe because phase order guarantees their roots: the window
+  walks run before the sweep, so any acted-on hit's root is already
+  archived — and the canonical fetch keeps an existence check as the
+  belt for the one leak (a failed window walk in the same run),
+  processing the parent only when it is genuinely missing and skipping
+  it otherwise (refreshing an archived root's content and reactions is
+  --maintenance work).
+- Date modifiers are evaluated in the searching user's *current profile
+  timezone at query time* (verified, including retroactive re-filing
+  after a tz change) **using the IANA zone's historical DST rules**
+  (verified against a production corpus spanning DST transitions: a
+  January day boundary follows the winter offset even when queried in
+  summer, and the spring-forward day is served as a 23-hour span). So
+  sweep-day arithmetic reads the user's IANA `tz` fresh each run and
+  derives day boundaries with `time.LoadLocation` — a fixed zone at the
+  current `tz_offset` (the fallback for unloadable zone names, and exact
+  for non-DST zones) would put historical boundaries an hour off across
+  a transition, letting an interrupted per-day sweep certify an hour the
+  day's query never served. Gap-free across tz changes and DST with no
+  standing overlap.
+- **One nonce per attempt, stable across pages** (an inert negated
+  term): search responses are cached BY QUERY STRING (verified — stale
+  results, including pre-tz-change day filings, served to repeated
+  queries), and that cuts both ways. Across attempts the nonce must
+  differ (fresh run = fresh results); WITHIN one day walk the string
+  must not vary — the cache is the walk's snapshot stabilizer. A
+  per-page nonce makes every page a fresh index query: a deletion
+  between pages shifts the ascending offsets down and drops a hit into
+  an already-consumed page while the walk still exhausts the claimed
+  pages and certifies the day. The nonce is therefore keyed to the run
+  (day and scope already vary the string; no scope+day pair is queried
+  twice in one run).
+- **Pager rules** (verified): `page` beyond 100 is silently *clamped to
+  page 1* — the pager must stop when the echoed `paging.page` differs
+  from the requested page, and bound itself by `min(paging.pages, 100)`.
+  A day certifies only from CONSUMPTION: the walk is complete only when
+  it exhausted the server's claimed pages, and every other exit — the
+  100-page bound with pages still claimed (nothing guarantees full
+  pages, so a sub-10k day can span more than 100 of them), a clamp-echo
+  mismatch, or empty pages — counts as truncation. The accurate
+  `pagination.total_count` is a secondary tripwire for a total beyond
+  the reachable ceiling even when the claimed page count fits the walk.
+  Degraded-mode note: if the server ever served persistently small
+  pages at moderate volume, every affected day would truncate — loud
+  failures plus catch-up churn, converging on unlimited runs — which is
+  noisy-but-safe (versus silently certifying past unserved hits) and
+  would be the signal to build `in:`-batch narrowing. A single-day,
+  single-scope result set beyond the ~10,000
+  reachable ceiling **fails loudly and converts the unreachable tail
+  into durable walk debt**: the day cannot be drained by search at all
+  (re-querying serves the same first 10k ascending; `on:` has no
+  intra-day lower bound), so every in-scope target is flagged for a
+  thread catch-up walk — which re-fetches every thread's replies and
+  therefore recovers the tail wherever it landed, non-channel IDs
+  included — in-flight catch-up cursors are re-pinned (a walk pinned
+  before the day's replies existed would never anchor their roots),
+  and the day's boundary advances (debt recorded — the sweep's own
+  invariant). The failure therefore happens once per truncated day
+  (an in-progress day re-fails until it is behind the pin-capped
+  boundary, since its unreachable tail keeps growing) and later runs
+  converge automatically — no `--full` needed. The earlier
+  park-and-fail design left the boundary IN the day forever, which
+  permanently wedged an overlapping `--full` repair session: the
+  session only closes on a clean pass, `--full` refuses to reset one
+  in flight, and conversations walked before the day never re-walk —
+  their tail replies were unrecoverable by any command. `in:`-batch
+  narrowing (a fresh 10k ceiling per channel scope) remains the
+  specified sweep-native efficiency escape, unbuilt until the tripwire
+  ever fires — `threads:replies` filtering makes it Enterprise-scale
+  rare.
+  Cursormark pagination is not supported on this method (parameter
+  silently ignored).
+- **Maintenance repairs replies too.** The rescan re-fetches thread
+  replies and re-processes everything — parent included, deliberately
+  without the archived-parent skip: repairing post-capture mutations to
+  source truth is the explicit repair pass's purpose. Thread selection
+  is ARCHIVE-driven, not window-driven: a recent reply can hang under a
+  root far older than any history window, so every thread holding an
+  archived reply inside the window is rescanned regardless of root age
+  (the archive is the index Slack does not provide), with the window's
+  page scan covering roots the archive has not linked yet. "Recent"
+  therefore genuinely keys on MESSAGE age. Scope note: mutations to
+  messages OLDER than the window are the true residual — Slack exposes
+  no edit feed, so only `--full` reaches them.
+- **Failure taxonomy.** FETCH failures (network/API) are isolated per
+  item — recorded, counted as `FetchErrors`, cursors held where coverage
+  is incomplete — and the run reports partial; this includes membership
+  listing outages (isolation and honesty are orthogonal). STORE failures
+  are fatal with the cursor held: a failed database write means the
+  local store is sick, and counting-and-continuing would advance cursors
+  past permanently omitted rows while reporting success (sharpest for
+  attachment rows, whose loss also orphans downloaded CAS bytes with no
+  pending marker for backfill to find — media download failures are
+  non-fatal ONLY because their durable marker write is itself fatally
+  checked). The one exemption is FTS: derived data with a repo-wide
+  self-healing path (`FTSNeedsBackfill` + `rebuild-fts` exist precisely
+  because every importer warn-and-continues on it), so it stays a
+  counter. Checkpoint writes are fatal too: the initial checkpoint is
+  load-bearing (newest-wins resume and the --full reset exist only in it
+  until the run completes), and a failing run persists its in-memory
+  final state via FailSyncWithCheckpoint so resume granularity is the
+  failure instant, not the last throttled flush. The sole remaining
+  best-effort write is recordItem telemetry.
+- **Guaranteed first unit.** A budget may end a run early, but it must
+  never gate a phase's FIRST unit of durable progress — the invariant
+  behind every convergence guarantee here. Violations recur as stalls:
+  a drain page that could be all-parent (fixed by the floor-2 page), a
+  catch-up flag that re-visited its final page forever (fixed by
+  clearing at walk end), a sweep day-charge that starved the fetch that
+  would advance the boundary (fixed structurally: the sweep now records
+  debt, and recording is never budget-gated). Budget-site audit: window
+  walks and catch-up pages are ≥1 message and advance a persisted
+  cursor; drain pages are ≥2 (the response may lead with the parent);
+  sweep discoveries become durable debt before any fetch is attempted.
+- **Every reply fetch is drain debt.** The sweep does not fetch threads
+  itself: each discovered group becomes a pending-thread entry on its
+  conversation, seeded with `drained-to = minHit − 1µs` so the drain
+  fetches exactly the tail, then the affected conversations are drained
+  in-phase with the sweep budget threaded through. The day's boundary
+  advances once debt is RECORDED (the walks' "cursor past page means
+  debt recorded" invariant, applied to the sweep) — a fetch failure or
+  spent budget parks the entry, not the boundary, and the next run's
+  drain-first step resumes it at reply granularity. One fetcher, one
+  budget discipline, one failure model for walks, catch-up, and sweep.
+- **Entry merges are decided against the coverage Floor, not progress.**
+  An entry claims "replies strictly after Floor" and has covered
+  (Floor, DrainedTo]. A tail discovery at/above the Floor is already
+  inside the claim and leaves the entry alone — overlapped sweep floors
+  re-discover the SAME hits every live pass, and re-seeding progress
+  from them would rewind the drain each run (a long tail would never
+  converge). A tail discovery BELOW the Floor is a late-indexed reply
+  surfacing beneath the claim while certification advances past it:
+  the entry widens down (Floor and resume point drop to the seed) —
+  this merge is that reply's last chance. A FULL record (walk or
+  catch-up, Floor = "") over an existing tail widens it to the root:
+  a parked mid-thread seed proves nothing below itself, and keeping it
+  would let the catch-up walk certify old replies it never fetched.
+  Legacy floor-less entries normalize to Floor = DrainedTo on load —
+  the misread that over-fetches instead of the one that skips.
+- **Tombstones never overwrite archived originals.** A deleted thread
+  root keeps a history row (`subtype: tombstone`, USLACKBOT,
+  reply_count kept — probed), so every re-read path serves it: the
+  window's clock-skew overlap, catch-up and gap re-walks, `--full`,
+  and `--maintenance`. The archive's contract is that deleted messages
+  stay archived, so processMessage skips a tombstone whose message
+  already exists — body, raw, and reactions all stand (the tombstone's
+  empty reaction set would otherwise wipe them) — and persists it only
+  as a placeholder for a never-archived root, giving orphaned replies
+  a resolvable thread link. The existence probe's store error aborts
+  the run like any other store failure: uncertainty must not read as
+  "missing" when that direction overwrites. This resolves the
+  previously-open repair-semantics tension in favor of archive
+  semantics (deletion is not a repairable source mutation; edits are).
+- **`--limit` bounds committed work via a resumable thread drain.** The
+  window walks record each discovered root as durable debt on a
+  per-conversation pending list — `(root ts, drained-to ts, remaining
+  reply_count forecast)` — before the page cursor advances, charging the
+  forecast against the run budget so root progress stays loosely aligned
+  with thread progress. The drain pays the list head-first, resuming each
+  thread with `oldest=drained-to` (a self-validating ts bound; the
+  archived root is not refetched) on budget-sized pages, converting
+  forecast to actuals as replies land. Invariants: the walk never fetches
+  a new history page while debt is outstanding (bounding the list at one
+  page's roots), and the drain runs before anything else touches the
+  conversation — so a standing `--limit` schedule converges to a complete
+  archive by itself, draining arbitrarily large threads across runs with
+  durable progress every run. Sweeps and
+  catch-up walks only run unlimited, so their thread fetches stay
+  whole-thread.
+- **The thread catch-up walk is resumable and budget-aware**, shaped like
+  the backfill: each page's roots are recorded as pending-drain debt
+  (charging their `reply_count` forecasts), paging holds while debt is
+  outstanding, and the page cursor persists (`CatchUpCursor`, with the
+  walk's pin in `CatchUpLatest` — page cursors are only valid against the
+  bound they were minted with). Scanned pages charge the budget too: the
+  re-read is the walk's dominant work. When the walk reaches the end, the
+  flag and cursor clear even with drain debt left — the debt lives on the
+  pending list, which drain-first pays unconditionally (keeping the flag
+  would re-visit the final page forever). A gone conversation clears its
+  debt as skipped work instead of wedging every future sync into partial
+  failure.
+- **The catch-up walk pins its upper bound at its own start time**, not
+  the original backfill pin: conversation-level debt (`--no-threads`
+  runs, non-channel sweep-gap recovery) can include replies to roots
+  created after the backfill, which a pin-bounded walk would never
+  anchor. Roots newer than the fresh pin need no walk (their replies
+  postdate the watermark by creation time), and the pin keeps the
+  newest-first pagination window stable during the walk.
+- **Limited runs sweep too**, with a work budget: searched days and
+  canonically fetched messages charge it, and exhaustion parks the
+  boundary at the last safe point without failing the run. Per-day
+  commits are durable, so a standing `--limit` schedule converges on
+  reply discovery like every other path — a permanently-capped sync
+  must never mean "no replies, ever". (A standing limit below the
+  workspace's message rate falls progressively behind — a throughput
+  ceiling, never a completeness loss.)
+- **`--full` is a repair SESSION, not a one-shot.** It resets the state
+  under a bumped generation and sets a repair-pending flag; every
+  subsequent run — full, plain, or limited — continues the repair
+  through the ordinary resumable walks until everything is Done and all
+  debt is paid. Merge treats generations as lineage: a newer generation
+  wins wholesale (an interrupted repair's checkpoint supersedes the
+  pre-repair success blob; field-wise blending would OR the old Done
+  flags over fresh partial cursors and silently abandon the repair),
+  and an older one is ignored.
+- **Duplicate file content keeps one row per Slack file ID** via the
+  Discord alias pattern: the schema's `(message_id, content_hash)`
+  uniqueness keeps the real hash on the first row; same-content siblings
+  become hashless alias rows sharing the trusted CAS path, re-derived as
+  downloaded on read (store read paths AND the message-detail API) — so
+  repairs never re-download and no file ID's metadata is silently
+  dropped. The re-derivation is provider-gated to `discord:`/`slack:`
+  deliberately: a Beeper hashless local path means pending/untrusted and
+  must stay hashless.
+- **One walk, pinned windows**: the initial backfill and every
+  incremental fetch are the SAME pinned window walk — backfill covers
+  `("", pin]`, every later walk covers `(Cursor − margin, pin]` — with
+  identical pagination, drain, budget, and resume machinery (`Cursor`
+  is a covered-through pin, advanced only when its window completes;
+  `BackfillCursor`/`BackfillLatest` are the in-flight walk's page
+  cursor and pin). The walker records each discovered root on the
+  pending-drain list before the containing page's cursor advances, so
+  "cursor past page" means "page durable and its thread debt recorded"
+  (the debt and the cursor persist in the same checkpointed blob).
+  Unlimited runs drain a page's debt immediately after the page;
+  limited runs carry the remainder across runs. Replies to window
+  roots therefore archive immediately with no search dependency; the
+  sweep's remaining job is late replies to roots below the previous
+  boundary.
+
+## Sweep algorithm
+
+Per source, after the per-conversation walks complete:
+
+```
+zone = current user IANA tz (users cache; historical DST rules — probed);
+       fall back to FixedZone(tz_offset) when the name will not load
+
+# Stamp adoption (targets without a SweptThrough):
+#   max(own backfill pin, watermark) — the pin is exact for a freshly
+#   completed backfill (inline thread fetches covered everything up to
+#   it, and the pin always postdates the watermark at completion time);
+#   the watermark is correct for legacy pre-stamp state.
+
+pin = tsFormat(now)                    # this sweep's boundary
+
+# Stamp adoption (targets without a SweptThrough):
+#   max(own walk pin, watermark) — the pin is exact for a freshly
+#   completed backfill (inline drains covered everything up to it, and
+#   the pin always postdates the watermark at completion time); the
+#   watermark is correct for legacy pre-stamp state.
+
+# Gap recovery, per target stamped behind the watermark:
+for conv C with SweptThrough < SweepWatermark:
+    if C is not a channel ID: set ThreadsPending; stamp = watermark
+    else: sweepRange(scope=C, floor=SweptThrough, searchEnd=watermark,
+                     ceiling=watermark) → stamp advances per day
+
+# Workspace sweep:
+floor = SweepWatermark, or min(SweptThrough of targets) on first sweep
+sweepRange(scope=none, floor, searchEnd=now, ceiling=pin)
+    → watermark advances per day; targets stamped at or past the floor
+      are stamped forward with it (a conversation parked behind by a
+      failed gap sweep keeps its stamp and retries next run)
+
+sweepRange(scope, floor, searchEnd, ceiling):
+    queryFloor = floor − lagMargin                 # the OVERLAP
+    budget: one charge per day, plus drained messages; recording debt is
+            never gated (guaranteed first unit holds structurally)
+    for day D = day(queryFloor, zone) … day(searchEnd, zone):  // ascending
+        for page = 1 … min(pages, 100):
+            q = `[in:<#scope>] threads:replies on:D -"<nonce>"`
+            stop if echoed page ≠ requested page               // clamp tell
+            collect hits: (channel_id, ts, permalink)
+        hits ∩ sweep targets, above queryFloor
+        group by permalink thread_ts (fallback: per hit)
+        record each group as pending-thread debt on its conversation
+            (drained-to = minHit − 1µs), then drain each conversation
+            with the sweep budget threaded through — fetch failures and
+            spent budget park the DEBT ENTRY, never the boundary
+        if day total > 10k ceiling:
+            advance to min(last hit, ceiling) if > floor; FAIL RUN; halt
+        advance to min(end of D, ceiling) if > floor; checkpoint
+```
+
+The boundary never passes unpersisted work, never derives from fetched
+content, and never regresses (overlap-region parks sit below the stored
+floor and are dropped). An aborted sweep resumes exactly where it
+stopped; everything downstream of discovery is the existing idempotent
+upsert machinery.
+
+## State
+
+Resume selection is **newest blob wins, wholesale** — states are never
+blended field-wise. Every run's first act is to checkpoint its resume
+state, so a checkpoint blob is by construction a superset of the success
+blob it was seeded from, and the store only surfaces checkpoints newer
+than the last success. Blending resurrected cleared phase state three
+separate times across reviews (a page cursor is only valid against the
+bound it was minted with); deleting the merge deletes the bug class. A
+`--full` reset needs no lineage marker for the same reason: the reset is
+the newest blob and simply supersedes. Concurrent runs on one source
+(unsupported) can drop the older run's tail progress under newest-wins —
+the safe direction: lower boundaries only re-fetch into upserts.
+
+```go
+type SyncState struct {
+    Conversations  map[string]*ConvState
+    SweepWatermark string // pin of the last workspace sweep; covered through this − margin
+    SweepOffset    int    // tz_offset in effect when the watermark was written (audit)
+    RepairPending  bool   // an in-flight --full repair session; completion is
+                          // judged against the CURRENTLY ELIGIBLE conversations
+                          // (departed/excluded ones must not wedge the session;
+                          // their generation-reset Done flags re-walk them on
+                          // any later re-entry)
+}
+
+type ConvState struct {
+    Cursor         string          // covered-through pin (window walks resume from this − margin)
+    BackfillCursor string          // in-flight window walk's page cursor
+    BackfillLatest string          // in-flight window walk's pin
+    Done           bool            // initial walk reached the beginning of history
+    SweptThrough   string          // pin of the last sweep covering this conversation
+    PendingThreads []PendingThread // outstanding thread-drain debt (≤ one page's roots)
+    ThreadsPending bool            // a catch-up walk is owed
+    CatchUpCursor  string          // resumable catch-up walk page cursor
+    CatchUpLatest  string          // the pin the walk was started under
+}
+
+type PendingThread struct {
+    RootTS    string // thread root (already archived with its page)
+    DrainedTo string // newest reply fetched; drain resumes oldest=DrainedTo
+    Forecast  int    // remaining reply_count estimate (budget pacing only)
+    Floor     string // coverage claim: replies owed strictly after this
+                     // ("" = from the root; tail entries carry their seed)
+}
+```
+
+`ConvState` loses `Threads` and the incremental window cursors
+(`incr_cursor`/`incr_max_ts`) — old checkpoints carrying those keys load
+cleanly; an upgraded mid-window checkpoint re-walks at most one window
+into idempotent upserts. Merge rules: generations gate everything (newer
+wins wholesale, older is ignored); within a generation the
+further-advanced watermark wins, carrying its offset with it;
+`SweptThrough`/`Cursor` merge further-advanced-wins per conversation;
+page cursors, pins, and `PendingThreads` follow non-empty-wins /
+emptiness-never-clears.
+
+## Probe ledger
+
+| Behavior | Verdict | Where |
+|---|---|---|
+| `threads:replies` returns replies only (no roots) | verified | sandbox + production workspace |
+| Search completeness for replies after a date | verified | production workspace |
+| New search API works without AI-features flag | verified | production workspace |
+| Unjoined public channels appear in results | verified — filter is load-bearing | sandbox (`#msgvault-probe-unjoined`) |
+| `in:<#ID>` scoping reliable; name form observed unreliable | verified / observed | production + sandbox |
+| Date modifiers use current profile tz at query time | verified (tz changed mid-test; messages re-filed) | sandbox |
+| Date filing uses IANA zone with HISTORICAL DST rules (not flat current offset) | verified — winter day boundary at the winter offset while queried in summer; brackets within minutes | production workspace (multi-year corpus, profile tz `America/New_York`) |
+| DST transition day served as a 23-hour span | verified — `on:` day starts at pre-transition midnight, ends at post-transition midnight | production workspace |
+| Results cached by query string (stale across tz change) | verified — nonce required | sandbox |
+| `page=101` silently clamps to page 1 | verified — echo check required | sandbox |
+| Cursormark pagination unsupported (ignored) | verified — 10k/query ceiling stands | sandbox |
+| `sort=timestamp asc` stable across full 11-page walk, no dups | verified | sandbox (1,099-message corpus) |
+| `pagination.total_count` accurate | verified at 1k scale | sandbox |
+| Reply-ts anchor serves ONLY that reply (root ts required for the thread) | verified — refutes the original any-ts assumption; no oldest/limit/cursor variant expands it | sandbox (2026-07-22) |
+| Root anchor includes the parent even below the `oldest` bound | verified | sandbox |
+| Deleting a REPLY: replies(ts=deleted) → thread_not_found; root anchor serves survivors | verified — drain entries must anchor at roots | sandbox |
+| Deleting a ROOT: thread persists as a `tombstone` (USLACKBOT, reply_count kept); root anchor, history row, and search indexing of orphaned replies all survive | verified — walk-recorded debt is safe; processMessage skips tombstones for archived messages on EVERY path (the parent-skip guard alone left overlap/catch-up/--full/--maintenance exposed) | sandbox |
+| >10k single-day behavior | unprobed (needs 3h seeded corpus); clamp+tripwire characterize it | — |
+
+## Testing
+
+- Fake server gains `/search.messages` with faithful semantics: reply
+  flattening, day filtering, `in:<#ID>` scoping, ascending sort,
+  pagination **including the page-clamp behavior**, and accurate totals.
+- e2e: late reply to an ancient thread discovered by sweep (the old
+  blind spot); watermark holds on canonical-fetch failure and resumes;
+  not-done conversations skipped; multi-page sweep days; the overlapped
+  floor recovers late-indexed replies past an advanced watermark and
+  clock-skew-hidden window arrivals;
+  a truncated day fails the run without certifying past it; an
+  excluded-then-re-included channel recovers its gap via the scoped
+  sweep; `--limit` bounds thread replies and leaves the page resumable;
+  tombstoned/omitted files keep their archived attachment rows;
+  tombstoned ROOTS never overwrite archived originals (overlap, --full,
+  --maintenance) and persist as placeholders when never archived;
+  a late-indexed reply below a parked entry's resume point merges the
+  entry's floor back down; a catch-up full-drain claim widens a parked
+  tail seed to the root;
+  `add-slack` rejects tokens without `search:read`.
+- Maintenance gating: edits invisible to plain incremental runs, caught
+  by `--maintenance`.
+- Live (env-gated, sandbox): `threads:replies` pin-test — asserts
+  replies-only results with a no-modifier control query, so a silent
+  change in Slack's modifier grammar fails a test instead of degrading
+  the sweep into noise.
+
+## Out of scope
+
+- `assistant.search.context` provider (interface accommodates it).
+- `in:`-batch narrowing implementation (specified; built if the
+  truncation tripwire ever fires in practice).
+- Concurrent fetch/persist pipeline — orthogonal performance work,
+  sequenced separately.

--- a/docs/usage/slack.md
+++ b/docs/usage/slack.md
@@ -1,0 +1,142 @@
+---
+title: Slack
+description: Archive your Slack workspaces — channels, group DMs, and DMs — via the Web API.
+---
+
+msgvault archives your own view of a Slack workspace: every public and
+private channel you are a member of, group DMs, and 1:1 DMs, with threads,
+reactions, @mentions, edits, and shared files. Each workspace becomes its own
+msgvault source; all Slack-archived messages share `message_type = slack` for
+search.
+
+Slack sync is strictly read-only: msgvault only calls read methods of the Web
+API and never posts, edits, or marks anything in Slack.
+
+## Prerequisites
+
+A **user token** from an internal Slack app you create yourself (a two-minute,
+one-time setup per workspace):
+
+1. Open [api.slack.com/apps](https://api.slack.com/apps) → **Create New
+   App** → **From scratch**, in your workspace.
+2. Under **OAuth & Permissions → Scopes → User Token Scopes**, add:
+   `channels:history`, `groups:history`, `im:history`, `mpim:history`,
+   `channels:read`, `groups:read`, `im:read`, `mpim:read`,
+   `users:read`, `users:read.email`, `files:read`, `reactions:read`,
+   `team:read`, `search:read`.
+3. Click **Install to Workspace** and copy the **User OAuth Token**
+   (`xoxp-…`).
+
+Because the app is yours and not distributed, it is **not** subject to
+Slack's non-Marketplace rate limits — history backfills run at full page size
+(999 messages per request) rather than the throttled 15.
+
+Some workspaces restrict app creation to admins; if that applies to yours,
+ask an admin to approve the app.
+
+## Add a workspace
+
+```bash
+msgvault add-slack
+```
+
+The command validates the token (`auth.test`, plus a `search.messages` probe
+— thread-reply archiving requires `search:read`, and a missing scope should
+fail setup, not every future sync), stores it at
+`tokens/slack_<team-id>_<user-id>.json` (0600), and registers the workspace
+as a `slack` source identified by `<team-id>:<user-id>`. Tokens are keyed by
+workspace *and* user, so two accounts in the same workspace coexist.
+
+Provide the token via the interactive prompt, `--token-file <path>`, or the
+`MSGVAULT_SLACK_TOKEN` environment variable:
+
+```bash
+MSGVAULT_SLACK_TOKEN="xoxp-..." msgvault add-slack
+msgvault add-slack --token-file ~/slack-token.txt
+```
+
+Repeat for additional workspaces — tokens are per-workspace and sources stay
+separately filterable in the TUI (`a`).
+
+## Sync
+
+```bash
+# First run backfills all history; later runs are incremental.
+msgvault sync-slack
+
+# One workspace only.
+msgvault sync-slack T0123456789
+
+# Repair path: re-fetch everything, upserting in place.
+msgvault sync-slack --full
+```
+
+| Flag | Description |
+|---|---|
+| `--limit N` | Max messages of work per conversation this run — thread replies count via their `reply_count` forecast, and the reply sweep gets the same budget workspace-wide. Every phase resumes next run (large threads, catch-up walks, and the sweep all make durable progress), so standing limited schedules converge; only the maintenance rescan is skipped |
+| `--full` | Start (or continue) a repair session: re-fetch and upsert every message in place. Interrupted or `--limit`-scoped repairs resume across subsequent runs of any kind until complete |
+| `--no-threads` | Skip thread-reply fetching this run (a later threaded run pays the debt automatically) |
+| `--maintenance` | Repair edits and reaction changes on recent messages, thread replies included (archives ignore post-capture mutations by default; "recent" keys on message age — edits to older messages need `--full`) |
+| `--no-media` | Skip file downloads this run (files stay pending for `backfill-slack-media`) |
+
+Backfills are resumable: interrupt with Ctrl-C and the next run continues
+from the last checkpoint. Incremental runs fetch new messages, re-scan the
+sweep for thread replies created since the last run.
+
+Slack's history API never returns thread replies in the main channel stream
+(unless "also sent to channel"), and offers no change feed. The importer
+discovers replies with a search sweep (`threads:replies`, day-granular,
+resumable via a UTC watermark): a reply is found by its **creation time**,
+so the age of its thread is irrelevant — no lookback window, no blind spot.
+Discovered replies are archived canonically via `conversations.replies`.
+A channel that was excluded (or unreadable) while sweeps advanced recovers
+automatically when it returns: the importer runs a channel-scoped catch-up
+sweep over the days it missed before rejoining the workspace-wide sweep.
+One documented edge: a single day whose reply count exceeds search's
+~10,000 reachable results per query cannot be fully swept — the run fails
+loudly (never silently skipping), records the unreachable remainder as
+thread catch-up debt, and later runs recover it automatically without
+search; per-channel query narrowing for this case is planned.
+Edits and reaction changes after capture are ignored by default; run
+`sync-slack --maintenance` to repair the recent window, or `--full` to
+repair everything.
+Deleted messages simply
+disappear from Slack — your archived copy is kept (archive semantics; nothing
+is ever deleted locally). This holds on every re-read path, `--full` and
+`--maintenance` included: a deleted thread root that Slack still serves as a
+tombstone row never overwrites the archived original.
+
+### Files
+
+Files are downloaded into content-addressed attachment storage, capped at
+`max_media_mb` per file. Files hosted outside `files.slack.com` (external
+links, connected drives) are recorded as metadata + permalink only. Failed
+downloads leave pending markers:
+
+```bash
+msgvault backfill-slack-media
+```
+
+retries them (idempotent; already-downloaded files are never re-fetched).
+The command always downloads, even while `[slack].media = false` keeps the
+scheduled syncs deferring files — that setting's documented workflow (defer
+now, backfill later) depends on it.
+
+## Daemon scheduling
+
+```toml
+[slack]
+enabled = true
+schedule = "*/30 * * * *"
+```
+
+The daemon then syncs every registered workspace on the schedule. See
+[Configuration](/configuration/#slack) for the full option list
+(channel include/exclude filters, media caps).
+
+## Identity unification
+
+Workspace members' profile emails (via `users:read.email`) link their Slack
+messages to the same participant as their archived mail, so searching a
+person spans both. Bots, deactivated members, and Slack Connect guests
+without a visible email resolve as Slack-only identities.

--- a/docs/usage/slack.md
+++ b/docs/usage/slack.md
@@ -80,15 +80,19 @@ msgvault sync-slack --full
 | `--no-media` | Skip file downloads this run (files stay pending for `backfill-slack-media`) |
 
 Backfills are resumable: interrupt with Ctrl-C and the next run continues
-from the last checkpoint. Incremental runs fetch new messages, re-scan the
-sweep for thread replies created since the last run.
+from the last checkpoint. Incremental runs fetch new messages and sweep for
+thread replies created since the last run.
 
 Slack's history API never returns thread replies in the main channel stream
 (unless "also sent to channel"), and offers no change feed. The importer
 discovers replies with a search sweep (`threads:replies`, day-granular,
 resumable via a UTC watermark): a reply is found by its **creation time**,
-so the age of its thread is irrelevant — no lookback window, no blind spot.
-Discovered replies are archived canonically via `conversations.replies`.
+so the age of its thread is irrelevant. Because Slack publishes no maximum
+search-index delay, the importer also re-walks one oldest-due conversation's
+canonical history and threads per run. Continued scheduled runs rotate across
+the workspace, eventually covering even a reply that search never indexes.
+Discovered replies and audits are archived canonically via
+`conversations.replies`.
 A channel that was excluded (or unreadable) while sweeps advanced recovers
 automatically when it returns: the importer runs a channel-scoped catch-up
 sweep over the days it missed before rejoining the workspace-wide sweep.
@@ -100,11 +104,11 @@ search; per-channel query narrowing for this case is planned.
 Edits and reaction changes after capture are ignored by default; run
 `sync-slack --maintenance` to repair the recent window, or `--full` to
 repair everything.
-Deleted messages simply
-disappear from Slack — your archived copy is kept (archive semantics; nothing
-is ever deleted locally). This holds on every re-read path, `--full` and
-`--maintenance` included: a deleted thread root that Slack still serves as a
-tombstone row never overwrites the archived original.
+Deleted messages never erase their archived content locally. They are marked
+deleted-at-source so active-message queries match Teams and Discord semantics.
+This holds on every re-read path, `--full` and `--maintenance` included: a
+deleted thread root that Slack still serves as a tombstone row never overwrites
+the archived body, raw JSON, attachments, or reactions.
 
 ### Files
 
@@ -121,6 +125,9 @@ retries them (idempotent; already-downloaded files are never re-fetched).
 The command always downloads, even while `[slack].media = false` keeps the
 scheduled syncs deferring files — that setting's documented workflow (defer
 now, backfill later) depends on it.
+If Slack removes a file before it is downloaded, msgvault keeps the last
+captured filename, size, and permalink as terminal metadata rather than
+deleting the row or retrying an unreachable file forever.
 
 ## Daemon scheduling
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -30,6 +30,7 @@ nav = [
     {"Microsoft Teams" = "usage/teams.md"},
     {"Discord" = "usage/discord.md"},
     {"Beeper" = "usage/beeper.md"},
+    {"Slack" = "usage/slack.md"},
     {"Meeting Transcripts" = "usage/meetings.md"},
     {"Exporting Data" = "usage/exporting.md"},
     {"Analytics & Stats" = "usage/analytics.md"},

--- a/internal/api/cli_allowlist_slack_test.go
+++ b/internal/api/cli_allowlist_slack_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The daemon-only CLI model means a command missing from the run allowlist
+// simply does not work end-to-end, with no compile-time signal — so the
+// Slack commands' presence is asserted explicitly.
+func TestCLIRunCommandAllowedSlackCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"add-slack"},
+		{"sync-slack"},
+		{"sync-slack", "T0123456789", "--full"},
+		{"backfill-slack-media"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			assert.True(t, cliRunCommandAllowed(args), "%v must be runnable via the daemon CLI", args)
+		})
+	}
+	assert.False(t, cliRunCommandAllowed([]string{"slack-not-a-command"}))
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1293,10 +1293,12 @@ func cliRunCommandAllowed(args []string) bool {
 		"add-granola",
 		"add-imap",
 		"add-o365",
+		"add-slack",
 		"add-synctech-sms-drive",
 		"add-teams",
 		"backfill-beeper-media",
 		"backfill-discord-media",
+		"backfill-slack-media",
 		"backfill-teams-media",
 		"build-embeddings",
 		"cancel-deletion",
@@ -1327,6 +1329,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"sync-circleback",
 		"sync-discord",
 		"sync-granola",
+		"sync-slack",
 		"sync-synctech-sms",
 		"sync-teams":
 		return true

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3633,6 +3633,7 @@ func TestSchedulerJobNameForSource(t *testing.T) {
 		{"granola", granola.SourceType, "acct-1", "granola:acct-1", true},
 		{"circleback", circleback.SourceType, "acct-2", "circleback:acct-2", true},
 		{"beeper", "beeper", "beeper-account-1", "beeper", true},
+		{"slack", "slack", "T01:U01", "slack", true},
 		{"account scheduler type", "gmail", "alice@example.com", "", false},
 	}
 	for _, tc := range cases {

--- a/internal/api/scheduler_jobs.go
+++ b/internal/api/scheduler_jobs.go
@@ -12,12 +12,19 @@ import (
 // sourceTypeBeeper mirrors the unexported sourceTypeBeeper constant in
 // internal/beeper (and cmd/msgvault/cmd/constants.go); it can't be imported
 // because it isn't exported, so the literal is duplicated here.
-const sourceTypeBeeper = "beeper"
+const (
+	sourceTypeBeeper = "beeper"
+	sourceTypeSlack  = "slack"
+)
 
 // BeeperJobName is the single generic-job name that drives every beeper
 // store source. cmd/msgvault/cmd/attachment_maintenance.go registers the
 // beeper sync job under this exact name.
 const BeeperJobName = sourceTypeBeeper
+
+// SlackJobName is the single generic-job name that drives the configured
+// Slack workspace source.
+const SlackJobName = sourceTypeSlack
 
 // SchedulerJobNameForSource returns the scheduler generic-job name that
 // drives syncing for a store source of the given type and identifier, and
@@ -57,6 +64,10 @@ func SchedulerJobNameForSource(sourceType, identifier string) (string, bool) {
 		// internal/beeper/importer.go GetOrCreateSource, one store source
 		// per beeper AccountID, all driven by the singleton "beeper" job).
 		return BeeperJobName, true
+	case sourceTypeSlack:
+		// One configured Slack workspace maps to one store source and one
+		// singleton daemon job.
+		return SlackJobName, true
 	default:
 		return "", false
 	}

--- a/internal/clirun/env.go
+++ b/internal/clirun/env.go
@@ -11,12 +11,16 @@ const EnvBeeperToken = "MSGVAULT_BEEPER_TOKEN" // #nosec G101 -- environment var
 // daemon-owned CLI subprocess.
 const EnvDiscordToken = "MSGVAULT_DISCORD_TOKEN" // #nosec G101 -- environment variable name, not a credential value
 
+// EnvSlackToken names the env var used to pass a Slack user token to a
+// daemon-owned CLI subprocess.
+const EnvSlackToken = "MSGVAULT_SLACK_TOKEN" // #nosec G101 -- environment variable name, not a credential value
+
 // EnvRemoteDeleteOptIn names the env var that opts into executing staged remote deletions.
 const EnvRemoteDeleteOptIn = "MSGVAULT_ENABLE_REMOTE_DELETE"
 
 func EnvAllowed(name string) bool {
 	switch name {
-	case EnvIMAPPassword, EnvBeeperToken, EnvDiscordToken, EnvRemoteDeleteOptIn:
+	case EnvIMAPPassword, EnvBeeperToken, EnvDiscordToken, EnvSlackToken, EnvRemoteDeleteOptIn:
 		return true
 	default:
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -328,6 +328,7 @@ type Config struct {
 	SynctechSMS  SynctechSMSConfig  `toml:"synctech_sms"`
 	GCal         []GCalSource       `toml:"gcal"`
 	Beeper       BeeperConfig       `toml:"beeper"`
+	Slack        SlackConfig        `toml:"slack"`
 	Granola      []GranolaSource    `toml:"granola"`
 	Circleback   []CirclebackSource `toml:"circleback"`
 	Backup       BackupConfig       `toml:"backup"`
@@ -904,6 +905,38 @@ type BeeperConfig struct {
 	Media *bool `toml:"media"`
 	// MaxMediaMB caps individual attachment downloads in MiB (0 = 100).
 	MaxMediaMB int `toml:"max_media_mb"`
+}
+
+// SlackConfig configures Slack workspace archive sources ([slack] table).
+// One block covers every registered workspace: tokens are per-workspace
+// files, so no per-workspace config entries are needed.
+type SlackConfig struct {
+	// Enabled gates the daemon scheduler job.
+	Enabled bool `toml:"enabled"`
+	// Schedule is a 5-field cron expression; empty = not daemon-scheduled.
+	Schedule string `toml:"schedule"`
+	// Channels is a channel-name include filter (no "#"; empty = archive
+	// every membership). DMs and group DMs are never filtered.
+	Channels []string `toml:"channels"`
+	// ExcludeChannels skips specific channel names.
+	ExcludeChannels []string `toml:"exclude_channels"`
+	// Media toggles file download (nil/absent = enabled).
+	Media *bool `toml:"media"`
+	// MaxMediaMB caps individual file downloads in MiB (0 = 100).
+	MaxMediaMB int `toml:"max_media_mb"`
+}
+
+// MediaEnabled reports whether file download is on (default true).
+func (s SlackConfig) MediaEnabled() bool {
+	return s.Media == nil || *s.Media
+}
+
+// MaxMediaBytes returns the per-file download cap in bytes (0 = importer default).
+func (s SlackConfig) MaxMediaBytes() int64 {
+	if s.MaxMediaMB > 0 {
+		return int64(s.MaxMediaMB) << 20
+	}
+	return 0
 }
 
 // MediaEnabled reports whether attachment download is on (default true).

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -655,6 +655,7 @@ func validateEditableCandidate(cfg *Config) error {
 	schedules := map[string]string{
 		"vector.embed.schedule.cron": cfg.Vector.Embed.Schedule.Cron,
 		"beeper.schedule":            cfg.Beeper.Schedule,
+		"slack.schedule":             cfg.Slack.Schedule,
 	}
 	for index, account := range cfg.Accounts {
 		schedules[fmt.Sprintf("accounts[%d].schedule", index)] = account.Schedule

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1321,6 +1321,23 @@ func TestEditConfigValidatesEnabledVectorCandidate(t *testing.T) {
 	assert.Equal(before, string(got))
 }
 
+func TestEditConfigRejectsInvalidSlackSchedule(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	before := "[slack]\nenabled = true\nschedule = \"0 * * * *\"\n"
+	require.NoError(os.WriteFile(path, []byte(before), 0o600))
+	snapshot, err := ReadConfigFile(path)
+	require.NoError(err)
+
+	_, err = EditConfigFile(path, snapshot.ETag, []Edit{{Key: "slack.schedule", Value: "not a cron"}})
+	require.ErrorIs(err, ErrInvalidConfigCandidate)
+	assert.Contains(err.Error(), "invalid slack.schedule")
+	got, readErr := os.ReadFile(path)
+	require.NoError(readErr)
+	assert.Equal(before, string(got))
+}
+
 func TestEditConfigPreservesModeAndExistingSymlink(t *testing.T) {
 	if runtime.GOOS == windowsOS {
 		t.Skip("symlink permission semantics differ on Windows")

--- a/internal/identityindex/schema.go
+++ b/internal/identityindex/schema.go
@@ -25,7 +25,7 @@ const (
 var (
 	TextMessageTypes = []string{
 		"whatsapp", "imessage", "sms", "mms", "rcs",
-		"google_voice_text", "teams", "discord", "beeper", "fbmessenger",
+		"google_voice_text", "teams", "discord", "beeper", "slack", "fbmessenger",
 	}
 	ChatFallbackMessageTypes = []string{"", "chat", "text"}
 	ChatConversationTypes    = []string{"direct_chat", "group_chat", "channel", "chat"}

--- a/internal/query/text_models.go
+++ b/internal/query/text_models.go
@@ -171,6 +171,7 @@ var KnownMessageTypes = []string{
 	"google_voice_call",
 	"google_voice_voicemail",
 	"beeper",
+	"slack",
 }
 
 // IsKnownMessageType reports whether mt is a message_type value that msgvault

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -1,0 +1,533 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	maxRetries = 8
+	// DefaultBaseURL is the Slack Web API root. Injected so tests can point
+	// at httptest servers.
+	DefaultBaseURL = "https://slack.com/api"
+
+	// historyPageLimit is the page size requested from conversations.history
+	// and conversations.replies. Internal (non-distributed) apps are granted
+	// up to 999; distributed non-Marketplace apps are clamped to 15 — the
+	// client honors whatever the server returns either way.
+	historyPageLimit = 999
+	// listPageLimit is the page size for enumeration methods.
+	listPageLimit = 200
+)
+
+// Web API method tiers (docs.slack.dev/apis/web-api/rate-limits). The
+// limiters run slightly under the published per-minute budgets so scheduled
+// daemon syncs never trip 429 in steady state; 429 + Retry-After remains the
+// authoritative backstop.
+var methodTiers = map[string]int{
+	"auth.test":             4,
+	"users.list":            2,
+	"users.conversations":   3,
+	"conversations.history": 3,
+	"conversations.replies": 3,
+	"conversations.members": 4,
+	"search.messages":       2,
+}
+
+// ErrNotFound reports a channel/thread/user that no longer exists.
+var ErrNotFound = errors.New("not found")
+
+// ErrAssetTooLarge reports a file exceeding the caller's size cap; the cap is
+// enforced while reading so oversized bodies are never fully buffered.
+var ErrAssetTooLarge = errors.New("file exceeds size cap")
+
+// ErrAuth reports a rejected or under-scoped token; callers surface it with
+// re-run-add-slack guidance instead of retrying.
+var ErrAuth = errors.New("slack auth error")
+
+// notFoundAPIErrors are Slack method errors that mean "the thing is gone",
+// not "the request failed".
+var notFoundAPIErrors = map[string]bool{
+	"channel_not_found": true,
+	"thread_not_found":  true,
+	"message_not_found": true,
+	"user_not_found":    true,
+	"file_not_found":    true,
+	"file_deleted":      true,
+}
+
+// authAPIErrors are Slack method errors that mean the token (not the
+// request) is the problem.
+var authAPIErrors = map[string]bool{
+	"invalid_auth":       true,
+	"not_authed":         true,
+	"account_inactive":   true,
+	"token_revoked":      true,
+	"token_expired":      true,
+	"missing_scope":      true,
+	"no_permission":      true,
+	"ekm_access_denied":  true,
+	"org_login_required": true,
+}
+
+// Client is a read-only Slack Web API client: it exposes only read methods
+// by construction, so the archiver can never mutate workspace state.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+	// limiters holds one token bucket per rate tier (see methodTiers).
+	limiters map[int]*rate.Limiter
+	// mediaTransport overrides the file-download transport (tests only; the
+	// API base URL is injectable but file URLs are validated against the real
+	// files.slack.com host).
+	mediaTransport http.RoundTripper
+}
+
+// NewClient creates a Client. baseURL "" means the real Slack API.
+func NewClient(baseURL, token string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	perMinute := func(n float64) *rate.Limiter {
+		return rate.NewLimiter(rate.Limit(n/60), 2)
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 60 * time.Second},
+		limiters: map[int]*rate.Limiter{
+			2: perMinute(18),
+			3: perMinute(45),
+			4: perMinute(90),
+		},
+	}
+}
+
+// disableRateLimits removes the per-tier pacing (tests only).
+func (c *Client) disableRateLimits() {
+	for tier := range c.limiters {
+		c.limiters[tier] = rate.NewLimiter(rate.Inf, 1)
+	}
+}
+
+// call POSTs a Web API method with form params, decoding the JSON body into
+// out (which must embed apiResponse via an ok/error check by the caller).
+// 429 and 5xx are retried with Retry-After / exponential back-off.
+func (c *Client) call(ctx context.Context, method string, params url.Values, out any) error {
+	// Strict method allowlist: reqURL is base + method, and the G704
+	// suppressions below rest on method being one of these package
+	// constants. Refusing unknown methods enforces that at runtime instead
+	// of by convention (and no new method can dodge tier classification).
+	tier, ok := methodTiers[method]
+	if !ok {
+		return fmt.Errorf("slack client: method %q is not allowlisted", method)
+	}
+	reqURL := c.baseURL + "/" + method
+	body := params.Encode()
+	for attempt := range maxRetries {
+		if err := c.limiters[tier].Wait(ctx); err != nil {
+			return fmt.Errorf("wait for slack rate limit: %w", err)
+		}
+		// reqURL is the constant Slack API base (or a test-injected httptest
+		// URL) plus an allowlisted package-constant method name (enforced
+		// above) — no remote or user input reaches it. gosec's taint
+		// analysis flags it via the env-var-driven live-probe test.
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(body)) // #nosec G704
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := c.http.Do(req) // #nosec G704 -- see reqURL above
+		if err != nil {
+			return fmt.Errorf("slack %s: %w", method, err)
+		}
+		data, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return fmt.Errorf("slack %s: read body: %w", method, readErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("slack %s: close body: %w", method, closeErr)
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("slack %s: status %d: %s", method, resp.StatusCode, truncate(data, 200))
+		}
+
+		var envelope apiResponse
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("slack %s: decode envelope: %w", method, err)
+		}
+		if !envelope.OK {
+			return apiError(method, &envelope)
+		}
+		if out != nil {
+			if err := json.Unmarshal(data, out); err != nil {
+				return fmt.Errorf("slack %s: decode response: %w", method, err)
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("slack %s: exhausted %d retries", method, maxRetries)
+}
+
+// apiError maps a Slack method-level error string to a typed error.
+func apiError(method string, envelope *apiResponse) error {
+	switch {
+	case notFoundAPIErrors[envelope.Error]:
+		return fmt.Errorf("slack %s: %s: %w", method, envelope.Error, ErrNotFound)
+	case authAPIErrors[envelope.Error]:
+		detail := ""
+		if envelope.Error == "missing_scope" {
+			detail = fmt.Sprintf(" (needs scope %q, token has %q)", envelope.Needed, envelope.Provided)
+		}
+		return fmt.Errorf("slack %s: %s%s: re-run 'msgvault add-slack' with an updated token: %w",
+			method, envelope.Error, detail, ErrAuth)
+	default:
+		return fmt.Errorf("slack %s: %s", method, envelope.Error)
+	}
+}
+
+// retryAfter parses a Retry-After header (seconds) or falls back to
+// exponential back-off capped at 60 s.
+func retryAfter(header string, attempt int) time.Duration {
+	if header != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}
+
+// AuthTest validates the token and identifies its workspace and user.
+func (c *Client) AuthTest(ctx context.Context) (*AuthTestResult, error) {
+	var out struct {
+		apiResponse
+		AuthTestResult
+	}
+	if err := c.call(ctx, "auth.test", url.Values{}, &out); err != nil {
+		return nil, err
+	}
+	return &out.AuthTestResult, nil
+}
+
+// AllConversations pages through the user's conversation memberships of all
+// four types, invoking fn per conversation.
+func (c *Client) AllConversations(ctx context.Context, fn func(Conversation) error) error {
+	cursor := ""
+	for {
+		params := url.Values{
+			"types":            {"public_channel,private_channel,mpim,im"},
+			"limit":            {strconv.Itoa(listPageLimit)},
+			"exclude_archived": {"false"},
+		}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var out struct {
+			apiResponse
+
+			Channels []Conversation `json:"channels"`
+		}
+		if err := c.call(ctx, "users.conversations", params, &out); err != nil {
+			return err
+		}
+		for i := range out.Channels {
+			if err := fn(out.Channels[i]); err != nil {
+				return err
+			}
+		}
+		cursor = out.Metadata.NextCursor
+		if cursor == "" {
+			return nil
+		}
+	}
+}
+
+// AllUsers pages through the workspace member list, invoking fn per user.
+func (c *Client) AllUsers(ctx context.Context, fn func(User) error) error {
+	cursor := ""
+	for {
+		params := url.Values{"limit": {strconv.Itoa(listPageLimit)}}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var out struct {
+			apiResponse
+
+			Members []User `json:"members"`
+		}
+		if err := c.call(ctx, "users.list", params, &out); err != nil {
+			return err
+		}
+		for i := range out.Members {
+			if err := fn(out.Members[i]); err != nil {
+				return err
+			}
+		}
+		cursor = out.Metadata.NextCursor
+		if cursor == "" {
+			return nil
+		}
+	}
+}
+
+// AllMembers pages through a conversation's member user IDs.
+func (c *Client) AllMembers(ctx context.Context, channelID string, fn func(userID string) error) error {
+	cursor := ""
+	for {
+		params := url.Values{
+			"channel": {channelID},
+			"limit":   {strconv.Itoa(listPageLimit)},
+		}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var out struct {
+			apiResponse
+
+			Members []string `json:"members"`
+		}
+		if err := c.call(ctx, "conversations.members", params, &out); err != nil {
+			return err
+		}
+		for _, id := range out.Members {
+			if err := fn(id); err != nil {
+				return err
+			}
+		}
+		cursor = out.Metadata.NextCursor
+		if cursor == "" {
+			return nil
+		}
+	}
+}
+
+// HistoryPage is one page of conversations.history / conversations.replies.
+type HistoryPage struct {
+	Messages   []Message
+	HasMore    bool
+	NextCursor string
+}
+
+// HistoryParams selects a slice of a conversation's history.
+type HistoryParams struct {
+	ChannelID string
+	Cursor    string // opaque page cursor; mutually advancing with Oldest
+	Oldest    string // lower ts bound ("" = beginning)
+	Latest    string // upper ts bound ("" = now)
+	// Inclusive makes the Oldest/Latest bounds inclusive (the edit rescan
+	// must re-read the cursor message itself; default exclusive bounds are
+	// what cursor-advancing walks need).
+	Inclusive bool
+}
+
+// HistoryPage fetches one page of top-level channel history. Slack pages
+// newest→oldest without a cursor; the importer requests oldest-bounded
+// windows and walks pages via NextCursor.
+func (c *Client) HistoryPage(ctx context.Context, p HistoryParams) (*HistoryPage, error) {
+	return c.historyPageWithLimit(ctx, p, historyPageLimit)
+}
+
+// historyPageWithLimit is HistoryPage with an explicit page size (the
+// importer sizes pages to the remaining --limit budget; the live throttle
+// probe uses tiny pages).
+func (c *Client) historyPageWithLimit(ctx context.Context, p HistoryParams, limit int) (*HistoryPage, error) {
+	params := url.Values{
+		"channel":   {p.ChannelID},
+		"limit":     {strconv.Itoa(limit)},
+		"inclusive": {strconv.FormatBool(p.Inclusive)},
+	}
+	if p.Cursor != "" {
+		params.Set("cursor", p.Cursor)
+	}
+	if p.Oldest != "" {
+		params.Set("oldest", p.Oldest)
+	}
+	if p.Latest != "" {
+		params.Set("latest", p.Latest)
+	}
+	var out struct {
+		apiResponse
+
+		Messages []Message `json:"messages"`
+		HasMore  bool      `json:"has_more"`
+	}
+	if err := c.call(ctx, "conversations.history", params, &out); err != nil {
+		return nil, err
+	}
+	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
+}
+
+// RepliesPage fetches one page of a thread's replies. rootTS must be the
+// thread ROOT's ts for full-thread results: probed live, a reply's ts
+// serves ONLY that reply (no bound or limit expands it), while a root
+// anchor serves the whole thread with the parent first — included even
+// below an oldest bound. Callers must skip or idempotently re-upsert the
+// included root, and re-anchor via a returned reply's thread_ts when they
+// only had a reply ts to start from (see drainPendingThreads).
+func (c *Client) RepliesPage(ctx context.Context, channelID, rootTS, cursor, oldest string) (*HistoryPage, error) {
+	return c.repliesPageWithLimit(ctx, channelID, rootTS, cursor, oldest, historyPageLimit)
+}
+
+// searchPageLimit is the result page size for search.messages (its maximum).
+const searchPageLimit = 100
+
+// maxSearchPages is the server-side page-number ceiling on search.messages.
+// Requests beyond it are silently CLAMPED to page 1 (probed live), so the
+// pager must both bound itself here and verify the echoed page number.
+const maxSearchPages = 100
+
+// SearchMatch is one search.messages hit, reduced to the fields the sweep
+// consumes. Search results are never archived directly (they are not native
+// message objects); they are pointers for canonical conversations.replies
+// fetches.
+type SearchMatch struct {
+	ChannelID string
+	TS        string
+	// RootTS is the thread root ts parsed from the permalink's thread_ts
+	// query parameter ("" when unparseable — the hit then becomes a solo
+	// drain entry anchored at the reply itself, which the drain re-anchors
+	// to the true root from the fetched reply's own thread_ts).
+	RootTS string
+}
+
+// SearchPage is one page of search.messages results.
+type SearchPage struct {
+	Matches []SearchMatch
+	// Page is the ECHOED page number: when it differs from the requested
+	// page, the server clamped the request (past its page ceiling) and the
+	// walk must stop.
+	Page  int
+	Pages int
+	Total int
+}
+
+// SearchMessagesPage runs one page of a search.messages query, always
+// timestamp-ascending (the sweep watermark requires stable ascending order;
+// probed stable across full walks with no duplicates).
+func (c *Client) SearchMessagesPage(ctx context.Context, query string, page int) (*SearchPage, error) {
+	params := url.Values{
+		"query":    {query},
+		"count":    {strconv.Itoa(searchPageLimit)},
+		"page":     {strconv.Itoa(page)},
+		"sort":     {"timestamp"},
+		"sort_dir": {"asc"},
+	}
+	var out struct {
+		apiResponse
+
+		Messages struct {
+			Total  int `json:"total"`
+			Paging struct {
+				Page  int `json:"page"`
+				Pages int `json:"pages"`
+			} `json:"paging"`
+			Matches []struct {
+				TS      string `json:"ts"`
+				Channel struct {
+					ID string `json:"id"`
+				} `json:"channel"`
+				Permalink string `json:"permalink"`
+			} `json:"matches"`
+		} `json:"messages"`
+	}
+	if err := c.call(ctx, "search.messages", params, &out); err != nil {
+		return nil, err
+	}
+	sp := &SearchPage{
+		Page:  out.Messages.Paging.Page,
+		Pages: out.Messages.Paging.Pages,
+		Total: out.Messages.Total,
+	}
+	for _, m := range out.Messages.Matches {
+		sp.Matches = append(sp.Matches, SearchMatch{
+			ChannelID: m.Channel.ID,
+			TS:        m.TS,
+			RootTS:    permalinkThreadTS(m.Permalink),
+		})
+	}
+	return sp, nil
+}
+
+// ValidateSearchScope verifies the token can call search.messages (user
+// scope search:read), which the reply sweep depends on. Run at add-slack
+// time so an under-scoped token fails setup with instructions instead of
+// failing every future sync's sweep.
+func (c *Client) ValidateSearchScope(ctx context.Context) error {
+	if _, err := c.SearchMessagesPage(ctx, "msgvault scope check", 1); err != nil {
+		if errors.Is(err, ErrAuth) {
+			return fmt.Errorf("token cannot use search.messages, which reply archiving requires — add the search:read user scope, reinstall the app, and retry with the new token: %w", err)
+		}
+		return fmt.Errorf("verify search.messages access: %w", err)
+	}
+	return nil
+}
+
+// permalinkThreadTS extracts the thread_ts query parameter from a message
+// permalink ("" when absent or unparseable). Used only as a grouping
+// optimization — never as the source of truth for thread membership.
+func permalinkThreadTS(permalink string) string {
+	u, err := url.Parse(permalink)
+	if err != nil {
+		return ""
+	}
+	return u.Query().Get("thread_ts")
+}
+
+// repliesPageWithLimit is RepliesPage with an explicit page size (sized to
+// the importer's remaining --limit budget).
+func (c *Client) repliesPageWithLimit(ctx context.Context, channelID, rootTS, cursor, oldest string, limit int) (*HistoryPage, error) {
+	params := url.Values{
+		"channel": {channelID},
+		"ts":      {rootTS},
+		"limit":   {strconv.Itoa(limit)},
+	}
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+	if oldest != "" {
+		params.Set("oldest", oldest)
+		params.Set("inclusive", "false")
+	}
+	var out struct {
+		apiResponse
+
+		Messages []Message `json:"messages"`
+		HasMore  bool      `json:"has_more"`
+	}
+	if err := c.call(ctx, "conversations.replies", params, &out); err != nil {
+		return nil, err
+	}
+	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
+}

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -389,6 +389,9 @@ func (c *Client) historyPageWithLimit(ctx context.Context, p HistoryParams, limi
 	if out.HasMore && out.Metadata.NextCursor == "" {
 		return nil, errors.New("conversations.history returned has_more without next_cursor")
 	}
+	if p.Cursor != "" && out.Metadata.NextCursor == p.Cursor {
+		return nil, errors.New("conversations.history returned repeated next_cursor")
+	}
 	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
 }
 
@@ -534,6 +537,9 @@ func (c *Client) repliesPageWithLimit(ctx context.Context, channelID, rootTS, cu
 	}
 	if out.HasMore && out.Metadata.NextCursor == "" {
 		return nil, errors.New("conversations.replies returned has_more without next_cursor")
+	}
+	if cursor != "" && out.Metadata.NextCursor == cursor {
+		return nil, errors.New("conversations.replies returned repeated next_cursor")
 	}
 	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
 }

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -386,6 +386,9 @@ func (c *Client) historyPageWithLimit(ctx context.Context, p HistoryParams, limi
 	if err := c.call(ctx, "conversations.history", params, &out); err != nil {
 		return nil, err
 	}
+	if out.HasMore && out.Metadata.NextCursor == "" {
+		return nil, errors.New("conversations.history returned has_more without next_cursor")
+	}
 	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
 }
 
@@ -528,6 +531,9 @@ func (c *Client) repliesPageWithLimit(ctx context.Context, channelID, rootTS, cu
 	}
 	if err := c.call(ctx, "conversations.replies", params, &out); err != nil {
 		return nil, err
+	}
+	if out.HasMore && out.Metadata.NextCursor == "" {
+		return nil, errors.New("conversations.replies returned has_more without next_cursor")
 	}
 	return &HistoryPage{Messages: out.Messages, HasMore: out.HasMore, NextCursor: out.Metadata.NextCursor}, nil
 }

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -55,6 +55,11 @@ var ErrAssetTooLarge = errors.New("file exceeds size cap")
 // re-run-add-slack guidance instead of retrying.
 var ErrAuth = errors.New("slack auth error")
 
+// ErrInvalidCursor reports an opaque Slack pagination cursor that can no
+// longer be used. Callers with a persisted cursor may restart its pinned
+// window from the first page.
+var ErrInvalidCursor = errors.New("invalid Slack pagination cursor")
+
 // notFoundAPIErrors are Slack method errors that mean "the thing is gone",
 // not "the request failed".
 var notFoundAPIErrors = map[string]bool{
@@ -199,6 +204,8 @@ func apiError(method string, envelope *apiResponse) error {
 	switch {
 	case notFoundAPIErrors[envelope.Error]:
 		return fmt.Errorf("slack %s: %s: %w", method, envelope.Error, ErrNotFound)
+	case envelope.Error == "invalid_cursor":
+		return fmt.Errorf("slack %s: %s: %w", method, envelope.Error, ErrInvalidCursor)
 	case authAPIErrors[envelope.Error]:
 		detail := ""
 		if envelope.Error == "missing_scope" {

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -460,8 +460,9 @@ func (c *Client) SearchMessagesPage(ctx context.Context, query string, page int)
 				Pages int `json:"pages"`
 			} `json:"paging"`
 			Matches []struct {
-				TS      string `json:"ts"`
-				Channel struct {
+				TS        string `json:"ts"`
+				ChannelID string `json:"channel_id"`
+				Channel   struct {
 					ID string `json:"id"`
 				} `json:"channel"`
 				Permalink string `json:"permalink"`
@@ -477,8 +478,12 @@ func (c *Client) SearchMessagesPage(ctx context.Context, query string, page int)
 		Total: out.Messages.Total,
 	}
 	for _, m := range out.Messages.Matches {
+		channelID := m.ChannelID
+		if channelID == "" {
+			channelID = m.Channel.ID
+		}
 		sp.Matches = append(sp.Matches, SearchMatch{
-			ChannelID: m.Channel.ID,
+			ChannelID: channelID,
 			TS:        m.TS,
 			RootTS:    permalinkThreadTS(m.Permalink),
 		})

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -1,0 +1,86 @@
+package slack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testClient(t *testing.T, f *fakeSlack) *Client {
+	t.Helper()
+	srv := f.serve()
+	c := NewClient(srv.URL, "xoxp-test")
+	c.disableRateLimits()
+	return c
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	f := newFakeSlack(t)
+	f.rateLimit429s = 2
+	c := testClient(t, f)
+
+	auth, err := c.AuthTest(context.Background())
+	require.NoError(t, err, "429s with Retry-After must be retried, not surfaced")
+	assert.Equal(t, "T01", auth.TeamID)
+	assert.Equal(t, "UME", auth.UserID)
+}
+
+func TestClientErrorMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiError string
+		want     error
+	}{
+		{"not found", "channel_not_found", ErrNotFound},
+		{"auth", "invalid_auth", ErrAuth},
+		{"missing scope", "missing_scope", ErrAuth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := apiError("conversations.history", &apiResponse{Error: tt.apiError})
+			assert.ErrorIs(t, err, tt.want)
+		})
+	}
+	err := apiError("conversations.history", &apiResponse{Error: "fatal_error"})
+	require.NotErrorIs(t, err, ErrNotFound)
+	require.NotErrorIs(t, err, ErrAuth)
+}
+
+func TestClientRejectsUnallowlistedMethods(t *testing.T) {
+	f := newFakeSlack(t)
+	c := testClient(t, f)
+
+	err := c.call(context.Background(), "chat.postMessage", nil, nil)
+	require.ErrorContains(t, err, "not allowlisted",
+		"the client must refuse methods outside its read-only allowlist before any request is made")
+}
+
+func TestValidateSearchScope(t *testing.T) {
+	f := newFakeSlack(t)
+	c := testClient(t, f)
+	require.NoError(t, c.ValidateSearchScope(context.Background()))
+
+	// A token minted without search:read must fail add-slack with
+	// remediation instructions, not fail every future sync's sweep.
+	f.searchMissingScope = true
+	err := c.ValidateSearchScope(context.Background())
+	require.ErrorIs(t, err, ErrAuth)
+	assert.ErrorContains(t, err, "search:read")
+}
+
+func TestClientPagination(t *testing.T) {
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "U1"}, {"id": "U2"}, {"id": "U3"}, {"id": "U4"}, {"id": "U5"},
+	}
+	c := testClient(t, f) // fake pageSize is 3: forces two pages
+
+	var ids []string
+	require.NoError(t, c.AllUsers(context.Background(), func(u User) error {
+		ids = append(ids, u.ID)
+		return nil
+	}))
+	assert.Equal(t, []string{"U1", "U2", "U3", "U4", "U5"}, ids)
+}

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -72,6 +72,40 @@ func TestValidateSearchScope(t *testing.T) {
 	assert.ErrorContains(t, err, "search:read")
 }
 
+func TestSearchMessagesPageDecodesChannelIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"ok": true,
+			"messages": {
+				"total": 2,
+				"paging": {"page": 1, "pages": 1},
+				"matches": [{
+					"channel_id": "C_REAL",
+					"channel": {"id": "C_STALE"},
+					"ts": "1700000001.000100",
+					"permalink": "https://example.slack.com/archives/C_REAL/p1700000001000100?thread_ts=1700000000.000100"
+				}, {
+					"channel": {"id": "C_LEGACY"},
+					"ts": "1700000011.000100",
+					"permalink": "https://example.slack.com/archives/C_LEGACY/p1700000011000100?thread_ts=1700000010.000100"
+				}]
+			}
+		}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+
+	page, err := client.SearchMessagesPage(context.Background(), "threads:replies", 1)
+	require.NoError(t, err)
+	require.Len(t, page.Matches, 2)
+	assert.Equal(t, "C_REAL", page.Matches[0].ChannelID)
+	assert.Equal(t, "1700000000.000100", page.Matches[0].RootTS)
+	assert.Equal(t, "C_LEGACY", page.Matches[1].ChannelID)
+}
+
 func TestClientPagination(t *testing.T) {
 	f := newFakeSlack(t)
 	f.users = []map[string]any{

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -38,6 +38,7 @@ func TestClientErrorMapping(t *testing.T) {
 		{"not found", "channel_not_found", ErrNotFound},
 		{"auth", "invalid_auth", ErrAuth},
 		{"missing scope", "missing_scope", ErrAuth},
+		{"invalid cursor", "invalid_cursor", ErrInvalidCursor},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -48,6 +49,7 @@ func TestClientErrorMapping(t *testing.T) {
 	err := apiError("conversations.history", &apiResponse{Error: "fatal_error"})
 	require.NotErrorIs(t, err, ErrNotFound)
 	require.NotErrorIs(t, err, ErrAuth)
+	require.NotErrorIs(t, err, ErrInvalidCursor)
 }
 
 func TestClientRejectsUnallowlistedMethods(t *testing.T) {

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -108,3 +108,25 @@ func TestClientRejectsHasMoreWithoutNextCursor(t *testing.T) {
 	_, err = client.RepliesPage(context.Background(), "C01", "123.000100", "", "")
 	require.ErrorContains(t, err, "has_more without next_cursor")
 }
+
+func TestClientRejectsRepeatedNextCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"ok": true,
+			"messages": [],
+			"has_more": true,
+			"response_metadata": {"next_cursor": "same"}
+		}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+
+	_, err := client.HistoryPage(context.Background(), HistoryParams{ChannelID: "C01", Cursor: "same"})
+	require.ErrorContains(t, err, "repeated next_cursor")
+
+	_, err = client.RepliesPage(context.Background(), "C01", "123.000100", "same", "")
+	require.ErrorContains(t, err, "repeated next_cursor")
+}

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -2,6 +2,8 @@ package slack
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,4 +85,26 @@ func TestClientPagination(t *testing.T) {
 		return nil
 	}))
 	assert.Equal(t, []string{"U1", "U2", "U3", "U4", "U5"}, ids)
+}
+
+func TestClientRejectsHasMoreWithoutNextCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"ok": true,
+			"messages": [],
+			"has_more": true,
+			"response_metadata": {"next_cursor": ""}
+		}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+
+	_, err := client.HistoryPage(context.Background(), HistoryParams{ChannelID: "C01"})
+	require.ErrorContains(t, err, "has_more without next_cursor")
+
+	_, err = client.RepliesPage(context.Background(), "C01", "123.000100", "", "")
+	require.ErrorContains(t, err, "has_more without next_cursor")
 }

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -75,6 +75,8 @@ func TestValidateSearchScope(t *testing.T) {
 }
 
 func TestSearchMessagesPageDecodesChannelIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte(`{
@@ -94,18 +96,18 @@ func TestSearchMessagesPageDecodesChannelIDs(t *testing.T) {
 				}]
 			}
 		}`))
-		require.NoError(t, err)
+		assert.NoError(err)
 	}))
 	t.Cleanup(srv.Close)
 	client := NewClient(srv.URL, "xoxp-test")
 	client.disableRateLimits()
 
 	page, err := client.SearchMessagesPage(context.Background(), "threads:replies", 1)
-	require.NoError(t, err)
-	require.Len(t, page.Matches, 2)
-	assert.Equal(t, "C_REAL", page.Matches[0].ChannelID)
-	assert.Equal(t, "1700000000.000100", page.Matches[0].RootTS)
-	assert.Equal(t, "C_LEGACY", page.Matches[1].ChannelID)
+	require.NoError(err)
+	require.Len(page.Matches, 2)
+	assert.Equal("C_REAL", page.Matches[0].ChannelID)
+	assert.Equal("1700000000.000100", page.Matches[0].RootTS)
+	assert.Equal("C_LEGACY", page.Matches[1].ChannelID)
 }
 
 func TestClientPagination(t *testing.T) {
@@ -132,7 +134,7 @@ func TestClientRejectsHasMoreWithoutNextCursor(t *testing.T) {
 			"has_more": true,
 			"response_metadata": {"next_cursor": ""}
 		}`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(srv.Close)
 	client := NewClient(srv.URL, "xoxp-test")
@@ -154,7 +156,7 @@ func TestClientRejectsRepeatedNextCursor(t *testing.T) {
 			"has_more": true,
 			"response_metadata": {"next_cursor": "same"}
 		}`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(srv.Close)
 	client := NewClient(srv.URL, "xoxp-test")

--- a/internal/slack/doc.go
+++ b/internal/slack/doc.go
@@ -1,0 +1,18 @@
+// Package slack archives a Slack workspace user's own conversations —
+// public/private channels they are a member of, group DMs, and 1:1 DMs —
+// via the Slack Web API using a user token from a user-created internal
+// (non-distributed) Slack app.
+//
+// Design: docs/internal/slack-ingestion-design.md. The package follows the
+// beeper/teams importer anatomy: a read-only rate-limited client, a
+// per-conversation cursor model persisted in sync_runs.cursor_after, and
+// persistence through the shared store schema (no new core tables).
+//
+// Two properties are load-bearing (probed live 2026-07-18):
+//   - Internal apps are exempt from the 2025 non-Marketplace rate-limit
+//     clampdown: conversations.history serves 999-message pages at Tier 3
+//     rates.
+//   - Thread replies never appear in oldest-filtered conversations.history
+//     (unless broadcast), so incremental sync tracks per-root reply cursors
+//     and re-polls conversations.replies for roots within a lookback window.
+package slack

--- a/internal/slack/doc.go
+++ b/internal/slack/doc.go
@@ -13,6 +13,7 @@
 //     clampdown: conversations.history serves 999-message pages at Tier 3
 //     rates.
 //   - Thread replies never appear in oldest-filtered conversations.history
-//     (unless broadcast), so incremental sync tracks per-root reply cursors
-//     and re-polls conversations.replies for roots within a lookback window.
+//     (unless broadcast), so incremental sync discovers them through
+//     search.messages and periodically re-walks canonical thread history as
+//     a completeness backstop for unbounded search-index lag.
 package slack

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -168,6 +168,9 @@ type fakeSlack struct {
 	// failHistoryContinuations fails only history requests carrying a page
 	// cursor, emulating a walk that dies partway through a multi-page window.
 	failHistoryContinuations bool
+	// forceHasMoreFalse exercises cursor pagination where the legacy
+	// has_more flag disagrees with a valid next_cursor.
+	forceHasMoreFalse bool
 	// ghosts lists conversation IDs that stay enumerable but 404 on read
 	// (see handleGhost).
 	ghosts []string
@@ -396,7 +399,7 @@ func (f *fakeSlack) handleHistory(w http.ResponseWriter, r *http.Request) {
 	}
 	f.reply(w, map[string]any{
 		"messages":          msgs,
-		"has_more":          next != "",
+		"has_more":          next != "" && !f.forceHasMoreFalse,
 		"response_metadata": map[string]any{"next_cursor": next},
 	})
 }
@@ -450,7 +453,7 @@ func (f *fakeSlack) handleReplies(w http.ResponseWriter, r *http.Request) {
 	}
 	f.reply(w, map[string]any{
 		"messages":          msgs,
-		"has_more":          next != "",
+		"has_more":          next != "" && !f.forceHasMoreFalse,
 		"response_metadata": map[string]any{"next_cursor": next},
 	})
 }

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -581,9 +581,9 @@ func (f *fakeSlack) handleSearch(w http.ResponseWriter, r *http.Request) {
 			permalink += "?thread_ts=" + h.rootTS + "&cid=" + h.channelID
 		}
 		matches = append(matches, map[string]any{
-			"ts":        h.ts,
-			"channel":   map[string]any{"id": h.channelID},
-			"permalink": permalink,
+			"ts":         h.ts,
+			"channel_id": h.channelID,
+			"permalink":  permalink,
 		})
 	}
 	f.reply(w, map[string]any{

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -168,6 +168,9 @@ type fakeSlack struct {
 	// failHistoryContinuations fails only history requests carrying a page
 	// cursor, emulating a walk that dies partway through a multi-page window.
 	failHistoryContinuations bool
+	// invalidHistoryCursors makes conversations.history reject the named
+	// cursor strings as expired/invalid Slack pagination state.
+	invalidHistoryCursors map[string]bool
 	// forceHasMoreFalse exercises cursor pagination where the legacy
 	// has_more flag disagrees with a valid next_cursor.
 	forceHasMoreFalse bool
@@ -199,8 +202,9 @@ func newFakeSlack(t *testing.T) *fakeSlack {
 		t: t, pageSize: 3,
 		failHistory: map[string]bool{}, failReplies: map[string]bool{},
 		failMembers: map[string]bool{}, searchHidden: map[string]bool{},
-		searchTruncateDays: map[string]bool{},
-		searchSnapshots:    map[string][]searchHit{},
+		searchTruncateDays:    map[string]bool{},
+		searchSnapshots:       map[string][]searchHit{},
+		invalidHistoryCursors: map[string]bool{},
 	}
 }
 
@@ -389,6 +393,10 @@ func (f *fakeSlack) handleHistory(w http.ResponseWriter, r *http.Request) {
 	}
 	if f.failHistoryContinuations && r.FormValue("cursor") != "" {
 		f.replyErr(w, "internal_error")
+		return
+	}
+	if f.invalidHistoryCursors[r.FormValue("cursor")] {
+		f.replyErr(w, "invalid_cursor")
 		return
 	}
 	visible := visibleHistory(c, r.FormValue("oldest"), r.FormValue("latest"), r.FormValue("inclusive") == "true")

--- a/internal/slack/fake_server_test.go
+++ b/internal/slack/fake_server_test.go
@@ -1,0 +1,593 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeMsg is one message held by the fake Slack server. Channel messages
+// live oldest→newest; ts values are assigned by the test.
+type fakeMsg struct {
+	TS        string
+	ThreadTS  string
+	User      string
+	BotID     string
+	Username  string
+	Subtype   string
+	Text      string
+	Edited    bool
+	Reactions []map[string]any
+	Files     []map[string]any
+	// LegacyAttachments/Blocks emit as "attachments"/"blocks" (bot payloads).
+	LegacyAttachments []map[string]any
+	Blocks            []map[string]any
+	// Replies holds the thread's replies (oldest→newest) when this message
+	// is a root. Reply fakeMsgs must carry ThreadTS = root TS.
+	Replies []fakeMsg
+}
+
+func (m *fakeMsg) toJSON() map[string]any {
+	out := map[string]any{"type": "message", "ts": m.TS, "text": m.Text}
+	if m.User != "" {
+		out["user"] = m.User
+	}
+	if m.BotID != "" {
+		out["bot_id"] = m.BotID
+		out["username"] = m.Username
+	}
+	if m.Subtype != "" {
+		out["subtype"] = m.Subtype
+	}
+	if m.ThreadTS != "" {
+		out["thread_ts"] = m.ThreadTS
+	}
+	if len(m.Replies) > 0 {
+		out["thread_ts"] = m.TS
+		out["reply_count"] = len(m.Replies)
+		out["latest_reply"] = m.Replies[len(m.Replies)-1].TS
+	}
+	if m.Edited {
+		out["edited"] = map[string]any{"user": m.User, "ts": m.TS}
+	}
+	if len(m.Reactions) > 0 {
+		out["reactions"] = m.Reactions
+	}
+	if len(m.Files) > 0 {
+		out["files"] = m.Files
+	}
+	if len(m.LegacyAttachments) > 0 {
+		out["attachments"] = m.LegacyAttachments
+	}
+	if len(m.Blocks) > 0 {
+		out["blocks"] = m.Blocks
+	}
+	return out
+}
+
+type fakeConv struct {
+	ID      string
+	Name    string
+	Kind    string // "public" | "private" | "mpim" | "im"
+	IMUser  string // peer for im
+	Members []string
+	Msgs    []fakeMsg // top-level messages, oldest → newest
+}
+
+func (c *fakeConv) toJSON() map[string]any {
+	out := map[string]any{"id": c.ID, "name": c.Name, "is_member": true}
+	switch c.Kind {
+	case "im":
+		out["is_im"] = true
+		out["user"] = c.IMUser
+	case "mpim":
+		out["is_mpim"] = true
+		out["is_private"] = true
+	case "private":
+		out["is_channel"] = true
+		out["is_private"] = true
+	default:
+		out["is_channel"] = true
+	}
+	return out
+}
+
+// tombstone replaces the message at ts with its deleted-root form as probed
+// live: subtype "tombstone", USLACKBOT sender, canonical text, no reactions
+// or files — while reply_count survives (emitted from the kept Replies), so
+// the thread stays discoverable and its orphaned replies stay served.
+func (c *fakeConv) tombstone(ts string) {
+	m := c.findRoot(ts)
+	m.User = "USLACKBOT"
+	m.BotID = ""
+	m.Username = ""
+	m.Subtype = "tombstone"
+	m.Text = "This message was deleted."
+	m.Edited = false
+	m.Reactions = nil
+	m.Files = nil
+}
+
+// findRoot resolves ts — a root's ts OR any reply's ts — to the thread's
+// root fakeMsg, mimicking conversations.replies' anchor resolution.
+func (c *fakeConv) findRoot(ts string) *fakeMsg {
+	for i := range c.Msgs {
+		if c.Msgs[i].TS == ts {
+			return &c.Msgs[i]
+		}
+		for j := range c.Msgs[i].Replies {
+			if c.Msgs[i].Replies[j].TS == ts {
+				return &c.Msgs[i]
+			}
+		}
+	}
+	return nil
+}
+
+// fakeSlack simulates the Slack Web API surface the importer uses, with
+// cursor pagination semantics matching the real API (newest-first history
+// pages, oldest-exclusive bounds, next_cursor continuation).
+type fakeSlack struct {
+	t        *testing.T
+	pageSize int
+
+	mu    sync.Mutex
+	users []map[string]any
+	convs []*fakeConv
+	// failHistory / failReplies / failMembers make the named channel / root
+	// ts answer a method error (a non-retryable fetch failure).
+	failHistory map[string]bool
+	failReplies map[string]bool
+	failMembers map[string]bool
+	// failSearch makes search.messages answer a method error.
+	failSearch bool
+	// searchMissingScope makes search.messages answer missing_scope (a
+	// token without search:read).
+	searchMissingScope bool
+	// searchPageSize overrides the honored count for search pagination
+	// (0 = honor the requested count).
+	searchPageSize int
+	// searchIndexedThrough hides hits newer than this ts, simulating search
+	// index lag ("" = everything indexed instantly).
+	searchIndexedThrough string
+	// searchHidden hides individual hits by ts, simulating OUT-OF-ORDER
+	// index lag: a message indexed later than ones created after it.
+	searchHidden map[string]bool
+	// searchTruncateDays makes the named on: days report a total beyond
+	// the reachable-result ceiling, emulating a persistently >10k day
+	// while other days stay pageable.
+	searchTruncateDays map[string]bool
+	// searchOmitThreadTS strips thread_ts from result permalinks, so hits
+	// arrive with unparseable roots (the solo-entry degradation path).
+	searchOmitThreadTS bool
+	// failHistoryContinuations fails only history requests carrying a page
+	// cursor, emulating a walk that dies partway through a multi-page window.
+	failHistoryContinuations bool
+	// ghosts lists conversation IDs that stay enumerable but 404 on read
+	// (see handleGhost).
+	ghosts []string
+	// rateLimit429s serves that many 429s (with Retry-After: 0) before
+	// succeeding, per method call sequence.
+	rateLimit429s int
+	// historyCalls counts conversations.history requests.
+	historyCalls int
+	// onHistory, when set, runs synchronously at the top of each
+	// conversations.history request (test-side fault injection at a
+	// deterministic mid-run point).
+	onHistory func(channelID string)
+	// onSearch, when set, runs synchronously at the top of each
+	// search.messages request (f.mu held — do not lock).
+	onSearch func(query string, page int)
+	// searchSnapshots memoizes the materialized hit list per query STRING,
+	// mirroring probed live behavior: search responses are cached by query
+	// string, so pages of one repeated query serve a consistent snapshot
+	// while a changed string (a fresh nonce) re-queries the live index.
+	searchSnapshots map[string][]searchHit
+}
+
+func newFakeSlack(t *testing.T) *fakeSlack {
+	t.Helper()
+	return &fakeSlack{
+		t: t, pageSize: 3,
+		failHistory: map[string]bool{}, failReplies: map[string]bool{},
+		failMembers: map[string]bool{}, searchHidden: map[string]bool{},
+		searchTruncateDays: map[string]bool{},
+		searchSnapshots:    map[string][]searchHit{},
+	}
+}
+
+// handleGhost keeps c in the users.conversations listing while making its
+// history/members lookups answer channel_not_found, like a conversation the
+// token can enumerate but not read.
+func (f *fakeSlack) handleGhost(c *fakeConv) {
+	f.ghosts = append(f.ghosts, c.ID)
+}
+
+func (f *fakeSlack) isGhost(id string) bool {
+	return slices.Contains(f.ghosts, id)
+}
+
+func (f *fakeSlack) conv(id string) *fakeConv {
+	if f.isGhost(id) {
+		return nil
+	}
+	for _, c := range f.convs {
+		if c.ID == id {
+			return c
+		}
+	}
+	return nil
+}
+
+func (f *fakeSlack) serve() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth.test", func(w http.ResponseWriter, r *http.Request) {
+		f.reply(w, map[string]any{
+			"url": "https://testers.slack.com/", "team": "Testers",
+			"user": "me", "team_id": "T01", "user_id": "UME",
+		})
+	})
+	mux.HandleFunc("/users.list", f.handleUsersList)
+	mux.HandleFunc("/users.conversations", f.handleUsersConversations)
+	mux.HandleFunc("/conversations.members", f.handleMembers)
+	mux.HandleFunc("/conversations.history", f.handleHistory)
+	mux.HandleFunc("/conversations.replies", f.handleReplies)
+	mux.HandleFunc("/search.messages", f.handleSearch)
+	// The 429 gate runs before any handler takes f.mu (reply is called with
+	// the mutex held, so it must not lock).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		limited := f.rateLimit429s > 0
+		if limited {
+			f.rateLimit429s--
+		}
+		f.mu.Unlock()
+		if limited {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		mux.ServeHTTP(w, r)
+	}))
+	f.t.Cleanup(srv.Close)
+	return srv
+}
+
+// reply writes a successful envelope. Callers may hold f.mu.
+func (f *fakeSlack) reply(w http.ResponseWriter, body map[string]any) {
+	body["ok"] = true
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		f.t.Errorf("encode fake response: %v", err)
+	}
+}
+
+func (f *fakeSlack) replyErr(w http.ResponseWriter, apiErr string) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": apiErr}); err != nil {
+		f.t.Errorf("encode fake error response: %v", err)
+	}
+}
+
+// page slices items[from:from+size] driven by the "cursor" form value (a
+// stringified index), returning the slice and the next cursor. Like the real
+// API, a "limit" smaller than the server's page size is honored.
+func (f *fakeSlack) page(r *http.Request, n int) (from, to int, next string) {
+	from = 0
+	if cur := r.FormValue("cursor"); cur != "" {
+		idx, err := strconv.Atoi(cur)
+		if err != nil {
+			f.t.Errorf("bad cursor %q", cur)
+			return 0, 0, ""
+		}
+		from = idx
+	}
+	size := f.pageSize
+	if raw := r.FormValue("limit"); raw != "" {
+		if limit, err := strconv.Atoi(raw); err == nil && limit > 0 && limit < size {
+			size = limit
+		}
+	}
+	to = min(from+size, n)
+	if to < n {
+		next = strconv.Itoa(to)
+	}
+	return from, to, next
+}
+
+func (f *fakeSlack) handleUsersList(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	from, to, next := f.page(r, len(f.users))
+	f.reply(w, map[string]any{
+		"members":           f.users[from:to],
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (f *fakeSlack) handleUsersConversations(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	channels := make([]map[string]any, 0, len(f.convs))
+	for _, c := range f.convs {
+		channels = append(channels, c.toJSON())
+	}
+	from, to, next := f.page(r, len(channels))
+	f.reply(w, map[string]any{
+		"channels":          channels[from:to],
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (f *fakeSlack) handleMembers(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := f.conv(r.FormValue("channel"))
+	if c == nil {
+		f.replyErr(w, "channel_not_found")
+		return
+	}
+	if f.failMembers[c.ID] {
+		f.replyErr(w, "internal_error")
+		return
+	}
+	from, to, next := f.page(r, len(c.Members))
+	f.reply(w, map[string]any{
+		"members":           c.Members[from:to],
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+// visibleHistory returns c's top-level messages newest→oldest within the
+// (oldest, latest) ts bounds — exclusive by default, inclusive like the real
+// API's inclusive=true when requested.
+func visibleHistory(c *fakeConv, oldest, latest string, inclusive bool) []fakeMsg {
+	var out []fakeMsg
+	for _, m := range slices.Backward(c.Msgs) {
+		switch {
+		case oldest == "":
+		case inclusive && tsLess(m.TS, oldest):
+			continue
+		case !inclusive && !tsLess(oldest, m.TS):
+			continue
+		}
+		switch {
+		case latest == "":
+		case inclusive && tsLess(latest, m.TS):
+			continue
+		case !inclusive && !tsLess(m.TS, latest):
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func (f *fakeSlack) handleHistory(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.historyCalls++
+	if f.onHistory != nil {
+		f.onHistory(r.FormValue("channel"))
+	}
+	c := f.conv(r.FormValue("channel"))
+	if c == nil {
+		f.replyErr(w, "channel_not_found")
+		return
+	}
+	if f.failHistory[c.ID] {
+		f.replyErr(w, "internal_error")
+		return
+	}
+	if f.failHistoryContinuations && r.FormValue("cursor") != "" {
+		f.replyErr(w, "internal_error")
+		return
+	}
+	visible := visibleHistory(c, r.FormValue("oldest"), r.FormValue("latest"), r.FormValue("inclusive") == "true")
+	from, to, next := f.page(r, len(visible))
+	msgs := make([]map[string]any, 0, to-from)
+	for _, m := range visible[from:to] {
+		msgs = append(msgs, m.toJSON())
+	}
+	f.reply(w, map[string]any{
+		"messages":          msgs,
+		"has_more":          next != "",
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (f *fakeSlack) handleReplies(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := f.conv(r.FormValue("channel"))
+	if c == nil {
+		f.replyErr(w, "channel_not_found")
+		return
+	}
+	rootTS := r.FormValue("ts")
+	if f.failReplies[rootTS] {
+		f.replyErr(w, "internal_error")
+		return
+	}
+	root := c.findRoot(rootTS)
+	if root == nil {
+		f.replyErr(w, "thread_not_found")
+		return
+	}
+	if root.TS != rootTS {
+		// Probed live: a REPLY ts anchor serves ONLY that reply — no
+		// oldest/limit/cursor combination expands it to the thread.
+		for i := range root.Replies {
+			if root.Replies[i].TS == rootTS {
+				f.reply(w, map[string]any{
+					"messages":          []map[string]any{root.Replies[i].toJSON()},
+					"has_more":          false,
+					"response_metadata": map[string]any{"next_cursor": ""},
+				})
+				return
+			}
+		}
+	}
+	oldest := r.FormValue("oldest")
+	// The real API serves the root first (even below the oldest bound —
+	// probed live), then replies oldest→newest.
+	all := []fakeMsg{*root}
+	for _, reply := range root.Replies {
+		if oldest != "" && !tsLess(oldest, reply.TS) {
+			continue
+		}
+		all = append(all, reply)
+	}
+	from, to, next := f.page(r, len(all))
+	msgs := make([]map[string]any, 0, to-from)
+	for _, m := range all[from:to] {
+		msgs = append(msgs, m.toJSON())
+	}
+	f.reply(w, map[string]any{
+		"messages":          msgs,
+		"has_more":          next != "",
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+// searchHit pairs a reply with its location for the fake search index.
+type searchHit struct {
+	channelID string
+	rootTS    string
+	ts        string
+}
+
+// handleSearch mimics search.messages closely enough for the sweep:
+// threads:replies filtering, on:/after: day bounds (UTC days — fake users
+// carry tz_offset 0), in:<#ID> scoping, negated terms ignored, ascending
+// timestamp sort, count/page pagination WITH the probed clamp behavior
+// (page numbers beyond 100 are silently served as page 1).
+func (f *fakeSlack) handleSearch(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failSearch {
+		f.replyErr(w, "fatal_error")
+		return
+	}
+	if f.searchMissingScope {
+		f.replyErr(w, "missing_scope")
+		return
+	}
+	query := r.FormValue("query")
+	if f.onSearch != nil {
+		page, _ := strconv.Atoi(r.FormValue("page"))
+		f.onSearch(query, page)
+	}
+	repliesOnly := false
+	var onDay, afterDay string
+	scopes := map[string]bool{}
+	for tok := range strings.FieldsSeq(query) {
+		switch {
+		case tok == "threads:replies":
+			repliesOnly = true
+		case strings.HasPrefix(tok, "on:"):
+			onDay = strings.TrimPrefix(tok, "on:")
+		case strings.HasPrefix(tok, "after:"):
+			afterDay = strings.TrimPrefix(tok, "after:")
+		case strings.HasPrefix(tok, "in:<#") && strings.HasSuffix(tok, ">"):
+			scopes[tok[len("in:<#"):len(tok)-1]] = true
+		}
+	}
+	day := func(ts string) string { return tsTime(ts).UTC().Format("2006-01-02") }
+	keep := func(ts string) bool {
+		if f.searchHidden[ts] {
+			return false // this message not yet indexed (out-of-order lag)
+		}
+		if f.searchIndexedThrough != "" && tsLess(f.searchIndexedThrough, ts) {
+			return false // not yet indexed
+		}
+		d := day(ts)
+		if onDay != "" && d != onDay {
+			return false
+		}
+		if afterDay != "" && d <= afterDay {
+			return false
+		}
+		return true
+	}
+
+	// Results are memoized per query STRING (probed live: responses are
+	// cached by query string) — repeated pages of one query serve a
+	// consistent snapshot; a changed string re-queries the live index.
+	hits, snapshotted := f.searchSnapshots[query]
+	if !snapshotted {
+		for _, c := range f.convs {
+			if len(scopes) > 0 && !scopes[c.ID] {
+				continue
+			}
+			for i := range c.Msgs {
+				root := &c.Msgs[i]
+				if !repliesOnly && keep(root.TS) {
+					hits = append(hits, searchHit{channelID: c.ID, ts: root.TS})
+				}
+				for j := range root.Replies {
+					if keep(root.Replies[j].TS) {
+						hits = append(hits, searchHit{channelID: c.ID, rootTS: root.TS, ts: root.Replies[j].TS})
+					}
+				}
+			}
+		}
+		f.searchSnapshots[query] = hits
+	}
+	slices.SortFunc(hits, func(a, b searchHit) int {
+		if tsLess(a.ts, b.ts) {
+			return -1
+		}
+		if tsLess(b.ts, a.ts) {
+			return 1
+		}
+		return 0
+	})
+
+	count, _ := strconv.Atoi(r.FormValue("count"))
+	if count <= 0 {
+		count = 20
+	}
+	if f.searchPageSize > 0 && f.searchPageSize < count {
+		count = f.searchPageSize
+	}
+	page, _ := strconv.Atoi(r.FormValue("page"))
+	if page <= 0 {
+		page = 1
+	}
+	if page > 100 {
+		page = 1 // probed live: past-the-ceiling pages are CLAMPED to page 1
+	}
+	total := len(hits)
+	if onDay != "" && f.searchTruncateDays[onDay] {
+		total = sweepTruncationCeiling + 1
+	}
+	pages := (total + count - 1) / count
+	from := min((page-1)*count, len(hits))
+	to := min(from+count, len(hits))
+
+	matches := make([]map[string]any, 0, to-from)
+	for _, h := range hits[from:to] {
+		permalink := "https://testers.slack.com/archives/" + h.channelID + "/p" + strings.ReplaceAll(h.ts, ".", "")
+		if h.rootTS != "" && !f.searchOmitThreadTS {
+			permalink += "?thread_ts=" + h.rootTS + "&cid=" + h.channelID
+		}
+		matches = append(matches, map[string]any{
+			"ts":        h.ts,
+			"channel":   map[string]any{"id": h.channelID},
+			"permalink": permalink,
+		})
+	}
+	f.reply(w, map[string]any{
+		"messages": map[string]any{
+			"total":   total,
+			"paging":  map[string]any{"count": count, "total": total, "page": page, "pages": pages},
+			"matches": matches,
+		},
+	})
+}

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -117,6 +117,11 @@ func NewImporter(s *store.Store, c *Client, teamID string) *Importer {
 	return &Importer{store: s, client: c, res: newParticipantResolver(s, teamID), now: time.Now}
 }
 
+// errInvalidResumeState distinguishes an unreadable durable state blob from a
+// failure to read the store itself. A full repair may discard the former, but
+// must continue to fail closed on the latter.
+var errInvalidResumeState = errors.New("invalid Slack resume state")
+
 // loadResumeState rebuilds the sync state for a source: NEWEST BLOB WINS,
 // wholesale. Every run's first act is to checkpoint its merged resume
 // state, so a checkpoint blob is by construction a superset of the success
@@ -133,11 +138,11 @@ func (imp *Importer) loadResumeState(sourceID int64) (*SyncState, error) {
 	cp, err := imp.store.GetLatestCheckpointedSync(sourceID)
 	if err == nil {
 		if cp == nil || !cp.CursorBefore.Valid {
-			return nil, errors.New("latest Slack checkpoint has no resume state")
+			return nil, fmt.Errorf("latest Slack checkpoint has no resume state: %w", errInvalidResumeState)
 		}
 		state, loadErr := LoadSyncState(cp.CursorBefore.String)
 		if loadErr != nil {
-			return nil, fmt.Errorf("decode latest Slack checkpoint: %w", loadErr)
+			return nil, fmt.Errorf("decode latest Slack checkpoint: %v: %w", loadErr, errInvalidResumeState)
 		}
 		return state, nil
 	}
@@ -148,11 +153,11 @@ func (imp *Importer) loadResumeState(sourceID int64) (*SyncState, error) {
 	prev, err := imp.store.GetLastSuccessfulSync(sourceID)
 	if err == nil {
 		if prev == nil || !prev.CursorAfter.Valid {
-			return nil, errors.New("last successful Slack sync has no resume state")
+			return nil, fmt.Errorf("last successful Slack sync has no resume state: %w", errInvalidResumeState)
 		}
 		state, loadErr := LoadSyncState(prev.CursorAfter.String)
 		if loadErr != nil {
-			return nil, fmt.Errorf("decode last successful Slack resume state: %w", loadErr)
+			return nil, fmt.Errorf("decode last successful Slack resume state: %v: %w", loadErr, errInvalidResumeState)
 		}
 		return state, nil
 	}
@@ -181,7 +186,10 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 
 	state, err := imp.loadResumeState(src.ID)
 	if err != nil {
-		return nil, fmt.Errorf("load Slack resume state: %w", err)
+		if !opts.Full || !errors.Is(err, errInvalidResumeState) {
+			return nil, fmt.Errorf("load Slack resume state: %w", err)
+		}
+		state = NewSyncState()
 	}
 	if opts.Full {
 		// --full starts a repair SESSION, not a one-shot: the reset is

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -142,7 +142,7 @@ func (imp *Importer) loadResumeState(sourceID int64) (*SyncState, error) {
 		}
 		state, loadErr := LoadSyncState(cp.CursorBefore.String)
 		if loadErr != nil {
-			return nil, fmt.Errorf("decode latest Slack checkpoint: %v: %w", loadErr, errInvalidResumeState)
+			return nil, fmt.Errorf("decode latest Slack checkpoint: %w: %w", loadErr, errInvalidResumeState)
 		}
 		return state, nil
 	}
@@ -157,7 +157,7 @@ func (imp *Importer) loadResumeState(sourceID int64) (*SyncState, error) {
 		}
 		state, loadErr := LoadSyncState(prev.CursorAfter.String)
 		if loadErr != nil {
-			return nil, fmt.Errorf("decode last successful Slack resume state: %v: %w", loadErr, errInvalidResumeState)
+			return nil, fmt.Errorf("decode last successful Slack resume state: %w: %w", loadErr, errInvalidResumeState)
 		}
 		return state, nil
 	}

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -32,14 +32,15 @@ const (
 
 // convScope carries per-conversation state through the persist call chain.
 type convScope struct {
-	channelID    string
-	convID       int64
-	sourceID     int64
-	syncID       int64
-	opts         ImportOptions
-	cs           *ConvState
-	toRecipients []messageRecipient
-	budgetUsed   int
+	channelID       string
+	convID          int64
+	sourceID        int64
+	syncID          int64
+	opts            ImportOptions
+	cs              *ConvState
+	toRecipients    []messageRecipient
+	membershipReady bool
+	budgetUsed      int
 }
 
 type messageRecipient struct {
@@ -246,12 +247,12 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 			return sum, err
 		}
 		before := sum.MessagesProcessed
-		var convID int64
-		if convID, err = imp.syncConversation(ctx, syncID, src.ID, c, opts, state, sum); err != nil {
+		var cc *convScope
+		if cc, err = imp.syncConversation(ctx, syncID, src.ID, c, opts, state, sum); err != nil {
 			return sum, err
 		}
-		if state.EnsureConv(c.ID).Done {
-			targets[c.ID] = sweepTarget{convID: convID}
+		if cc.membershipReady && state.EnsureConv(c.ID).Done {
+			targets[c.ID] = sweepTarget{convID: cc.convID, toRecipients: cc.toRecipients}
 		}
 		sum.ConversationsProcessed++
 		if opts.Progress != nil {
@@ -334,20 +335,27 @@ func includeConversation(c *Conversation, opts *ImportOptions) bool {
 // incremental fetch are the same walk). Thread replies are owed by the
 // walks as recorded drain debt (paid before anything else each run) and
 // discovered by the reply sweep thereafter.
-func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int64, c *Conversation, opts ImportOptions, state *SyncState, sum *ImportSummary) (int64, error) {
+func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int64, c *Conversation, opts ImportOptions, state *SyncState, sum *ImportSummary) (*convScope, error) {
 	convID, err := imp.store.EnsureConversationWithType(sourceID, c.ID, conversationType(c), conversationTitle(c, imp.res.displayName))
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	toRecipients, err := imp.ensureMembership(ctx, syncID, convID, c, opts, sum)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	cs := state.EnsureConv(c.ID)
 	cc := &convScope{
 		channelID: c.ID, convID: convID, sourceID: sourceID, syncID: syncID,
 		opts: opts, cs: cs, toRecipients: toRecipients,
+		membershipReady: !c.IsMpim || toRecipients != nil,
+	}
+	// MPIM membership defines every message's "to" snapshot. A failed
+	// members call must hold both history and reply debt so the retry can
+	// persist messages only after their recipients are known.
+	if !cc.membershipReady {
+		return cc, nil
 	}
 
 	// DEBT IS SENIOR TO NEW WORK — both debt channels, uniformly. The
@@ -358,12 +366,12 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 	// saturates --limit starve the debt forever while the windows keep up.
 	if len(cs.PendingThreads) > 0 && !opts.NoThreads {
 		if err := imp.drainPendingThreads(ctx, cc, sum); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	if cs.Done && cs.ThreadsPending && !opts.NoThreads {
 		if err := imp.threadCatchUp(ctx, cc, state, sum); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 
@@ -373,7 +381,7 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 	// (they record conversation-level debt, never list entries).
 	if len(cs.PendingThreads) == 0 || opts.NoThreads {
 		if err := imp.walkWindow(ctx, cc, state, sum); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	// Second chance for catch-up debt: the run that COMPLETES the initial
@@ -382,7 +390,7 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 	// starvation risk: already-Done conversations get the senior slot.
 	if cs.Done && cs.ThreadsPending && !opts.NoThreads {
 		if err := imp.threadCatchUp(ctx, cc, state, sum); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	// The maintenance rescan (edits and reaction repair) runs only when
@@ -391,15 +399,15 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 	// scoped runs regardless.
 	if cs.Done && opts.Maintenance && opts.Limit == 0 {
 		if err := imp.rescanHead(ctx, cc, sum); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
-	return convID, nil
+	return cc, nil
 }
 
-// ensureMembership records the conversation's member list. Membership fetch
-// failures are counted but not fatal: message archiving must not be blocked
-// by a members listing outage.
+// ensureMembership records the conversation's member list. Channel failures
+// are isolated from message archiving, while MPIM callers hold progress
+// because membership defines their per-message recipient snapshot.
 func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64, c *Conversation, opts ImportOptions, sum *ImportSummary) ([]messageRecipient, error) {
 	var members []store.ConversationParticipantRef
 	directRecipients := make([]messageRecipient, 0)
@@ -430,7 +438,10 @@ func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64,
 			}
 			if errors.Is(err, ErrNotFound) {
 				imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
-				return nil, nil
+				// Known-gone is distinct from a transient outage. Let the
+				// history path confirm/record the gone conversation rather
+				// than parking it forever as missing membership.
+				return []messageRecipient{}, nil
 			}
 			// Isolated (message archiving proceeds) but honest: a members
 			// listing outage is a fetch failure and the run must report

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -32,13 +32,19 @@ const (
 
 // convScope carries per-conversation state through the persist call chain.
 type convScope struct {
-	channelID  string
-	convID     int64
-	sourceID   int64
-	syncID     int64
-	opts       ImportOptions
-	cs         *ConvState
-	budgetUsed int
+	channelID    string
+	convID       int64
+	sourceID     int64
+	syncID       int64
+	opts         ImportOptions
+	cs           *ConvState
+	toRecipients []messageRecipient
+	budgetUsed   int
+}
+
+type messageRecipient struct {
+	id   int64
+	name string
 }
 
 // committed is the run's total committed work for this conversation:
@@ -158,7 +164,8 @@ func (imp *Importer) loadResumeState(sourceID int64) (*SyncState, error) {
 // Import runs a backfill-then-incremental sync of the workspace user's
 // conversations. New conversations backfill their full history (resumable
 // across interrupted runs); completed ones fetch only messages newer than
-// the stored cursor, then poll tracked threads for late replies.
+// the stored cursor, then discover late replies with search plus periodic
+// canonical thread audits.
 func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
 	start := imp.now()
 	if opts.TeamID == "" || opts.UserID == "" {
@@ -332,12 +339,16 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 	if err != nil {
 		return 0, err
 	}
-	if err := imp.ensureMembership(ctx, syncID, convID, c, opts, sum); err != nil {
+	toRecipients, err := imp.ensureMembership(ctx, syncID, convID, c, opts, sum)
+	if err != nil {
 		return 0, err
 	}
 
 	cs := state.EnsureConv(c.ID)
-	cc := &convScope{channelID: c.ID, convID: convID, sourceID: sourceID, syncID: syncID, opts: opts, cs: cs}
+	cc := &convScope{
+		channelID: c.ID, convID: convID, sourceID: sourceID, syncID: syncID,
+		opts: opts, cs: cs, toRecipients: toRecipients,
+	}
 
 	// DEBT IS SENIOR TO NEW WORK — both debt channels, uniformly. The
 	// drain list first (its pages already advanced past these roots), then
@@ -389,8 +400,9 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 // ensureMembership records the conversation's member list. Membership fetch
 // failures are counted but not fatal: message archiving must not be blocked
 // by a members listing outage.
-func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64, c *Conversation, opts ImportOptions, sum *ImportSummary) error {
+func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64, c *Conversation, opts ImportOptions, sum *ImportSummary) ([]messageRecipient, error) {
 	var members []store.ConversationParticipantRef
+	directRecipients := make([]messageRecipient, 0)
 	add := func(userID string) error {
 		pid, err := imp.res.resolveID(userID)
 		if err != nil {
@@ -398,24 +410,27 @@ func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64,
 		}
 		if pid != 0 {
 			members = append(members, store.ConversationParticipantRef{ParticipantID: pid, Role: "member"})
+			if c.IsIM || c.IsMpim {
+				directRecipients = append(directRecipients, messageRecipient{id: pid, name: imp.res.displayName(userID)})
+			}
 		}
 		return nil
 	}
 	if c.IsIM {
 		if err := add(c.User); err != nil {
-			return err
+			return nil, err
 		}
 		if err := add(opts.UserID); err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		if err := imp.client.AllMembers(ctx, c.ID, add); err != nil {
 			if ctx.Err() != nil {
-				return ctx.Err()
+				return nil, ctx.Err()
 			}
 			if errors.Is(err, ErrNotFound) {
 				imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
-				return nil
+				return nil, nil
 			}
 			// Isolated (message archiving proceeds) but honest: a members
 			// listing outage is a fetch failure and the run must report
@@ -423,13 +438,13 @@ func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64,
 			imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
-			return nil
+			return nil, nil
 		}
 	}
 	if err := imp.store.ReplaceConversationParticipants(convID, members); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return directRecipients, nil
 }
 
 // walkWindow walks one pinned window of the conversation's top-level
@@ -554,6 +569,9 @@ func (imp *Importer) walkWindow(ctx context.Context, cc *convScope, state *SyncS
 			// not leave the stamp to a fallback that reads a moved value.
 			if initial && !cc.opts.NoThreads && cs.SweptThrough == "" {
 				cs.SweptThrough = cs.BackfillLatest
+			}
+			if initial && !cc.opts.NoThreads && cs.AuditedThrough == "" {
+				cs.AuditedThrough = cs.BackfillLatest
 			}
 			cs.BackfillLatest = ""
 			return nil
@@ -745,6 +763,8 @@ func (imp *Importer) threadCatchUp(ctx context.Context, cc *convScope, state *Sy
 				imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
 				cs.ThreadsPending = false
 				cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+				cs.AuditPending = false
+				cs.AuditedThrough = tsFormat(imp.now())
 				if cs.SweptThrough == "" {
 					cs.SweptThrough = tsFormat(imp.now())
 				}
@@ -775,8 +795,13 @@ func (imp *Importer) threadCatchUp(ctx context.Context, cc *convScope, state *Sy
 			// only schedules walks) and the cursor clear even when drain
 			// debt remains. Keeping the flag here would re-visit this final
 			// page forever, re-recording its already-drained threads.
+			auditPin := cs.CatchUpLatest
 			cs.ThreadsPending = false
 			cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+			if auditPin != "" {
+				cs.AuditedThrough = auditPin
+			}
+			cs.AuditPending = false
 			return nil
 		}
 		cs.CatchUpCursor = page.NextCursor
@@ -802,16 +827,11 @@ func (imp *Importer) parentArchived(sourceID int64, channelID, ts string) (bool,
 	return len(ids) > 0, nil
 }
 
-// rescanHead re-pages the conversation's trailing thread-lookback window,
-// re-upserting messages in place. It serves two purposes the ts cursor
-// cannot (history is keyed by original ts): catching edits and reaction
-// changes, and DISCOVERING newly-created thread roots — a first reply to an
-// older message never appears in cursor-bounded history, but the re-read
-// parent now carries reply_count > 0 and gets tracked for reply polling.
-// The window matches the thread lookback so root discovery covers the whole
-// tracking period. Its upper bound is the cursor message INCLUSIVE: with
-// the default exclusive bounds, edits to the newest archived message would
-// stay invisible until a newer message moved the cursor past it.
+// rescanHead re-pages the bounded maintenance window, re-upserting messages
+// and their threads to repair edits and reaction changes. Its upper bound is
+// the cursor message INCLUSIVE: with the default exclusive bounds, edits to
+// the newest archived message would stay invisible until a newer message
+// moved the cursor past it.
 func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportSummary) error {
 	oldest := fmt.Sprintf("%d.000000", imp.now().Add(-maintenanceRescanWindow).Unix())
 	if cc.cs.Cursor != "" && tsLess(cc.cs.Cursor, oldest) {
@@ -969,6 +989,11 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 	}
 
 	msg, text := mapMessage(m, cc.channelID, cc.convID, cc.sourceID, m.User == cc.opts.UserID, imp.res.displayName)
+	existing, err := imp.store.MessageExistsBatch(cc.sourceID, []string{msg.SourceMessageID})
+	if err != nil {
+		return fmt.Errorf("check existing Slack message: %w", err)
+	}
+	_, wasExisting := existing[msg.SourceMessageID]
 	// Raw JSON is mandatory and doubles as the final completeness marker.
 	// Validate it before starting any persistence writes.
 	raw := []byte(m.Raw)
@@ -976,7 +1001,6 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		return fmt.Errorf("slack message %s has no raw JSON archive", msg.SourceMessageID)
 	}
 	var senderPID int64
-	var err error
 	if m.User != "" {
 		senderPID, err = imp.res.resolveID(m.User)
 	} else if m.BotID != "" {
@@ -1012,7 +1036,7 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		return err
 	}
 
-	if err := imp.persistRecipients(messageID, m, senderPID); err != nil {
+	if err := imp.persistRecipients(messageID, m, senderPID, cc.toRecipients); err != nil {
 		return err
 	}
 	if err := imp.persistReactions(messageID, m); err != nil {
@@ -1048,15 +1072,25 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		return fmt.Errorf("archive slack message raw: %w", err)
 	}
 
-	sum.MessagesProcessed++
-	sum.MessagesAdded++
+	if sum.processedMessageIDs == nil {
+		sum.processedMessageIDs = make(map[string]struct{})
+	}
+	if _, counted := sum.processedMessageIDs[msg.SourceMessageID]; !counted {
+		sum.processedMessageIDs[msg.SourceMessageID] = struct{}{}
+		sum.MessagesProcessed++
+		if wasExisting {
+			sum.MessagesUpdated++
+		} else {
+			sum.MessagesAdded++
+		}
+	}
 	return nil
 }
 
 // persistRecipients writes the shared sender and mention recipient sets.
 // Conversation membership remains in conversation_participants rather than
 // being fanned out into a "to" row on every channel message.
-func (imp *Importer) persistRecipients(messageID int64, m *Message, senderPID int64) error {
+func (imp *Importer) persistRecipients(messageID int64, m *Message, senderPID int64, toRecipients []messageRecipient) error {
 	var fromIDs []int64
 	var fromNames []string
 	if senderPID != 0 {
@@ -1069,6 +1103,23 @@ func (imp *Importer) persistRecipients(messageID int64, m *Message, senderPID in
 	}
 	if err := imp.store.ReplaceMessageRecipients(messageID, "from", fromIDs, fromNames); err != nil {
 		return err
+	}
+	// Direct-chat membership has a concrete addressee meaning. A nil slice
+	// means membership lookup failed, so preserve any prior snapshot; a
+	// successful empty snapshot (including a channel) deliberately clears it.
+	if toRecipients != nil {
+		var toIDs []int64
+		var toNames []string
+		for _, recipient := range toRecipients {
+			if recipient.id == 0 || recipient.id == senderPID {
+				continue
+			}
+			toIDs = append(toIDs, recipient.id)
+			toNames = append(toNames, recipient.name)
+		}
+		if err := imp.store.ReplaceMessageRecipients(messageID, "to", toIDs, toNames); err != nil {
+			return err
+		}
 	}
 
 	var ids []int64
@@ -1138,6 +1189,7 @@ func (imp *Importer) checkpointNow(syncID int64, state *SyncState, sum *ImportSu
 		PageToken:         blob,
 		MessagesProcessed: int64(sum.MessagesProcessed),
 		MessagesAdded:     int64(sum.MessagesAdded),
+		MessagesUpdated:   int64(sum.MessagesUpdated),
 		ErrorsCount:       int64(sum.Errors),
 	}); err != nil {
 		return fmt.Errorf("write sync checkpoint: %w", err)
@@ -1158,6 +1210,7 @@ func (imp *Importer) failCheckpoint(state *SyncState, sum *ImportSummary) *store
 		PageToken:         blob,
 		MessagesProcessed: int64(sum.MessagesProcessed),
 		MessagesAdded:     int64(sum.MessagesAdded),
+		MessagesUpdated:   int64(sum.MessagesUpdated),
 		ErrorsCount:       int64(sum.Errors),
 	}
 }
@@ -1234,14 +1287,14 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 			return sum, err
 		}
 		raw, rerr := imp.store.GetMessageRaw(item.MessageID)
-		if rerr != nil {
+		if rerr != nil && !errors.Is(rerr, sql.ErrNoRows) {
 			// Store-read failure: the local database is sick — fatal, like
 			// every store failure (see processMessage).
 			err = fmt.Errorf("read archived raw for %s: %w", item.SourceMessageID, rerr)
 			return sum, err
 		}
 		var m Message
-		if len(raw) == 0 || m.UnmarshalJSON(raw) != nil {
+		if errors.Is(rerr, sql.ErrNoRows) || len(raw) == 0 || m.UnmarshalJSON(raw) != nil {
 			// The archived raw is missing or malformed: this pass cannot
 			// repair it (--full re-fetches the message and rewrites the
 			// raw). Record it actionably, keep the pending count honest —

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -122,18 +122,37 @@ func NewImporter(s *store.Store, c *Client, teamID string) *Importer {
 // Under CONCURRENT runs on one source (unsupported: daemon plus manual CLI
 // simultaneously) newest-wins can drop the older run's tail progress — the
 // safe direction: lower boundaries only re-fetch into idempotent upserts.
-func (imp *Importer) loadResumeState(sourceID int64) *SyncState {
-	if cp, err := imp.store.GetLatestCheckpointedSync(sourceID); err == nil && cp != nil && cp.CursorBefore.Valid {
-		if s, lerr := LoadSyncState(cp.CursorBefore.String); lerr == nil {
-			return s
+func (imp *Importer) loadResumeState(sourceID int64) (*SyncState, error) {
+	cp, err := imp.store.GetLatestCheckpointedSync(sourceID)
+	if err == nil {
+		if cp == nil || !cp.CursorBefore.Valid {
+			return nil, errors.New("latest Slack checkpoint has no resume state")
 		}
-	}
-	if prev, err := imp.store.GetLastSuccessfulSync(sourceID); err == nil && prev != nil && prev.CursorAfter.Valid {
-		if s, lerr := LoadSyncState(prev.CursorAfter.String); lerr == nil {
-			return s
+		state, loadErr := LoadSyncState(cp.CursorBefore.String)
+		if loadErr != nil {
+			return nil, fmt.Errorf("decode latest Slack checkpoint: %w", loadErr)
 		}
+		return state, nil
 	}
-	return NewSyncState()
+	if !errors.Is(err, store.ErrSyncRunNotFound) {
+		return nil, fmt.Errorf("read latest Slack checkpoint: %w", err)
+	}
+
+	prev, err := imp.store.GetLastSuccessfulSync(sourceID)
+	if err == nil {
+		if prev == nil || !prev.CursorAfter.Valid {
+			return nil, errors.New("last successful Slack sync has no resume state")
+		}
+		state, loadErr := LoadSyncState(prev.CursorAfter.String)
+		if loadErr != nil {
+			return nil, fmt.Errorf("decode last successful Slack resume state: %w", loadErr)
+		}
+		return state, nil
+	}
+	if !errors.Is(err, store.ErrSyncRunNotFound) {
+		return nil, fmt.Errorf("read last successful Slack sync: %w", err)
+	}
+	return NewSyncState(), nil
 }
 
 // Import runs a backfill-then-incremental sync of the workspace user's
@@ -152,7 +171,10 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 	imp.opts, imp.sourceID = opts, src.ID
 	sum := &ImportSummary{SourceID: src.ID}
 
-	state := imp.loadResumeState(src.ID)
+	state, err := imp.loadResumeState(src.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load Slack resume state: %w", err)
+	}
 	if opts.Full {
 		// --full starts a repair SESSION, not a one-shot: the reset is
 		// checkpointed as this run's first act, making it the newest state
@@ -939,6 +961,9 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 			return fmt.Errorf("tombstone existence check: %w", err)
 		}
 		if len(ids) > 0 {
+			if err := imp.store.MarkMessageDeleted(cc.sourceID, sourceMessageID(cc.channelID, m.TS)); err != nil {
+				return fmt.Errorf("mark Slack message deleted: %w", err)
+			}
 			return nil
 		}
 	}
@@ -987,7 +1012,7 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		return err
 	}
 
-	if err := imp.persistMentions(messageID, m); err != nil {
+	if err := imp.persistRecipients(messageID, m, senderPID); err != nil {
 		return err
 	}
 	if err := imp.persistReactions(messageID, m); err != nil {
@@ -1004,6 +1029,18 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		}
 	}
 
+	// Keep the shared source-deletion lifecycle in sync without sacrificing
+	// archived Slack content. Tombstones preserve the prior snapshot above,
+	// but still mark it inactive; a live message reappearing later clears a
+	// stale marker, matching the Teams and Discord importers.
+	if m.Subtype == "tombstone" {
+		if err := imp.store.MarkMessageDeleted(cc.sourceID, msg.SourceMessageID); err != nil {
+			return fmt.Errorf("mark Slack message deleted: %w", err)
+		}
+	} else if err := imp.store.ClearMessageDeletedFromSource(cc.sourceID, msg.SourceMessageID); err != nil {
+		return fmt.Errorf("clear Slack message tombstone: %w", err)
+	}
+
 	// Archive the exact original message JSON (captured at decode time) only
 	// after every fatal auxiliary write succeeds. Tombstone retries use its
 	// presence as the durable signal that this whole snapshot completed.
@@ -1016,10 +1053,24 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 	return nil
 }
 
-// persistMentions writes "mention" recipient rows. No from/to rows are
-// written: sender attribution lives in messages.sender_id and membership in
-// conversation_participants (WhatsApp/Beeper precedent).
-func (imp *Importer) persistMentions(messageID int64, m *Message) error {
+// persistRecipients writes the shared sender and mention recipient sets.
+// Conversation membership remains in conversation_participants rather than
+// being fanned out into a "to" row on every channel message.
+func (imp *Importer) persistRecipients(messageID int64, m *Message, senderPID int64) error {
+	var fromIDs []int64
+	var fromNames []string
+	if senderPID != 0 {
+		senderName := imp.res.displayName(m.User)
+		if senderName == "" {
+			senderName = m.Username
+		}
+		fromIDs = append(fromIDs, senderPID)
+		fromNames = append(fromNames, senderName)
+	}
+	if err := imp.store.ReplaceMessageRecipients(messageID, "from", fromIDs, fromNames); err != nil {
+		return err
+	}
+
 	var ids []int64
 	var names []string
 	for _, uid := range m.MentionedUserIDs() {
@@ -1152,7 +1203,10 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 	// This run's sync_runs row becomes the source's newest completed run and
 	// Import loads its cursor_after as the resume baseline — carry the
 	// existing sync state forward verbatim or the next sync would restart.
-	state := imp.loadResumeState(src.ID)
+	state, err := imp.loadResumeState(src.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load Slack resume state: %w", err)
+	}
 	stateBlob, err := state.Marshal()
 	if err != nil {
 		return nil, err

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -803,12 +803,15 @@ func (imp *Importer) threadCatchUp(ctx context.Context, cc *convScope, state *Sy
 			// The WALK is complete: every root it owed is now recorded as
 			// durable PendingThreads debt, which the drain-first step pays
 			// unconditionally on every threaded run — so the flag (which
-			// only schedules walks) and the cursor clear even when drain
-			// debt remains. Keeping the flag here would re-visit this final
-			// page forever, re-recording its already-drained threads.
+			// only schedules walks) normally clears even when drain debt
+			// remains. A truncated search interval can require a later pin:
+			// finish this cursor-valid walk, then leave the flag set so the
+			// next run starts the queued follow-up instead of restarting the
+			// same walk on every overlap.
 			auditPin := cs.CatchUpLatest
-			cs.ThreadsPending = false
 			cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+			cs.ThreadsPending = cs.TruncatedSweepThrough != "" &&
+				tsLess(auditPin, cs.TruncatedSweepThrough)
 			if auditPin != "" {
 				cs.AuditedThrough = auditPin
 			}

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -504,6 +504,10 @@ func (imp *Importer) walkWindow(ctx context.Context, cc *convScope, state *SyncS
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			if errors.Is(err, ErrInvalidCursor) && cs.BackfillCursor != "" {
+				cs.BackfillCursor = ""
+				continue
+			}
 			if errors.Is(err, ErrNotFound) {
 				// Enumerated but unreadable (observed live: a sandbox
 				// provisioning-bot DM) or since deleted. There is nothing to
@@ -763,6 +767,10 @@ func (imp *Importer) threadCatchUp(ctx context.Context, cc *convScope, state *Sy
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
+			}
+			if errors.Is(err, ErrInvalidCursor) && cs.CatchUpCursor != "" {
+				cs.CatchUpCursor = ""
+				continue
 			}
 			if errors.Is(err, ErrNotFound) {
 				// The conversation is gone: there is nothing left to fetch,

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -618,7 +618,11 @@ func (imp *Importer) drainPendingThreads(ctx context.Context, cc *convScope, sum
 				// which is --maintenance work, not the drain's. It is only
 				// processed when missing (this fetch is then the first to
 				// see the root, and SetReplyTo needs it in place).
-				if imp.parentArchived(cc.sourceID, cc.channelID, m.TS) {
+				archived, err := imp.parentArchived(cc.sourceID, cc.channelID, m.TS)
+				if err != nil {
+					return fmt.Errorf("check archived thread parent: %w", err)
+				}
+				if archived {
 					continue
 				}
 				if err := imp.processMessage(ctx, cc, m, sum); err != nil {
@@ -763,15 +767,17 @@ func (imp *Importer) threadCatchUp(ctx context.Context, cc *convScope, state *Sy
 	}
 }
 
-// parentArchived reports whether a thread parent is already in the archive.
-// Uncertainty (a store error) reads as "not archived" so the parent gets
-// processed — an idempotent upsert is the safe direction.
-func (imp *Importer) parentArchived(sourceID int64, channelID, ts string) bool {
-	ids, err := imp.store.MessageExistsBatch(sourceID, []string{sourceMessageID(channelID, ts)})
+// parentArchived reports whether a thread parent has a complete archived
+// snapshot. A message row without raw JSON may be left by an interrupted
+// persistence attempt and must be retried. Store errors are returned so the
+// caller holds its thread debt rather than refreshing an archived parent on
+// uncertainty.
+func (imp *Importer) parentArchived(sourceID int64, channelID, ts string) (bool, error) {
+	ids, err := imp.store.MessageExistsWithRawBatch(sourceID, []string{sourceMessageID(channelID, ts)})
 	if err != nil {
-		return false
+		return false, err
 	}
-	return len(ids) > 0
+	return len(ids) > 0, nil
 }
 
 // rescanHead re-pages the conversation's trailing thread-lookback window,
@@ -922,10 +928,13 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		// --full, or --maintenance (the empty tombstone would also wipe
 		// archived reactions via ReplaceReactions). It IS persisted when the
 		// message was never archived: the placeholder gives orphaned replies
-		// a row for SetReplyTo to resolve against. The existence probe
-		// cannot swallow its error toward "missing" — that direction
-		// overwrites — so store failure aborts like every other store op.
-		ids, err := imp.store.MessageExistsBatch(cc.sourceID, []string{sourceMessageID(cc.channelID, m.TS)})
+		// a row for SetReplyTo to resolve against. Raw JSON is written only
+		// after every fatal auxiliary snapshot, so row+raw is the durable
+		// completeness marker; a row alone may be a partial placeholder from
+		// an interrupted attempt and must be retried. The probe cannot swallow
+		// its error toward "missing" — that direction overwrites — so store
+		// failure aborts like every other store op.
+		ids, err := imp.store.MessageExistsWithRawBatch(cc.sourceID, []string{sourceMessageID(cc.channelID, m.TS)})
 		if err != nil {
 			return fmt.Errorf("tombstone existence check: %w", err)
 		}
@@ -935,6 +944,12 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 	}
 
 	msg, text := mapMessage(m, cc.channelID, cc.convID, cc.sourceID, m.User == cc.opts.UserID, imp.res.displayName)
+	// Raw JSON is mandatory and doubles as the final completeness marker.
+	// Validate it before starting any persistence writes.
+	raw := []byte(m.Raw)
+	if len(raw) == 0 {
+		return fmt.Errorf("slack message %s has no raw JSON archive", msg.SourceMessageID)
+	}
 	var senderPID int64
 	var err error
 	if m.User != "" {
@@ -954,15 +969,6 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 	}
 	if err := imp.store.UpsertMessageBody(messageID, sql.NullString{String: text, Valid: text != ""}, sql.NullString{}); err != nil {
 		return err
-	}
-	// Archive the exact original message JSON (captured at decode time) so
-	// no API field is lost to our partial struct modelling.
-	raw := []byte(m.Raw)
-	if len(raw) == 0 {
-		return fmt.Errorf("slack message %s has no raw JSON archive", msg.SourceMessageID)
-	}
-	if err := imp.store.UpsertMessageRawWithFormat(messageID, raw, "slack_json"); err != nil {
-		return fmt.Errorf("archive slack message raw: %w", err)
 	}
 	// FTS is the one warn-and-continue store write: the index is derived
 	// from the (fatally-checked) message row and body, holes are detected
@@ -996,6 +1002,13 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		if err := imp.store.SetReplyTo(cc.sourceID, sourceMessageID(cc.channelID, m.TS), sourceMessageID(cc.channelID, m.ThreadTS)); err != nil {
 			return fmt.Errorf("link thread reply: %w", err)
 		}
+	}
+
+	// Archive the exact original message JSON (captured at decode time) only
+	// after every fatal auxiliary write succeeds. Tombstone retries use its
+	// presence as the durable signal that this whole snapshot completed.
+	if err := imp.store.UpsertMessageRawWithFormat(messageID, raw, "slack_json"); err != nil {
+		return fmt.Errorf("archive slack message raw: %w", err)
 	}
 
 	sum.MessagesProcessed++

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -1,0 +1,1230 @@
+package slack
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const sourceTypeSlack = "slack"
+
+// checkpointMinInterval throttles checkpoint flushes: the state blob is
+// O(conversations + tracked threads) JSON. A variable so tests can disable
+// the throttle.
+var checkpointMinInterval = 15 * time.Second
+
+const (
+	// checkpointPageInterval flushes the sync checkpoint every N pages inside
+	// a single conversation backfill (a busy channel can hold years of pages).
+	checkpointPageInterval = 10
+	// maintenanceRescanWindow bounds the explicit --maintenance rescan.
+	maintenanceRescanWindow = 30 * 24 * time.Hour
+	// maxRescanPages caps the rescan walk for pathologically busy channels;
+	// busier windows are only fully repaired by --full runs.
+	maxRescanPages = 10
+)
+
+// convScope carries per-conversation state through the persist call chain.
+type convScope struct {
+	channelID  string
+	convID     int64
+	sourceID   int64
+	syncID     int64
+	opts       ImportOptions
+	cs         *ConvState
+	budgetUsed int
+}
+
+// committed is the run's total committed work for this conversation:
+// messages actually processed plus the reply forecasts of recorded-but-
+// undrained thread debt. Charging the forecast at recording time keeps the
+// root walk loosely aligned with thread progress — a --limit budget bounds
+// what a run commits to, not just what it has retrieved so far.
+func (cc *convScope) committed() int {
+	n := cc.budgetUsed
+	if cc.cs != nil {
+		n += cc.cs.PendingForecast()
+	}
+	return n
+}
+
+func (cc *convScope) limitReached() bool {
+	return cc.opts.Limit > 0 && cc.committed() >= cc.opts.Limit
+}
+
+// actualsExhausted reports the budget spent on work actually performed. The
+// thread drain gates on this rather than limitReached: draining converts
+// forecast into actuals (roughly budget-neutral), so outstanding forecast
+// must not block paying the very debt it accounts for.
+func (cc *convScope) actualsExhausted() bool {
+	return cc.opts.Limit > 0 && cc.budgetUsed >= cc.opts.Limit
+}
+
+// pageBudget sizes history page requests to the remaining --limit budget
+// (net of committed thread debt), so a small limit cannot be overshot by an
+// entire 999-message page.
+func (cc *convScope) pageBudget() int {
+	if cc.opts.Limit <= 0 {
+		return historyPageLimit
+	}
+	remaining := max(cc.opts.Limit-cc.committed(), 1)
+	return min(remaining, historyPageLimit)
+}
+
+// drainPageBudget sizes thread-drain page requests to the remaining actual
+// budget (see actualsExhausted), floored at 2: the response may lead with
+// the already-archived parent, and a one-message page holding only the
+// parent would advance nothing. The floor bounds the overshoot at one
+// message per drain visit.
+func (cc *convScope) drainPageBudget() int {
+	if cc.opts.Limit <= 0 {
+		return historyPageLimit
+	}
+	remaining := max(cc.opts.Limit-cc.budgetUsed, 2)
+	return min(remaining, historyPageLimit)
+}
+
+// Importer ingests one Slack workspace user's conversations into the
+// msgvault store. One Import run covers one workspace (= one source).
+type Importer struct {
+	store          *store.Store
+	client         *Client
+	res            *participantResolver
+	lastCheckpoint time.Time
+	// now is a clock hook for tests.
+	now func() time.Time
+	// opts/sourceID scope the current run (the importer is single-threaded;
+	// set at the top of Import/BackfillMedia).
+	opts     ImportOptions
+	sourceID int64
+}
+
+// NewImporter creates an Importer backed by the given store and Slack client.
+func NewImporter(s *store.Store, c *Client, teamID string) *Importer {
+	return &Importer{store: s, client: c, res: newParticipantResolver(s, teamID), now: time.Now}
+}
+
+// loadResumeState rebuilds the sync state for a source: NEWEST BLOB WINS,
+// wholesale. Every run's first act is to checkpoint its merged resume
+// state, so a checkpoint blob is by construction a superset of the success
+// blob it was seeded from — and GetLatestCheckpointedSync only returns
+// checkpoints from runs newer than the last success. Field-wise blending
+// across runs is therefore pure risk with zero benefit: it resurrected
+// cleared phase state (a completed window's cleared page cursor re-paired
+// with an advanced Cursor = invalid pagination against a foreign bound).
+//
+// Under CONCURRENT runs on one source (unsupported: daemon plus manual CLI
+// simultaneously) newest-wins can drop the older run's tail progress — the
+// safe direction: lower boundaries only re-fetch into idempotent upserts.
+func (imp *Importer) loadResumeState(sourceID int64) *SyncState {
+	if cp, err := imp.store.GetLatestCheckpointedSync(sourceID); err == nil && cp != nil && cp.CursorBefore.Valid {
+		if s, lerr := LoadSyncState(cp.CursorBefore.String); lerr == nil {
+			return s
+		}
+	}
+	if prev, err := imp.store.GetLastSuccessfulSync(sourceID); err == nil && prev != nil && prev.CursorAfter.Valid {
+		if s, lerr := LoadSyncState(prev.CursorAfter.String); lerr == nil {
+			return s
+		}
+	}
+	return NewSyncState()
+}
+
+// Import runs a backfill-then-incremental sync of the workspace user's
+// conversations. New conversations backfill their full history (resumable
+// across interrupted runs); completed ones fetch only messages newer than
+// the stored cursor, then poll tracked threads for late replies.
+func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
+	start := imp.now()
+	if opts.TeamID == "" || opts.UserID == "" {
+		return nil, errors.New("slack team and user IDs required")
+	}
+	src, err := imp.store.GetOrCreateSource(sourceTypeSlack, opts.TeamID+":"+opts.UserID)
+	if err != nil {
+		return nil, err
+	}
+	imp.opts, imp.sourceID = opts, src.ID
+	sum := &ImportSummary{SourceID: src.ID}
+
+	state := imp.loadResumeState(src.ID)
+	if opts.Full {
+		// --full starts a repair SESSION, not a one-shot: the reset is
+		// checkpointed as this run's first act, making it the newest state
+		// blob (which resume selection takes wholesale), and the session
+		// persists until every eligible conversation's walk completes and
+		// all thread debt is paid. A --full while a repair is already in
+		// flight therefore CONTINUES it — interrupted and --limit-scoped
+		// repairs converge across runs of any kind instead of restarting
+		// at the newest page forever.
+		if !state.RepairPending {
+			state = NewSyncState()
+			state.RepairPending = true
+		}
+	}
+
+	syncID, err := imp.store.StartSync(src.ID, sourceTypeSlack)
+	if err != nil {
+		return nil, err
+	}
+	// Failures below must ASSIGN to err (never shadow it with :=) so this
+	// defer records them on the run — WITH the in-memory final state, so
+	// resume granularity is the failure instant, not the last throttled
+	// flush (best-effort on the way down: the failure may itself be a
+	// checkpoint write).
+	defer func() {
+		if err != nil {
+			_ = imp.store.FailSyncWithCheckpoint(syncID, err.Error(), imp.failCheckpoint(state, sum))
+		}
+	}()
+
+	// Persist the merged resume state immediately: if this run fails before
+	// its first checkpoint, the next run must still find the prior progress.
+	// Load-bearing for newest-wins resume and the --full reset — fatal on
+	// failure, never silent.
+	if err = imp.checkpointNow(syncID, state, sum); err != nil {
+		return sum, err
+	}
+
+	// Identity resolution is load-bearing for cross-archive dedup: without
+	// the member cache every sender would resolve as a bare ID, splitting
+	// people from their mail identities.
+	if err = imp.res.loadUsers(ctx, imp.client); err != nil {
+		return sum, fmt.Errorf("refresh slack users: %w", err)
+	}
+
+	var convs []Conversation
+	err = imp.client.AllConversations(ctx, func(c Conversation) error {
+		if includeConversation(&c, &opts) {
+			convs = append(convs, c)
+		}
+		return nil
+	})
+	if err != nil {
+		return sum, fmt.Errorf("enumerate slack conversations: %w", err)
+	}
+
+	total := len(convs)
+	targets := map[string]sweepTarget{}
+	for idx := range convs {
+		c := &convs[idx]
+		if err = ctx.Err(); err != nil {
+			return sum, err
+		}
+		before := sum.MessagesProcessed
+		var convID int64
+		if convID, err = imp.syncConversation(ctx, syncID, src.ID, c, opts, state, sum); err != nil {
+			return sum, err
+		}
+		if state.EnsureConv(c.ID).Done {
+			targets[c.ID] = sweepTarget{convID: convID}
+		}
+		sum.ConversationsProcessed++
+		if opts.Progress != nil {
+			opts.Progress(fmt.Sprintf("conversation %d/%d (%s): %d messages",
+				idx+1, total, conversationTitle(c, imp.res.displayName), sum.MessagesProcessed-before))
+		}
+		// Flush checkpoint so an interrupted run resumes from this point.
+		if err = imp.checkpoint(syncID, state, sum); err != nil {
+			return sum, err
+		}
+	}
+
+	// Reply sweep: discovers thread replies created since the watermark and
+	// archives them canonically. Limited runs participate with a work
+	// budget — certification parks safely when it runs out, so standing
+	// --limit schedules still converge on reply discovery. --no-threads
+	// skips it explicitly.
+	if !opts.NoThreads {
+		if err = imp.sweepReplies(ctx, syncID, targets, state, sum); err != nil {
+			return sum, err
+		}
+		if err = imp.checkpoint(syncID, state, sum); err != nil {
+			return sum, err
+		}
+	}
+
+	if err = imp.store.RecomputeConversationStats(src.ID); err != nil {
+		return sum, err
+	}
+	// A repair session ends only on a clean pass that leaves nothing owed
+	// among the conversations this run could actually reach.
+	if state.RepairPending && sum.FetchErrors == 0 {
+		eligible := make(map[string]bool, len(convs))
+		for i := range convs {
+			eligible[convs[i].ID] = true
+		}
+		if state.RepairComplete(eligible) {
+			state.RepairPending = false
+		}
+	}
+	// Mid-run checkpoints are throttled, so persist the final counters before
+	// completing (CompleteSync only writes status and cursor).
+	if err = imp.checkpointNow(syncID, state, sum); err != nil {
+		return sum, err
+	}
+	if sum.FetchErrors > 0 {
+		// Fetch failures are isolated so healthy conversations still sync,
+		// but the run must remain failed and caller-visible; the checkpoint
+		// above preserves all partial progress for the next attempt.
+		sum.Duration = imp.now().Sub(start)
+		err = fmt.Errorf("partial Slack sync: %d fetch error(s)", sum.FetchErrors)
+		return sum, err
+	}
+	blob, _ := state.Marshal()
+	if err = imp.store.CompleteSync(syncID, blob); err != nil {
+		return sum, err
+	}
+	sum.Duration = imp.now().Sub(start)
+	return sum, nil
+}
+
+// includeConversation applies the channel include/exclude name filters.
+// DMs and group DMs are never filtered (the filters exist to skip noisy
+// channels, not people).
+func includeConversation(c *Conversation, opts *ImportOptions) bool {
+	if c.IsIM || c.IsMpim {
+		return true
+	}
+	if slices.Contains(opts.ExcludeChannels, c.Name) {
+		return false
+	}
+	if len(opts.IncludeChannels) == 0 {
+		return true
+	}
+	return slices.Contains(opts.IncludeChannels, c.Name)
+}
+
+// syncConversation ensures the conversation row and membership, then walks
+// the conversation's next pinned window (the initial backfill and every
+// incremental fetch are the same walk). Thread replies are owed by the
+// walks as recorded drain debt (paid before anything else each run) and
+// discovered by the reply sweep thereafter.
+func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int64, c *Conversation, opts ImportOptions, state *SyncState, sum *ImportSummary) (int64, error) {
+	convID, err := imp.store.EnsureConversationWithType(sourceID, c.ID, conversationType(c), conversationTitle(c, imp.res.displayName))
+	if err != nil {
+		return 0, err
+	}
+	if err := imp.ensureMembership(ctx, syncID, convID, c, opts, sum); err != nil {
+		return 0, err
+	}
+
+	cs := state.EnsureConv(c.ID)
+	cc := &convScope{channelID: c.ID, convID: convID, sourceID: sourceID, syncID: syncID, opts: opts, cs: cs}
+
+	// DEBT IS SENIOR TO NEW WORK — both debt channels, uniformly. The
+	// drain list first (its pages already advanced past these roots), then
+	// the catch-up walk (--no-threads backfills, non-channel gap recovery,
+	// stamp-less adoption): both are finite, and running them behind the
+	// window walk would let a channel whose top-level arrival rate
+	// saturates --limit starve the debt forever while the windows keep up.
+	if len(cs.PendingThreads) > 0 && !opts.NoThreads {
+		if err := imp.drainPendingThreads(ctx, cc, sum); err != nil {
+			return 0, err
+		}
+	}
+	if cs.Done && cs.ThreadsPending && !opts.NoThreads {
+		if err := imp.threadCatchUp(ctx, cc, state, sum); err != nil {
+			return 0, err
+		}
+	}
+
+	// One-page invariant: a walk never fetches a new history page while
+	// thread debt is outstanding, which is what keeps the pending list
+	// bounded by a single page's roots. --no-threads runs may still page
+	// (they record conversation-level debt, never list entries).
+	if len(cs.PendingThreads) == 0 || opts.NoThreads {
+		if err := imp.walkWindow(ctx, cc, state, sum); err != nil {
+			return 0, err
+		}
+	}
+	// Second chance for catch-up debt: the run that COMPLETES the initial
+	// walk pays it immediately (budget permitting) instead of waiting a
+	// run — the senior slot above ran while Done was still false. No
+	// starvation risk: already-Done conversations get the senior slot.
+	if cs.Done && cs.ThreadsPending && !opts.NoThreads {
+		if err := imp.threadCatchUp(ctx, cc, state, sum); err != nil {
+			return 0, err
+		}
+	}
+	// The maintenance rescan (edits and reaction repair) runs only when
+	// explicitly requested: archives ignore post-capture mutations by
+	// default. It never charges the fetch budget and is skipped on
+	// scoped runs regardless.
+	if cs.Done && opts.Maintenance && opts.Limit == 0 {
+		if err := imp.rescanHead(ctx, cc, sum); err != nil {
+			return 0, err
+		}
+	}
+	return convID, nil
+}
+
+// ensureMembership records the conversation's member list. Membership fetch
+// failures are counted but not fatal: message archiving must not be blocked
+// by a members listing outage.
+func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64, c *Conversation, opts ImportOptions, sum *ImportSummary) error {
+	var members []store.ConversationParticipantRef
+	add := func(userID string) error {
+		pid, err := imp.res.resolveID(userID)
+		if err != nil {
+			return err
+		}
+		if pid != 0 {
+			members = append(members, store.ConversationParticipantRef{ParticipantID: pid, Role: "member"})
+		}
+		return nil
+	}
+	if c.IsIM {
+		if err := add(c.User); err != nil {
+			return err
+		}
+		if err := add(opts.UserID); err != nil {
+			return err
+		}
+	} else {
+		if err := imp.client.AllMembers(ctx, c.ID, add); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				return nil
+			}
+			// Isolated (message archiving proceeds) but honest: a members
+			// listing outage is a fetch failure and the run must report
+			// partial, not success.
+			imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+	}
+	if err := imp.store.ReplaceConversationParticipants(convID, members); err != nil {
+		return err
+	}
+	return nil
+}
+
+// walkWindow walks one pinned window of the conversation's top-level
+// history newest→oldest via cursor pages: the initial backfill covers
+// ("", pin] and every later (incremental) walk covers (Cursor, pin]. The
+// pin is the EXACT instant the walk started, never rounded forward — a
+// forward-rounded pin would claim coverage of instants the walk cannot have
+// covered and let arrivals inside the rounding shift the pinned pagination
+// — and the window is inclusive of the pin, matching Cursor's
+// covered-through meaning. Pinning happens BEFORE the first page: page
+// cursors index into the bounded window, so introducing the bound mid-walk
+// would shift the window under an already-issued cursor and skip messages.
+// On completion Cursor advances to the pin (an empty window is one cheap
+// page). Fetch errors leave the walk resumable rather than failing the run.
+func (imp *Importer) walkWindow(ctx context.Context, cc *convScope, state *SyncState, sum *ImportSummary) error {
+	cs := cc.cs
+	initial := !cs.Done
+	if cs.BackfillLatest == "" {
+		cs.BackfillLatest = tsFormat(imp.now())
+	}
+	pages := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cc.limitReached() {
+			return nil // resumable: the pin and page cursor persist
+		}
+		// The window floor overlaps back by the margin (like the sweep's):
+		// the pin is OUR clock, message ts is SLACK's — skew between them
+		// could otherwise hide a message created just below the pin after
+		// the walk read that region. Overlap re-fetches resolve into
+		// idempotent upserts.
+		oldest := cs.Cursor
+		if oldest != "" {
+			oldest = overlapFloor(oldest)
+		}
+		page, err := imp.client.historyPageWithLimit(ctx, HistoryParams{
+			ChannelID: cc.channelID,
+			Cursor:    cs.BackfillCursor,
+			Oldest:    oldest,
+			Latest:    cs.BackfillLatest,
+			Inclusive: true,
+		}, cc.pageBudget())
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				// Enumerated but unreadable (observed live: a sandbox
+				// provisioning-bot DM) or since deleted. There is nothing to
+				// fetch — recording it as a hard error would wedge every
+				// future run into partial failure. A vacuous stamp keeps
+				// the stamp-less adoption from flagging catch-up churn for
+				// a channel with nothing to cover.
+				imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				cs.Done = true
+				cs.BackfillCursor, cs.BackfillLatest = "", ""
+				if cs.SweptThrough == "" {
+					cs.SweptThrough = tsFormat(imp.now())
+				}
+				return nil
+			}
+			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		for i := range page.Messages {
+			if err := imp.processMessage(ctx, cc, &page.Messages[i], sum); err != nil {
+				return err
+			}
+		}
+		cc.budgetUsed += len(page.Messages)
+		// Record each discovered root as durable thread-drain debt BEFORE the
+		// page's cursor advances: "cursor past page" means "page durable and
+		// its thread debt recorded". Recording charges the root's
+		// reply_count forecast against the budget (see committed), so a run
+		// commits to the reply work even when the drain is deferred.
+		if cc.opts.NoThreads {
+			// An initial walk consumed threadless flags catch-up debt
+			// UNCONDITIONALLY — the flag means "this history was walked
+			// without thread coverage", not "threads existed at walk time".
+			// A message with no replies today can gain its first reply
+			// later, and for a never-swept conversation the sweep-boundary
+			// adoption falls back to Cursor, which threadless windows keep
+			// advancing — the reply would land below every future floor.
+			// The catch-up walk re-reads history at ITS OWN time, when such
+			// a message reports reply_count and is recovered. Incremental
+			// windows still need no flag: their roots' replies all postdate
+			// the (stalled, since sweeps skip --no-threads runs) sweep
+			// boundaries, so the next threaded sweep owns them by creation
+			// time.
+			if initial {
+				cs.ThreadsPending = true
+			}
+		} else {
+			for i := range page.Messages {
+				m := &page.Messages[i]
+				if m.IsThreadRoot() {
+					cs.RecordPendingThread(m.TS, m.ReplyCount)
+				}
+			}
+			if err := imp.drainPendingThreads(ctx, cc, sum); err != nil {
+				return err
+			}
+		}
+		if !page.HasMore || page.NextCursor == "" {
+			cs.Done = true
+			cs.BackfillCursor = ""
+			// Guard against a stale-merge resurrected window whose pin is
+			// older than the covered-through bound: Cursor never regresses.
+			if tsLess(cs.Cursor, cs.BackfillLatest) {
+				cs.Cursor = cs.BackfillLatest
+			}
+			// A THREADED initial walk certifies its own reply coverage at
+			// completion: the inline drains covered every thread through
+			// the pin. Stamping here (crash-safe via the conversation-loop
+			// checkpoint) means the sweep never has to GUESS this
+			// conversation's boundary — Cursor keeps advancing with every
+			// later window, so a run that dies before its sweep phase must
+			// not leave the stamp to a fallback that reads a moved value.
+			if initial && !cc.opts.NoThreads && cs.SweptThrough == "" {
+				cs.SweptThrough = cs.BackfillLatest
+			}
+			cs.BackfillLatest = ""
+			return nil
+		}
+		cs.BackfillCursor = page.NextCursor
+		if len(cs.PendingThreads) > 0 {
+			// The drain was clipped by the budget or a fetch failure: hold
+			// further paging (one-page invariant). The debt and the advanced
+			// cursor persist together, so the next run drains first and
+			// resumes from the next page — every limited run makes durable
+			// progress.
+			return nil
+		}
+		pages++
+		if pages%checkpointPageInterval == 0 {
+			if err := imp.checkpoint(cc.syncID, state, sum); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// drainPendingThreads pays the conversation's recorded thread debt head-
+// first. Each thread resumes from its DrainedTo ts (oldest-exclusive), so
+// progress is durable at reply granularity and the root is not refetched on
+// resume. Fetched messages charge the budget as actuals while decrementing
+// the entry's forecast — converting the charge recorded at discovery time
+// rather than paying twice. Fetch failures park the entry at its resume
+// point and are isolated like all fetch errors; only store/context failures
+// abort the run.
+func (imp *Importer) drainPendingThreads(ctx context.Context, cc *convScope, sum *ImportSummary) error {
+	cs := cc.cs
+	if cc.opts.Progress != nil && len(cs.PendingThreads) > 0 {
+		cc.opts.Progress(fmt.Sprintf("%s: draining %d owed thread(s), ~%d replies remaining",
+			cc.channelID, len(cs.PendingThreads), cs.PendingForecast()))
+	}
+	for len(cs.PendingThreads) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cc.actualsExhausted() {
+			return nil // debt persists; the next run drains first
+		}
+		pt := &cs.PendingThreads[0]
+		oldest := pt.DrainedTo
+		if oldest == "" {
+			oldest = pt.RootTS // the root itself was archived with its page
+		}
+		page, err := imp.client.repliesPageWithLimit(ctx, cc.channelID, pt.RootTS, "", oldest, cc.drainPageBudget())
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				// Thread gone between discovery and drain: expected churn.
+				imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, pt.RootTS), "thread", store.SyncRunItemStatusSkipped, "slack_thread_gone", err)
+				cs.PendingThreads = cs.PendingThreads[1:]
+				continue
+			}
+			imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, pt.RootTS), "thread", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil // entry parked at DrainedTo; retried next run
+		}
+		progressed := false
+		reanchored := false
+		preDrained := pt.DrainedTo
+		for i := range page.Messages {
+			m := &page.Messages[i]
+			if m.IsThreadReply() && m.ThreadTS != pt.RootTS {
+				// The entry was anchored at a REPLY (an unparseable-permalink
+				// sweep hit): replies(ts=<reply>) serves ONLY that reply
+				// (probed live — no bound or limit changes it). The reply's
+				// own thread_ts names the true root; adopt it and keep
+				// draining so the FULL thread is fetched, the parent guard
+				// can fire, and sibling replies are covered.
+				pt.RootTS = m.ThreadTS
+				reanchored = true
+			}
+			if !m.IsThreadReply() {
+				// The response leads with the parent regardless of bounds.
+				// Skip it when already archived — no write, no charge:
+				// re-persisting would refresh its content and reactions,
+				// which is --maintenance work, not the drain's. It is only
+				// processed when missing (this fetch is then the first to
+				// see the root, and SetReplyTo needs it in place).
+				if imp.parentArchived(cc.sourceID, cc.channelID, m.TS) {
+					continue
+				}
+				if err := imp.processMessage(ctx, cc, m, sum); err != nil {
+					return err
+				}
+				cc.budgetUsed++
+				continue
+			}
+			if err := imp.processMessage(ctx, cc, m, sum); err != nil {
+				return err
+			}
+			cc.budgetUsed++
+			sum.RepliesFetched++
+			if pt.DrainedTo == "" || tsLess(pt.DrainedTo, m.TS) {
+				pt.DrainedTo = m.TS
+				progressed = true
+			}
+			if pt.Forecast > 0 {
+				pt.Forecast--
+			}
+		}
+		if !page.HasMore || page.NextCursor == "" {
+			if reanchored {
+				// Re-fetch from the true root before settling — and roll the
+				// resume point back below the solo reply, so the root-
+				// anchored pass re-serves it AFTER its parent (SetReplyTo
+				// resolves at persist time; a reply persisted before its
+				// missing parent would keep a NULL thread link forever).
+				pt.DrainedTo = preDrained
+				continue
+			}
+			cs.PendingThreads = cs.PendingThreads[1:]
+			continue
+		}
+		if !progressed {
+			// More pages claimed but no reply advanced the resume point
+			// (defensive: should be impossible with ascending replies).
+			// Park rather than loop forever.
+			imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, pt.RootTS), "thread", store.SyncRunItemStatusError, "slack_drain_stalled",
+				fmt.Errorf("thread %s drain made no progress past %s", pt.RootTS, oldest))
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+	}
+	return nil
+}
+
+// threadCatchUp re-walks a conversation's history fetching ONLY thread
+// replies, paying conversation-level thread debt: a --no-threads backfill
+// whose pages advanced past roots without fetches, or a non-channel
+// conversation recovering a sweep gap. Pure re-read: every persist is an
+// upsert. ThreadsPending clears only when the walk finishes with no drain
+// debt left, so failures retry.
+//
+// The walk is shaped like the backfill: each page's roots are recorded as
+// drain debt (charging their reply_count forecasts), paging holds while
+// debt is outstanding, and the page cursor persists in CatchUpCursor — so
+// limited runs make durable progress and a standing --limit schedule
+// converges instead of restarting the walk forever.
+//
+// The upper bound pins at the WALK's start (persisted in CatchUpLatest;
+// page cursors are only valid against the bound they were minted with) —
+// not the original backfill pin: gap-recovery debt includes replies to
+// roots created after the backfill, which a pin-bounded walk would never
+// anchor. Roots newer than the walk pin need none of this (their replies
+// postdate the sweep watermark by creation time), and the pin keeps the
+// newest-first pagination window stable while the walk runs.
+func (imp *Importer) threadCatchUp(ctx context.Context, cc *convScope, state *SyncState, sum *ImportSummary) error {
+	cs := cc.cs
+	if cs.CatchUpLatest == "" {
+		cs.CatchUpLatest = tsFormat(imp.now()) // exact instant, never rounded forward
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cc.limitReached() {
+			return nil // resumes from CatchUpCursor next run
+		}
+		page, err := imp.client.historyPageWithLimit(ctx, HistoryParams{
+			ChannelID: cc.channelID,
+			Cursor:    cs.CatchUpCursor,
+			Latest:    cs.CatchUpLatest,
+			Inclusive: true,
+		}, cc.pageBudget())
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				// The conversation is gone: there is nothing left to fetch,
+				// ever. Clearing the debt here keeps one deleted channel
+				// from wedging every future workspace sync into failure —
+				// and a vacuous stamp keeps the stamp-less adoption from
+				// re-flagging it (nothing exists to cover; the gap
+				// machinery owns any later resurrection).
+				imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				cs.ThreadsPending = false
+				cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+				if cs.SweptThrough == "" {
+					cs.SweptThrough = tsFormat(imp.now())
+				}
+				return nil
+			}
+			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil // cursor stays; retried next run
+		}
+		// The page itself is only scanned for roots, but it still charges
+		// the budget: re-reading history is the walk's dominant work, and
+		// an uncharged scan would let a "limited" run page unboundedly.
+		cc.budgetUsed += len(page.Messages)
+		for i := range page.Messages {
+			m := &page.Messages[i]
+			if m.IsThreadRoot() {
+				cs.RecordPendingThread(m.TS, m.ReplyCount)
+			}
+		}
+		if err := imp.drainPendingThreads(ctx, cc, sum); err != nil {
+			return err
+		}
+		if !page.HasMore || page.NextCursor == "" {
+			// The WALK is complete: every root it owed is now recorded as
+			// durable PendingThreads debt, which the drain-first step pays
+			// unconditionally on every threaded run — so the flag (which
+			// only schedules walks) and the cursor clear even when drain
+			// debt remains. Keeping the flag here would re-visit this final
+			// page forever, re-recording its already-drained threads.
+			cs.ThreadsPending = false
+			cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+			return nil
+		}
+		cs.CatchUpCursor = page.NextCursor
+		if len(cs.PendingThreads) > 0 {
+			return nil // one-page invariant: pay before paging further
+		}
+		if err := imp.checkpoint(cc.syncID, state, sum); err != nil {
+			return err
+		}
+	}
+}
+
+// parentArchived reports whether a thread parent is already in the archive.
+// Uncertainty (a store error) reads as "not archived" so the parent gets
+// processed — an idempotent upsert is the safe direction.
+func (imp *Importer) parentArchived(sourceID int64, channelID, ts string) bool {
+	ids, err := imp.store.MessageExistsBatch(sourceID, []string{sourceMessageID(channelID, ts)})
+	if err != nil {
+		return false
+	}
+	return len(ids) > 0
+}
+
+// rescanHead re-pages the conversation's trailing thread-lookback window,
+// re-upserting messages in place. It serves two purposes the ts cursor
+// cannot (history is keyed by original ts): catching edits and reaction
+// changes, and DISCOVERING newly-created thread roots — a first reply to an
+// older message never appears in cursor-bounded history, but the re-read
+// parent now carries reply_count > 0 and gets tracked for reply polling.
+// The window matches the thread lookback so root discovery covers the whole
+// tracking period. Its upper bound is the cursor message INCLUSIVE: with
+// the default exclusive bounds, edits to the newest archived message would
+// stay invisible until a newer message moved the cursor past it.
+func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportSummary) error {
+	oldest := fmt.Sprintf("%d.000000", imp.now().Add(-maintenanceRescanWindow).Unix())
+	if cc.cs.Cursor != "" && tsLess(cc.cs.Cursor, oldest) {
+		// Everything newer than the cursor was just fetched by the
+		// incremental pass; nothing older than it has been archived yet.
+		return nil
+	}
+	// Thread selection cannot go through the history window alone: a
+	// recent reply can hang under a root older than the window, and the
+	// rescan's contract keys on MESSAGE age. The archive is the index
+	// Slack does not provide — rescan every thread that holds an archived
+	// reply inside the window, regardless of root age, then let the page
+	// scan below cover roots the archive has not linked yet (deduped).
+	rescanned := map[string]bool{}
+	rootIDs, err := imp.store.ListSlackRecentReplyThreadRoots(cc.sourceID, cc.convID, imp.now().Add(-maintenanceRescanWindow))
+	if err != nil {
+		return fmt.Errorf("list recent-reply thread roots: %w", err)
+	}
+	for _, id := range rootIDs {
+		_, rootTS, ok := strings.Cut(id, ":")
+		if !ok {
+			continue
+		}
+		rescanned[rootTS] = true
+		if err := imp.rescanThread(ctx, cc, rootTS, sum); err != nil {
+			return err
+		}
+	}
+
+	pageCursor := ""
+	for range maxRescanPages {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Full pages, no budget interplay: the rescan only runs on unlimited
+		// syncs (see syncConversation) and never charges the fetch budget.
+		page, err := imp.client.historyPageWithLimit(ctx, HistoryParams{
+			ChannelID: cc.channelID,
+			Cursor:    pageCursor,
+			Oldest:    oldest,
+			Latest:    cc.cs.Cursor,
+			Inclusive: true,
+		}, historyPageLimit)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
+				return nil
+			}
+			imp.recordItem(cc.syncID, cc.channelID, "fetch", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		for i := range page.Messages {
+			if err := imp.processMessage(ctx, cc, &page.Messages[i], sum); err != nil {
+				return err
+			}
+		}
+		// Repair thread REPLIES too: history structurally excludes them,
+		// and the rescan's contract is edits/reactions on recent messages
+		// — replies included.
+		for i := range page.Messages {
+			m := &page.Messages[i]
+			if !m.IsThreadRoot() || rescanned[m.TS] {
+				continue
+			}
+			rescanned[m.TS] = true
+			if err := imp.rescanThread(ctx, cc, m.TS, sum); err != nil {
+				return err
+			}
+		}
+		if !page.HasMore || page.NextCursor == "" {
+			return nil
+		}
+		pageCursor = page.NextCursor
+	}
+	return nil
+}
+
+// rescanThread re-fetches a thread's replies during the maintenance rescan,
+// re-processing every message INCLUDING the archived parent — the one
+// deliberate exception to the archived-parent skip: repairing post-capture
+// mutations to source truth is exactly what the explicit repair pass is
+// for. Unlimited-only (like the rescan itself), full pages, idempotent.
+func (imp *Importer) rescanThread(ctx context.Context, cc *convScope, rootTS string, sum *ImportSummary) error {
+	pageCursor := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := imp.client.repliesPageWithLimit(ctx, cc.channelID, rootTS, pageCursor, "", historyPageLimit)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if errors.Is(err, ErrNotFound) {
+				imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, rootTS), "maintenance", store.SyncRunItemStatusSkipped, "slack_thread_gone", err)
+				return nil
+			}
+			imp.recordItem(cc.syncID, sourceMessageID(cc.channelID, rootTS), "maintenance", store.SyncRunItemStatusError, "slack_fetch_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		for i := range page.Messages {
+			if err := imp.processMessage(ctx, cc, &page.Messages[i], sum); err != nil {
+				return err
+			}
+		}
+		if !page.HasMore || page.NextCursor == "" {
+			return nil
+		}
+		pageCursor = page.NextCursor
+	}
+}
+
+// processMessage persists one message and its auxiliary rows. Store-level
+// failures are fatal (they indicate DB problems); per-item auxiliary
+// failures are fatal too — a failed write means the local database is sick,
+// and the held cursor makes the abort resumable — with ONE documented
+// exemption: FTS, which is derived data with a repo-wide self-healing path
+// (FTSNeedsBackfill + rebuild-fts exist precisely because importers
+// warn-and-continue on it).
+func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Message, sum *ImportSummary) error {
+	if m.Type != "message" || m.TS == "" {
+		return nil
+	}
+	if m.Subtype == "tombstone" {
+		// A deleted thread root persists in history and replies as a
+		// tombstone row (USLACKBOT, reply_count kept — probed live). The
+		// archive keeps deleted content, so a tombstone never overwrites an
+		// archived original — not on window overlap, catch-up/gap re-reads,
+		// --full, or --maintenance (the empty tombstone would also wipe
+		// archived reactions via ReplaceReactions). It IS persisted when the
+		// message was never archived: the placeholder gives orphaned replies
+		// a row for SetReplyTo to resolve against. The existence probe
+		// cannot swallow its error toward "missing" — that direction
+		// overwrites — so store failure aborts like every other store op.
+		ids, err := imp.store.MessageExistsBatch(cc.sourceID, []string{sourceMessageID(cc.channelID, m.TS)})
+		if err != nil {
+			return fmt.Errorf("tombstone existence check: %w", err)
+		}
+		if len(ids) > 0 {
+			return nil
+		}
+	}
+
+	msg, text := mapMessage(m, cc.channelID, cc.convID, cc.sourceID, m.User == cc.opts.UserID, imp.res.displayName)
+	var senderPID int64
+	var err error
+	if m.User != "" {
+		senderPID, err = imp.res.resolveID(m.User)
+	} else if m.BotID != "" {
+		senderPID, err = imp.res.resolveBot(m.BotID, m.Username)
+	}
+	if err != nil {
+		return err
+	}
+	if senderPID != 0 {
+		msg.SenderID = sql.NullInt64{Int64: senderPID, Valid: true}
+	}
+	messageID, err := imp.store.UpsertMessage(&msg)
+	if err != nil {
+		return err
+	}
+	if err := imp.store.UpsertMessageBody(messageID, sql.NullString{String: text, Valid: text != ""}, sql.NullString{}); err != nil {
+		return err
+	}
+	// Archive the exact original message JSON (captured at decode time) so
+	// no API field is lost to our partial struct modelling.
+	raw := []byte(m.Raw)
+	if len(raw) == 0 {
+		return fmt.Errorf("slack message %s has no raw JSON archive", msg.SourceMessageID)
+	}
+	if err := imp.store.UpsertMessageRawWithFormat(messageID, raw, "slack_json"); err != nil {
+		return fmt.Errorf("archive slack message raw: %w", err)
+	}
+	// FTS is the one warn-and-continue store write: the index is derived
+	// from the (fatally-checked) message row and body, holes are detected
+	// by FTSNeedsBackfill's anti-join, and rebuild-fts repopulates them —
+	// the same policy every other importer follows.
+	if err := imp.store.UpsertFTS(messageID, "", text, imp.res.displayName(m.User), "", ""); err != nil {
+		sum.Errors++
+	}
+	if m.Edited != nil {
+		if err := imp.store.SetMessageEdited(messageID); err != nil {
+			return fmt.Errorf("set message edited: %w", err)
+		}
+	}
+
+	if err := imp.persistFiles(ctx, cc.syncID, messageID, m, cc.opts, sum); err != nil {
+		return err
+	}
+
+	if err := imp.persistMentions(messageID, m); err != nil {
+		return err
+	}
+	if err := imp.persistReactions(messageID, m); err != nil {
+		return err
+	}
+
+	// Thread replies link to their root by source-message-ID lookup. Roots
+	// always reach the archive before or with their replies (history pages
+	// carry roots; the replies response carries the root first), and
+	// SetReplyTo resolves to NULL harmlessly if one is missing.
+	if m.IsThreadReply() {
+		if err := imp.store.SetReplyTo(cc.sourceID, sourceMessageID(cc.channelID, m.TS), sourceMessageID(cc.channelID, m.ThreadTS)); err != nil {
+			return fmt.Errorf("link thread reply: %w", err)
+		}
+	}
+
+	sum.MessagesProcessed++
+	sum.MessagesAdded++
+	return nil
+}
+
+// persistMentions writes "mention" recipient rows. No from/to rows are
+// written: sender attribution lives in messages.sender_id and membership in
+// conversation_participants (WhatsApp/Beeper precedent).
+func (imp *Importer) persistMentions(messageID int64, m *Message) error {
+	var ids []int64
+	var names []string
+	for _, uid := range m.MentionedUserIDs() {
+		pid, err := imp.res.resolveID(uid)
+		if err != nil {
+			return err
+		}
+		if pid == 0 {
+			continue
+		}
+		ids = append(ids, pid)
+		names = append(names, imp.res.displayName(uid))
+	}
+	return imp.store.ReplaceMessageRecipients(messageID, "mention", ids, names)
+}
+
+// persistReactions replaces the message's reactions from the embedded
+// aggregates. Slack reactions carry no timestamp; created_at approximates
+// with the target message's timestamp (cosmetic only). The API may truncate
+// a reaction's user list on very popular messages — the archived raw JSON
+// preserves the counts.
+func (imp *Importer) persistReactions(messageID int64, m *Message) error {
+	var reactions []store.ReactionRef
+	for _, rc := range m.Reactions {
+		for _, uid := range rc.Users {
+			pid, err := imp.res.resolveID(uid)
+			if err != nil {
+				return err
+			}
+			if pid == 0 {
+				continue
+			}
+			reactions = append(reactions, store.ReactionRef{
+				ParticipantID: pid,
+				Type:          "emoji",
+				Value:         rc.Name,
+				CreatedAt:     tsTime(m.TS),
+			})
+		}
+	}
+	return imp.store.ReplaceReactions(messageID, reactions)
+}
+
+// checkpoint persists the sync state mid-run so an interrupted run resumes.
+// Flushes are throttled (see checkpointMinInterval).
+func (imp *Importer) checkpoint(syncID int64, state *SyncState, sum *ImportSummary) error {
+	if time.Since(imp.lastCheckpoint) < checkpointMinInterval {
+		return nil
+	}
+	return imp.checkpointNow(syncID, state, sum)
+}
+
+// checkpointNow persists the sync state unconditionally: for the initial
+// resume-state write and the final counters, which must never be skipped.
+// Failures are FATAL like every store write (failure taxonomy): the initial
+// checkpoint is load-bearing — newest-wins resume and the --full reset both
+// exist only in it until the run completes — and a silently lost checkpoint
+// would let an interrupted repair evaporate with no error ever surfaced.
+func (imp *Importer) checkpointNow(syncID int64, state *SyncState, sum *ImportSummary) error {
+	blob, err := state.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal sync state: %w", err)
+	}
+	if err := imp.store.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+		PageToken:         blob,
+		MessagesProcessed: int64(sum.MessagesProcessed),
+		MessagesAdded:     int64(sum.MessagesAdded),
+		ErrorsCount:       int64(sum.Errors),
+	}); err != nil {
+		return fmt.Errorf("write sync checkpoint: %w", err)
+	}
+	imp.lastCheckpoint = time.Now()
+	return nil
+}
+
+// failCheckpoint builds the checkpoint persisted alongside a run failure,
+// so resume granularity is the failure instant, not the last throttled
+// flush. Nil when the state cannot marshal (FailSync alone then).
+func (imp *Importer) failCheckpoint(state *SyncState, sum *ImportSummary) *store.Checkpoint {
+	blob, err := state.Marshal()
+	if err != nil {
+		return nil
+	}
+	return &store.Checkpoint{
+		PageToken:         blob,
+		MessagesProcessed: int64(sum.MessagesProcessed),
+		MessagesAdded:     int64(sum.MessagesAdded),
+		ErrorsCount:       int64(sum.Errors),
+	}
+}
+
+// recordItem records a per-item outcome on the sync run.
+func (imp *Importer) recordItem(syncID int64, sourceMessageID, phase, status, kind string, err error) {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	_ = imp.store.RecordSyncRunItem(store.SyncRunItem{
+		SyncRunID:       syncID,
+		SourceMessageID: sourceMessageID,
+		Phase:           phase,
+		Status:          status,
+		ErrorKind:       kind,
+		ErrorMessage:    msg,
+	})
+}
+
+// BackfillMedia retries pending Slack file downloads for one workspace:
+// every message that still has a pending marker is re-read from the archived
+// raw JSON and its files re-persisted. Idempotent (content-addressed
+// storage, replace-by-prefix rows).
+func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
+	// An explicit media backfill IS the download request. NoMedia means
+	// "defer downloads, leave pending markers for backfill-slack-media" —
+	// honoring it here would make the payer re-record the markers and
+	// report success while downloading nothing, a no-op for exactly the
+	// configuration ([slack].media = false) whose documented workflow
+	// depends on this command.
+	opts.NoMedia = false
+	start := imp.now()
+	if opts.AttachmentsDir == "" {
+		return nil, errors.New("attachments dir required")
+	}
+	src, err := imp.store.GetOrCreateSource(sourceTypeSlack, opts.TeamID+":"+opts.UserID)
+	if err != nil {
+		return nil, err
+	}
+	imp.opts, imp.sourceID = opts, src.ID
+	sum := &ImportSummary{SourceID: src.ID}
+	// This run's sync_runs row becomes the source's newest completed run and
+	// Import loads its cursor_after as the resume baseline — carry the
+	// existing sync state forward verbatim or the next sync would restart.
+	state := imp.loadResumeState(src.ID)
+	stateBlob, err := state.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	syncID, err := imp.store.StartSync(src.ID, "slack_media")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = imp.store.FailSyncWithCheckpoint(syncID, err.Error(), imp.failCheckpoint(state, sum))
+		}
+	}()
+	if err = imp.checkpointNow(syncID, state, sum); err != nil {
+		return sum, err
+	}
+
+	pending, err := imp.store.ListSlackPendingAttachmentMessages(src.ID)
+	if err != nil {
+		return sum, err
+	}
+	invalidRaw := 0
+	for _, item := range pending {
+		if err = ctx.Err(); err != nil {
+			return sum, err
+		}
+		raw, rerr := imp.store.GetMessageRaw(item.MessageID)
+		if rerr != nil {
+			// Store-read failure: the local database is sick — fatal, like
+			// every store failure (see processMessage).
+			err = fmt.Errorf("read archived raw for %s: %w", item.SourceMessageID, rerr)
+			return sum, err
+		}
+		var m Message
+		if len(raw) == 0 || m.UnmarshalJSON(raw) != nil {
+			// The archived raw is missing or malformed: this pass cannot
+			// repair it (--full re-fetches the message and rewrites the
+			// raw). Record it actionably, keep the pending count honest —
+			// the markers stay in place and discoverable — and fail the run
+			// as partial below instead of reporting a clean sweep.
+			imp.recordItem(syncID, item.SourceMessageID, "attachment", store.SyncRunItemStatusError, "slack_raw_invalid",
+				fmt.Errorf("archived raw JSON for %s is missing or malformed; run sync-slack --full to re-fetch it", item.SourceMessageID))
+			sum.Errors++
+			invalidRaw++
+			sum.AttachmentsPending += imp.pendingMarkerCount(item.MessageID)
+			continue
+		}
+		if err = imp.persistFiles(ctx, syncID, item.MessageID, &m, opts, sum); err != nil {
+			return sum, err
+		}
+		sum.MessagesProcessed++
+	}
+	if err = imp.checkpointNow(syncID, state, sum); err != nil {
+		return sum, err
+	}
+	if invalidRaw > 0 {
+		sum.Duration = imp.now().Sub(start)
+		err = fmt.Errorf("partial Slack media backfill: %d message(s) with invalid archived raw JSON (run sync-slack --full to repair)", invalidRaw)
+		return sum, err
+	}
+	if err = imp.store.CompleteSync(syncID, stateBlob); err != nil {
+		return sum, err
+	}
+	sum.Duration = imp.now().Sub(start)
+	return sum, nil
+}
+
+// pendingMarkerCount counts a message's pending attachment markers (rows
+// with no content hash that are not metadata-only links), so a skipped
+// message still reports its undone work honestly. Best-effort: on a read
+// error it returns 1 — the message is in the pending list, so at least one
+// marker exists.
+func (imp *Importer) pendingMarkerCount(messageID int64) int {
+	refs, err := imp.store.MessageSlackAttachments(messageID)
+	if err != nil {
+		return 1
+	}
+	n := 0
+	for _, ref := range refs {
+		if ref.ContentHash == "" && ref.MediaType != "link" {
+			n++
+		}
+	}
+	if n == 0 {
+		return 1
+	}
+	return n
+}

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -842,10 +842,10 @@ func (imp *Importer) parentArchived(sourceID int64, channelID, ts string) (bool,
 }
 
 // rescanHead re-pages the bounded maintenance window, re-upserting messages
-// and their threads to repair edits and reaction changes. Its upper bound is
-// the cursor message INCLUSIVE: with the default exclusive bounds, edits to
-// the newest archived message would stay invisible until a newer message
-// moved the cursor past it.
+// and, unless NoThreads is set, their threads to repair edits and reaction
+// changes. Its upper bound is the cursor message INCLUSIVE: with the default
+// exclusive bounds, edits to the newest archived message would stay invisible
+// until a newer message moved the cursor past it.
 func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportSummary) error {
 	oldest := fmt.Sprintf("%d.000000", imp.now().Add(-maintenanceRescanWindow).Unix())
 	if cc.cs.Cursor != "" && tsLess(cc.cs.Cursor, oldest) {
@@ -860,18 +860,20 @@ func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportS
 	// reply inside the window, regardless of root age, then let the page
 	// scan below cover roots the archive has not linked yet (deduped).
 	rescanned := map[string]bool{}
-	rootIDs, err := imp.store.ListSlackRecentReplyThreadRoots(cc.sourceID, cc.convID, imp.now().Add(-maintenanceRescanWindow))
-	if err != nil {
-		return fmt.Errorf("list recent-reply thread roots: %w", err)
-	}
-	for _, id := range rootIDs {
-		_, rootTS, ok := strings.Cut(id, ":")
-		if !ok {
-			continue
+	if !cc.opts.NoThreads {
+		rootIDs, err := imp.store.ListSlackRecentReplyThreadRoots(cc.sourceID, cc.convID, imp.now().Add(-maintenanceRescanWindow))
+		if err != nil {
+			return fmt.Errorf("list recent-reply thread roots: %w", err)
 		}
-		rescanned[rootTS] = true
-		if err := imp.rescanThread(ctx, cc, rootTS, sum); err != nil {
-			return err
+		for _, id := range rootIDs {
+			_, rootTS, ok := strings.Cut(id, ":")
+			if !ok {
+				continue
+			}
+			rescanned[rootTS] = true
+			if err := imp.rescanThread(ctx, cc, rootTS, sum); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -909,15 +911,18 @@ func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportS
 		}
 		// Repair thread REPLIES too: history structurally excludes them,
 		// and the rescan's contract is edits/reactions on recent messages
-		// — replies included.
-		for i := range page.Messages {
-			m := &page.Messages[i]
-			if !m.IsThreadRoot() || rescanned[m.TS] {
-				continue
-			}
-			rescanned[m.TS] = true
-			if err := imp.rescanThread(ctx, cc, m.TS, sum); err != nil {
-				return err
+		// — replies included unless --no-threads explicitly suppresses
+		// every reply-fetching path for this run.
+		if !cc.opts.NoThreads {
+			for i := range page.Messages {
+				m := &page.Messages[i]
+				if !m.IsThreadRoot() || rescanned[m.TS] {
+					continue
+				}
+				rescanned[m.TS] = true
+				if err := imp.rescanThread(ctx, cc, m.TS, sum); err != nil {
+					return err
+				}
 			}
 		}
 		if page.NextCursor == "" {

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -552,7 +552,7 @@ func (imp *Importer) walkWindow(ctx context.Context, cc *convScope, state *SyncS
 				return err
 			}
 		}
-		if !page.HasMore || page.NextCursor == "" {
+		if page.NextCursor == "" {
 			cs.Done = true
 			cs.BackfillCursor = ""
 			// Guard against a stale-merge resurrected window whose pin is
@@ -684,7 +684,7 @@ func (imp *Importer) drainPendingThreads(ctx context.Context, cc *convScope, sum
 				pt.Forecast--
 			}
 		}
-		if !page.HasMore || page.NextCursor == "" {
+		if page.NextCursor == "" {
 			if reanchored {
 				// Re-fetch from the true root before settling — and roll the
 				// resume point back below the solo reply, so the root-
@@ -788,7 +788,7 @@ func (imp *Importer) threadCatchUp(ctx context.Context, cc *convScope, state *Sy
 		if err := imp.drainPendingThreads(ctx, cc, sum); err != nil {
 			return err
 		}
-		if !page.HasMore || page.NextCursor == "" {
+		if page.NextCursor == "" {
 			// The WALK is complete: every root it owed is now recorded as
 			// durable PendingThreads debt, which the drain-first step pays
 			// unconditionally on every threaded run — so the flag (which
@@ -906,7 +906,7 @@ func (imp *Importer) rescanHead(ctx context.Context, cc *convScope, sum *ImportS
 				return err
 			}
 		}
-		if !page.HasMore || page.NextCursor == "" {
+		if page.NextCursor == "" {
 			return nil
 		}
 		pageCursor = page.NextCursor
@@ -944,7 +944,7 @@ func (imp *Importer) rescanThread(ctx context.Context, cc *convScope, rootTS str
 				return err
 			}
 		}
-		if !page.HasMore || page.NextCursor == "" {
+		if page.NextCursor == "" {
 			return nil
 		}
 		pageCursor = page.NextCursor

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -177,6 +177,22 @@ func TestImportEndToEnd(t *testing.T) {
 		WHERE m.message_type = 'slack' AND mr.recipient_type = 'from'`).Scan(&fromRows))
 	assert.Equal(totalWorkspaceMessages, fromRows,
 		"every Slack sender must use the shared from-recipient model as well as messages.sender_id")
+	var directRecipients int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*)
+		FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		JOIN conversations c ON c.id = m.conversation_id
+		WHERE c.source_conversation_id = ? AND mr.recipient_type = 'to'`), "D01").Scan(&directRecipients))
+	assert.Equal(1, directRecipients, "a direct message must address the other member")
+	var groupRecipients int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*)
+		FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		JOIN conversations c ON c.id = m.conversation_id
+		WHERE c.source_conversation_id = ? AND mr.recipient_type = 'to'`), "G01").Scan(&groupRecipients))
+	assert.Equal(2, groupRecipients, "a group DM must address every member except its sender")
 	var body string
 	require.NoError(st.DB().QueryRow(st.Rebind(`
 		SELECT mb.body_text FROM message_bodies mb
@@ -214,6 +230,23 @@ func TestImportEndToEnd(t *testing.T) {
 		JOIN conversations c ON c.id = cp.conversation_id
 		WHERE c.source_conversation_id = ?`), "C01").Scan(&members))
 	assert.Equal(3, members)
+}
+
+func TestFullRepairReportsUpdatesRatherThanAdds(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+
+	first, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.Equal(totalWorkspaceMessages, first.MessagesAdded)
+	require.Zero(first.MessagesUpdated)
+
+	opts.Full = true
+	second, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Zero(t, second.MessagesAdded)
+	assert.Equal(t, totalWorkspaceMessages, second.MessagesUpdated)
 }
 
 func TestImportIncrementalCatchesNewMessagesAndLateReplies(t *testing.T) {
@@ -590,6 +623,42 @@ func TestSweepOverlapRecoversLateIndexedReplies(t *testing.T) {
 	require.Equal(1, n, "the overlapped floor must re-cover replies the index served late")
 }
 
+func TestCanonicalThreadAuditRecoversReplyNeverServedBySearch(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The reply remains absent from search well beyond the overlap margin.
+	// Search is useful discovery, but it cannot be the only durable
+	// completeness mechanism because Slack publishes no indexing-lag bound.
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "never indexed"})
+	f.searchIndexedThrough = tsMinusMicro(lateReply)
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(8 * 24 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Zero(n, "test setup: search must still hide the reply when the periodic audit is scheduled")
+
+	imp.now = func() time.Time { return time.Now().Add(8*24*time.Hour + time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Equal(1, n,
+		"a canonical history/thread audit must eventually recover replies regardless of search indexing lag")
+}
+
 func TestWindowOverlapAbsorbsClockSkew(t *testing.T) {
 	require := require.New(t)
 	f := testWorkspace(t)
@@ -735,6 +804,34 @@ func TestBackfillMediaReportsInvalidRaw(t *testing.T) {
 	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
 	require.NoError(err)
 	require.Len(pending, 1)
+}
+
+func TestBackfillMediaReportsMissingRaw(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_RAWMISSING", "name": "missing.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_RAWMISSING/missing.png",
+			"permalink":   "https://testers.slack.com/files/F_RAWMISSING"},
+	}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+	opts.NoMedia = true
+	opts.AttachmentsDir = t.TempDir()
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "C01:"+ts(6)).Scan(&messageID))
+	_, err = st.DB().Exec(st.Rebind(`DELETE FROM message_raw WHERE message_id = ?`), messageID)
+	require.NoError(err)
+
+	sum, err := imp.BackfillMedia(context.Background(), opts)
+	require.Error(err, "missing archived raw must report a partial media backfill")
+	require.Positive(sum.AttachmentsPending,
+		"missing raw is a per-item repair condition and must retain/count its pending marker")
 }
 
 func TestSweepDebtSurvivesDeletedAnchorReply(t *testing.T) {

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -296,6 +296,47 @@ func TestImportIncrementalCatchesNewMessagesAndLateReplies(t *testing.T) {
 	}
 }
 
+func TestReplySweepPersistsDirectChatRecipients(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	dmReply := tsFresh(0)
+	mpimReply := tsFresh(1)
+	f.mu.Lock()
+	dmRoot := f.conv("D01").findRoot(ts(20))
+	dmRoot.Replies = append(dmRoot.Replies,
+		fakeMsg{TS: dmReply, ThreadTS: dmRoot.TS, User: "UME", Text: "late DM reply"})
+	mpimRoot := f.conv("G01").findRoot(ts(10))
+	mpimRoot.Replies = append(mpimRoot.Replies,
+		fakeMsg{TS: mpimReply, ThreadTS: mpimRoot.TS, User: "UALICE", Text: "late group reply"})
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var dmRecipients int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'to'`),
+		"D01:"+dmReply).Scan(&dmRecipients))
+	assert.Equal(t, 1, dmRecipients, "late DM reply addresses the other member")
+
+	var mpimRecipients int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'to'`),
+		"G01:"+mpimReply).Scan(&mpimRecipients))
+	assert.Equal(t, 2, mpimRecipients, "late MPIM reply addresses every member except its sender")
+}
+
 func TestImportIncrementalMidWindowFailureDoesNotAdvanceCursor(t *testing.T) {
 	require := require.New(t)
 	f := testWorkspace(t)
@@ -1426,6 +1467,41 @@ func TestMembershipFetchFailureMarksRunPartial(t *testing.T) {
 	require.NoError(st.DB().QueryRow(st.Rebind(
 		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(0)).Scan(&n))
 	require.Equal(1, n, "isolation: the channel's messages still archive despite the membership failure")
+}
+
+func TestMPIMMembershipFailureHoldsHistoryUntilRecipientsAvailable(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	f.failMembers["G01"] = true
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(err, "an MPIM membership outage must leave the run partial")
+	require.Positive(sum.FetchErrors)
+
+	var messages int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		WHERE c.source_conversation_id = ?`), "G01").Scan(&messages))
+	assert.Zero(t, messages, "MPIM history must not advance without the recipient snapshot")
+
+	state := requireResumeState(t, imp, sum.SourceID).EnsureConv("G01")
+	assert.False(t, state.Done)
+	assert.Empty(t, state.Cursor)
+
+	f.failMembers["G01"] = false
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var recipients int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'to'`),
+		"G01:"+ts(10)).Scan(&recipients))
+	assert.Equal(t, 2, recipients, "the retry archives MPIM history with complete recipients")
 }
 
 func TestLimitedSweepDrainsBigTailAcrossRuns(t *testing.T) {

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1859,12 +1860,13 @@ func TestSweepTruncatedDayFailsOnceAndConvergesViaCatchUp(t *testing.T) {
 	require.True(requireResumeState(t, imp, src.ID).EnsureConv("C09").ThreadsPending,
 		"the unreachable tail must be recorded as thread catch-up debt")
 
-	// Once the day is over, the boundary passes it (debt recorded — the
-	// day is never re-queried) and the catch-up walk recovers the reply
-	// search could never serve. The tool converges with NO manual --full.
+	// Once the day is over, the persisted debt marker lets the overlap
+	// certify it without re-querying, and the catch-up walk recovers the
+	// reply search could never serve. The tool converges with NO manual
+	// --full.
 	imp.now = func() time.Time { return time.Now().Add(25 * time.Hour) }
 	_, err = imp.Import(context.Background(), opts)
-	require.Error(err, "the still-open truncated day re-fails until it is behind the boundary")
+	require.NoError(err, "the converted day must not fail again on its overlap retry")
 	imp.now = func() time.Time { return time.Now().Add(26 * time.Hour) }
 	_, err = imp.Import(context.Background(), opts)
 	require.NoError(err, "past the truncated day the sweep must converge without --full")
@@ -1875,6 +1877,82 @@ func TestSweepTruncatedDayFailsOnceAndConvergesViaCatchUp(t *testing.T) {
 	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
 	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
 	assert.Equal(distinct, total)
+}
+
+func TestSweepLimitOneConvergesPastTruncatedDayOverlap(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	unreachable := tsFresh(5)
+	f.mu.Lock()
+	f.conv("C09").findRoot(rootTS).Replies = append(f.conv("C09").findRoot(rootTS).Replies,
+		fakeMsg{TS: unreachable, ThreadTS: rootTS, User: "UME", Text: "beyond the ceiling"})
+	f.searchHidden[unreachable] = true
+	truncatedDay := tsTime(unreachable).UTC().Format("2006-01-02")
+	f.searchTruncateDays[truncatedDay] = true
+	truncatedDayQueries := 0
+	f.onSearch = func(query string, page int) {
+		if page == 1 && strings.Contains(query, "on:"+truncatedDay) {
+			truncatedDayQueries++
+		}
+	}
+	f.mu.Unlock()
+
+	limited := opts
+	limited.Limit = 1
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_, err = imp.Import(context.Background(), limited)
+	require.Error(err, "the first truncated search must remain caller-visible")
+
+	dayStart := time.Date(
+		tsTime(unreachable).UTC().Year(),
+		tsTime(unreachable).UTC().Month(),
+		tsTime(unreachable).UTC().Day(),
+		0, 0, 0, 0, time.UTC,
+	)
+	nextDay := dayStart.AddDate(0, 0, 1)
+	firstRetryNow := nextDay.Add(time.Hour)
+	imp.now = func() time.Time { return firstRetryNow }
+	_, err = imp.Import(context.Background(), limited)
+	require.NoError(err, "overlap retries must not re-report a truncation already converted to catch-up debt")
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	state := requireResumeState(t, imp, src.ID)
+	cs := state.EnsureConv("C09")
+	assert.NotEmpty(cs.CatchUpCursor, "the limited canonical walk must retain its page progress")
+	assert.NotEmpty(cs.CatchUpLatest, "the limited canonical walk must retain its original pin")
+	assert.True(tsLess(tsFormat(nextDay), state.SweepWatermark),
+		"certification must advance beyond the truncated day's next boundary")
+
+	converged := false
+	for run := 2; run <= 10; run++ {
+		runNow := nextDay.Add(time.Duration(run) * time.Hour)
+		imp.now = func() time.Time { return runNow }
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(err, "overlap retries must not re-report a truncation already converted to catch-up debt")
+
+		var archived int
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+unreachable).Scan(&archived))
+		if archived == 1 {
+			converged = true
+			break
+		}
+	}
+	assert.True(converged, "a standing Limit: 1 schedule must finish the persisted catch-up walk")
+	assert.Equal(1, truncatedDayQueries, "the overlap must not spend each run re-querying the converted day")
+
+	state = requireResumeState(t, imp, src.ID)
+	assert.False(state.EnsureConv("C09").ThreadsPending)
+	assert.Empty(state.EnsureConv("C09").CatchUpCursor)
+	assert.Empty(state.EnsureConv("C09").CatchUpLatest)
 }
 
 func TestTruncatedSweepDuringRepairUnwedgesSession(t *testing.T) {

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -803,6 +803,122 @@ func TestImportRejectsMalformedNewestResumeState(t *testing.T) {
 	assert.Contains(t, err.Error(), "load Slack resume state")
 }
 
+func TestImportRestartsExpiredPersistedWindowCursorAtPinnedBound(t *testing.T) {
+	f := newFakeSlack(t)
+	f.users = []map[string]any{{
+		"id": "UME", "name": "me", "real_name": "Test User",
+		"profile": map[string]any{"email": "me@example.com"},
+	}}
+	f.convs = []*fakeConv{{
+		ID: "C01", Name: "general", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{
+			{TS: ts(0), User: "UME", Text: "inside pinned window"},
+			{TS: ts(2), User: "UME", Text: "above pinned window"},
+		},
+	}}
+	f.invalidHistoryCursors["expired-window"] = true
+	imp, opts := testImporter(t, f)
+	opts.NoThreads = true
+
+	pin := ts(1)
+	state := NewSyncState()
+	cs := state.EnsureConv("C01")
+	cs.Done = true
+	cs.Cursor = ts(-1)
+	cs.BackfillCursor = "expired-window"
+	cs.BackfillLatest = pin
+	src, err := imp.store.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
+	require.NoError(t, err)
+	runID, err := imp.store.StartSync(src.ID, "slack")
+	require.NoError(t, err)
+	require.NoError(t, imp.store.CompleteSync(runID, mustMarshal(t, state)))
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Zero(t, sum.FetchErrors)
+
+	got := requireResumeState(t, imp, src.ID).EnsureConv("C01")
+	assert.Equal(t, pin, got.Cursor, "restarted pagination must retain the original window pin")
+	assert.Empty(t, got.BackfillCursor)
+	assert.Empty(t, got.BackfillLatest)
+
+	var inside, above int
+	require.NoError(t, imp.store.DB().QueryRow(imp.store.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(0)).Scan(&inside))
+	require.NoError(t, imp.store.DB().QueryRow(imp.store.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(2)).Scan(&above))
+	assert.Equal(t, 1, inside)
+	assert.Zero(t, above, "restarting an expired page cursor must not widen the pinned window")
+}
+
+func TestImportRestartsExpiredPersistedCatchUpCursorAtPinnedBound(t *testing.T) {
+	f := newFakeSlack(t)
+	f.users = []map[string]any{{
+		"id": "UME", "name": "me", "real_name": "Test User",
+		"profile": map[string]any{"email": "me@example.com"},
+	}}
+	rootTS := ts(-100)
+	replyTS := ts(-50)
+	f.convs = []*fakeConv{{
+		ID: "C01", Name: "general", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{{
+			TS: rootTS, User: "UME", Text: "old root",
+			Replies: []fakeMsg{{TS: replyTS, ThreadTS: rootTS, User: "UME", Text: "owed reply"}},
+		}},
+	}}
+	f.invalidHistoryCursors["expired-catch-up"] = true
+	imp, opts := testImporter(t, f)
+
+	pin := ts(0)
+	state := NewSyncState()
+	cs := state.EnsureConv("C01")
+	cs.Done = true
+	cs.Cursor = pin
+	cs.ThreadsPending = true
+	cs.CatchUpCursor = "expired-catch-up"
+	cs.CatchUpLatest = pin
+	cs.SweptThrough = tsFormat(imp.now())
+	src, err := imp.store.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
+	require.NoError(t, err)
+	runID, err := imp.store.StartSync(src.ID, "slack")
+	require.NoError(t, err)
+	require.NoError(t, imp.store.CompleteSync(runID, mustMarshal(t, state)))
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Zero(t, sum.FetchErrors)
+
+	got := requireResumeState(t, imp, src.ID).EnsureConv("C01")
+	assert.Equal(t, pin, got.AuditedThrough, "restarted pagination must retain the original catch-up pin")
+	assert.False(t, got.ThreadsPending)
+	assert.Empty(t, got.CatchUpCursor)
+	assert.Empty(t, got.CatchUpLatest)
+
+	var replies int
+	require.NoError(t, imp.store.DB().QueryRow(imp.store.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+replyTS).Scan(&replies))
+	assert.Equal(t, 1, replies)
+}
+
+func TestImportSurfacesInvalidCursorWithoutPersistedPageCursor(t *testing.T) {
+	f := newFakeSlack(t)
+	f.users = []map[string]any{{
+		"id": "UME", "name": "me", "real_name": "Test User",
+		"profile": map[string]any{"email": "me@example.com"},
+	}}
+	f.convs = []*fakeConv{{
+		ID: "C01", Name: "general", Kind: "public", Members: []string{"UME"},
+	}}
+	f.invalidHistoryCursors[""] = true
+	imp, opts := testImporter(t, f)
+	opts.NoThreads = true
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "partial Slack sync")
+	assert.Positive(t, sum.FetchErrors, "cursorless invalid_cursor must remain a visible fetch failure")
+}
+
 func mustMarshal(t *testing.T, s *SyncState) string {
 	t.Helper()
 	blob, err := s.Marshal()

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -2377,6 +2377,78 @@ func TestTombstonePlaceholderKeepsOrphanedReplies(t *testing.T) {
 	assert.Equal(1, n)
 }
 
+func TestTombstonePlaceholderRetriesIncompletePersistence(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS, _ := tombstoneWorkspace(t)
+	f.conv("C80").tombstone(rootTS)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// Break the final auxiliary snapshot write. The message row and body have
+	// already been upserted, but the tombstone is not complete and must remain
+	// eligible for retry.
+	_, err := st.DB().Exec(`DROP TABLE reactions`)
+	require.NoError(err)
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "the auxiliary store failure must abort the run")
+
+	rootID := "C80:" + rootTS
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), rootID).Scan(&messageID))
+	_, err = st.GetMessageRaw(messageID)
+	require.Error(err, "raw JSON is the completion marker and must be written only after fatal auxiliary snapshots")
+
+	// Once the store heals, the held cursor re-serves the tombstone. A row
+	// without the completion marker must be processed rather than mistaken
+	// for a previously archived original.
+	require.NoError(st.InitSchema())
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Positive(sum.MessagesProcessed)
+
+	raw, err := st.GetMessageRaw(messageID)
+	require.NoError(err)
+	assert.Contains(string(raw), `"subtype":"tombstone"`)
+}
+
+func TestParentArchivedRequiresRawCompletionMarker(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeSlack(t)
+	imp, _ := testImporter(t, f)
+	st := imp.store
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	convID, err := st.EnsureConversationWithType(src.ID, "C80", "channel", "#keep")
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID:  convID,
+		SourceID:        src.ID,
+		SourceMessageID: "C80:123.000100",
+		MessageType:     "slack",
+	})
+	require.NoError(err)
+
+	archived, err := imp.parentArchived(src.ID, "C80", "123.000100")
+	require.NoError(err)
+	assert.False(archived,
+		"a partial row must remain eligible when a replies response re-serves its parent")
+
+	require.NoError(st.UpsertMessageRawWithFormat(messageID, []byte(`{"type":"message"}`), "slack_json"))
+	archived, err = imp.parentArchived(src.ID, "C80", "123.000100")
+	require.NoError(err)
+	assert.True(archived,
+		"row plus raw archive is a complete parent snapshot")
+
+	_, err = st.DB().Exec(`DROP TABLE message_raw`)
+	require.NoError(err)
+	_, err = imp.parentArchived(src.ID, "C80", "123.000100")
+	require.Error(err, "a failed completion probe must hold thread debt instead of refreshing the parent")
+}
+
 func TestLateIndexedReplyMovesParkedDrainBackward(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 	"testing"
 	"time"
@@ -168,6 +169,14 @@ func TestImportEndToEnd(t *testing.T) {
 		JOIN messages m ON m.id = mr.message_id
 		WHERE m.source_message_id = ? AND mr.recipient_type = 'mention'`), "C01:"+ts(1)).Scan(&mentions))
 	assert.Equal(1, mentions)
+	var fromRows int
+	require.NoError(st.DB().QueryRow(`
+		SELECT COUNT(DISTINCT m.id)
+		FROM messages m
+		JOIN message_recipients mr ON mr.message_id = m.id
+		WHERE m.message_type = 'slack' AND mr.recipient_type = 'from'`).Scan(&fromRows))
+	assert.Equal(totalWorkspaceMessages, fromRows,
+		"every Slack sender must use the shared from-recipient model as well as messages.sender_id")
 	var body string
 	require.NoError(st.DB().QueryRow(st.Rebind(`
 		SELECT mb.body_text FROM message_bodies mb
@@ -565,7 +574,7 @@ func TestSweepOverlapRecoversLateIndexedReplies(t *testing.T) {
 	require.NoError(st.DB().QueryRow(st.Rebind(
 		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
 	require.Zero(n, "test setup: the reply must be invisible to search on this run")
-	state := imp.loadResumeState(sum.SourceID)
+	state := requireResumeState(t, imp, sum.SourceID)
 	require.True(tsLess(lateReply, state.SweepWatermark),
 		"test setup: the watermark must have advanced past the unindexed reply")
 
@@ -646,11 +655,29 @@ func TestLoadResumeStateNewestBlobWins(t *testing.T) {
 	// Resume must take the newest blob WHOLESALE. Blending would let run
 	// A's stale page cursor and pin survive B's clears — an advanced
 	// Cursor paired with a foreign page cursor and an inverted window.
-	state := imp.loadResumeState(src.ID)
+	state := requireResumeState(t, imp, src.ID)
 	got := state.EnsureConv("C01")
 	assert.Equal("150.000001", got.Cursor)
 	assert.Empty(got.BackfillCursor, "a completed window's cleared page cursor must not be resurrected")
 	assert.Empty(got.BackfillLatest, "a completed window's cleared pin must not be resurrected")
+}
+
+func TestImportRejectsMalformedNewestResumeState(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	src, err := st.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
+	require.NoError(err)
+	runID, err := st.StartSync(src.ID, "slack")
+	require.NoError(err)
+	require.NoError(st.UpdateSyncCheckpoint(runID, &store.Checkpoint{PageToken: `{"version":`}))
+	require.NoError(st.FailSync(runID, "interrupted"))
+
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err)
+	assert.Contains(t, err.Error(), "load Slack resume state")
 }
 
 func mustMarshal(t *testing.T, s *SyncState) string {
@@ -658,6 +685,13 @@ func mustMarshal(t *testing.T, s *SyncState) string {
 	blob, err := s.Marshal()
 	require.NoError(t, err)
 	return blob
+}
+
+func requireResumeState(t *testing.T, imp *Importer, sourceID int64) *SyncState {
+	t.Helper()
+	state, err := imp.loadResumeState(sourceID)
+	require.NoError(t, err)
+	return state
 }
 
 func TestBackfillMediaReportsInvalidRaw(t *testing.T) {
@@ -920,7 +954,7 @@ func TestCatchUpDebtNotStarvedBySaturatedWindows(t *testing.T) {
 	}
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	require.False(imp.loadResumeState(src.ID).EnsureConv("C70").ThreadsPending,
+	require.False(requireResumeState(t, imp, src.ID).EnsureConv("C70").ThreadsPending,
 		"the finite catch-up debt must clear; it is senior to new window work")
 }
 
@@ -945,7 +979,7 @@ func TestCrashBeforeSweepStampsCoverage(t *testing.T) {
 	f.mu.Unlock()
 	sum, err := imp.Import(context.Background(), opts)
 	require.Error(err, "the store failure at the last conversation is fatal")
-	state := imp.loadResumeState(sum.SourceID)
+	state := requireResumeState(t, imp, sum.SourceID)
 	require.True(state.EnsureConv("C01").Done, "the first conversation's walk completed")
 	require.NotEmpty(state.EnsureConv("C01").SweptThrough,
 		"a completing threaded initial walk must stamp its own reply coverage")
@@ -1104,7 +1138,7 @@ func TestFailedRunPersistsFinalState(t *testing.T) {
 
 	sum, err := imp.Import(context.Background(), opts)
 	require.NoError(err)
-	before := imp.loadResumeState(sum.SourceID)
+	before := requireResumeState(t, imp, sum.SourceID)
 
 	// Fresh work lands in TWO conversations; the store breaks between them
 	// (the fake drops the reactions table just before serving the LAST
@@ -1129,7 +1163,7 @@ func TestFailedRunPersistsFinalState(t *testing.T) {
 	_, err = imp.Import(context.Background(), opts)
 	require.Error(err, "the reactions write failure is fatal")
 
-	after := imp.loadResumeState(sum.SourceID)
+	after := requireResumeState(t, imp, sum.SourceID)
 	assert.True(tsLess(before.EnsureConv("C01").Cursor, after.EnsureConv("C01").Cursor),
 		"the failure-path checkpoint must persist the completed first conversation's progress")
 
@@ -1366,7 +1400,7 @@ func TestRepairCompletesDespiteDepartedConversations(t *testing.T) {
 
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	state := imp.loadResumeState(src.ID)
+	state := requireResumeState(t, imp, src.ID)
 	assert.False(state.RepairPending,
 		"a conversation that left the eligible set must not hold the repair session open")
 }
@@ -1455,7 +1489,7 @@ func TestFullRepairSurvivesInterruption(t *testing.T) {
 
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	state := imp.loadResumeState(src.ID)
+	state := requireResumeState(t, imp, src.ID)
 	assert.False(state.RepairPending, "the repair session clears once everything is walked and paid")
 }
 
@@ -1491,7 +1525,7 @@ func TestScopedFullRepairConverges(t *testing.T) {
 
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	state := imp.loadResumeState(src.ID)
+	state := requireResumeState(t, imp, src.ID)
 	assert.False(state.RepairPending)
 }
 
@@ -1637,7 +1671,7 @@ func TestSweepTruncatedDayFailsOnceAndConvergesViaCatchUp(t *testing.T) {
 	assert.Equal(1, n)
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	require.True(imp.loadResumeState(src.ID).EnsureConv("C09").ThreadsPending,
+	require.True(requireResumeState(t, imp, src.ID).EnsureConv("C09").ThreadsPending,
 		"the unreachable tail must be recorded as thread catch-up debt")
 
 	// Once the day is over, the boundary passes it (debt recorded — the
@@ -1690,7 +1724,7 @@ func TestTruncatedSweepDuringRepairUnwedgesSession(t *testing.T) {
 	require.Error(err, "the truncated day fails the repair run loudly")
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	require.True(imp.loadResumeState(src.ID).RepairPending, "the failed pass must not close the session")
+	require.True(requireResumeState(t, imp, src.ID).RepairPending, "the failed pass must not close the session")
 
 	// Plain runs continue the session. Once the truncated day is behind
 	// the boundary, a clean pass pays the catch-up debt and closes it.
@@ -1699,7 +1733,7 @@ func TestTruncatedSweepDuringRepairUnwedgesSession(t *testing.T) {
 	imp.now = func() time.Time { return time.Now().Add(26 * time.Hour) }
 	_, err = imp.Import(context.Background(), opts)
 	require.NoError(err, "the session must converge; a permanently re-truncating sweep wedges RepairPending forever")
-	state := imp.loadResumeState(src.ID)
+	state := requireResumeState(t, imp, src.ID)
 	assert.False(state.RepairPending, "the clean pass closes the repair session")
 	assert.False(state.EnsureConv("C09").ThreadsPending)
 	var n int
@@ -1738,7 +1772,7 @@ func TestSweepRecoversGapForReIncludedChannel(t *testing.T) {
 	_, err = imp.Import(context.Background(), excluded)
 	require.NoError(err)
 
-	state := imp.loadResumeState(sum.SourceID)
+	state := requireResumeState(t, imp, sum.SourceID)
 	require.True(tsLess(gapReply, state.SweepWatermark),
 		"test setup: the watermark must have certified past the excluded channel's reply")
 	var n int
@@ -1874,7 +1908,7 @@ func TestGapCatchUpCoversPostBackfillRoots(t *testing.T) {
 	_, err = imp.Import(context.Background(), excluded)
 	require.NoError(err)
 
-	state := imp.loadResumeState(sum.SourceID)
+	state := requireResumeState(t, imp, sum.SourceID)
 	require.True(tsLess(gapReply, state.SweepWatermark),
 		"test setup: the watermark must have certified past the excluded channel's reply")
 
@@ -1969,7 +2003,7 @@ func TestStandingLimitPaysCatchUpDebt(t *testing.T) {
 
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	state := imp.loadResumeState(src.ID)
+	state := requireResumeState(t, imp, src.ID)
 	assert.False(state.EnsureConv("C40").ThreadsPending, "the debt flag clears once the walk finishes clean")
 }
 
@@ -1996,7 +2030,7 @@ func TestCatchUpClearsDebtForGoneConversation(t *testing.T) {
 	require.NoError(err, "a gone conversation with catch-up debt must not fail the run")
 	assert.Zero(sum.FetchErrors)
 
-	state := imp.loadResumeState(sum.SourceID)
+	state := requireResumeState(t, imp, sum.SourceID)
 	assert.False(state.EnsureConv("C01").ThreadsPending, "debt for a gone conversation clears — there is nothing left to fetch")
 }
 
@@ -2305,11 +2339,13 @@ func TestTombstoneNeverOverwritesArchivedOriginal(t *testing.T) {
 		t.Helper()
 		var body string
 		var msgID int64
+		var deletedAt sql.NullTime
 		require.NoError(st.DB().QueryRow(st.Rebind(`
-			SELECT m.id, mb.body_text FROM messages m
+			SELECT m.id, mb.body_text, m.deleted_from_source_at FROM messages m
 			JOIN message_bodies mb ON mb.message_id = m.id
-			WHERE m.source_message_id = ?`), rootID).Scan(&msgID, &body))
+			WHERE m.source_message_id = ?`), rootID).Scan(&msgID, &body, &deletedAt))
 		assert.Equal("the original words", body, "%s must not overwrite the archived body with the tombstone", path)
+		assert.True(deletedAt.Valid, "%s must mark the archived message deleted at Slack", path)
 		var reactions int
 		require.NoError(st.DB().QueryRow(st.Rebind(`
 			SELECT COUNT(*) FROM reactions WHERE message_id = ?`), msgID).Scan(&reactions))
@@ -2356,11 +2392,13 @@ func TestTombstonePlaceholderKeepsOrphanedReplies(t *testing.T) {
 	require.NoError(err)
 
 	var body string
+	var deletedAt sql.NullTime
 	require.NoError(st.DB().QueryRow(st.Rebind(`
-		SELECT mb.body_text FROM messages m
+		SELECT mb.body_text, m.deleted_from_source_at FROM messages m
 		JOIN message_bodies mb ON mb.message_id = m.id
-		WHERE m.source_message_id = ?`), "C80:"+rootTS).Scan(&body))
+		WHERE m.source_message_id = ?`), "C80:"+rootTS).Scan(&body, &deletedAt))
 	assert.Equal("This message was deleted.", body)
+	assert.True(deletedAt.Valid, "a tombstone placeholder must be excluded from active-message queries")
 	var linked int
 	require.NoError(st.DB().QueryRow(st.Rebind(`
 		SELECT COUNT(*) FROM messages
@@ -2411,6 +2449,31 @@ func TestTombstonePlaceholderRetriesIncompletePersistence(t *testing.T) {
 	raw, err := st.GetMessageRaw(messageID)
 	require.NoError(err)
 	assert.Contains(string(raw), `"subtype":"tombstone"`)
+	var deletedAt sql.NullTime
+	require.NoError(st.DB().QueryRow(
+		`SELECT deleted_from_source_at FROM messages WHERE id = ?`, messageID).Scan(&deletedAt))
+	assert.True(deletedAt.Valid)
+}
+
+func TestMessageReappearanceClearsSlackTombstone(t *testing.T) {
+	require := require.New(t)
+	f, rootTS, _ := tombstoneWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	rootID := "C80:" + rootTS
+	require.NoError(st.MarkMessageDeleted(sum.SourceID, rootID))
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var deletedAt sql.NullTime
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT deleted_from_source_at FROM messages WHERE source_message_id = ?`), rootID).Scan(&deletedAt))
+	assert.False(t, deletedAt.Valid, "a live message re-served by Slack must clear its stale tombstone")
 }
 
 func TestParentArchivedRequiresRawCompletionMarker(t *testing.T) {
@@ -2568,7 +2631,7 @@ func TestCatchUpFullDrainOverridesParkedTailSeed(t *testing.T) {
 	}
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	cs := imp.loadResumeState(src.ID).EnsureConv("C90")
+	cs := requireResumeState(t, imp, src.ID).EnsureConv("C90")
 	assert.False(cs.ThreadsPending, "catch-up debt is paid")
 	assert.Empty(cs.PendingThreads, "drain debt is paid")
 }
@@ -2606,7 +2669,7 @@ func TestSweepSmallPagesBeyondWalkBoundRecordedAsDebt(t *testing.T) {
 	require.Error(err, "a day the pager cannot fully consume must fail loudly, not certify past unserved hits")
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
-	require.True(imp.loadResumeState(src.ID).EnsureConv("C09").ThreadsPending,
+	require.True(requireResumeState(t, imp, src.ID).EnsureConv("C09").ThreadsPending,
 		"the unserved tail must be recorded as thread catch-up debt")
 
 	// The catch-up walk recovers the reply the pager could never serve;

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -804,25 +804,36 @@ func TestImportRejectsMalformedNewestResumeState(t *testing.T) {
 }
 
 func TestFullImportRepairsMalformedNewestResumeState(t *testing.T) {
-	f := testWorkspace(t)
-	imp, opts := testImporter(t, f)
-	st := imp.store
+	tests := []struct {
+		name string
+		blob string
+	}{
+		{name: "invalid JSON", blob: `{"version":`},
+		{name: "null conversation", blob: `{"conversations":{"C01":null}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := testWorkspace(t)
+			imp, opts := testImporter(t, f)
+			st := imp.store
 
-	src, err := st.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
-	require.NoError(t, err)
-	runID, err := st.StartSync(src.ID, "slack")
-	require.NoError(t, err)
-	require.NoError(t, st.UpdateSyncCheckpoint(runID, &store.Checkpoint{PageToken: `{"version":`}))
-	require.NoError(t, st.FailSync(runID, "interrupted"))
+			src, err := st.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
+			require.NoError(t, err)
+			runID, err := st.StartSync(src.ID, "slack")
+			require.NoError(t, err)
+			require.NoError(t, st.UpdateSyncCheckpoint(runID, &store.Checkpoint{PageToken: tt.blob}))
+			require.NoError(t, st.FailSync(runID, "interrupted"))
 
-	opts.Full = true
-	_, err = imp.Import(context.Background(), opts)
-	require.NoError(t, err, "--full must replace malformed durable state with a fresh repair session")
+			opts.Full = true
+			_, err = imp.Import(context.Background(), opts)
+			require.NoError(t, err, "--full must replace malformed durable state with a fresh repair session")
 
-	var messages int
-	require.NoError(t, st.DB().QueryRow(st.Rebind(
-		`SELECT COUNT(*) FROM messages WHERE source_id = ?`), src.ID).Scan(&messages))
-	assert.Positive(t, messages, "the repair must traverse and archive the workspace")
+			var messages int
+			require.NoError(t, st.DB().QueryRow(st.Rebind(
+				`SELECT COUNT(*) FROM messages WHERE source_id = ?`), src.ID).Scan(&messages))
+			assert.Positive(t, messages, "the repair must traverse and archive the workspace")
+		})
+	}
 }
 
 func TestLoadResumeStateSurfacesDatabaseReadFailure(t *testing.T) {

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -803,6 +803,42 @@ func TestImportRejectsMalformedNewestResumeState(t *testing.T) {
 	assert.Contains(t, err.Error(), "load Slack resume state")
 }
 
+func TestFullImportRepairsMalformedNewestResumeState(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	src, err := st.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
+	require.NoError(t, err)
+	runID, err := st.StartSync(src.ID, "slack")
+	require.NoError(t, err)
+	require.NoError(t, st.UpdateSyncCheckpoint(runID, &store.Checkpoint{PageToken: `{"version":`}))
+	require.NoError(t, st.FailSync(runID, "interrupted"))
+
+	opts.Full = true
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(t, err, "--full must replace malformed durable state with a fresh repair session")
+
+	var messages int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_id = ?`), src.ID).Scan(&messages))
+	assert.Positive(t, messages, "the repair must traverse and archive the workspace")
+}
+
+func TestLoadResumeStateSurfacesDatabaseReadFailure(t *testing.T) {
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	src, err := st.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
+	require.NoError(t, err)
+	require.NoError(t, st.DB().Close())
+
+	_, err = imp.loadResumeState(src.ID)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "read latest Slack checkpoint")
+}
+
 func TestImportRestartsExpiredPersistedWindowCursorAtPinnedBound(t *testing.T) {
 	f := newFakeSlack(t)
 	f.users = []map[string]any{{

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -232,6 +232,18 @@ func TestImportEndToEnd(t *testing.T) {
 	assert.Equal(3, members)
 }
 
+func TestImportUsesNextCursorWhenHasMoreIsFalse(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	f.forceHasMoreFalse = true
+	imp, opts := testImporter(t, f)
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(t, totalWorkspaceMessages, sum.MessagesAdded,
+		"a non-empty next_cursor must continue history and reply pagination regardless of has_more")
+}
+
 func TestFullRepairReportsUpdatesRatherThanAdds(t *testing.T) {
 	require := require.New(t)
 	f := testWorkspace(t)

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -1231,6 +1231,41 @@ func TestMaintenanceRepairsReplyEdits(t *testing.T) {
 	assert.Equal("ancient reply (stealth edit)", readBody(), "--maintenance must repair reply edits, not only top-level messages")
 }
 
+func TestMaintenanceNoThreadsRepairsOnlyTopLevelMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	f.mu.Lock()
+	f.conv("C01").Msgs[7].Text = "hello 7 (maintenance edit)"
+	f.conv("C01").Msgs[5].Replies[0].Text = "reply one (maintenance edit)"
+	f.mu.Unlock()
+
+	combined := opts
+	combined.Maintenance = true
+	combined.NoThreads = true
+	_, err = imp.Import(context.Background(), combined)
+	require.NoError(err)
+
+	readBody := func(sourceMessageID string) string {
+		var body string
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT mb.body_text FROM message_bodies mb
+			JOIN messages m ON m.id = mb.message_id
+			WHERE m.source_message_id = ?`), sourceMessageID).Scan(&body))
+		return body
+	}
+	assert.Equal("hello 7 (maintenance edit)", readBody("C01:"+ts(7)),
+		"--maintenance must still repair top-level messages")
+	assert.Equal("reply one", readBody("C01:"+ts(100)),
+		"--no-threads must suppress maintenance reply traversal")
+}
+
 func TestFirstReplyToUnthreadedMessageRecoveredByCatchUp(t *testing.T) {
 	require := require.New(t)
 	f := newFakeSlack(t)

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -1,0 +1,2711 @@
+package slack
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// tsBase anchors test message times ~25h in the past: recent enough that
+// thread roots stay inside the 30-day tracking lookback, old enough that
+// offsets up to a few hours never land in the future.
+var tsBase = time.Now().Add(-25 * time.Hour).UTC().Truncate(time.Second)
+
+// ts renders a Slack ts for offset minutes after tsBase.
+func ts(minutes int) string {
+	return strconv.FormatInt(tsBase.Add(time.Duration(minutes)*time.Minute).Unix(), 10) + ".000100"
+}
+
+// tsFresh renders a Slack ts a few seconds in the future — a message created
+// "now", strictly after any backfill pin or sweep watermark taken earlier in
+// the test (real replies are always created at post time, never back-dated).
+func tsFresh(offsetSeconds int) string {
+	return strconv.FormatInt(time.Now().Add(time.Duration(2+offsetSeconds)*time.Second).Unix(), 10) + ".000100"
+}
+
+// testWorkspace builds a fake workspace exercising every persist path:
+// channels with threads, reactions, mentions, edits, bot messages, a group
+// DM, and a 1:1 DM.
+func testWorkspace(t *testing.T) *fakeSlack {
+	t.Helper()
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "real_name": "Test User",
+			"profile": map[string]any{"email": "me@example.com", "display_name": "Me"}},
+		{"id": "UALICE", "name": "alice", "real_name": "Alice Example",
+			"profile": map[string]any{"email": "alice@example.com", "display_name": "Alice"}},
+		{"id": "UBOB", "name": "bob", "real_name": "Bob Example",
+			"profile": map[string]any{}}, // no email: resolves by bare ID
+	}
+	general := &fakeConv{
+		ID: "C01", Name: "general", Kind: "public",
+		Members: []string{"UME", "UALICE", "UBOB"},
+	}
+	for i := range 8 {
+		general.Msgs = append(general.Msgs, fakeMsg{TS: ts(i), User: "UALICE", Text: "hello " + strconv.Itoa(i)})
+	}
+	general.Msgs[1].Text = "ping <@UME> see <https://example.com|the docs>"
+	general.Msgs[2].Reactions = []map[string]any{
+		{"name": "thumbsup", "users": []string{"UME", "UBOB"}, "count": 2},
+	}
+	general.Msgs[3].Edited = true
+	general.Msgs[4].User = ""
+	general.Msgs[4].BotID = "B042"
+	general.Msgs[4].Username = "deploybot"
+	general.Msgs[4].Text = ""
+	general.Msgs[4].LegacyAttachments = []map[string]any{
+		{"fallback": "Build #42 failed on main"},
+	}
+	general.Msgs[5].Replies = []fakeMsg{
+		{TS: ts(100), ThreadTS: general.Msgs[5].TS, User: "UBOB", Text: "reply one"},
+		{TS: ts(101), ThreadTS: general.Msgs[5].TS, User: "UME", Text: "reply two"},
+	}
+	f.convs = []*fakeConv{
+		general,
+		{ID: "C02", Name: "secrets", Kind: "private",
+			Members: []string{"UME", "UALICE"},
+			Msgs:    []fakeMsg{{TS: ts(30), User: "UALICE", Text: "private hi"}}},
+		{ID: "G01", Name: "mpdm-me--alice--bob-1", Kind: "mpim",
+			Members: []string{"UME", "UALICE", "UBOB"},
+			Msgs:    []fakeMsg{{TS: ts(10), User: "UME", Text: "group hi"}}},
+		{ID: "D01", Kind: "im", IMUser: "UALICE",
+			Msgs: []fakeMsg{{TS: ts(20), User: "UALICE", Text: "dm hi"}}},
+	}
+	return f
+}
+
+// totalWorkspaceMessages is the archived-row count for the full test
+// workspace: 8 channel + 1 private + 1 mpim + 1 im top-level, plus 2 thread
+// replies (the root re-upserts in place).
+const totalWorkspaceMessages = 13
+
+func testImporter(t *testing.T, f *fakeSlack) (*Importer, ImportOptions) {
+	t.Helper()
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+	return imp, ImportOptions{TeamID: "T01", UserID: "UME", NoMedia: true}
+}
+
+func TestImportEndToEnd(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(4, sum.ConversationsProcessed)
+	assert.Equal(2, sum.RepliesFetched)
+	assert.Zero(sum.FetchErrors)
+
+	var msgCount int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&msgCount))
+	assert.Equal(totalWorkspaceMessages, msgCount)
+
+	// Conversation types and titles.
+	var title, convType string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT title, conversation_type FROM conversations WHERE source_conversation_id = ?`), "C01").
+		Scan(&title, &convType))
+	assert.Equal("#general", title)
+	assert.Equal("channel", convType)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT title, conversation_type FROM conversations WHERE source_conversation_id = ?`), "D01").
+		Scan(&title, &convType))
+	assert.Equal("Alice", title)
+	assert.Equal("direct_chat", convType)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT title, conversation_type FROM conversations WHERE source_conversation_id = ?`), "C02").
+		Scan(&title, &convType))
+	assert.Equal("#secrets", title, "private channels archive like channels")
+	assert.Equal("channel", convType)
+	var privateMsgs int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages m JOIN conversations c ON c.id = m.conversation_id
+		WHERE c.source_conversation_id = ?`), "C02").Scan(&privateMsgs))
+	assert.Equal(1, privateMsgs)
+
+	// Email-based identity: Alice deduped against mail archives by address.
+	var aliceID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM participants WHERE email_address = ?`), "alice@example.com").Scan(&aliceID))
+
+	// Thread replies linked to their root.
+	var linked int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_message_id = ? AND parent.source_message_id = ?`),
+		"C01:"+ts(100), "C01:"+ts(5)).Scan(&linked))
+	assert.Equal(1, linked)
+
+	// Reactions: two users on message 2.
+	var reactions int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ? AND r.reaction_value = 'thumbsup'`), "C01:"+ts(2)).Scan(&reactions))
+	assert.Equal(2, reactions)
+
+	// Mention row for <@UME>, with mrkdwn rendered in the body.
+	var mentions int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM message_recipients mr
+		JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'mention'`), "C01:"+ts(1)).Scan(&mentions))
+	assert.Equal(1, mentions)
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(1)).Scan(&body))
+	assert.Equal("ping @Me see the docs (https://example.com)", body)
+
+	// Edited flag, bot sender, raw archive format.
+	var edited bool
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT is_edited FROM messages WHERE source_message_id = ?`), "C01:"+ts(3)).Scan(&edited))
+	assert.True(edited)
+	var botSender string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT p.display_name FROM messages m JOIN participants p ON p.id = m.sender_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(4)).Scan(&botSender))
+	assert.Equal("deploybot", botSender)
+	// The bot message's content lives in a legacy attachment (empty text);
+	// its fallback must be the searchable body.
+	var botBody string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(4)).Scan(&botBody))
+	assert.Equal("Build #42 failed on main", botBody)
+	var rawFormat string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mr.raw_format FROM message_raw mr JOIN messages m ON m.id = mr.message_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(0)).Scan(&rawFormat))
+	assert.Equal("slack_json", rawFormat)
+
+	// Membership recorded.
+	var members int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversation_participants cp
+		JOIN conversations c ON c.id = cp.conversation_id
+		WHERE c.source_conversation_id = ?`), "C01").Scan(&members))
+	assert.Equal(3, members)
+}
+
+func TestImportIncrementalCatchesNewMessagesAndLateReplies(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A new top-level message and a late reply to the (old) thread root —
+	// both created "now" (real arrivals are never back-dated); the clock
+	// warps forward so the next run's window pins past them.
+	newTop := tsFresh(0)
+	f.mu.Lock()
+	general := f.conv("C01")
+	general.Msgs = append(general.Msgs, fakeMsg{TS: newTop, User: "UBOB", Text: "fresh news"})
+	lateReply := tsFresh(1)
+	root := general.findRoot(ts(5))
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: root.TS, User: "UALICE", Text: "late reply"})
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(1, sum.RepliesFetched, "only the late reply is new; earlier replies are behind the thread cursor")
+
+	for _, id := range []string{"C01:" + newTop, "C01:" + lateReply} {
+		var n int
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), id).Scan(&n))
+		assert.Equal(1, n, id)
+	}
+}
+
+func TestImportIncrementalMidWindowFailureDoesNotAdvanceCursor(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Five new messages arriving "now": an incremental window of two pages
+	// (fake pageSize 3, newest-first). Page one serves the newest three;
+	// page two dies.
+	burst := make([]string, 5)
+	f.mu.Lock()
+	general := f.conv("C01")
+	for i := range 5 {
+		burst[i] = tsFresh(i)
+		general.Msgs = append(general.Msgs, fakeMsg{TS: burst[i], User: "UBOB", Text: "burst " + strconv.Itoa(i)})
+	}
+	f.failHistoryContinuations = true
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "a run with fetch errors must not report success")
+
+	// The cursor must not have advanced past the unfetched older page: after
+	// healing, ALL five burst messages are archived exactly once.
+	f.mu.Lock()
+	f.failHistoryContinuations = false
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	for i := range 5 {
+		var n int
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+burst[i]).Scan(&n))
+		assert.Equal(t, 1, n, "burst message %d", i)
+	}
+}
+
+func TestBackfillThreadFetchFailureParksDrainDebt(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// Backfill records each root as drain debt before its page's cursor
+	// advances; a reply-fetch failure parks the debt entry at its resume
+	// point, and the run must not report success.
+	f.failReplies[ts(5)] = true
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(err, "a run with fetch errors must not report success")
+	assert.Positive(sum.FetchErrors)
+
+	// The replies never landed.
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(100)).Scan(&n))
+	assert.Zero(n)
+
+	// Healed: the resumed backfill refetches the page and its threads.
+	f.mu.Lock()
+	delete(f.failReplies, ts(5))
+	f.mu.Unlock()
+	sum, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(2, sum.RepliesFetched)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(100)).Scan(&n))
+	assert.Equal(1, n)
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(distinct, total, "page refetch after thread failure must not duplicate")
+}
+
+func TestImportHistoryFailureLeavesConversationResumable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	f.failHistory["C01"] = true
+	_, err := imp.Import(context.Background(), opts)
+	require.Error(err)
+
+	// The healthy conversations still synced.
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "D01:"+ts(20)).Scan(&n))
+	assert.Equal(1, n)
+
+	f.mu.Lock()
+	delete(f.failHistory, "C01")
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.Equal(totalWorkspaceMessages, total)
+}
+
+func TestImportInterruptResumesWithoutDuplicates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// Cancel partway through the first run: as soon as the first history
+	// page has been served, mid-conversation-walk.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		for {
+			f.mu.Lock()
+			served := f.historyCalls > 0
+			f.mu.Unlock()
+			if served {
+				cancel()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	_, _ = imp.Import(ctx, opts)
+
+	// Resume to completion: every message exactly once.
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(totalWorkspaceMessages, total)
+	assert.Equal(distinct, total)
+}
+
+func TestImportFullReUpsertsInPlace(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// An old message is edited at the source; only --full re-walks it.
+	f.mu.Lock()
+	f.conv("C01").Msgs[0].Text = "hello 0 (edited)"
+	f.mu.Unlock()
+
+	full := opts
+	full.Full = true
+	_, err = imp.Import(context.Background(), full)
+	require.NoError(err)
+
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(0)).Scan(&body))
+	assert.Equal("hello 0 (edited)", body)
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.Equal(totalWorkspaceMessages, total, "full run must upsert, not duplicate")
+}
+
+func TestImportLimitLeavesBackfillResumable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// A cap below #general's 8 top-level messages: the first run must stop
+	// early without marking the conversation complete or advancing past
+	// unfetched pages.
+	limited := opts
+	limited.Limit = 4
+	limited.NoThreads = true
+	_, err := imp.Import(context.Background(), limited)
+	require.NoError(err)
+	var partial int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&partial))
+	assert.Less(partial, totalWorkspaceMessages)
+
+	// An uncapped run completes the backfill: every message exactly once.
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(totalWorkspaceMessages, total, "limited first run must not lose messages")
+	assert.Equal(distinct, total)
+}
+
+// oldThreadWorkspace builds a workspace whose only thread root is ~10 days
+// old — far older than any recent-activity window, so reply capture can only
+// come from mechanisms that key on the REPLY's creation time.
+func oldThreadWorkspace(t *testing.T) (*fakeSlack, string) {
+	t.Helper()
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	rootTS := ts(-14400) // ~10 days before tsBase
+	f.convs = []*fakeConv{{
+		ID: "C09", Name: "archive", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{
+			{TS: rootTS, User: "UME", Text: "ancient root",
+				Replies: []fakeMsg{{TS: ts(-14390), ThreadTS: rootTS, User: "UME", Text: "ancient reply"}}},
+			{TS: ts(0), User: "UME", Text: "recent chatter"},
+		},
+	}}
+	return f, rootTS
+}
+
+func TestSweepFindsLateReplyToAncientThread(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A NEW reply lands on the ~10-day-old thread after backfill. No
+	// lookback window applies: the sweep discovers by the reply's creation
+	// time, so root age is irrelevant (the old design's documented LB-3
+	// blind spot).
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "late reply"})
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var linked int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_message_id = ? AND parent.source_message_id = ?`),
+		"C09:"+lateReply, "C09:"+rootTS).Scan(&linked))
+	assert.Equal(t, 1, linked, "the sweep must archive and link a late reply to an ancient root")
+}
+
+// A failed canonical fetch parks the sweep's discovery as drain debt: the
+// boundary may advance (the debt entry owns recovery), the run stays
+// partial, and the next run's drain-first step archives the reply.
+func TestSweepFetchFailureParksAsDrainDebt(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "late reply"})
+	// The drain anchors its replies call at the thread's parsed ROOT ts.
+	f.failReplies[rootTS] = true
+	f.mu.Unlock()
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(err, "a sweep with a failed canonical fetch must not report success")
+	assert.Positive(sum.FetchErrors)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Zero(n)
+
+	// Healed: the watermark parked before the failed hit, so the next sweep
+	// re-discovers and archives it — exactly once.
+	f.mu.Lock()
+	delete(f.failReplies, rootTS)
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	assert.Equal(1, n)
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(distinct, total)
+}
+
+func TestSweepOverlapRecoversLateIndexedReplies(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A reply lands, but the search index has not served it yet when the
+	// next sweep runs: the watermark (this sweep's pin) advances PAST its
+	// creation time. The stored boundary means "archived through boundary
+	// minus the lag margin", and the next sweep's floor overlaps back by
+	// that margin — without the overlap, the late-indexed reply would sit
+	// below the floor forever.
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "late reply"})
+	f.searchIndexedThrough = tsMinusMicro(lateReply) // index lag: hit not served yet
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Zero(n, "test setup: the reply must be invisible to search on this run")
+	state := imp.loadResumeState(sum.SourceID)
+	require.True(tsLess(lateReply, state.SweepWatermark),
+		"test setup: the watermark must have advanced past the unindexed reply")
+
+	// The index catches up; the overlapped floor must recover the reply.
+	f.mu.Lock()
+	f.searchIndexedThrough = ""
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(2 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Equal(1, n, "the overlapped floor must re-cover replies the index served late")
+}
+
+func TestWindowOverlapAbsorbsClockSkew(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// Run 1's clock runs 5 minutes AHEAD of Slack's: the window pin (our
+	// clock) lands above message ts values (Slack's clock) that don't exist
+	// yet. A message then arrives with a ts BELOW the stored pin.
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	skewed := tsFresh(0) // real-clock ts, below run 1's skewed pin
+	f.mu.Lock()
+	f.conv("C01").Msgs = append(f.conv("C01").Msgs, fakeMsg{TS: skewed, User: "UBOB", Text: "skewed arrival"})
+	f.mu.Unlock()
+
+	// The next window's floor overlaps back by the lag margin, so a
+	// message hidden under the pin by clock skew is still fetched.
+	imp.now = func() time.Time { return time.Now().Add(6 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+skewed).Scan(&n))
+	require.Equal(1, n, "a message below the pin by clock skew must be recovered by the window overlap")
+}
+
+func TestLoadResumeStateNewestBlobWins(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, _ := testImporter(t, f)
+	st := imp.store
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+
+	// Run A: a --limit run that SUCCEEDED mid-window — its success blob
+	// carries a live (page cursor, pin) pair.
+	midWindow := NewSyncState()
+	mcs := midWindow.EnsureConv("C01")
+	mcs.Done = true
+	mcs.Cursor = "100.000001"
+	mcs.BackfillCursor = "opaque-page-3"
+	mcs.BackfillLatest = "150.000001"
+	runA, err := st.StartSync(src.ID, "slack")
+	require.NoError(err)
+	require.NoError(st.CompleteSync(runA, mustMarshal(t, midWindow)))
+
+	// Run B: completed that window (cleared the pair, advanced Cursor to
+	// the pin) but FAILED later — it exists only as a checkpoint.
+	cleared := NewSyncState()
+	ccs := cleared.EnsureConv("C01")
+	ccs.Done = true
+	ccs.Cursor = "150.000001"
+	runB, err := st.StartSync(src.ID, "slack")
+	require.NoError(err)
+	require.NoError(st.UpdateSyncCheckpoint(runB, &store.Checkpoint{PageToken: mustMarshal(t, cleared)}))
+	require.NoError(st.FailSync(runB, "unrelated fetch failure"))
+
+	// Resume must take the newest blob WHOLESALE. Blending would let run
+	// A's stale page cursor and pin survive B's clears — an advanced
+	// Cursor paired with a foreign page cursor and an inverted window.
+	state := imp.loadResumeState(src.ID)
+	got := state.EnsureConv("C01")
+	assert.Equal("150.000001", got.Cursor)
+	assert.Empty(got.BackfillCursor, "a completed window's cleared page cursor must not be resurrected")
+	assert.Empty(got.BackfillLatest, "a completed window's cleared pin must not be resurrected")
+}
+
+func mustMarshal(t *testing.T, s *SyncState) string {
+	t.Helper()
+	blob, err := s.Marshal()
+	require.NoError(t, err)
+	return blob
+}
+
+func TestBackfillMediaReportsInvalidRaw(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_RAWBAD", "name": "b.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_RAWBAD/b.png",
+			"permalink":   "https://testers.slack.com/files/F_RAWBAD"},
+	}
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	// Import with media deferred: the file becomes a pending marker.
+	opts := ImportOptions{TeamID: "T01", UserID: "UME", NoMedia: true, AttachmentsDir: t.TempDir()}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The archived raw JSON is corrupted at rest. The media backfill must
+	// report the run as PARTIAL with the pending work still counted — not
+	// silently skip the message and report a clean, zero-pending sweep.
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "C01:"+ts(6)).Scan(&messageID))
+	require.NoError(st.UpsertMessageRawWithFormat(messageID, []byte("{not json"), "slack_json"))
+
+	opts.NoMedia = false
+	sum, err := imp.BackfillMedia(context.Background(), opts)
+	require.Error(err, "invalid archived raw must fail the media backfill as partial, not report success")
+	require.Positive(sum.AttachmentsPending, "the skipped message's markers must stay in the pending count")
+
+	// The marker remains discoverable for the next attempt (after --full).
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(err)
+	require.Len(pending, 1)
+}
+
+func TestSweepDebtSurvivesDeletedAnchorReply(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Two late replies are discovered together; the budget defers their
+	// drain to a later run. Between discovery and drain, the FIRST reply
+	// is deleted at the source. The debt entry must anchor at the thread's
+	// root — anchored at the (now dead) hit, the drain would drop the
+	// whole entry as thread-gone and lose the surviving sibling below the
+	// already-advanced watermark.
+	r1, r2 := tsFresh(0), tsFresh(1)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies,
+		fakeMsg{TS: r1, ThreadTS: rootTS, User: "UME", Text: "first"},
+		fakeMsg{TS: r2, ThreadTS: rootTS, User: "UME", Text: "second"})
+	f.mu.Unlock()
+
+	// Discovery run: --limit 1 exhausts on the day-charge, so the debt is
+	// recorded but undrained; the watermark advances well past both hits.
+	imp.now = func() time.Time { return time.Now().Add(15 * time.Minute) }
+	limited := opts
+	limited.Limit = 1
+	_, err = imp.Import(context.Background(), limited)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+r2).Scan(&n))
+	require.Zero(n, "test setup: the drain must have been deferred")
+
+	// The first reply is deleted at the source; later sweeps cannot help
+	// (their overlapped floor is already above both hits).
+	f.mu.Lock()
+	root = f.conv("C09").findRoot(rootTS)
+	root.Replies = root.Replies[:len(root.Replies)-2]
+	root.Replies = append(root.Replies, fakeMsg{TS: r2, ThreadTS: rootTS, User: "UME", Text: "second"})
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(16 * time.Minute) }
+	_, err = imp.Import(context.Background(), limited)
+	require.NoError(err)
+	imp.now = func() time.Time { return time.Now().Add(17 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+r2).Scan(&n))
+	require.Equal(1, n, "the surviving sibling must be drained via the root anchor despite the deleted hit")
+}
+
+func TestGapRecoveryResetsInFlightCatchUp(t *testing.T) {
+	require := require.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	// A legacy G-prefixed channel (non-C: gap recovery uses the catch-up
+	// walk) big enough that a limited catch-up stays mid-flight for
+	// several runs, plus a channel keeping the watermark moving.
+	oldRoot := fakeMsg{TS: ts(0), User: "UME", Text: "old root",
+		Replies: []fakeMsg{{TS: ts(1), ThreadTS: ts(0), User: "UME", Text: "old reply"}}}
+	legacy := &fakeConv{ID: "G05", Name: "legacy", Kind: "private", Members: []string{"UME"}, Msgs: []fakeMsg{oldRoot}}
+	for i := range 12 {
+		legacy.Msgs = append(legacy.Msgs, fakeMsg{TS: ts(100 + i), User: "UME", Text: "top " + strconv.Itoa(i)})
+	}
+	f.convs = []*fakeConv{legacy,
+		{ID: "C11", Name: "keep", Kind: "public", Members: []string{"UME"},
+			Msgs: []fakeMsg{{TS: ts(2), User: "UME", Text: "keep hi"}}}}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// --no-threads backfill leaves catch-up debt; one limited threaded run
+	// starts the walk and leaves it MID-FLIGHT under its original pin.
+	noThreads := opts
+	noThreads.NoThreads = true
+	_, err := imp.Import(context.Background(), noThreads)
+	require.NoError(err)
+	limited := opts
+	limited.Limit = 4
+	_, err = imp.Import(context.Background(), limited)
+	require.NoError(err)
+
+	// A new root arrives ABOVE the walk's pin and is archived by a window
+	// walk whose own pin lands well past it — so later windows' overlap
+	// floors (cursor − margin) sit above the root and never re-fetch it,
+	// exactly like a months-old root in production. Then, while the
+	// channel is excluded, it gains a reply and the watermark certifies
+	// past it.
+	newRoot := tsFresh(0)
+	f.mu.Lock()
+	f.conv("G05").Msgs = append(f.conv("G05").Msgs, fakeMsg{TS: newRoot, User: "UME", Text: "root above pin"})
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(20 * time.Minute) }
+	_, err = imp.Import(context.Background(), limited)
+	require.NoError(err)
+
+	gapReply := tsFresh(5)
+	f.mu.Lock()
+	f.conv("G05").findRoot(newRoot).Replies = []fakeMsg{{TS: gapReply, ThreadTS: newRoot, User: "UME", Text: "reply while excluded"}}
+	f.mu.Unlock()
+	excluded := opts
+	excluded.ExcludeChannels = []string{"legacy"}
+	imp.now = func() time.Time { return time.Now().Add(time.Hour) }
+	_, err = imp.Import(context.Background(), excluded)
+	require.NoError(err)
+
+	// Re-entry: gap recovery fires while the old walk is still mid-flight.
+	// It must RESET the walk — resumed under its original pin, the walk
+	// would never anchor the new root, then clear the flag as if done,
+	// and the stamped-forward boundary would certify the reply covered.
+	imp.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+	_, err = imp.Import(context.Background(), limited)
+	require.NoError(err)
+	imp.now = func() time.Time { return time.Now().Add(3 * time.Hour) }
+	for range 8 {
+		_, err = imp.Import(context.Background(), opts)
+		require.NoError(err)
+	}
+
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "G05:"+gapReply).Scan(&n))
+	require.Equal(1, n, "gap recovery must re-pin an in-flight catch-up walk so absence-era replies to post-pin roots are anchored")
+}
+
+func TestFileWithoutPermalinkKeepsPendingMarker(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	// Slack serves a hosted file with NO permalink: the marker row must
+	// still land (the store silently skips empty-storage-path rows, which
+	// would make the file invisible to backfill forever, with no error).
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_NOPERM", "name": "n.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_NOPERM/n.png"},
+	}
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	client.mediaTransport = &recordingTransport{body: "png07"}
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	opts := ImportOptions{TeamID: "T01", UserID: "UME", NoMedia: true, AttachmentsDir: t.TempDir()}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(err)
+	require.Len(pending, 1, "a permalink-less file must still leave a durable pending marker")
+
+	// And the backfill can pay it.
+	opts.NoMedia = false
+	sum, err := imp.BackfillMedia(context.Background(), opts)
+	require.NoError(err)
+	require.Equal(1, sum.AttachmentsDownloaded)
+}
+
+func TestCatchUpDebtNotStarvedBySaturatedWindows(t *testing.T) {
+	require := require.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	oldRoot := fakeMsg{TS: ts(0), User: "UME", Text: "old root"}
+	for i := range 3 {
+		oldRoot.Replies = append(oldRoot.Replies,
+			fakeMsg{TS: ts(i + 1), ThreadTS: oldRoot.TS, User: "UME", Text: "old reply " + strconv.Itoa(i)})
+	}
+	conv := &fakeConv{ID: "C70", Name: "busy", Kind: "public", Members: []string{"UME"}, Msgs: []fakeMsg{oldRoot}}
+	for i := range 5 {
+		conv.Msgs = append(conv.Msgs, fakeMsg{TS: ts(100 + i), User: "UME", Text: "old top " + strconv.Itoa(i)})
+	}
+	f.convs = []*fakeConv{conv}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	noThreads := opts
+	noThreads.NoThreads = true
+	_, err := imp.Import(context.Background(), noThreads)
+	require.NoError(err)
+
+	// Top-level traffic saturates the --limit budget EVERY run. Catch-up
+	// debt is finite; junior to the window walk it would get zero budget
+	// forever, while the windows keep up and the run looks healthy.
+	limited := opts
+	limited.Limit = 4
+	for k := 1; k <= 8; k++ {
+		f.mu.Lock()
+		for i := range 4 {
+			arrival := tsFormat(time.Now().Add(time.Duration(k-1)*time.Minute + time.Duration(10+i)*time.Second))
+			f.conv("C70").Msgs = append(f.conv("C70").Msgs, fakeMsg{TS: arrival, User: "UME", Text: "arrival"})
+		}
+		f.mu.Unlock()
+		warp := time.Duration(k) * time.Minute
+		imp.now = func() time.Time { return time.Now().Add(warp) }
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+
+	for i := range 3 {
+		var n int
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C70:"+ts(i+1)).Scan(&n))
+		require.Equal(1, n, "catch-up debt must converge even when windows saturate the budget (reply %d)", i)
+	}
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	require.False(imp.loadResumeState(src.ID).EnsureConv("C70").ThreadsPending,
+		"the finite catch-up debt must clear; it is senior to new window work")
+}
+
+func TestCrashBeforeSweepStampsCoverage(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// The very first (threaded) run completes #general's initial walk but
+	// dies at the LAST conversation — BEFORE the sweep phase ever runs, so
+	// no adoption happens. The completing walk must have stamped its own
+	// coverage: later runs advance Cursor with every window, and a
+	// boundary guessed from Cursor would sit past the interval.
+	checkpointMinInterval = time.Hour
+	f.mu.Lock()
+	f.onHistory = func(channelID string) {
+		if channelID == "D01" {
+			_, _ = st.DB().Exec(`DROP TABLE reactions`)
+		}
+	}
+	f.mu.Unlock()
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(err, "the store failure at the last conversation is fatal")
+	state := imp.loadResumeState(sum.SourceID)
+	require.True(state.EnsureConv("C01").Done, "the first conversation's walk completed")
+	require.NotEmpty(state.EnsureConv("C01").SweptThrough,
+		"a completing threaded initial walk must stamp its own reply coverage")
+
+	// A reply lands in the crash-to-restart interval; the healed run, 20
+	// minutes later, must sweep it — its floor derives from the stamp, not
+	// from the Cursor the new window is about to advance.
+	intervalReply := tsFresh(0)
+	f.mu.Lock()
+	f.onHistory = nil
+	root := f.conv("C01").findRoot(ts(5))
+	root.Replies = append(root.Replies, fakeMsg{TS: intervalReply, ThreadTS: ts(5), User: "UALICE", Text: "interval reply"})
+	f.mu.Unlock()
+	require.NoError(st.InitSchema())
+
+	imp.now = func() time.Time { return time.Now().Add(20 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+intervalReply).Scan(&n))
+	require.Equal(1, n, "a reply created between a crash-before-sweep and the restart must not fall below the boundary")
+}
+
+func TestLegacyStampLessStateTriggersCatchUp(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// A legacy blob: conversation done, Cursor advanced by many windows,
+	// NO SweptThrough stamp (written before completion-stamping existed).
+	// The reply below Cursor − margin is invisible to any sweep whose
+	// boundary is guessed from Cursor; only a conservative catch-up walk
+	// can recover it.
+	legacyReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: legacyReply, ThreadTS: rootTS, User: "UME", Text: "pre-stamp reply"})
+	f.mu.Unlock()
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	legacy := NewSyncState()
+	lcs := legacy.EnsureConv("C09")
+	lcs.Done = true
+	lcs.Cursor = tsFormat(time.Now().Add(30 * time.Minute))
+	runA, err := st.StartSync(src.ID, "slack")
+	require.NoError(err)
+	require.NoError(st.CompleteSync(runA, mustMarshal(t, legacy)))
+
+	imp.now = func() time.Time { return time.Now().Add(31 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	imp.now = func() time.Time { return time.Now().Add(32 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+legacyReply).Scan(&n))
+	require.Equal(1, n, "a stamp-less legacy state must recover via the conservative catch-up walk, not a Cursor-guessed boundary")
+}
+
+func TestMaintenanceRepairsReplyEdits(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A REPLY is edited at the source. Plain runs ignore post-capture
+	// mutations; --maintenance promises to repair recent messages —
+	// replies included, which history alone can never serve.
+	f.mu.Lock()
+	f.conv("C09").findRoot(rootTS).Replies[0].Text = "ancient reply (stealth edit)"
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	replyID := "C09:" + f.conv("C09").findRoot(rootTS).Replies[0].TS
+	readBody := func() string {
+		var body string
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT mb.body_text FROM message_bodies mb
+			JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), replyID).Scan(&body))
+		return body
+	}
+	assert.Equal("ancient reply", readBody(), "plain runs ignore post-capture reply edits")
+
+	maint := opts
+	maint.Maintenance = true
+	_, err = imp.Import(context.Background(), maint)
+	require.NoError(err)
+	assert.Equal("ancient reply (stealth edit)", readBody(), "--maintenance must repair reply edits, not only top-level messages")
+}
+
+func TestFirstReplyToUnthreadedMessageRecoveredByCatchUp(t *testing.T) {
+	require := require.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	// A channel with NO threads at all when the --no-threads backfill runs.
+	f.convs = []*fakeConv{{
+		ID: "C60", Name: "quiet", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{
+			{TS: ts(0), User: "UME", Text: "plain old message"},
+			{TS: ts(1), User: "UME", Text: "another plain one"},
+		},
+	}}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	noThreads := opts
+	noThreads.NoThreads = true
+	_, err := imp.Import(context.Background(), noThreads)
+	require.NoError(err)
+
+	// The old message gains its FIRST reply, and further --no-threads
+	// windows advance Cursor well past it. The conversation has never been
+	// swept, so the first threaded run's boundary adoption falls back to
+	// Cursor — the reply sits below every future sweep floor. Only an
+	// unconditionally-flagged catch-up walk (which re-reads history at ITS
+	// OWN time, when the message reports reply_count) can recover it.
+	firstReply := tsFresh(0)
+	f.mu.Lock()
+	f.conv("C60").findRoot(ts(0)).Replies = []fakeMsg{{TS: firstReply, ThreadTS: ts(0), User: "UME", Text: "first ever reply"}}
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(20 * time.Minute) }
+	_, err = imp.Import(context.Background(), noThreads)
+	require.NoError(err)
+
+	imp.now = func() time.Time { return time.Now().Add(21 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var linked int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_message_id = ? AND parent.source_message_id = ?`),
+		"C60:"+firstReply, "C60:"+ts(0)).Scan(&linked))
+	require.Equal(1, linked, "a first reply to a message that was unthreaded during a --no-threads backfill must be recovered")
+}
+
+func TestFailedRunPersistsFinalState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	before := imp.loadResumeState(sum.SourceID)
+
+	// Fresh work lands in TWO conversations; the store breaks between them
+	// (the fake drops the reactions table just before serving the LAST
+	// conversation's history, so the first conversation's window completes
+	// and the last one's persist fails fatally). With throttled flushes
+	// suppressed, the ONLY record of the first conversation's completed
+	// window is the failure-path checkpoint — a plain FailSync would
+	// resume from the pre-run baseline and silently discard that progress.
+	checkpointMinInterval = time.Hour
+	okMsg, badMsg := tsFresh(0), tsFresh(1)
+	f.mu.Lock()
+	f.conv("C01").Msgs = append(f.conv("C01").Msgs, fakeMsg{TS: okMsg, User: "UALICE", Text: "fine"})
+	f.conv("D01").Msgs = append(f.conv("D01").Msgs, fakeMsg{TS: badMsg, User: "UALICE", Text: "plain"})
+	f.onHistory = func(channelID string) {
+		if channelID == "D01" {
+			_, _ = st.DB().Exec(`DROP TABLE reactions`)
+		}
+	}
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "the reactions write failure is fatal")
+
+	after := imp.loadResumeState(sum.SourceID)
+	assert.True(tsLess(before.EnsureConv("C01").Cursor, after.EnsureConv("C01").Cursor),
+		"the failure-path checkpoint must persist the completed first conversation's progress")
+
+	f.mu.Lock()
+	f.onHistory = nil
+	f.mu.Unlock()
+	require.NoError(st.InitSchema())
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	require.Equal(distinct, total)
+}
+
+func TestInitialWalkPinPersistsAcrossResumedRuns(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// The initial walk spans several limited runs. Its pin must be the
+	// FIRST run's instant, persisted across resumes: on completion Cursor
+	// becomes that pin, and the sweep-boundary adoption stamps it — a pin
+	// refreshed per resume would stamp a later instant, and a reply
+	// created mid-backfill to an already-walked root would land below the
+	// adopted floor forever.
+	limited := opts
+	limited.Limit = 2
+	_, err := imp.Import(context.Background(), limited)
+	require.NoError(err)
+
+	midBackfillReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: midBackfillReply, ThreadTS: rootTS, User: "UME", Text: "mid-backfill reply"})
+	f.mu.Unlock()
+
+	// Later resumes run 20+ minutes on: a refreshed pin would place the
+	// adopted boundary (minus the overlap margin) above the reply.
+	imp.now = func() time.Time { return time.Now().Add(20 * time.Minute) }
+	for range 8 {
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	imp.now = func() time.Time { return time.Now().Add(21 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+midBackfillReply).Scan(&n))
+	require.Equal(1, n, "a reply created mid-backfill must stay above the adopted sweep boundary (original pin)")
+}
+
+func TestStoreWriteFailureHoldsCursorAndResumes(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A new message arrives carrying reactions, and the reactions table is
+	// gone (standing in for any sick-database write failure). The run must
+	// FAIL with the cursor held — counting the failure and advancing would
+	// permanently omit the rows while reporting success.
+	fresh := tsFresh(0)
+	f.mu.Lock()
+	f.conv("C01").Msgs = append(f.conv("C01").Msgs, fakeMsg{TS: fresh, User: "UALICE", Text: "reacted",
+		Reactions: []map[string]any{{"name": "tada", "users": []string{"UME", "UBOB"}, "count": 2}}})
+	f.mu.Unlock()
+	_, err = st.DB().Exec(`DROP TABLE reactions`)
+	require.NoError(err)
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "a failed auxiliary store write must fail the run, not count and continue")
+
+	// The database heals (InitSchema is idempotent); the held cursor makes
+	// the next run refetch the message and persist everything exactly once.
+	require.NoError(st.InitSchema())
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var reactions int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM reactions r JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ?`), "C01:"+fresh).Scan(&reactions))
+	require.Equal(2, reactions, "the held cursor must let the healed run recover the lost rows")
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	require.Equal(distinct, total)
+}
+
+func TestAttachmentRowFailureFailsRun(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A new message carries a file, and the attachment rows cannot be
+	// written. This is THE permanent-loss vector: without a durable pending
+	// marker the file is invisible to backfill-slack-media forever, so the
+	// run must stop rather than advance past it.
+	fresh := tsFresh(0)
+	f.mu.Lock()
+	f.conv("C01").Msgs = append(f.conv("C01").Msgs, fakeMsg{TS: fresh, User: "UALICE", Text: "with file",
+		Files: []map[string]any{{"id": "F_HELD", "name": "h.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_HELD/h.png",
+			"permalink":   "https://testers.slack.com/files/F_HELD"}}})
+	f.mu.Unlock()
+	_, err = st.DB().Exec(`DROP TABLE attachments`)
+	require.NoError(err)
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "a failed attachment row write must fail the run — the marker was never durable")
+
+	// Heal: the dropped table also lost its migration-created unique index,
+	// so clear that marker before the idempotent re-init (a test-only
+	// artifact of injecting failure via DROP TABLE).
+	_, err = st.DB().Exec(st.Rebind(`DELETE FROM applied_migrations WHERE name = ?`), "attachments_content_hash_unique_index")
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var marker int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM attachments WHERE source_attachment_id = ?`), "slack:F_HELD").Scan(&marker))
+	require.Equal(1, marker, "the healed run must persist the (pending) attachment row exactly once")
+}
+
+func TestMembershipFetchFailureMarksRunPartial(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	f.failMembers["C01"] = true
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// Membership failures stay ISOLATED (message archiving proceeds) but
+	// honest: the run reports partial instead of success.
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(err, "a members-listing outage is a fetch failure; the run must not report success")
+	require.Positive(sum.FetchErrors)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(0)).Scan(&n))
+	require.Equal(1, n, "isolation: the channel's messages still archive despite the membership failure")
+}
+
+func TestLimitedSweepDrainsBigTailAcrossRuns(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A swept thread grows a 30-reply tail. A limited sweep must not fetch
+	// it wholesale — the tail becomes drain debt, paid in budget-sized,
+	// reply-granular pages across runs.
+	tail := make([]string, 30)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	for i := range tail {
+		tail[i] = tsFresh(i)
+		root.Replies = append(root.Replies, fakeMsg{TS: tail[i], ThreadTS: rootTS, User: "UME", Text: "tail " + strconv.Itoa(i)})
+	}
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	limited := opts
+	limited.Limit = 4
+	_, err = imp.Import(context.Background(), limited)
+	require.NoError(err)
+	// Count just the tail replies present after one limited run.
+	tailCount := func() int {
+		n := 0
+		for _, ts := range tail {
+			var c int
+			require.NoError(st.DB().QueryRow(st.Rebind(
+				`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+ts).Scan(&c))
+			n += c
+		}
+		return n
+	}
+	assert.LessOrEqual(tailCount(), 8, "a --limit 4 run must not fetch a 30-reply tail wholesale")
+
+	for range 15 {
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	assert.Equal(30, tailCount(), "repeated limited runs must drain the whole tail")
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(distinct, total)
+}
+
+func TestRepairCompletesDespiteDepartedConversations(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A repair session starts and partially walks #general…
+	full := opts
+	full.Full = true
+	full.Limit = 3
+	_, err = imp.Import(context.Background(), full)
+	require.NoError(err)
+
+	// …then #general is excluded from scope. Completion is a question
+	// about the currently ELIGIBLE set: the unreachable conversation must
+	// not wedge the session open forever (its generation-reset Done flag
+	// already guarantees a fresh walk if it ever re-enters).
+	excluded := opts
+	excluded.ExcludeChannels = []string{"general"}
+	for range 3 {
+		_, err = imp.Import(context.Background(), excluded)
+		require.NoError(err)
+	}
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	state := imp.loadResumeState(src.ID)
+	assert.False(state.RepairPending,
+		"a conversation that left the eligible set must not hold the repair session open")
+}
+
+func TestLimitOneSweepConverges(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "late reply"})
+	f.mu.Unlock()
+
+	// Guaranteed-first-unit rule: at --limit 1 the sweep's day-charge alone
+	// exhausts the budget, so without the progress guarantee every run
+	// would park at the same boundary before its first fetch, forever.
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	limited := opts
+	limited.Limit = 1
+	for range 3 {
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Equal(1, n, "--limit 1 sweeps must still make durable progress every run")
+}
+
+func TestFullRepairSurvivesInterruption(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// An old message is edited at the source; --full is the repair path.
+	f.mu.Lock()
+	f.conv("C01").Msgs[0].Text = "hello 0 (repaired)"
+	baseline := f.historyCalls
+	f.mu.Unlock()
+
+	// The repair run dies mid-walk. Its generation-stamped checkpoint must
+	// SUPERSEDE the pre-repair success blob — field-wise blending would OR
+	// the old Done flags over the fresh partial cursors and silently
+	// abandon the repair half-done.
+	full := opts
+	full.Full = true
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		for {
+			f.mu.Lock()
+			served := f.historyCalls > baseline
+			f.mu.Unlock()
+			if served {
+				cancel()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	_, _ = imp.Import(ctx, full)
+
+	// A PLAIN run continues (and completes) the repair session.
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(0)).Scan(&body))
+	assert.Equal("hello 0 (repaired)", body, "an interrupted --full must be finished by later runs, not abandoned")
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(distinct, total)
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	state := imp.loadResumeState(src.ID)
+	assert.False(state.RepairPending, "the repair session clears once everything is walked and paid")
+}
+
+func TestScopedFullRepairConverges(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The OLDEST message is edited: a --full that restarts at the newest
+	// page on every invocation would never reach it under a small --limit.
+	f.mu.Lock()
+	f.conv("C01").Msgs[0].Text = "hello 0 (deep repair)"
+	f.mu.Unlock()
+
+	full := opts
+	full.Full = true
+	full.Limit = 3
+	for range 12 {
+		_, err = imp.Import(context.Background(), full)
+		require.NoError(err)
+	}
+
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM message_bodies mb
+		JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(0)).Scan(&body))
+	assert.Equal("hello 0 (deep repair)", body, "repeated --full --limit runs must converge on the repair, not restart it")
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	state := imp.loadResumeState(src.ID)
+	assert.False(state.RepairPending)
+}
+
+func TestSweepProcessesUnarchivedParent(t *testing.T) {
+	require := require.New(t)
+	f, _ := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A brand-new root gets an instant reply, and the window walk that
+	// would archive the root FAILS this run. The sweep still discovers the
+	// reply; the canonical fetch must process the (missing) parent so the
+	// thread link resolves — skipping it unconditionally would persist the
+	// reply with a permanently NULL parent link.
+	newRoot, newReply := tsFresh(0), tsFresh(1)
+	f.mu.Lock()
+	f.conv("C09").Msgs = append(f.conv("C09").Msgs, fakeMsg{TS: newRoot, User: "UME", Text: "instant root",
+		Replies: []fakeMsg{{TS: newReply, ThreadTS: newRoot, User: "UME", Text: "instant reply"}}})
+	f.failHistory["C09"] = true
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "the failed window walk keeps the run partial")
+
+	var linked int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_message_id = ? AND parent.source_message_id = ?`),
+		"C09:"+newReply, "C09:"+newRoot).Scan(&linked))
+	require.Equal(1, linked, "the sweep must archive AND link a reply whose root it is first to see")
+}
+
+func TestSoloSweepEntryReanchorsToTrueRoot(t *testing.T) {
+	require := require.New(t)
+	f, _ := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A brand-new root gets an instant reply, the window walk that would
+	// archive the root FAILS, and the hit's permalink carries no thread_ts
+	// — so the sweep records a SOLO entry anchored at the reply. Probed
+	// live: replies(ts=<reply>) serves ONLY that reply, so the drain must
+	// re-anchor at the reply's own thread_ts and re-serve it after the
+	// parent — otherwise the parent is never fetched and the reply keeps a
+	// NULL thread link forever.
+	newRoot, newReply := tsFresh(0), tsFresh(1)
+	f.mu.Lock()
+	f.conv("C09").Msgs = append(f.conv("C09").Msgs, fakeMsg{TS: newRoot, User: "UME", Text: "solo root",
+		Replies: []fakeMsg{{TS: newReply, ThreadTS: newRoot, User: "UME", Text: "solo reply"}}})
+	f.failHistory["C09"] = true
+	f.searchOmitThreadTS = true
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "the failed window walk keeps the run partial")
+
+	var linked int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_message_id = ? AND parent.source_message_id = ?`),
+		"C09:"+newReply, "C09:"+newRoot).Scan(&linked))
+	require.Equal(1, linked, "a solo drain entry must re-anchor at the true root and link the reply")
+}
+
+func TestSweepFetchDoesNotRefreshArchivedParent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A reaction lands on the archived root, then a late reply arrives.
+	// The sweep's canonical fetch must skip the already-archived parent:
+	// refreshing its content and reactions is post-capture mutation repair,
+	// which belongs to --maintenance, not the sweep.
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Reactions = []map[string]any{{"name": "eyes", "users": []string{"UME"}, "count": 1}}
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "late reply"})
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Equal(1, n, "the late reply itself is archived")
+	var reactions int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM reactions r JOIN messages m ON m.id = r.message_id
+		WHERE m.source_message_id = ?`), "C09:"+rootTS).Scan(&reactions))
+	assert.Zero(reactions, "a sweep fetch must not refresh the archived parent's reactions outside --maintenance")
+}
+
+func TestSweepTruncatedDayFailsOnceAndConvergesViaCatchUp(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The day gains a reachable reply and — on a DIFFERENT thread — one
+	// beyond the ceiling (hidden from search entirely, so no drain entry
+	// can reach it). The day persistently reports >10k results.
+	reachable, unreachable := tsFresh(0), tsFresh(5)
+	f.mu.Lock()
+	f.conv("C09").findRoot(rootTS).Replies = append(f.conv("C09").findRoot(rootTS).Replies,
+		fakeMsg{TS: reachable, ThreadTS: rootTS, User: "UME", Text: "reachable reply"})
+	other := f.conv("C09").findRoot(ts(0))
+	other.Replies = append(other.Replies, fakeMsg{TS: unreachable, ThreadTS: ts(0), User: "UME", Text: "beyond the ceiling"})
+	f.searchHidden[unreachable] = true
+	f.searchTruncateDays[tsTime(unreachable).UTC().Format("2006-01-02")] = true
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	sum, err := imp.Import(context.Background(), opts)
+	require.Error(err, "a truncated sweep day must fail the run loudly")
+	assert.Positive(sum.FetchErrors)
+	// The reachable results (the day's earliest, ascending) were archived,
+	// and the unreachable tail became durable catch-up debt.
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+reachable).Scan(&n))
+	assert.Equal(1, n)
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	require.True(imp.loadResumeState(src.ID).EnsureConv("C09").ThreadsPending,
+		"the unreachable tail must be recorded as thread catch-up debt")
+
+	// Once the day is over, the boundary passes it (debt recorded — the
+	// day is never re-queried) and the catch-up walk recovers the reply
+	// search could never serve. The tool converges with NO manual --full.
+	imp.now = func() time.Time { return time.Now().Add(25 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "the still-open truncated day re-fails until it is behind the boundary")
+	imp.now = func() time.Time { return time.Now().Add(26 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err, "past the truncated day the sweep must converge without --full")
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+unreachable).Scan(&n))
+	assert.Equal(1, n, "the catch-up walk must recover the reply beyond the search ceiling")
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(distinct, total)
+}
+
+func TestTruncatedSweepDuringRepairUnwedgesSession(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A repair session overlaps a persistently truncated day. The session
+	// can only close on a clean pass, and --full refuses to reset one in
+	// flight — so if the sweep re-truncates on the same day forever, the
+	// tool is wedged permanently. Recording the tail as catch-up debt and
+	// advancing the boundary past the day must unwedge it.
+	reachable, unreachable := tsFresh(0), tsFresh(5)
+	f.mu.Lock()
+	f.conv("C09").findRoot(rootTS).Replies = append(f.conv("C09").findRoot(rootTS).Replies,
+		fakeMsg{TS: reachable, ThreadTS: rootTS, User: "UME", Text: "reachable reply"})
+	other := f.conv("C09").findRoot(ts(0))
+	other.Replies = append(other.Replies, fakeMsg{TS: unreachable, ThreadTS: ts(0), User: "UME", Text: "beyond the ceiling"})
+	f.searchHidden[unreachable] = true
+	f.searchTruncateDays[tsTime(unreachable).UTC().Format("2006-01-02")] = true
+	f.mu.Unlock()
+
+	full := opts
+	full.Full = true
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_, err = imp.Import(context.Background(), full)
+	require.Error(err, "the truncated day fails the repair run loudly")
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	require.True(imp.loadResumeState(src.ID).RepairPending, "the failed pass must not close the session")
+
+	// Plain runs continue the session. Once the truncated day is behind
+	// the boundary, a clean pass pays the catch-up debt and closes it.
+	imp.now = func() time.Time { return time.Now().Add(25 * time.Hour) }
+	_, _ = imp.Import(context.Background(), opts)
+	imp.now = func() time.Time { return time.Now().Add(26 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err, "the session must converge; a permanently re-truncating sweep wedges RepairPending forever")
+	state := imp.loadResumeState(src.ID)
+	assert.False(state.RepairPending, "the clean pass closes the repair session")
+	assert.False(state.EnsureConv("C09").ThreadsPending)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+unreachable).Scan(&n))
+	assert.Equal(1, n)
+}
+
+func TestSweepRecoversGapForReIncludedChannel(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	// A second channel that stays included throughout, so sweeps keep
+	// advancing the workspace watermark while #archive is excluded.
+	f.convs = append(f.convs, &fakeConv{
+		ID: "C11", Name: "keep", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{{TS: ts(1), User: "UME", Text: "keep hi"}},
+	})
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// While #archive is excluded, a reply lands on its ancient thread, and
+	// enough (warped) time passes that the workspace watermark certifies
+	// past the reply's creation time.
+	gapReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: gapReply, ThreadTS: rootTS, User: "UME", Text: "reply while excluded"})
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Hour) }
+	excluded := opts
+	excluded.ExcludeChannels = []string{"archive"}
+	_, err = imp.Import(context.Background(), excluded)
+	require.NoError(err)
+
+	state := imp.loadResumeState(sum.SourceID)
+	require.True(tsLess(gapReply, state.SweepWatermark),
+		"test setup: the watermark must have certified past the excluded channel's reply")
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+gapReply).Scan(&n))
+	require.Zero(n, "test setup: the reply must not be archived while its channel is excluded")
+
+	// Re-included: the channel re-enters certified behind the watermark; a
+	// channel-scoped gap sweep must recover the reply that the workspace
+	// sweep — floored at the watermark — will never revisit.
+	imp.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+gapReply).Scan(&n))
+	assert.Equal(t, 1, n, "a reply created while its channel was excluded must be recovered on re-entry")
+}
+
+func TestImportLimitBoundsThreadReplies(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	busyRoot := fakeMsg{TS: ts(0), User: "UME", Text: "busy root"}
+	for i := range 12 {
+		busyRoot.Replies = append(busyRoot.Replies,
+			fakeMsg{TS: ts(i + 1), ThreadTS: busyRoot.TS, User: "UME", Text: "reply " + strconv.Itoa(i)})
+	}
+	f.convs = []*fakeConv{{
+		ID: "C20", Name: "busy", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{busyRoot},
+	}}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// One discovered thread must not blow through the budget: its
+	// reply_count forecast charges the run at recording time, and the drain
+	// fetches on budget-sized pages, parking the remainder as durable debt.
+	limited := opts
+	limited.Limit = 3
+	_, err := imp.Import(context.Background(), limited)
+	require.NoError(err)
+	var partial int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&partial))
+	assert.Positive(partial)
+	assert.LessOrEqual(partial, 4, "--limit 3 must bound thread replies, not just top-level history")
+
+	// The unlimited run completes the thread: every message exactly once.
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(13, total, "resumed runs must recover the budget-clipped replies")
+	assert.Equal(distinct, total)
+}
+
+func TestStandingLimitConvergesThroughThreadDebt(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	// The OLDEST message is a root with more replies than the standing
+	// limit; several newer top-levels sit above it. Newest-first pagination
+	// reaches the root last, so the drain must carry the thread across runs.
+	busyRoot := fakeMsg{TS: ts(0), User: "UME", Text: "busy root"}
+	for i := range 12 {
+		busyRoot.Replies = append(busyRoot.Replies,
+			fakeMsg{TS: ts(i + 1), ThreadTS: busyRoot.TS, User: "UME", Text: "reply " + strconv.Itoa(i)})
+	}
+	conv := &fakeConv{ID: "C30", Name: "steady", Kind: "public", Members: []string{"UME"}, Msgs: []fakeMsg{busyRoot}}
+	for i := range 5 {
+		conv.Msgs = append(conv.Msgs, fakeMsg{TS: ts(100 + i), User: "UME", Text: "top " + strconv.Itoa(i)})
+	}
+	f.convs = []*fakeConv{conv}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// A standing --limit cron must converge to a complete archive BY
+	// ITSELF: each run makes durable progress (history pages, then reply
+	// drain resumed from the per-thread drained-to ts) — no unlimited run
+	// required, no stall.
+	limited := opts
+	limited.Limit = 4
+	for range 12 {
+		_, err := imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(18, total, "repeated limited runs must drain the whole archive, thread included")
+	assert.Equal(distinct, total)
+}
+
+func TestGapCatchUpCoversPostBackfillRoots(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	// A legacy G-prefixed private channel (name-filterable, but outside the
+	// probed in:<#C…> search-scope form, so its gap recovery runs through
+	// the thread catch-up walk) plus a channel that keeps the workspace
+	// watermark advancing while it is excluded.
+	f.convs = append(f.convs,
+		&fakeConv{ID: "G05", Name: "legacy", Kind: "private", Members: []string{"UME"},
+			Msgs: []fakeMsg{{TS: ts(2), User: "UME", Text: "legacy hi"}}},
+		&fakeConv{ID: "C11", Name: "keep", Kind: "public", Members: []string{"UME"},
+			Msgs: []fakeMsg{{TS: ts(1), User: "UME", Text: "keep hi"}}},
+	)
+	_ = rootTS
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// While #legacy is excluded, a NEW thread starts there — root AND reply
+	// both created after the channel's backfill pin — and the watermark
+	// certifies past them. A catch-up walk bounded by the original pin
+	// would never anchor this root, losing the reply permanently.
+	gapRoot, gapReply := tsFresh(0), tsFresh(1)
+	f.mu.Lock()
+	f.conv("G05").Msgs = append(f.conv("G05").Msgs, fakeMsg{TS: gapRoot, User: "UME", Text: "root while excluded",
+		Replies: []fakeMsg{{TS: gapReply, ThreadTS: gapRoot, User: "UME", Text: "reply while excluded"}}})
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Hour) }
+	excluded := opts
+	excluded.ExcludeChannels = []string{"legacy"}
+	_, err = imp.Import(context.Background(), excluded)
+	require.NoError(err)
+
+	state := imp.loadResumeState(sum.SourceID)
+	require.True(tsLess(gapReply, state.SweepWatermark),
+		"test setup: the watermark must have certified past the excluded channel's reply")
+
+	// Re-entry flags the gap as thread debt; the following run's catch-up
+	// walk must cover roots created AFTER the original backfill pin.
+	imp.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	imp.now = func() time.Time { return time.Now().Add(3 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "G05:"+gapReply).Scan(&n))
+	require.Equal(1, n, "gap recovery must anchor threads rooted after the backfill pin")
+}
+
+func TestStandingLimitSweepsLateReplies(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// A standing --limit schedule must still discover replies: the sweep
+	// participates in limited runs with a work budget instead of being
+	// skipped outright (which would mean a permanently-capped sync NEVER
+	// archives another reply).
+	limited := opts
+	limited.Limit = 6
+	for range 4 {
+		_, err := imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "late reply"})
+	f.mu.Unlock()
+
+	for range 4 {
+		_, err := imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	require.Equal(1, n, "limited runs must sweep in late replies — no unlimited run required")
+}
+
+func TestStandingLimitPaysCatchUpDebt(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	busyRoot := fakeMsg{TS: ts(0), User: "UME", Text: "busy root"}
+	for i := range 10 {
+		busyRoot.Replies = append(busyRoot.Replies,
+			fakeMsg{TS: ts(i + 1), ThreadTS: busyRoot.TS, User: "UME", Text: "reply " + strconv.Itoa(i)})
+	}
+	conv := &fakeConv{ID: "C40", Name: "debtor", Kind: "public", Members: []string{"UME"}, Msgs: []fakeMsg{busyRoot}}
+	for i := range 6 {
+		conv.Msgs = append(conv.Msgs, fakeMsg{TS: ts(100 + i), User: "UME", Text: "top " + strconv.Itoa(i)})
+	}
+	f.convs = []*fakeConv{conv}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// A --no-threads backfill leaves conversation-level thread debt…
+	noThreads := opts
+	noThreads.NoThreads = true
+	_, err := imp.Import(context.Background(), noThreads)
+	require.NoError(err)
+
+	// …which repeated LIMITED threaded runs must pay by themselves: the
+	// catch-up walk checkpoints its page cursor and drains through the
+	// shared pending-thread machinery, so a standing --limit schedule
+	// converges instead of skipping the walk forever.
+	limited := opts
+	limited.Limit = 4
+	for range 14 {
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(17, total, "limited runs must pay --no-threads debt without an unlimited run")
+	assert.Equal(distinct, total)
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	state := imp.loadResumeState(src.ID)
+	assert.False(state.EnsureConv("C40").ThreadsPending, "the debt flag clears once the walk finishes clean")
+}
+
+func TestCatchUpClearsDebtForGoneConversation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+
+	// Build conversation-level thread debt, then delete the channel at the
+	// source. The catch-up walk must treat the gone channel as skipped
+	// work and CLEAR the debt — a retryable error here would wedge every
+	// future workspace sync into partial failure, permanently.
+	noThreads := opts
+	noThreads.NoThreads = true
+	_, err := imp.Import(context.Background(), noThreads)
+	require.NoError(err)
+
+	f.mu.Lock()
+	f.handleGhost(f.conv("C01"))
+	f.mu.Unlock()
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err, "a gone conversation with catch-up debt must not fail the run")
+	assert.Zero(sum.FetchErrors)
+
+	state := imp.loadResumeState(sum.SourceID)
+	assert.False(state.EnsureConv("C01").ThreadsPending, "debt for a gone conversation clears — there is nothing left to fetch")
+}
+
+func TestSweepDayBoundariesFollowHistoricalDST(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("tzdata unavailable")
+	}
+	require.NotNil(ny)
+
+	// Search files messages by the user's IANA zone with HISTORICAL DST
+	// rules (probed live against a corpus spanning transitions: winter
+	// boundary at EST midnight even when queried in summer; the spring-
+	// forward day served as a 23-hour span). Certification boundaries must
+	// match, or an interrupted per-day sweep could certify an hour the
+	// day's query never served.
+	jan15 := time.Date(2026, 1, 15, 0, 0, 0, 0, ny)
+	assert.Equal("2026-01-16T05:00:00Z", nextDayStart(jan15, ny).UTC().Format(time.RFC3339),
+		"winter boundary is EST midnight (-5), regardless of the current offset")
+	jun15 := time.Date(2026, 6, 15, 0, 0, 0, 0, ny)
+	assert.Equal("2026-06-16T04:00:00Z", nextDayStart(jun15, ny).UTC().Format(time.RFC3339),
+		"summer boundary is EDT midnight (-4)")
+	mar8 := time.Date(2026, 3, 8, 0, 0, 0, 0, ny)
+	assert.Equal("2026-03-08T05:00:00Z", mar8.UTC().Format(time.RFC3339))
+	assert.Equal("2026-03-09T04:00:00Z", nextDayStart(mar8, ny).UTC().Format(time.RFC3339),
+		"the spring-forward day is 23 hours (probed live: on:2026-03-08 served exactly this span)")
+
+	// The resolver serves the IANA zone when it loads; sweeping with the
+	// flat current offset instead would put winter boundaries an hour off.
+	r := &participantResolver{users: map[string]User{
+		"UNY":  {ID: "UNY", TZ: "America/New_York", TZOffset: -4 * 3600},
+		"UBAD": {ID: "UBAD", TZ: "Not/AZone", TZOffset: 7200},
+	}}
+	winter := time.Date(2026, 1, 16, 5, 0, 0, 0, time.UTC).In(r.tzLocation("UNY"))
+	assert.Equal(0, winter.Hour(), "sweep-day arithmetic must apply the historical winter offset, not the current one")
+	_, off := time.Date(2026, 1, 15, 0, 0, 0, 0, r.tzLocation("UBAD")).Zone()
+	assert.Equal(7200, off, "an unloadable zone name falls back to the fixed current offset")
+}
+
+func TestSweepSkipsNotDoneConversations(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	// A second conversation that cannot finish backfilling: its search hits
+	// must be ignored — the backfill owns not-done conversations.
+	f.convs = append(f.convs, &fakeConv{
+		ID: "C10", Name: "stuck", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{
+			{TS: ts(-100), User: "UME", Text: "stuck root",
+				Replies: []fakeMsg{{TS: tsFresh(4), ThreadTS: ts(-100), User: "UME", Text: "stuck late reply"}}},
+		},
+	})
+	f.failHistory["C10"] = true
+	stuckReply := f.convs[len(f.convs)-1].Msgs[0].Replies[0].TS
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	// C09 completes and gets a late reply; C10 never finishes backfill.
+	_, err := imp.Import(context.Background(), opts)
+	require.Error(err) // C10's history failure keeps the run partial
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "late reply"})
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err) // still partial: C10 still failing
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	assert.Equal(1, n, "done conversations are swept even while others are stuck")
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C10:"+stuckReply).Scan(&n))
+	assert.Zero(n, "not-done conversations are owned by backfill, never the sweep")
+
+	// C10 heals: its backfill fetches root AND replies inline.
+	f.mu.Lock()
+	delete(f.failHistory, "C10")
+	f.mu.Unlock()
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C10:"+stuckReply).Scan(&n))
+	assert.Equal(1, n)
+}
+
+func TestImportLimitBoundsProcessedMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	limited := opts
+	limited.Limit = 1
+	limited.NoThreads = true
+	_, err := imp.Import(context.Background(), limited)
+	require.NoError(err)
+
+	// Page requests are sized to the remaining budget, so each conversation
+	// processes at most its limit — not a full server page.
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.LessOrEqual(total, 4, "--limit 1 must not fetch whole pages per conversation")
+	assert.Positive(total)
+}
+
+func TestImportLimitedRunsDrainIncrementalBacklog(t *testing.T) {
+	require := require.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A 9-message backlog arriving "now" against a standing --limit 2:
+	// without the persisted window page cursor, every limited run would
+	// restart from the newest page and the backlog would never drain.
+	backlog := make([]string, 9)
+	f.mu.Lock()
+	general := f.conv("C01")
+	for i := range 9 {
+		backlog[i] = tsFresh(i)
+		general.Msgs = append(general.Msgs, fakeMsg{TS: backlog[i], User: "UBOB", Text: "backlog " + strconv.Itoa(i)})
+	}
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(time.Minute) }
+	limited := opts
+	limited.Limit = 2
+	limited.NoThreads = true
+	for range 8 {
+		_, err = imp.Import(context.Background(), limited)
+		require.NoError(err)
+	}
+	for i := range 9 {
+		var n int
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+backlog[i]).Scan(&n))
+		assert.Equal(t, 1, n, "backlog message %d must be drained by repeated limited runs", i)
+	}
+}
+
+func TestImportDiscoversFirstReplyToOlderMessage(t *testing.T) {
+	require := require.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	// The 10-day-old message starts with NO replies: it is archived as a
+	// plain message, not tracked as a thread root.
+	f.mu.Lock()
+	f.conv("C09").findRoot(rootTS).Replies = nil
+	f.mu.Unlock()
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// First reply arrives long after archiving. The reply sweep must
+	// discover it by creation time — the parent's age is irrelevant.
+	lateReply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = []fakeMsg{{TS: lateReply, ThreadTS: rootTS, User: "UME", Text: "first ever reply"}}
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+lateReply).Scan(&n))
+	assert.Equal(t, 1, n, "a first reply to an older message must be swept in without --full")
+}
+
+func TestMaintenanceRescanIsExplicit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Edit the NEWEST archived message: archives ignore post-capture
+	// mutations by default, so plain incremental runs must not see it.
+	// The explicit --maintenance rescan repairs it (its inclusive upper
+	// bound covers the cursor message itself).
+	f.mu.Lock()
+	last := len(f.conv("C01").Msgs) - 1
+	f.conv("C01").Msgs[last].Text = "hello 7 (stealth edit)"
+	f.mu.Unlock()
+
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var body string
+	readBody := func() string {
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT mb.body_text FROM message_bodies mb
+			JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), "C01:"+ts(7)).Scan(&body))
+		return body
+	}
+	assert.Equal("hello 7", readBody(), "plain runs ignore post-capture edits")
+
+	maint := opts
+	maint.Maintenance = true
+	_, err = imp.Import(context.Background(), maint)
+	require.NoError(err)
+	assert.Equal("hello 7 (stealth edit)", readBody(), "--maintenance repairs edits")
+}
+
+func TestImportGoneConversationIsSkippedNotFatal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	// Enumerated but unreadable: history answers channel_not_found (observed
+	// live with a sandbox provisioning-bot DM). The fake 404s any channel it
+	// has no record of, so listing a ghost entry reproduces it exactly.
+	f.convs = append(f.convs, &fakeConv{ID: "D_GONE", Kind: "im", IMUser: "UALICE"})
+	ghost := f.convs[len(f.convs)-1]
+	f.handleGhost(ghost)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err, "a permanently-gone conversation must not fail the run")
+	assert.Zero(sum.FetchErrors)
+
+	// Everything else archived normally.
+	var total int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	assert.Equal(totalWorkspaceMessages, total)
+}
+
+func TestImportChannelFilters(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	opts.ExcludeChannels = []string{"general"}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversations WHERE source_conversation_id = ?`), "C01").Scan(&n))
+	assert.Zero(n, "excluded channel must not be archived")
+	// DMs are never filtered.
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversations WHERE source_conversation_id = ?`), "D01").Scan(&n))
+	assert.Equal(1, n)
+}
+
+// tsAgo renders a Slack ts for a moment shortly in the past — close enough
+// to "now" that the next run's clock-skew window overlap re-covers it.
+func tsAgo(d time.Duration) string {
+	return strconv.FormatInt(time.Now().Add(-d).Unix(), 10) + ".000100"
+}
+
+// tombstoneWorkspace is a channel whose root (reactions, a reply) sits
+// minutes below the first run's pin, inside every later trigger surface:
+// the incremental window's clock-skew overlap, --full, and --maintenance.
+func tombstoneWorkspace(t *testing.T) (*fakeSlack, string, string) {
+	t.Helper()
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	rootTS := tsAgo(5 * time.Minute)
+	replyTS := tsAgo(4 * time.Minute)
+	f.convs = []*fakeConv{{
+		ID: "C80", Name: "keep", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{{
+			TS: rootTS, User: "UME", Text: "the original words",
+			Reactions: []map[string]any{{"name": "wave", "users": []string{"UME"}, "count": 1}},
+			Replies:   []fakeMsg{{TS: replyTS, ThreadTS: rootTS, User: "UME", Text: "kept reply"}},
+		}},
+	}}
+	return f, rootTS, replyTS
+}
+
+func TestTombstoneNeverOverwritesArchivedOriginal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS, _ := tombstoneWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The root is deleted at the source. Slack keeps serving the row as a
+	// tombstone (probed live), so every re-read path would upsert it over
+	// the archived original — the archive promises deleted messages stay.
+	f.mu.Lock()
+	f.conv("C80").tombstone(rootTS)
+	f.mu.Unlock()
+
+	rootID := "C80:" + rootTS
+	checkIntact := func(path string) {
+		t.Helper()
+		var body string
+		var msgID int64
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT m.id, mb.body_text FROM messages m
+			JOIN message_bodies mb ON mb.message_id = m.id
+			WHERE m.source_message_id = ?`), rootID).Scan(&msgID, &body))
+		assert.Equal("the original words", body, "%s must not overwrite the archived body with the tombstone", path)
+		var reactions int
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT COUNT(*) FROM reactions WHERE message_id = ?`), msgID).Scan(&reactions))
+		assert.Equal(1, reactions, "%s must not wipe archived reactions with the tombstone's empty set", path)
+		raw, err := st.GetMessageRaw(msgID)
+		require.NoError(err)
+		assert.Contains(string(raw), "the original words", "%s must not replace the archived raw JSON", path)
+	}
+
+	// Incremental: the window's clock-skew overlap re-serves the root.
+	imp.now = func() time.Time { return time.Now().Add(1 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	checkIntact("incremental overlap")
+
+	full := opts
+	full.Full = true
+	imp.now = func() time.Time { return time.Now().Add(2 * time.Minute) }
+	_, err = imp.Import(context.Background(), full)
+	require.NoError(err)
+	checkIntact("--full")
+
+	maint := opts
+	maint.Maintenance = true
+	imp.now = func() time.Time { return time.Now().Add(3 * time.Minute) }
+	_, err = imp.Import(context.Background(), maint)
+	require.NoError(err)
+	checkIntact("--maintenance")
+}
+
+func TestTombstonePlaceholderKeepsOrphanedReplies(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS, replyTS := tombstoneWorkspace(t)
+	// Deleted BEFORE ever being archived: the tombstone is the only parent
+	// Slack will ever serve. It must be persisted as a placeholder so the
+	// orphaned replies (probed: they survive deletion) archive with a
+	// resolvable thread link.
+	f.conv("C80").tombstone(rootTS)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text FROM messages m
+		JOIN message_bodies mb ON mb.message_id = m.id
+		WHERE m.source_message_id = ?`), "C80:"+rootTS).Scan(&body))
+	assert.Equal("This message was deleted.", body)
+	var linked int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages
+		WHERE source_message_id = ? AND reply_to_message_id IS NOT NULL`), "C80:"+replyTS).Scan(&linked))
+	assert.Equal(1, linked, "the orphaned reply must link to the tombstone placeholder")
+
+	// Re-reads of the placeholder skip like any other archived tombstone.
+	imp.now = func() time.Time { return time.Now().Add(1 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C80:"+rootTS).Scan(&n))
+	assert.Equal(1, n)
+}
+
+func TestLateIndexedReplyMovesParkedDrainBackward(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Two replies land; R1 is indexed LATE (out of order), so the first
+	// sweep sees only R2 and seeds the drain entry just below it. The
+	// fetch failure parks that entry — and a parked entry must not anchor
+	// the thread's coverage above a hit discovered later.
+	r1, r2 := tsFresh(0), tsFresh(5)
+	f.mu.Lock()
+	root := f.conv("C09").findRoot(rootTS)
+	root.Replies = append(root.Replies,
+		fakeMsg{TS: r1, ThreadTS: rootTS, User: "UME", Text: "late-indexed reply"},
+		fakeMsg{TS: r2, ThreadTS: rootTS, User: "UME", Text: "promptly-indexed reply"})
+	f.searchHidden[r1] = true
+	f.failReplies[rootTS] = true
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "the parked drain is a fetch failure; the run must not report success")
+
+	// R1 surfaces in the next sweep's overlap pass while the entry is
+	// still parked: its resume point must move BACKWARD below R1.
+	f.mu.Lock()
+	delete(f.searchHidden, r1)
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(20 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err)
+
+	// By now the certified boundary is far above R1 — no future sweep will
+	// re-serve it. Only the merged-back entry can recover it.
+	f.mu.Lock()
+	delete(f.failReplies, rootTS)
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(40 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+r1).Scan(&n))
+	assert.Equal(1, n, "late-indexed reply below the parked entry's resume point must still be fetched")
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+r2).Scan(&n))
+	assert.Equal(1, n)
+}
+
+func TestCatchUpFullDrainOverridesParkedTailSeed(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	rootTS := ts(0)
+	f.convs = []*fakeConv{{
+		ID: "C90", Name: "debtor", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{
+			{TS: rootTS, User: "UME", Text: "unthreaded-era root",
+				Replies: []fakeMsg{
+					{TS: ts(100), ThreadTS: rootTS, User: "UME", Text: "old reply one"},
+					{TS: ts(101), ThreadTS: rootTS, User: "UME", Text: "old reply two"},
+				}},
+			{TS: ts(1), User: "UME", Text: "filler one"},
+			{TS: ts(2), User: "UME", Text: "filler two"},
+		},
+	}}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+	f.failReplies[rootTS] = true
+
+	// A --no-threads era leaves the root's old replies as catch-up debt.
+	noThreads := opts
+	noThreads.NoThreads = true
+	_, err := imp.Import(context.Background(), noThreads)
+	require.NoError(err)
+
+	// A NEW reply lands; saturated threaded runs let the sweep record a
+	// TAIL entry (seeded just below the new reply) that the failing drain
+	// parks. The catch-up walk then re-encounters the root: its full-drain
+	// claim must override the parked mid-thread seed, or the old replies
+	// are skipped forever while the flag clears as paid.
+	r3 := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C90").findRoot(rootTS)
+	root.Replies = append(root.Replies, fakeMsg{TS: r3, ThreadTS: rootTS, User: "UME", Text: "fresh reply"})
+	f.mu.Unlock()
+
+	limited := opts
+	limited.Limit = 1
+	for i := range 4 {
+		imp.now = func() time.Time { return time.Now().Add(time.Duration(5+i) * time.Minute) }
+		// Partial failures are expected while the drain fetch fails; every
+		// run still persists its state (FailSyncWithCheckpoint).
+		_, _ = imp.Import(context.Background(), limited)
+	}
+
+	f.mu.Lock()
+	delete(f.failReplies, rootTS)
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(10 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var n int
+	for _, tsWant := range []string{ts(100), ts(101), r3} {
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C90:"+tsWant).Scan(&n))
+		assert.Equal(1, n, "reply %s must be archived after catch-up", tsWant)
+	}
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	cs := imp.loadResumeState(src.ID).EnsureConv("C90")
+	assert.False(cs.ThreadsPending, "catch-up debt is paid")
+	assert.Empty(cs.PendingThreads, "drain debt is paid")
+}
+
+func TestSweepSmallPagesBeyondWalkBoundRecordedAsDebt(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The server serves ONE hit per page, so a 102-hit day claims 102
+	// pages while its total sits far below the 10k ceiling — the pager's
+	// 100-page walk cannot consume it. The unserved tail (the day's
+	// NEWEST hits, ascending order) lands on a second thread that gets no
+	// drain entry from the served hits, so only recorded catch-up debt
+	// can ever recover it.
+	f.mu.Lock()
+	f.searchPageSize = 1
+	bigRoot := f.conv("C09").findRoot(rootTS)
+	for i := range 101 {
+		bigRoot.Replies = append(bigRoot.Replies,
+			fakeMsg{TS: tsFresh(i), ThreadTS: rootTS, User: "UME", Text: "burst " + strconv.Itoa(i)})
+	}
+	beyondWalk := tsFresh(110)
+	other := f.conv("C09").findRoot(ts(0))
+	other.Replies = append(other.Replies, fakeMsg{TS: beyondWalk, ThreadTS: ts(0), User: "UME", Text: "past the page walk"})
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.Error(err, "a day the pager cannot fully consume must fail loudly, not certify past unserved hits")
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	require.True(imp.loadResumeState(src.ID).EnsureConv("C09").ThreadsPending,
+		"the unserved tail must be recorded as thread catch-up debt")
+
+	// The catch-up walk recovers the reply the pager could never serve;
+	// once the day is behind the boundary the sweep runs clean again.
+	imp.now = func() time.Time { return time.Now().Add(25 * time.Hour) }
+	_, _ = imp.Import(context.Background(), opts)
+	imp.now = func() time.Time { return time.Now().Add(26 * time.Hour) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+beyondWalk).Scan(&n))
+	assert.Equal(1, n, "the reply beyond the 100-page walk must be recovered via catch-up")
+	var total, distinct int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type='slack'`).Scan(&total))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(DISTINCT source_message_id) FROM messages WHERE message_type='slack'`).Scan(&distinct))
+	assert.Equal(distinct, total)
+}
+
+func TestBackfillMediaDownloadsDespiteNoMediaConfig(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_CFGOFF", "name": "c.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_CFGOFF/c.png",
+			"permalink":   "https://testers.slack.com/files/F_CFGOFF"},
+	}
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	client.mediaTransport = &recordingTransport{body: "png03"}
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	// [slack].media = false shapes the options with NoMedia set — for the
+	// sync AND, via the shared options builder, for backfill-slack-media.
+	// The sync defers the file as a pending marker; the explicit backfill
+	// must download it anyway: it IS the payment for that deferral, and
+	// honoring the flag would no-op the exact workflow the config
+	// documents (defer now, backfill later).
+	opts := ImportOptions{TeamID: "T01", UserID: "UME", NoMedia: true, AttachmentsDir: t.TempDir()}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	bsum, err := imp.BackfillMedia(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(1, bsum.AttachmentsDownloaded, "backfill-slack-media must download even when [slack].media=false shaped its options")
+	assert.Zero(bsum.AttachmentsPending)
+	var hash string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(a.content_hash,'') FROM attachments a
+		WHERE a.source_attachment_id = ?`), "slack:F_CFGOFF").Scan(&hash))
+	assert.NotEmpty(hash)
+}
+
+func TestSweepPagesServeOneSnapshotDespiteMidWalkDeletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, rootTS := oldThreadWorkspace(t)
+	f.convs[0].Msgs = append(f.convs[0].Msgs, fakeMsg{TS: ts(1), User: "UME", Text: "third thread seed"})
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Three fresh replies on three separate threads, one search page each.
+	// Between page 1 and page 2 the page-1 reply is DELETED at the source:
+	// a fresh index query per page would shift the ascending offsets down
+	// and silently skip the middle reply while the walk still exhausts the
+	// claimed pages — only a stable query string (one nonce per attempt,
+	// probed: responses are cached by query string) keeps the walk on the
+	// snapshot page 1 was served from.
+	rA, rB, rC := tsFresh(0), tsFresh(5), tsFresh(10)
+	f.mu.Lock()
+	f.searchPageSize = 1
+	f.conv("C09").findRoot(rootTS).Replies = append(f.conv("C09").findRoot(rootTS).Replies,
+		fakeMsg{TS: rA, ThreadTS: rootTS, User: "UME", Text: "first hit"})
+	f.conv("C09").findRoot(ts(0)).Replies = append(f.conv("C09").findRoot(ts(0)).Replies,
+		fakeMsg{TS: rB, ThreadTS: ts(0), User: "UME", Text: "middle hit"})
+	f.conv("C09").findRoot(ts(1)).Replies = append(f.conv("C09").findRoot(ts(1)).Replies,
+		fakeMsg{TS: rC, ThreadTS: ts(1), User: "UME", Text: "last hit"})
+	f.onSearch = func(query string, page int) {
+		if page == 2 {
+			if root := f.conv("C09").findRoot(rootTS); len(root.Replies) > 1 {
+				root.Replies = root.Replies[:1] // delete rA mid-walk (keep the ancient reply)
+			}
+		}
+	}
+	f.mu.Unlock()
+
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var n int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+rB).Scan(&n))
+	assert.Equal(1, n, "a mid-walk deletion must not shift the middle hit out of the page walk")
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C09:"+rC).Scan(&n))
+	assert.Equal(1, n)
+}
+
+func TestMaintenanceRepairsRecentReplyUnderAncientRoot(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeSlack(t)
+	f.users = []map[string]any{
+		{"id": "UME", "name": "me", "profile": map[string]any{"email": "me@example.com"}},
+	}
+	// The root predates the maintenance rescan window by a wide margin:
+	// selecting threads through the history window alone can never reach
+	// it, even though its reply — and the reply's later edit — are recent.
+	ancientRoot := ts(-57600) // ~40 days before tsBase
+	f.convs = []*fakeConv{{
+		ID: "C95", Name: "annals", Kind: "public", Members: []string{"UME"},
+		Msgs: []fakeMsg{
+			{TS: ancientRoot, User: "UME", Text: "forty-day-old root"},
+			{TS: ts(0), User: "UME", Text: "recent chatter"},
+		},
+	}}
+	imp, opts := testImporter(t, f)
+	st := imp.store
+
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// A fresh reply lands on the ancient thread and is archived by the
+	// sweep; runs advance the watermark past it so no overlap re-fetch
+	// can mask the repair path.
+	reply := tsFresh(0)
+	f.mu.Lock()
+	root := f.conv("C95").findRoot(ancientRoot)
+	root.Replies = append(root.Replies, fakeMsg{TS: reply, ThreadTS: ancientRoot, User: "UME", Text: "recent reply"})
+	f.mu.Unlock()
+	imp.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	imp.now = func() time.Time { return time.Now().Add(20 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The reply is edited at the source. Plain runs ignore post-capture
+	// mutations (the reply sits below every sweep floor now).
+	f.mu.Lock()
+	f.conv("C95").findRoot(ancientRoot).Replies[0].Text = "recent reply (stealth edit)"
+	f.mu.Unlock()
+	replyID := "C95:" + reply
+	readBody := func() string {
+		var body string
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT mb.body_text FROM message_bodies mb
+			JOIN messages m ON m.id = mb.message_id WHERE m.source_message_id = ?`), replyID).Scan(&body))
+		return body
+	}
+	imp.now = func() time.Time { return time.Now().Add(31 * time.Minute) }
+	_, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal("recent reply", readBody(), "plain runs ignore post-capture reply edits")
+
+	// --maintenance repairs it: the reply is a RECENT message, and the
+	// contract keys on message age — the root's age must not matter.
+	maint := opts
+	maint.Maintenance = true
+	imp.now = func() time.Time { return time.Now().Add(32 * time.Minute) }
+	_, err = imp.Import(context.Background(), maint)
+	require.NoError(err)
+	assert.Equal("recent reply (stealth edit)", readBody(),
+		"--maintenance must repair a recent reply even when its thread root predates the rescan window")
+}

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -813,44 +813,50 @@ func TestFullImportRepairsMalformedNewestResumeState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
 			f := testWorkspace(t)
 			imp, opts := testImporter(t, f)
 			st := imp.store
 
 			src, err := st.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
-			require.NoError(t, err)
+			require.NoError(err)
 			runID, err := st.StartSync(src.ID, "slack")
-			require.NoError(t, err)
-			require.NoError(t, st.UpdateSyncCheckpoint(runID, &store.Checkpoint{PageToken: tt.blob}))
-			require.NoError(t, st.FailSync(runID, "interrupted"))
+			require.NoError(err)
+			require.NoError(st.UpdateSyncCheckpoint(runID, &store.Checkpoint{PageToken: tt.blob}))
+			require.NoError(st.FailSync(runID, "interrupted"))
 
 			opts.Full = true
 			_, err = imp.Import(context.Background(), opts)
-			require.NoError(t, err, "--full must replace malformed durable state with a fresh repair session")
+			require.NoError(err, "--full must replace malformed durable state with a fresh repair session")
 
 			var messages int
-			require.NoError(t, st.DB().QueryRow(st.Rebind(
+			require.NoError(st.DB().QueryRow(st.Rebind(
 				`SELECT COUNT(*) FROM messages WHERE source_id = ?`), src.ID).Scan(&messages))
-			assert.Positive(t, messages, "the repair must traverse and archive the workspace")
+			assert.Positive(messages, "the repair must traverse and archive the workspace")
 		})
 	}
 }
 
 func TestLoadResumeStateSurfacesDatabaseReadFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	f := testWorkspace(t)
 	imp, opts := testImporter(t, f)
 	st := imp.store
 
 	src, err := st.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
-	require.NoError(t, err)
-	require.NoError(t, st.DB().Close())
+	require.NoError(err)
+	require.NoError(st.DB().Close())
 
 	_, err = imp.loadResumeState(src.ID)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "read latest Slack checkpoint")
+	require.Error(err)
+	assert.ErrorContains(err, "read latest Slack checkpoint")
 }
 
 func TestImportRestartsExpiredPersistedWindowCursorAtPinnedBound(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	f := newFakeSlack(t)
 	f.users = []map[string]any{{
 		"id": "UME", "name": "me", "real_name": "Test User",
@@ -875,30 +881,32 @@ func TestImportRestartsExpiredPersistedWindowCursorAtPinnedBound(t *testing.T) {
 	cs.BackfillCursor = "expired-window"
 	cs.BackfillLatest = pin
 	src, err := imp.store.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
-	require.NoError(t, err)
+	require.NoError(err)
 	runID, err := imp.store.StartSync(src.ID, "slack")
-	require.NoError(t, err)
-	require.NoError(t, imp.store.CompleteSync(runID, mustMarshal(t, state)))
+	require.NoError(err)
+	require.NoError(imp.store.CompleteSync(runID, mustMarshal(t, state)))
 
 	sum, err := imp.Import(context.Background(), opts)
-	require.NoError(t, err)
-	assert.Zero(t, sum.FetchErrors)
+	require.NoError(err)
+	assert.Zero(sum.FetchErrors)
 
 	got := requireResumeState(t, imp, src.ID).EnsureConv("C01")
-	assert.Equal(t, pin, got.Cursor, "restarted pagination must retain the original window pin")
-	assert.Empty(t, got.BackfillCursor)
-	assert.Empty(t, got.BackfillLatest)
+	assert.Equal(pin, got.Cursor, "restarted pagination must retain the original window pin")
+	assert.Empty(got.BackfillCursor)
+	assert.Empty(got.BackfillLatest)
 
 	var inside, above int
-	require.NoError(t, imp.store.DB().QueryRow(imp.store.Rebind(
+	require.NoError(imp.store.DB().QueryRow(imp.store.Rebind(
 		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(0)).Scan(&inside))
-	require.NoError(t, imp.store.DB().QueryRow(imp.store.Rebind(
+	require.NoError(imp.store.DB().QueryRow(imp.store.Rebind(
 		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+ts(2)).Scan(&above))
-	assert.Equal(t, 1, inside)
-	assert.Zero(t, above, "restarting an expired page cursor must not widen the pinned window")
+	assert.Equal(1, inside)
+	assert.Zero(above, "restarting an expired page cursor must not widen the pinned window")
 }
 
 func TestImportRestartsExpiredPersistedCatchUpCursorAtPinnedBound(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	f := newFakeSlack(t)
 	f.users = []map[string]any{{
 		"id": "UME", "name": "me", "real_name": "Test User",
@@ -926,25 +934,25 @@ func TestImportRestartsExpiredPersistedCatchUpCursorAtPinnedBound(t *testing.T) 
 	cs.CatchUpLatest = pin
 	cs.SweptThrough = tsFormat(imp.now())
 	src, err := imp.store.GetOrCreateSource("slack", opts.TeamID+":"+opts.UserID)
-	require.NoError(t, err)
+	require.NoError(err)
 	runID, err := imp.store.StartSync(src.ID, "slack")
-	require.NoError(t, err)
-	require.NoError(t, imp.store.CompleteSync(runID, mustMarshal(t, state)))
+	require.NoError(err)
+	require.NoError(imp.store.CompleteSync(runID, mustMarshal(t, state)))
 
 	sum, err := imp.Import(context.Background(), opts)
-	require.NoError(t, err)
-	assert.Zero(t, sum.FetchErrors)
+	require.NoError(err)
+	assert.Zero(sum.FetchErrors)
 
 	got := requireResumeState(t, imp, src.ID).EnsureConv("C01")
-	assert.Equal(t, pin, got.AuditedThrough, "restarted pagination must retain the original catch-up pin")
-	assert.False(t, got.ThreadsPending)
-	assert.Empty(t, got.CatchUpCursor)
-	assert.Empty(t, got.CatchUpLatest)
+	assert.Equal(pin, got.AuditedThrough, "restarted pagination must retain the original catch-up pin")
+	assert.False(got.ThreadsPending)
+	assert.Empty(got.CatchUpCursor)
+	assert.Empty(got.CatchUpLatest)
 
 	var replies int
-	require.NoError(t, imp.store.DB().QueryRow(imp.store.Rebind(
+	require.NoError(imp.store.DB().QueryRow(imp.store.Rebind(
 		`SELECT COUNT(*) FROM messages WHERE source_message_id = ?`), "C01:"+replyTS).Scan(&replies))
-	assert.Equal(t, 1, replies)
+	assert.Equal(1, replies)
 }
 
 func TestImportSurfacesInvalidCursorWithoutPersistedPageCursor(t *testing.T) {
@@ -962,7 +970,7 @@ func TestImportSurfacesInvalidCursorWithoutPersistedPageCursor(t *testing.T) {
 
 	sum, err := imp.Import(context.Background(), opts)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "partial Slack sync")
+	require.ErrorContains(t, err, "partial Slack sync")
 	assert.Positive(t, sum.FetchErrors, "cursorless invalid_cursor must remain a visible fetch failure")
 }
 
@@ -1670,6 +1678,7 @@ func TestMembershipFetchFailureMarksRunPartial(t *testing.T) {
 
 func TestMPIMMembershipFailureHoldsHistoryUntilRecipientsAvailable(t *testing.T) {
 	require := require.New(t)
+	assert := assert.New(t)
 	f := testWorkspace(t)
 	f.failMembers["G01"] = true
 	imp, opts := testImporter(t, f)
@@ -1684,11 +1693,11 @@ func TestMPIMMembershipFailureHoldsHistoryUntilRecipientsAvailable(t *testing.T)
 		SELECT COUNT(*) FROM messages m
 		JOIN conversations c ON c.id = m.conversation_id
 		WHERE c.source_conversation_id = ?`), "G01").Scan(&messages))
-	assert.Zero(t, messages, "MPIM history must not advance without the recipient snapshot")
+	assert.Zero(messages, "MPIM history must not advance without the recipient snapshot")
 
 	state := requireResumeState(t, imp, sum.SourceID).EnsureConv("G01")
-	assert.False(t, state.Done)
-	assert.Empty(t, state.Cursor)
+	assert.False(state.Done)
+	assert.Empty(state.Cursor)
 
 	f.failMembers["G01"] = false
 	_, err = imp.Import(context.Background(), opts)
@@ -1700,7 +1709,7 @@ func TestMPIMMembershipFailureHoldsHistoryUntilRecipientsAvailable(t *testing.T)
 		JOIN messages m ON m.id = mr.message_id
 		WHERE m.source_message_id = ? AND mr.recipient_type = 'to'`),
 		"G01:"+ts(10)).Scan(&recipients))
-	assert.Equal(t, 2, recipients, "the retry archives MPIM history with complete recipients")
+	assert.Equal(2, recipients, "the retry archives MPIM history with complete recipients")
 }
 
 func TestLimitedSweepDrainsBigTailAcrossRuns(t *testing.T) {
@@ -2911,8 +2920,8 @@ func TestTombstonePlaceholderRetriesIncompletePersistence(t *testing.T) {
 	require.NoError(err)
 	assert.Contains(string(raw), `"subtype":"tombstone"`)
 	var deletedAt sql.NullTime
-	require.NoError(st.DB().QueryRow(
-		`SELECT deleted_from_source_at FROM messages WHERE id = ?`, messageID).Scan(&deletedAt))
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT deleted_from_source_at FROM messages WHERE id = ?`), messageID).Scan(&deletedAt))
 	assert.True(deletedAt.Valid)
 }
 

--- a/internal/slack/live_429_test.go
+++ b/internal/slack/live_429_test.go
@@ -1,0 +1,86 @@
+package slack
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingTransport records the status codes flowing through the client so
+// the test can prove a real 429 occurred and was absorbed.
+type countingTransport struct {
+	requests   int
+	got429     int
+	retryAfter string
+}
+
+func (ct *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ct.requests++
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err == nil && resp.StatusCode == http.StatusTooManyRequests {
+		ct.got429++
+		ct.retryAfter = resp.Header.Get("Retry-After")
+	}
+	return resp, err
+}
+
+// TestLive429RetryAfter validates the client's throttle handling against the
+// REAL Slack API. It is skipped unless both env vars are set:
+//
+//	MSGVAULT_SLACK_LIVE_TOKEN   user token for a DEV workspace you own
+//	MSGVAULT_SLACK_LIVE_CHANNEL a channel ID with some history
+//
+// With the client's own pacing disabled it requests tiny history pages until
+// Slack throttles (Tier 3 ≈ 50/min), then asserts the throttled call still
+// returned successfully via Retry-After retry. Bounded to maxProbeRequests /
+// probeDeadline; stops at the first observed 429. Run this only against a
+// development workspace.
+func TestLive429RetryAfter(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	token := os.Getenv("MSGVAULT_SLACK_LIVE_TOKEN")
+	channel := os.Getenv("MSGVAULT_SLACK_LIVE_CHANNEL")
+	if token == "" || channel == "" {
+		t.Skip("set MSGVAULT_SLACK_LIVE_TOKEN and MSGVAULT_SLACK_LIVE_CHANNEL to run the live throttle probe")
+	}
+
+	const maxProbeRequests = 500
+	const probeDeadline = 4 * time.Minute
+
+	ct := &countingTransport{}
+	c := NewClient("", token)
+	c.disableRateLimits()
+	c.http.Transport = ct
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeDeadline)
+	defer cancel()
+
+	calls := 0
+	for ct.got429 == 0 && ct.requests < maxProbeRequests {
+		// limit=1 keeps responses tiny; every request still counts against
+		// the per-minute budget.
+		params := HistoryParams{ChannelID: channel}
+		page, err := c.historyPageWithLimit(ctx, params, 1)
+		if ctx.Err() != nil {
+			// Ran out of probe time before Slack throttled (observed live:
+			// enforcement lags the published budget until earlier traffic has
+			// accumulated). Inconclusive, not a failure.
+			t.Skipf("no 429 within %v / %d requests — inconclusive", probeDeadline, ct.requests)
+		}
+		require.NoError(err, "call %d must succeed even when throttled mid-way", calls)
+		require.NotNil(page)
+		calls++
+	}
+
+	if ct.got429 == 0 {
+		t.Skipf("no 429 within %d requests — workspace budget higher than expected; inconclusive, not a failure", ct.requests)
+	}
+	t.Logf("throttled after %d requests; Retry-After=%q; %d successful calls returned", ct.requests, ct.retryAfter, calls)
+	assert.Positive(calls, "the throttled call must have completed via retry")
+	assert.NotEmpty(ct.retryAfter, "Slack 429s must carry Retry-After for the backoff to honor")
+}

--- a/internal/slack/mapping.go
+++ b/internal/slack/mapping.go
@@ -1,0 +1,212 @@
+package slack
+
+import (
+	"database/sql"
+	"regexp"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// messageType is the msgvault message_type for all Slack-archived messages.
+const messageType = "slack"
+
+// sourceMessageID composes the archive identity of a Slack message. A ts is
+// only unique within its channel, hence the composite key.
+func sourceMessageID(channelID, ts string) string {
+	return channelID + ":" + ts
+}
+
+// mentionRe matches user mentions in raw Slack message text: <@U123>,
+// <@W123> (Enterprise Grid), optionally with a |label suffix.
+var mentionRe = regexp.MustCompile(`<@([UW][A-Z0-9]+)(?:\|[^>]*)?>`)
+
+// tokenRe matches every <…> mrkdwn token for text rendering.
+var tokenRe = regexp.MustCompile(`<([^<>]+)>`)
+
+// MentionedUserIDs returns the user IDs mentioned in the message text
+// (deduped, in first-appearance order).
+func (m *Message) MentionedUserIDs() []string {
+	var ids []string
+	seen := map[string]bool{}
+	for _, match := range mentionRe.FindAllStringSubmatch(m.Text, -1) {
+		if id := match[1]; !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// renderText converts raw Slack mrkdwn to plain text for FTS and display:
+// mention/channel/link tokens are resolved to readable forms and HTML
+// entities unescaped. lookupName resolves a user ID to a display name (may
+// return "").
+func renderText(raw string, lookupName func(userID string) string) string {
+	text := tokenRe.ReplaceAllStringFunc(raw, func(tok string) string {
+		inner := tok[1 : len(tok)-1]
+		body, label, hasLabel := strings.Cut(inner, "|")
+		switch {
+		case strings.HasPrefix(body, "@"):
+			if hasLabel && label != "" {
+				return "@" + label
+			}
+			if name := lookupName(strings.TrimPrefix(body, "@")); name != "" {
+				return "@" + name
+			}
+			return "@" + strings.TrimPrefix(body, "@")
+		case strings.HasPrefix(body, "#"):
+			if hasLabel && label != "" {
+				return "#" + label
+			}
+			return body
+		case strings.HasPrefix(body, "!"):
+			// Special mentions: <!here>, <!channel>, <!everyone>, <!date^…|fallback>.
+			if hasLabel && label != "" {
+				return label
+			}
+			return "@" + strings.TrimPrefix(body, "!")
+		default:
+			// Link: <url> or <url|label>.
+			if hasLabel && label != "" {
+				return label + " (" + body + ")"
+			}
+			return body
+		}
+	})
+	text = strings.ReplaceAll(text, "&lt;", "<")
+	text = strings.ReplaceAll(text, "&gt;", ">")
+	text = strings.ReplaceAll(text, "&amp;", "&")
+	return text
+}
+
+// placeholderBody synthesizes a searchable body for text-less messages.
+func placeholderBody(m *Message) string {
+	if len(m.Files) > 0 {
+		if m.Files[0].Name != "" {
+			return "[file: " + m.Files[0].Name + "]"
+		}
+		return "[file]"
+	}
+	return ""
+}
+
+// payloadText extracts searchable text from legacy attachments and Block Kit
+// blocks — where bots and integrations often carry their entire content
+// while the message text stays empty. Per attachment, the mandatory fallback
+// summary wins; otherwise the individual parts are composed. rich_text
+// blocks are skipped (they duplicate the message text field).
+func payloadText(m *Message, lookupName func(string) string) string {
+	var parts []string
+	add := func(s string) {
+		if s = strings.TrimSpace(renderText(s, lookupName)); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	for i := range m.Attachments {
+		a := &m.Attachments[i]
+		if a.Fallback != "" {
+			add(a.Fallback)
+			continue
+		}
+		add(a.Pretext)
+		add(a.Title)
+		add(a.Text)
+		for _, f := range a.Fields {
+			add(strings.TrimSpace(f.Title + ": " + f.Value))
+		}
+		add(a.Footer)
+	}
+	for i := range m.Blocks {
+		b := &m.Blocks[i]
+		switch b.Type {
+		case "section", "header":
+			if b.Text != nil {
+				add(b.Text.Text)
+			}
+			for _, f := range b.Fields {
+				add(f.Text)
+			}
+		case "context":
+			for _, e := range b.Elements {
+				add(e.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func snippet(text string) string {
+	r := []rune(text)
+	if len(r) > 100 {
+		return string(r[:100])
+	}
+	return text
+}
+
+// mapMessage converts a Slack Message into a store.Message plus its rendered
+// plain-text body. isFromMe is decided by the caller (archiving user's ID).
+//
+// Legacy-attachment/block text is appended for bot-authored messages and
+// used as the body for text-less ones. User messages WITH text keep only
+// that text: their attachments are link unfurls, and indexing page previews
+// would pollute FTS with content the person never wrote.
+func mapMessage(m *Message, channelID string, conversationID, storeSourceID int64, isFromMe bool, lookupName func(string) string) (store.Message, string) {
+	text := strings.TrimSpace(renderText(m.Text, lookupName))
+	if m.BotID != "" || text == "" {
+		if extra := payloadText(m, lookupName); extra != "" {
+			if text == "" {
+				text = extra
+			} else {
+				text += "\n" + extra
+			}
+		}
+	}
+	if text == "" {
+		text = placeholderBody(m)
+	}
+	t := tsTime(m.TS)
+	msg := store.Message{
+		ConversationID:  conversationID,
+		SourceID:        storeSourceID,
+		SourceMessageID: sourceMessageID(channelID, m.TS),
+		MessageType:     messageType,
+		SentAt:          sql.NullTime{Time: t, Valid: !t.IsZero()},
+		ReceivedAt:      sql.NullTime{Time: t, Valid: !t.IsZero()},
+		IsFromMe:        isFromMe,
+		Snippet:         sql.NullString{String: snippet(text), Valid: text != ""},
+		HasAttachments:  len(m.Files) > 0,
+		AttachmentCount: len(m.Files),
+	}
+	return msg, text
+}
+
+// conversationType maps a Slack conversation to the msgvault conversation
+// type: channels (public/private) → "channel", group DMs → "group_chat",
+// DMs → "direct_chat".
+func conversationType(c *Conversation) string {
+	switch {
+	case c.IsIM:
+		return "direct_chat"
+	case c.IsMpim:
+		return "group_chat"
+	default:
+		return "channel"
+	}
+}
+
+// conversationTitle renders a display title: "#name" for channels, the peer's
+// name for DMs, the member-list name Slack assigns for group DMs.
+func conversationTitle(c *Conversation, lookupName func(string) string) string {
+	switch {
+	case c.IsIM:
+		if name := lookupName(c.User); name != "" {
+			return name
+		}
+		return c.User
+	case c.IsMpim:
+		return c.Name
+	default:
+		return "#" + c.Name
+	}
+}

--- a/internal/slack/mapping_test.go
+++ b/internal/slack/mapping_test.go
@@ -1,0 +1,173 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderText(t *testing.T) {
+	names := map[string]string{"UALICE": "Alice"}
+	lookup := func(id string) string { return names[id] }
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain", "hello world", "hello world"},
+		{"mention known", "hi <@UALICE>", "hi @Alice"},
+		{"mention unknown", "hi <@UGONE>", "hi @UGONE"},
+		{"mention labeled", "hi <@UGONE|ghost>", "hi @ghost"},
+		{"channel", "see <#C042|general>", "see #general"},
+		{"special", "<!here> heads up", "@here heads up"},
+		{"link labeled", "read <https://example.com|the docs>", "read the docs (https://example.com)"},
+		{"link bare", "read <https://example.com>", "read https://example.com"},
+		{"entities", "a &lt;b&gt; &amp; c", "a <b> & c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, renderText(tt.in, lookup))
+		})
+	}
+}
+
+func TestMentionedUserIDs(t *testing.T) {
+	m := Message{Text: "<@UALICE> meet <@WBOB|bob>, again <@UALICE>; not <#C1|chan> or <!here>"}
+	assert.Equal(t, []string{"UALICE", "WBOB"}, m.MentionedUserIDs())
+}
+
+func TestTsTimeAndOrdering(t *testing.T) {
+	assert := assert.New(t)
+	tm := tsTime("1734567890.123456")
+	assert.Equal(time.Date(2024, 12, 19, 0, 24, 50, 123456000, time.UTC), tm)
+	assert.True(tsTime("").IsZero())
+	assert.True(tsTime("garbage").IsZero())
+
+	// Numeric, not lexical: a 9-digit second count sorts before a 10-digit one.
+	assert.True(tsLess("999999999.000001", "1734567890.000001"))
+	assert.False(tsLess("1734567890.000002", "1734567890.000001"))
+}
+
+func TestMessageRawCapturedOnDecode(t *testing.T) {
+	blob := `{"type":"message","ts":"1.000001","text":"hi","unmodeled_field":{"kept":true}}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(blob), &m))
+	assert.JSONEq(t, blob, string(m.Raw), "raw archive must preserve fields the struct does not model")
+}
+
+func TestThreadPredicates(t *testing.T) {
+	assert := assert.New(t)
+	root := Message{TS: "5.0", ThreadTS: "5.0", ReplyCount: 2}
+	reply := Message{TS: "6.0", ThreadTS: "5.0"}
+	plain := Message{TS: "7.0"}
+	assert.True(root.IsThreadRoot())
+	assert.False(root.IsThreadReply())
+	assert.True(reply.IsThreadReply())
+	assert.False(reply.IsThreadRoot())
+	assert.False(plain.IsThreadRoot())
+	assert.False(plain.IsThreadReply())
+}
+
+func TestPayloadTextExtraction(t *testing.T) {
+	lookup := func(string) string { return "" }
+
+	t.Run("fallback wins per attachment", func(t *testing.T) {
+		m := Message{Attachments: []LegacyAttachment{
+			{Fallback: "Build #42 failed", Title: "ignored", Text: "ignored too"},
+		}}
+		assert.Equal(t, "Build #42 failed", payloadText(&m, lookup))
+	})
+
+	t.Run("composed parts when no fallback", func(t *testing.T) {
+		m := Message{Attachments: []LegacyAttachment{{
+			Pretext: "Deploy finished",
+			Title:   "api-server v1.2.3",
+			Text:    "all checks green",
+			Fields: []struct {
+				Title string `json:"title"`
+				Value string `json:"value"`
+			}{{Title: "Env", Value: "prod"}},
+			Footer: "deploybot",
+		}}}
+		assert.Equal(t, "Deploy finished\napi-server v1.2.3\nall checks green\nEnv: prod\ndeploybot",
+			payloadText(&m, lookup))
+	})
+
+	t.Run("shape-shifting block elements decode (live regression)", func(t *testing.T) {
+		// Observed live: actions-block buttons carry text as an OBJECT while
+		// context elements carry it as a string; both must decode, and image
+		// elements (no text) must not error.
+		blob := `{"type":"message","ts":"1.000001","bot_id":"B1","blocks":[
+			{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"Approve"}}]},
+			{"type":"context","elements":[{"type":"mrkdwn","text":"requested by alice"},{"type":"image","image_url":"https://x.example/i.png","alt_text":"pic"}]}
+		]}`
+		var m Message
+		require.NoError(t, json.Unmarshal([]byte(blob), &m))
+		assert.Equal(t, "requested by alice", payloadText(&m, lookup),
+			"context text extracted; button labels and images are not content")
+	})
+
+	t.Run("block kit section header context", func(t *testing.T) {
+		m := Message{Blocks: []Block{
+			{Type: "header", Text: &BlockText{Type: "plain_text", Text: "Alert!"}},
+			{Type: "section", Text: &BlockText{Type: "mrkdwn", Text: "disk *full* on <https://host.example|host>"},
+				Fields: []BlockText{{Type: "mrkdwn", Text: "Sev: 1"}}},
+			{Type: "context", Elements: []BlockElement{{Type: "mrkdwn", Text: "triggered 5m ago"}}},
+			{Type: "rich_text"}, // duplicates message text: never extracted
+			{Type: "divider"},
+		}}
+		assert.Equal(t, "Alert!\ndisk *full* on host (https://host.example)\nSev: 1\ntriggered 5m ago",
+			payloadText(&m, lookup))
+	})
+}
+
+func TestMapMessagePayloadRules(t *testing.T) {
+	lookup := func(string) string { return "" }
+	unfurl := []LegacyAttachment{{Fallback: "Some Page Title — example.com"}}
+
+	t.Run("bot message with empty text gets payload body", func(t *testing.T) {
+		m := Message{TS: "1.000001", BotID: "B1", Attachments: unfurl}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "Some Page Title — example.com", text)
+	})
+
+	t.Run("bot message with text appends payload", func(t *testing.T) {
+		m := Message{TS: "1.000001", BotID: "B1", Text: "heads up", Attachments: unfurl}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "heads up\nSome Page Title — example.com", text)
+	})
+
+	t.Run("user message with text ignores unfurl attachments", func(t *testing.T) {
+		m := Message{TS: "1.000001", User: "U1", Text: "check https://example.com", Attachments: unfurl}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "check https://example.com", text)
+	})
+
+	t.Run("files placeholder still applies when no payload", func(t *testing.T) {
+		m := Message{TS: "1.000001", User: "U1", Files: []File{{Name: "a.png"}}}
+		_, text := mapMessage(&m, "C1", 1, 1, false, lookup)
+		assert.Equal(t, "[file: a.png]", text)
+	})
+}
+
+func TestConversationTypeAndTitle(t *testing.T) {
+	assert := assert.New(t)
+	lookup := func(id string) string {
+		if id == "UALICE" {
+			return "Alice"
+		}
+		return ""
+	}
+	channel := &Conversation{IsChannel: true, Name: "general"}
+	assert.Equal("channel", conversationType(channel))
+	assert.Equal("#general", conversationTitle(channel, lookup))
+
+	im := &Conversation{IsIM: true, User: "UALICE"}
+	assert.Equal("direct_chat", conversationType(im))
+	assert.Equal("Alice", conversationTitle(im, lookup))
+
+	mpim := &Conversation{IsMpim: true, Name: "mpdm-a--b-1"}
+	assert.Equal("group_chat", conversationType(mpim))
+	assert.Equal("mpdm-a--b-1", conversationTitle(mpim, lookup))
+}

--- a/internal/slack/media.go
+++ b/internal/slack/media.go
@@ -1,0 +1,277 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// defaultMaxMediaBytes caps individual file downloads (config max_media_mb
+// overrides).
+const defaultMaxMediaBytes = int64(100 << 20)
+
+// mediaHost is the only host file bytes are ever fetched from with the
+// bearer token. Message JSON is attacker-influenceable (any workspace member
+// authors it), so fetching arbitrary url_private values would hand the token
+// to whatever host the URL names — the Slack analogue of the Graph
+// token-exfiltration finding on the Teams PR. Off-host files are recorded as
+// metadata-only link rows instead.
+const mediaHost = "files.slack.com"
+
+// errOffHost reports a file URL that is not on files.slack.com.
+var errOffHost = errors.New("file URL not on files.slack.com")
+
+// slackAttachmentID namespaces Slack-managed attachment rows in
+// attachments.source_attachment_id.
+func slackAttachmentID(fileID string) string {
+	return "slack:" + fileID
+}
+
+// mediaTypeOf maps a Slack file's mimetype to msgvault's attachments.media_type.
+func mediaTypeOf(f *File) string {
+	switch {
+	case strings.HasPrefix(f.Mimetype, "image/"):
+		return "image"
+	case strings.HasPrefix(f.Mimetype, "video/"):
+		return "video"
+	case strings.HasPrefix(f.Mimetype, "audio/"):
+		return "audio"
+	default:
+		return "document"
+	}
+}
+
+// fetchableURL validates a file's private URL for token-bearing download:
+// https, exactly files.slack.com, no userinfo. Anything else is off-host.
+func fetchableURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse file URL: %w", err)
+	}
+	if u.Scheme != "https" || u.User != nil || !strings.EqualFold(u.Host, mediaHost) {
+		return "", fmt.Errorf("%q: %w", rawURL, errOffHost)
+	}
+	return u.String(), nil
+}
+
+// mediaTimeout bounds one file download. The API client's 60s whole-request
+// timeout starves large files on slow links (~14 Mbps just to move the
+// default 100 MiB cap before the deadline), permanently pending perfectly
+// valid files — every backfill retry hits the same wall. The bound scales
+// with the size cap at a ~128 KiB/s floor rate with a generous minimum, so
+// any download making modest progress completes, while remaining finite:
+// an unattended scheduled sync must never hang forever on a stalled read.
+func mediaTimeout(maxBytes int64) time.Duration {
+	scaled := time.Duration(maxBytes/(128<<10)) * time.Second
+	if scaled < 10*time.Minute {
+		return 10 * time.Minute
+	}
+	return scaled
+}
+
+// DownloadFile fetches a files.slack.com URL with the bearer token, capped at
+// maxBytes. Redirects are refused entirely: a redirect off-host would carry
+// the token, and same-host redirects do not occur in practice.
+func (c *Client) DownloadFile(ctx context.Context, rawURL string, maxBytes int64) ([]byte, error) {
+	fetchURL, err := fetchableURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	client := &http.Client{
+		Timeout: mediaTimeout(maxBytes),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return fmt.Errorf("refusing redirect to %s: %w", req.URL.Host, errOffHost)
+		},
+	}
+	if c.mediaTransport != nil {
+		client.Transport = c.mediaTransport
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("slack file GET: status %d", resp.StatusCode)
+	}
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxMediaBytes
+	}
+	if resp.ContentLength > maxBytes {
+		return nil, fmt.Errorf("slack file GET: %d bytes: %w", resp.ContentLength, ErrAssetTooLarge)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("slack file GET: read body: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, ErrAssetTooLarge
+	}
+	return data, nil
+}
+
+// persistFiles downloads a message's files into content-addressed storage
+// and replaces the message's Slack attachment rows. Already-downloaded media
+// (matched by source_attachment_id) is kept without re-fetching — including
+// files the source has since tombstoned or dropped from the message
+// (archive semantics: source deletions never propagate). External or
+// off-host files become metadata-only link rows (media_type "link", the
+// permalink as storage path); failed or over-cap downloads leave a pending
+// marker row (no content hash) for BackfillMedia to retry.
+//
+// DOWNLOAD failures are non-fatal because they leave that durable marker;
+// STORE failures are fatal and hold the cursor — a row write that fails
+// leaves downloaded bytes orphaned in CAS with no marker, invisible to
+// backfill forever, so the run must stop rather than advance past it.
+func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, m *Message, opts ImportOptions, sum *ImportSummary) error {
+	existing, err := imp.store.MessageSlackAttachments(messageID)
+	if err != nil {
+		return fmt.Errorf("read attachment rows: %w", err)
+	}
+	if len(m.Files) == 0 && len(existing) == 0 {
+		return nil
+	}
+	maxBytes := opts.MaxMediaBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxMediaBytes
+	}
+	refs := make([]store.AttachmentRef, 0, len(m.Files))
+	seen := map[string]bool{}
+	for i := range m.Files {
+		f := &m.Files[i]
+		if f.ID == "" || f.Mode == "tombstone" {
+			continue // preserved below if a downloaded row already exists
+		}
+		sourceAttID := slackAttachmentID(f.ID)
+		seen[sourceAttID] = true
+		if prev, ok := existing[sourceAttID]; ok && prev.ContentHash != "" {
+			refs = append(refs, prev)
+			continue
+		}
+		fetchRef := f.URLPrivate
+		if fetchRef == "" {
+			fetchRef = f.URLPrivateDownload
+		}
+		// The store write silently skips rows with an empty storage path, so
+		// a file Slack serves without a permalink would lose its marker (and
+		// with it any chance of backfill) with no error. Fall back to the
+		// fetch URL, then to a deterministic sentinel: the row must exist.
+		storageRef := f.Permalink
+		if storageRef == "" {
+			storageRef = fetchRef
+		}
+		if storageRef == "" {
+			storageRef = "slack:pending:" + f.ID
+		}
+		linkRow := store.AttachmentRef{
+			Filename:           f.Name,
+			MimeType:           f.Mimetype,
+			StoragePath:        storageRef,
+			Size:               int(f.Size),
+			SourceAttachmentID: sourceAttID,
+			MediaType:          "link",
+		}
+		pendingRow := linkRow
+		pendingRow.MediaType = ""
+
+		// pend leaves a retryable marker; link records metadata permanently.
+		pend := func(status, kind string, err error) {
+			imp.recordItem(syncID, sourceMessageID("", m.TS), "attachment", status, kind, err)
+			refs = append(refs, pendingRow)
+			sum.AttachmentsPending++
+			if status == store.SyncRunItemStatusError {
+				sum.Errors++
+			}
+		}
+		if _, herr := fetchableURL(fetchRef); herr != nil || f.IsExternal {
+			// Off-host / external: never fetched with the token (see mediaHost).
+			refs = append(refs, linkRow)
+			continue
+		}
+		if opts.NoMedia || opts.AttachmentsDir == "" {
+			// Deferred, not declined: a pending marker keeps the file
+			// discoverable by backfill-slack-media once media is enabled.
+			// A link row here would hide it from the pending queries
+			// forever (link rows are reserved for genuinely external
+			// files that must never be fetched with the token).
+			refs = append(refs, pendingRow)
+			sum.AttachmentsPending++
+			continue
+		}
+		if f.Size > 0 && f.Size > maxBytes {
+			pend(store.SyncRunItemStatusSkipped, "slack_media_too_large",
+				fmt.Errorf("file %s is %d bytes (cap %d)", f.ID, f.Size, maxBytes))
+			continue
+		}
+		data, derr := imp.client.DownloadFile(ctx, fetchRef, maxBytes)
+		if errors.Is(derr, ErrAssetTooLarge) {
+			pend(store.SyncRunItemStatusSkipped, "slack_media_too_large", derr)
+			continue
+		}
+		if derr != nil {
+			if ctx.Err() != nil {
+				// Interrupted: keep the pending marker without charging an error.
+				refs = append(refs, pendingRow)
+				sum.AttachmentsPending++
+				continue
+			}
+			pend(store.SyncRunItemStatusError, "slack_media_error", derr)
+			continue
+		}
+		ma := &mime.Attachment{Filename: f.Name, ContentType: f.Mimetype, Content: data}
+		storagePath, serr := export.StoreAttachmentFile(opts.AttachmentsDir, ma)
+		if serr != nil || storagePath == "" {
+			pend(store.SyncRunItemStatusError, "slack_media_error", serr)
+			continue
+		}
+		stored := store.AttachmentRef{
+			Filename:           f.Name,
+			MimeType:           f.Mimetype,
+			StoragePath:        storagePath,
+			ContentHash:        ma.ContentHash,
+			Size:               len(data),
+			SourceAttachmentID: sourceAttID,
+			MediaType:          mediaTypeOf(f),
+		}
+		refs = append(refs, stored)
+		sum.AttachmentsDownloaded++
+	}
+	// Files tombstoned or omitted at the source keep their archived rows —
+	// downloaded media AND metadata-only link rows (all the record we will
+	// ever have for an external file): a Slack-side deletion, or an edit
+	// that drops a file, must never reach into the archive. Only stale
+	// pending markers clear: a gone file can never be fetched, and keeping
+	// its marker would wedge the pending queue forever.
+	var keep []string
+	for id, prev := range existing {
+		if (prev.ContentHash != "" || prev.MediaType == "link") && !seen[id] {
+			keep = append(keep, id)
+		}
+	}
+	sort.Strings(keep)
+	for _, id := range keep {
+		refs = append(refs, existing[id])
+	}
+	if err := imp.store.ReplaceMessageSlackAttachments(messageID, refs); err != nil {
+		return fmt.Errorf("replace attachment rows: %w", err)
+	}
+	if err := imp.store.RecomputeMessageAttachmentStats(messageID); err != nil {
+		return fmt.Errorf("recompute attachment stats: %w", err)
+	}
+	return nil
+}

--- a/internal/slack/media.go
+++ b/internal/slack/media.go
@@ -31,6 +31,16 @@ const mediaHost = "files.slack.com"
 // errOffHost reports a file URL that is not on files.slack.com.
 var errOffHost = errors.New("file URL not on files.slack.com")
 
+// fileHTTPError preserves the response status so callers can distinguish
+// terminal source deletion from a retryable download failure.
+type fileHTTPError struct {
+	statusCode int
+}
+
+func (e *fileHTTPError) Error() string {
+	return fmt.Sprintf("slack file GET: status %d", e.statusCode)
+}
+
 // slackAttachmentID namespaces Slack-managed attachment rows in
 // attachments.source_attachment_id.
 func slackAttachmentID(fileID string) string {
@@ -107,7 +117,7 @@ func (c *Client) DownloadFile(ctx context.Context, rawURL string, maxBytes int64
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("slack file GET: status %d", resp.StatusCode)
+		return nil, &fileHTTPError{statusCode: resp.StatusCode}
 	}
 	if maxBytes <= 0 {
 		maxBytes = defaultMaxMediaBytes
@@ -221,6 +231,17 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 		data, derr := imp.client.DownloadFile(ctx, fetchRef, maxBytes)
 		if errors.Is(derr, ErrAssetTooLarge) {
 			pend(store.SyncRunItemStatusSkipped, "slack_media_too_large", derr)
+			continue
+		}
+		var httpErr *fileHTTPError
+		if errors.As(derr, &httpErr) &&
+			(httpErr.statusCode == http.StatusNotFound || httpErr.statusCode == http.StatusGone) {
+			// Slack can keep file metadata after the backing bytes have been
+			// deleted. Preserve the permalink and file provenance as a
+			// metadata-only link, but terminate retry debt that can never pay.
+			imp.recordItem(syncID, sourceMessageID("", m.TS), "attachment",
+				store.SyncRunItemStatusSkipped, "slack_media_gone", derr)
+			refs = append(refs, linkRow)
 			continue
 		}
 		if derr != nil {

--- a/internal/slack/media.go
+++ b/internal/slack/media.go
@@ -251,21 +251,24 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 		refs = append(refs, stored)
 		sum.AttachmentsDownloaded++
 	}
-	// Files tombstoned or omitted at the source keep their archived rows —
-	// downloaded media AND metadata-only link rows (all the record we will
-	// ever have for an external file): a Slack-side deletion, or an edit
-	// that drops a file, must never reach into the archive. Only stale
-	// pending markers clear: a gone file can never be fetched, and keeping
-	// its marker would wedge the pending queue forever.
+	// Files tombstoned or omitted at the source keep their archived rows.
+	// Downloaded media and existing metadata-only links survive unchanged;
+	// pending markers become terminal metadata-only links. The conversion
+	// preserves the last captured filename, URL, and size without wedging a
+	// retry queue that can no longer fetch the file.
 	var keep []string
-	for id, prev := range existing {
-		if (prev.ContentHash != "" || prev.MediaType == "link") && !seen[id] {
+	for id := range existing {
+		if !seen[id] {
 			keep = append(keep, id)
 		}
 	}
 	sort.Strings(keep)
 	for _, id := range keep {
-		refs = append(refs, existing[id])
+		ref := existing[id]
+		if ref.ContentHash == "" && ref.MediaType != "link" {
+			ref.MediaType = "link"
+		}
+		refs = append(refs, ref)
 	}
 	if err := imp.store.ReplaceMessageSlackAttachments(messageID, refs); err != nil {
 		return fmt.Errorf("replace attachment rows: %w", err)

--- a/internal/slack/media_test.go
+++ b/internal/slack/media_test.go
@@ -188,6 +188,8 @@ func TestPersistFilesLinkRowsAndPendingMarkers(t *testing.T) {
 func TestPersistFilesTreatsGoneDownloadsAsTerminalLinks(t *testing.T) {
 	for _, status := range []int{http.StatusNotFound, http.StatusGone} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
 			f := testWorkspace(t)
 			f.conv("C01").Msgs[6].Files = []map[string]any{
 				{"id": "F_GONE", "name": "deleted.png", "mimetype": "image/png", "size": 123,
@@ -210,32 +212,32 @@ func TestPersistFilesTreatsGoneDownloadsAsTerminalLinks(t *testing.T) {
 				NoMedia: true, AttachmentsDir: t.TempDir(), MaxMediaBytes: 1 << 20,
 			}
 			sum, err := imp.Import(context.Background(), opts)
-			require.NoError(t, err)
-			require.Equal(t, 1, sum.AttachmentsPending)
+			require.NoError(err)
+			require.Equal(1, sum.AttachmentsPending)
 
 			src, err := st.GetOrCreateSource("slack", "T01:UME")
-			require.NoError(t, err)
+			require.NoError(err)
 			pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
-			require.NoError(t, err)
-			require.Len(t, pending, 1, "media-disabled import must create genuine pending debt")
+			require.NoError(err)
+			require.Len(pending, 1, "media-disabled import must create genuine pending debt")
 
 			opts.NoMedia = false
 			sum, err = imp.BackfillMedia(context.Background(), opts)
-			require.NoError(t, err)
-			assert.Zero(t, sum.AttachmentsPending)
-			assert.Zero(t, sum.Errors)
+			require.NoError(err)
+			assert.Zero(sum.AttachmentsPending)
+			assert.Zero(sum.Errors)
 
 			pending, err = st.ListSlackPendingAttachmentMessages(src.ID)
-			require.NoError(t, err)
-			assert.Empty(t, pending, "a deleted Slack file must not remain pending")
+			require.NoError(err)
+			assert.Empty(pending, "a deleted Slack file must not remain pending")
 
 			var messageID int64
-			require.NoError(t, st.DB().QueryRow(st.Rebind(
+			require.NoError(st.DB().QueryRow(st.Rebind(
 				`SELECT id FROM messages WHERE source_message_id = ?`), "C01:"+ts(6)).Scan(&messageID))
 			refs, err := st.MessageSlackAttachments(messageID)
-			require.NoError(t, err)
-			require.Contains(t, refs, "slack:F_GONE")
-			assert.Equal(t, store.AttachmentRef{
+			require.NoError(err)
+			require.Contains(refs, "slack:F_GONE")
+			assert.Equal(store.AttachmentRef{
 				Filename:           "deleted.png",
 				MimeType:           "image/png",
 				StoragePath:        "https://testers.slack.com/files/F_GONE",

--- a/internal/slack/media_test.go
+++ b/internal/slack/media_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
 
@@ -182,6 +183,68 @@ func TestPersistFilesLinkRowsAndPendingMarkers(t *testing.T) {
 	pending, err = st.ListSlackPendingAttachmentMessages(src.ID)
 	require.NoError(err)
 	assert.Empty(pending)
+}
+
+func TestPersistFilesTreatsGoneDownloadsAsTerminalLinks(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusGone} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			f := testWorkspace(t)
+			f.conv("C01").Msgs[6].Files = []map[string]any{
+				{"id": "F_GONE", "name": "deleted.png", "mimetype": "image/png", "size": 123,
+					"url_private": "https://files.slack.com/files-pri/T01-F_GONE/deleted.png",
+					"permalink":   "https://testers.slack.com/files/F_GONE"},
+			}
+
+			prevInterval := checkpointMinInterval
+			checkpointMinInterval = 0
+			t.Cleanup(func() { checkpointMinInterval = prevInterval })
+			srv := f.serve()
+			client := NewClient(srv.URL, "xoxp-test")
+			client.disableRateLimits()
+			client.mediaTransport = &recordingTransport{status: status}
+			st := testutil.NewTestStore(t)
+			imp := NewImporter(st, client, "T01")
+
+			opts := ImportOptions{
+				TeamID: "T01", UserID: "UME",
+				NoMedia: true, AttachmentsDir: t.TempDir(), MaxMediaBytes: 1 << 20,
+			}
+			sum, err := imp.Import(context.Background(), opts)
+			require.NoError(t, err)
+			require.Equal(t, 1, sum.AttachmentsPending)
+
+			src, err := st.GetOrCreateSource("slack", "T01:UME")
+			require.NoError(t, err)
+			pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
+			require.NoError(t, err)
+			require.Len(t, pending, 1, "media-disabled import must create genuine pending debt")
+
+			opts.NoMedia = false
+			sum, err = imp.BackfillMedia(context.Background(), opts)
+			require.NoError(t, err)
+			assert.Zero(t, sum.AttachmentsPending)
+			assert.Zero(t, sum.Errors)
+
+			pending, err = st.ListSlackPendingAttachmentMessages(src.ID)
+			require.NoError(t, err)
+			assert.Empty(t, pending, "a deleted Slack file must not remain pending")
+
+			var messageID int64
+			require.NoError(t, st.DB().QueryRow(st.Rebind(
+				`SELECT id FROM messages WHERE source_message_id = ?`), "C01:"+ts(6)).Scan(&messageID))
+			refs, err := st.MessageSlackAttachments(messageID)
+			require.NoError(t, err)
+			require.Contains(t, refs, "slack:F_GONE")
+			assert.Equal(t, store.AttachmentRef{
+				Filename:           "deleted.png",
+				MimeType:           "image/png",
+				StoragePath:        "https://testers.slack.com/files/F_GONE",
+				Size:               123,
+				SourceAttachmentID: "slack:F_GONE",
+				MediaType:          "link",
+			}, refs["slack:F_GONE"])
+		})
+	}
 }
 
 func TestPersistFilesPreservesTombstonedAndOmittedDownloads(t *testing.T) {

--- a/internal/slack/media_test.go
+++ b/internal/slack/media_test.go
@@ -1,0 +1,380 @@
+package slack
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestFetchableURLHostRestriction(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		ok   bool
+	}{
+		{"real host", "https://files.slack.com/files-pri/T01-F01/a.png", true},
+		{"case-insensitive host", "https://FILES.SLACK.COM/files-pri/T01-F01/a.png", true},
+		{"attacker host", "https://attacker.example/files-pri/T01-F01/a.png", false},
+		{"subdomain spoof", "https://files.slack.com.attacker.example/a.png", false},
+		{"http downgrade", "http://files.slack.com/a.png", false},
+		{"userinfo trick", "https://files.slack.com@attacker.example/a.png", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := fetchableURL(tt.url)
+			if tt.ok {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+// recordingTransport serves canned bodies for files.slack.com and records
+// every request it sees (it must never see an off-host one).
+type recordingTransport struct {
+	requests []string
+	body     string
+	// bodyByPath overrides body per URL path (distinct content hashes:
+	// the store dedupes same-hash rows per message).
+	bodyByPath map[string]string
+	redirect   string // when set, answer 302 to this location
+	status     int
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.requests = append(rt.requests, req.URL.String())
+	if rt.redirect != "" {
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     http.Header{"Location": {rt.redirect}},
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	}
+	status := rt.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	body := rt.body
+	if b, ok := rt.bodyByPath[req.URL.Path]; ok {
+		body = b
+	}
+	return &http.Response{
+		StatusCode:    status,
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}, nil
+}
+
+func TestDownloadFileRefusesOffHostAndRedirects(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	rt := &recordingTransport{body: "bytes"}
+	c := NewClient("", "xoxp-test")
+	c.mediaTransport = rt
+
+	// Off-host: rejected before any request is made.
+	_, err := c.DownloadFile(context.Background(), "https://attacker.example/x", 100)
+	require.ErrorIs(err, errOffHost)
+	assert.Empty(rt.requests, "the token must never travel to an off-host URL")
+
+	// On-host succeeds.
+	data, err := c.DownloadFile(context.Background(), "https://files.slack.com/files-pri/T01-F01/a.png", 100)
+	require.NoError(err)
+	assert.Equal("bytes", string(data))
+	require.Len(rt.requests, 1)
+
+	// A redirect — even one a compromised response injects — is refused.
+	rt.redirect = "https://attacker.example/steal"
+	_, err = c.DownloadFile(context.Background(), "https://files.slack.com/files-pri/T01-F02/b.png", 100)
+	require.ErrorIs(err, errOffHost)
+	assert.Len(rt.requests, 2, "the redirect target must not be followed")
+}
+
+func TestDownloadFileSizeCap(t *testing.T) {
+	rt := &recordingTransport{body: strings.Repeat("x", 64)}
+	c := NewClient("", "xoxp-test")
+	c.mediaTransport = rt
+	_, err := c.DownloadFile(context.Background(), "https://files.slack.com/files-pri/T01-F01/a.png", 10)
+	assert.ErrorIs(t, err, ErrAssetTooLarge)
+}
+
+func TestPersistFilesLinkRowsAndPendingMarkers(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	general := f.conv("C01")
+	general.Msgs[6].Files = []map[string]any{
+		{"id": "F_OK", "name": "a.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_OK/a.png",
+			"permalink":   "https://testers.slack.com/files/F_OK"},
+		{"id": "F_EXT", "name": "doc.pdf", "mimetype": "application/pdf", "is_external": true,
+			"url_private": "https://ext.example/doc.pdf",
+			"permalink":   "https://testers.slack.com/files/F_EXT"},
+		{"id": "F_BIG", "name": "video.mp4", "mimetype": "video/mp4", "size": 1 << 40,
+			"url_private": "https://files.slack.com/files-pri/T01-F_BIG/video.mp4",
+			"permalink":   "https://testers.slack.com/files/F_BIG"},
+	}
+
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	client.mediaTransport = &recordingTransport{body: "png01"}
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	opts := ImportOptions{
+		TeamID: "T01", UserID: "UME",
+		AttachmentsDir: t.TempDir(), MaxMediaBytes: 1 << 20,
+	}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT a.source_attachment_id, COALESCE(a.content_hash, ''), COALESCE(a.media_type, '')
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(6))
+	require.NoError(err)
+	defer func() { _ = rows.Close() }()
+	got := map[string][2]string{}
+	for rows.Next() {
+		var id, hash, mediaType string
+		require.NoError(rows.Scan(&id, &hash, &mediaType))
+		got[id] = [2]string{hash, mediaType}
+	}
+	require.NoError(rows.Err())
+
+	require.Len(got, 3)
+	assert.NotEmpty(got["slack:F_OK"][0], "on-host file downloads into content-addressed storage")
+	assert.Equal("image", got["slack:F_OK"][1])
+	assert.Empty(got["slack:F_EXT"][0])
+	assert.Equal("link", got["slack:F_EXT"][1], "external file records metadata only")
+	assert.Empty(got["slack:F_BIG"][0])
+	assert.Empty(got["slack:F_BIG"][1], "over-cap file leaves a retryable pending marker")
+
+	// The pending list sees the over-cap marker but not the link row.
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(err)
+	require.Len(pending, 1)
+
+	// Raising the cap and backfilling repairs the pending download (the
+	// declared size in the archived raw JSON no longer exceeds it).
+	opts.MaxMediaBytes = 1 << 50
+	sum, err := imp.BackfillMedia(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(1, sum.AttachmentsDownloaded)
+	pending, err = st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(err)
+	assert.Empty(pending)
+}
+
+func TestPersistFilesPreservesTombstonedAndOmittedDownloads(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_TOMB", "name": "t.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_TOMB/t.png",
+			"permalink":   "https://testers.slack.com/files/F_TOMB"},
+		{"id": "F_GONE", "name": "g.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_GONE/g.png",
+			"permalink":   "https://testers.slack.com/files/F_GONE"},
+		{"id": "F_PEND", "name": "big.mp4", "mimetype": "video/mp4", "size": 1 << 40,
+			"url_private": "https://files.slack.com/files-pri/T01-F_PEND/big.mp4",
+			"permalink":   "https://testers.slack.com/files/F_PEND"},
+		{"id": "F_LINK", "name": "doc.pdf", "mimetype": "application/pdf", "is_external": true,
+			"url_private": "https://ext.example/doc.pdf",
+			"permalink":   "https://testers.slack.com/files/F_LINK"},
+	}
+
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	client.mediaTransport = &recordingTransport{body: "png03", bodyByPath: map[string]string{
+		"/files-pri/T01-F_GONE/g.png": "png04",
+	}}
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	opts := ImportOptions{
+		TeamID: "T01", UserID: "UME",
+		AttachmentsDir: t.TempDir(), MaxMediaBytes: 1 << 20,
+	}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// The source deletes one downloaded file (tombstone) and an edit drops
+	// the others from the message entirely; the oversized pending marker
+	// and the external link's metadata row also stop being listed.
+	// Deletions at the source must never reach into the archive — the
+	// downloaded rows AND the metadata-only link row survive; only the
+	// stale pending marker has nothing to keep.
+	f.mu.Lock()
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_TOMB", "mode": "tombstone"},
+	}
+	f.mu.Unlock()
+
+	full := opts
+	full.Full = true
+	_, err = imp.Import(context.Background(), full)
+	require.NoError(err)
+
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT a.source_attachment_id, COALESCE(a.content_hash, ''), COALESCE(a.media_type, '')
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "C01:"+ts(6))
+	require.NoError(err)
+	defer func() { _ = rows.Close() }()
+	got := map[string][2]string{}
+	for rows.Next() {
+		var id, hash, mediaType string
+		require.NoError(rows.Scan(&id, &hash, &mediaType))
+		got[id] = [2]string{hash, mediaType}
+	}
+	require.NoError(rows.Err())
+
+	assert.NotEmpty(got["slack:F_TOMB"][0], "a tombstoned file keeps its archived attachment row")
+	assert.NotEmpty(got["slack:F_GONE"][0], "a file dropped by an edit keeps its archived attachment row")
+	assert.Equal("link", got["slack:F_LINK"][1], "an omitted external file keeps its metadata-only link row")
+	_, pendKept := got["slack:F_PEND"]
+	assert.False(pendKept, "a stale pending marker clears once the source stops listing the file")
+}
+
+func TestPersistFilesKeepsAliasRowsForDuplicateContent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	// Two distinct Slack files whose bytes are identical (the transport
+	// serves one body for every path): the schema's (message_id,
+	// content_hash) uniqueness must not silently drop the second file ID.
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_DUP1", "name": "a.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_DUP1/a.png",
+			"permalink":   "https://testers.slack.com/files/F_DUP1"},
+		{"id": "F_DUP2", "name": "copy-of-a.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_DUP2/copy-of-a.png",
+			"permalink":   "https://testers.slack.com/files/F_DUP2"},
+	}
+
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	rt := &recordingTransport{body: "png05"}
+	client.mediaTransport = rt
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	opts := ImportOptions{
+		TeamID: "T01", UserID: "UME",
+		AttachmentsDir: t.TempDir(), MaxMediaBytes: 1 << 20,
+	}
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	// Both file IDs keep a row: one carries the hash, the duplicate is an
+	// alias (same CAS path, hash re-derived on read).
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "C01:"+ts(6)).Scan(&messageID))
+	refs, err := st.MessageSlackAttachments(messageID)
+	require.NoError(err)
+	require.Len(refs, 2, "duplicate-content file IDs must both keep attachment rows")
+	assert.NotEmpty(refs["slack:F_DUP1"].ContentHash)
+	assert.NotEmpty(refs["slack:F_DUP2"].ContentHash, "the alias row must read back as downloaded")
+	assert.Equal(refs["slack:F_DUP1"].StoragePath, refs["slack:F_DUP2"].StoragePath)
+
+	// Aliases are downloaded, not pending — and repairs must not re-fetch.
+	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(err)
+	assert.Empty(pending, "alias rows are downloaded, never pending work")
+
+	full := opts
+	full.Full = true
+	_, err = imp.Import(context.Background(), full)
+	require.NoError(err)
+	assert.Len(rt.requests, 2, "a repair pass must not re-download duplicate-content files")
+	refs, err = st.MessageSlackAttachments(messageID)
+	require.NoError(err)
+	assert.Len(refs, 2)
+}
+
+func TestNoMediaDefersFilesAsPendingNotLinks(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{
+		{"id": "F_DEFER", "name": "b.png", "mimetype": "image/png", "size": 5,
+			"url_private": "https://files.slack.com/files-pri/T01-F_DEFER/b.png",
+			"permalink":   "https://testers.slack.com/files/F_DEFER"},
+	}
+
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	client.mediaTransport = &recordingTransport{body: "png02"}
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	// Sync with media disabled: the hosted file must become a PENDING
+	// marker — a link row would hide it from backfill forever.
+	opts := ImportOptions{TeamID: "T01", UserID: "UME", NoMedia: true, AttachmentsDir: t.TempDir()}
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(1, sum.AttachmentsPending)
+
+	src, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
+	require.NoError(err)
+	require.Len(pending, 1, "a --no-media deferred hosted file must stay discoverable")
+
+	// Enabling media and backfilling downloads it.
+	opts.NoMedia = false
+	bsum, err := imp.BackfillMedia(context.Background(), opts)
+	require.NoError(err)
+	assert.Equal(1, bsum.AttachmentsDownloaded)
+	var hash string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(a.content_hash,'') FROM attachments a
+		WHERE a.source_attachment_id = ?`), "slack:F_DEFER").Scan(&hash))
+	assert.NotEmpty(hash)
+}
+
+func TestMediaTimeoutScalesWithCap(t *testing.T) {
+	assert := assert.New(t)
+	// The API client's 60s whole-request deadline starves large downloads
+	// on slow links; the media bound must scale with the size cap (~128
+	// KiB/s floor rate) above a generous minimum, and never be infinite.
+	assert.Equal(10*time.Minute, mediaTimeout(1<<20), "small caps get the floor")
+	assert.Equal(800*time.Second, mediaTimeout(100<<20), "default 100 MiB cap ≈ 13m20s")
+	assert.Equal(8192*time.Second, mediaTimeout(1<<30), "bigger caps scale up")
+	assert.Greater(mediaTimeout(1), time.Minute, "never anywhere near the 60s API deadline")
+}

--- a/internal/slack/media_test.go
+++ b/internal/slack/media_test.go
@@ -223,11 +223,10 @@ func TestPersistFilesPreservesTombstonedAndOmittedDownloads(t *testing.T) {
 	require.NoError(err)
 
 	// The source deletes one downloaded file (tombstone) and an edit drops
-	// the others from the message entirely; the oversized pending marker
-	// and the external link's metadata row also stop being listed.
-	// Deletions at the source must never reach into the archive — the
-	// downloaded rows AND the metadata-only link row survive; only the
-	// stale pending marker has nothing to keep.
+	// the others from the message entirely. Deletions at the source must
+	// never reach into the archive: downloaded rows survive, and a pending
+	// row becomes terminal metadata so the file remains discoverable without
+	// wedging the retry queue forever.
 	f.mu.Lock()
 	f.conv("C01").Msgs[6].Files = []map[string]any{
 		{"id": "F_TOMB", "mode": "tombstone"},
@@ -256,8 +255,8 @@ func TestPersistFilesPreservesTombstonedAndOmittedDownloads(t *testing.T) {
 	assert.NotEmpty(got["slack:F_TOMB"][0], "a tombstoned file keeps its archived attachment row")
 	assert.NotEmpty(got["slack:F_GONE"][0], "a file dropped by an edit keeps its archived attachment row")
 	assert.Equal("link", got["slack:F_LINK"][1], "an omitted external file keeps its metadata-only link row")
-	_, pendKept := got["slack:F_PEND"]
-	assert.False(pendKept, "a stale pending marker clears once the source stops listing the file")
+	assert.Equal("link", got["slack:F_PEND"][1],
+		"a pending file omitted at the source must become terminal metadata rather than disappear")
 }
 
 func TestPersistFilesKeepsAliasRowsForDuplicateContent(t *testing.T) {

--- a/internal/slack/participants.go
+++ b/internal/slack/participants.go
@@ -1,0 +1,172 @@
+package slack
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// participantIdentifierType namespaces Slack user IDs in
+// participant_identifiers. IDs are only unique per workspace, so the stored
+// identifier value is "<team_id>:<user_id>".
+const participantIdentifierType = "slack"
+
+// participantResolver resolves Slack user IDs to msgvault participant IDs,
+// seeded once per run from users.list and cached thereafter.
+//
+// Resolution ladder (Beeper precedent, minus the phone rung — Slack profiles
+// carry emails, not reliable E.164 phones):
+//  1. Profile email → EnsureParticipant, deduping the person against mail
+//     archives (and Teams' AAD→email resolutions).
+//  2. Bare Slack user ID → EnsureParticipantByIdentifier("slack", …).
+type participantResolver struct {
+	store  *store.Store
+	teamID string
+	// users caches users.list rows by user ID for display names and titles.
+	users map[string]User
+	// rich caches email-based resolutions; fallback caches bare-ID ones.
+	// Kept separate so a fallback cached before the users refresh cannot
+	// block a later email-based dedup (Beeper precedent).
+	rich     map[string]int64
+	fallback map[string]int64
+}
+
+func newParticipantResolver(s *store.Store, teamID string) *participantResolver {
+	return &participantResolver{
+		store: s, teamID: teamID,
+		users: map[string]User{}, rich: map[string]int64{}, fallback: map[string]int64{},
+	}
+}
+
+// identifierValue namespaces a Slack user ID with its workspace.
+func (r *participantResolver) identifierValue(userID string) string {
+	return r.teamID + ":" + userID
+}
+
+// loadUsers refreshes the workspace member cache. Identity resolution is
+// load-bearing for cross-archive dedup, so callers treat failure as fatal
+// for the run.
+func (r *participantResolver) loadUsers(ctx context.Context, c *Client) error {
+	return c.AllUsers(ctx, func(u User) error {
+		r.users[u.ID] = u
+		return nil
+	})
+}
+
+// tzLocation returns the cached user's timezone as a *time.Location: the
+// IANA zone when its name loads (search date modifiers follow the zone's
+// historical DST rules — probed live), falling back to a fixed zone at the
+// current tz_offset (correct for non-DST zones; the pre-probe behavior
+// otherwise).
+func (r *participantResolver) tzLocation(userID string) *time.Location {
+	u := r.users[userID]
+	if u.TZ != "" {
+		if loc, err := time.LoadLocation(u.TZ); err == nil {
+			return loc
+		}
+	}
+	return time.FixedZone("user", u.TZOffset)
+}
+
+// tzOffset returns the cached user's tz_offset in seconds (0 when unknown).
+// Read fresh each run: search date modifiers evaluate in the user's CURRENT
+// profile timezone.
+func (r *participantResolver) tzOffset(userID string) int {
+	return r.users[userID].TZOffset
+}
+
+// displayName returns the best-known name for a user ID ("" when unknown).
+func (r *participantResolver) displayName(userID string) string {
+	if u, ok := r.users[userID]; ok {
+		return u.DisplayName()
+	}
+	return ""
+}
+
+// resolveID resolves a Slack user ID to a participant ID, creating the
+// participant if needed. Unknown IDs (Slack Connect guests, departed users
+// missing from users.list) resolve by bare identifier with no display name.
+func (r *participantResolver) resolveID(userID string) (int64, error) {
+	if userID == "" {
+		return 0, nil
+	}
+	if pid, ok := r.rich[userID]; ok {
+		return pid, nil
+	}
+	if pid, ok := r.fallback[userID]; ok {
+		return pid, nil
+	}
+	u, known := r.users[userID]
+	if known && strings.Contains(u.Profile.Email, "@") && !u.IsBot {
+		pid, err := r.byEmail(u.Profile.Email, u.DisplayName())
+		if err != nil {
+			return 0, err
+		}
+		if err := r.recordRich(userID, pid); err != nil {
+			return 0, err
+		}
+		return pid, nil
+	}
+	name := ""
+	if known {
+		name = u.DisplayName()
+	}
+	pid, err := r.store.EnsureParticipantByIdentifier(participantIdentifierType, r.identifierValue(userID), name)
+	if err != nil {
+		return 0, err
+	}
+	r.fallback[userID] = pid
+	return pid, nil
+}
+
+// recordRich persists the Slack user ID as an identifier of the email-based
+// participant, so later runs resolve bare sightings to the same person. A
+// prior weak (bare-ID) owner is the same Slack user seen with less metadata:
+// its history is merged into the rich participant rather than left split.
+func (r *participantResolver) recordRich(userID string, pid int64) error {
+	value := r.identifierValue(userID)
+	prev, _, err := r.store.ParticipantByIdentifier(participantIdentifierType, value)
+	if err != nil {
+		return err
+	}
+	if prev != 0 && prev != pid {
+		if err := r.store.MergeParticipants(prev, pid); err != nil {
+			return err
+		}
+	}
+	if err := r.store.SetParticipantIdentifier(pid, participantIdentifierType, value); err != nil {
+		return err
+	}
+	r.rich[userID] = pid
+	delete(r.fallback, userID)
+	return nil
+}
+
+// resolveBot resolves a bot sender (bot_id + optional username). Bots never
+// dedup by email; they are namespaced by bot ID.
+func (r *participantResolver) resolveBot(botID, username string) (int64, error) {
+	if botID == "" {
+		return 0, nil
+	}
+	key := "bot:" + botID
+	if pid, ok := r.fallback[key]; ok {
+		return pid, nil
+	}
+	pid, err := r.store.EnsureParticipantByIdentifier(participantIdentifierType, r.identifierValue(key), username)
+	if err != nil {
+		return 0, err
+	}
+	r.fallback[key] = pid
+	return pid, nil
+}
+
+func (r *participantResolver) byEmail(email, displayName string) (int64, error) {
+	email = strings.ToLower(email)
+	domain := ""
+	if at := strings.LastIndex(email, "@"); at >= 0 {
+		domain = email[at+1:]
+	}
+	return r.store.EnsureParticipant(email, displayName, domain)
+}

--- a/internal/slack/sweep.go
+++ b/internal/slack/sweep.go
@@ -236,6 +236,23 @@ func (imp *Importer) sweepRange(ctx context.Context, syncID int64, scope, floor 
 	day = time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, loc)
 	end := searchEnd.In(loc)
 	for !day.After(end) {
+		nextDay := nextDayStart(day, loc)
+		nextBoundary := tsFormat(nextDay.UTC())
+		if truncatedSweepCovered(targets, state, nextBoundary) {
+			// This exact scope/day already failed closed by converting its
+			// unreachable tail into a canonical catch-up walk. The overlap
+			// is normally re-searched for late indexing, but re-running a
+			// known truncation cannot discover its tail; under --limit 1 it
+			// would instead consume every run's budget and reset the walk
+			// before it could advance. Certification is safe because the
+			// persisted catch-up debt covers every in-scope thread.
+			advance(nextBoundary)
+			if err := imp.checkpoint(syncID, state, sum); err != nil {
+				return err
+			}
+			day = nextDay
+			continue
+		}
 		if budget.exhausted() {
 			return nil // certification stays at the last committed boundary
 		}
@@ -276,24 +293,33 @@ func (imp *Importer) sweepRange(ctx context.Context, syncID int64, scope, floor 
 			for cid := range targets {
 				cs := state.EnsureConv(cid)
 				cs.ThreadsPending = true
-				// An in-flight catch-up walk was pinned before this day's
-				// replies existed; roots created after its pin would never
-				// be anchored. Re-pin it (idempotent re-walk).
-				cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+				// Preserve an in-flight catch-up: its cursor is valid only
+				// against its persisted pin. The through marker queues a
+				// follow-up walk when that pin predates this day boundary.
+				cs.recordTruncatedSweep(nextBoundary)
 			}
 			imp.recordItem(syncID, item, "sweep", store.SyncRunItemStatusError, "slack_sweep_truncated",
 				fmt.Errorf("day %s exceeds the %d reachable results per query; the unreachable tail is recorded as thread catch-up debt and recovers on subsequent runs (see the sweep design doc)", dayStr, sweepTruncationCeiling))
 			sum.FetchErrors++
 			sum.Errors++
 		}
-		nextDay := nextDayStart(day, loc)
-		advance(tsFormat(nextDay.UTC()))
+		advance(nextBoundary)
 		if err := imp.checkpoint(syncID, state, sum); err != nil {
 			return err
 		}
 		day = nextDay
 	}
 	return nil
+}
+
+func truncatedSweepCovered(targets map[string]sweepTarget, state *SyncState, boundary string) bool {
+	for cid := range targets {
+		through := state.EnsureConv(cid).TruncatedSweepThrough
+		if through == "" || tsLess(through, boundary) {
+			return false
+		}
+	}
+	return len(targets) > 0
 }
 
 // sweepDay runs the paged threads:replies query for one user-tz day,

--- a/internal/slack/sweep.go
+++ b/internal/slack/sweep.go
@@ -1,0 +1,439 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	// sweepLagMargin keeps certification behind real time so a sweep cannot
+	// certify an instant whose messages may not be indexed yet.
+	sweepLagMargin = 10 * time.Minute
+	// sweepTruncationCeiling is search.messages' reachable-result ceiling
+	// per query (count 100 × page cap 100). A single-day total beyond it
+	// fails the run: results past the ceiling cannot be reached by paging,
+	// and re-querying the same day serves the same first 10k (ascending
+	// order is stable), so no amount of retrying drains it. Recovery is
+	// `--full` (backfill's inline thread fetches need no search); per-scope
+	// `in:`-batch narrowing is the specified (unbuilt) sweep-native escape
+	// hatch — see docs/internal/slack-reply-sweep-design.md.
+	sweepTruncationCeiling = searchPageLimit * maxSearchPages
+)
+
+// sweepTarget is a done conversation eligible for reply archiving.
+type sweepTarget struct {
+	convID int64
+}
+
+// sweepBudget bounds a limited run's sweep work (limit 0 = unlimited). Days
+// searched and canonically fetched messages both charge it: fetches are the
+// message work, and the per-day charge keeps a long catch-up from paging
+// through months of queries on a run that promised to be small. Exhaustion
+// parks certification at the last safe boundary WITHOUT failing the run —
+// per-day commits are durable, so repeated limited runs converge.
+type sweepBudget struct{ limit, used int }
+
+func (b *sweepBudget) exhausted() bool { return b.limit > 0 && b.used >= b.limit }
+
+// sweepReplies discovers thread replies created since each conversation's
+// certification stamp via search.messages (threads:replies) and archives
+// them through canonical conversations.replies fetches.
+//
+// Certification is per conversation (ConvState.SweptThrough) with the
+// workspace watermark (SweepWatermark) tracking the current target set as a
+// whole. A conversation that re-enters the target set behind the watermark —
+// it was excluded, gone, or filtered while sweeps advanced — first recovers
+// its gap with a channel-scoped sweep; then one workspace-wide sweep runs
+// from the watermark. Certification derives only from fully-searched
+// intervals, never from fetched content (a canonical fetch returns whole
+// threads, including replies newer than the search index horizon).
+func (imp *Importer) sweepReplies(ctx context.Context, syncID int64, targets map[string]sweepTarget, state *SyncState, sum *ImportSummary) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	// Date modifiers evaluate in the user's CURRENT profile timezone at
+	// query time (probed live, including retroactive re-filing after a tz
+	// change) using the IANA zone's HISTORICAL DST rules (probed live
+	// against a corpus spanning DST transitions: a January day boundary
+	// follows the winter offset even when queried in summer, and the
+	// transition day itself is served as a 23-hour day). Day arithmetic
+	// must therefore use the zone read this run, not a fixed offset.
+	loc := imp.res.tzLocation(imp.opts.UserID)
+	offset := imp.res.tzOffset(imp.opts.UserID)
+	budget := &sweepBudget{limit: imp.opts.Limit}
+	now := imp.now().UTC()
+	// The sweep's boundary is its own PIN (this run's start instant): the
+	// stored watermark/stamps mean "replies at or before boundary − lag
+	// margin are certainly archived", and every floor overlaps back by the
+	// margin so replies the index had not yet served at boundary time are
+	// re-covered by the next sweep. One boundary per run, shared with the
+	// window walks; index lag is absorbed by the overlap, not by a lagged
+	// certification.
+	pin := tsFormat(now)
+
+	ids := make([]string, 0, len(targets))
+	for cid := range targets {
+		ids = append(ids, cid)
+	}
+	sort.Strings(ids)
+
+	// A stamp-less done conversation has an UNKNOWABLE coverage start:
+	// threaded initial walks stamp themselves at completion, so reaching
+	// here means legacy state or a pre-stamping blob — and Cursor cannot
+	// serve as the boundary (it advances with every window walk; a run
+	// that died before its sweep phase leaves days of replies between the
+	// real coverage edge and the current pin). Conservative recovery
+	// mirrors the non-C gap fallback: flag a catch-up walk (re-reading
+	// history at ITS OWN time recovers every reply below its fresh pin)
+	// and stamp forward to this sweep's pin, whose trailing margin the
+	// next sweep re-covers.
+	for _, cid := range ids {
+		cs := state.EnsureConv(cid)
+		if cs.SweptThrough != "" {
+			continue
+		}
+		cs.ThreadsPending = true
+		cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+		cs.SweptThrough = pin
+	}
+
+	// Gap recovery: a target certified behind the workspace watermark
+	// missed sweeps while absent from the target set.
+	for _, cid := range ids {
+		cs := state.Conversations[cid]
+		if state.SweepWatermark == "" || !tsLess(cs.SweptThrough, state.SweepWatermark) {
+			continue
+		}
+		if !strings.HasPrefix(cid, "C") {
+			// in:<#ID> scoping is only probed reliable for channel IDs.
+			// DMs and group DMs recover through the thread catch-up walk
+			// instead (fetches every thread, so the gap's bounds are moot);
+			// the flag persists until a clean pass, so stamping forward
+			// here cannot lose the debt.
+			cs.ThreadsPending = true
+			// An in-flight catch-up walk was pinned BEFORE the gap: roots
+			// created between its pin and the absence would never be
+			// anchored, while the stamp below claims them covered. Reset
+			// the walk so it re-pins at its own start (re-walking resolves
+			// into idempotent upserts).
+			cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+			cs.SweptThrough = state.SweepWatermark
+			continue
+		}
+		err := imp.sweepRange(ctx, syncID, cid, cs.SweptThrough, tsTime(state.SweepWatermark), state.SweepWatermark,
+			map[string]sweepTarget{cid: targets[cid]}, loc, budget, state, sum,
+			func(certified string) { cs.SweptThrough = certified })
+		if err != nil {
+			return err
+		}
+	}
+
+	// Workspace-wide sweep from the watermark (first sweep: from the
+	// earliest certification among targets).
+	floor := state.SweepWatermark
+	if floor == "" {
+		for _, cid := range ids {
+			st := state.Conversations[cid].SweptThrough
+			if st == "" {
+				continue
+			}
+			if floor == "" || tsLess(st, floor) {
+				floor = st
+			}
+		}
+	}
+	if floor == "" {
+		return nil // nothing backfilled yet; backfill owns all replies so far
+	}
+	// Hits above the pin (created after this sweep started) are acted on
+	// too when the index serves them early — harmless upserts; the next
+	// sweep's window re-covers them by construction.
+	return imp.sweepRange(ctx, syncID, "", floor, now, pin, targets, loc, budget, state, sum,
+		func(certified string) {
+			state.SweepWatermark, state.SweepOffset = certified, offset
+			for _, cid := range ids {
+				cs := state.Conversations[cid]
+				// Only a conversation already certified through the sweep's
+				// floor is contiguously covered to the new boundary; one
+				// parked behind (a failed gap sweep) keeps its stamp so the
+				// gap is retried next run.
+				if !tsLess(cs.SweptThrough, floor) && tsLess(cs.SweptThrough, certified) {
+					cs.SweptThrough = certified
+				}
+			}
+		})
+}
+
+// sweepRange drains the threads:replies search for one scope ("" =
+// workspace-wide; a channel ID = in:<#ID>-scoped), day by day in the user's
+// current timezone. floor is the stored boundary (a pin); the query and hit
+// filter OVERLAP back by the lag margin so replies the search index had not
+// served by the previous sweep are re-covered (into idempotent upserts).
+// commit is invoked with each newly advanced boundary — end of a completed
+// day, capped at ceiling and never regressing below floor — so multi-day
+// catch-ups checkpoint per day. Discovery and fetch failures are recorded,
+// the boundary parks at the last safe point, and the sweep stops; only
+// store/context failures return an error.
+func (imp *Importer) sweepRange(ctx context.Context, syncID int64, scope, floor string, searchEnd time.Time, ceiling string, targets map[string]sweepTarget, loc *time.Location, budget *sweepBudget, state *SyncState, sum *ImportSummary, commit func(certified string)) error {
+	queryFloor := overlapFloor(floor)
+	// The boundary only ever advances: overlap-region parks and yesterday's
+	// day-end sit below the stored floor and must not regress it.
+	advance := func(v string) {
+		if c := minTS(v, ceiling); tsLess(floor, c) {
+			commit(c)
+		}
+	}
+	day := tsTime(queryFloor).In(loc)
+	day = time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, loc)
+	end := searchEnd.In(loc)
+	for !day.After(end) {
+		if budget.exhausted() {
+			return nil // certification stays at the last committed boundary
+		}
+		budget.used++
+		dayStr := day.Format("2006-01-02")
+		item := dayStr
+		if scope != "" {
+			item = scope + ":" + dayStr
+		}
+		hits, truncated, err := imp.sweepDay(ctx, syncID, scope, dayStr, targets)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// Discovery failure: nothing this day was processed;
+			// certification stays where the last complete day left it.
+			imp.recordItem(syncID, item, "sweep", store.SyncRunItemStatusError, "slack_search_error", err)
+			sum.FetchErrors++
+			sum.Errors++
+			return nil
+		}
+		if err := imp.recordSweepDebt(ctx, syncID, hits, queryFloor, targets, budget, state, sum); err != nil {
+			return err // store/context failure: fatal for the run
+		}
+		if truncated {
+			// The rest of the day is unreachable to search, so it is
+			// converted into durable WALK debt instead of parking the
+			// boundary forever: the missed tail is thread replies in
+			// unknowable threads among the targets, and the catch-up walk
+			// re-fetches EVERY thread's replies, so flagging every in-scope
+			// target covers it regardless of where it landed (non-channel
+			// IDs included). With the debt recorded, the boundary advances
+			// past the day — the sweep's own invariant — so this failure
+			// happens ONCE and later runs converge by paying the flags,
+			// instead of re-truncating on the same day forever (which also
+			// wedged RepairPending sessions permanently: they demand a
+			// clean pass, while --full refuses to reset one in flight).
+			for cid := range targets {
+				cs := state.EnsureConv(cid)
+				cs.ThreadsPending = true
+				// An in-flight catch-up walk was pinned before this day's
+				// replies existed; roots created after its pin would never
+				// be anchored. Re-pin it (idempotent re-walk).
+				cs.CatchUpCursor, cs.CatchUpLatest = "", ""
+			}
+			imp.recordItem(syncID, item, "sweep", store.SyncRunItemStatusError, "slack_sweep_truncated",
+				fmt.Errorf("day %s exceeds the %d reachable results per query; the unreachable tail is recorded as thread catch-up debt and recovers on subsequent runs (see the sweep design doc)", dayStr, sweepTruncationCeiling))
+			sum.FetchErrors++
+			sum.Errors++
+		}
+		nextDay := nextDayStart(day, loc)
+		advance(tsFormat(nextDay.UTC()))
+		if err := imp.checkpoint(syncID, state, sum); err != nil {
+			return err
+		}
+		day = nextDay
+	}
+	return nil
+}
+
+// sweepDay runs the paged threads:replies query for one user-tz day,
+// returning hits filtered to sweep targets (ascending by ts) and whether
+// the day's total exceeds the reachable-result ceiling.
+func (imp *Importer) sweepDay(ctx context.Context, syncID int64, scope, day string, targets map[string]sweepTarget) ([]SearchMatch, bool, error) {
+	var hits []SearchMatch
+	truncated := false
+	complete := false
+	query := imp.sweepQuery(scope, day, syncID)
+	for page := 1; page <= maxSearchPages; page++ {
+		sp, err := imp.client.SearchMessagesPage(ctx, query, page)
+		if err != nil {
+			return nil, false, err
+		}
+		// Past-the-ceiling requests are silently CLAMPED to page 1 (probed
+		// live): a mismatched echo means the walk must stop, not loop.
+		if sp.Page != page {
+			break
+		}
+		for _, m := range sp.Matches {
+			if _, ok := targets[m.ChannelID]; ok {
+				hits = append(hits, m)
+			}
+		}
+		if page == 1 && sp.Total > sweepTruncationCeiling {
+			// The reported total already exceeds what paging can reach —
+			// flagged even when the claimed page count fits the walk.
+			truncated = true
+		}
+		if page >= sp.Pages {
+			complete = true
+			break
+		}
+	}
+	// Certification derives from CONSUMPTION, never from an inferred
+	// ceiling: the day is complete only when the walk exited by exhausting
+	// the server's claimed pages. Every other exit — the page bound with
+	// pages still claimed (the server may serve smaller pages than
+	// requested, putting a sub-10k day past 100 pages), a clamp-echo
+	// mismatch, or empty pages that never advance to the claimed count —
+	// leaves unserved results and must be treated as truncation, feeding
+	// the recorded-debt recovery instead of certifying past unseen replies.
+	if !complete {
+		truncated = true
+	}
+	sort.Slice(hits, func(i, j int) bool { return tsLess(hits[i].TS, hits[j].TS) })
+	return hits, truncated, nil
+}
+
+// sweepQuery builds one day's query. The negated nonce term is semantically
+// inert and makes every query string unique: search results are cached by
+// query string (probed live — a cached result can serve stale day filings
+// and miss recently indexed messages).
+func (imp *Importer) sweepQuery(scope, day string, syncID int64) string {
+	// One nonce per ATTEMPT, stable across the walk's pages. Search
+	// responses are cached BY QUERY STRING (probed live), and that cuts
+	// both ways: stale results across attempts — why the nonce exists —
+	// and a consistent result-set snapshot WITHIN one walk — why the page
+	// number must never vary the string. A per-page nonce makes every
+	// page a fresh index query; a deletion between pages then shifts the
+	// ascending offsets down and drops a hit into an already-consumed
+	// page, while the walk still exhausts the claimed pages and certifies
+	// the day complete. syncID is fresh per run, and no (scope, day) pair
+	// is queried twice within one run, so per-attempt uniqueness holds.
+	q := fmt.Sprintf(`threads:replies on:%s -"zqsweep%d"`, day, syncID)
+	if scope != "" {
+		q = fmt.Sprintf("in:<#%s> ", scope) + q
+	}
+	return q
+}
+
+// recordSweepDebt converts discovered hits into per-conversation drain
+// debt — one entry per thread, seeded to resume just before the group's
+// earliest hit — then drains each affected conversation with the sweep
+// budget threaded through. Hits at or below queryFloor (the overlapped
+// floor: stored boundary − lag margin) are already archived and skipped.
+//
+// Recording is never budget-gated: the recorded entry IS the durable
+// progress that lets the day's boundary advance (the walks' "cursor past
+// page means debt recorded" invariant, applied to the sweep), so the
+// guaranteed-first-unit rule holds structurally — a run whose budget is
+// gone still converts its discoveries into debt that the next run's
+// drain-first step pays. Fetching is entirely the drain's job:
+// budget-sized pages, reply-granular resume, gone-thread churn handling,
+// and the guarded parent skip all come with it.
+func (imp *Importer) recordSweepDebt(ctx context.Context, syncID int64, hits []SearchMatch, queryFloor string, targets map[string]sweepTarget, budget *sweepBudget, state *SyncState, sum *ImportSummary) error {
+	type group struct {
+		channelID string
+		anchorTS  string // any ts within the thread; replies resolves it
+		minHit    string
+	}
+	var groups []group
+	index := map[string]int{}
+	for _, h := range hits {
+		if !tsLess(queryFloor, h.TS) {
+			continue // at/below the overlapped floor: already archived
+		}
+		key := h.ChannelID + ":" + h.RootTS
+		if h.RootTS == "" {
+			key = h.ChannelID + ":solo:" + h.TS // unparseable permalink: per-hit entry
+		}
+		if i, ok := index[key]; ok {
+			if tsLess(h.TS, groups[i].minHit) {
+				groups[i].minHit = h.TS
+			}
+			continue
+		}
+		index[key] = len(groups)
+		// Anchor at the parsed root when available: an anchor is the ts the
+		// drain's replies call resolves the thread by, and a hit REPLY can
+		// be deleted between discovery and drain — a dead anchor would drop
+		// the whole entry as thread-gone, losing its sibling hits below the
+		// already-advanced watermark. Roots are the stable choice (and they
+		// dedupe against walk-recorded entries for the same thread).
+		anchor := h.RootTS
+		if anchor == "" {
+			anchor = h.TS
+		}
+		groups = append(groups, group{channelID: h.ChannelID, anchorTS: anchor, minHit: h.TS})
+	}
+
+	touched := map[string]bool{}
+	for _, g := range groups {
+		state.EnsureConv(g.channelID).RecordPendingThreadTail(g.anchorTS, tsMinusMicro(g.minHit))
+		touched[g.channelID] = true
+	}
+	ids := make([]string, 0, len(touched))
+	for cid := range touched {
+		ids = append(ids, cid)
+	}
+	sort.Strings(ids)
+	for _, cid := range ids {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// The drain gates on actuals; seeding from the sweep budget makes
+		// the workspace budget bound this phase's fetch work, and reading
+		// it back carries the spend across conversations and days.
+		cc := &convScope{channelID: cid, convID: targets[cid].convID, sourceID: imp.sourceID, syncID: syncID, opts: imp.opts, cs: state.Conversations[cid], budgetUsed: budget.used}
+		if err := imp.drainPendingThreads(ctx, cc, sum); err != nil {
+			return err
+		}
+		budget.used = cc.budgetUsed
+	}
+	return nil
+}
+
+// nextDayStart returns the start of the calendar day after day in loc,
+// honoring the zone's historical DST rules: a transition day is 23 or 25
+// hours long, and a midnight that does not exist normalizes forward. This
+// boundary is load-bearing for certification — search files messages by the
+// zone's civil day (probed live), so a fixed-offset boundary could certify
+// an hour the day's query never served.
+func nextDayStart(day time.Time, loc *time.Location) time.Time {
+	return time.Date(day.Year(), day.Month(), day.Day()+1, 0, 0, 0, 0, loc)
+}
+
+// overlapFloor returns the boundary minus the lag margin: the instant from
+// which queries and hit filters resume, re-covering replies the search
+// index may not have served when the boundary was written.
+func overlapFloor(boundary string) string {
+	return tsFormat(tsTime(boundary).Add(-sweepLagMargin))
+}
+
+// tsFormat renders a UTC instant as a Slack ts string (microsecond fraction).
+func tsFormat(t time.Time) string {
+	return fmt.Sprintf("%d.%06d", t.Unix(), t.Nanosecond()/1000)
+}
+
+// minTS returns the earlier of two Slack ts strings.
+func minTS(a, b string) string {
+	if tsLess(b, a) {
+		return b
+	}
+	return a
+}
+
+// tsMinusMicro returns the ts one microsecond earlier (Slack ts strings have
+// microsecond resolution), for exclusive-bound arithmetic.
+func tsMinusMicro(ts string) string {
+	if !strings.Contains(ts, ".") {
+		return ts
+	}
+	t := tsTime(ts).Add(-time.Microsecond)
+	return tsFormat(t)
+}

--- a/internal/slack/sweep.go
+++ b/internal/slack/sweep.go
@@ -23,6 +23,11 @@ const (
 	// `in:`-batch narrowing is the specified (unbuilt) sweep-native escape
 	// hatch — see docs/internal/slack-reply-sweep-design.md.
 	sweepTruncationCeiling = searchPageLimit * maxSearchPages
+	// canonicalThreadAuditInterval keeps a recently completed canonical walk
+	// from being selected again immediately. Search remains the cheap
+	// discovery path; oldest-due canonical walks provide eventual
+	// completeness across continued scheduled runs.
+	canonicalThreadAuditInterval = 7 * 24 * time.Hour
 )
 
 // sweepTarget is a done conversation eligible for reply archiving.
@@ -67,13 +72,11 @@ func (imp *Importer) sweepReplies(ctx context.Context, syncID int64, targets map
 	offset := imp.res.tzOffset(imp.opts.UserID)
 	budget := &sweepBudget{limit: imp.opts.Limit}
 	now := imp.now().UTC()
-	// The sweep's boundary is its own PIN (this run's start instant): the
-	// stored watermark/stamps mean "replies at or before boundary − lag
-	// margin are certainly archived", and every floor overlaps back by the
-	// margin so replies the index had not yet served at boundary time are
-	// re-covered by the next sweep. One boundary per run, shared with the
-	// window walks; index lag is absorbed by the overlap, not by a lagged
-	// certification.
+	// The sweep's boundary is its own PIN (this run's start instant). Every
+	// floor overlaps back by the lag margin to absorb normal index delay;
+	// the periodic canonical audit covers the unbounded case where search
+	// never serves a reply. One boundary per run is shared with the window
+	// walks.
 	pin := tsFormat(now)
 
 	ids := make([]string, 0, len(targets))
@@ -153,7 +156,7 @@ func (imp *Importer) sweepReplies(ctx context.Context, syncID int64, targets map
 	// Hits above the pin (created after this sweep started) are acted on
 	// too when the index serves them early — harmless upserts; the next
 	// sweep's window re-covers them by construction.
-	return imp.sweepRange(ctx, syncID, "", floor, now, pin, targets, loc, budget, state, sum,
+	if err := imp.sweepRange(ctx, syncID, "", floor, now, pin, targets, loc, budget, state, sum,
 		func(certified string) {
 			state.SweepWatermark, state.SweepOffset = certified, offset
 			for _, cid := range ids {
@@ -166,14 +169,54 @@ func (imp *Importer) sweepReplies(ctx context.Context, syncID int64, targets map
 					cs.SweptThrough = certified
 				}
 			}
-		})
+		}); err != nil {
+		return err
+	}
+	imp.scheduleCanonicalThreadAudit(targets, state, now)
+	return nil
+}
+
+// scheduleCanonicalThreadAudit records one bounded unit of canonical
+// completeness work per run. Oldest-due first makes every active
+// conversation converge without turning each scheduled sync into a full
+// workspace history walk.
+func (imp *Importer) scheduleCanonicalThreadAudit(targets map[string]sweepTarget, state *SyncState, now time.Time) {
+	cutoff := tsFormat(now.Add(-canonicalThreadAuditInterval))
+	selected := ""
+	selectedStamp := ""
+	for cid := range targets {
+		cs := state.EnsureConv(cid)
+		if cs.ThreadsPending || cs.AuditPending || len(cs.PendingThreads) > 0 ||
+			cs.CatchUpCursor != "" || cs.CatchUpLatest != "" {
+			continue
+		}
+		if cs.AuditedThrough != "" && tsLess(cutoff, cs.AuditedThrough) {
+			continue
+		}
+		candidateOlder := cs.AuditedThrough == "" && selectedStamp != ""
+		sameMissingStamp := cs.AuditedThrough == "" && selectedStamp == ""
+		sameKnownStamp := cs.AuditedThrough != "" && cs.AuditedThrough == selectedStamp
+		if selected == "" || candidateOlder ||
+			(cs.AuditedThrough != "" && selectedStamp != "" && tsLess(cs.AuditedThrough, selectedStamp)) ||
+			((sameMissingStamp || sameKnownStamp) && cid < selected) {
+			selected = cid
+			selectedStamp = cs.AuditedThrough
+		}
+	}
+	if selected == "" {
+		return
+	}
+	cs := state.EnsureConv(selected)
+	cs.ThreadsPending = true
+	cs.AuditPending = true
+	cs.CatchUpCursor, cs.CatchUpLatest = "", ""
 }
 
 // sweepRange drains the threads:replies search for one scope ("" =
 // workspace-wide; a channel ID = in:<#ID>-scoped), day by day in the user's
 // current timezone. floor is the stored boundary (a pin); the query and hit
-// filter OVERLAP back by the lag margin so replies the search index had not
-// served by the previous sweep are re-covered (into idempotent upserts).
+// filter OVERLAP back by the lag margin so normally delayed search results
+// are re-covered (into idempotent upserts).
 // commit is invoked with each newly advanced boundary — end of a completed
 // day, capped at ceiling and never regressing below floor — so multi-day
 // catch-ups checkpoint per day. Discovery and fetch failures are recorded,
@@ -326,7 +369,8 @@ func (imp *Importer) sweepQuery(scope, day string, syncID int64) string {
 // debt — one entry per thread, seeded to resume just before the group's
 // earliest hit — then drains each affected conversation with the sweep
 // budget threaded through. Hits at or below queryFloor (the overlapped
-// floor: stored boundary − lag margin) are already archived and skipped.
+// floor: stored boundary − lag margin) were handled by an earlier search
+// interval and are skipped; canonical audits backstop search omissions.
 //
 // Recording is never budget-gated: the recorded entry IS the durable
 // progress that lets the day's boundary advance (the walks' "cursor past

--- a/internal/slack/sweep.go
+++ b/internal/slack/sweep.go
@@ -32,7 +32,8 @@ const (
 
 // sweepTarget is a done conversation eligible for reply archiving.
 type sweepTarget struct {
-	convID int64
+	convID       int64
+	toRecipients []messageRecipient
 }
 
 // sweepBudget bounds a limited run's sweep work (limit 0 = unlimited). Days
@@ -433,7 +434,12 @@ func (imp *Importer) recordSweepDebt(ctx context.Context, syncID int64, hits []S
 		// The drain gates on actuals; seeding from the sweep budget makes
 		// the workspace budget bound this phase's fetch work, and reading
 		// it back carries the spend across conversations and days.
-		cc := &convScope{channelID: cid, convID: targets[cid].convID, sourceID: imp.sourceID, syncID: syncID, opts: imp.opts, cs: state.Conversations[cid], budgetUsed: budget.used}
+		target := targets[cid]
+		cc := &convScope{
+			channelID: cid, convID: target.convID, sourceID: imp.sourceID,
+			syncID: syncID, opts: imp.opts, cs: state.Conversations[cid],
+			toRecipients: target.toRecipients, budgetUsed: budget.used,
+		}
 		if err := imp.drainPendingThreads(ctx, cc, sum); err != nil {
 			return err
 		}

--- a/internal/slack/sweep_live_test.go
+++ b/internal/slack/sweep_live_test.go
@@ -1,0 +1,65 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveThreadsRepliesModifierPin freezes the observed behavior of the
+// UNDOCUMENTED threads:replies search modifier against the REAL Slack API.
+// The sweep's correctness and its ceiling math both assume the modifier
+// returns thread replies exclusively; a silent change in Slack's modifier
+// grammar must fail this test rather than degrade the sweep into noise.
+//
+// Skipped unless both env vars are set (dev workspace only):
+//
+//	MSGVAULT_SLACK_LIVE_TOKEN    user token with search:read
+//	MSGVAULT_SLACK_LIVE_CHANNEL  channel ID containing at least one thread
+//	                             (root + replies) and at least one plain
+//	                             top-level message
+func TestLiveThreadsRepliesModifierPin(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	token := os.Getenv("MSGVAULT_SLACK_LIVE_TOKEN")
+	channel := os.Getenv("MSGVAULT_SLACK_LIVE_CHANNEL")
+	if token == "" || channel == "" {
+		t.Skip("set MSGVAULT_SLACK_LIVE_TOKEN and MSGVAULT_SLACK_LIVE_CHANNEL to run the modifier pin-test")
+	}
+
+	c := NewClient("", token)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	nonce := time.Now().UnixNano()
+
+	// Modifier query: every hit must be a reply (permalink carries thread_ts).
+	modQ := fmt.Sprintf(`threads:replies in:<#%s> -"zqpin%d"`, channel, nonce)
+	mod, err := c.SearchMessagesPage(ctx, modQ, 1)
+	require.NoError(err)
+	require.NotEmpty(mod.Matches, "fixture channel must contain thread replies")
+	for _, m := range mod.Matches {
+		assert.NotEmpty(m.RootTS,
+			"threads:replies returned a non-reply hit (ts %s) — the modifier's replies-only contract is broken", m.TS)
+	}
+
+	// Control query (no modifier): proves the channel also holds non-reply
+	// messages, i.e. the modifier is doing the filtering — without this the
+	// assertion above would pass vacuously on an all-replies channel.
+	ctlQ := fmt.Sprintf(`in:<#%s> -"zqpinctl%d"`, channel, nonce)
+	ctl, err := c.SearchMessagesPage(ctx, ctlQ, 1)
+	require.NoError(err)
+	control := false
+	for _, m := range ctl.Matches {
+		if m.RootTS == "" {
+			control = true
+			break
+		}
+	}
+	assert.True(control,
+		"control query returned only replies — fixture channel needs a plain top-level message for the pin-test to be meaningful")
+}

--- a/internal/slack/sweep_live_test.go
+++ b/internal/slack/sweep_live_test.go
@@ -43,6 +43,8 @@ func TestLiveThreadsRepliesModifierPin(t *testing.T) {
 	require.NoError(err)
 	require.NotEmpty(mod.Matches, "fixture channel must contain thread replies")
 	for _, m := range mod.Matches {
+		assert.Equal(channel, m.ChannelID,
+			"threads:replies returned a match without the scoped channel ID (ts %s)", m.TS)
 		assert.NotEmpty(m.RootTS,
 			"threads:replies returned a non-reply hit (ts %s) — the modifier's replies-only contract is broken", m.TS)
 	}
@@ -55,6 +57,8 @@ func TestLiveThreadsRepliesModifierPin(t *testing.T) {
 	require.NoError(err)
 	control := false
 	for _, m := range ctl.Matches {
+		assert.Equal(channel, m.ChannelID,
+			"control query returned a match without the scoped channel ID (ts %s)", m.TS)
 		if m.RootTS == "" {
 			control = true
 			break

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -1,0 +1,231 @@
+package slack
+
+import (
+	"encoding/json"
+)
+
+// PendingThread is one thread whose replies a window walk still owes: the
+// containing history page was consumed (and the page cursor advanced), but
+// the reply fetch was deferred or clipped by the --limit budget.
+type PendingThread struct {
+	RootTS string `json:"root"`
+	// DrainedTo is the newest reply ts fetched so far ("" = not started):
+	// the drain resumes with oldest=DrainedTo (exclusive), a self-validating
+	// ts bound rather than an opaque page cursor.
+	DrainedTo string `json:"drained_to,omitempty"`
+	// Forecast is the remaining reply_count estimate, charged against the
+	// run budget at recording time and converted to actuals as the drain
+	// fetches replies. Pacing and progress only — never a completeness
+	// signal (counts can be stale).
+	Forecast int `json:"forecast,omitempty"`
+	// Floor is the entry's coverage claim: replies are owed strictly after
+	// it ("" = from the root, the walks' full-drain claim; tail entries
+	// carry their seed). The entry has covered (Floor, DrainedTo] and will
+	// cover (Floor, ∞) when drained. Merges are decided against Floor, not
+	// DrainedTo: a re-discovered hit above the Floor is already owed
+	// (progress stands — rolling DrainedTo back would rewind the drain on
+	// every overlapped sweep and never converge), while a hit at or below
+	// it is genuinely outside the claim and widens the entry.
+	Floor string `json:"floor,omitempty"`
+}
+
+// ConvState tracks one conversation's sync progress.
+//
+// Every fetch of top-level history is a pinned WINDOW WALK — the initial
+// backfill walks ("", pin]; every later (incremental) walk covers
+// (Cursor, pin]. Cursor is therefore a covered-through bound: top-level
+// messages at or before it are persisted and their threads' replies (as of
+// each walk) drained. BackfillLatest pins an in-flight walk's upper bound
+// (arrivals must not shift the pinned newest-first pagination) and
+// BackfillCursor is its resumable page cursor; both clear when the walk
+// completes and Cursor advances to the pin. Done means the initial walk
+// reached the beginning of history.
+type ConvState struct {
+	Cursor         string `json:"cursor,omitempty"`
+	BackfillCursor string `json:"backfill_cursor,omitempty"`
+	BackfillLatest string `json:"backfill_latest,omitempty"`
+	Done           bool   `json:"done,omitempty"`
+	// ThreadsPending marks conversation-level thread debt: any initial
+	// walk under --no-threads (unconditionally — a message can become a
+	// thread root after the walk), or a non-channel conversation
+	// recovering a sweep gap. The thread catch-up walk pays it
+	// and clears the flag when the walk finishes; CatchUpCursor/
+	// CatchUpLatest checkpoint a partially-walked catch-up (the page cursor
+	// to resume from and the pin the walk was started under — page cursors
+	// are only valid against the bound they were minted with), so limited
+	// runs drain the walk across runs instead of restarting it.
+	ThreadsPending bool   `json:"threads_pending,omitempty"`
+	CatchUpCursor  string `json:"catch_up_cursor,omitempty"`
+	CatchUpLatest  string `json:"catch_up_latest,omitempty"`
+	// PendingThreads is the window walks' outstanding thread-drain debt,
+	// bounded by one history page's roots: a walk never fetches a new
+	// page while any entry is outstanding. Drained head-first; an entry
+	// leaves the list only when its thread is fully fetched (or the
+	// thread is gone).
+	PendingThreads []PendingThread `json:"pending_threads,omitempty"`
+	// SweptThrough is this conversation's reply-sweep boundary: the pin of
+	// the last sweep that covered it (replies created at or before
+	// SweptThrough − the lag margin are certainly archived; the margin is
+	// re-covered by the next sweep's overlapped floor, absorbing search
+	// index lag). It normally tracks the workspace SweepWatermark; it lags
+	// when the conversation missed sweeps (excluded, gone, or filtered
+	// while the watermark advanced), which the next sweep repairs with a
+	// channel-scoped gap sweep before stamping it forward.
+	SweptThrough string `json:"swept_through,omitempty"`
+}
+
+// SyncState holds per-conversation cursors plus the reply-sweep watermark
+// for one Slack source, persisted as JSON in sync_runs.cursor_after
+// (checkpointed mid-run in cursor_before). Resume selection is newest-blob-
+// wins — states are never blended field-wise (see loadResumeState). Legacy
+// blobs carrying per-root "threads" maps, incremental window cursors
+// ("incr_cursor"/"incr_max_ts"), or a "generation" marker load cleanly;
+// those fields no longer exist (an upgraded mid-window checkpoint re-walks
+// at most one window into idempotent upserts).
+type SyncState struct {
+	Conversations map[string]*ConvState `json:"conversations"` // key = channel ID
+	// SweepWatermark is the pin of the last completed workspace sweep for
+	// the current target set (each conversation's own boundary is its
+	// SweptThrough). Replies created at or before it minus the lag margin
+	// are certainly archived; the trailing margin is re-covered by the next
+	// sweep's overlapped floor. It advances only behind persisted work.
+	SweepWatermark string `json:"sweep_watermark,omitempty"`
+	// SweepOffset records the user tz_offset (seconds) in effect when the
+	// watermark was written. Audit trail only: sweep-day arithmetic always
+	// uses the IANA zone current at query time (probed live).
+	SweepOffset int `json:"sweep_offset,omitempty"`
+	// RepairPending marks an in-flight --full repair session. While set,
+	// every run — full, plain, or limited — continues the repair through
+	// the ordinary resumable walks; it clears when every eligible
+	// conversation is Done with all thread debt paid. The --full reset it
+	// rides on needs no lineage marker: resume selection is newest-blob-
+	// wins (see loadResumeState), so the reset state simply supersedes.
+	RepairPending bool `json:"repair_pending,omitempty"`
+}
+
+func NewSyncState() *SyncState {
+	return &SyncState{Conversations: map[string]*ConvState{}}
+}
+
+func LoadSyncState(blob string) (*SyncState, error) {
+	s := NewSyncState()
+	if blob == "" {
+		return s, nil
+	}
+	if err := json.Unmarshal([]byte(blob), s); err != nil {
+		return nil, err
+	}
+	if s.Conversations == nil {
+		s.Conversations = map[string]*ConvState{}
+	}
+	// Legacy drain entries predate the Floor field. An in-flight entry
+	// with progress but no floor is normalized to Floor = DrainedTo — the
+	// safe misread in both directions: a legacy TAIL read as full coverage
+	// would silently skip replies below its seed, while a legacy FULL walk
+	// entry read as a tail merely widens down and re-fetches an idempotent
+	// stretch if a hit surfaces beneath its progress.
+	for _, cs := range s.Conversations {
+		for i := range cs.PendingThreads {
+			if cs.PendingThreads[i].Floor == "" && cs.PendingThreads[i].DrainedTo != "" {
+				cs.PendingThreads[i].Floor = cs.PendingThreads[i].DrainedTo
+			}
+		}
+	}
+	return s, nil
+}
+
+func (s *SyncState) Marshal() (string, error) {
+	b, err := json.Marshal(s)
+	return string(b), err
+}
+
+// RecordPendingThread commits a thread to the drain debt as FULL coverage:
+// every reply from the root onward (Floor = ""). An existing entry with the
+// same claim keeps its progress — that progress is contiguous from the root
+// (a page refetched after a failure re-discovers its roots harmlessly). An
+// existing TAIL entry cannot satisfy the claim: its parked DrainedTo proves
+// nothing below its own seed, and keeping it would silently skip every
+// reply under that seed while the caller (a walk or catch-up) certifies
+// the thread covered. Such an entry WIDENS: progress resets to the root
+// and the fresh forecast is taken. The reset re-fetches the tail's stretch
+// into idempotent upserts, at most once — the widened entry answers every
+// later record as full coverage.
+func (cs *ConvState) RecordPendingThread(rootTS string, forecast int) {
+	for i := range cs.PendingThreads {
+		if cs.PendingThreads[i].RootTS == rootTS {
+			if cs.PendingThreads[i].Floor != "" {
+				cs.PendingThreads[i].Floor = ""
+				cs.PendingThreads[i].DrainedTo = ""
+				cs.PendingThreads[i].Forecast = forecast
+			}
+			return
+		}
+	}
+	cs.PendingThreads = append(cs.PendingThreads, PendingThread{RootTS: rootTS, Forecast: forecast})
+}
+
+// RecordPendingThreadTail records a thread whose replies are owed from
+// drainedTo (exclusive) onward — the reply sweep's shape: anchorTS is any
+// in-thread ts (conversations.replies resolves it) and drainedTo sits just
+// before the earliest discovered hit. The merge with an existing entry is
+// decided against the entry's coverage Floor, NOT its progress:
+//   - seed at/above the Floor: the hit is already inside the entry's claim
+//     (fetched, or ahead of the resume point) — the entry stands. Sweep
+//     floors overlap, so live runs re-discover the SAME hits every pass;
+//     re-seeding progress from them would rewind the drain each run and a
+//     long tail would never converge.
+//   - seed below the Floor: a late-indexed reply surfaced beneath the
+//     claim; the day's certification is already advancing past it, so this
+//     merge is its last chance — the entry widens down (Floor and resume
+//     point drop to the seed). The re-fetch of the already-drained stretch
+//     above is an idempotent upsert.
+func (cs *ConvState) RecordPendingThreadTail(anchorTS, drainedTo string) {
+	for i := range cs.PendingThreads {
+		if cs.PendingThreads[i].RootTS == anchorTS {
+			if cs.PendingThreads[i].Floor != "" && tsLess(drainedTo, cs.PendingThreads[i].Floor) {
+				cs.PendingThreads[i].Floor = drainedTo
+				cs.PendingThreads[i].DrainedTo = drainedTo
+			}
+			return
+		}
+	}
+	cs.PendingThreads = append(cs.PendingThreads, PendingThread{RootTS: anchorTS, DrainedTo: drainedTo, Floor: drainedTo})
+}
+
+// PendingForecast sums the remaining reply forecasts of the outstanding
+// drain debt: the budget charge for work committed but not yet performed.
+func (cs *ConvState) PendingForecast() int {
+	n := 0
+	for i := range cs.PendingThreads {
+		n += cs.PendingThreads[i].Forecast
+	}
+	return n
+}
+
+// EnsureConv returns the (created-if-missing) state for channelID.
+func (s *SyncState) EnsureConv(channelID string) *ConvState {
+	cs, ok := s.Conversations[channelID]
+	if !ok {
+		cs = &ConvState{}
+		s.Conversations[channelID] = cs
+	}
+	return cs
+}
+
+// RepairComplete reports whether an in-flight repair session has finished:
+// every ELIGIBLE conversation's initial walk is done and all its thread
+// debt is paid. Completion is a question about the currently eligible set
+// (the conversations this run enumerated), not the historical one: state is
+// deliberately retained for departed/excluded conversations (it powers gap
+// recovery and re-entry resume), and a conversation the repair can no
+// longer reach must not wedge the session open forever — its generation-
+// reset Done flag already guarantees a fresh walk if it ever re-enters.
+func (s *SyncState) RepairComplete(eligible map[string]bool) bool {
+	for cid := range eligible {
+		cs, ok := s.Conversations[cid]
+		if !ok || !cs.Done || cs.ThreadsPending || len(cs.PendingThreads) > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -48,15 +48,22 @@ type ConvState struct {
 	// ThreadsPending marks conversation-level thread debt: any initial
 	// walk under --no-threads (unconditionally — a message can become a
 	// thread root after the walk), or a non-channel conversation
-	// recovering a sweep gap. The thread catch-up walk pays it
-	// and clears the flag when the walk finishes; CatchUpCursor/
-	// CatchUpLatest checkpoint a partially-walked catch-up (the page cursor
-	// to resume from and the pin the walk was started under — page cursors
-	// are only valid against the bound they were minted with), so limited
-	// runs drain the walk across runs instead of restarting it.
+	// recovering a sweep gap, or an unreachable truncated search interval.
+	// The thread catch-up walk pays it and clears the flag when the required
+	// coverage is reached; CatchUpCursor/CatchUpLatest checkpoint a
+	// partially-walked catch-up (the page cursor to resume from and the pin
+	// the walk was started under — page cursors are only valid against the
+	// bound they were minted with), so limited runs drain the walk across
+	// runs instead of restarting it.
 	ThreadsPending bool   `json:"threads_pending,omitempty"`
 	CatchUpCursor  string `json:"catch_up_cursor,omitempty"`
 	CatchUpLatest  string `json:"catch_up_latest,omitempty"`
+	// TruncatedSweepThrough is the exclusive day boundary through which a
+	// truncated search interval has been converted into this conversation's
+	// canonical catch-up debt. It remains as the durable scope/day marker
+	// after payment; ThreadsPending stays set until a completed catch-up walk
+	// was pinned at or beyond this boundary.
+	TruncatedSweepThrough string `json:"truncated_sweep_through,omitempty"`
 	// PendingThreads is the window walks' outstanding thread-drain debt,
 	// bounded by one history page's roots: a walk never fetches a new
 	// page while any entry is outstanding. Drained head-first; an entry
@@ -217,6 +224,12 @@ func (s *SyncState) EnsureConv(channelID string) *ConvState {
 		s.Conversations[channelID] = cs
 	}
 	return cs
+}
+
+func (cs *ConvState) recordTruncatedSweep(boundary string) {
+	if cs.TruncatedSweepThrough == "" || tsLess(cs.TruncatedSweepThrough, boundary) {
+		cs.TruncatedSweepThrough = boundary
+	}
 }
 
 // RepairComplete reports whether an in-flight repair session has finished:

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -135,7 +135,7 @@ func LoadSyncState(blob string) (*SyncState, error) {
 	}
 	for channelID, cs := range s.Conversations {
 		if cs == nil {
-			return nil, fmt.Errorf("Slack sync state conversation %q is null", channelID)
+			return nil, fmt.Errorf("slack sync state conversation %q is null", channelID)
 		}
 	}
 	// Legacy drain entries predate the Floor field. An in-flight entry

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // PendingThread is one thread whose replies a window walk still owes: the
@@ -131,6 +132,11 @@ func LoadSyncState(blob string) (*SyncState, error) {
 	}
 	if s.Conversations == nil {
 		s.Conversations = map[string]*ConvState{}
+	}
+	for channelID, cs := range s.Conversations {
+		if cs == nil {
+			return nil, fmt.Errorf("Slack sync state conversation %q is null", channelID)
+		}
 	}
 	// Legacy drain entries predate the Floor field. An in-flight entry
 	// with progress but no floor is normalized to Floor = DrainedTo — the

--- a/internal/slack/syncstate.go
+++ b/internal/slack/syncstate.go
@@ -64,14 +64,21 @@ type ConvState struct {
 	// thread is gone).
 	PendingThreads []PendingThread `json:"pending_threads,omitempty"`
 	// SweptThrough is this conversation's reply-sweep boundary: the pin of
-	// the last sweep that covered it (replies created at or before
-	// SweptThrough − the lag margin are certainly archived; the margin is
-	// re-covered by the next sweep's overlapped floor, absorbing search
-	// index lag). It normally tracks the workspace SweepWatermark; it lags
+	// the last search sweep that covered it. The next sweep overlaps the
+	// boundary to absorb ordinary search-index lag; periodic canonical
+	// audits cover replies that search never indexes. It normally tracks
+	// the workspace SweepWatermark; it lags
 	// when the conversation missed sweeps (excluded, gone, or filtered
 	// while the watermark advanced), which the next sweep repairs with a
 	// channel-scoped gap sweep before stamping it forward.
 	SweptThrough string `json:"swept_through,omitempty"`
+	// AuditedThrough is the pin of the last canonical history/thread walk.
+	// Search has no published maximum indexing lag, so one conversation at
+	// a time is periodically re-walked as a completeness backstop.
+	AuditedThrough string `json:"audited_through,omitempty"`
+	// AuditPending distinguishes a periodic canonical audit from other
+	// ThreadsPending causes so completion can advance AuditedThrough.
+	AuditPending bool `json:"audit_pending,omitempty"`
 }
 
 // SyncState holds per-conversation cursors plus the reply-sweep watermark
@@ -86,9 +93,9 @@ type SyncState struct {
 	Conversations map[string]*ConvState `json:"conversations"` // key = channel ID
 	// SweepWatermark is the pin of the last completed workspace sweep for
 	// the current target set (each conversation's own boundary is its
-	// SweptThrough). Replies created at or before it minus the lag margin
-	// are certainly archived; the trailing margin is re-covered by the next
-	// sweep's overlapped floor. It advances only behind persisted work.
+	// SweptThrough). The trailing margin is re-covered by the next sweep,
+	// while canonical audits independently provide eventual completeness.
+	// It advances only behind persisted search-discovery work.
 	SweepWatermark string `json:"sweep_watermark,omitempty"`
 	// SweepOffset records the user tz_offset (seconds) in effect when the
 	// watermark was written. Audit trail only: sweep-day arithmetic always

--- a/internal/slack/syncstate_test.go
+++ b/internal/slack/syncstate_test.go
@@ -1,0 +1,42 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncStateRoundTrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	s := NewSyncState()
+	cs := s.EnsureConv("C01")
+	cs.Cursor = "100.000001"
+	cs.Done = true
+	s.SweepWatermark = "150.000001"
+	s.SweepOffset = 7200
+
+	blob, err := s.Marshal()
+	require.NoError(err)
+	loaded, err := LoadSyncState(blob)
+	require.NoError(err)
+	lcs := loaded.EnsureConv("C01")
+	assert.Equal("100.000001", lcs.Cursor)
+	assert.True(lcs.Done)
+	assert.Equal("150.000001", loaded.SweepWatermark)
+	assert.Equal(7200, loaded.SweepOffset)
+}
+
+func TestSyncStateLegacyThreadsBlobLoads(t *testing.T) {
+	assert := assert.New(t)
+	// Checkpoints written by the superseded thread-tracking design carry a
+	// per-conversation "threads" map; they must load cleanly (the key is
+	// simply ignored) so an upgrade never breaks resume.
+	blob := `{"conversations":{"C01":{"cursor":"100.000001","done":true,"threads":{"50.000001":"60.000001"}}}}`
+	loaded, err := LoadSyncState(blob)
+	require.NoError(t, err)
+	assert.Equal("100.000001", loaded.EnsureConv("C01").Cursor)
+	assert.True(loaded.EnsureConv("C01").Done)
+	assert.Empty(loaded.SweepWatermark, "legacy blobs start the sweep from the first-sweep floor")
+}

--- a/internal/slack/syncstate_test.go
+++ b/internal/slack/syncstate_test.go
@@ -42,12 +42,14 @@ func TestSyncStateLegacyThreadsBlobLoads(t *testing.T) {
 }
 
 func TestLoadSyncStateRejectsNullConversation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	var state *SyncState
 	var err error
-	require.NotPanics(t, func() {
+	require.NotPanics(func() {
 		state, err = LoadSyncState(`{"conversations":{"C01":null}}`)
 	})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, `conversation "C01" is null`)
-	assert.Nil(t, state)
+	require.Error(err)
+	require.ErrorContains(err, `conversation "C01" is null`)
+	assert.Nil(state)
 }

--- a/internal/slack/syncstate_test.go
+++ b/internal/slack/syncstate_test.go
@@ -40,3 +40,14 @@ func TestSyncStateLegacyThreadsBlobLoads(t *testing.T) {
 	assert.True(loaded.EnsureConv("C01").Done)
 	assert.Empty(loaded.SweepWatermark, "legacy blobs start the sweep from the first-sweep floor")
 }
+
+func TestLoadSyncStateRejectsNullConversation(t *testing.T) {
+	var state *SyncState
+	var err error
+	require.NotPanics(t, func() {
+		state, err = LoadSyncState(`{"conversations":{"C01":null}}`)
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `conversation "C01" is null`)
+	assert.Nil(t, state)
+}

--- a/internal/slack/token.go
+++ b/internal/slack/token.go
@@ -1,0 +1,96 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/msgvault/internal/fileutil"
+)
+
+// tokenFile stores one workspace user's token plus the identity it resolved
+// to at add-slack time. Tokens are per-workspace-user, matching the source
+// identifier: two users of the same workspace on one machine must not share
+// (or clobber) each other's token.
+type tokenFile struct {
+	AccessToken string `json:"access_token"`
+	TeamID      string `json:"team_id"`
+	TeamDomain  string `json:"team_domain"`
+	UserID      string `json:"user_id"`
+}
+
+// tokenPath returns the token file path for a workspace user.
+func tokenPath(tokensDir, teamID, userID string) string {
+	return filepath.Join(tokensDir, "slack_"+teamID+"_"+userID+".json")
+}
+
+// SaveToken saves a workspace's user token atomically (temp file + rename)
+// with fileutil.Secure* hardening.
+func SaveToken(tokensDir, teamID, teamDomain, userID, token string) error {
+	if err := fileutil.SecureMkdirAll(tokensDir, 0700); err != nil {
+		return fmt.Errorf("create tokens dir: %w", err)
+	}
+	data, err := json.Marshal(tokenFile{ //nolint:gosec // serialized to a 0600 file on the user's own machine
+		AccessToken: token, TeamID: teamID, TeamDomain: teamDomain, UserID: userID,
+	})
+	if err != nil {
+		return err
+	}
+	path := tokenPath(tokensDir, teamID, userID)
+
+	tmpFile, err := os.CreateTemp(tokensDir, ".slack-token-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp token file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp token file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp token file: %w", err)
+	}
+	if err := fileutil.SecureChmod(tmpPath, 0600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp token file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename temp token file: %w", err)
+	}
+	return nil
+}
+
+// LoadToken loads a workspace user's stored token, validating that the file
+// belongs to the requested identity.
+func LoadToken(tokensDir, teamID, userID string) (string, error) {
+	data, err := os.ReadFile(tokenPath(tokensDir, teamID, userID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("no Slack token for %s in workspace %s (run 'add-slack' first)", userID, teamID)
+		}
+		return "", fmt.Errorf("read slack token: %w", err)
+	}
+	var tf tokenFile
+	if err := json.Unmarshal(data, &tf); err != nil {
+		return "", fmt.Errorf("parse slack token: %w", err)
+	}
+	if (tf.TeamID != "" && tf.TeamID != teamID) || (tf.UserID != "" && tf.UserID != userID) {
+		return "", fmt.Errorf("slack token file for %s/%s holds identity %s/%s — re-run 'add-slack'",
+			teamID, userID, tf.TeamID, tf.UserID)
+	}
+	return tf.AccessToken, nil
+}
+
+// DeleteToken removes a workspace user's token file. Missing file is not an error.
+func DeleteToken(tokensDir, teamID, userID string) error {
+	err := os.Remove(tokenPath(tokensDir, teamID, userID))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/slack/token_test.go
+++ b/internal/slack/token_test.go
@@ -1,0 +1,51 @@
+package slack
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two users of the same workspace must hold independent tokens: a shared
+// per-team file would be clobbered by the second add-slack, syncing one
+// user's source with the other's token and deleting the survivor's token on
+// remove-account.
+func TestTokensAreIsolatedPerWorkspaceUser(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	require.NoError(SaveToken(dir, "T01", "testers", "UME", "xoxp-me"))
+	require.NoError(SaveToken(dir, "T01", "testers", "UOTHER", "xoxp-other"))
+
+	mine, err := LoadToken(dir, "T01", "UME")
+	require.NoError(err)
+	other, err := LoadToken(dir, "T01", "UOTHER")
+	require.NoError(err)
+	assert.Equal("xoxp-me", mine)
+	assert.Equal("xoxp-other", other)
+
+	require.NoError(DeleteToken(dir, "T01", "UOTHER"))
+	mine, err = LoadToken(dir, "T01", "UME")
+	require.NoError(err, "removing one user's token must not touch the other's")
+	assert.Equal("xoxp-me", mine)
+	_, err = LoadToken(dir, "T01", "UOTHER")
+	require.ErrorContains(err, "run 'add-slack' first")
+}
+
+func TestLoadTokenRejectsIdentityMismatch(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	require.NoError(SaveToken(dir, "T01", "testers", "UME", "xoxp-me"))
+
+	// A token file renamed or copied across identities must not be served.
+	src := tokenPath(dir, "T01", "UME")
+	dst := tokenPath(dir, "T01", "UIMPOSTOR")
+	data, err := os.ReadFile(src)
+	require.NoError(err)
+	require.NoError(os.WriteFile(dst, data, 0o600))
+
+	_, err = LoadToken(dir, "T01", "UIMPOSTOR")
+	require.ErrorContains(err, "holds identity")
+}

--- a/internal/slack/types.go
+++ b/internal/slack/types.go
@@ -1,0 +1,320 @@
+package slack
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// apiResponse is the envelope every Slack Web API method returns.
+type apiResponse struct {
+	OK       bool   `json:"ok"`
+	Error    string `json:"error"`
+	Needed   string `json:"needed"`   // set on missing_scope errors
+	Provided string `json:"provided"` // set on missing_scope errors
+	Metadata struct {
+		NextCursor string `json:"next_cursor"`
+	} `json:"response_metadata"`
+}
+
+// AuthTestResult identifies the token's workspace and user.
+type AuthTestResult struct {
+	URL    string `json:"url"`
+	Team   string `json:"team"`
+	User   string `json:"user"`
+	TeamID string `json:"team_id"`
+	UserID string `json:"user_id"`
+}
+
+// Conversation is one channel/group DM/DM from conversations.list or
+// users.conversations.
+type Conversation struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IsChannel  bool   `json:"is_channel"`
+	IsGroup    bool   `json:"is_group"`
+	IsIM       bool   `json:"is_im"`
+	IsMpim     bool   `json:"is_mpim"`
+	IsPrivate  bool   `json:"is_private"`
+	IsArchived bool   `json:"is_archived"`
+	IsMember   bool   `json:"is_member"`
+	User       string `json:"user"` // IM peer user ID (im only)
+	NumMembers int    `json:"num_members"`
+}
+
+// User is one workspace member from users.list.
+type User struct {
+	ID      string `json:"id"`
+	TeamID  string `json:"team_id"`
+	Name    string `json:"name"` // legacy handle
+	Deleted bool   `json:"deleted"`
+	IsBot   bool   `json:"is_bot"`
+	// TZ (IANA name) and TZOffset (current seconds from UTC) drive
+	// sweep-day arithmetic: search date modifiers evaluate in the user's
+	// IANA zone WITH historical DST rules (probed live against a corpus
+	// spanning DST transitions), so the zone is authoritative and the
+	// offset is the fallback for unloadable zone names.
+	TZ       string `json:"tz"`
+	TZOffset int    `json:"tz_offset"`
+	Profile  UserProfile
+	RealName string `json:"real_name"`
+}
+
+// UserProfile carries the displayable identity fields of a User.
+type UserProfile struct {
+	Email       string `json:"email"` // requires users:read.email; empty otherwise
+	RealName    string `json:"real_name"`
+	DisplayName string `json:"display_name"`
+	BotID       string `json:"bot_id"`
+}
+
+// UnmarshalJSON flattens the nested profile object into User.
+func (u *User) UnmarshalJSON(b []byte) error {
+	type alias User // avoid recursion into this method
+	var a struct {
+		alias
+
+		Profile UserProfile `json:"profile"`
+	}
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*u = User(a.alias)
+	u.Profile = a.Profile
+	return nil
+}
+
+// DisplayName returns the best human-readable name for the user.
+func (u *User) DisplayName() string {
+	for _, s := range []string{u.Profile.DisplayName, u.Profile.RealName, u.RealName, u.Name} {
+		if s != "" {
+			return s
+		}
+	}
+	return u.ID
+}
+
+// Reaction is one emoji reaction aggregate on a message.
+type Reaction struct {
+	Name  string   `json:"name"`  // emoji name, e.g. "thumbsup"
+	Users []string `json:"users"` // reacting user IDs (may be truncated by the API)
+	Count int      `json:"count"`
+}
+
+// File is a file shared into a conversation. URLPrivate is only fetched when
+// its host is files.slack.com (see media.go); everything else is recorded as
+// metadata.
+type File struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Mimetype           string `json:"mimetype"`
+	Size               int64  `json:"size"`
+	URLPrivate         string `json:"url_private"`
+	URLPrivateDownload string `json:"url_private_download"`
+	Permalink          string `json:"permalink"`
+	Mode               string `json:"mode"` // "tombstone" when deleted, "external", …
+	IsExternal         bool   `json:"is_external"`
+}
+
+// Edited marks a message as edited.
+type Edited struct {
+	User string `json:"user"`
+	TS   string `json:"ts"`
+}
+
+// LegacyAttachment is Slack's pre-Block-Kit rich payload ("secondary
+// attachment"). Bots and integrations often carry their entire content here
+// with an empty message text; user messages get them as link unfurls.
+type LegacyAttachment struct {
+	Fallback string `json:"fallback"` // required plain-text summary
+	Pretext  string `json:"pretext"`
+	Title    string `json:"title"`
+	Text     string `json:"text"`
+	Fields   []struct {
+		Title string `json:"title"`
+		Value string `json:"value"`
+	} `json:"fields"`
+	Footer string `json:"footer"`
+}
+
+// Block is a Block Kit layout block, modelled only deeply enough to extract
+// searchable text: section/header text, section fields, and context
+// elements. rich_text blocks are deliberately not extracted — they duplicate
+// the message's own text field.
+type Block struct {
+	Type     string         `json:"type"`
+	Text     *BlockText     `json:"text"`
+	Fields   []BlockText    `json:"fields"`
+	Elements []BlockElement `json:"elements"`
+}
+
+// BlockText is a Block Kit text object (plain_text or mrkdwn).
+type BlockText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// BlockElement is one entry of a block's elements array. Its text field is
+// shape-shifting across block kinds (observed live): a plain string on
+// context mrkdwn/plain_text elements, a nested text object on actions-block
+// buttons, and absent on rich_text/image elements. All shapes must decode —
+// a strict model here made conversations.history undecodable.
+type BlockElement struct {
+	Type string
+	Text string
+}
+
+// UnmarshalJSON decodes a BlockElement tolerantly (see type comment).
+func (e *BlockElement) UnmarshalJSON(b []byte) error {
+	var probe struct {
+		Type string          `json:"type"`
+		Text json.RawMessage `json:"text"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		return err
+	}
+	e.Type = probe.Type
+	if len(probe.Text) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(probe.Text, &s) == nil {
+		e.Text = s
+		return nil
+	}
+	var bt BlockText
+	if json.Unmarshal(probe.Text, &bt) == nil {
+		e.Text = bt.Text
+	}
+	return nil
+}
+
+// Message is one message from conversations.history / conversations.replies.
+type Message struct {
+	Type        string     `json:"type"`    // "message"
+	Subtype     string     `json:"subtype"` // "", "bot_message", "channel_join", "thread_broadcast", …
+	TS          string     `json:"ts"`      // message identity within its channel
+	ThreadTS    string     `json:"thread_ts"`
+	User        string     `json:"user"`
+	BotID       string     `json:"bot_id"`
+	Username    string     `json:"username"` // bot display name
+	Text        string     `json:"text"`
+	Edited      *Edited    `json:"edited"`
+	ReplyCount  int        `json:"reply_count"`
+	LatestReply string     `json:"latest_reply"`
+	Reactions   []Reaction `json:"reactions"`
+	Files       []File     `json:"files"`
+	// Attachments are legacy rich payloads; Blocks are Block Kit layout
+	// blocks. Both feed FTS via payloadText (see mapping.go).
+	Attachments []LegacyAttachment `json:"attachments"`
+	Blocks      []Block            `json:"blocks"`
+	// Raw holds the exact original JSON for this message, captured during
+	// decode (see UnmarshalJSON) and archived verbatim so no API field is
+	// lost to our partial struct modelling.
+	Raw json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON decodes a Message while retaining the original bytes in Raw.
+func (m *Message) UnmarshalJSON(b []byte) error {
+	type alias Message // avoid recursion into this method
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*m = Message(a)
+	m.Raw = json.RawMessage(strings.Clone(string(b)))
+	return nil
+}
+
+// IsThreadRoot reports whether m is the root of a thread with replies.
+func (m *Message) IsThreadRoot() bool {
+	return m.ThreadTS != "" && m.ThreadTS == m.TS && m.ReplyCount > 0
+}
+
+// IsThreadReply reports whether m is a reply inside a thread (not the root).
+// Broadcast replies ("thread_broadcast") also satisfy this.
+func (m *Message) IsThreadReply() bool {
+	return m.ThreadTS != "" && m.ThreadTS != m.TS
+}
+
+// Time converts a Slack ts string ("1734567890.123456") to UTC time.
+// The zero time is returned for unparseable input.
+func tsTime(ts string) time.Time {
+	if ts == "" {
+		return time.Time{}
+	}
+	sec, frac, _ := strings.Cut(ts, ".")
+	s, err := strconv.ParseInt(sec, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	var ns int64
+	if frac != "" {
+		// Fractional part is microseconds, zero-padded to 6 digits.
+		padded := (frac + "000000")[:6]
+		if us, perr := strconv.ParseInt(padded, 10, 64); perr == nil {
+			ns = us * int64(time.Microsecond)
+		}
+	}
+	return time.Unix(s, ns).UTC()
+}
+
+// tsLess compares two Slack ts strings numerically (seconds, then fraction).
+// String comparison is not safe: second counts can differ in digit length.
+func tsLess(a, b string) bool {
+	at, bt := tsTime(a), tsTime(b)
+	if at.Equal(bt) {
+		return a < b // fall back to lexical for stability
+	}
+	return at.Before(bt)
+}
+
+// ImportOptions configures one Import run.
+type ImportOptions struct {
+	// TeamID is the workspace to sync; with UserID it forms the msgvault
+	// source identifier ("<team_id>:<user_id>").
+	TeamID string
+	// UserID is the archiving user (from auth.test at add-slack time).
+	UserID string
+	// Limit caps messages processed per conversation this run (0 = no
+	// limit). A limited backfill leaves the conversation resumable.
+	Limit int
+	// Full ignores stored cursors: every conversation is re-walked and every
+	// message re-upserted in place (repair path).
+	Full bool
+	// NoThreads skips the reply sweep (and backfill's inline thread
+	// fetching) for scoped first runs.
+	NoThreads bool
+	// Maintenance runs the explicit edits/reactions rescan. Archives ignore
+	// post-capture mutations by default.
+	Maintenance bool
+	// AttachmentsDir is the content-addressed attachment store root. Empty
+	// disables media download (as does NoMedia).
+	AttachmentsDir string
+	// NoMedia skips file downloads entirely.
+	NoMedia bool
+	// MaxMediaBytes caps individual file downloads (0 = 100 MB).
+	MaxMediaBytes int64
+	// IncludeChannels/ExcludeChannels filter by channel name (no "#").
+	// Include empty = all memberships. DMs/group DMs are never filtered.
+	IncludeChannels []string
+	ExcludeChannels []string
+	// Progress, if non-nil, is called after each conversation with a
+	// human-readable status line.
+	Progress func(msg string) `json:"-"`
+}
+
+// ImportSummary reports the outcome of one Import run.
+type ImportSummary struct {
+	SourceID               int64
+	ConversationsProcessed int
+	MessagesProcessed      int
+	MessagesAdded          int
+	RepliesFetched         int
+	AttachmentsDownloaded  int
+	AttachmentsPending     int
+	FetchErrors            int
+	Errors                 int
+	Duration               time.Duration
+}

--- a/internal/slack/types.go
+++ b/internal/slack/types.go
@@ -311,10 +311,12 @@ type ImportSummary struct {
 	ConversationsProcessed int
 	MessagesProcessed      int
 	MessagesAdded          int
+	MessagesUpdated        int
 	RepliesFetched         int
 	AttachmentsDownloaded  int
 	AttachmentsPending     int
 	FetchErrors            int
 	Errors                 int
 	Duration               time.Duration
+	processedMessageIDs    map[string]struct{}
 }

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -290,7 +290,14 @@ func (s *Store) GetMessageContext(ctx context.Context, id int64) (*APIMessage, e
 		if strings.HasPrefix(storagePath, "http://") || strings.HasPrefix(storagePath, "https://") {
 			att.ContentHash = ""
 			att.URL = storagePath
-		} else if att.ContentHash == "" && strings.HasPrefix(sourceAttachmentID, "discord:") {
+		} else if att.ContentHash == "" &&
+			(strings.HasPrefix(sourceAttachmentID, "discord:") || strings.HasPrefix(sourceAttachmentID, "slack:")) {
+			// A hashless Discord/Slack row whose storage path validates as
+			// a trusted CAS path is a duplicate-content alias; re-derive
+			// its hash so the attachment stays accessible. The provider
+			// gate is load-bearing: a Beeper hashless local path means
+			// pending/untrusted and must stay hashless (see
+			// TestBeeperHashlessLocalPathRemainsPending).
 			if pathHash, ok := casPathHash(storagePath); ok {
 				att.ContentHash = pathHash
 			}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -69,6 +69,7 @@ func (s *Store) listPendingAttachmentMessages(sourceID int64, providerPrefix str
 		    WHERE a.message_id = m.id
 		      AND a.source_attachment_id LIKE ?
 		      AND (a.content_hash IS NULL OR a.content_hash = '')
+		      AND COALESCE(a.media_type, '') <> 'link'
 		  )
 	`, sourceID, providerPrefix+"%")
 	if err != nil {
@@ -132,6 +133,15 @@ func normalizeDiscordAttachmentRefs(refs []AttachmentRef) []AttachmentRef {
 // URLs, provider sentinels, malformed paths, and hash/path mismatches are not
 // considered downloaded.
 func IsDiscordAttachmentDownloaded(ref AttachmentRef) bool {
+	return casAttachmentDownloaded(ref)
+}
+
+// casAttachmentDownloaded reports whether a provider attachment row
+// references a trusted local SHA-256 CAS path (shared by the Discord and
+// Slack media paths). A duplicate-content alias may omit its hash; URLs,
+// provider sentinels, malformed paths, and hash/path mismatches are not
+// considered downloaded.
+func casAttachmentDownloaded(ref AttachmentRef) bool {
 	pathHash, ok := casPathHash(ref.StoragePath)
 	if !ok {
 		return false

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -287,6 +287,37 @@ func TestBeeperHashlessLocalPathRemainsPending(t *testing.T) {
 	assert.Empty(message.Attachments[0].ContentHash)
 }
 
+func TestSlackAliasRowsServeHashesThroughMessageAPI(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("slack", "T01:UME")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(source.ID, "C01", "channel", "general")
+	require.NoError(err)
+	messageID := insertStoreTestMessage(t, st, source.ID, conversationID, "C01:1.000100")
+
+	// Two Slack files sharing one CAS blob: normalization keeps the hash on
+	// the first row and writes the duplicate as a hashless alias.
+	contentHash := strings.Repeat("ab", 32)
+	casPath := contentHash[:2] + "/" + contentHash
+	require.NoError(st.ReplaceMessageSlackAttachments(messageID, []store.AttachmentRef{
+		{Filename: "a.png", StoragePath: casPath, ContentHash: contentHash, SourceAttachmentID: "slack:F1", MediaType: "image"},
+		{Filename: "copy.png", StoragePath: casPath, ContentHash: contentHash, SourceAttachmentID: "slack:F2", MediaType: "image"},
+	}))
+
+	// The message-detail API must serve BOTH attachments as accessible:
+	// the alias row's hash re-derives from its trusted CAS path.
+	message, err := st.GetMessage(messageID)
+	require.NoError(err)
+	require.Len(message.Attachments, 2)
+	for _, att := range message.Attachments {
+		assert.Equal(contentHash, att.ContentHash,
+			"a Slack duplicate-content alias must stay accessible through the API (%s)", att.Filename)
+		assert.Empty(att.URL)
+	}
+}
+
 func TestReplaceAndListMessageDiscordAttachments(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2963,6 +2963,147 @@ func (s *Store) ListBeeperPendingAttachmentMessages(sourceID int64) ([]BeeperPen
 	return s.listPendingAttachmentMessages(sourceID, "beeper:")
 }
 
+// ListSlackRecentReplyThreadRoots returns the source_message_ids of thread
+// roots in one conversation that have an archived REPLY sent at or after
+// since. The archive is the index Slack does not provide: the maintenance
+// rescan repairs recent messages by MESSAGE age, and a recent reply can
+// hang under a root far older than any history window — selecting threads
+// through the root's age alone leaves such replies unrepairable.
+func (s *Store) ListSlackRecentReplyThreadRoots(sourceID, conversationID int64, since time.Time) ([]string, error) {
+	rows, err := s.db.Query(`
+		SELECT p.source_message_id
+		FROM messages p
+		WHERE p.source_id = ?
+		  AND p.conversation_id = ?
+		  AND EXISTS (
+		      SELECT 1 FROM messages c
+		      WHERE c.reply_to_message_id = p.id AND c.sent_at >= ?
+		  )
+		ORDER BY p.source_message_id
+	`, sourceID, conversationID, since)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var roots []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		roots = append(roots, id)
+	}
+	return roots, rows.Err()
+}
+
+// ListSlackPendingAttachmentMessages returns the messages of a slack source
+// that still have pending attachment markers. Metadata-only link rows
+// (media_type "link") are deliberate non-downloads, and hashless
+// duplicate-content alias rows resolving to a trusted local CAS path are
+// downloaded (see normalizeSlackAttachmentRefs) — neither is pending work.
+func (s *Store) ListSlackPendingAttachmentMessages(sourceID int64) ([]PendingAttachmentMessage, error) {
+	rows, err := s.db.Query(`
+		SELECT m.id, m.source_message_id, c.source_conversation_id,
+		       a.storage_path, COALESCE(a.content_hash, ''), COALESCE(a.media_type, '')
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		JOIN attachments a ON a.message_id = m.id
+		WHERE m.source_id = ?
+		  AND a.source_attachment_id LIKE ?
+		ORDER BY m.id, a.id
+	`, sourceID, "slack:%")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var pending []PendingAttachmentMessage
+	var current PendingAttachmentMessage
+	var haveCurrent, currentPending bool
+	flushCurrent := func() {
+		if haveCurrent && currentPending {
+			pending = append(pending, current)
+		}
+	}
+	for rows.Next() {
+		var item PendingAttachmentMessage
+		var ref AttachmentRef
+		if err := rows.Scan(
+			&item.MessageID, &item.SourceMessageID, &item.ChatID,
+			&ref.StoragePath, &ref.ContentHash, &ref.MediaType,
+		); err != nil {
+			return nil, err
+		}
+		if !haveCurrent || item.MessageID != current.MessageID {
+			flushCurrent()
+			current = item
+			haveCurrent = true
+			currentPending = false
+		}
+		if ref.MediaType != "link" && ref.ContentHash == "" && !casAttachmentDownloaded(ref) {
+			currentPending = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	flushCurrent()
+	return pending, nil
+}
+
+// ReplaceMessageSlackAttachments replaces Slack-managed attachment rows for
+// a message (rows whose source_attachment_id carries the "slack:" prefix).
+// Duplicate-content refs are normalized into alias rows first (see
+// normalizeSlackAttachmentRefs) so every Slack file ID keeps a row.
+func (s *Store) ReplaceMessageSlackAttachments(messageID int64, refs []AttachmentRef) error {
+	refs = normalizeSlackAttachmentRefs(refs)
+	return s.replaceMessageProviderAttachments(messageID, "slack:", refs)
+}
+
+// normalizeSlackAttachmentRefs preserves one row per Slack file ID when
+// several files on a message share one CAS blob. The schema's
+// (message_id, content_hash) uniqueness keeps the real hash on the first
+// row; later duplicates retain the same trusted local path with an empty
+// hash (the Discord alias pattern). Pending markers and link rows carry
+// permalink URLs, never CAS paths, so they pass through untouched.
+func normalizeSlackAttachmentRefs(refs []AttachmentRef) []AttachmentRef {
+	normalized := append([]AttachmentRef(nil), refs...)
+	seen := make(map[string]struct{}, len(normalized))
+	for i := range normalized {
+		contentHash := strings.ToLower(normalized[i].ContentHash)
+		if contentHash == "" {
+			continue
+		}
+		if _, ok := seen[contentHash]; ok {
+			normalized[i].ContentHash = ""
+			continue
+		}
+		seen[contentHash] = struct{}{}
+	}
+	return normalized
+}
+
+// MessageSlackAttachments returns the message's existing Slack-managed
+// attachment rows keyed by source_attachment_id, so re-persisting a message
+// can keep already-downloaded media without re-fetching it. Alias rows get
+// their hash re-derived from the CAS path, so callers see them as
+// downloaded.
+func (s *Store) MessageSlackAttachments(messageID int64) (map[string]AttachmentRef, error) {
+	refs, err := s.messageProviderAttachments(messageID, "slack:")
+	if err != nil {
+		return nil, err
+	}
+	for sourceAttachmentID, ref := range refs {
+		if ref.ContentHash == "" {
+			if pathHash, ok := casPathHash(ref.StoragePath); ok {
+				ref.ContentHash = pathHash
+				refs[sourceAttachmentID] = ref
+			}
+		}
+	}
+	return refs, nil
+}
+
 // ReplaceMessageLinkAttachments replaces URL-backed attachment rows for a message.
 // It intentionally leaves content-addressed local attachment paths (for example
 // downloaded inline media) untouched.


### PR DESCRIPTION
Archive your own view of a Slack workspace — public/private channels you're a member of, group DMs, and 1:1 DMs — via the Web API, searchable alongside mail and other chat sources through the existing TUI / FTS / Parquet analytics.

Supersedes #489. Since that PR opened, live probing established that Slack's search API reliably returns thread replies by creation time (`threads:replies`, day-granular bounds, stable ascending pagination) — enabling a simpler and more correct reply-capture architecture than the lookback-window thread polling reviewed there. Design docs: `docs/internal/slack-ingestion-design.md` (base) and `docs/internal/slack-reply-sweep-design.md` (reply sweep, with the full probe ledger).

## Usage

```bash
msgvault add-slack     # user token (xoxp-…) from an internal app you create — 2-minute setup, scope list in docs/usage/slack.md
msgvault sync-slack    # first run backfills full history; later runs are incremental
```

Each workspace membership is its own source (`slack`, `<team-id>:<user-id>`); multiple workspaces coexist and stay separately filterable in the TUI. A `[slack]` config block covers daemon scheduling, channel include/exclude filters, and a media size cap.

## How replies are captured

- **Backfill** walks each conversation's history and fetches every thread's replies inline, before the containing page's cursor advances — interrupt/resume-safe by construction.
- **Incremental** fetches new top-level messages by cursor, then runs a **reply sweep**: a `search.messages threads:replies` query over the days since a per-source UTC watermark discovers replies by *creation time* — a reply to a thread of any age is found (no tracking window, no blind spot). Hits are pointers only; archiving always goes through canonical `conversations.replies` fetches into the standard upsert path.
- Sweep mechanics follow live-probed behaviors documented in the design doc: date modifiers evaluate in the user's *current profile timezone* (offset read fresh each run; watermark stored as a UTC instant so tz changes and DST are gap-free); every query string carries an inert nonce (search results are cached by query string); the pager stops on a mismatched echoed page number (past-the-cap pages are silently clamped to page 1) and logs a tripwire if a single day exceeds the reachable ceiling.
- Edits and reaction changes after capture are **ignored by default** (archive semantics); `sync-slack --maintenance` repairs the recent window, `--full` repairs everything. A backfill run under `--no-threads` leaves a recorded debt that the next threaded run pays automatically.

## What's stored

Message text with FTS (mrkdwn rendered, mentions resolved to names, bot `attachments`/`blocks` payloads extracted), threads (root+reply via `reply_to_message_id`), reactions, @mention recipient rows, conversation membership, files in the content-addressed attachment store, and the verbatim API JSON per message (`raw_format = slack_json`). Members' profile emails unify their Slack identity with their archived mail. Reuses the existing chat schema — no new core tables.

## Safety and correctness properties

- The client is read-only by construction (strict method allowlist) and internal-app rate limits apply (999-message pages; the 2025 non-Marketplace clampdown targets distributed apps only — probed live).
- File bytes are fetched only from `files.slack.com` (no redirects); external/off-host files are metadata + permalink; failed/deferred downloads (incl. `--no-media`) stay discoverable by `backfill-slack-media`.
- Every cursor — backfill page chain, incremental window, sweep watermark — advances only behind persisted work; checkpoints merge atomically per cursor unit; all writes are upserts, so at-least-once fetching yields exactly-once storage.
- Conversations that enumerate but 404 on read are skipped, not fatal (observed live).

## Store/query changes

Slack attachment-row methods share prefix-parameterized helpers with the Beeper ones; `"slack"` registered in `KnownMessageTypes` / `TextMessageTypes`.

Validated against live workspaces: full backfill (1,100+ message channel), interrupt/resume, threads incl. cross-run late replies, reactions (incl. custom emoji), media into CAS packs, a real 429 absorbed via Retry-After, history depth past 8 years, and the sweep's search behaviors (replies-only modifier, unjoined-channel leakage → filtered, tz re-filing, query caching, page clamping — each with an env-gated live pin-test or fake-server regression test).

Planned follow-ups (separate PRs): opt-in archiving of unjoined public channels via an explicit config allowlist; concurrent fetch/persist pipeline.
