### PR TITLE
build(docker): enable sqlite_vec so vector search works in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@
 # Pin by digest for reproducibility; update periodically
 FROM golang:1.26-bookworm@sha256:18aedc16aa19b3fd7ded7245fc14b109e054d65d22ed53c355c899582bbb2113 AS builder
 
-# Install build dependencies for CGO (SQLite, DuckDB)
+# Install build dependencies for CGO (SQLite, DuckDB).
+# libsqlite3-dev provides sqlite3.h, required to compile the sqlite-vec
+# extension (asg017/sqlite-vec-go-bindings) under -tags sqlite_vec.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gcc \
     g++ \
     make \
     git \
+    libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
@@ -25,7 +28,7 @@ ARG BUILD_DATE=unknown
 
 # Note: Module path must match go.mod (go.kenn.io/msgvault)
 RUN CGO_ENABLED=1 go build \
-    -tags fts5 \
+    -tags "fts5 sqlite_vec" \
     -trimpath \
     -ldflags="-s -w \
         -X go.kenn.io/msgvault/cmd/msgvault/cmd.Version=${VERSION} \


### PR DESCRIPTION
The published Docker image builds with `-tags fts5` only, so starting `serve` with `[vector] enabled = true` fails at startup ("binary was built without -tags sqlite_vec") and vector/hybrid search is unavailable in Docker deployments — even though the Makefile already builds `fts5 sqlite_vec`.

Two changes are required:
- add `sqlite_vec` to the build tags, and
- install `libsqlite3-dev` in the builder stage, because the sqlite-vec cgo binding (asg017/sqlite-vec-go-bindings) includes sqlite3.h at compile time.

Verified by building the image and running `serve` with vector enabled against an OpenAI-compatible embedding endpoint: /health reports vector ready and `msgvault embeddings build` populates the index.