### PR TITLE
feat(imap): add folder listing and filtering for imap sync

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6351,6 +6351,20 @@ paths:
           name: email
           schema:
             type: string
+        - description: IMAP folder names to include (repeatable)
+          in: query
+          name: folder
+          schema:
+            items:
+              type: string
+            type: array
+        - description: IMAP folder names to exclude (repeatable)
+          in: query
+          name: skip-folder
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         "200":
           content:
@@ -6404,6 +6418,20 @@ paths:
           name: noresume
           schema:
             type: boolean
+        - description: IMAP folder names to include (repeatable)
+          in: query
+          name: folder
+          schema:
+            items:
+              type: string
+            type: array
+        - description: IMAP folder names to exclude (repeatable)
+          in: query
+          name: skip-folder
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         "200":
           content:

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -77,6 +77,26 @@ func TestSaveIMAPFolderStates_ErrorsBlockPersistence(t *testing.T) {
 	assert.Empty(t, loaded, "a run with fetch errors must not advance folder high water marks")
 }
 
+func TestSaveIMAPFolderStates_LeavesDeferredFoldersUnpersisted(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX":   1,
+		"Archive": 0,
+	})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(err)
+
+	client := listedIMAPClient(t, addr, imapFolderStateSaveOption(st, src))
+	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{}, 0)
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	assert.Contains(t, loaded, "Archive")
+	assert.NotContains(t, loaded, "INBOX",
+		"a folder with an unacknowledged message must remain retryable")
+}
+
 func TestSaveIMAPFolderStates_LimitTruncationBlocksPersistence(t *testing.T) {
 	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 5})

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -129,20 +129,32 @@ func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
 		"a resync against an unchanged server must list no messages")
 }
 
-func TestIMAPFolderStateOptions_ForceRescanBypassesSavedStates(t *testing.T) {
+func TestIMAPFolderStateOptions_ForceRescanRetainsStatesAndEnumerates(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(
+		t, map[string]int{"INBOX": 1})
 	st := testutil.NewTestStore(t)
-	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	src, err := st.GetOrCreateSource(
+		"imap", "imap://alice@example.com")
 	require.NoError(err)
 
-	require.NoError(st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
-		{Mailbox: "INBOX", UIDValidity: 42, UIDNext: 100},
-	}))
+	first := listedIMAPClient(t, addr)
+	saveIMAPFolderStates(st, src, first, &gmail.SyncSummary{}, 0)
+	require.NoError(first.Close())
 
-	assert.Empty(imapFolderStateOptions(st, src, true),
-		"--noresume must ignore saved folder states so every mailbox is re-enumerated")
-	assert.NotEmpty(imapFolderStateOptions(st, src, false))
+	opts := imapFolderStateOptions(st, src, true)
+	require.Len(opts, 2,
+		"--noresume needs saved identity state and forced enumeration")
+
+	second := listedIMAPClient(t, addr, opts...)
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := second.ListMessages(ctx, "", "")
+	require.NoError(err)
+	assert.Len(resp.Messages, 1,
+		"forced enumeration must not skip an unchanged mailbox")
 }
 
 func TestIMAPFolderStateSaveOption_PersistsCompletedFolders(t *testing.T) {

--- a/cmd/msgvault/cmd/listfolders.go
+++ b/cmd/msgvault/cmd/listfolders.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	imapclient "go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/microsoft"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/textutil"
+)
+
+func newListFoldersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-folders [name]",
+		Short: "List IMAP folders (mailboxes) available for an account",
+		Long: `List all IMAP folders (mailboxes) available for one or all
+IMAP accounts, along with message count. This helps you
+choose which folders to include or exclude via --folders or
+--skip-folders on the sync command.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+			return runListFoldersLocal(cmd, args)
+		},
+	}
+	return cmd
+}
+
+func runListFoldersLocal(cmd *cobra.Command, args []string) error {
+	s, cleanup, err := openWritableStoreAndInit()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	ctx := cmd.Context()
+
+	var sources []*store.Source
+	if len(args) == 1 {
+		matches, err := s.GetSourcesByIdentifierOrDisplayName(args[0])
+		if err != nil {
+			return fmt.Errorf("lookup source: %w", err)
+		}
+		for _, src := range matches {
+			if src.SourceType == sourceTypeIMAP {
+				sources = append(sources, src)
+			}
+		}
+		if len(sources) == 0 && len(matches) > 0 {
+			return fmt.Errorf("account %q is not an IMAP source (type: %s)", args[0], matches[0].SourceType)
+		}
+	} else {
+		all, err := s.ListSources(sourceTypeIMAP)
+		if err != nil {
+			return fmt.Errorf("list IMAP sources: %w", err)
+		}
+		sources = all
+	}
+	if len(sources) == 0 {
+		return errors.New("no IMAP accounts configured")
+	}
+
+	for i, src := range sources {
+		if i > 0 {
+			fmt.Println()
+		}
+		if err := listFolders(ctx, src); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func listFolders(ctx context.Context, src *store.Source) error {
+	if cfg == nil {
+		return errors.New("configuration not loaded")
+	}
+	displayID := src.Identifier
+	if src.DisplayName.Valid && src.DisplayName.String != "" {
+		displayID = src.DisplayName.String
+	}
+	fmt.Printf("Account: %s\n", displayID)
+
+	skip, err := imapSkipReason(src)
+	if err != nil {
+		return err
+	}
+	if skip != "" {
+		fmt.Println(skip)
+		return nil
+	}
+
+	imapCfg, err := imapclient.ConfigFromJSON(src.SyncConfig.String)
+	if err != nil {
+		return fmt.Errorf("malformed IMAP config: %w", err)
+	}
+
+	var password string
+	var tokenFn func(ctx context.Context) (string, error)
+	msClientID := cfg.Microsoft.ClientID
+	msTenant := cfg.Microsoft.EffectiveTenantID()
+	msTokensDir := cfg.TokensDir()
+
+	switch imapCfg.EffectiveAuthMethod() {
+	case imapclient.AuthXOAuth2:
+		if msClientID == "" {
+			fmt.Println("  Microsoft OAuth not configured — add [microsoft] section to config.toml")
+			return errors.New("no Microsoft client ID configured")
+		}
+		msRedirectURI := cfg.Microsoft.EffectiveRedirectURI()
+		msMgr := microsoft.NewManager(msClientID, msTenant, msRedirectURI, msTokensDir, logger)
+		if !msMgr.HasToken(imapCfg.Username) {
+			fmt.Println("  Microsoft token not found — run 'add-o365' first")
+			return fmt.Errorf("no Microsoft token for %s", imapCfg.Username)
+		}
+		tokenFn, err = msMgr.TokenSource(ctx, imapCfg.Username)
+		if err != nil {
+			fmt.Printf("  Failed to load token: %v (run 'add-o365' first)\n", err)
+			return fmt.Errorf("load Microsoft token: %w", err)
+		}
+	default:
+		password, err = imapclient.LoadCredentials(cfg.TokensDir(), src.Identifier)
+		if err != nil {
+			fmt.Println("  Credentials not found — run 'add-imap' first")
+			return fmt.Errorf("load credentials: %w", err)
+		}
+	}
+
+	folders, err := imapclient.NewClient(imapCfg, password, imapclient.WithTokenSource(tokenFn)).ListMailboxes(ctx)
+	if err != nil {
+		return fmt.Errorf("list mailboxes: %w", err)
+	}
+
+	fmt.Printf("\n  %-35s %10s\n", "Folder", "Messages")
+	fmt.Println("  " + strings.Repeat("-", 46))
+	for _, f := range folders {
+		if f.NumMessages == -1 {
+			fmt.Printf("  %-35s %10s\n", textutil.SanitizeTerminal(f.Mailbox), "??")
+		} else {
+			fmt.Printf("  %-35s %10d\n", textutil.SanitizeTerminal(f.Mailbox), f.NumMessages)
+		}
+	}
+	fmt.Println()
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(newListFoldersCmd())
+}

--- a/cmd/msgvault/cmd/listfolders_test.go
+++ b/cmd/msgvault/cmd/listfolders_test.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestListFoldersCmd_NoIMAPAccounts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/msgvault.db"
+
+	s, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(s.InitSchema(), "init schema")
+
+	// Only Gmail source
+	_, err = s.GetOrCreateSource("gmail", "g@example.com")
+	require.NoError(err, "create gmail source")
+	_ = s.Close()
+
+	savedCfg := cfg
+	savedLogger := logger
+	defer func() {
+		cfg = savedCfg
+		logger = savedLogger
+	}()
+
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	root := newTestRootCmd()
+	root.AddCommand(newListFoldersCmd())
+	root.SetArgs([]string{"list-folders"})
+
+	err = root.Execute()
+	require.Error(err)
+	assert.ErrorContains(err, "no IMAP accounts configured")
+}
+
+func TestListFoldersCmd_GmailIdentifier(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/msgvault.db"
+
+	s, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(s.InitSchema(), "init schema")
+
+	_, err = s.GetOrCreateSource("gmail", "g@example.com")
+	require.NoError(err, "create gmail source")
+	_ = s.Close()
+
+	savedCfg := cfg
+	savedLogger := logger
+	defer func() {
+		cfg = savedCfg
+		logger = savedLogger
+	}()
+
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	root := newTestRootCmd()
+	root.AddCommand(newListFoldersCmd())
+	root.SetArgs([]string{"list-folders", "g@example.com"})
+
+	err = root.Execute()
+	require.Error(err)
+	assert.ErrorContains(err, "not an IMAP source")
+}
+
+func TestListFoldersCmd_IMAPNoCredentials(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/msgvault.db"
+
+	s, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(s.InitSchema(), "init schema")
+
+	_, err = s.GetOrCreateSource("imap", "i@example.com")
+	require.NoError(err, "create imap source")
+	_ = s.Close()
+
+	secretsPath := filepath.Join(tmpDir, "client_secret.json")
+	require.NoError(os.WriteFile(secretsPath, []byte(fakeClientSecrets), 0600),
+		"write client secrets")
+
+	savedCfg := cfg
+	savedLogger := logger
+	defer func() {
+		cfg = savedCfg
+		logger = savedLogger
+	}()
+
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+		OAuth:   config.OAuthConfig{ClientSecrets: secretsPath},
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// Capture stdout
+	getOutput := captureStdout(t)
+
+	root := newTestRootCmd()
+	root.AddCommand(newListFoldersCmd())
+	root.SetArgs([]string{"list-folders", "i@example.com"})
+
+	err = root.Execute()
+	// No error expected - it just prints "Credentials not found" and returns nil
+	require.NoError(err)
+
+	output := getOutput()
+	assert.Contains(output, "no credentials")
+}
+
+func TestListFoldersCmd_ListAllPrintsEachSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/msgvault.db"
+
+	s, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(s.InitSchema(), "init schema")
+
+	_, err = s.GetOrCreateSource("imap", "a@example.com")
+	require.NoError(err, "create imap source a")
+	_, err = s.GetOrCreateSource("imap", "b@example.com")
+	require.NoError(err, "create imap source b")
+	_ = s.Close()
+
+	secretsPath := filepath.Join(tmpDir, "client_secret.json")
+	require.NoError(os.WriteFile(secretsPath, []byte(fakeClientSecrets), 0600),
+		"write client secrets")
+
+	savedCfg := cfg
+	savedLogger := logger
+	defer func() {
+		cfg = savedCfg
+		logger = savedLogger
+	}()
+
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+		OAuth:   config.OAuthConfig{ClientSecrets: secretsPath},
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// Both sources should have "Credentials not found" in stdout
+	getOutput := captureStdout(t)
+
+	root := newTestRootCmd()
+	root.AddCommand(newListFoldersCmd())
+	root.SetArgs([]string{"list-folders"})
+
+	err = root.Execute()
+	require.NoError(err)
+
+	output := getOutput()
+	assert.Contains(output, "a@example.com")
+	assert.Contains(output, "b@example.com")
+	assert.Contains(output, "no credentials")
+}
+
+func TestListFoldersCmd_BrokenOAuthDoesNotBlockIMAP(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	tmpDir := t.TempDir()
+	dbPath := tmpDir + "/msgvault.db"
+
+	s, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(s.InitSchema(), "init schema")
+
+	_, err = s.GetOrCreateSource("imap", "i@example.com")
+	require.NoError(err, "create imap source")
+	_, err = s.GetOrCreateSource("gmail", "g@example.com")
+	require.NoError(err, "create gmail source")
+	_ = s.Close()
+
+	// Write a malformed client_secret.json.
+	secretsPath := filepath.Join(tmpDir, "client_secret.json")
+	require.NoError(os.WriteFile(secretsPath, []byte("not json"), 0600), "write secrets")
+
+	savedCfg := cfg
+	savedLogger := logger
+	defer func() {
+		cfg = savedCfg
+		logger = savedLogger
+	}()
+
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+		OAuth:   config.OAuthConfig{ClientSecrets: secretsPath},
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	getOutput := captureStdout(t)
+
+	root := newTestRootCmd()
+	root.AddCommand(newListFoldersCmd())
+	root.SetArgs([]string{"list-folders"})
+
+	err = root.Execute()
+	// IMAP sources still get processed even with broken OAuth
+	require.NoError(err)
+
+	output := getOutput()
+	assert.Contains(output, "i@example.com")
+	assert.Contains(output, "no credentials")
+}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1060,6 +1060,15 @@ func (a *storeAPIAdapter) runCLISyncWithRunner(
 	}, emitWarning)
 }
 
+// emitFolderArgs appends a --folders/<--skip-folders> flag for each
+// element in values, e.g. "--folders Inbox --folders Archive".
+func emitFolderArgs(args []string, flag string, values []string) []string {
+	for _, v := range values {
+		args = append(args, flag, v)
+	}
+	return args
+}
+
 func cliSyncSubprocessArgs(req api.CLISyncRequest) []string {
 	if req.Full {
 		args := []string{"sync-full"}
@@ -1078,12 +1087,16 @@ func cliSyncSubprocessArgs(req api.CLISyncRequest) []string {
 		if req.Limit > 0 {
 			args = append(args, "--limit", strconv.Itoa(req.Limit))
 		}
+		args = emitFolderArgs(args, "--folders", req.Folders)
+		args = emitFolderArgs(args, "--skip-folders", req.SkipFolders)
 		if req.Email != "" {
 			args = append(args, req.Email)
 		}
 		return args
 	}
-	args := []string{"sync"}
+	args := []string{syncIncrementalCmd.Name()}
+	args = emitFolderArgs(args, "--folders", req.Folders)
+	args = emitFolderArgs(args, "--skip-folders", req.SkipFolders)
 	if req.Email != "" {
 		args = append(args, req.Email)
 	}

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -641,6 +641,32 @@ func TestStoreAPIAdapterRunCLISyncPacksOnlyAfterSubprocessSuccess(t *testing.T) 
 	}
 }
 
+func TestCLISyncSubprocessArgsIncrementalIncludesFolderFilters(t *testing.T) {
+	assert.Equal(t,
+		[]string{"sync", "--folders", "INBOX", "--folders", "Archive", "--skip-folders", "Trash", "alice@example.com"},
+		cliSyncSubprocessArgs(api.CLISyncRequest{
+			Email:       "alice@example.com",
+			Folders:     []string{"INBOX", "Archive"},
+			SkipFolders: []string{"Trash"},
+		}),
+	)
+	assert.Equal(t,
+		[]string{"sync", "--folders", "Folder,With,Comma", "alice@example.com"},
+		cliSyncSubprocessArgs(api.CLISyncRequest{
+			Email:   "alice@example.com",
+			Folders: []string{"Folder,With,Comma"},
+		}),
+	)
+	assert.Equal(t,
+		[]string{"sync", "--folders", "Path\\To\\File", "--skip-folders", "Fold,er", "alice@example.com"},
+		cliSyncSubprocessArgs(api.CLISyncRequest{
+			Email:       "alice@example.com",
+			Folders:     []string{"Path\\To\\File"},
+			SkipFolders: []string{"Fold,er"},
+		}),
+	)
+}
+
 func TestStoreAPIAdapterRunCLICommandPacksOnlyAllowlistedSuccess(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -305,5 +305,7 @@ func runIncrementalSync(ctx context.Context, s *store.Store, getOAuthMgr func(st
 }
 
 func init() {
+	syncIncrementalCmd.Flags().StringArrayVar(&syncFolders, "folders", []string{}, "Folder names to include (repeatable)")
+	syncIncrementalCmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folders", []string{}, "Folder names to exclude (repeatable)")
 	rootCmd.AddCommand(syncIncrementalCmd)
 }

--- a/cmd/msgvault/cmd/sync_http.go
+++ b/cmd/msgvault/cmd/sync_http.go
@@ -14,7 +14,10 @@ import (
 )
 
 func runSyncIncrementalHTTP(cmd *cobra.Command, args []string) error {
-	req := daemonclient.CLISyncRequest{}
+	req := daemonclient.CLISyncRequest{
+		Folders:     parseFolderFilter(syncFolders),
+		SkipFolders: parseFolderFilter(syncSkipFolders),
+	}
 	if len(args) == 1 {
 		req.Email = args[0]
 	}
@@ -23,12 +26,14 @@ func runSyncIncrementalHTTP(cmd *cobra.Command, args []string) error {
 
 func runSyncFullHTTP(cmd *cobra.Command, args []string) error {
 	req := daemonclient.CLISyncRequest{
-		Full:     true,
-		Query:    syncQuery,
-		NoResume: syncNoResume,
-		Before:   syncBefore,
-		After:    syncAfter,
-		Limit:    syncLimit,
+		Full:        true,
+		Query:       syncQuery,
+		NoResume:    syncNoResume,
+		Before:      syncBefore,
+		After:       syncAfter,
+		Limit:       syncLimit,
+		Folders:     parseFolderFilter(syncFolders),
+		SkipFolders: parseFolderFilter(syncSkipFolders),
 	}
 	if len(args) == 1 {
 		req.Email = args[0]

--- a/cmd/msgvault/cmd/sync_http_test.go
+++ b/cmd/msgvault/cmd/sync_http_test.go
@@ -26,6 +26,8 @@ func TestSyncUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 		assert.Equal(http.MethodPost, r.Method, "method")
 		assert.Equal("/api/v1/cli/sync", r.URL.Path, "path")
 		assert.Equal("alice@example.com", r.URL.Query().Get("email"), "email query")
+		assert.ElementsMatch([]string{"INBOX", "Archive"}, r.URL.Query()["folder"], "folder query")
+		assert.Equal([]string{"Trash"}, r.URL.Query()["skip-folder"], "skip-folder query")
 		requests.Add(1)
 
 		w.Header().Set("Content-Type", "application/x-ndjson")
@@ -36,11 +38,19 @@ func TestSyncUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	configureRemoteSyncTest(t, server.URL)
+	resetSyncFullFlagsForTest(t)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: syncIncrementalCmd.Use, Args: syncIncrementalCmd.Args, RunE: syncIncrementalCmd.RunE}
-	cmd.SetArgs([]string{"alice@example.com"})
+	cmd.Flags().StringArrayVar(&syncFolders, "folders", []string{}, "IMAP folders to include")
+	cmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folders", []string{}, "IMAP folders to exclude")
+	cmd.SetArgs([]string{
+		"alice@example.com",
+		"--folders", "INBOX",
+		"--folders", "Archive",
+		"--skip-folders", "Trash",
+	})
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 
@@ -320,16 +330,22 @@ func resetSyncFullFlagsForTest(t *testing.T) {
 	oldBefore := syncBefore
 	oldAfter := syncAfter
 	oldLimit := syncLimit
+	oldFolders := syncFolders
+	oldSkipFolders := syncSkipFolders
 	syncQuery = ""
 	syncNoResume = false
 	syncBefore = ""
 	syncAfter = ""
 	syncLimit = 0
+	syncFolders = []string{}
+	syncSkipFolders = []string{}
 	t.Cleanup(func() {
 		syncQuery = oldQuery
 		syncNoResume = oldNoResume
 		syncBefore = oldBefore
 		syncAfter = oldAfter
 		syncLimit = oldLimit
+		syncFolders = oldFolders
+		syncSkipFolders = oldSkipFolders
 	})
 }

--- a/cmd/msgvault/cmd/sync_test.go
+++ b/cmd/msgvault/cmd/sync_test.go
@@ -616,3 +616,93 @@ func TestSyncCmd_GmailOnlyBrokenOAuthSurfacesError(t *testing.T) {
 		})
 	}
 }
+
+func TestTrimFolderFilter(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "nil returns nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty slice returns nil",
+			input: []string{},
+			want:  nil,
+		},
+		{
+			name:  "single folder",
+			input: []string{"Inbox"},
+			want:  []string{"Inbox"},
+		},
+		{
+			name:  "trims whitespace",
+			input: []string{"  inbox  ", "  Sent  ", "  trash  "},
+			want:  []string{"inbox", "Sent", "trash"},
+		},
+		{
+			name:  "skips blank entries",
+			input: []string{"Inbox", "", "Sent"},
+			want:  []string{"Inbox", "Sent"},
+		},
+		{
+			name:  "skips whitespace-only entries",
+			input: []string{"Inbox", "   ", "Sent"},
+			want:  []string{"Inbox", "Sent"},
+		},
+		{
+			name:  "all whitespace returns empty slice",
+			input: []string{"  ", "   "},
+			want:  []string{},
+		},
+		{
+			name:  "nested folder names preserved",
+			input: []string{"Projects/Alpha", "Projects/Beta", "Inbox"},
+			want:  []string{"Projects/Alpha", "Projects/Beta", "Inbox"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseFolderFilter(tc.input)
+			assert.Equal(t, tc.want, got, "parseFolderFilter(%q)", tc.input)
+		})
+	}
+}
+
+func TestSyncCommandRegistersFolderFlags(t *testing.T) {
+	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("folders"))
+	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("skip-folders"))
+}
+
+// Full e2e integration with an in-memory IMAP server is tested in
+// internal/imap/client_folderstate_test.go via WithFolderFilter().
+
+func TestTrimFolderFilter_DoesNotBlockOnErrorInSyncFull(t *testing.T) {
+	// Verify the CLI accepts --folders and --skip-folders through
+	// parseFolderFilter without error, even when the value is
+	// malformed or whitespace-only.
+	require := require.New(t)
+	assert := assert.New(t)
+	savedFolders := syncFolders
+	savedSkip := syncSkipFolders
+	defer func() {
+		syncFolders = savedFolders
+		syncSkipFolders = savedSkip
+	}()
+
+	// parseFolderFilter is called unconditionally; it must never
+	// return nil on every path where it's called with real user input.
+	assert.Equal([]string{}, parseFolderFilter([]string{"  "}), "whitespace returns empty slice")
+	assert.Equal([]string{"A", "B"}, parseFolderFilter([]string{"A", "B"}), "multiple values")
+	// nil is returned only when the input slice is empty, not when
+	// it contains only whitespace or blank entries.
+	assert.Nil(parseFolderFilter([]string(nil)), "empty slice input returns nil")
+
+	// All-whitespace input returns empty slice (no error, no crash).
+	require.NotPanics(func() { parseFolderFilter([]string{"  ", "   "}) })
+	require.NotPanics(func() { parseFolderFilter([]string{"", "  ", ""}) })
+}

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -23,11 +23,13 @@ import (
 )
 
 var (
-	syncQuery    string
-	syncNoResume bool
-	syncBefore   string
-	syncAfter    string
-	syncLimit    int
+	syncQuery       string
+	syncNoResume    bool
+	syncBefore      string
+	syncAfter       string
+	syncLimit       int
+	syncFolders     []string // folder names to include (from --folders flag)
+	syncSkipFolders []string // folder names to exclude (from --skip-folders flag)
 )
 
 var syncFullCmd = &cobra.Command{
@@ -349,24 +351,28 @@ func loadIMAPFolderStates(s *store.Store, sourceID int64) (map[string]imaplib.Fo
 	return states, nil
 }
 
-// imapFolderStateOptions loads saved per-mailbox states for an IMAP
-// source so its client can skip unchanged mailboxes during listing.
-// forceRescan (--noresume) bypasses the saved states so every mailbox
-// is freshly enumerated. Load failures only cost the optimization, so
-// they are logged and swallowed.
-func imapFolderStateOptions(s *store.Store, src *store.Source, forceRescan bool) []imaplib.Option {
-	if forceRescan || src.SourceType != sourceTypeIMAP {
+// imapFolderStateOptions retains saved UIDVALIDITY metadata for identity
+// validation. forceRescan disables listing shortcuts without discarding it.
+func imapFolderStateOptions(
+	s *store.Store,
+	src *store.Source,
+	forceRescan bool,
+) []imaplib.Option {
+	if src.SourceType != sourceTypeIMAP {
 		return nil
 	}
+
+	var opts []imaplib.Option
 	states, err := loadIMAPFolderStates(s, src.ID)
 	if err != nil {
 		logger.Warn("failed to load IMAP folder states", "source", src.Identifier, "error", err)
-		return nil
+	} else if len(states) > 0 {
+		opts = append(opts, imaplib.WithFolderStates(states))
 	}
-	if len(states) == 0 {
-		return nil
+	if forceRescan {
+		opts = append(opts, imaplib.WithForceFullEnumeration())
 	}
-	return []imaplib.Option{imaplib.WithFolderStates(states)}
+	return opts
 }
 
 func saveIMAPFolderState(s *store.Store, src *store.Source, mailbox string, st imaplib.FolderState) {
@@ -420,6 +426,20 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	// saved folder high water marks and re-enumerate every mailbox. A clean
 	// completed run still saves fresh high water marks afterwards.
 	imapOpts := imapFolderStateOptions(s, src, syncNoResume)
+
+	// Pass CLI folder filter strings to the IMAP client. The IMAP
+	// client selects the effective include list (CLI --folders when
+	// set, otherwise config Folders) and applies CLI --skip-folders
+	// as an exclusion on top. Both CLI filters are applied in a
+	// single call to filterMailboxes so --folders can fully
+	// override configuration and --skip-folders works together with
+	// --folders.
+	imapOpts = append(imapOpts,
+		imaplib.WithFolderFilter(
+			parseFolderFilter(syncFolders),
+			parseFolderFilter(syncSkipFolders),
+		))
+
 	if src.SourceType == sourceTypeIMAP {
 		imapOpts = append(imapOpts,
 			imaplib.WithListProgress(progress.OnIMAPListProgress),
@@ -528,7 +548,21 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	return nil
 }
 
-// buildSyncQuery constructs a Gmail search query from flags.
+// trimFolderFilter trims whitespace from folder names and removes empty
+// entries. Returns nil when the input slice is empty.
+func parseFolderFilter(folders []string) []string {
+	if len(folders) == 0 {
+		return nil
+	}
+	kept := make([]string, 0, len(folders))
+	for _, f := range folders {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			kept = append(kept, f)
+		}
+	}
+	return kept
+}
 func buildSyncQuery() string {
 	parts := []string{}
 
@@ -795,5 +829,7 @@ func init() {
 	syncFullCmd.Flags().StringVar(&syncBefore, "before", "", "Only messages before this date (YYYY-MM-DD)")
 	syncFullCmd.Flags().StringVar(&syncAfter, "after", "", "Only messages after this date (YYYY-MM-DD)")
 	syncFullCmd.Flags().IntVar(&syncLimit, "limit", 0, "Limit number of messages (for testing)")
+	syncFullCmd.Flags().StringArrayVar(&syncFolders, "folders", []string{}, "Folder names to include (repeatable)")
+	syncFullCmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folders", []string{}, "Folder names to exclude (repeatable)")
 	rootCmd.AddCommand(syncFullCmd)
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -101,6 +101,22 @@ After adding an account, sync it with `msgvault sync-full`. IMAP accounts use th
 
 ---
 
+## list-folders
+
+List the selectable folders in one or all configured IMAP accounts, including
+an approximate message count for each folder.
+
+```bash
+msgvault list-folders [account]
+```
+
+Use the folder names in repeated `--folders` or `--skip-folders` flags on
+`sync-full` and `sync`. When the account argument is omitted, the command lists
+folders for every configured IMAP account. See
+[IMAP Folder Sync](/usage/imap/) for examples and matching rules.
+
+---
+
 ## add-o365
 
 Add a Microsoft 365 or Outlook.com account via OAuth2 with XOAUTH2 IMAP authentication.
@@ -190,6 +206,8 @@ msgvault sync-full [email] [flags]
 | `--before YYYY-MM-DD` | Only messages before this date |
 | `--query` | Gmail search query filter |
 | `--noresume` | Ignore checkpoints, start fresh |
+| `--folders NAME` | Scan this IMAP folder (repeatable) |
+| `--skip-folders NAME` | Skip this IMAP folder (repeatable) |
 | `--verbose` | Detailed progress output |
 
 The CLI sends the sync request to the configured remote server or local daemon
@@ -204,12 +222,20 @@ SQLite writer beside `msgvault serve`.
 Sync new and changed messages. Gmail accounts use the Gmail History API; IMAP accounts perform a mailbox scan and skip messages already in the database. When called without an email argument, syncs all accounts that have completed an initial full sync.
 
 ```bash
-msgvault sync [email]
+msgvault sync [email] [flags]
 ```
+
+| Flag | Description |
+|---|---|
+| `--folders NAME` | Scan this IMAP folder (repeatable) |
+| `--skip-folders NAME` | Skip this IMAP folder (repeatable) |
 
 The CLI sends the incremental sync request to the configured remote server or
 local daemon and streams the daemon's stdout/stderr back to the terminal. The
 daemon serializes this work with other archive mutations.
+
+Folder filters are applied only to IMAP accounts. See
+[IMAP Folder Sync](/usage/imap/) for examples and matching rules.
 
 ---
 

--- a/docs/scripts/check_markdown_sources.py
+++ b/docs/scripts/check_markdown_sources.py
@@ -46,6 +46,7 @@ PUBLIC_MARKDOWN = {
     "usage/deletion.md",
     "usage/discord.md",
     "usage/exporting.md",
+    "usage/imap.md",
     "usage/importing.md",
     "usage/multi-account.md",
     "usage/querying.md",

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -165,14 +165,17 @@ For STARTTLS connections (port 143), add `--starttls`:
 msgvault add-imap --host mail.example.com --username you@example.com --starttls
 ```
 
-After adding the account, sync it the same way as a Gmail account:
+After adding the account, list its folders and start a sync:
 
 ```bash
-msgvault sync-full
+msgvault list-folders you@fastmail.com
+msgvault sync-full you@fastmail.com
 ```
 
 IMAP accounts are stored in the same database as Gmail accounts. All tools
 (Web UI, TUI, search, MCP, and REST API) work with IMAP messages the same way.
+To start with only part of a large account, see
+[IMAP Folder Sync](/usage/imap/) for `--folders` and `--skip-folders` examples.
 
 !!! tip "Microsoft 365 / Outlook.com"
     For Outlook, Hotmail, Live.com, and Microsoft 365 accounts, `add-o365` provides OAuth-based access without app passwords. It auto-detects the correct IMAP host and configures XOAUTH2 authentication. See the [OAuth Setup guide](/guides/oauth-setup/#microsoft-365-outlook-hotmail) for details.

--- a/docs/usage/imap.md
+++ b/docs/usage/imap.md
@@ -1,0 +1,119 @@
+---
+title: IMAP Folder Sync
+description: List IMAP folders and choose which folders msgvault scans during a sync.
+---
+
+# IMAP Folder Sync
+
+By default, msgvault scans every selectable folder in an IMAP account. You can
+limit a sync to the folders you need or skip folders that are large or
+unimportant. This is useful when you want to try msgvault with a small part of
+an account before starting a complete archive.
+
+Folder filters work with both `sync-full` and `sync`. They affect IMAP accounts
+only.
+
+## Find the Folder Names
+
+Ask the IMAP server for its folder names before creating a filter:
+
+```bash
+msgvault list-folders you@example.com
+```
+
+The command shows each selectable folder and its approximate message count:
+
+```text
+Account: you@example.com
+
+  Folder                                Messages
+  ----------------------------------------------
+  INBOX                                     1240
+  Archive                                  18342
+  Projects/Alpha                             217
+  Trash                                       36
+```
+
+Leave out the account name to list folders for every configured IMAP account:
+
+```bash
+msgvault list-folders
+```
+
+Some servers do not provide a message count for every folder. In that case,
+msgvault shows `??`, but you can still use the folder name in a filter.
+
+## Sync Only Selected Folders
+
+Repeat `--folders` once for each folder you want to include:
+
+```bash
+msgvault sync-full you@example.com \
+  --folders INBOX \
+  --folders Archive
+```
+
+To scan the same folders during a later sync:
+
+```bash
+msgvault sync you@example.com \
+  --folders INBOX \
+  --folders Archive
+```
+
+Each flag takes one complete folder name. Repeat the flag instead of joining
+names with commas. This also means a folder whose name contains a comma works
+without special handling:
+
+```bash
+msgvault sync-full you@example.com --folders "Receipts, 2025"
+```
+
+## Skip Selected Folders
+
+Use `--skip-folders` to scan every folder except the ones you name:
+
+```bash
+msgvault sync-full you@example.com \
+  --skip-folders Trash \
+  --skip-folders Spam
+```
+
+You can combine include and exclude filters. msgvault first keeps the folders
+named by `--folders`, then removes any named by `--skip-folders`:
+
+```bash
+msgvault sync-full you@example.com \
+  --folders INBOX \
+  --folders Archive \
+  --folders "Archive/Newsletters" \
+  --skip-folders "Archive/Newsletters"
+```
+
+That example scans `INBOX` and `Archive`.
+
+## Matching Rules
+
+- Folder names are matched exactly, without wildcards or prefix matching.
+- Matching is case-insensitive.
+- Nested folders use the full name shown by `list-folders`, such as
+  `Projects/Alpha`.
+- With no folder flags, msgvault scans every selectable folder.
+- Folder flags apply to one command invocation. Repeat them in later commands
+  when you want the same filter.
+- If a command syncs several account types, folder flags affect only its IMAP
+  accounts.
+
+## What Filtering Changes
+
+A folder filter limits which remote IMAP folders msgvault scans during that
+run. It does not delete messages from the server or remove messages already in
+the local archive.
+
+An email can appear in more than one IMAP folder. During a filtered scan,
+msgvault keeps the stable identity and folder labels learned by earlier,
+broader scans while adding information from the selected folders. A later sync
+without folder flags scans the complete account again.
+
+Folder filtering works the same whether the CLI uses a local daemon or a
+configured remote msgvault server.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -22,6 +22,7 @@ nav = [
   {"Web UI & API Server" = "api-server.md"},
   {"Changelog" = "changelog.md"},
   {"CLI Usage" = [
+    {"IMAP Folder Sync" = "usage/imap.md"},
     {"Searching" = "usage/searching.md"},
     {"Vector Search" = "usage/vector-search.md"},
     {"Importing Local Email" = "usage/importing.md"},

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -386,13 +386,15 @@ type CLICacheBuildEvent struct {
 }
 
 type CLISyncRequest struct {
-	Full     bool
-	Email    string
-	Query    string
-	NoResume bool
-	Before   string
-	After    string
-	Limit    int
+	Full        bool
+	Email       string
+	Query       string
+	NoResume    bool
+	Before      string
+	After       string
+	Limit       int
+	Folders     []string
+	SkipFolders []string
 }
 
 type CLISyncEvent struct {
@@ -982,6 +984,16 @@ func parseCLISyncRequest(r *http.Request, full bool) (CLISyncRequest, *apiHTTPEr
 		Before: values.Get("before"),
 		After:  values.Get("after"),
 	}
+	for _, v := range values["folder"] {
+		if v != "" {
+			req.Folders = append(req.Folders, v)
+		}
+	}
+	for _, v := range values["skip-folder"] {
+		if v != "" {
+			req.SkipFolders = append(req.SkipFolders, v)
+		}
+	}
 	if rawNoResume := values.Get("noresume"); rawNoResume != "" {
 		noResume, err := strconv.ParseBool(rawNoResume)
 		if err != nil {
@@ -1318,6 +1330,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"import-synctech-sms",
 		"import-whatsapp",
 		"list-deletions",
+		"list-folders",
 		"logs",
 		"pack-attachments",
 		"repair-dates",

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -922,6 +922,29 @@ func TestHandleCLISyncFullStreamsOutput(t *testing.T) {
 	assert.Equal(CLISyncEvent{Type: cliStreamEventTypeComplete}, events[2], "complete event")
 }
 
+func TestHandleCLISyncAcceptsFolderFilters(t *testing.T) {
+	var gotReq CLISyncRequest
+	st := &mockStore{
+		syncFunc: func(_ context.Context, req CLISyncRequest, _ func(CLISyncEvent) error) error {
+			gotReq = req
+			return nil
+		},
+	}
+	srv := newCLIHandlerTestServer(st)
+
+	resp := servePOSTTestRequest(
+		srv,
+		"/api/v1/cli/sync?email=alice@example.com&folder=INBOX&folder=Archive&skip-folder=Trash",
+	)
+
+	requireNDJSONResponse(t, resp)
+	assert.Equal(t, CLISyncRequest{
+		Email:       "alice@example.com",
+		Folders:     []string{"INBOX", "Archive"},
+		SkipFolders: []string{"Trash"},
+	}, gotReq)
+}
+
 func TestHandleCLIVerifyStreamsOutput(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -518,7 +518,11 @@ func rawRouteParameters(operationID string) []*huma.Param {
 	case "buildCLICache":
 		return []*huma.Param{queryBooleanParam("full_rebuild", "Rebuild all cache files from scratch")}
 	case "syncCLI":
-		return []*huma.Param{queryStringParam("email", "Account email or display name to sync", false)}
+		return []*huma.Param{
+			queryStringParam("email", "Account email or display name to sync", false),
+			queryRefArrayParam("folder", "IMAP folder names to include (repeatable)"),
+			queryRefArrayParam("skip-folder", "IMAP folder names to exclude (repeatable)"),
+		}
 	case "syncFullCLI":
 		return []*huma.Param{
 			queryStringParam("email", "Account email or display name to sync", false),
@@ -527,6 +531,8 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryStringParam("before", "Only messages before this YYYY-MM-DD date", false),
 			queryIntegerParam("limit", "Maximum messages to sync"),
 			queryBooleanParam("noresume", "Ignore checkpoints and start fresh"),
+			queryRefArrayParam("folder", "IMAP folder names to include (repeatable)"),
+			queryRefArrayParam("skip-folder", "IMAP folder names to exclude (repeatable)"),
 		}
 	case "verifyCLI":
 		return []*huma.Param{
@@ -808,6 +814,12 @@ func queryIntegerParam(name, doc string) *huma.Param {
 func queryIntegerArrayParam(name, doc string) *huma.Param {
 	p := param(name, "query", huma.TypeArray, doc, false)
 	p.Schema.Items = &huma.Schema{Type: huma.TypeInteger, Format: "int64"}
+	return p
+}
+
+func queryRefArrayParam(name, doc string) *huma.Param {
+	p := param(name, "query", huma.TypeArray, doc, false)
+	p.Schema.Items = &huma.Schema{Type: huma.TypeString}
 	return p
 }
 

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -34,13 +34,15 @@ type CLIStats struct {
 type CLICacheStats = cacheops.CacheStats
 
 type CLISyncRequest struct {
-	Full     bool
-	Email    string
-	Query    string
-	NoResume bool
-	Before   string
-	After    string
-	Limit    int
+	Full        bool
+	Email       string
+	Query       string
+	NoResume    bool
+	Before      string
+	After       string
+	Limit       int
+	Folders     []string
+	SkipFolders []string
 }
 
 type CLIVerifyRequest struct {
@@ -386,18 +388,22 @@ func (c *Client) RunCLISync(
 		path = "/api/v1/cli/sync-full"
 		return c.runCLIStream(ctx, path, "sync", &generated.SyncFullCLIRequestOptions{
 			Query: &generated.SyncFullCLIQuery{
-				Email:    optionalString(req.Email),
-				Query:    optionalString(req.Query),
-				Noresume: optionalBool(req.NoResume),
-				Before:   optionalString(req.Before),
-				After:    optionalString(req.After),
-				Limit:    optionalPositiveInt64(req.Limit),
+				Email:      optionalString(req.Email),
+				Query:      optionalString(req.Query),
+				Noresume:   optionalBool(req.NoResume),
+				Before:     optionalString(req.Before),
+				After:      optionalString(req.After),
+				Limit:      optionalPositiveInt64(req.Limit),
+				Folder:     req.Folders,
+				SkipFolder: req.SkipFolders,
 			},
 		}, output)
 	}
 	return c.runCLIStream(ctx, path, "sync", &generated.SyncCLIRequestOptions{
 		Query: &generated.SyncCLIQuery{
-			Email: optionalString(req.Email),
+			Email:      optionalString(req.Email),
+			Folder:     req.Folders,
+			SkipFolder: req.SkipFolders,
 		},
 	}, output)
 }

--- a/internal/daemonclient/store_adapter_test.go
+++ b/internal/daemonclient/store_adapter_test.go
@@ -182,6 +182,32 @@ func TestLegacyAdapterUsesClientRootContext(t *testing.T) {
 	require.Error(<-done, "canceled compatibility request")
 }
 
+func TestRunCLISyncSendsIncrementalFolderFilters(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method, "method")
+		assert.Equal("/api/v1/cli/sync", r.URL.Path, "path")
+		assert.ElementsMatch([]string{"INBOX", "Archive"}, r.URL.Query()["folder"], "folder query")
+		assert.Equal([]string{"Trash"}, r.URL.Query()["skip-folder"], "skip-folder query")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	st, err := New(Config{URL: srv.URL, AllowInsecure: true, HTTPClient: srv.Client()})
+	require.NoError(err, "New")
+
+	err = st.RunCLISync(context.Background(), CLISyncRequest{
+		Folders:     []string{"INBOX", "Archive"},
+		SkipFolders: []string{"Trash"},
+	}, func(string, string) error {
+		return nil
+	})
+	require.NoError(err)
+}
+
 func TestRunCLICommandStreamsOutput(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/gmail/api.go
+++ b/internal/gmail/api.go
@@ -104,6 +104,15 @@ type RawMessageBatchResult struct {
 	Err     error
 }
 
+// MessageLabelsBatchResult is one per-message result from a batch label fetch.
+// LabelIDs is nil when the fetch failed; Err preserves the per-message cause.
+type MessageLabelsBatchResult struct {
+	ID              string
+	LabelIDs        []string
+	RFC822MessageID string
+	Err             error
+}
+
 // HistoryResponse contains changes since a history ID.
 type HistoryResponse struct {
 	History       []HistoryRecord

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -638,3 +638,17 @@ func (c *Client) SourceMessageMatches(
 	return normalizeRFC822MessageID(actualRFC822MessageID) ==
 		normalizeRFC822MessageID(expectedRFC822MessageID), true, nil
 }
+
+// IsPreferredSourceMessageID reports whether messageID belongs to the
+// mailbox advertised with the \All special-use attribute. A complete scan
+// may use that mailbox's identifier as the stable canonical source ID.
+func (c *Client) IsPreferredSourceMessageID(messageID string) bool {
+	mailbox, _, err := parseCompositeID(messageID)
+	if err != nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.allMailFolder != "" && mailbox == c.allMailFolder
+}

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
+	"strings"
 
 	imap "github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -67,6 +69,28 @@ func rawMIMEMessageID(rawMIME []byte) string {
 	return msgID
 }
 
+func normalizeRFC822MessageID(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "<") && strings.HasSuffix(value, ">") {
+		return value[1 : len(value)-1]
+	}
+	return value
+}
+
+func (c *Client) labelsForMessage(mailbox, rfc822MessageID string) []string {
+	labels := []string{mailbox}
+	if c.msgIDToLabels == nil || rfc822MessageID == "" {
+		return labels
+	}
+
+	for _, label := range c.msgIDToLabels[rfc822MessageID] {
+		if label != mailbox {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}
+
 func (c *Client) applyFetchResults(
 	results []gmailapi.RawMessageBatchResult,
 	uidToIdx map[imap.UID]int,
@@ -92,10 +116,9 @@ func (c *Client) applyFetchResults(
 			continue
 		}
 
-		// Dedup by RFC822 Message-ID when listing All Mail alongside
-		// Trash/Spam. On Gmail these are disjoint, but non-Gmail servers may
-		// overlap. Return a non-nil stub with empty Raw so the caller treats
-		// this as a skip, not a fetch error.
+		// Dedup by RFC822 Message-ID when fully enumerated mailboxes overlap.
+		// Return a non-nil stub with empty Raw so the caller treats this as a
+		// skip, not a fetch error.
 		msgID := compositeID(mailbox, msgBuf.UID)
 		var rfc822MessageID string
 		if c.seenRFC822IDs != nil || c.msgIDToLabels != nil {
@@ -111,22 +134,11 @@ func (c *Client) applyFetchResults(
 			c.seenRFC822IDs[rfc822MessageID] = true
 		}
 
-		labels := []string{mailbox}
-
 		// Merge labels from other mailboxes via the label map built during
 		// listing. The map keys on RFC822 Message-ID and maps to the other
 		// mailbox names the message appears in. Skip the current mailbox to
 		// avoid duplicates that would violate the message_labels primary key.
-		if c.msgIDToLabels != nil &&
-			rfc822MessageID != "" {
-			if extra, ok := c.msgIDToLabels[rfc822MessageID]; ok {
-				for _, lbl := range extra {
-					if lbl != mailbox {
-						labels = append(labels, lbl)
-					}
-				}
-			}
-		}
+		labels := c.labelsForMessage(mailbox, rfc822MessageID)
 
 		results[idx].Message = &gmailapi.RawMessage{
 			ID:           msgID,
@@ -325,4 +337,304 @@ func (c *Client) GetMessagesRawBatchWithErrors(ctx context.Context, messageIDs [
 		}
 	}
 	return results, nil
+}
+
+func newLabelBatchResults(messageIDs []string) []gmailapi.MessageLabelsBatchResult {
+	results := make([]gmailapi.MessageLabelsBatchResult, len(messageIDs))
+	for i, id := range messageIDs {
+		results[i].ID = id
+	}
+	return results
+}
+
+func markLabelBatchError(results []gmailapi.MessageLabelsBatchResult, items []batchFetchItem, err error) {
+	for _, item := range items {
+		results[item.idx].Err = err
+	}
+}
+
+func (c *Client) applyLabelFetchResults(
+	results []gmailapi.MessageLabelsBatchResult,
+	uidToIdx map[imap.UID]int,
+	mailbox string,
+	chunk []batchFetchItem,
+	msgs []*imapclient.FetchMessageBuffer,
+) {
+	seenUIDs := make(map[imap.UID]bool, len(msgs))
+	for _, msgBuf := range msgs {
+		idx, ok := uidToIdx[msgBuf.UID]
+		if !ok {
+			continue
+		}
+		seenUIDs[msgBuf.UID] = true
+		if len(msgBuf.BodySection) == 0 {
+			results[idx].Err = errIMAPFetchResultMissing
+			continue
+		}
+		rfc822MessageID := rawMIMEMessageID(msgBuf.BodySection[0].Bytes)
+		results[idx].LabelIDs = c.labelsForMessage(mailbox, rfc822MessageID)
+		results[idx].RFC822MessageID = rfc822MessageID
+		results[idx].Err = nil
+	}
+
+	for _, item := range chunk {
+		if !seenUIDs[item.uid] && results[item.idx].Err == nil {
+			results[item.idx].Err = errIMAPFetchResultMissing
+		}
+	}
+}
+
+func (c *Client) selectLabelBatchMailbox(
+	ctx context.Context,
+	mailbox string,
+	items []batchFetchItem,
+	results []gmailapi.MessageLabelsBatchResult,
+) (bool, error) {
+	err := c.selectMailbox(mailbox)
+	if err == nil {
+		return true, nil
+	}
+	if isNetworkError(err) {
+		c.logger.Warn("network error selecting mailbox for label fetch, reconnecting",
+			"mailbox", mailbox, "error", err)
+		if reconErr := c.reconnect(ctx); reconErr != nil {
+			return false, fmt.Errorf("reconnect failed fetching labels from mailbox %q: %w", mailbox, reconErr)
+		}
+		err = c.selectMailbox(mailbox)
+		if err == nil {
+			return true, nil
+		}
+		c.logger.Warn("skipping mailbox label batch after reconnect",
+			"mailbox", mailbox, "error", err)
+	} else {
+		c.logger.Warn("skipping mailbox label batch", "mailbox", mailbox, "error", err)
+	}
+	markLabelBatchError(results, items, err)
+	return false, nil
+}
+
+func (c *Client) fetchMailboxLabelBatch(
+	ctx context.Context,
+	mailbox string,
+	items []batchFetchItem,
+	fetchOpts *imap.FetchOptions,
+	results []gmailapi.MessageLabelsBatchResult,
+) error {
+	uidToIdx := make(map[imap.UID]int, len(items))
+	for _, item := range items {
+		uidToIdx[item.uid] = item.idx
+	}
+
+	for chunkStart := 0; chunkStart < len(items); chunkStart += fetchChunkSize {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		end := min(chunkStart+fetchChunkSize, len(items))
+		chunk := items[chunkStart:end]
+		var uidSet imap.UIDSet
+		for _, item := range chunk {
+			uidSet.AddNum(item.uid)
+		}
+
+		msgs, fatal, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
+		if fatal {
+			return err
+		}
+		if err != nil {
+			markLabelBatchError(results, chunk, err)
+			markLabelBatchError(results, items[end:], errIMAPSkippedAfterChunkFailed)
+			return nil
+		}
+		c.applyLabelFetchResults(results, uidToIdx, mailbox, chunk, msgs)
+	}
+	return nil
+}
+
+// GetMessageLabelsBatch fetches only the Message-ID header needed to recover
+// mailbox memberships for existing messages. It deliberately avoids BODY[]
+// so rescans can refresh labels without downloading message bodies or
+// attachments again. Per-message failures do not abort the rest of the batch.
+func (c *Client) GetMessageLabelsBatch(ctx context.Context, messageIDs []string) ([]gmailapi.MessageLabelsBatchResult, error) {
+	results := newLabelBatchResults(messageIDs)
+	byMailbox := make(map[string][]batchFetchItem, 4)
+	for i, id := range messageIDs {
+		mailbox, uid, err := parseCompositeID(id)
+		if err != nil {
+			results[i].Err = err
+			continue
+		}
+		byMailbox[mailbox] = append(byMailbox[mailbox], batchFetchItem{idx: i, uid: uid})
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.connect(ctx); err != nil {
+		return nil, err
+	}
+
+	fetchOpts := messageIDHeaderFetchOptions()
+	for _, mailbox := range batchMailboxOrder(byMailbox, c.allMailFolder) {
+		if ctx.Err() != nil {
+			return results, ctx.Err()
+		}
+
+		items := byMailbox[mailbox]
+		ok, err := c.selectLabelBatchMailbox(ctx, mailbox, items, results)
+		if err != nil {
+			return results, err
+		}
+		if !ok {
+			continue
+		}
+
+		if err := c.fetchMailboxLabelBatch(ctx, mailbox, items, fetchOpts, results); err != nil {
+			return results, err
+		}
+	}
+
+	return results, nil
+}
+
+func (c *Client) sourceMessageMetadata(
+	ctx context.Context, messageID string,
+) (string, bool, error) {
+	invalidated, err := c.sourceMessageIDInvalidated(messageID)
+	if err != nil {
+		return "", false, err
+	}
+	if invalidated {
+		return "", false, nil
+	}
+
+	results, err := c.GetMessageLabelsBatch(ctx, []string{messageID})
+	if err != nil {
+		return "", false, err
+	}
+	if len(results) != 1 {
+		return "", false, fmt.Errorf(
+			"source message validation returned %d results", len(results))
+	}
+	if results[0].Err != nil {
+		if errors.Is(results[0].Err, errIMAPFetchResultMissing) {
+			return "", false, nil
+		}
+		return "", false, results[0].Err
+	}
+	return results[0].RFC822MessageID, true, nil
+}
+
+func (c *Client) sourceMessageIDInvalidated(
+	messageID string,
+) (bool, error) {
+	matches, known, err := c.sourceMessageIDEpochMatches(messageID)
+	return known && !matches, err
+}
+
+func (c *Client) sourceMessageIDEpochMatches(
+	messageID string,
+) (matches bool, known bool, err error) {
+	mailbox, _, err := parseCompositeID(messageID)
+	if err != nil {
+		return false, false, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.mailboxCache != nil &&
+		!slices.Contains(c.mailboxCache, mailbox) {
+		return false, true, nil
+	}
+	prior, hasPrior := c.priorFolderStates[mailbox]
+	observed, hasObserved := c.observedFolderStates[mailbox]
+	if !hasPrior || !hasObserved {
+		return false, false, nil
+	}
+	return prior.UIDValidity == observed.UIDValidity, true, nil
+}
+
+// SeedValidatedMessageDedup records a fetched RFC822 identity only after sync
+// has validated the exact source ID and reconciled its labels.
+func (c *Client) SeedValidatedMessageDedup(
+	messageID, rfc822MessageID string,
+) error {
+	mailbox, _, err := parseCompositeID(messageID)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	seedDedup := mailbox == c.allMailFolder ||
+		(c.allMailFolder == "" && c.labelMapComplete)
+	if seedDedup &&
+		c.seenRFC822IDs != nil &&
+		rfc822MessageID != "" {
+		c.seenRFC822IDs[rfc822MessageID] = true
+	}
+	return nil
+}
+
+// SourceMessageExists reports whether an exact mailbox|uid identifier still
+// exists. A missing FETCH result is definitive absence; all other failures are
+// returned so callers can retry without replacing a canonical identifier.
+func (c *Client) SourceMessageExists(
+	ctx context.Context, messageID string,
+) (bool, error) {
+	_, exists, err := c.sourceMessageMetadata(ctx, messageID)
+	return exists, err
+}
+
+// FetchedSourceMessageMatches validates identity metadata already fetched for
+// an exact source ID, including the mailbox's UIDVALIDITY epoch.
+func (c *Client) FetchedSourceMessageMatches(
+	messageID, expectedRFC822MessageID, actualRFC822MessageID string,
+) (matches bool, conclusive bool, err error) {
+	epochMatches, epochKnown, err := c.sourceMessageIDEpochMatches(messageID)
+	if err != nil {
+		return false, false, err
+	}
+	if epochKnown && !epochMatches {
+		return false, true, nil
+	}
+
+	expected := normalizeRFC822MessageID(expectedRFC822MessageID)
+	actual := normalizeRFC822MessageID(actualRFC822MessageID)
+	if expected != "" && actual != "" {
+		return expected == actual, true, nil
+	}
+	if epochKnown {
+		return true, true, nil
+	}
+	return false, false, nil
+}
+
+// SourceMessageMatches reports whether an exact mailbox|uid identifier still
+// resolves to the expected RFC822 Message-ID. A UIDVALIDITY change invalidates
+// the identifier even when the same numeric UID has since been reused.
+func (c *Client) SourceMessageMatches(
+	ctx context.Context,
+	messageID, expectedRFC822MessageID string,
+) (matches bool, conclusive bool, err error) {
+	mailbox, _, err := parseCompositeID(messageID)
+	if err != nil {
+		return false, false, err
+	}
+	c.mu.Lock()
+	included := c.mailboxIncludedLocked(mailbox)
+	c.mu.Unlock()
+	if !included {
+		return false, false, nil
+	}
+
+	actualRFC822MessageID, exists, err := c.sourceMessageMetadata(ctx, messageID)
+	if err != nil {
+		return false, false, err
+	}
+	if !exists {
+		return false, true, nil
+	}
+	return normalizeRFC822MessageID(actualRFC822MessageID) ==
+		normalizeRFC822MessageID(expectedRFC822MessageID), true, nil
 }

--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -1,6 +1,7 @@
 package imap
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gmailapi "go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/testutil"
 )
 
 func TestNewRawBatchResultsKeepsInputIDs(t *testing.T) {
@@ -75,6 +77,258 @@ func TestBatchMailboxOrderPutsAllMailFirst(t *testing.T) {
 		batchMailboxOrder(byMailbox, ""))
 }
 
+func TestMessageIDHeaderFetchOptionsAvoidsRawMessageBody(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	opts := messageIDHeaderFetchOptions()
+
+	assert.True(opts.UID)
+	assert.False(opts.InternalDate)
+	assert.False(opts.RFC822Size)
+	require.Len(opts.BodySection, 1)
+	assert.True(opts.BodySection[0].Peek)
+	assert.Equal(imapapi.PartSpecifierHeader, opts.BodySection[0].Specifier)
+	assert.Equal([]string{"Message-ID"}, opts.BodySection[0].HeaderFields)
+}
+
+func TestGetMessageLabelsBatchPreservesPerMessageMissingUID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 1})
+	client := newTestClient(t, addr)
+
+	results, err := client.GetMessageLabelsBatch(
+		context.Background(),
+		[]string{"INBOX|1", "INBOX|99"},
+	)
+
+	require.NoError(err)
+	require.Len(results, 2)
+	assert.Equal("INBOX|1", results[0].ID)
+	assert.Equal([]string{"INBOX"}, results[0].LabelIDs)
+	require.NoError(results[0].Err)
+	assert.Equal("INBOX|99", results[1].ID)
+	assert.Nil(results[1].LabelIDs)
+	require.ErrorIs(results[1].Err, errIMAPFetchResultMissing)
+}
+
+func TestLabelOnlyRescanDefersAllMailDedupUntilValidated(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{
+			"All Mail": 0,
+			"Archive":  0,
+		},
+		map[string][]imapapi.MailboxAttr{
+			"All Mail": {imapapi.MailboxAttrAll},
+		},
+	)
+	const messageID = "overlapping-rescan@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "All Mail", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", messageID)
+	client := newTestClient(t, addr)
+
+	require.ElementsMatch(
+		[]string{"All Mail|1", "Archive|1"},
+		listAllMessages(t, client),
+	)
+
+	labelResults, err := client.GetMessageLabelsBatch(
+		context.Background(),
+		[]string{"All Mail|1"},
+	)
+	require.NoError(err)
+	require.Len(labelResults, 1)
+	require.NoError(labelResults[0].Err)
+	assert.ElementsMatch(
+		[]string{"All Mail", "Archive"},
+		labelResults[0].LabelIDs,
+	)
+	assert.Equal(messageID, labelResults[0].RFC822MessageID)
+	assert.NotContains(client.seenRFC822IDs, messageID,
+		"label metadata must not become dedup authority before validation")
+
+	require.NoError(client.SeedValidatedMessageDedup(
+		"All Mail|1",
+		labelResults[0].RFC822MessageID,
+	))
+	assert.Contains(client.seenRFC822IDs, messageID)
+
+	rawResults, err := client.GetMessagesRawBatchWithErrors(
+		context.Background(),
+		[]string{"Archive|1"},
+	)
+	require.NoError(err)
+	require.Len(rawResults, 1)
+	require.NoError(rawResults[0].Err)
+	require.NotNil(rawResults[0].Message)
+	assert.Nil(rawResults[0].Message.Raw,
+		"the overlapping mailbox copy must remain a dedup stub")
+}
+
+func TestSeedValidatedMessageDedupEligibility(t *testing.T) {
+	tests := []struct {
+		name             string
+		messageID        string
+		rfc822MessageID  string
+		allMailFolder    string
+		labelMapComplete bool
+		wantSeen         map[string]bool
+		wantErr          bool
+	}{
+		{
+			name:            "canonical all mail",
+			messageID:       "All Mail|1",
+			rfc822MessageID: "canonical@example.com",
+			allMailFolder:   "All Mail",
+			wantSeen: map[string]bool{
+				"existing@example.com":  true,
+				"canonical@example.com": true,
+			},
+		},
+		{
+			name:             "complete server without all mail",
+			messageID:        "Archive|1",
+			rfc822MessageID:  "complete@example.com",
+			labelMapComplete: true,
+			wantSeen: map[string]bool{
+				"existing@example.com": true,
+				"complete@example.com": true,
+			},
+		},
+		{
+			name:            "noncanonical mailbox on all mail server",
+			messageID:       "Archive|1",
+			rfc822MessageID: "alternate@example.com",
+			allMailFolder:   "All Mail",
+			wantSeen: map[string]bool{
+				"existing@example.com": true,
+			},
+		},
+		{
+			name:            "incomplete server without all mail",
+			messageID:       "Archive|1",
+			rfc822MessageID: "incomplete@example.com",
+			wantSeen: map[string]bool{
+				"existing@example.com": true,
+			},
+		},
+		{
+			name:             "empty rfc822 identity",
+			messageID:        "Archive|1",
+			labelMapComplete: true,
+			wantSeen: map[string]bool{
+				"existing@example.com": true,
+			},
+		},
+		{
+			name:            "malformed composite id",
+			messageID:       "not-a-composite-id",
+			rfc822MessageID: "malformed@example.com",
+			wantSeen: map[string]bool{
+				"existing@example.com": true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				allMailFolder:    tt.allMailFolder,
+				labelMapComplete: tt.labelMapComplete,
+				seenRFC822IDs: map[string]bool{
+					"existing@example.com": true,
+				},
+			}
+
+			err := c.SeedValidatedMessageDedup(
+				tt.messageID,
+				tt.rfc822MessageID,
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantSeen, c.seenRFC822IDs)
+		})
+	}
+}
+
+func TestIncompleteLabelMapDisablesCrossMailboxDedup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServerWithOneShotSelectError(
+		t,
+		map[string]int{
+			"All Mail": 0,
+			"Archive":  0,
+		},
+		map[string][]imapapi.MailboxAttr{
+			"All Mail": {imapapi.MailboxAttrAll},
+		},
+		"Archive",
+	)
+	const messageID = "incomplete-membership@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "All Mail", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", messageID)
+	client := newTestClient(t, addr)
+
+	ids := listAllMessages(t, client)
+	require.ElementsMatch(
+		[]string{"All Mail|1", "Archive|1"},
+		ids,
+	)
+	assert.False(client.LabelsSnapshotComplete())
+
+	results, err := client.GetMessagesRawBatchWithErrors(
+		context.Background(), ids)
+	require.NoError(err)
+	require.Len(results, 2)
+	for _, result := range results {
+		require.NoError(result.Err)
+		require.NotNil(result.Message)
+		require.NotEmpty(result.Message.Raw,
+			"an incomplete membership map must not produce dedup stubs")
+		mailbox, _, err := parseCompositeID(result.ID)
+		require.NoError(err)
+		assert.Contains(result.Message.LabelIDs, mailbox)
+	}
+}
+
+func TestApplyLabelFetchResultsMarksOnlyMissingUID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	results := newLabelBatchResults([]string{"Archive|10", "Archive|11"})
+	uidToIdx := map[imapapi.UID]int{
+		imapapi.UID(10): 0,
+		imapapi.UID(11): 1,
+	}
+	chunk := []batchFetchItem{
+		{idx: 0, uid: imapapi.UID(10)},
+		{idx: 1, uid: imapapi.UID(11)},
+	}
+	msgs := []*imapclient.FetchMessageBuffer{
+		fetchMessageBuffer(
+			"message-10",
+			[]byte("Message-ID: <message-10@example.com>\r\n\r\n"),
+		),
+	}
+
+	var c Client
+	c.applyLabelFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+
+	assert.Equal([]string{"Archive"}, results[0].LabelIDs)
+	require.NoError(results[0].Err)
+	assert.Nil(results[1].LabelIDs)
+	require.ErrorIs(results[1].Err, errIMAPFetchResultMissing)
+}
+
 func TestApplyFetchResultsMarksMissingUIDs(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -88,7 +342,7 @@ func TestApplyFetchResultsMarksMissingUIDs(t *testing.T) {
 		{idx: 1, uid: imapapi.UID(11)},
 	}
 	msgs := []*imapclient.FetchMessageBuffer{
-		fetchMessageBuffer(imapapi.UID(10), "message-10", []byte("raw-10")),
+		fetchMessageBuffer("message-10", []byte("raw-10")),
 	}
 
 	var c Client
@@ -116,7 +370,7 @@ func TestApplyFetchResultsMarksMissingRawBody(t *testing.T) {
 		},
 		{
 			name: "empty body",
-			msg:  fetchMessageBuffer(imapapi.UID(10), "message-10", nil),
+			msg:  fetchMessageBuffer("message-10", nil),
 		},
 	}
 
@@ -143,7 +397,6 @@ func TestApplyFetchResultsPreservesDedupStub(t *testing.T) {
 	chunk := []batchFetchItem{{idx: 0, uid: imapapi.UID(10)}}
 	msgs := []*imapclient.FetchMessageBuffer{
 		fetchMessageBuffer(
-			imapapi.UID(10),
 			"duplicate@example.com",
 			[]byte("Message-ID: <duplicate@example.com>\r\n\r\nbody"),
 		),
@@ -277,9 +530,9 @@ func TestApplyFetchResultsImportsWhenRawMessageIDMissingOrInvalid(t *testing.T) 
 	}
 }
 
-func fetchMessageBuffer(uid imapapi.UID, messageID string, raw []byte) *imapclient.FetchMessageBuffer {
+func fetchMessageBuffer(messageID string, raw []byte) *imapclient.FetchMessageBuffer {
 	return &imapclient.FetchMessageBuffer{
-		UID:        uid,
+		UID:        imapapi.UID(10),
 		Envelope:   &imapapi.Envelope{MessageID: messageID},
 		RFC822Size: int64(len(raw)),
 		BodySection: []imapclient.FetchBodySectionBuffer{

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -46,17 +46,32 @@ func WithListProgress(fn func(done, total int, mailbox string, found, unchanged 
 	return func(c *Client) { c.listProgress = fn }
 }
 
+// WithFolderFilter sets folder include/exclude lists for a single sync run.
+// --folders/--skip-folders replaces or filters the config's folder list.
+func WithFolderFilter(include, exclude []string) Option {
+	return func(c *Client) {
+		c.folderFilterInclude = include
+		c.folderFilterExclude = exclude
+	}
+}
+
 // fetchChunkSize is the maximum number of UIDs per UID FETCH command.
 // Large FETCH sets cause server-side timeouts on big mailboxes; chunking
 // keeps each round-trip short.
-const fetchChunkSize = 50
-
+//
 // listPageSize is the number of message IDs returned per ListMessages
 // call. Each page ends with a checkpoint write and a progress update,
 // and IMAP fetches are slow enough (single connection, chunked FETCH)
 // that Gmail-sized 500-message pages left half-minute gaps between
 // progress updates.
-const listPageSize = 100
+const (
+	fetchChunkSize = 50
+	listPageSize   = 100
+)
+
+// Trash is the canonical fallback name for the trash mailbox on servers
+// that do not advertise \Trash via special-use attributes.
+const Trash = "Trash"
 
 // Client implements gmail.API for IMAP servers.
 type Client struct {
@@ -75,10 +90,16 @@ type Client struct {
 	junkMailbox         string               // cached junk/spam mailbox name
 	allMailFolder       string               // mailbox with \All attribute (empty if not detected)
 	msgIDToLabels       map[string][]string  // RFC822 Message-ID → mailbox memberships
-	seenRFC822IDs       map[string]bool      // dedup across All Mail + Trash/Spam
+	seenRFC822IDs       map[string]bool      // dedup overlapping mailbox copies
+	labelMapComplete    bool                 // latest listing collected every mailbox membership
 	since               time.Time            // IMAP SINCE date filter (zero = no filter)
 	before              time.Time            // IMAP BEFORE date filter (zero = no filter)
 
+	// folderFilter overrides which mailboxes are included in the sync.
+	// Zero-valued (empty include and exclude) means "all mailboxes".
+	folderFilterInclude, folderFilterExclude []string
+
+	forceFullEnumeration bool
 	priorFolderStates    map[string]FolderState // saved states from the last completed sync
 	observedFolderStates map[string]FolderState // states captured during this session's listing
 	folderStateSave      func(string, FolderState)
@@ -99,14 +120,43 @@ type Client struct {
 // NewClient creates a new IMAP client.
 func NewClient(cfg *Config, password string, opts ...Option) *Client {
 	c := &Client{
-		config:   cfg,
-		password: password,
-		logger:   slog.Default(),
+		config:           cfg,
+		password:         password,
+		logger:           slog.Default(),
+		labelMapComplete: true,
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
 	return c
+}
+
+// LabelsSnapshotComplete reports whether a sync sees every mailbox label.
+// Folder- and date-filtered syncs only have a partial label view and must not
+// replace labels or canonical message IDs discovered by an earlier full sync.
+func (c *Client) LabelsSnapshotComplete() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.labelMapComplete &&
+		c.config != nil &&
+		!c.labelsSnapshotFilteredLocked()
+}
+
+// LabelsSnapshotFiltered reports whether folder or date filters explicitly
+// constrain the mailbox membership view.
+func (c *Client) LabelsSnapshotFiltered() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.labelsSnapshotFilteredLocked()
+}
+
+func (c *Client) labelsSnapshotFilteredLocked() bool {
+	return c.config != nil &&
+		(!c.since.IsZero() ||
+			!c.before.IsZero() ||
+			len(c.config.Folders) > 0 ||
+			len(c.folderFilterInclude) > 0 ||
+			len(c.folderFilterExclude) > 0)
 }
 
 // connect establishes and authenticates the IMAP connection. Caller must hold mu.
@@ -269,7 +319,7 @@ func (c *Client) listMailboxesLocked() ([]string, error) {
 
 	// Fallback: look for common trash folder names
 	if c.trashMailbox == "" {
-		for _, candidate := range []string{"Trash", "[Gmail]/Trash", "Deleted Items", "Deleted Messages"} {
+		for _, candidate := range []string{Trash, "[Gmail]/Trash", "Deleted Items", "Deleted Messages"} {
 			for _, mb := range names {
 				if strings.EqualFold(mb, candidate) {
 					c.trashMailbox = mb
@@ -441,8 +491,10 @@ func (c *Client) fetchMailboxMessageIDs(
 	return result, nil
 }
 
-// buildLabelMap enumerates non-All-Mail mailboxes and fetches
-// Message-ID headers to build a Message-ID → mailbox membership map.
+// buildLabelMap enumerates every mailbox except \All (whose memberships come
+// from the other mailboxes) and fetches Message-ID headers to build a
+// Message-ID → mailbox membership map. When \All is absent, every mailbox is
+// included.
 // Caller must hold mu.
 func (c *Client) buildLabelMap(
 	ctx context.Context, allMailboxes []string,
@@ -496,6 +548,12 @@ func (c *Client) buildLabelMap(
 // mailboxes so labels are preserved.
 // Caller must hold mu and have an active connection.
 func (c *Client) buildMessageListCache(ctx context.Context) error {
+	// Stay conservative until both membership collection and message
+	// enumeration finish. Any recoverable mailbox failure makes labels from
+	// this listing additive rather than authoritative.
+	c.labelMapComplete = false
+	c.seenRFC822IDs = nil
+
 	allMailboxes, err := c.listMailboxesLocked()
 	if err != nil {
 		if isNetworkError(err) {
@@ -509,21 +567,31 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		}
 	}
 
+	// Apply folder selection once against the full LIST result so CLI
+	// includes can override configuration, and CLI exclusions apply
+	// regardless of whether --folders was provided.
+	allMailboxes = filterMailboxes(
+		allMailboxes,
+		c.effectiveFolderIncludeLocked(),
+		c.folderFilterExclude,
+	)
+
 	// Determine which mailboxes to list for canonical message IDs.
 	listMailboxes := allMailboxes
 	isGmailAllMail := false
 	if c.allMailFolder != "" {
 		isGmailAllMail = strings.HasPrefix(c.allMailFolder, "[Gmail]/")
-		if isGmailAllMail {
+		if isGmailAllMail && slices.Contains(allMailboxes, c.allMailFolder) {
 			// Gmail's All Mail contains every message except Trash
 			// and Spam. Enumerate those alongside All Mail to catch
-			// messages only in those folders.
+			// messages only in those folders, but only when each
+			// canonical mailbox remains in the effective folder filter.
 			listMailboxes = []string{c.allMailFolder}
-			if c.trashMailbox != "" {
+			if slices.Contains(allMailboxes, c.trashMailbox) {
 				listMailboxes = append(
 					listMailboxes, c.trashMailbox)
 			}
-			if c.junkMailbox != "" {
+			if slices.Contains(allMailboxes, c.junkMailbox) {
 				listMailboxes = append(
 					listMailboxes, c.junkMailbox)
 			}
@@ -542,7 +610,8 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	if trackFolders {
 		c.observedFolderStates = make(map[string]FolderState, len(allMailboxes))
 		folderStatuses, unchangedStatuses = c.observeFolderStates(ctx, allMailboxes)
-		if c.allMailFolder != "" &&
+		if !c.forceFullEnumeration &&
+			c.allMailFolder != "" &&
 			len(folderStatuses) == len(allMailboxes) &&
 			unchangedStatuses == len(allMailboxes) {
 			maps.Copy(c.observedFolderStates, folderStatuses)
@@ -553,29 +622,46 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			c.logger.Info("skipped unchanged mailboxes",
 				"unchanged", unchangedStatuses, "total", len(allMailboxes))
 			c.messageListCache = []gmailapi.MessageID{}
+			c.labelMapComplete = true
 			return nil
 		}
 	} else {
 		c.clearFolderAcknowledgements()
 	}
 
-	labelMapComplete := true
+	// A scan without saved folder states enumerates every UID, so it can build
+	// an authoritative membership map even when the server has no \All
+	// mailbox. Saved-state scans may skip unchanged mailboxes or enumerate only
+	// UIDs above UIDNEXT; keep those partial views additive.
+	fullScanWithoutAll := c.allMailFolder == "" &&
+		trackFolders &&
+		(c.forceFullEnumeration || len(c.priorFolderStates) == 0) &&
+		c.config != nil &&
+		len(c.config.Folders) == 0 &&
+		len(c.folderFilterInclude) == 0 &&
+		len(c.folderFilterExclude) == 0
+	buildMembershipMap := c.allMailFolder != "" || fullScanWithoutAll
+	labelMapComplete := false
 	if c.allMailFolder != "" {
 		// On non-Gmail servers with \All, enumerate all selectable
 		// mailboxes — \All may not be a superset of every folder.
-		// Enable dedup to handle overlaps regardless of server.
-		c.seenRFC822IDs = make(map[string]bool)
 		c.logger.Info("detected All Mail folder via \\All attribute",
 			"folder", c.allMailFolder,
 			"gmail", isGmailAllMail,
 			"trash", c.trashMailbox,
 			"junk", c.junkMailbox,
 			"total_mailboxes", len(allMailboxes))
-
-		var err error
-		labelMapComplete, err = c.buildLabelMap(ctx, allMailboxes)
-		if err != nil {
-			return err
+	}
+	if buildMembershipMap {
+		var mapErr error
+		labelMapComplete, mapErr = c.buildLabelMap(ctx, allMailboxes)
+		if mapErr != nil {
+			return mapErr
+		}
+		if labelMapComplete {
+			// A complete membership map lets the first raw result carry every
+			// mailbox label before overlapping copies become dedup stubs.
+			c.seenRFC822IDs = make(map[string]bool)
 		}
 	}
 
@@ -592,18 +678,20 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 				observed = &status
 				trackState = status
 				canTrackFolder = true
-				if prior, ok := c.priorFolderStates[mailbox]; ok &&
-					prior.UIDValidity == status.UIDValidity &&
-					prior.UIDNext <= status.UIDNext {
-					if prior.UIDNext == status.UIDNext {
-						// Unchanged since the last completed sync:
-						// no new messages possible, skip enumeration.
-						c.observedFolderStates[mailbox] = status
-						unchangedFolders++
-						return true
+				if !c.forceFullEnumeration {
+					if prior, ok := c.priorFolderStates[mailbox]; ok &&
+						prior.UIDValidity == status.UIDValidity &&
+						prior.UIDNext <= status.UIDNext {
+						if prior.UIDNext == status.UIDNext {
+							// Unchanged since the last completed sync:
+							// no new messages possible, skip enumeration.
+							c.observedFolderStates[mailbox] = status
+							unchangedFolders++
+							return true
+						}
+						// Only new messages need listing.
+						minUID = imap.UID(prior.UIDNext)
 					}
-					// Only new messages need listing.
-					minUID = imap.UID(prior.UIDNext)
 				}
 			}
 		} else if trackFolders && c.allMailFolder != "" {
@@ -663,6 +751,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	}
 
 	c.messageListCache = messages
+	c.labelMapComplete = labelMapComplete && enumerationComplete
 	return nil
 }
 
@@ -680,9 +769,87 @@ func isNetworkError(err error) bool {
 		strings.Contains(msg, "EOF")
 }
 
+// mailboxIncludedLocked reports whether mailbox is in the effective folder
+// selection. Caller must hold mu.
+func (c *Client) mailboxIncludedLocked(mailbox string) bool {
+	return len(filterMailboxes(
+		[]string{mailbox},
+		c.effectiveFolderIncludeLocked(),
+		c.folderFilterExclude,
+	)) == 1
+}
+
+// effectiveFolderIncludeLocked returns the active folder allow list. Caller
+// must hold mu.
+func (c *Client) effectiveFolderIncludeLocked() []string {
+	// CLI --folders replaces config folders when set; otherwise use
+	// config.Folders.
+	if len(c.folderFilterInclude) > 0 {
+		return c.folderFilterInclude
+	}
+	return c.config.Folders
+}
+
+// filterMailboxes applies an include list (allow-list) and/or an
+// exclude list (deny-list) to the mailbox names returned by LIST.
+// Include and exclude are case-insensitive. Empty lists are no-ops.
+// If both are non-empty, include is applied first, then exclude.
+// When include is empty but exclude is set, the result is all
+// mailboxes minus the excluded names (case-insensitive). When
+// include is set but exclude is empty, only the names in include
+// are kept (case-insensitively).
+func filterMailboxes(all []string, include, exclude []string) []string {
+	if len(include) == 0 && len(exclude) == 0 {
+		return all
+	}
+	lcInclude := make(map[string]bool, len(include))
+	for _, f := range include {
+		lcInclude[strings.ToLower(f)] = true
+	}
+	lcExclude := make(map[string]bool, len(exclude))
+	for _, f := range exclude {
+		lcExclude[strings.ToLower(f)] = true
+	}
+	var out = make([]string, 0, len(all))
+	for _, m := range all {
+		lc := strings.ToLower(m)
+		if len(lcInclude) > 0 && !lcInclude[lc] {
+			continue
+		}
+		if len(lcExclude) > 0 && lcExclude[lc] {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
 // hasAttr checks whether attr is in the attrs list.
 func hasAttr(attrs []imap.MailboxAttr, attr imap.MailboxAttr) bool {
 	return slices.Contains(attrs, attr)
+}
+
+// MailboxInfo is the result of listing a mailbox with its count.
+type MailboxInfo struct {
+	Mailbox     string
+	NumMessages int64 // -1 = count unavailable
+}
+
+// listMailboxesLockedFromConn returns all selectable mailbox names
+// for an already-connected IMAP client. It skips NoSelect mailboxes.
+func listMailboxesLockedFromConn(conn *imapclient.Client) ([]string, error) {
+	items, err := conn.List("", "*", nil).Collect()
+	if err != nil {
+		return nil, fmt.Errorf("LIST: %w", err)
+	}
+	var names []string
+	for _, item := range items {
+		if hasAttr(item.Attrs, imap.MailboxAttrNoSelect) {
+			continue
+		}
+		names = append(names, item.Mailbox)
+	}
+	return names, nil
 }
 
 // compositeID builds a message identifier as "mailbox|uid".
@@ -751,6 +918,42 @@ func (c *Client) ListLabels(ctx context.Context) ([]*gmailapi.Label, error) {
 		return nil, err
 	}
 	return labels, nil
+}
+
+// ListMailboxes returns all selectable mailbox names for this
+// account. It connects, authenticates, and runs LIST "" "*. The
+// result includes the approximate message count for each folder.
+func (c *Client) ListMailboxes(ctx context.Context) ([]MailboxInfo, error) {
+	var info []MailboxInfo
+	err := c.withConn(ctx, func(conn *imapclient.Client) error {
+		names, err := listMailboxesLockedFromConn(conn)
+		if err != nil {
+			return err
+		}
+		for _, mb := range names {
+			// STATUS round-trip per mailbox — the go-imap/v2 library
+			// at v2.0.0-beta.8 does not expose a multi-mailbox batch
+			// STATUS call, so we issue one STATUS per folder.  This
+			// can be replaced with a single batch STATUS once the
+			// library adds a multi-mailbox API or a newer version is
+			// adopted. See: github.com/emersion/go-imap/issues
+			status, err := conn.Status(mb, &imap.StatusOptions{NumMessages: true}).Wait()
+			if err != nil {
+				info = append(info, MailboxInfo{Mailbox: mb, NumMessages: -1})
+				continue
+			}
+			count := int64(0)
+			if status.NumMessages != nil {
+				count = int64(*status.NumMessages)
+			}
+			info = append(info, MailboxInfo{Mailbox: mb, NumMessages: count})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 // ListMessages returns a page of message IDs from all IMAP mailboxes.
@@ -849,7 +1052,7 @@ func (c *Client) TrashMessage(ctx context.Context, messageID string) error {
 		}
 		trashMailbox := c.trashMailbox
 		if trashMailbox == "" {
-			trashMailbox = "Trash"
+			trashMailbox = Trash
 		}
 		var uidSet imap.UIDSet
 		uidSet.AddNum(uid)

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -2,6 +2,7 @@ package imap
 
 import (
 	"context"
+	"maps"
 	"net"
 	"strconv"
 	"strings"
@@ -590,6 +591,8 @@ func TestSourceMessageExistsPreservesListedMailboxSelectionError(t *testing.T) {
 }
 
 func TestSourceMessageMatchesDefersExcludedMailbox(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServerWithSelectError(
 		t,
 		map[string]int{
@@ -602,13 +605,13 @@ func TestSourceMessageMatchesDefersExcludedMailbox(t *testing.T) {
 	client := newTestClient(
 		t, addr, WithFolderFilter([]string{"INBOX"}, nil))
 
-	require.Equal(t, []string{"INBOX|1"}, listAllMessages(t, client))
+	require.Equal([]string{"INBOX|1"}, listAllMessages(t, client))
 
 	matches, conclusive, err := client.SourceMessageMatches(
 		context.Background(), "Archive|1", "excluded@example.com")
-	require.NoError(t, err)
-	assert.False(t, matches)
-	assert.False(t, conclusive)
+	require.NoError(err)
+	assert.False(matches)
+	assert.False(conclusive)
 }
 
 func TestSourceMessageMatchesRFC822Identity(t *testing.T) {
@@ -675,9 +678,7 @@ func TestFetchedSourceMessageMatchesIdentityMatrix(t *testing.T) {
 	require.NoError(t, user.Delete("Removed"))
 
 	changedEpoch := make(map[string]FolderState, len(saved))
-	for mailbox, state := range saved {
-		changedEpoch[mailbox] = state
-	}
+	maps.Copy(changedEpoch, saved)
 	state := changedEpoch["INBOX"]
 	state.UIDValidity++
 	changedEpoch["INBOX"] = state
@@ -768,6 +769,8 @@ func TestFetchedSourceMessageMatchesIdentityMatrix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
 			client := newTestClient(t, addr, tt.opts...)
 			listAllMessages(t, client)
 
@@ -777,12 +780,12 @@ func TestFetchedSourceMessageMatchesIdentityMatrix(t *testing.T) {
 				tt.actualID,
 			)
 			if tt.wantErr {
-				require.Error(t, err)
+				require.Error(err)
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantMatch, matches)
-			assert.Equal(t, tt.conclusive, conclusive)
+			require.NoError(err)
+			assert.Equal(tt.wantMatch, matches)
+			assert.Equal(tt.conclusive, conclusive)
 		})
 	}
 }

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	imapv2 "github.com/emersion/go-imap/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/testutil"
@@ -238,4 +240,644 @@ func TestAcknowledgeMessagesFlushesFolderStateWhenFolderComplete(t *testing.T) {
 
 	client.AcknowledgeMessages(context.Background(), []string{"INBOX|2"})
 	assert.Len(saved, 2, "duplicate acknowledgements must not save a folder twice")
+}
+
+// TestWithFolderFilter_IncludesOnlySelectedMailboxes verifies that
+// WithFolderFilter with an include list limits ListMessages to only
+// the specified folders.
+func TestWithFolderFilter_IncludesOnlySelectedMailboxes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	// Provide INBOX, Archive, Trash — we only want Inbox and Trash via filter.
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
+
+	client := newTestClient(t, addr,
+		WithFolderFilter([]string{"INBOX", "Trash"}, nil),
+	)
+
+	ids := listAllMessages(t, client)
+	// Archive should be excluded; only INBOX and Trash messages.
+	assert.Len(ids, 3, "only INBOX and Trash should be listed")
+
+	var inboxCount, trashCount int
+	for _, id := range ids {
+		if strings.HasPrefix(id, "INBOX|") {
+			inboxCount++
+		}
+		if strings.HasPrefix(id, "Trash|") {
+			trashCount++
+		}
+		assert.True(strings.HasPrefix(id, "INBOX") || strings.HasPrefix(id, "Trash"), "unexpected mailbox in results: %s", id)
+	}
+	assert.Equal(2, inboxCount, "INBOX messages")
+	assert.Equal(1, trashCount, "Trash messages")
+
+	// Archive should not appear.
+	for _, id := range ids {
+		assert.False(strings.HasPrefix(id, "Archive|"), "Archive should not be listed")
+	}
+
+	// Folder states recorded should only include the filtered mailboxes.
+	states := client.ObservedFolderStates()
+	require.Contains(states, "INBOX")
+	require.Contains(states, "Trash")
+	assert.NotContains(states, "Archive", "Archive state should not be recorded")
+}
+
+// TestWithFolderFilter_ExcludesSpecifiedMailboxes verifies that
+// WithFolderFilter with an exclude list removes the specified
+// mailboxes from ListMessages.
+func TestWithFolderFilter_ExcludesSpecifiedMailboxes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
+
+	client := newTestClient(t, addr,
+		WithFolderFilter(nil, []string{"Trash"}),
+	)
+
+	ids := listAllMessages(t, client)
+	require.Len(ids, 5, "INBOX(2) + Archive(3) = 5 after excluding Trash(1)")
+
+	for _, id := range ids {
+		assert.False(strings.HasPrefix(id, "Trash|"), "Trash should not be listed")
+	}
+
+	states := client.ObservedFolderStates()
+	require.Contains(states, "INBOX")
+	require.Contains(states, "Archive")
+	assert.NotContains(states, "Trash", "Trash state should not be recorded")
+}
+
+// TestWithFolderFilter_ConfigFoldersRespectsIncludeList verifies that
+// the Folders field in the IMAP config is applied during
+// buildMessageListCache via filterMailboxes before any CLI filter would.
+func TestWithFolderFilter_ConfigFoldersRespectsIncludeList(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Drafts": 1})
+
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(err)
+
+	// Configure the client with Folders = ["Archive"] so only Archive
+	// should appear during ListMessages.
+	client := NewClient(&Config{
+		Host:     host,
+		Port:     port,
+		Username: testutil.IMAPTestUsername,
+		Folders:  []string{"Archive"},
+	}, testutil.IMAPTestPassword)
+	t.Cleanup(func() { _ = client.Close() })
+
+	ids := listAllMessages(t, client)
+	require.Len(ids, 3, "only messages from Archive should be listed")
+
+	// All results must be from Archive.
+	for _, id := range ids {
+		assert.True(strings.HasPrefix(id, "Archive|"), "expected Archive mailbox, got: %s", id)
+	}
+
+	states := client.ObservedFolderStates()
+	require.Contains(states, "Archive")
+	assert.NotContains(states, "INBOX")
+	assert.NotContains(states, "Drafts")
+}
+
+// TestWithFolderFilter_CLIReplacingConfig verifies that a CLI --folders
+// include filter fully replaces the config's include list when set.
+// CLI exclusions apply on top of the effective include regardless.
+func TestWithFolderFilter_CLIReplacingConfig(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// Case 1: CLI include replaces config include — config says
+	// Archive, --folders says INBOX, expect only INBOX.
+	t.Run("CLI include replaces config include", func(t *testing.T) {
+		addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
+
+		host, portStr, err := net.SplitHostPort(addr)
+		require.NoError(err)
+		port, err := strconv.Atoi(portStr)
+		require.NoError(err)
+
+		client := NewClient(&Config{
+			Host:     host,
+			Port:     port,
+			Username: testutil.IMAPTestUsername,
+			Folders:  []string{"Archive"},
+		}, testutil.IMAPTestPassword,
+			WithFolderFilter([]string{"INBOX"}, nil),
+		)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ids := listAllMessages(t, client)
+		assert.Len(ids, 2, "CLI include replaces config include — only INBOX listed")
+
+		for _, id := range ids {
+			assert.True(strings.HasPrefix(id, "INBOX|"), "expected INBOX, got: %s", id)
+		}
+	})
+
+	// Case 2: CLI include + CLI exclude applied together — config
+	// includes nothing, --folders=["Inbox,Archive"],
+	// --skip-folders=["Inbox"]. Expect only Archive.
+	t.Run("CLI include and CLI exclude combine", func(t *testing.T) {
+		addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
+
+		host, portStr, err := net.SplitHostPort(addr)
+		require.NoError(err)
+		port, err := strconv.Atoi(portStr)
+		require.NoError(err)
+
+		client := NewClient(&Config{
+			Host:     host,
+			Port:     port,
+			Username: testutil.IMAPTestUsername,
+		}, testutil.IMAPTestPassword,
+			WithFolderFilter([]string{"Inbox", "Archive"}, []string{"Inbox"}),
+		)
+		t.Cleanup(func() { _ = client.Close() })
+
+		ids := listAllMessages(t, client)
+		require.Len(ids, 3, "include Inbox+Archive minus exclude Inbox = Archive only")
+
+		for _, id := range ids {
+			assert.True(strings.HasPrefix(id, "Archive|"), "expected Archive, got: %s", id)
+		}
+	})
+}
+
+// TestWithFolderFilter_CLIExcludeWithConfigIncludes verifies that when
+// only --skip-folders is set (CLI exclude), it excludes from the config's
+// include list. With no config Folders set, --skip-folders excludes from
+// all mailboxes.
+func TestWithFolderFilter_CLIExcludeConfigIncludes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
+
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(err)
+
+	// Config includes Archive, CLI excludes Trash.
+	// Result: Archive - Trash∩Archive (nothing) = Archive only.
+	client := NewClient(&Config{
+		Host:     host,
+		Port:     port,
+		Username: testutil.IMAPTestUsername,
+		Folders:  []string{"Archive"},
+	}, testutil.IMAPTestPassword,
+		WithFolderFilter(nil, []string{"Trash"}),
+	)
+	t.Cleanup(func() { _ = client.Close() })
+
+	ids := listAllMessages(t, client)
+	// Config says Archive (2 messages), Trash is excluded but doesn't overlap.
+	require.Len(ids, 3, "Archive only (Trash excluded, config doesn't include Trash)")
+
+	for _, id := range ids {
+		assert.True(strings.HasPrefix(id, "Archive|"), "expected Archive, got: %s", id)
+	}
+
+	// Now test CLI exclude with no config folders — exclude from ALL.
+	addr2, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
+	host2, portStr2, err := net.SplitHostPort(addr2)
+	require.NoError(err)
+	port2, err := strconv.Atoi(portStr2)
+	require.NoError(err)
+
+	client2 := NewClient(&Config{
+		Host:     host2,
+		Port:     port2,
+		Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword,
+		WithFolderFilter(nil, []string{"Archive"}),
+	)
+	t.Cleanup(func() { _ = client2.Close() })
+
+	ids2 := listAllMessages(t, client2)
+	require.Len(ids2, 3, "all minus Archive (INBOX(2) + Trash(1))")
+
+	for _, id := range ids2 {
+		assert.False(strings.HasPrefix(id, "Archive|"), "Archive should not appear when excluded with no config")
+	}
+}
+
+// TestWithFolderFilter_NoConfigNoCLIIncludesAll verifies that when
+// neither config folders nor CLI folder filters are set, all mailboxes
+// are listed (no-op filter).
+func TestWithFolderFilter_NoConfigNoCLIIncludesAll(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Drafts": 1})
+
+	client := newTestClient(t, addr)
+	ids := listAllMessages(t, client)
+	assert.Len(t, ids, 6, "without filters all mailboxes should list")
+}
+
+func TestClientReportsLabelSnapshotCompleteness(t *testing.T) {
+	after := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, time.February, 3, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		cfg          *Config
+		opts         []Option
+		wantComplete bool
+		wantFiltered bool
+	}{
+		{
+			name:         "unfiltered",
+			cfg:          &Config{},
+			wantComplete: true,
+		},
+		{
+			name:         "config include",
+			cfg:          &Config{Folders: []string{"INBOX"}},
+			wantFiltered: true,
+		},
+		{
+			name:         "runtime include",
+			cfg:          &Config{},
+			opts:         []Option{WithFolderFilter([]string{"INBOX"}, nil)},
+			wantFiltered: true,
+		},
+		{
+			name:         "runtime exclude",
+			cfg:          &Config{},
+			opts:         []Option{WithFolderFilter(nil, []string{"Trash"})},
+			wantFiltered: true,
+		},
+		{
+			name:         "after filter",
+			cfg:          &Config{},
+			opts:         []Option{WithDateFilter(after, time.Time{})},
+			wantFiltered: true,
+		},
+		{
+			name:         "before filter",
+			cfg:          &Config{},
+			opts:         []Option{WithDateFilter(time.Time{}, before)},
+			wantFiltered: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			client := NewClient(tt.cfg, "", tt.opts...)
+			completeness, ok := any(client).(interface {
+				LabelsSnapshotComplete() bool
+			})
+			require.True(ok, "IMAP client must report label snapshot completeness")
+			assert.Equal(tt.wantComplete, completeness.LabelsSnapshotComplete())
+
+			filtering, ok := any(client).(interface {
+				LabelsSnapshotFiltered() bool
+			})
+			require.True(ok, "IMAP client must report explicit snapshot filters")
+			assert.Equal(tt.wantFiltered, filtering.LabelsSnapshotFiltered())
+		})
+	}
+}
+
+func TestSourceMessageExists(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 1})
+	client := newTestClient(t, addr)
+
+	exists, err := client.SourceMessageExists(
+		context.Background(), "INBOX|1")
+	require.NoError(err)
+	require.True(exists)
+
+	exists, err = client.SourceMessageExists(
+		context.Background(), "INBOX|99")
+	require.NoError(err)
+	require.False(exists)
+
+	require.Equal([]string{"INBOX|1"}, listAllMessages(t, client))
+
+	exists, err = client.SourceMessageExists(
+		context.Background(), "Renamed|1")
+	require.NoError(err)
+	require.False(exists)
+
+	_, err = client.SourceMessageExists(context.Background(), "invalid")
+	require.Error(err)
+}
+
+func TestSourceMessageExistsPreservesListedMailboxSelectionError(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServerWithSelectError(
+		t,
+		map[string]int{"INBOX": 1},
+		nil,
+		"INBOX",
+	)
+	client := newTestClient(t, addr)
+
+	require.Empty(listAllMessages(t, client))
+	require.Equal([]string{"INBOX"}, client.mailboxCache)
+
+	_, err := client.SourceMessageExists(
+		context.Background(), "INBOX|1")
+	require.Error(err)
+}
+
+func TestSourceMessageMatchesDefersExcludedMailbox(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServerWithSelectError(
+		t,
+		map[string]int{
+			"Archive": 1,
+			"INBOX":   1,
+		},
+		nil,
+		"Archive",
+	)
+	client := newTestClient(
+		t, addr, WithFolderFilter([]string{"INBOX"}, nil))
+
+	require.Equal(t, []string{"INBOX|1"}, listAllMessages(t, client))
+
+	matches, conclusive, err := client.SourceMessageMatches(
+		context.Background(), "Archive|1", "excluded@example.com")
+	require.NoError(t, err)
+	assert.False(t, matches)
+	assert.False(t, conclusive)
+}
+
+func TestSourceMessageMatchesRFC822Identity(t *testing.T) {
+	require := require.New(t)
+	addr, user := testutil.StartIMAPMemServer(
+		t, map[string]int{"INBOX": 0})
+	const messageID = "source-match@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+	client := newTestClient(t, addr)
+	require.Equal([]string{"INBOX|1"}, listAllMessages(t, client))
+
+	matches, conclusive, err := client.SourceMessageMatches(
+		context.Background(), "INBOX|1", messageID)
+	require.NoError(err)
+	require.True(matches)
+	require.True(conclusive)
+
+	matches, conclusive, err = client.SourceMessageMatches(
+		context.Background(), "INBOX|1", "<"+messageID+">")
+	require.NoError(err)
+	require.True(matches)
+	require.True(conclusive)
+
+	matches, conclusive, err = client.SourceMessageMatches(
+		context.Background(), "INBOX|1", "replacement@example.com")
+	require.NoError(err)
+	require.False(matches)
+	require.True(conclusive)
+}
+
+func TestSourceMessageMatchesRejectsUIDValidityChange(t *testing.T) {
+	require := require.New(t)
+	addr, user := testutil.StartIMAPMemServer(
+		t, map[string]int{"INBOX": 0})
+	const messageID = "uidvalidity-match@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+
+	first := newTestClient(t, addr)
+	require.Equal([]string{"INBOX|1"}, listAllMessages(t, first))
+	stale := first.ObservedFolderStates()
+	require.NoError(first.Close())
+	state := stale["INBOX"]
+	state.UIDValidity++
+	stale["INBOX"] = state
+
+	second := newTestClient(t, addr, WithFolderStates(stale))
+	require.Equal([]string{"INBOX|1"}, listAllMessages(t, second))
+	matches, conclusive, err := second.SourceMessageMatches(
+		context.Background(), "INBOX|1", messageID)
+	require.NoError(err)
+	require.False(matches)
+	require.True(conclusive)
+}
+
+func TestFetchedSourceMessageMatchesIdentityMatrix(t *testing.T) {
+	addr, user := testutil.StartIMAPMemServer(
+		t, map[string]int{"INBOX": 0, "Removed": 0})
+	const messageID = "fetched-source@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+	first := newTestClient(t, addr)
+	require.Equal(t, []string{"INBOX|1"}, listAllMessages(t, first))
+	saved := first.ObservedFolderStates()
+	require.NoError(t, first.Close())
+	require.NoError(t, user.Delete("Removed"))
+
+	changedEpoch := make(map[string]FolderState, len(saved))
+	for mailbox, state := range saved {
+		changedEpoch[mailbox] = state
+	}
+	state := changedEpoch["INBOX"]
+	state.UIDValidity++
+	changedEpoch["INBOX"] = state
+
+	tests := []struct {
+		name       string
+		opts       []Option
+		sourceID   string
+		expectedID string
+		actualID   string
+		wantMatch  bool
+		conclusive bool
+		wantErr    bool
+	}{
+		{
+			name:       "same epoch with both IDs missing",
+			opts:       []Option{WithFolderStates(saved)},
+			sourceID:   "INBOX|1",
+			wantMatch:  true,
+			conclusive: true,
+		},
+		{
+			name:       "changed epoch with both IDs missing",
+			opts:       []Option{WithFolderStates(changedEpoch)},
+			sourceID:   "INBOX|1",
+			conclusive: true,
+		},
+		{
+			name:       "missing epoch with both IDs missing",
+			sourceID:   "INBOX|1",
+			conclusive: false,
+		},
+		{
+			name:       "removed mailbox",
+			opts:       []Option{WithFolderStates(saved)},
+			sourceID:   "Removed|1",
+			conclusive: true,
+		},
+		{
+			name:       "equal nonempty IDs normalize angle brackets",
+			sourceID:   "INBOX|1",
+			expectedID: "<" + messageID + ">",
+			actualID:   messageID,
+			wantMatch:  true,
+			conclusive: true,
+		},
+		{
+			name:       "unequal nonempty IDs",
+			sourceID:   "INBOX|1",
+			expectedID: "old@example.com",
+			actualID:   messageID,
+			conclusive: true,
+		},
+		{
+			name:       "only archived ID missing without epoch",
+			sourceID:   "INBOX|1",
+			actualID:   messageID,
+			conclusive: false,
+		},
+		{
+			name:       "only fetched ID missing without epoch",
+			sourceID:   "INBOX|1",
+			expectedID: messageID,
+			conclusive: false,
+		},
+		{
+			name:       "only archived ID missing in same epoch",
+			opts:       []Option{WithFolderStates(saved)},
+			sourceID:   "INBOX|1",
+			actualID:   messageID,
+			wantMatch:  true,
+			conclusive: true,
+		},
+		{
+			name:       "only fetched ID missing in same epoch",
+			opts:       []Option{WithFolderStates(saved)},
+			sourceID:   "INBOX|1",
+			expectedID: messageID,
+			wantMatch:  true,
+			conclusive: true,
+		},
+		{
+			name:     "malformed composite ID",
+			sourceID: "not-composite",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, addr, tt.opts...)
+			listAllMessages(t, client)
+
+			matches, conclusive, err := client.FetchedSourceMessageMatches(
+				tt.sourceID,
+				tt.expectedID,
+				tt.actualID,
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMatch, matches)
+			assert.Equal(t, tt.conclusive, conclusive)
+		})
+	}
+}
+
+func TestClientReportsCompleteSnapshotWithoutAllMailboxOnFullScan(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX":   1,
+		"Archive": 1,
+	})
+	client := newTestClient(t, addr)
+
+	require.Len(t, listAllMessages(t, client), 2)
+
+	assert.True(t, client.LabelsSnapshotComplete(),
+		"a fully enumerated server has an authoritative membership snapshot")
+}
+
+func TestClientReportsIncompleteSnapshotWithoutAllMailboxOnHighWaterScan(t *testing.T) {
+	require := require.New(t)
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX":   1,
+		"Archive": 1,
+	})
+	first := newTestClient(t, addr)
+	require.Len(listAllMessages(t, first), 2)
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+
+	testutil.AppendIMAPMessage(t, user, "Archive")
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	require.Equal([]string{"Archive|2"}, listAllMessages(t, second))
+
+	assert.False(t, second.LabelsSnapshotComplete(),
+		"a high-water scan does not see memberships below the saved UIDNEXT")
+}
+
+func TestClientReportsIncompleteMailboxMembershipCollection(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServerWithSelectError(
+		t,
+		map[string]int{
+			"All Mail": 1,
+			"Archive":  1,
+		},
+		map[string][]imapv2.MailboxAttr{
+			"All Mail": {imapv2.MailboxAttrAll},
+		},
+		"Archive",
+	)
+	client := newTestClient(t, addr)
+
+	require.Equal(t, []string{"All Mail|1"}, listAllMessages(t, client))
+
+	assert.False(t, client.LabelsSnapshotComplete(),
+		"a failed mailbox membership scan must not be authoritative")
+}
+
+func TestWithFolderFilter_GmailCanonicalMailboxesHonorFilters(t *testing.T) {
+	startServer := func(t *testing.T) string {
+		t.Helper()
+		addr, _ := testutil.StartIMAPMemServerWithSpecialUse(
+			t,
+			map[string]int{
+				"INBOX":            2,
+				"[Gmail]/All Mail": 3,
+				"[Gmail]/Trash":    1,
+				"[Gmail]/Spam":     1,
+			},
+			map[string][]imapv2.MailboxAttr{
+				"[Gmail]/All Mail": {imapv2.MailboxAttrAll},
+				"[Gmail]/Trash":    {imapv2.MailboxAttrTrash},
+				"[Gmail]/Spam":     {imapv2.MailboxAttrJunk},
+			},
+		)
+		return addr
+	}
+
+	t.Run("include only INBOX", func(t *testing.T) {
+		client := newTestClient(t, startServer(t),
+			WithFolderFilter([]string{"INBOX"}, nil))
+
+		ids := listAllMessages(t, client)
+		require.Len(t, ids, 2)
+		for _, id := range ids {
+			assert.True(t, strings.HasPrefix(id, "INBOX|"), "unexpected message ID %q", id)
+		}
+	})
+
+	t.Run("exclude Trash", func(t *testing.T) {
+		client := newTestClient(t, startServer(t),
+			WithFolderFilter(nil, []string{"[Gmail]/Trash"}))
+
+		ids := listAllMessages(t, client)
+		require.NotEmpty(t, ids)
+		for _, id := range ids {
+			assert.False(t, strings.HasPrefix(id, "[Gmail]/Trash|"), "Trash must not be enumerated: %q", id)
+		}
+	})
 }

--- a/internal/imap/config.go
+++ b/internal/imap/config.go
@@ -28,6 +28,13 @@ type Config struct {
 	STARTTLS   bool       `json:"starttls"` // STARTTLS upgrade (port 143)
 	Username   string     `json:"username"`
 	AuthMethod AuthMethod `json:"auth_method,omitempty"`
+
+	// Folders is a case-insensitive allow list. When non-empty,
+	// only these mailboxes are synced. An empty list means "all
+	// mailboxes". CLI --folders/--skip-folders override this config:
+	// they are applied after config folders in
+	// buildMessageListCache, so CLI values always take precedence.
+	Folders []string `json:"folders,omitempty"`
 }
 
 // EffectiveAuthMethod returns the auth method, defaulting to password
@@ -99,7 +106,21 @@ func ConfigFromJSON(s string) (*Config, error) {
 	if err := json.Unmarshal([]byte(s), &c); err != nil {
 		return nil, fmt.Errorf("parse IMAP config: %w", err)
 	}
+	c.Folders = trimFolders(c.Folders)
 	return &c, nil
+}
+
+// trimFolders trims leading and trailing whitespace from each folder name
+// in the list. It returns an empty slice if the result is empty after trimming.
+func trimFolders(folders []string) []string {
+	trimmed := make([]string, 0, len(folders))
+	for _, f := range folders {
+		t := strings.TrimSpace(f)
+		if t != "" {
+			trimmed = append(trimmed, t)
+		}
+	}
+	return trimmed
 }
 
 // ParseIdentifier parses a config from an identifier URL like "imaps://user@host:port".

--- a/internal/imap/config_test.go
+++ b/internal/imap/config_test.go
@@ -150,3 +150,60 @@ func TestConfigAuthMethod_XOAuth2(t *testing.T) {
 	assert.Equal(t, AuthXOAuth2, cfg.AuthMethod, "AuthMethod")
 	assert.Equal(t, AuthXOAuth2, cfg.EffectiveAuthMethod(), "EffectiveAuthMethod()")
 }
+
+func TestTrimFolders(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "no whitespace",
+			input: []string{"Inbox", "Sent"},
+			want:  []string{"Inbox", "Sent"},
+		},
+		{
+			name:  "trailing spaces",
+			input: []string{"Inbox ", " Sent Items"},
+			want:  []string{"Inbox", "Sent Items"},
+		},
+		{
+			name:  "leading and trailing spaces",
+			input: []string{"  Inbox  ", "  Sent  "},
+			want:  []string{"Inbox", "Sent"},
+		},
+		{
+			name:  "empty after trim is removed",
+			input: []string{"Inbox", "  ", "", "Sent"},
+			want:  []string{"Inbox", "Sent"},
+		},
+		{
+			name:  "all whitespace is empty slice",
+			input: []string{"  ", ""},
+			want:  []string{},
+		},
+		{
+			name:  "nil input returns empty slice",
+			input: nil,
+			want:  []string{},
+		},
+		{
+			name:  "empty input",
+			input: []string{},
+			want:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trimFolders(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConfigFromJSON_FoldersTrimmed(t *testing.T) {
+	cfg, err := ConfigFromJSON(`{"host":"imap.example.com","port":993,"username":"user","folders":["  Inbox  "," Sent Items ","  "]}`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Inbox", "Sent Items"}, cfg.Folders)
+}

--- a/internal/imap/filter_test.go
+++ b/internal/imap/filter_test.go
@@ -1,0 +1,120 @@
+package imap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterMailboxes(t *testing.T) {
+	cases := []struct {
+		name     string
+		all      []string
+		include  []string
+		exclude  []string
+		expected []string
+	}{
+		{
+			name:     "full list when no filters",
+			all:      []string{"Inbox", "Sent", "Trash"},
+			expected: []string{"Inbox", "Sent", "Trash"},
+		},
+		{
+			name:     "include only",
+			all:      []string{"Inbox", "Sent Items", "Trash", "Archive"},
+			include:  []string{"Inbox", "Sent Items"},
+			expected: []string{"Inbox", "Sent Items"},
+		},
+		{
+			name:     "include only case insensitive",
+			all:      []string{"Inbox", "Sent Items", "trash", "Archive"},
+			include:  []string{"inbox", "SENT ITEMS"},
+			expected: []string{"Inbox", "Sent Items"},
+		},
+		{
+			name:     "exclude only",
+			all:      []string{"Inbox", "Sent Items", "Trash", "Archive"},
+			exclude:  []string{"Trash"},
+			expected: []string{"Inbox", "Sent Items", "Archive"},
+		},
+		{
+			name:     "exclude only case insensitive",
+			all:      []string{"Inbox", "Sent Items", "trash", "Archive"},
+			exclude:  []string{"TRASH"},
+			expected: []string{"Inbox", "Sent Items", "Archive"},
+		},
+		{
+			name:     "include and exclude",
+			all:      []string{"Inbox", "Sent Items", "Trash", "Archive", "Projects"},
+			include:  []string{"Inbox", "Projects", "Trash"},
+			exclude:  []string{"Trash"},
+			expected: []string{"Inbox", "Projects"},
+		},
+		{
+			name:     "include no match returns empty slice",
+			all:      []string{"Inbox", "Sent"},
+			include:  []string{"Deleted Items"},
+			expected: []string{},
+		},
+		{
+			name:     "exclude all returns empty slice",
+			all:      []string{"Inbox", "Sent"},
+			exclude:  []string{"Inbox", "Sent"},
+			expected: []string{},
+		},
+		{
+			name:     "empty input",
+			all:      nil,
+			include:  []string{"Inbox"},
+			expected: []string{},
+		},
+		{
+			name:     "include with duplicates",
+			all:      []string{"Inbox", "Sent", "Inbox", "Trash"},
+			include:  []string{"Inbox", "Sent"},
+			expected: []string{"Inbox", "Sent", "Inbox"},
+		},
+		{
+			name:     "exclude only removes specified",
+			all:      []string{"Inbox", "Deleted Items", "Search Results", "Sent Items"},
+			exclude:  []string{"Deleted Items", "Search Results"},
+			expected: []string{"Inbox", "Sent Items"},
+		},
+		{
+			name:     "mixed case mailboxes",
+			all:      []string{"Inbox", "Sent Items", "trash"},
+			include:  []string{"inbox", "sent items"},
+			expected: []string{"Inbox", "Sent Items"},
+		},
+		{
+			name:     "nested folders",
+			all:      []string{"Projects/Alpha", "Projects/Beta", "Inbox"},
+			include:  []string{"Projects/Alpha", "inbox"},
+			expected: []string{"Projects/Alpha", "Inbox"},
+		},
+		{
+			name:     "non-matching filter returns empty slice",
+			all:      []string{"Inbox", "Sent", "Trash"},
+			include:  []string{"Nonexistent"},
+			expected: []string{},
+		},
+		{
+			name:     "empty include single exclude",
+			all:      []string{"Inbox", "Sent", "Trash"},
+			exclude:  []string{"Trash"},
+			expected: []string{"Inbox", "Sent"},
+		},
+		{
+			name:     "empty exclude single include",
+			all:      []string{"Inbox", "Sent", "Trash"},
+			include:  []string{"Inbox"},
+			expected: []string{"Inbox"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, filterMailboxes(tc.all, tc.include, tc.exclude))
+		})
+	}
+}

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -3,7 +3,6 @@ package imap
 import (
 	"context"
 	"fmt"
-	"maps"
 
 	imap "github.com/emersion/go-imap/v2"
 )
@@ -43,9 +42,10 @@ func WithFolderStateSave(fn func(string, FolderState)) Option {
 
 // ObservedFolderStates returns the per-mailbox states captured during
 // the last message-list enumeration, for persistence after a completed
-// sync. Mailboxes whose STATUS or enumeration failed are absent, so
-// saved state for them is left untouched. Returns nil when folder
-// tracking was disabled (date filter or no listing yet).
+// sync. Mailboxes whose STATUS or enumeration failed are absent, and
+// mailboxes with unacknowledged messages are omitted, so saved state for
+// them is left untouched. Returns nil when folder tracking was disabled
+// (date filter or no listing yet).
 func (c *Client) ObservedFolderStates() map[string]FolderState {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -53,7 +53,12 @@ func (c *Client) ObservedFolderStates() map[string]FolderState {
 		return nil
 	}
 	states := make(map[string]FolderState, len(c.observedFolderStates))
-	maps.Copy(states, c.observedFolderStates)
+	for mailbox, state := range c.observedFolderStates {
+		if c.pendingFolderCounts[mailbox] > 0 {
+			continue
+		}
+		states[mailbox] = state
+	}
 	return states
 }
 

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -29,6 +29,12 @@ func WithFolderStates(states map[string]FolderState) Option {
 	return func(c *Client) { c.priorFolderStates = states }
 }
 
+// WithForceFullEnumeration keeps saved folder identity metadata but disables
+// UIDNEXT and unchanged-mailbox shortcuts for this client session.
+func WithForceFullEnumeration() Option {
+	return func(c *Client) { c.forceFullEnumeration = true }
+}
+
 // WithFolderStateSave sets a callback that is invoked after all listed
 // messages for a mailbox have been safely handled by the syncer.
 func WithFolderStateSave(fn func(string, FolderState)) Option {

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -121,6 +121,13 @@ type MessageMetadataRecord struct {
 	Metadata sql.NullString
 }
 
+// MessageWithRawMetadata identifies an archived message and the RFC822
+// identity stored with its raw MIME.
+type MessageWithRawMetadata struct {
+	ID              int64
+	RFC822MessageID sql.NullString
+}
+
 // UnresolvedMessageReply is a message whose provider metadata may contain a
 // durable source reply reference but whose generic reply link is still NULL.
 // Importers decode their own metadata shape and call SetReplyTo once the
@@ -473,6 +480,39 @@ func (s *Store) GetMessageIDByRFC822ID(
 	return id, err
 }
 
+// GetMessageSourceID returns the provider-specific identifier for a message.
+func (s *Store) GetMessageSourceID(messageID int64) (string, error) {
+	var sourceMessageID string
+	err := s.db.QueryRow(
+		`SELECT source_message_id FROM messages WHERE id = ?`,
+		messageID,
+	).Scan(&sourceMessageID)
+	return sourceMessageID, err
+}
+
+// RekeyMessageSourceID changes a provider-specific identifier only while it
+// still has the value observed by the caller.
+func (s *Store) RekeyMessageSourceID(
+	messageID int64,
+	expectedSourceMessageID, newSourceMessageID string,
+) (bool, error) {
+	result, err := s.db.Exec(
+		`UPDATE messages SET source_message_id = ?
+		 WHERE id = ? AND source_message_id = ?`,
+		newSourceMessageID,
+		messageID,
+		expectedSourceMessageID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("rekey message source ID: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read rekeyed row count: %w", err)
+	}
+	return affected == 1, nil
+}
+
 // UpdateMessageOnDedup updates an existing message's composite ID
 // and labels when a cross-mailbox RFC822 dedup match is found.
 // This ensures future syncs recognize the message under its new
@@ -480,17 +520,59 @@ func (s *Store) GetMessageIDByRFC822ID(
 func (s *Store) UpdateMessageOnDedup(
 	messageID int64, newSourceMessageID string,
 	labelIDs []int64,
-) error {
-	return s.withTx(func(tx *loggedTx) error {
-		if _, err := tx.Exec(
-			`UPDATE messages SET source_message_id = ?
-			 WHERE id = ?`,
-			newSourceMessageID, messageID,
-		); err != nil {
-			return fmt.Errorf("update source_message_id: %w", err)
+) (bool, error) {
+	return s.updateMessageOnDedup(
+		messageID, newSourceMessageID, labelIDs, true)
+}
+
+// UpdateMessageOnPartialDedup updates an existing message's composite ID and
+// merges newly observed labels. It is used when the new ID is authoritative
+// but the scan did not observe every mailbox membership.
+func (s *Store) UpdateMessageOnPartialDedup(
+	messageID int64, newSourceMessageID string,
+	labelIDs []int64,
+) (bool, error) {
+	return s.updateMessageOnDedup(
+		messageID, newSourceMessageID, labelIDs, false)
+}
+
+func (s *Store) updateMessageOnDedup(
+	messageID int64, newSourceMessageID string,
+	labelIDs []int64, replaceLabels bool,
+) (bool, error) {
+	var changed bool
+	err := s.withTx(func(tx *loggedTx) error {
+		var currentSourceMessageID string
+		if err := tx.QueryRow(
+			`SELECT source_message_id FROM messages WHERE id = ?`,
+			messageID,
+		).Scan(&currentSourceMessageID); err != nil {
+			return fmt.Errorf("get source_message_id: %w", err)
 		}
-		return replaceMessageLabelsTx(tx, messageID, labelIDs)
+
+		sourceIDChanged := currentSourceMessageID != newSourceMessageID
+		if sourceIDChanged {
+			if _, err := tx.Exec(
+				`UPDATE messages SET source_message_id = ?
+				 WHERE id = ?`,
+				newSourceMessageID, messageID,
+			); err != nil {
+				return fmt.Errorf("update source_message_id: %w", err)
+			}
+		}
+
+		labelsChanged, err := s.reconcileMessageLabelsTx(
+			tx, messageID, labelIDs, replaceLabels)
+		if err != nil {
+			return err
+		}
+		changed = sourceIDChanged || labelsChanged
+		return nil
 	})
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
 }
 
 // MigrateSourceMessageID rewrites a legacy source_message_id to a new value
@@ -583,6 +665,45 @@ func (s *Store) MessageExistsWithRawBatch(sourceID int64, sourceMessageIDs []str
 			result[srcID] = id
 			return nil
 		})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// MessageMetadataWithRawBatch returns identity metadata for messages that
+// already have raw MIME stored.
+func (s *Store) MessageMetadataWithRawBatch(
+	sourceID int64,
+	sourceMessageIDs []string,
+) (map[string]MessageWithRawMetadata, error) {
+	result := make(map[string]MessageWithRawMetadata)
+	if len(sourceMessageIDs) == 0 {
+		return result, nil
+	}
+
+	err := queryInChunks(
+		s.db,
+		sourceMessageIDs,
+		[]any{sourceID},
+		`SELECT m.source_message_id, m.id, m.rfc822_message_id
+		 FROM messages m
+		 JOIN message_raw mr ON mr.message_id = m.id
+		 WHERE m.source_id = ? AND m.source_message_id IN (%s)`,
+		func(rows *loggedRows) error {
+			var sourceMessageID string
+			var metadata MessageWithRawMetadata
+			if err := rows.Scan(
+				&sourceMessageID,
+				&metadata.ID,
+				&metadata.RFC822MessageID,
+			); err != nil {
+				return err
+			}
+			result[sourceMessageID] = metadata
+			return nil
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1508,6 +1629,90 @@ func (s *Store) ReplaceMessageLabels(messageID int64, labelIDs []int64) error {
 	})
 }
 
+// ReconcileMessageLabels replaces or merges labels and reports whether the
+// persisted label set changed.
+func (s *Store) ReconcileMessageLabels(
+	messageID int64, labelIDs []int64, replace bool,
+) (bool, error) {
+	var changed bool
+	err := s.withTx(func(tx *loggedTx) error {
+		var err error
+		changed, err = s.reconcileMessageLabelsTx(
+			tx, messageID, labelIDs, replace)
+		return err
+	})
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
+}
+
+func (s *Store) reconcileMessageLabelsTx(
+	tx *loggedTx, messageID int64, labelIDs []int64, replace bool,
+) (bool, error) {
+	rows, err := tx.Query(`
+		SELECT label_id FROM message_labels WHERE message_id = ?
+	`, messageID)
+	if err != nil {
+		return false, err
+	}
+
+	existing := make(map[int64]struct{})
+	for rows.Next() {
+		var labelID int64
+		if err := rows.Scan(&labelID); err != nil {
+			_ = rows.Close()
+			return false, err
+		}
+		existing[labelID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return false, err
+	}
+	if err := rows.Close(); err != nil {
+		return false, err
+	}
+
+	desired := make(map[int64]struct{}, len(labelIDs))
+	for _, labelID := range labelIDs {
+		desired[labelID] = struct{}{}
+	}
+
+	if replace {
+		changed := len(existing) != len(desired)
+		if !changed {
+			for labelID := range desired {
+				if _, ok := existing[labelID]; !ok {
+					changed = true
+					break
+				}
+			}
+		}
+		if !changed {
+			return false, nil
+		}
+		if err := replaceMessageLabelsTx(tx, messageID, labelIDs); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	missing := make([]int64, 0, len(desired))
+	for labelID := range desired {
+		if _, ok := existing[labelID]; !ok {
+			missing = append(missing, labelID)
+		}
+	}
+	if len(missing) == 0 {
+		return false, nil
+	}
+	if err := s.addMessageLabelsTx(tx, messageID, missing); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func replaceMessageLabelsTx(tx querier, messageID int64, labelIDs []int64) error {
 	_, err := tx.Exec(`
 		DELETE FROM message_labels WHERE message_id = ?
@@ -1542,20 +1747,26 @@ func (s *Store) AddMessageLabels(messageID int64, labelIDs []int64) error {
 		return nil
 	}
 	return s.withTx(func(tx *loggedTx) error {
-		return insertInChunks(tx, chunkInsert{
-			totalRows:    len(labelIDs),
-			valuesPerRow: 2,
-			prefix:       s.dialect.InsertOrIgnorePrefix("INSERT OR IGNORE INTO message_labels (message_id, label_id) VALUES "),
-			suffix:       s.dialect.InsertOrIgnoreSuffix(),
-		}, func(start, end int) ([]string, []any) {
-			values := make([]string, end-start)
-			args := make([]any, 0, (end-start)*2)
-			for i := start; i < end; i++ {
-				values[i-start] = "(?, ?)"
-				args = append(args, messageID, labelIDs[i])
-			}
-			return values, args
-		})
+		return s.addMessageLabelsTx(tx, messageID, labelIDs)
+	})
+}
+
+func (s *Store) addMessageLabelsTx(
+	tx *loggedTx, messageID int64, labelIDs []int64,
+) error {
+	return insertInChunks(tx, chunkInsert{
+		totalRows:    len(labelIDs),
+		valuesPerRow: 2,
+		prefix:       s.dialect.InsertOrIgnorePrefix("INSERT OR IGNORE INTO message_labels (message_id, label_id) VALUES "),
+		suffix:       s.dialect.InsertOrIgnoreSuffix(),
+	}, func(start, end int) ([]string, []any) {
+		values := make([]string, end-start)
+		args := make([]any, 0, (end-start)*2)
+		for i := start; i < end; i++ {
+			values[i-start] = "(?, ?)"
+			args = append(args, messageID, labelIDs[i])
+		}
+		return values, args
 	})
 }
 
@@ -1781,6 +1992,38 @@ func (s *Store) CountMessagesWithRaw(sourceID int64) (int64, error) {
 		WHERE m.source_id = ? AND %s
 	`, LiveMessagesWhere("m", true)), sourceID).Scan(&count)
 	return count, err
+}
+
+// CountMessagesPerMailbox returns a map of mailbox name to message count
+// for a given source. It counts live messages grouped by their label name
+// using the message_labels/labels join. Only messages with labels appear
+// in the result (messages without any folder/label mapping are excluded).
+func (s *Store) CountMessagesPerMailbox(sourceID int64) (map[string]int64, error) {
+	result := make(map[string]int64)
+	rows, err := s.db.Query(fmt.Sprintf(`
+		SELECT l.name, COUNT(DISTINCT m.id)
+		  FROM messages m
+		  JOIN message_labels ml ON ml.message_id = m.id
+		  JOIN labels l ON l.id = ml.label_id
+		 WHERE m.source_id = ? AND l.source_id = ? AND %s
+		 GROUP BY l.name
+	`, LiveMessagesWhere("", true)), sourceID, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var name string
+		var count int64
+		if err := rows.Scan(&name, &count); err != nil {
+			return nil, err
+		}
+		result[name] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // GetRandomMessageIDs returns a random sample of message IDs for a source.

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -774,3 +774,49 @@ func readDisplayName(t *testing.T, st *store.Store, pid int64) string {
 	).Scan(&name), "scan display_name")
 	return name.String
 }
+
+func TestCountMessagesPerMailbox(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	source, err := st.GetOrCreateSource("imap", "user@example.com")
+	require.NoError(err, "GetOrCreateSource")
+
+	convID, err := st.EnsureConversation(source.ID, "conv-1", "Test Chat")
+	require.NoError(err, "EnsureConversation")
+
+	// Create labels for each folder/mbox
+	labelMap, err := st.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
+		"INBOX":  {Name: "INBOX", Type: "system"},
+		"Sent":   {Name: "Sent", Type: "system"},
+		"Drafts": {Name: "Drafts", Type: "system"},
+	})
+	require.NoError(err, "EnsureLabelsBatch")
+
+	// Insert messages
+	msgs := []*store.Message{
+		{SourceID: source.ID, SourceMessageID: "INBOX|100", ConversationID: convID, MessageType: "email"},
+		{SourceID: source.ID, SourceMessageID: "INBOX|200", ConversationID: convID, MessageType: "email"},
+		{SourceID: source.ID, SourceMessageID: "Sent|300", ConversationID: convID, MessageType: "email"},
+		{SourceID: source.ID, SourceMessageID: "Drafts|400", ConversationID: convID, MessageType: "email"},
+	}
+
+	msgIDs := make([]int64, len(msgs))
+	for i, msg := range msgs {
+		msgIDs[i], err = st.UpsertMessage(msg)
+		require.NoError(err, "UpsertMessage")
+	}
+
+	// Associate messages with labels (mimicking folder membership)
+	require.NoError(st.LinkMessageLabel(msgIDs[0], labelMap["INBOX"]))
+	require.NoError(st.LinkMessageLabel(msgIDs[1], labelMap["INBOX"]))
+	require.NoError(st.LinkMessageLabel(msgIDs[2], labelMap["Sent"]))
+	require.NoError(st.LinkMessageLabel(msgIDs[3], labelMap["Drafts"]))
+
+	counts, err := st.CountMessagesPerMailbox(source.ID)
+	require.NoError(err, "CountMessagesPerMailbox")
+	assert.Equal(int64(2), counts["INBOX"], "INBOX count")
+	assert.Equal(int64(1), counts["Sent"], "Sent count")
+	assert.Equal(int64(1), counts["Drafts"], "Drafts count")
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1431,6 +1431,153 @@ func TestStore_AddMessageLabels(t *testing.T) {
 	f.AssertLabelCount(msgID, 4)
 }
 
+func TestStore_ReconcileMessageLabelsReportsChanges(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("msg-reconcile-labels")
+	labels := f.EnsureLabels(map[string]string{
+		"INBOX":   "Inbox",
+		"STARRED": "Starred",
+		"SENT":    "Sent",
+	}, "system")
+	require.NoError(f.Store.ReplaceMessageLabels(
+		messageID, []int64{labels["INBOX"]}))
+
+	changed, err := f.Store.ReconcileMessageLabels(
+		messageID, []int64{labels["INBOX"]}, false)
+	require.NoError(err)
+	assert.False(changed)
+
+	changed, err = f.Store.ReconcileMessageLabels(
+		messageID, []int64{labels["STARRED"]}, false)
+	require.NoError(err)
+	assert.True(changed)
+
+	changed, err = f.Store.ReconcileMessageLabels(
+		messageID, []int64{labels["INBOX"], labels["STARRED"]}, true)
+	require.NoError(err)
+	assert.False(changed)
+
+	changed, err = f.Store.ReconcileMessageLabels(
+		messageID, []int64{labels["SENT"]}, true)
+	require.NoError(err)
+	assert.True(changed)
+	f.AssertLabelCount(messageID, 1)
+	f.AssertMessageHasLabel(messageID, labels["SENT"])
+}
+
+func TestStore_DedupReconciliationReportsChanges(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("INBOX|1")
+	labels := f.EnsureLabels(map[string]string{
+		"INBOX":   "Inbox",
+		"Archive": "Archive",
+		"Trash":   "Trash",
+	}, "system")
+	require.NoError(f.Store.ReplaceMessageLabels(
+		messageID, []int64{labels["INBOX"]}))
+
+	changed, err := f.Store.UpdateMessageOnDedup(
+		messageID, "Archive|2", []int64{labels["Archive"]})
+	require.NoError(err)
+	assert.True(changed)
+	sourceMessageID, err := f.Store.GetMessageSourceID(messageID)
+	require.NoError(err)
+	assert.Equal("Archive|2", sourceMessageID)
+	f.AssertLabelCount(messageID, 1)
+	f.AssertMessageHasLabel(messageID, labels["Archive"])
+
+	changed, err = f.Store.UpdateMessageOnDedup(
+		messageID, "Archive|2", []int64{labels["Archive"]})
+	require.NoError(err)
+	assert.False(changed)
+
+	changed, err = f.Store.UpdateMessageOnPartialDedup(
+		messageID, "Trash|3", []int64{labels["Trash"]})
+	require.NoError(err)
+	assert.True(changed)
+	sourceMessageID, err = f.Store.GetMessageSourceID(messageID)
+	require.NoError(err)
+	assert.Equal("Trash|3", sourceMessageID)
+	f.AssertLabelCount(messageID, 2)
+	f.AssertMessageHasLabel(messageID, labels["Archive"])
+	f.AssertMessageHasLabel(messageID, labels["Trash"])
+
+	changed, err = f.Store.UpdateMessageOnPartialDedup(
+		messageID, "Trash|3", []int64{labels["Trash"]})
+	require.NoError(err)
+	assert.False(changed)
+}
+
+func TestStore_MessageMetadataWithRawBatch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+
+	withRaw := storetest.NewMessage(f.Source.ID, f.ConvID).
+		WithSourceMessageID("INBOX|1").
+		Build()
+	withRaw.RFC822MessageID = sql.NullString{
+		String: "<old@example.com>",
+		Valid:  true,
+	}
+	withRawID, err := f.Store.PersistMessage(&store.MessagePersistData{
+		Message: withRaw,
+		RawMIME: sampleRawMessage,
+	})
+	require.NoError(err)
+
+	withoutRaw := storetest.NewMessage(f.Source.ID, f.ConvID).
+		WithSourceMessageID("INBOX|2").
+		Build()
+	_, err = f.Store.UpsertMessage(withoutRaw)
+	require.NoError(err)
+
+	got, err := f.Store.MessageMetadataWithRawBatch(
+		f.Source.ID,
+		[]string{"INBOX|1", "INBOX|2", "INBOX|3"},
+	)
+	require.NoError(err)
+	require.Len(got, 1)
+	assert.Equal(withRawID, got["INBOX|1"].ID)
+	assert.Equal(
+		sql.NullString{String: "<old@example.com>", Valid: true},
+		got["INBOX|1"].RFC822MessageID,
+	)
+}
+
+func TestStore_RekeyMessageSourceIDRequiresExpectedID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("INBOX|1")
+
+	changed, err := f.Store.RekeyMessageSourceID(
+		messageID,
+		"wrong|1",
+		"msgvault-invalidated:1",
+	)
+	require.NoError(err)
+	assert.False(changed)
+	sourceMessageID, err := f.Store.GetMessageSourceID(messageID)
+	require.NoError(err)
+	assert.Equal("INBOX|1", sourceMessageID)
+
+	changed, err = f.Store.RekeyMessageSourceID(
+		messageID,
+		"INBOX|1",
+		"msgvault-invalidated:1",
+	)
+	require.NoError(err)
+	assert.True(changed)
+	sourceMessageID, err = f.Store.GetMessageSourceID(messageID)
+	require.NoError(err)
+	assert.Equal("msgvault-invalidated:1", sourceMessageID)
+}
+
 func TestStore_RemoveMessageLabels(t *testing.T) {
 	require := require.New(t)
 	f := storetest.New(t)

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -177,7 +177,9 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 						continue
 					}
 					threadID := newMsgThreads[newMsgIDs[i]]
-					if err := s.ingestMessage(source.ID, raw, threadID, labelMap); err != nil {
+					if _, err := s.ingestMessage(
+						ctx, source.ID, raw, threadID, labelMap,
+					); err != nil {
 						s.logger.Warn("failed to ingest added message", "id", newMsgIDs[i], "error", err)
 						s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
 						checkpoint.ErrorsCount++
@@ -301,7 +303,9 @@ func (s *Syncer) handleLabelChange(ctx context.Context, syncID, sourceID int64, 
 				checkpoint.ErrorsCount++
 				return false, err
 			}
-			if err := s.ingestMessage(sourceID, raw, threadID, labelMap); err != nil {
+			if _, err := s.ingestMessage(
+				ctx, sourceID, raw, threadID, labelMap,
+			); err != nil {
 				s.recordSyncItem(syncID, messageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
 				checkpoint.ErrorsCount++
 				return false, err

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -86,6 +86,10 @@ type sourceMessageMatcher interface {
 	) (matches bool, conclusive bool, err error)
 }
 
+type preferredIMAPSourceID interface {
+	IsPreferredSourceMessageID(messageID string) bool
+}
+
 type fetchedSourceMessageMatcher interface {
 	FetchedSourceMessageMatches(
 		messageID, expectedRFC822MessageID, actualRFC822MessageID string,
@@ -1125,8 +1129,29 @@ func (s *Syncer) ingestMessage(
 			if matches {
 				changed, err := s.store.ReconcileMessageLabels(
 					existingID, labelIDs, complete)
+				if err != nil {
+					return false, fmt.Errorf(
+						"reconcile validated dedup labels: %w", err)
+				}
+				if complete && oldSourceMessageID != data.message.SourceMessageID {
+					if preferred, ok := s.client.(preferredIMAPSourceID); ok &&
+						preferred.IsPreferredSourceMessageID(data.message.SourceMessageID) {
+						rekeyed, err := s.store.RekeyMessageSourceID(
+							existingID, oldSourceMessageID, data.message.SourceMessageID)
+						if err != nil {
+							return false, fmt.Errorf(
+								"adopt preferred IMAP source ID: %w", err)
+						}
+						if !rekeyed {
+							return false, fmt.Errorf(
+								"preferred IMAP source ID %q changed before adoption",
+								data.message.SourceMessageID)
+						}
+						changed = true
+					}
+				}
 				return dedupMutationResult(
-					changed, "reconcile validated dedup labels", err)
+					changed, "reconcile validated dedup labels", nil)
 			}
 			if complete {
 				changed, err := s.store.UpdateMessageOnDedup(

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -2,6 +2,7 @@
 package sync
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -21,6 +22,12 @@ import (
 
 // ErrHistoryExpired indicates that the Gmail history ID is too old and a full sync is required.
 var ErrHistoryExpired = errors.New("history expired - run full sync")
+
+const (
+	labelTypeSystem               = "system"
+	sourceTypeIMAP                = "imap"
+	invalidatedIMAPSourceIDPrefix = "msgvault-invalidated:"
+)
 
 // Options configures sync behavior.
 type Options struct {
@@ -68,6 +75,33 @@ type messageAcknowledger interface {
 	AcknowledgeMessages(ctx context.Context, messageIDs []string)
 }
 
+type labelSnapshotCompleteness interface {
+	LabelsSnapshotComplete() bool
+}
+
+type sourceMessageMatcher interface {
+	SourceMessageMatches(
+		ctx context.Context,
+		messageID, expectedRFC822MessageID string,
+	) (matches bool, conclusive bool, err error)
+}
+
+type fetchedSourceMessageMatcher interface {
+	FetchedSourceMessageMatches(
+		messageID, expectedRFC822MessageID, actualRFC822MessageID string,
+	) (matches bool, conclusive bool, err error)
+}
+
+type validatedMessageDedupSeeder interface {
+	SeedValidatedMessageDedup(
+		messageID, rfc822MessageID string,
+	) error
+}
+
+type messageLabelBatchReader interface {
+	GetMessageLabelsBatch(ctx context.Context, messageIDs []string) ([]gmail.MessageLabelsBatchResult, error)
+}
+
 // New creates a new Syncer.
 func New(client gmail.API, store *store.Store, opts *Options) *Syncer {
 	if opts == nil {
@@ -93,6 +127,11 @@ func (s *Syncer) WithLogger(logger *slog.Logger) *Syncer {
 func (s *Syncer) WithProgress(p gmail.SyncProgress) *Syncer {
 	s.progress = p
 	return s
+}
+
+func (s *Syncer) labelsSnapshotComplete() bool {
+	completeness, ok := s.client.(labelSnapshotCompleteness)
+	return !ok || completeness.LabelsSnapshotComplete()
 }
 
 // syncState holds the state for a sync operation.
@@ -157,9 +196,16 @@ func (s *Syncer) initSyncState(sourceID int64) (*syncState, error) {
 type batchResult struct {
 	processed    int64
 	added        int64
+	updated      int64
 	skipped      int64
 	oldestDate   time.Time
 	acknowledged []string
+}
+
+type inconclusiveLabelRefresh struct {
+	labelIDs         []int64
+	rfc822MessageID  string
+	snapshotComplete bool
 }
 
 // processBatch processes a single batch of messages from a list response.
@@ -179,48 +225,213 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 	}
 
 	// Check which messages already exist
-	existingMap, err := s.store.MessageExistsWithRawBatch(sourceID, messageIDs)
+	existingMap, err := s.store.MessageMetadataWithRawBatch(
+		sourceID, messageIDs)
 	if err != nil {
 		return nil, fmt.Errorf("check existing: %w", err)
 	}
 
-	// Filter to new messages
-	var newIDs []string
+	// Existing exact IDs only need current label metadata. Clients with a
+	// lightweight metadata path use it for both complete snapshots (replace
+	// labels) and incomplete snapshots (merge labels). Keep the old fallback
+	// for clients that cannot fetch labels separately.
+	snapshotComplete := s.labelsSnapshotComplete()
+	labelReader, canReadLabels := s.client.(messageLabelBatchReader)
+	var fetchIDs []string
+	var labelRefreshIDs []string
+	var existingCount int
+	inconclusiveRefreshes := make(map[string]inconclusiveLabelRefresh)
 	for _, id := range messageIDs {
 		if _, exists := existingMap[id]; !exists {
-			newIDs = append(newIDs, id)
+			fetchIDs = append(fetchIDs, id)
 			continue
 		}
-		result.acknowledged = append(result.acknowledged, id)
+		existingCount++
+		if canReadLabels {
+			labelRefreshIDs = append(labelRefreshIDs, id)
+			continue
+		}
+		if snapshotComplete {
+			result.acknowledged = append(result.acknowledged, id)
+			continue
+		}
+		fetchIDs = append(fetchIDs, id)
 	}
 
 	result.processed = int64(len(messageIDs))
-	result.skipped = int64(len(messageIDs) - len(newIDs))
+	result.skipped = int64(existingCount)
 
-	// Fetch and ingest new messages
-	if len(newIDs) > 0 {
-		rawMessages, err := s.getMessagesRawBatchWithDiagnostics(ctx, newIDs)
+	if len(labelRefreshIDs) > 0 {
+		labelResults, err := labelReader.GetMessageLabelsBatch(ctx, labelRefreshIDs)
 		if err != nil {
-			for _, id := range newIDs {
+			for _, id := range labelRefreshIDs {
 				s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, err)
 			}
-			checkpoint.ErrorsCount += int64(len(newIDs))
+			checkpoint.ErrorsCount += int64(len(labelRefreshIDs))
+			return nil, fmt.Errorf("fetch message labels: %w", err)
+		}
+
+		for i, sourceMessageID := range labelRefreshIDs {
+			if i >= len(labelResults) {
+				err := errors.New("label metadata missing from batch response")
+				s.logger.Warn("failed to fetch message labels",
+					"id", sourceMessageID, "error", err)
+				s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, err)
+				checkpoint.ErrorsCount++
+				continue
+			}
+			labelResult := labelResults[i]
+			if labelResult.Err != nil {
+				s.logger.Warn("failed to fetch message labels",
+					"id", sourceMessageID, "error", labelResult.Err)
+				s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, labelResult.Err)
+				checkpoint.ErrorsCount++
+				continue
+			}
+
+			existing := existingMap[sourceMessageID]
+			labelIDs := labelIDsFor(labelResult.LabelIDs, labelMap)
+			if s.opts.SourceType == sourceTypeIMAP {
+				matcher, ok := s.client.(fetchedSourceMessageMatcher)
+				if !ok {
+					err := errors.New(
+						"fetched source validation unavailable for IMAP exact-ID refresh")
+					s.logger.Warn("failed to validate existing message identity",
+						"id", sourceMessageID, "error", err)
+					s.recordSyncItem(
+						syncID,
+						sourceMessageID,
+						syncItemPhaseIngest,
+						store.SyncRunItemStatusError,
+						syncItemKindIngestError,
+						err,
+					)
+					checkpoint.ErrorsCount++
+					continue
+				}
+
+				matches, conclusive, err := matcher.FetchedSourceMessageMatches(
+					sourceMessageID,
+					existing.RFC822MessageID.String,
+					labelResult.RFC822MessageID,
+				)
+				if err != nil {
+					s.logger.Warn("failed to validate existing message identity",
+						"id", sourceMessageID, "error", err)
+					s.recordSyncItem(
+						syncID,
+						sourceMessageID,
+						syncItemPhaseIngest,
+						store.SyncRunItemStatusError,
+						syncItemKindIngestError,
+						err,
+					)
+					checkpoint.ErrorsCount++
+					continue
+				}
+				if !conclusive {
+					inconclusiveRefreshes[sourceMessageID] =
+						inconclusiveLabelRefresh{
+							labelIDs:         labelIDs,
+							rfc822MessageID:  labelResult.RFC822MessageID,
+							snapshotComplete: snapshotComplete,
+						}
+					fetchIDs = append(fetchIDs, sourceMessageID)
+					continue
+				}
+				if !matches {
+					err := s.preserveReusedIMAPSource(
+						existing.ID, sourceMessageID)
+					if err != nil {
+						s.logger.Warn("failed to preserve reused IMAP source ID",
+							"id", sourceMessageID, "error", err)
+						s.recordSyncItem(
+							syncID,
+							sourceMessageID,
+							syncItemPhaseIngest,
+							store.SyncRunItemStatusError,
+							syncItemKindIngestError,
+							err,
+						)
+						checkpoint.ErrorsCount++
+						continue
+					}
+					delete(existingMap, sourceMessageID)
+					fetchIDs = append(fetchIDs, sourceMessageID)
+					result.skipped--
+					continue
+				}
+			}
+
+			changed, err := s.reconcileValidatedMessageLabels(
+				existing.ID,
+				sourceMessageID,
+				labelResult.RFC822MessageID,
+				labelIDs,
+				snapshotComplete,
+			)
+			if err != nil {
+				s.logger.Warn("failed to refresh existing message labels",
+					"id", sourceMessageID, "error", err)
+				s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
+				checkpoint.ErrorsCount++
+				continue
+			}
+			if changed {
+				result.updated++
+				result.skipped--
+			}
+			result.acknowledged = append(result.acknowledged, sourceMessageID)
+		}
+	}
+
+	// Raw MIME is needed for new messages and as a compatibility fallback for
+	// incomplete snapshots whose client cannot fetch labels separately.
+	if len(fetchIDs) > 0 {
+		rawMessages, err := s.getMessagesRawBatchWithDiagnostics(ctx, fetchIDs)
+		if err != nil {
+			for _, id := range fetchIDs {
+				s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, err)
+			}
+			checkpoint.ErrorsCount += int64(len(fetchIDs))
 			return nil, fmt.Errorf("fetch messages: %w", err)
 		}
 
 		for i, fetch := range rawMessages {
+			sourceMessageID := fetchIDs[i]
+			existing, alreadyExists := existingMap[sourceMessageID]
+			pendingRefresh, needsRawComparison :=
+				inconclusiveRefreshes[sourceMessageID]
 			raw := fetch.Message
 			if raw == nil {
 				if isGmailNotFound(fetch.Err) {
-					s.logger.Debug("skipping message deleted before fetch", "id", newIDs[i])
-					s.recordSyncItem(syncID, newIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
-					result.skipped++
-					result.acknowledged = append(result.acknowledged, newIDs[i])
+					s.logger.Debug("skipping message deleted before fetch", "id", sourceMessageID)
+					s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
+					if !alreadyExists {
+						result.skipped++
+					}
+					result.acknowledged = append(result.acknowledged, sourceMessageID)
 					continue
 				}
 				errMsg := syncItemErrorMessage(fetch.Err, errRawBatchMissing.Error())
-				s.logger.Warn("failed to fetch message", "id", newIDs[i], "error", errMsg)
-				s.recordSyncItem(syncID, newIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, fetch.Err)
+				s.logger.Warn("failed to fetch message", "id", sourceMessageID, "error", errMsg)
+				s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, fetch.Err)
+				checkpoint.ErrorsCount++
+				continue
+			}
+			if needsRawComparison && raw.Raw == nil {
+				err := errors.New(
+					"inconclusive IMAP identity returned a dedup stub")
+				s.logger.Warn("failed to compare existing message identity",
+					"id", sourceMessageID, "error", err)
+				s.recordSyncItem(
+					syncID,
+					sourceMessageID,
+					syncItemPhaseIngest,
+					store.SyncRunItemStatusError,
+					syncItemKindIngestError,
+					err,
+				)
 				checkpoint.ErrorsCount++
 				continue
 			}
@@ -228,8 +439,100 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			// dedup skip (e.g. same message in All Mail and Trash).
 			// Distinct from []byte{} which is a genuine empty body.
 			if raw.Raw == nil {
-				result.skipped++
-				result.acknowledged = append(result.acknowledged, newIDs[i])
+				if !alreadyExists {
+					result.skipped++
+				}
+				result.acknowledged = append(result.acknowledged, sourceMessageID)
+				continue
+			}
+
+			if needsRawComparison {
+				archivedRaw, err := s.store.GetMessageRaw(existing.ID)
+				if err != nil {
+					s.logger.Warn("failed to load archived message for identity comparison",
+						"id", sourceMessageID, "error", err)
+					s.recordSyncItem(
+						syncID,
+						sourceMessageID,
+						syncItemPhaseIngest,
+						store.SyncRunItemStatusError,
+						syncItemKindIngestError,
+						err,
+					)
+					checkpoint.ErrorsCount++
+					continue
+				}
+				if bytes.Equal(archivedRaw, raw.Raw) {
+					changed, err := s.reconcileValidatedMessageLabels(
+						existing.ID,
+						sourceMessageID,
+						pendingRefresh.rfc822MessageID,
+						pendingRefresh.labelIDs,
+						pendingRefresh.snapshotComplete,
+					)
+					if err != nil {
+						s.logger.Warn("failed to refresh raw-validated message labels",
+							"id", sourceMessageID, "error", err)
+						s.recordSyncItem(
+							syncID,
+							sourceMessageID,
+							syncItemPhaseIngest,
+							store.SyncRunItemStatusError,
+							syncItemKindIngestError,
+							err,
+						)
+						checkpoint.ErrorsCount++
+						continue
+					}
+					if changed {
+						result.updated++
+						result.skipped--
+					}
+					result.acknowledged = append(
+						result.acknowledged, sourceMessageID)
+					summary.BytesDownloaded += int64(len(raw.Raw))
+					continue
+				}
+
+				if err := s.preserveReusedIMAPSource(
+					existing.ID, sourceMessageID); err != nil {
+					s.logger.Warn("failed to preserve reused IMAP source ID",
+						"id", sourceMessageID, "error", err)
+					s.recordSyncItem(
+						syncID,
+						sourceMessageID,
+						syncItemPhaseIngest,
+						store.SyncRunItemStatusError,
+						syncItemKindIngestError,
+						err,
+					)
+					checkpoint.ErrorsCount++
+					continue
+				}
+				delete(existingMap, sourceMessageID)
+				alreadyExists = false
+				result.skipped--
+			}
+
+			if alreadyExists {
+				changed, err := s.store.ReconcileMessageLabels(
+					existing.ID,
+					labelIDsFor(raw.LabelIDs, labelMap),
+					false,
+				)
+				if err != nil {
+					s.logger.Warn("failed to merge existing message labels",
+						"id", sourceMessageID, "error", err)
+					s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
+					checkpoint.ErrorsCount++
+					continue
+				}
+				if changed {
+					result.updated++
+					result.skipped--
+				}
+				result.acknowledged = append(result.acknowledged, sourceMessageID)
+				summary.BytesDownloaded += int64(len(raw.Raw))
 				continue
 			}
 
@@ -246,22 +549,35 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 				}
 			}
 
-			threadID := threadIDs[newIDs[i]]
-			err := s.ingestMessage(sourceID, raw, threadID, labelMap)
+			threadID := threadIDs[sourceMessageID]
+			updated, err := s.ingestMessage(
+				ctx, sourceID, raw, threadID, labelMap)
 			if err != nil {
+				if errors.Is(err, errDeferredIMAPIdentity) {
+					if updated {
+						result.updated++
+					} else {
+						result.skipped++
+					}
+					continue
+				}
 				if errors.Is(err, errDuplicateRFC822) {
-					result.skipped++
-					result.acknowledged = append(result.acknowledged, newIDs[i])
+					if updated {
+						result.updated++
+					} else {
+						result.skipped++
+					}
+					result.acknowledged = append(result.acknowledged, sourceMessageID)
 					continue
 				}
 				s.logger.Warn("failed to ingest message", "id", raw.ID, "error", err)
-				s.recordSyncItem(syncID, newIDs[i], syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
+				s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
 				checkpoint.ErrorsCount++
 				continue
 			}
 
 			result.added++
-			result.acknowledged = append(result.acknowledged, newIDs[i])
+			result.acknowledged = append(result.acknowledged, sourceMessageID)
 			summary.BytesDownloaded += int64(len(raw.Raw))
 		}
 
@@ -371,6 +687,7 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 
 		state.checkpoint.MessagesProcessed += result.processed
 		state.checkpoint.MessagesAdded += result.added
+		state.checkpoint.MessagesUpdated += result.updated
 		if ack, ok := s.client.(messageAcknowledger); ok && len(result.acknowledged) > 0 {
 			ack.AcknowledgeMessages(ctx, result.acknowledged)
 		}
@@ -455,7 +772,7 @@ func (s *Syncer) syncLabels(ctx context.Context, sourceID int64) (map[string]int
 		if labelType == "" {
 			labelType = "user"
 			if store.IsSystemLabel(l.ID) {
-				labelType = "system"
+				labelType = labelTypeSystem
 			}
 		}
 		labelInfos[l.ID] = store.LabelInfo{Name: l.Name, Type: labelType}
@@ -517,7 +834,7 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 	// ThreadID is just the composite message ID. Derive a thread
 	// key from MIME threading headers to group related messages
 	// into conversations.
-	if s.opts.SourceType == "imap" {
+	if s.opts.SourceType == sourceTypeIMAP {
 		if derived := deriveThreadKey(parsed); derived != "" {
 			threadID = derived
 		}
@@ -723,48 +1040,187 @@ func (s *Syncer) persistMessage(data *messageData, labelMap map[string]int64) (i
 // composite IDs change when messages move between mailboxes.
 var errDuplicateRFC822 = errors.New("duplicate RFC822 Message-ID")
 
-// ingestMessage parses and stores a single message. Returns
-// errDuplicateRFC822 for IMAP deduplication skips.
-func (s *Syncer) ingestMessage(sourceID int64, raw *gmail.RawMessage, threadID string, labelMap map[string]int64) error {
+// errDeferredIMAPIdentity signals that deduplication found an archived
+// canonical ID whose mailbox is outside the current folder selection. The
+// alternate ID remains unacknowledged so a later inclusive scan retries it.
+var errDeferredIMAPIdentity = errors.New(
+	"deferred IMAP source identity validation")
+
+func labelIDsFor(sourceLabelIDs []string, labelMap map[string]int64) []int64 {
+	labelIDs := make([]int64, 0, len(sourceLabelIDs))
+	for _, label := range sourceLabelIDs {
+		if id, ok := labelMap[label]; ok {
+			labelIDs = append(labelIDs, id)
+		}
+	}
+	return labelIDs
+}
+
+// ingestMessage parses and stores a single message. The boolean reports
+// whether RFC822 dedup reconciliation changed an existing message. It returns
+// errDuplicateRFC822 or errDeferredIMAPIdentity for IMAP deduplication skips.
+func (s *Syncer) ingestMessage(
+	ctx context.Context,
+	sourceID int64,
+	raw *gmail.RawMessage,
+	threadID string,
+	labelMap map[string]int64,
+) (bool, error) {
 	data, err := s.parseToModel(sourceID, raw, threadID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// For IMAP sources, check if a message with the same RFC822
 	// Message-ID already exists under a different composite ID.
 	// This handles messages that moved between mailboxes across
 	// syncs (e.g. All Mail → Trash changes the mailbox|uid key).
-	// When matched, update the existing row's composite ID and
-	// labels so future syncs skip it at the ID-filtering stage
-	// instead of re-downloading the MIME body each time.
-	if s.opts.SourceType == "imap" &&
+	// Validate the archived composite ID before replacing it regardless of
+	// snapshot completeness. Completeness controls only whether reconciled
+	// labels replace the stored memberships or merge with them.
+	if s.opts.SourceType == sourceTypeIMAP &&
 		data.message.RFC822MessageID.Valid {
 		existingID, err := s.store.GetMessageIDByRFC822ID(
 			sourceID, data.message.RFC822MessageID.String)
 		if err != nil {
-			return fmt.Errorf("check rfc822 dedup: %w", err)
+			return false, fmt.Errorf("check rfc822 dedup: %w", err)
 		}
 		if existingID > 0 {
-			var labelIDs []int64
-			for _, lbl := range data.gmailLabelIDs {
-				if id, ok := labelMap[lbl]; ok {
-					labelIDs = append(labelIDs, id)
+			labelIDs := labelIDsFor(data.gmailLabelIDs, labelMap)
+			matcher, ok := s.client.(sourceMessageMatcher)
+			if !ok {
+				return false, errors.New(
+					"exact source validation unavailable for IMAP dedup")
+			}
+
+			oldSourceMessageID, err := s.store.GetMessageSourceID(existingID)
+			if err != nil {
+				return false, fmt.Errorf("get dedup source ID: %w", err)
+			}
+			matches := false
+			conclusive := true
+			if !isInvalidatedIMAPSourceID(oldSourceMessageID) {
+				matches, conclusive, err = matcher.SourceMessageMatches(
+					ctx,
+					oldSourceMessageID,
+					data.message.RFC822MessageID.String,
+				)
+				if err != nil {
+					return false, fmt.Errorf(
+						"validate dedup source ID %q: %w",
+						oldSourceMessageID, err)
 				}
 			}
-			if err := s.store.UpdateMessageOnDedup(
+			if !conclusive {
+				changed, err := s.store.ReconcileMessageLabels(
+					existingID, labelIDs, false)
+				return dedupMutationResultWithSentinel(
+					changed,
+					"merge deferred dedup labels",
+					err,
+					errDeferredIMAPIdentity,
+				)
+			}
+			complete := s.labelsSnapshotComplete()
+			if matches {
+				changed, err := s.store.ReconcileMessageLabels(
+					existingID, labelIDs, complete)
+				return dedupMutationResult(
+					changed, "reconcile validated dedup labels", err)
+			}
+			if complete {
+				changed, err := s.store.UpdateMessageOnDedup(
+					existingID,
+					data.message.SourceMessageID,
+					labelIDs,
+				)
+				return dedupMutationResult(
+					changed, "update dedup message", err)
+			}
+			changed, err := s.store.UpdateMessageOnPartialDedup(
 				existingID,
 				data.message.SourceMessageID,
 				labelIDs,
-			); err != nil {
-				return fmt.Errorf("update dedup message: %w", err)
-			}
-			return errDuplicateRFC822
+			)
+			return dedupMutationResult(
+				changed, "update moved dedup message", err)
 		}
 	}
 
 	_, err = s.persistMessage(data, labelMap)
-	return err
+	return false, err
+}
+
+func invalidatedIMAPSourceID(messageID int64) string {
+	return invalidatedIMAPSourceIDPrefix +
+		strconv.FormatInt(messageID, 10)
+}
+
+func (s *Syncer) preserveReusedIMAPSource(
+	existingID int64,
+	sourceMessageID string,
+) error {
+	rekeyed, err := s.store.RekeyMessageSourceID(
+		existingID,
+		sourceMessageID,
+		invalidatedIMAPSourceID(existingID),
+	)
+	if err != nil {
+		return err
+	}
+	if !rekeyed {
+		return fmt.Errorf(
+			"source message ID %q changed before invalidation",
+			sourceMessageID,
+		)
+	}
+	return nil
+}
+
+func (s *Syncer) reconcileValidatedMessageLabels(
+	existingID int64,
+	sourceMessageID string,
+	rfc822MessageID string,
+	labelIDs []int64,
+	snapshotComplete bool,
+) (bool, error) {
+	changed, err := s.store.ReconcileMessageLabels(
+		existingID, labelIDs, snapshotComplete)
+	if err != nil {
+		return false, err
+	}
+	if seeder, ok := s.client.(validatedMessageDedupSeeder); ok {
+		if err := seeder.SeedValidatedMessageDedup(
+			sourceMessageID, rfc822MessageID); err != nil {
+			return false, fmt.Errorf("seed validated message dedup: %w", err)
+		}
+	}
+	return changed, nil
+}
+
+func isInvalidatedIMAPSourceID(sourceMessageID string) bool {
+	return strings.HasPrefix(
+		sourceMessageID, invalidatedIMAPSourceIDPrefix)
+}
+
+func dedupMutationResult(
+	changed bool,
+	action string,
+	err error,
+) (bool, error) {
+	return dedupMutationResultWithSentinel(
+		changed, action, err, errDuplicateRFC822)
+}
+
+func dedupMutationResultWithSentinel(
+	changed bool,
+	action string,
+	err, sentinel error,
+) (bool, error) {
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", action, err)
+	}
+	return changed, sentinel
 }
 
 // ensureAddressUTF8 validates and converts address names to valid UTF-8 in place.

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -3,12 +3,15 @@ package sync
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -16,8 +19,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/gmail"
+	imapclient "go.kenn.io/msgvault/internal/imap"
 	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
 	testemail "go.kenn.io/msgvault/internal/testutil/email"
 )
 
@@ -618,9 +623,9 @@ func TestIncrementalSyncWithLabelRemoved(t *testing.T) {
 func TestIncrementalSyncLabelAddedToNewMessage(t *testing.T) {
 	env := newTestEnv(t)
 	source := env.CreateSourceWithHistory(t, "12340")
-	_, err := env.Store.EnsureLabel(source.ID, "INBOX", "Inbox", "system")
+	_, err := env.Store.EnsureLabel(source.ID, "INBOX", "Inbox", labelTypeSystem)
 	require.NoError(t, err, "EnsureLabel INBOX")
-	_, err = env.Store.EnsureLabel(source.ID, "STARRED", "Starred", "system")
+	_, err = env.Store.EnsureLabel(source.ID, "STARRED", "Starred", labelTypeSystem)
 	require.NoError(t, err, "EnsureLabel STARRED")
 
 	env.Mock.Profile.MessagesTotal = 1
@@ -1250,7 +1255,7 @@ func TestProcessBatch_AllNew(t *testing.T) {
 	env := newTestEnv(t)
 	source := env.CreateSource(t)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
-		"INBOX": {Name: "Inbox", Type: "system"},
+		"INBOX": {Name: "Inbox", Type: labelTypeSystem},
 	})
 	checkpoint := &store.Checkpoint{}
 	summary := &gmail.SyncSummary{}
@@ -1284,7 +1289,7 @@ func TestProcessBatch_AllExisting(t *testing.T) {
 
 	source, _ := env.Store.GetOrCreateSource("gmail", testEmail)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
-		"INBOX": {Name: "Inbox", Type: "system"},
+		"INBOX": {Name: "Inbox", Type: labelTypeSystem},
 	})
 	checkpoint := &store.Checkpoint{}
 	summary := &gmail.SyncSummary{}
@@ -1315,7 +1320,7 @@ func TestProcessBatch_MixedNewAndExisting(t *testing.T) {
 
 	source, _ := env.Store.GetOrCreateSource("gmail", testEmail)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
-		"INBOX": {Name: "Inbox", Type: "system"},
+		"INBOX": {Name: "Inbox", Type: labelTypeSystem},
 	})
 	checkpoint := &store.Checkpoint{}
 	summary := &gmail.SyncSummary{}
@@ -1344,7 +1349,7 @@ func TestProcessBatch_OldestDatePropagation(t *testing.T) {
 	env := newTestEnv(t)
 	source := env.CreateSource(t)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
-		"INBOX": {Name: "Inbox", Type: "system"},
+		"INBOX": {Name: "Inbox", Type: labelTypeSystem},
 	})
 	checkpoint := &store.Checkpoint{}
 	summary := &gmail.SyncSummary{}
@@ -1391,7 +1396,7 @@ func TestProcessBatch_ErrorsCount(t *testing.T) {
 	env := newTestEnv(t)
 	source := env.CreateSource(t)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
-		"INBOX": {Name: "Inbox", Type: "system"},
+		"INBOX": {Name: "Inbox", Type: labelTypeSystem},
 	})
 	checkpoint := &store.Checkpoint{}
 	summary := &gmail.SyncSummary{}
@@ -1427,7 +1432,7 @@ func TestProcessBatch_GmailNotFoundIsSkipped(t *testing.T) {
 	env := newTestEnv(t)
 	source := env.CreateSource(t)
 	labelMap, _ := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
-		"INBOX": {Name: "Inbox", Type: "system"},
+		"INBOX": {Name: "Inbox", Type: labelTypeSystem},
 	})
 	checkpoint := &store.Checkpoint{}
 	summary := &gmail.SyncSummary{}
@@ -1869,7 +1874,7 @@ func TestDeriveThreadKey(t *testing.T) {
 func TestIMAPThreading(t *testing.T) {
 	env := newTestEnv(t)
 	env.SetOptions(t, func(o *Options) {
-		o.SourceType = "imap"
+		o.SourceType = sourceTypeIMAP
 	})
 
 	// Build three messages in a thread:
@@ -1938,7 +1943,7 @@ func TestIMAPCrossSyncDedup(t *testing.T) {
 	assert := assert.New(t)
 	env := newTestEnv(t)
 	env.SetOptions(t, func(o *Options) {
-		o.SourceType = "imap"
+		o.SourceType = sourceTypeIMAP
 	})
 
 	msg := testemail.NewMessage().
@@ -1958,9 +1963,14 @@ func TestIMAPCrossSyncDedup(t *testing.T) {
 	// Second sync: message moved to Trash (different composite ID)
 	delete(env.Mock.Messages, "INBOX|42")
 	env.Mock.AddMessage("TRASH|99", msg, []string{"TRASH"})
+	validationAPI := &sourceValidationAPI{MockAPI: env.Mock}
+	env.Syncer = New(validationAPI, env.Store, env.Syncer.opts)
 	summary = runFullSync(t, env)
 	// Should be skipped via RFC822 Message-ID dedup, not re-imported
-	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
 
 	// Only one message should exist in the database
 	var count int
@@ -1981,6 +1991,1131 @@ func TestIMAPCrossSyncDedup(t *testing.T) {
 	// Labels should reflect the new mailbox.
 	assertMessageHasLabel(t, env.Store, "TRASH|99", "TRASH")
 	assertMessageNotHasLabel(t, env.Store, "TRASH|99", "INBOX")
+}
+
+func TestIMAPFullRescanWithoutAllReconcilesMovedMessage(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	const messageID = "moved-between-folders@example.com"
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX": 0,
+		"Trash": 0,
+	})
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	assertMessageHasLabel(t, env.Store, "INBOX|1", "INBOX")
+	require.NoError(firstClient.TrashMessage(env.Context, "INBOX|1"))
+	require.NoError(firstClient.Close())
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
+
+	var sourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal(t, "Trash|1", sourceMessageID)
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Trash")
+	assertMessageNotHasLabel(t, env.Store, sourceMessageID, "INBOX")
+}
+
+func TestIMAPFullRescanWithoutAllPreservesExistingIDForOverlappingFolders(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	const messageID = "overlapping-folders@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	var originalSourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&originalSourceMessageID)
+	require.NoError(err)
+	assertMessageHasLabel(t, env.Store, originalSourceMessageID, "Archive")
+	assertMessageHasLabel(t, env.Store, originalSourceMessageID, "INBOX")
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
+
+	var rescannedSourceMessageID string
+	err = env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&rescannedSourceMessageID)
+	require.NoError(err)
+	assert.Equal(t, originalSourceMessageID, rescannedSourceMessageID)
+	assertMessageHasLabel(t, env.Store, rescannedSourceMessageID, "Archive")
+	assertMessageHasLabel(t, env.Store, rescannedSourceMessageID, "INBOX")
+}
+
+func TestIMAPHighWaterMoveReplacesMissingIDAndMergesLabels(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX": 0,
+		"Trash": 0,
+	})
+	const messageID = "high-water-move@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(firstClient.TrashMessage(env.Context, "INBOX|1"))
+	require.NoError(firstClient.Close())
+
+	secondClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderStates(saved))
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+
+	var sourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal("Trash|1", sourceMessageID)
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "INBOX")
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Trash")
+}
+
+func TestIMAPUIDValidityReusePreservesOldAndArchivesNewMessage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	const oldRFC822ID = "uid-reuse-old@example.com"
+	const newRFC822ID = "uid-reuse-new@example.com"
+	testutil.AppendIMAPMessageWithMessageID(
+		t, user, "Archive", oldRFC822ID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(firstClient.Close())
+
+	require.NoError(user.Delete("Archive"))
+	require.NoError(user.Create("Archive", nil))
+	testutil.AppendIMAPMessageWithMessageID(
+		t, user, "Archive", newRFC822ID)
+
+	secondClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderStates(saved))
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(1)),
+		Updated: new(int64(0)),
+		Skipped: new(int64(0)),
+	})
+	saved = secondClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(secondClient.Close())
+
+	type archivedIdentity struct {
+		id              int64
+		sourceMessageID string
+	}
+	identities := make(map[string]archivedIdentity)
+	rows, err := env.Store.DB().Query(
+		`SELECT id, source_message_id, rfc822_message_id FROM messages`,
+	)
+	require.NoError(err)
+	for rows.Next() {
+		var id int64
+		var sourceMessageID string
+		var rfc822MessageID sql.NullString
+		require.NoError(rows.Scan(
+			&id, &sourceMessageID, &rfc822MessageID))
+		identities[strings.Trim(rfc822MessageID.String, "<>")] =
+			archivedIdentity{
+				id:              id,
+				sourceMessageID: sourceMessageID,
+			}
+	}
+	require.NoError(rows.Err())
+	require.NoError(rows.Close())
+	require.Len(identities, 2)
+
+	oldIdentity := identities[oldRFC822ID]
+	newIdentity := identities[newRFC822ID]
+	assert.True(strings.HasPrefix(
+		oldIdentity.sourceMessageID,
+		"msgvault-invalidated:",
+	))
+	assert.Equal("Archive|1", newIdentity.sourceMessageID)
+
+	oldRaw, err := env.Store.GetMessageRaw(oldIdentity.id)
+	require.NoError(err)
+	assert.Contains(string(oldRaw), "Message-ID: <"+oldRFC822ID+">")
+	newRaw, err := env.Store.GetMessageRaw(newIdentity.id)
+	require.NoError(err)
+	assert.Contains(string(newRaw), "Message-ID: <"+newRFC822ID+">")
+
+	thirdClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderStates(saved))
+	env.Syncer = New(thirdClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(0)),
+	})
+
+	var currentSourceMessageID string
+	err = env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages
+		 WHERE rfc822_message_id = ?`,
+		"<"+newRFC822ID+">",
+	).Scan(&currentSourceMessageID)
+	require.NoError(err)
+	assert.Equal("Archive|1", currentSourceMessageID)
+}
+
+func TestIMAPNoResumeUIDValidityReuseArchivesReplacement(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	opts.NoResume = true
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	const oldRFC822ID = "noresume-uid-reuse-old@example.com"
+	const newRFC822ID = "noresume-uid-reuse-new@example.com"
+	testutil.AppendIMAPMessageWithMessageID(
+		t, user, "Archive", oldRFC822ID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	require.NoError(user.Delete("Archive"))
+	require.NoError(user.Create("Archive", nil))
+	testutil.AppendIMAPMessageWithMessageID(
+		t, user, "Archive", newRFC822ID)
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(1)),
+		Updated: new(int64(0)),
+		Skipped: new(int64(0)),
+	})
+	saved := secondClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(secondClient.Close())
+
+	type archivedIdentity struct {
+		id              int64
+		sourceMessageID string
+	}
+	identities := make(map[string]archivedIdentity)
+	rows, err := env.Store.DB().Query(
+		`SELECT id, source_message_id, rfc822_message_id FROM messages`,
+	)
+	require.NoError(err)
+	for rows.Next() {
+		var id int64
+		var sourceMessageID string
+		var rfc822MessageID sql.NullString
+		require.NoError(rows.Scan(
+			&id, &sourceMessageID, &rfc822MessageID))
+		identities[strings.Trim(rfc822MessageID.String, "<>")] =
+			archivedIdentity{
+				id:              id,
+				sourceMessageID: sourceMessageID,
+			}
+	}
+	require.NoError(rows.Err())
+	require.NoError(rows.Close())
+	require.Len(identities, 2)
+
+	oldIdentity := identities[oldRFC822ID]
+	newIdentity := identities[newRFC822ID]
+	assert.True(strings.HasPrefix(
+		oldIdentity.sourceMessageID,
+		invalidatedIMAPSourceIDPrefix,
+	))
+	assert.Equal("Archive|1", newIdentity.sourceMessageID)
+
+	oldRaw, err := env.Store.GetMessageRaw(oldIdentity.id)
+	require.NoError(err)
+	assert.Contains(string(oldRaw), "Message-ID: <"+oldRFC822ID+">")
+	newRaw, err := env.Store.GetMessageRaw(newIdentity.id)
+	require.NoError(err)
+	assert.Contains(string(newRaw), "Message-ID: <"+newRFC822ID+">")
+
+	opts.NoResume = false
+	thirdClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderStates(saved))
+	env.Syncer = New(thirdClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(0)),
+		Skipped: new(int64(0)),
+	})
+}
+
+func TestIMAPForcedUIDReuseWithoutMessageIDArchivesReplacement(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	opts.NoResume = true
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	testutil.AppendIMAPMessageWithoutMessageID(
+		t, user, "Archive", "old missing-ID body")
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(firstClient.Close())
+
+	require.NoError(user.Delete("Archive"))
+	require.NoError(user.Create("Archive", nil))
+	testutil.AppendIMAPMessageWithoutMessageID(
+		t, user, "Archive", "replacement missing-ID body")
+
+	secondClient := newSyncTestIMAPClient(
+		t,
+		addr,
+		imapclient.WithFolderStates(saved),
+		imapclient.WithForceFullEnumeration(),
+	)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(1)),
+		Updated: new(int64(0)),
+		Skipped: new(int64(0)),
+	})
+	assertMissingIDArchiveState(
+		t,
+		env.Store,
+		"old missing-ID body",
+		"replacement missing-ID body",
+	)
+}
+
+func TestIMAPMissingIdentityRawComparisonKeepsEqualMessage(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	testutil.AppendIMAPMessageWithoutMessageID(
+		t, user, "Archive", "unchanged missing-ID body")
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(0)),
+		Skipped: new(int64(1)),
+	})
+	assert.Positive(t, summary.BytesDownloaded,
+		"inconclusive identity should fetch raw MIME for comparison")
+	assertMessageCount(t, env.Store, 1)
+}
+
+func TestIMAPAsymmetricMessageIDUsesRawComparison(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	const messageID = "asymmetric-identity@example.com"
+	testutil.AppendIMAPMessageWithMessageID(
+		t, user, "Archive", messageID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	_, err := env.Store.DB().Exec(
+		`UPDATE messages SET rfc822_message_id = NULL`,
+	)
+	require.NoError(err)
+
+	for range 2 {
+		client := newSyncTestIMAPClient(t, addr)
+		env.Syncer = New(client, env.Store, opts)
+		summary = runFullSync(t, env)
+		assertSummary(t, summary, WantSummary{
+			Added:   new(int64(0)),
+			Updated: new(int64(0)),
+			Skipped: new(int64(1)),
+		})
+		assert.Positive(t, summary.BytesDownloaded,
+			"inconclusive identity should fetch raw MIME for comparison")
+		require.NoError(client.Close())
+		assertMessageCount(t, env.Store, 1)
+	}
+}
+
+func TestIMAPMissingIdentityRawComparisonArchivesDifferentMessage(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	testutil.AppendIMAPMessageWithoutMessageID(
+		t, user, "Archive", "old unknown-epoch body")
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	require.NoError(user.Delete("Archive"))
+	require.NoError(user.Create("Archive", nil))
+	testutil.AppendIMAPMessageWithoutMessageID(
+		t, user, "Archive", "replacement unknown-epoch body")
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(1)),
+		Updated: new(int64(0)),
+		Skipped: new(int64(0)),
+	})
+	assertMissingIDArchiveState(
+		t,
+		env.Store,
+		"old unknown-epoch body",
+		"replacement unknown-epoch body",
+	)
+}
+
+func assertMissingIDArchiveState(
+	t *testing.T,
+	st *store.Store,
+	oldBody string,
+	newBody string,
+) {
+	t.Helper()
+	require := require.New(t)
+
+	type archivedMessage struct {
+		id              int64
+		sourceMessageID string
+		raw             string
+	}
+	var archived []archivedMessage
+	rows, err := st.DB().Query(`SELECT id, source_message_id FROM messages`)
+	require.NoError(err)
+	for rows.Next() {
+		var msg archivedMessage
+		require.NoError(rows.Scan(&msg.id, &msg.sourceMessageID))
+		raw, err := st.GetMessageRaw(msg.id)
+		require.NoError(err)
+		msg.raw = string(raw)
+		archived = append(archived, msg)
+	}
+	require.NoError(rows.Err())
+	require.NoError(rows.Close())
+	require.Len(archived, 2)
+
+	var oldMessage, newMessage *archivedMessage
+	for i := range archived {
+		switch {
+		case strings.Contains(archived[i].raw, oldBody):
+			oldMessage = &archived[i]
+		case strings.Contains(archived[i].raw, newBody):
+			newMessage = &archived[i]
+		}
+	}
+	require.NotNil(oldMessage)
+	require.NotNil(newMessage)
+	assert.True(t, strings.HasPrefix(
+		oldMessage.sourceMessageID,
+		invalidatedIMAPSourceIDPrefix,
+	))
+	assert.Equal(t, "Archive|1", newMessage.sourceMessageID)
+}
+
+func TestIMAPFilteredMoveReconcilesBeforeAdvancingFolderState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX": 0,
+		"Trash": 0,
+	})
+	const messageID = "filtered-high-water-move@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	trashBefore := saved["Trash"]
+	require.NoError(firstClient.TrashMessage(env.Context, "INBOX|1"))
+	require.NoError(firstClient.Close())
+
+	secondClient := newSyncTestIMAPClient(
+		t,
+		addr,
+		imapclient.WithFolderStates(saved),
+		imapclient.WithFolderFilter([]string{"Trash"}, nil),
+		imapclient.WithFolderStateSave(
+			func(mailbox string, state imapclient.FolderState) {
+				saved[mailbox] = state
+			},
+		),
+	)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+	require.NoError(secondClient.Close())
+
+	var sourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal("INBOX|1", sourceMessageID)
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "INBOX")
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Trash")
+	assert.Equal(trashBefore, saved["Trash"])
+
+	thirdClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderStates(saved))
+	env.Syncer = New(thirdClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+
+	err = env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal("Trash|1", sourceMessageID)
+}
+
+func TestIMAPHighWaterRenameReplacesMissingMailboxID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	const messageID = "high-water-mailbox-rename@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", messageID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(firstClient.Close())
+	require.NoError(user.Rename("Archive", "Projects", nil))
+
+	acknowledged := make(map[string]imapclient.FolderState)
+	secondClient := newSyncTestIMAPClient(
+		t,
+		addr,
+		imapclient.WithFolderStates(saved),
+		imapclient.WithFolderStateSave(
+			func(mailbox string, state imapclient.FolderState) {
+				acknowledged[mailbox] = state
+			},
+		),
+	)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+		Errors:  new(int64(0)),
+	})
+
+	var sourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal("Projects|1", sourceMessageID)
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Archive")
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Projects")
+	assert.Contains(acknowledged, "Projects")
+}
+
+func TestIMAPHighWaterOverlapPreservesValidID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive":  0,
+		"INBOX":    0,
+		"Projects": 0,
+	})
+	const messageID = "high-water-overlap@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+
+	var originalSourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&originalSourceMessageID)
+	require.NoError(err)
+	require.NoError(firstClient.Close())
+
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Projects", messageID)
+	secondClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderStates(saved))
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+
+	var rescannedSourceMessageID string
+	err = env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&rescannedSourceMessageID)
+	require.NoError(err)
+	assert.Equal(originalSourceMessageID, rescannedSourceMessageID)
+	assertMessageHasLabel(t, env.Store, rescannedSourceMessageID, "Archive")
+	assertMessageHasLabel(t, env.Store, rescannedSourceMessageID, "INBOX")
+	assertMessageHasLabel(t, env.Store, rescannedSourceMessageID, "Projects")
+}
+
+func TestIMAPCompleteCrossPageOverlapPreservesValidID(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive":  0,
+		"INBOX":    0,
+		"Projects": 0,
+	})
+	const messageID = "complete-cross-page-overlap@example.com"
+	testutil.AppendIMAPMessageWithMessageID(
+		t, user, "Projects", messageID)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	var originalSourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages
+		 WHERE rfc822_message_id = ?`,
+		"<"+messageID+">",
+	).Scan(&originalSourceMessageID)
+	require.NoError(err)
+	require.Equal("Projects|1", originalSourceMessageID)
+
+	testutil.AppendIMAPMessageWithMessageID(
+		t, user, "Archive", messageID)
+	for i := range 99 {
+		testutil.AppendIMAPMessageWithMessageID(
+			t,
+			user,
+			"Archive",
+			fmt.Sprintf(
+				"complete-page-filler-%03d@example.com", i),
+		)
+	}
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(99)),
+		Updated: new(int64(1)),
+		Skipped: new(int64(1)),
+	})
+
+	var rescannedSourceMessageID string
+	err = env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages
+		 WHERE rfc822_message_id = ?`,
+		"<"+messageID+">",
+	).Scan(&rescannedSourceMessageID)
+	require.NoError(err)
+	assert.Equal(t, originalSourceMessageID, rescannedSourceMessageID)
+	assertMessageHasLabel(
+		t, env.Store, rescannedSourceMessageID, "Archive")
+	assertMessageHasLabel(
+		t, env.Store, rescannedSourceMessageID, "Projects")
+}
+
+type sourceValidationAPI struct {
+	*gmail.MockAPI
+	sourceMatches bool
+}
+
+func (a *sourceValidationAPI) SourceMessageMatches(
+	context.Context, string, string,
+) (bool, bool, error) {
+	return a.sourceMatches, true, nil
+}
+
+type highWaterValidationAPI struct {
+	*gmail.MockAPI
+
+	validationErr error
+	acknowledged  []string
+}
+
+func (*highWaterValidationAPI) LabelsSnapshotComplete() bool {
+	return false
+}
+
+func (*highWaterValidationAPI) LabelsSnapshotFiltered() bool {
+	return false
+}
+
+func (a *highWaterValidationAPI) SourceMessageMatches(
+	context.Context, string, string,
+) (bool, bool, error) {
+	return false, true, a.validationErr
+}
+
+func (a *highWaterValidationAPI) AcknowledgeMessages(
+	_ context.Context, messageIDs []string,
+) {
+	a.acknowledged = append(a.acknowledged, messageIDs...)
+}
+
+func TestIMAPHighWaterValidationFailureRemainsRetryable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	env.Syncer = New(env.Mock, env.Store, opts)
+
+	msg := testemail.NewMessage().
+		Subject("High-water validation failure").
+		Header("Message-ID", "<high-water-validation@example.com>").
+		Body("The old source ID cannot be validated yet.").
+		Bytes()
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.AddMessage("INBOX|42", msg, []string{"INBOX"})
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+
+	delete(env.Mock.Messages, "INBOX|42")
+	env.Mock.AddMessage("TRASH|99", msg, []string{"TRASH"})
+	validationErr := errors.New("synthetic validation timeout")
+	highWaterAPI := &highWaterValidationAPI{
+		MockAPI:       env.Mock,
+		validationErr: validationErr,
+	}
+	env.Syncer = New(highWaterAPI, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(0)),
+		Errors:  new(int64(1)),
+	})
+
+	var sourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal("INBOX|42", sourceMessageID)
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "INBOX")
+	assertMessageNotHasLabel(t, env.Store, sourceMessageID, "TRASH")
+	assert.NotContains(highWaterAPI.acknowledged, "TRASH|99")
+}
+
+func newSyncTestIMAPClient(
+	t *testing.T, addr string, clientOpts ...imapclient.Option,
+) *imapclient.Client {
+	t.Helper()
+	host, portString, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portString)
+	require.NoError(t, err)
+
+	client := imapclient.NewClient(&imapclient.Config{
+		Host:     host,
+		Port:     port,
+		Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword, clientOpts...)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+type incompleteLabelSnapshotAPI struct {
+	*gmail.MockAPI
+
+	sourceMatches bool
+}
+
+func (*incompleteLabelSnapshotAPI) LabelsSnapshotComplete() bool {
+	return false
+}
+
+func (*incompleteLabelSnapshotAPI) LabelsSnapshotFiltered() bool {
+	return true
+}
+
+func (a *incompleteLabelSnapshotAPI) SourceMessageMatches(
+	context.Context, string, string,
+) (bool, bool, error) {
+	return a.sourceMatches, true, nil
+}
+
+type labelMetadataSnapshotAPI struct {
+	*gmail.MockAPI
+
+	complete    bool
+	filtered    bool
+	labelCalls  [][]string
+	labelErrors map[string]error
+	seedCalls   [][2]string
+}
+
+func (a *labelMetadataSnapshotAPI) LabelsSnapshotComplete() bool {
+	return a.complete
+}
+
+func (a *labelMetadataSnapshotAPI) LabelsSnapshotFiltered() bool {
+	return a.filtered
+}
+
+func (*labelMetadataSnapshotAPI) FetchedSourceMessageMatches(
+	string, string, string,
+) (bool, bool, error) {
+	return true, true, nil
+}
+
+func (a *labelMetadataSnapshotAPI) SeedValidatedMessageDedup(
+	messageID, rfc822MessageID string,
+) error {
+	a.seedCalls = append(
+		a.seedCalls,
+		[2]string{messageID, rfc822MessageID},
+	)
+	return nil
+}
+
+func (a *labelMetadataSnapshotAPI) GetMessageLabelsBatch(_ context.Context, messageIDs []string) ([]gmail.MessageLabelsBatchResult, error) {
+	a.labelCalls = append(a.labelCalls, append([]string(nil), messageIDs...))
+
+	results := make([]gmail.MessageLabelsBatchResult, len(messageIDs))
+	for i, id := range messageIDs {
+		results[i].ID = id
+		if err := a.labelErrors[id]; err != nil {
+			results[i].Err = err
+			continue
+		}
+		msg, ok := a.Messages[id]
+		if !ok {
+			results[i].Err = &gmail.NotFoundError{Path: "/messages/" + id}
+			continue
+		}
+		results[i].LabelIDs = append([]string(nil), msg.LabelIDs...)
+	}
+	return results, nil
+}
+
+func TestIMAPFilteredRescanPreservesCanonicalIDAndMergesLabels(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	env.Syncer = New(env.Mock, env.Store, opts)
+	env.Mock.Labels = []*gmail.Label{
+		{ID: "[Gmail]/All Mail", Name: "All Mail", Type: labelTypeSystem},
+		{ID: "Archive", Name: "Archive", Type: "user"},
+		{ID: "INBOX", Name: "INBOX", Type: labelTypeSystem},
+	}
+
+	msg := testemail.NewMessage().
+		Subject("Filtered rescan").
+		Header("Message-ID", "<filtered-rescan@example.com>").
+		Body("Same message through a partial mailbox view.").
+		Bytes()
+
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.AddMessage("[Gmail]/All Mail|42", msg, []string{"[Gmail]/All Mail", "Archive"})
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+
+	delete(env.Mock.Messages, "[Gmail]/All Mail|42")
+	env.Mock.AddMessage("INBOX|7", msg, []string{"INBOX"})
+	env.Syncer = New(&incompleteLabelSnapshotAPI{
+		MockAPI:       env.Mock,
+		sourceMatches: true,
+	}, env.Store, opts)
+
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
+
+	var sourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal("[Gmail]/All Mail|42", sourceMessageID,
+		"a filtered rescan must preserve the canonical source_message_id")
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "[Gmail]/All Mail")
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Archive")
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "INBOX")
+}
+
+func TestIMAPFilteredRescanExactIDMergesNewLabels(t *testing.T) {
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	env.Syncer = New(env.Mock, env.Store, opts)
+	env.Mock.Labels = []*gmail.Label{
+		{ID: "[Gmail]/All Mail", Name: "All Mail", Type: labelTypeSystem},
+		{ID: "Archive", Name: "Archive", Type: "user"},
+	}
+
+	const sourceMessageID = "[Gmail]/All Mail|42"
+	msg := testemail.NewMessage().
+		Subject("Exact-ID filtered rescan").
+		Header("Message-ID", "<exact-id-filtered-rescan@example.com>").
+		Body("Same composite ID through a partial mailbox view.").
+		Bytes()
+
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.AddMessage(sourceMessageID, msg, []string{"[Gmail]/All Mail"})
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	assertMessageNotHasLabel(t, env.Store, sourceMessageID, "Archive")
+
+	env.Mock.Messages[sourceMessageID].LabelIDs = []string{"[Gmail]/All Mail", "Archive"}
+	callsBeforeRescan := len(env.Mock.GetMessageCalls)
+	filteredAPI := &labelMetadataSnapshotAPI{
+		MockAPI:  env.Mock,
+		filtered: true,
+	}
+	env.Syncer = New(filteredAPI, env.Store, opts)
+
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
+	assert.Len(t, env.Mock.GetMessageCalls, callsBeforeRescan,
+		"existing messages should not download raw MIME to refresh labels")
+	assert.Equal(t, [][]string{{sourceMessageID}}, filteredAPI.labelCalls)
+	assert.Equal(t, [][2]string{{sourceMessageID, ""}}, filteredAPI.seedCalls)
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "[Gmail]/All Mail")
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Archive")
+}
+
+func TestIMAPCompleteRescanReplacesExactIDLabels(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	env.Syncer = New(env.Mock, env.Store, opts)
+	env.Mock.Labels = []*gmail.Label{
+		{ID: "[Gmail]/All Mail", Name: "All Mail", Type: labelTypeSystem},
+		{ID: "Archive", Name: "Archive", Type: "user"},
+	}
+
+	const sourceMessageID = "[Gmail]/All Mail|42"
+	msg := testemail.NewMessage().
+		Subject("Complete exact-ID rescan").
+		Header("Message-ID", "<complete-exact-id-rescan@example.com>").
+		Body("Labels become authoritative again after an unfiltered rescan.").
+		Bytes()
+
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.AddMessage(sourceMessageID, msg, []string{"[Gmail]/All Mail"})
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+
+	env.Mock.Messages[sourceMessageID].LabelIDs = []string{"[Gmail]/All Mail", "Archive"}
+	filteredAPI := &labelMetadataSnapshotAPI{
+		MockAPI:  env.Mock,
+		filtered: true,
+	}
+	env.Syncer = New(filteredAPI, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "Archive")
+
+	env.Mock.Messages[sourceMessageID].LabelIDs = []string{"[Gmail]/All Mail"}
+	completeAPI := &labelMetadataSnapshotAPI{MockAPI: env.Mock, complete: true}
+	env.Syncer = New(completeAPI, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+	assert.Equal([][]string{{sourceMessageID}}, completeAPI.labelCalls)
+	assertMessageHasLabel(t, env.Store, sourceMessageID, "[Gmail]/All Mail")
+	assertMessageNotHasLabel(t, env.Store, sourceMessageID, "Archive")
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err)
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err)
+	assert.Equal(int64(1), run.MessagesUpdated)
+
+	completeAPI.labelCalls = nil
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(0)),
+	})
+	assert.Equal([][]string{{sourceMessageID}}, completeAPI.labelCalls)
+}
+
+func TestIMAPLabelMetadataFailureDoesNotAbortBatch(t *testing.T) {
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	env.Syncer = New(env.Mock, env.Store, opts)
+	env.Mock.Labels = []*gmail.Label{
+		{ID: "[Gmail]/All Mail", Name: "All Mail", Type: labelTypeSystem},
+		{ID: "Archive", Name: "Archive", Type: "user"},
+	}
+
+	const firstID = "[Gmail]/All Mail|41"
+	const vanishedID = "[Gmail]/All Mail|42"
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.AddMessage(firstID, testMIME(), []string{"[Gmail]/All Mail"})
+	env.Mock.AddMessage(vanishedID, testMIME(), []string{"[Gmail]/All Mail"})
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
+
+	env.Mock.Messages[firstID].LabelIDs = []string{"[Gmail]/All Mail", "Archive"}
+	filteredAPI := &labelMetadataSnapshotAPI{
+		MockAPI:  env.Mock,
+		filtered: true,
+		labelErrors: map[string]error{
+			vanishedID: errors.New("UID vanished before metadata fetch"),
+		},
+	}
+	env.Syncer = New(filteredAPI, env.Store, opts)
+
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:  new(int64(0)),
+		Errors: new(int64(1)),
+	})
+	assertMessageHasLabel(t, env.Store, firstID, "Archive")
+	assertMessageNotHasLabel(t, env.Store, vanishedID, "Archive")
+	assert.Equal(t, [][2]string{{firstID, ""}}, filteredAPI.seedCalls,
+		"failed label metadata must not seed dedup state")
 }
 
 // TestIncrementalSyncLabelRemovedWithMissingRaw verifies that removing a label

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2210,6 +2210,7 @@ func TestIMAPUIDValidityReusePreservesOldAndArchivesNewMessage(t *testing.T) {
 		`SELECT id, source_message_id, rfc822_message_id FROM messages`,
 	)
 	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
 	for rows.Next() {
 		var id int64
 		var sourceMessageID string
@@ -2223,7 +2224,6 @@ func TestIMAPUIDValidityReusePreservesOldAndArchivesNewMessage(t *testing.T) {
 			}
 	}
 	require.NoError(rows.Err())
-	require.NoError(rows.Close())
 	require.Len(identities, 2)
 
 	oldIdentity := identities[oldRFC822ID]
@@ -2309,6 +2309,7 @@ func TestIMAPNoResumeUIDValidityReuseArchivesReplacement(t *testing.T) {
 		`SELECT id, source_message_id, rfc822_message_id FROM messages`,
 	)
 	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
 	for rows.Next() {
 		var id int64
 		var sourceMessageID string
@@ -2322,7 +2323,6 @@ func TestIMAPNoResumeUIDValidityReuseArchivesReplacement(t *testing.T) {
 			}
 	}
 	require.NoError(rows.Err())
-	require.NoError(rows.Close())
 	require.Len(identities, 2)
 
 	oldIdentity := identities[oldRFC822ID]
@@ -2530,6 +2530,7 @@ func assertMissingIDArchiveState(
 	var archived []archivedMessage
 	rows, err := st.DB().Query(`SELECT id, source_message_id FROM messages`)
 	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
 	for rows.Next() {
 		var msg archivedMessage
 		require.NoError(rows.Scan(&msg.id, &msg.sourceMessageID))
@@ -2539,7 +2540,6 @@ func assertMissingIDArchiveState(
 		archived = append(archived, msg)
 	}
 	require.NoError(rows.Err())
-	require.NoError(rows.Close())
 	require.Len(archived, 2)
 
 	var oldMessage, newMessage *archivedMessage
@@ -2800,6 +2800,7 @@ func TestIMAPCompleteCrossPageOverlapPreservesValidID(t *testing.T) {
 
 type sourceValidationAPI struct {
 	*gmail.MockAPI
+
 	sourceMatches bool
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	imapv2 "github.com/emersion/go-imap/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/gmail"
@@ -2071,6 +2072,49 @@ func TestIMAPFullRescanWithoutAllPreservesExistingIDForOverlappingFolders(t *tes
 	assert.Equal(t, originalSourceMessageID, rescannedSourceMessageID)
 	assertMessageHasLabel(t, env.Store, rescannedSourceMessageID, "Archive")
 	assertMessageHasLabel(t, env.Store, rescannedSourceMessageID, "INBOX")
+}
+
+func TestIMAPCompleteSnapshotAdoptsAllMailCanonicalID(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"All Mail": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{
+			"All Mail": {imapv2.MailboxAttrAll},
+		},
+	)
+	const messageID = "canonical-all-mail@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "All Mail", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+
+	firstClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderFilter([]string{"INBOX"}, nil))
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+
+	var sourceMessageID string
+	err := env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	require.Equal("INBOX|1", sourceMessageID)
+	require.NoError(firstClient.Close())
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Updated: new(int64(1))})
+
+	err = env.Store.DB().QueryRow(
+		`SELECT source_message_id FROM messages LIMIT 1`,
+	).Scan(&sourceMessageID)
+	require.NoError(err)
+	assert.Equal(t, "All Mail|1", sourceMessageID)
 }
 
 func TestIMAPHighWaterMoveReplacesMissingIDAndMergesLabels(t *testing.T) {

--- a/internal/sync/testenv_test.go
+++ b/internal/sync/testenv_test.go
@@ -124,6 +124,7 @@ func startSyncRun(t *testing.T, env *TestEnv, sourceID int64) int64 {
 // WantSummary specifies expected SyncSummary values. Nil fields are not checked.
 type WantSummary struct {
 	Added   *int64
+	Updated *int64
 	Errors  *int64
 	Skipped *int64
 	Found   *int64
@@ -135,6 +136,9 @@ func assertSummary(t *testing.T, s *gmail.SyncSummary, want WantSummary) {
 	t.Helper()
 	if want.Added != nil {
 		assert.Equal(t, *want.Added, s.MessagesAdded, "messages added")
+	}
+	if want.Updated != nil {
+		assert.Equal(t, *want.Updated, s.MessagesUpdated, "messages updated")
 	}
 	if want.Errors != nil {
 		assert.Equal(t, *want.Errors, s.Errors, "errors")

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -2,7 +2,9 @@ package testutil
 
 import (
 	"bytes"
+	"fmt"
 	"net"
+	"sort"
 	"testing"
 
 	imap "github.com/emersion/go-imap/v2"
@@ -24,11 +26,102 @@ type imapLiteral struct {
 
 func (l imapLiteral) Size() int64 { return int64(l.Len()) }
 
+type specialUseSession struct {
+	imapserver.Session
+
+	mailboxes  []string
+	specialUse map[string][]imap.MailboxAttr
+}
+
+type selectErrorSession struct {
+	imapserver.Session
+
+	mailbox   string
+	remaining int
+}
+
+func (s *selectErrorSession) Select(
+	mailbox string,
+	options *imap.SelectOptions,
+) (*imap.SelectData, error) {
+	if mailbox == s.mailbox && s.remaining != 0 {
+		if s.remaining > 0 {
+			s.remaining--
+		}
+		return nil, fmt.Errorf("synthetic SELECT failure for %q", mailbox)
+	}
+	data, err := s.Session.Select(mailbox, options)
+	if err != nil {
+		return nil, fmt.Errorf("select %q: %w", mailbox, err)
+	}
+	return data, nil
+}
+
+func (s *specialUseSession) List(
+	w *imapserver.ListWriter,
+	ref string,
+	patterns []string,
+	_ *imap.ListOptions,
+) error {
+	for _, mailbox := range s.mailboxes {
+		matches := false
+		for _, pattern := range patterns {
+			if imapserver.MatchList(mailbox, '/', ref, pattern) {
+				matches = true
+				break
+			}
+		}
+		if !matches {
+			continue
+		}
+		if err := w.WriteList(&imap.ListData{
+			Mailbox: mailbox,
+			Delim:   '/',
+			Attrs:   s.specialUse[mailbox],
+		}); err != nil {
+			return fmt.Errorf("write LIST response for %q: %w", mailbox, err)
+		}
+	}
+	return nil
+}
+
 // AppendIMAPMessage appends one synthetic RFC822 message to a mailbox
 // of an in-memory IMAP test user.
 func AppendIMAPMessage(t *testing.T, user *imapmemserver.User, mailbox string) {
 	t.Helper()
-	body := []byte("From: alice@example.com\r\nTo: bob@example.com\r\n\r\nbody\r\n")
+	AppendIMAPMessageWithoutMessageID(t, user, mailbox, "body")
+}
+
+// AppendIMAPMessageWithoutMessageID appends one synthetic RFC822 message with
+// the supplied body and no Message-ID header.
+func AppendIMAPMessageWithoutMessageID(
+	t *testing.T,
+	user *imapmemserver.User,
+	mailbox string,
+	messageBody string,
+) {
+	t.Helper()
+	body := fmt.Appendf(nil,
+		"From: alice@example.com\r\nTo: bob@example.com\r\n\r\n%s\r\n",
+		messageBody,
+	)
+	_, err := user.Append(mailbox, imapLiteral{bytes.NewReader(body)}, &imap.AppendOptions{})
+	require.NoError(t, err)
+}
+
+// AppendIMAPMessageWithMessageID appends one synthetic RFC822 message with
+// the supplied Message-ID to a mailbox of an in-memory IMAP test user.
+func AppendIMAPMessageWithMessageID(
+	t *testing.T,
+	user *imapmemserver.User,
+	mailbox string,
+	messageID string,
+) {
+	t.Helper()
+	body := fmt.Appendf(nil,
+		"Message-ID: <%s>\r\nFrom: alice@example.com\r\nTo: bob@example.com\r\n\r\nbody\r\n",
+		messageID,
+	)
 	_, err := user.Append(mailbox, imapLiteral{bytes.NewReader(body)}, &imap.AppendOptions{})
 	require.NoError(t, err)
 }
@@ -39,20 +132,86 @@ func AppendIMAPMessage(t *testing.T, user *imapmemserver.User, mailbox string) {
 // down via t.Cleanup.
 func StartIMAPMemServer(t *testing.T, messagesPerMailbox map[string]int) (string, *imapmemserver.User) {
 	t.Helper()
+	return startIMAPMemServer(t, messagesPerMailbox, nil, "", 0)
+}
 
+// StartIMAPMemServerWithSpecialUse runs an in-memory IMAP server whose LIST
+// responses advertise the supplied special-use attributes.
+func StartIMAPMemServerWithSpecialUse(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	specialUse map[string][]imap.MailboxAttr,
+) (string, *imapmemserver.User) {
+	t.Helper()
+	return startIMAPMemServer(t, messagesPerMailbox, specialUse, "", 0)
+}
+
+// StartIMAPMemServerWithSelectError runs an in-memory IMAP server that rejects
+// SELECT for one mailbox while serving all other mailboxes normally.
+func StartIMAPMemServerWithSelectError(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	specialUse map[string][]imap.MailboxAttr,
+	selectErrorMailbox string,
+) (string, *imapmemserver.User) {
+	t.Helper()
+	return startIMAPMemServer(
+		t, messagesPerMailbox, specialUse, selectErrorMailbox, -1)
+}
+
+// StartIMAPMemServerWithOneShotSelectError runs an in-memory IMAP server that
+// rejects the first SELECT for one mailbox, then serves it normally.
+func StartIMAPMemServerWithOneShotSelectError(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	specialUse map[string][]imap.MailboxAttr,
+	selectErrorMailbox string,
+) (string, *imapmemserver.User) {
+	t.Helper()
+	return startIMAPMemServer(
+		t, messagesPerMailbox, specialUse, selectErrorMailbox, 1)
+}
+
+func startIMAPMemServer(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	specialUse map[string][]imap.MailboxAttr,
+	selectErrorMailbox string,
+	selectErrorCount int,
+) (string, *imapmemserver.User) {
+	t.Helper()
 	user := imapmemserver.NewUser(IMAPTestUsername, IMAPTestPassword)
+	mailboxes := make([]string, 0, len(messagesPerMailbox))
 	for mailbox, count := range messagesPerMailbox {
 		require.NoError(t, user.Create(mailbox, nil))
+		mailboxes = append(mailboxes, mailbox)
 		for range count {
 			AppendIMAPMessage(t, user, mailbox)
 		}
 	}
+	sort.Strings(mailboxes)
 	memServer := imapmemserver.New()
 	memServer.AddUser(user)
 
 	server := imapserver.New(&imapserver.Options{
 		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return memServer.NewSession(), nil, nil
+			var session imapserver.Session
+			session = memServer.NewSession()
+			if len(specialUse) > 0 {
+				session = &specialUseSession{
+					Session:    session,
+					mailboxes:  mailboxes,
+					specialUse: specialUse,
+				}
+			}
+			if selectErrorMailbox != "" {
+				session = &selectErrorSession{
+					Session:   session,
+					mailbox:   selectErrorMailbox,
+					remaining: selectErrorCount,
+				}
+			}
+			return session, nil, nil
 		},
 		InsecureAuth: true,
 	})

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -200,6 +200,12 @@ type GetCLIStatsQuery struct {
 type SyncCLIQuery struct {
 	// Email Account email or display name to sync
 	Email *string `json:"email,omitempty"`
+
+	// Folder IMAP folder names to include (repeatable)
+	Folder []string `json:"folder,omitempty"`
+
+	// SkipFolder IMAP folder names to exclude (repeatable)
+	SkipFolder []string `json:"skip-folder,omitempty"`
 }
 
 type SyncFullCLIQuery struct {
@@ -220,6 +226,12 @@ type SyncFullCLIQuery struct {
 
 	// Noresume Ignore checkpoints and start fresh
 	Noresume *bool `json:"noresume,omitempty"`
+
+	// Folder IMAP folder names to include (repeatable)
+	Folder []string `json:"folder,omitempty"`
+
+	// SkipFolder IMAP folder names to exclude (repeatable)
+	SkipFolder []string `json:"skip-folder,omitempty"`
 }
 
 type VerifyCLIQuery struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -6120,6 +6120,20 @@ paths:
           name: email
           schema:
             type: string
+        - description: IMAP folder names to include (repeatable)
+          in: query
+          name: folder
+          schema:
+            items:
+              type: string
+            type: array
+        - description: IMAP folder names to exclude (repeatable)
+          in: query
+          name: skip-folder
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         "200":
           content:
@@ -6173,6 +6187,20 @@ paths:
           name: noresume
           schema:
             type: boolean
+        - description: IMAP folder names to include (repeatable)
+          in: query
+          name: folder
+          schema:
+            items:
+              type: string
+            type: array
+        - description: IMAP folder names to exclude (repeatable)
+          in: query
+          name: skip-folder
+          schema:
+            items:
+              type: string
+            type: array
       responses:
         "200":
           content:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -5707,6 +5707,10 @@ export interface operations {
             query?: {
                 /** @description Account email or display name to sync */
                 email?: string;
+                /** @description IMAP folder names to include (repeatable) */
+                folder?: string[];
+                /** @description IMAP folder names to exclude (repeatable) */
+                "skip-folder"?: string[];
             };
             header?: never;
             path?: never;
@@ -5749,6 +5753,10 @@ export interface operations {
                 limit?: number;
                 /** @description Ignore checkpoints and start fresh */
                 noresume?: boolean;
+                /** @description IMAP folder names to include (repeatable) */
+                folder?: string[];
+                /** @description IMAP folder names to exclude (repeatable) */
+                "skip-folder"?: string[];
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## What changed

- Adds `msgvault list-folders [account]` to show selectable IMAP folders and approximate message counts. Without an account name, it lists folders for every configured IMAP account.
- Adds repeatable `--folders` and `--skip-folders` options to both `sync-full` and `sync`. Each flag takes one complete folder name, so names containing commas work correctly.
- Supports the same folder filters when the CLI talks to a local daemon or a configured remote server.
- Keeps filtered scans narrow, including on servers with Gmail-style All Mail, Trash, and Junk folders.
- Preserves stable message identities during filtered or incomplete rescans. These scans add newly observed folder labels without removing labels learned earlier. An unfiltered scan replaces stale labels only when every mailbox was collected successfully.
- Refreshes labels for messages that are already archived by fetching only lightweight Message-ID headers. Raw message bodies and attachments are downloaded only for new messages.
- Handles metadata failures per message, so a UID that disappears after listing does not prevent other messages in the batch from updating.
- Adds a Zensical guide, setup examples, and complete CLI reference entries for folder discovery, matching rules, and safe filtered syncs.

## Why

A first sync can take a long time on a large IMAP account. Folder filtering lets someone start with a useful subset, confirm that msgvault fits their needs, and expand the archive later. It also lets ongoing syncs ignore folders that are not useful to the local archive.

## How to use it

First, find the folder names reported by the server:

```bash
msgvault list-folders you@example.com
```

Sync only selected folders by repeating `--folders`:

```bash
msgvault sync-full you@example.com \
  --folders INBOX \
  --folders Archive
```

Or scan everything except selected folders by repeating `--skip-folders`:

```bash
msgvault sync you@example.com \
  --skip-folders Trash \
  --skip-folders Spam
```

Folder names use exact, case-insensitive matching. When include and exclude flags are combined, msgvault applies the include list first and then removes excluded folders. The flags affect IMAP accounts only and apply to the current command. With no folder flags, msgvault scans every selectable folder.

Filtering changes which remote folders are scanned; it does not delete messages from the provider or remove messages already stored in the local archive.

Closes #196.