### PR TITLE
Repair missing and implausible message dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ make lint                     # Run linter
 
 # Maintenance
 ./msgvault repair-encoding                            # Fix UTF-8 encoding issues
+./msgvault repair-dates                              # Preview missing/implausible date repairs
+./msgvault repair-dates --apply                      # Apply repairs (and rebuild SQLite analytics cache)
 
 # Agent skills
 ./msgvault skills install                             # Install agent skills (Claude Code, Codex)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ available with `msgvault tui`.
 | `update` | Update msgvault to the latest version |
 | `setup` | Interactive first-run configuration wizard |
 | `repair-encoding` | Fix UTF-8 encoding issues |
+| `repair-dates` | Report or repair missing and implausible email sent dates |
 | `list-senders` / `list-domains` / `list-labels` | Explore metadata |
 
 See the [CLI Reference](https://msgvault.io/cli-reference/) for full details.
@@ -149,7 +150,7 @@ msgvault can search your archive semantically using vector embeddings in additio
 
 A separate MCP tool, `find_similar_messages`, returns nearest neighbors for a seed message. See the [Vector Search guide](https://msgvault.io/usage/vector-search/) for setup, backfill, and troubleshooting.
 
-> **Archive writes are daemon-owned.** CLI writer commands such as `msgvault sync-full`, `msgvault embeddings build`, `msgvault repair-encoding`, and `msgvault rebuild-fts` send their work to the configured remote server or local background daemon. The daemon serializes archive mutations and streams progress back to your terminal, so normal CLI ergonomics stay the same without opening a second SQLite writer process.
+> **Archive writes are daemon-owned.** CLI writer commands such as `msgvault sync-full`, `msgvault embeddings build`, `msgvault repair-dates --apply`, and `msgvault rebuild-fts` send their work to the configured remote server or local background daemon. The daemon serializes archive mutations and streams progress back to your terminal, so normal CLI ergonomics stay the same without opening a second SQLite writer process.
 
 Large archives can scope an embedding generation with `[vector.embed.scope] message_types = ["sms", "mms"]`. Scoped vector and hybrid searches must include a matching `message_type` filter so a partial index is never used as if it covered the whole archive.
 

--- a/cmd/msgvault/cmd/repair_dates.go
+++ b/cmd/msgvault/cmd/repair_dates.go
@@ -1,0 +1,518 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const dateRepairSampleLimit = 10
+
+var repairDatesApply bool
+
+var repairDatesCmd = &cobra.Command{
+	Use:   "repair-dates",
+	Short: "Repair missing or implausible email sent dates",
+	Long: `Scan email messages whose stored sent_at is missing, before 1990, or
+more than 30 days in the future. For each candidate, resolve a canonical sent
+time from the Date header, the oldest plausible Received timestamp, or stored
+source metadata.
+
+The default is a read-only report. Pass --apply to update the archive, write an
+audit ledger under the data directory, and rebuild the analytics cache for
+SQLite archives. Original source files and remote servers are never modified.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isDaemonCLISubprocess() {
+			return runDaemonCLICommandHTTPFromCobra(cmd, args)
+		}
+		return runRepairDatesLocal(cmd, repairDatesApply, time.Now().UTC())
+	},
+}
+
+type plannedDateRepair struct {
+	store.MessageDateRepair
+
+	source    mime.DateSource
+	oldSentAt sql.NullTime
+}
+
+// unresolvedDateReason categorizes why a candidate could not be resolved to
+// a plausible sent time, so operators can see what signal is missing instead
+// of just a bare count.
+type unresolvedDateReason string
+
+const (
+	unresolvedDateHeaderUnusable unresolvedDateReason = "date-header-unusable"
+	unresolvedReceivedUnusable   unresolvedDateReason = "received-headers-unusable"
+	unresolvedNoDateSignal       unresolvedDateReason = "no-date-signal"
+)
+
+type unresolvedDateCandidate struct {
+	id     int64
+	reason unresolvedDateReason
+}
+
+type dateRepairPlan struct {
+	candidateCount  int
+	repairs         []plannedDateRepair
+	rawMIMEFailures int
+	unresolved      []unresolvedDateCandidate
+}
+
+func runRepairDatesLocal(
+	cmd *cobra.Command,
+	apply bool,
+	now time.Time,
+) (runErr error) {
+	ctx := cmd.Context()
+	st, cleanup, err := openWritableStoreAndInit()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	plan, err := scanAndPlanDateRepairs(ctx, st, now)
+	if err != nil {
+		return err
+	}
+	printDateRepairPlan(cmd, plan)
+
+	if !apply {
+		if _, err := fmt.Fprintln(
+			cmd.OutOrStdout(),
+			"\nDry run: no rows were modified. Re-run with --apply to write repairs.",
+		); err != nil {
+			return fmt.Errorf("write date repair dry-run summary: %w", err)
+		}
+		return nil
+	}
+	if len(plan.repairs) == 0 {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Nothing to repair."); err != nil {
+			return fmt.Errorf("write empty date repair summary: %w", err)
+		}
+		return nil
+	}
+
+	lowerBound, upperBound := mime.PlausibleDateBounds(now)
+	ledgerPath, err := availableDateRepairLedgerPath(cfg.Data.DataDir, now)
+	if err != nil {
+		return err
+	}
+	ledger := newDateRepairLedger(plan, now)
+	if err := writeDateRepairLedger(ledgerPath, ledger); err != nil {
+		return fmt.Errorf("write date repair ledger: %w", err)
+	}
+
+	usesAnalyticsCache := dateRepairUsesAnalyticsCache(cfg.DatabaseDSN())
+	unlockCache := func() error { return nil }
+	if usesAnalyticsCache {
+		cacheLock, err := lockCacheAndInvalidateSyncState(cfg.AnalyticsDir())
+		if err != nil {
+			return fmt.Errorf("protect analytics cache for date repair: %w", err)
+		}
+		released := false
+		unlockCache = func() error {
+			if released {
+				return nil
+			}
+			released = true
+			return wrapError(cacheLock.Unlock(), "release analytics cache lock")
+		}
+		defer func() {
+			runErr = errors.Join(runErr, unlockCache())
+		}()
+	}
+
+	if err := applyPlannedDateRepairs(
+		ctx,
+		st,
+		plan,
+		lowerBound,
+		upperBound,
+		ledgerPath,
+		ledger,
+	); err != nil {
+		return err
+	}
+
+	ledger.Status = "applied"
+	appliedAt := time.Now().UTC()
+	ledger.AppliedAt = &appliedAt
+	if err := writeDateRepairLedger(ledgerPath, ledger); err != nil {
+		return dateRepairPostApplyRecoveryError(
+			"audit ledger finalization failed",
+			err,
+		)
+	}
+
+	cacheRebuilt := false
+	if usesAnalyticsCache {
+		if _, err := buildCacheLocked(
+			cfg.DatabaseDSN(),
+			cfg.AnalyticsDir(),
+			true,
+			false,
+		); err != nil {
+			ledger.Status = "applied-cache-failed"
+			ledger.Error = err.Error()
+			_ = writeDateRepairLedger(ledgerPath, ledger)
+			return dateRepairCacheRefreshError(err)
+		}
+		cacheRebuilt = true
+	}
+
+	ledger.Status = "complete"
+	ledger.CacheRebuilt = cacheRebuilt
+	completedAt := time.Now().UTC()
+	ledger.CompletedAt = &completedAt
+	if err := writeDateRepairLedger(ledgerPath, ledger); err != nil {
+		return fmt.Errorf(
+			"date repairs and cache refresh completed, but audit ledger finalization failed: %w",
+			err,
+		)
+	}
+
+	cacheSummary := "Analytics cache not used for PostgreSQL."
+	if cacheRebuilt {
+		cacheSummary = "Analytics cache rebuilt."
+	}
+	if _, err = fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"Repaired %d message(s).\nRepair ledger: %s\n%s\n",
+		len(plan.repairs),
+		ledgerPath,
+		cacheSummary,
+	); err != nil {
+		return fmt.Errorf("write completed date repair summary: %w", err)
+	}
+	return nil
+}
+
+func dateRepairUsesAnalyticsCache(dsn string) bool {
+	return !store.IsPostgresURL(dsn)
+}
+
+func applyPlannedDateRepairs(
+	ctx context.Context,
+	st *store.Store,
+	plan *dateRepairPlan,
+	lowerBound, upperBound time.Time,
+	ledgerPath string,
+	ledger *dateRepairLedger,
+) error {
+	updates := make([]store.MessageDateRepair, len(plan.repairs))
+	for i := range plan.repairs {
+		updates[i] = plan.repairs[i].MessageDateRepair
+	}
+	if err := st.ApplyMessageDateRepairs(
+		ctx,
+		updates,
+		lowerBound,
+		upperBound,
+	); err != nil {
+		ledger.Status = "failed"
+		ledger.Error = err.Error()
+		if ledgerErr := writeDateRepairLedger(ledgerPath, ledger); ledgerErr != nil {
+			return errors.Join(
+				err,
+				fmt.Errorf("record failed date repair in audit ledger: %w", ledgerErr),
+			)
+		}
+		return err
+	}
+	return nil
+}
+
+func dateRepairCacheRefreshError(err error) error {
+	return dateRepairPostApplyRecoveryError("analytics cache refresh failed", err)
+}
+
+func dateRepairPostApplyRecoveryError(problem string, err error) error {
+	return fmt.Errorf(
+		"date repairs applied, but %s; "+
+			"run `msgvault build-cache --full-rebuild` to retry: %w",
+		problem,
+		err,
+	)
+}
+
+func scanAndPlanDateRepairs(
+	ctx context.Context,
+	st *store.Store,
+	now time.Time,
+) (*dateRepairPlan, error) {
+	lowerBound, upperBound := mime.PlausibleDateBounds(now)
+	candidates, err := st.ListMessageDateRepairCandidates(
+		ctx,
+		lowerBound,
+		upperBound,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &dateRepairPlan{candidateCount: len(candidates)}
+	for _, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		parsed := &mime.Message{}
+		raw, rawErr := st.GetMessageRaw(candidate.ID)
+		if rawErr != nil {
+			plan.rawMIMEFailures++
+		} else {
+			var parseErr error
+			parsed, parseErr = mime.Parse(raw)
+			if parseErr != nil {
+				plan.rawMIMEFailures++
+				parsed = &mime.Message{}
+			}
+		}
+
+		var fallback time.Time
+		if candidate.InternalDate.Valid {
+			fallback = candidate.InternalDate.Time
+		}
+		resolved, source := mime.ResolveMessageDate(
+			parsed.Date,
+			parsed.ReceivedDates,
+			fallback,
+			now,
+		)
+		if resolved.IsZero() {
+			plan.unresolved = append(plan.unresolved, unresolvedDateCandidate{
+				id:     candidate.ID,
+				reason: classifyUnresolvedDate(parsed),
+			})
+			continue
+		}
+		plan.repairs = append(plan.repairs, plannedDateRepair{
+			MessageDateRepair: store.MessageDateRepair{
+				ID:                     candidate.ID,
+				SentAt:                 resolved,
+				ExpectedLastModifiedAt: candidate.LastModifiedAt,
+			},
+			source:    source,
+			oldSentAt: candidate.SentAt,
+		})
+	}
+	return plan, nil
+}
+
+// unresolvedDateReasonOrder fixes the print order to match the precedence
+// ResolveMessageDate checks signals in: header, then received, then neither.
+var unresolvedDateReasonOrder = []unresolvedDateReason{
+	unresolvedDateHeaderUnusable,
+	unresolvedReceivedUnusable,
+	unresolvedNoDateSignal,
+}
+
+var unresolvedDateReasonLabel = map[unresolvedDateReason]string{
+	unresolvedDateHeaderUnusable: "Date header present but not a plausible date",
+	unresolvedReceivedUnusable:   "Received headers present but none plausible",
+	unresolvedNoDateSignal:       "no Date header, no Received headers",
+}
+
+// printUnresolvedDateSamples groups unresolved candidates by reason and
+// prints a capped sample of message IDs per group, so operators can look up
+// exactly which messages are still corrupt instead of only a bare count.
+func printUnresolvedDateSamples(out io.Writer, unresolved []unresolvedDateCandidate) {
+	byReason := make(map[unresolvedDateReason][]int64, len(unresolvedDateReasonOrder))
+	for _, u := range unresolved {
+		byReason[u.reason] = append(byReason[u.reason], u.id)
+	}
+	for _, reason := range unresolvedDateReasonOrder {
+		ids := byReason[reason]
+		if len(ids) == 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "  %s: %d (%s)\n", reason, len(ids), unresolvedDateReasonLabel[reason])
+		for i, id := range ids {
+			if i >= dateRepairSampleLimit {
+				_, _ = fmt.Fprintf(out, "    ... and %d more\n", len(ids)-dateRepairSampleLimit)
+				break
+			}
+			_, _ = fmt.Fprintf(out, "    message %d\n", id)
+		}
+	}
+}
+
+// classifyUnresolvedDate explains why ResolveMessageDate produced no
+// plausible time, in the same header/received/fallback order it checks.
+func classifyUnresolvedDate(parsed *mime.Message) unresolvedDateReason {
+	if parsed.RawDateHeader != "" {
+		return unresolvedDateHeaderUnusable
+	}
+	if len(parsed.ReceivedDates) > 0 {
+		return unresolvedReceivedUnusable
+	}
+	return unresolvedNoDateSignal
+}
+
+func printDateRepairPlan(cmd *cobra.Command, plan *dateRepairPlan) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(
+		out,
+		"Found %d message(s) with missing or implausible sent_at.\n",
+		plan.candidateCount,
+	)
+	_, _ = fmt.Fprintf(out, "Repairable: %d\n", len(plan.repairs))
+	if plan.rawMIMEFailures > 0 {
+		_, _ = fmt.Fprintf(
+			out,
+			"Candidates lacking usable raw MIME: %d "+
+				"(source metadata may still resolve them)\n",
+			plan.rawMIMEFailures,
+		)
+	}
+	if len(plan.unresolved) > 0 {
+		_, _ = fmt.Fprintf(out, "No plausible replacement: %d\n", len(plan.unresolved))
+		printUnresolvedDateSamples(out, plan.unresolved)
+	}
+	for i, repair := range plan.repairs {
+		if i >= dateRepairSampleLimit {
+			_, _ = fmt.Fprintf(
+				out,
+				"... and %d more\n",
+				len(plan.repairs)-dateRepairSampleLimit,
+			)
+			break
+		}
+		old := "missing"
+		if repair.oldSentAt.Valid {
+			old = repair.oldSentAt.Time.UTC().Format(time.RFC3339)
+		}
+		_, _ = fmt.Fprintf(
+			out,
+			"  message %d: %s -> %s (%s)\n",
+			repair.ID,
+			old,
+			repair.SentAt.UTC().Format(time.RFC3339),
+			repair.source,
+		)
+	}
+}
+
+type dateRepairLedger struct {
+	Version      int                     `json:"version"`
+	Kind         string                  `json:"kind"`
+	Status       string                  `json:"status"`
+	StartedAt    time.Time               `json:"started_at"`
+	AppliedAt    *time.Time              `json:"applied_at,omitempty"`
+	CompletedAt  *time.Time              `json:"completed_at,omitempty"`
+	CacheRebuilt bool                    `json:"cache_rebuilt"`
+	Error        string                  `json:"error,omitempty"`
+	Repairs      []dateRepairLedgerEntry `json:"repairs"`
+}
+
+type dateRepairLedgerEntry struct {
+	MessageID int64           `json:"message_id"`
+	OldSentAt *time.Time      `json:"old_sent_at"`
+	NewSentAt time.Time       `json:"new_sent_at"`
+	Source    mime.DateSource `json:"source"`
+}
+
+func newDateRepairLedger(
+	plan *dateRepairPlan,
+	now time.Time,
+) *dateRepairLedger {
+	entries := make([]dateRepairLedgerEntry, len(plan.repairs))
+	for i, repair := range plan.repairs {
+		var oldSentAt *time.Time
+		if repair.oldSentAt.Valid {
+			old := repair.oldSentAt.Time.UTC()
+			oldSentAt = &old
+		}
+		entries[i] = dateRepairLedgerEntry{
+			MessageID: repair.ID,
+			OldSentAt: oldSentAt,
+			NewSentAt: repair.SentAt.UTC(),
+			Source:    repair.source,
+		}
+	}
+	return &dateRepairLedger{
+		Version:   1,
+		Kind:      "message-date-repair",
+		Status:    "applying",
+		StartedAt: now.UTC(),
+		Repairs:   entries,
+	}
+}
+
+func availableDateRepairLedgerPath(dataDir string, now time.Time) (string, error) {
+	dir := filepath.Join(dataDir, "repairs")
+	stem := "dates-" + now.UTC().Format("20060102T150405.000000000Z")
+	for suffix := 0; ; suffix++ {
+		filename := stem + ".json"
+		if suffix > 0 {
+			filename = fmt.Sprintf("%s-%d.json", stem, suffix)
+		}
+		path := filepath.Join(dir, filename)
+		_, err := os.Lstat(path)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return path, nil
+		case err != nil:
+			return "", fmt.Errorf("check date repair ledger path: %w", err)
+		}
+	}
+}
+
+func writeDateRepairLedger(path string, ledger *dateRepairLedger) error {
+	if ledger == nil {
+		return errors.New("nil date repair ledger")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create repairs directory: %w", err)
+	}
+	file, err := os.CreateTemp(dir, ".dates-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary ledger: %w", err)
+	}
+	tempPath := file.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("set ledger permissions: %w", err)
+	}
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(ledger); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("encode ledger: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync ledger: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close ledger: %w", err)
+	}
+	if err := replaceOutputFile(tempPath, path); err != nil {
+		return fmt.Errorf("publish ledger: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	repairDatesCmd.Flags().BoolVar(
+		&repairDatesApply,
+		"apply",
+		false,
+		"write repaired dates to the archive",
+	)
+	rootCmd.AddCommand(repairDatesCmd)
+}

--- a/cmd/msgvault/cmd/repair_dates_test.go
+++ b/cmd/msgvault/cmd/repair_dates_test.go
@@ -1,0 +1,453 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestRepairDatesAlwaysProxiesThroughDaemonCLIRunner(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server, requests := newDaemonCLIRunnerTestServer(t,
+		func(req daemonCLIRunTestRequest) {
+			assert.Equal([]string{"repair-dates", "--apply"}, req.Args)
+		},
+		`{"type":"stdout","data":"Repaired 1 message(s).\n"}`,
+		`{"type":"complete"}`,
+	)
+	configureRemoteDaemonForTest(t, server.URL)
+	t.Setenv(daemonCLISubprocessEnv, "")
+
+	var apply bool
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{
+		Use: repairDatesCmd.Use, Args: repairDatesCmd.Args, RunE: repairDatesCmd.RunE,
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "write repaired dates")
+	cmd.SetArgs([]string{"--apply"})
+	cmd.SetOut(&stdout)
+
+	require.NoError(cmd.Execute())
+	assert.Equal(1, int(requests.Load()))
+	assert.Contains(stdout.String(), "Repaired 1 message(s)")
+}
+
+func TestRunRepairDatesLocalDryRunApplyAndIdempotency(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dataDir := t.TempDir()
+	savedCfg := cfg
+	cfg = &config.Config{
+		HomeDir: dataDir,
+		Data:    config.DataConfig{DataDir: dataDir},
+	}
+	t.Cleanup(func() { cfg = savedCfg })
+
+	st, err := store.OpenForTest(cfg.DatabaseDSN())
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("gmail", "archive@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversation(
+		source.ID,
+		"date-repair-thread",
+		"Date repair",
+	)
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID:  conversationID,
+		SourceID:        source.ID,
+		SourceMessageID: "date-repair-message",
+		MessageType:     "email",
+		SentAt: sql.NullTime{
+			Time:  time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+			Valid: true,
+		},
+		InternalDate: sql.NullTime{
+			Time:  time.Date(2015, 5, 5, 12, 0, 0, 0, time.UTC),
+			Valid: true,
+		},
+	})
+	require.NoError(err)
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Date: Thu, 1 Jan 1970 00:00:00 +0000\r\n" +
+		"Received: by edge.example.com; Wed, 3 Jan 2007 16:05:06 +0000\r\n" +
+		"Received: by mx.example.com; Tue, 2 Jan 2007 15:04:05 +0000\r\n" +
+		"Subject: Synthetic date repair\r\n" +
+		"\r\nBody\r\n")
+	require.NoError(st.UpsertMessageRaw(messageID, raw))
+	fallbackDate := time.Date(2012, 4, 3, 10, 0, 0, 0, time.UTC)
+	fallbackMessageID, err := st.UpsertMessage(&store.Message{
+		ConversationID:  conversationID,
+		SourceID:        source.ID,
+		SourceMessageID: "date-repair-fallback-message",
+		MessageType:     "email",
+		SentAt: sql.NullTime{
+			Time:  time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+			Valid: true,
+		},
+		InternalDate: sql.NullTime{Time: fallbackDate, Valid: true},
+	})
+	require.NoError(err)
+	require.NoError(st.Close())
+
+	now := time.Date(2026, 7, 23, 12, 0, 0, 123, time.UTC)
+	var dryRunOut bytes.Buffer
+	dryRunCmd := &cobra.Command{}
+	dryRunCmd.SetContext(context.Background())
+	dryRunCmd.SetOut(&dryRunOut)
+	require.NoError(runRepairDatesLocal(dryRunCmd, false, now))
+	assert.Contains(dryRunOut.String(), "Repairable: 2")
+	assert.Contains(
+		dryRunOut.String(),
+		"Candidates lacking usable raw MIME: 1 "+
+			"(source metadata may still resolve them)",
+	)
+	assert.Contains(dryRunOut.String(), "Dry run: no rows were modified")
+	assert.Equal(
+		time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+		readMessageSentAt(t, cfg.DatabaseDSN(), messageID),
+	)
+	assert.Equal(
+		time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+		readMessageSentAt(t, cfg.DatabaseDSN(), fallbackMessageID),
+	)
+	_, err = os.Stat(filepath.Join(dataDir, "repairs"))
+	require.ErrorIs(err, os.ErrNotExist)
+
+	var applyOut bytes.Buffer
+	applyCmd := &cobra.Command{}
+	applyCmd.SetContext(context.Background())
+	applyCmd.SetOut(&applyOut)
+	require.NoError(runRepairDatesLocal(applyCmd, true, now))
+	assert.Contains(applyOut.String(), "Repaired 2 message(s)")
+	assert.Contains(applyOut.String(), "Analytics cache rebuilt")
+	assert.Equal(
+		time.Date(2007, 1, 2, 15, 4, 5, 0, time.UTC),
+		readMessageSentAt(t, cfg.DatabaseDSN(), messageID),
+	)
+	assert.Equal(
+		fallbackDate,
+		readMessageSentAt(t, cfg.DatabaseDSN(), fallbackMessageID),
+	)
+
+	ledgerPaths, err := filepath.Glob(filepath.Join(dataDir, "repairs", "dates-*.json"))
+	require.NoError(err)
+	require.Len(ledgerPaths, 1)
+	ledgerBytes, err := os.ReadFile(ledgerPaths[0])
+	require.NoError(err)
+	var ledger dateRepairLedger
+	require.NoError(json.Unmarshal(ledgerBytes, &ledger))
+	assert.Equal("complete", ledger.Status)
+	assert.True(ledger.CacheRebuilt)
+	require.Len(ledger.Repairs, 2)
+	assert.Equal(messageID, ledger.Repairs[0].MessageID)
+	assert.Equal("received-oldest-plausible", string(ledger.Repairs[0].Source))
+	assert.Equal(fallbackMessageID, ledger.Repairs[1].MessageID)
+	assert.Equal("source-fallback", string(ledger.Repairs[1].Source))
+
+	var secondApplyOut bytes.Buffer
+	secondApplyCmd := &cobra.Command{}
+	secondApplyCmd.SetContext(context.Background())
+	secondApplyCmd.SetOut(&secondApplyOut)
+	require.NoError(runRepairDatesLocal(secondApplyCmd, true, now))
+	assert.Contains(secondApplyOut.String(), "Nothing to repair")
+	ledgerPaths, err = filepath.Glob(filepath.Join(dataDir, "repairs", "dates-*.json"))
+	require.NoError(err)
+	assert.Len(ledgerPaths, 1)
+}
+
+func TestRunRepairDatesLocalReportsUnresolvedReasons(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dataDir := t.TempDir()
+	savedCfg := cfg
+	cfg = &config.Config{
+		HomeDir: dataDir,
+		Data:    config.DataConfig{DataDir: dataDir},
+	}
+	t.Cleanup(func() { cfg = savedCfg })
+
+	st, err := store.OpenForTest(cfg.DatabaseDSN())
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("apple-mail", "archive@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversation(
+		source.ID,
+		"unresolved-date-thread",
+		"Unresolved dates",
+	)
+	require.NoError(err)
+
+	newCandidate := func(sourceMessageID string, raw []byte) int64 {
+		id, err := st.UpsertMessage(&store.Message{
+			ConversationID:  conversationID,
+			SourceID:        source.ID,
+			SourceMessageID: sourceMessageID,
+			MessageType:     "email",
+			SentAt: sql.NullTime{
+				Time:  time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+				Valid: true,
+			},
+		})
+		require.NoError(err)
+		require.NoError(st.UpsertMessageRaw(id, raw))
+		return id
+	}
+
+	// Date header present but unparseable.
+	headerUnusableID := newCandidate("header-unusable", []byte(
+		"From: sender@example.com\r\n"+
+			"To: recipient@example.com\r\n"+
+			"Date: not a real date\r\n"+
+			"Subject: A\r\n\r\nBody\r\n"))
+
+	// Received headers present, but every hop is outside the plausible range.
+	receivedUnusableID := newCandidate("received-unusable", []byte(
+		"From: sender@example.com\r\n"+
+			"To: recipient@example.com\r\n"+
+			"Received: by mx.example.com; Mon, 02 Jan 1980 15:04:05 +0000\r\n"+
+			"Subject: B\r\n\r\nBody\r\n"))
+
+	// No Date header and no Received headers at all.
+	noSignalID := newCandidate("no-signal", []byte(
+		"From: sender@example.com\r\n"+
+			"To: recipient@example.com\r\n"+
+			"Subject: C\r\n\r\nBody\r\n"))
+
+	require.NoError(st.Close())
+
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	var dryRunOut bytes.Buffer
+	dryRunCmd := &cobra.Command{}
+	dryRunCmd.SetContext(context.Background())
+	dryRunCmd.SetOut(&dryRunOut)
+	require.NoError(runRepairDatesLocal(dryRunCmd, false, now))
+
+	out := dryRunOut.String()
+	assert.Contains(out, "Repairable: 0")
+	assert.Contains(out, "No plausible replacement: 3")
+	assert.Contains(out, "date-header-unusable: 1 (Date header present but not a plausible date)")
+	assert.Contains(out, fmt.Sprintf("message %d", headerUnusableID))
+	assert.Contains(out, "received-headers-unusable: 1 (Received headers present but none plausible)")
+	assert.Contains(out, fmt.Sprintf("message %d", receivedUnusableID))
+	assert.Contains(out, "no-date-signal: 1 (no Date header, no Received headers)")
+	assert.Contains(out, fmt.Sprintf("message %d", noSignalID))
+}
+
+func TestAvailableDateRepairLedgerPathDoesNotOverwriteExistingLedger(t *testing.T) {
+	require := require.New(t)
+	dataDir := t.TempDir()
+	now := time.Date(2026, 7, 23, 12, 0, 0, 123, time.UTC)
+	first, err := availableDateRepairLedgerPath(dataDir, now)
+	require.NoError(err)
+	require.NoError(os.MkdirAll(filepath.Dir(first), 0o700))
+	require.NoError(os.WriteFile(first, []byte("{}\n"), 0o600))
+
+	second, err := availableDateRepairLedgerPath(dataDir, now)
+	require.NoError(err)
+	assert.NotEqual(t, first, second)
+	assert.Equal(t, "dates-20260723T120000.000000123Z-1.json", filepath.Base(second))
+}
+
+func TestApplyPlannedDateRepairsRecordsGuardFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dataDir := t.TempDir()
+	st, err := store.OpenForTest(filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("gmail", "archive@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversation(
+		source.ID,
+		"guarded-date-repair",
+		"Guarded date repair",
+	)
+	require.NoError(err)
+	currentSentAt := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID:  conversationID,
+		SourceID:        source.ID,
+		SourceMessageID: "guarded-date-repair-message",
+		MessageType:     "email",
+		SentAt:          sql.NullTime{Time: currentSentAt, Valid: true},
+	})
+	require.NoError(err)
+
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	lowerBound, upperBound := mime.PlausibleDateBounds(now)
+	plan := &dateRepairPlan{
+		candidateCount: 1,
+		repairs: []plannedDateRepair{{
+			MessageDateRepair: store.MessageDateRepair{
+				ID:     messageID,
+				SentAt: time.Date(2007, 1, 2, 15, 4, 5, 0, time.UTC),
+			},
+			source: mime.DateSourceReceived,
+			oldSentAt: sql.NullTime{
+				Time:  time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+				Valid: true,
+			},
+		}},
+	}
+	ledger := newDateRepairLedger(plan, now)
+	ledgerPath := filepath.Join(dataDir, "repairs", "guard-failure.json")
+	require.NoError(writeDateRepairLedger(ledgerPath, ledger))
+
+	err = applyPlannedDateRepairs(
+		context.Background(),
+		st,
+		plan,
+		lowerBound,
+		upperBound,
+		ledgerPath,
+		ledger,
+	)
+	require.ErrorContains(err, "changed after date repair planning")
+	var persistedSentAt time.Time
+	require.NoError(st.DB().QueryRow(
+		st.Rebind("SELECT sent_at FROM messages WHERE id = ?"),
+		messageID,
+	).Scan(&persistedSentAt))
+	assert.Equal(currentSentAt, persistedSentAt.UTC())
+
+	ledgerBytes, err := os.ReadFile(ledgerPath)
+	require.NoError(err)
+	var persisted dateRepairLedger
+	require.NoError(json.Unmarshal(ledgerBytes, &persisted))
+	assert.Equal("failed", persisted.Status)
+	assert.Contains(persisted.Error, "changed after date repair planning")
+	require.Len(persisted.Repairs, 1)
+	assert.Equal(messageID, persisted.Repairs[0].MessageID)
+}
+
+func TestDateRepairCacheRefreshErrorProvidesRecoveryCommand(t *testing.T) {
+	cause := errors.New("synthetic cache failure")
+
+	err := dateRepairCacheRefreshError(cause)
+
+	require.ErrorIs(t, err, cause)
+	require.ErrorContains(t, err, "msgvault build-cache --full-rebuild")
+}
+
+func TestDateRepairPostApplyLedgerErrorProvidesRecoveryCommand(t *testing.T) {
+	cause := errors.New("synthetic ledger failure")
+
+	err := dateRepairPostApplyRecoveryError(
+		"audit ledger finalization failed",
+		cause,
+	)
+
+	require.ErrorIs(t, err, cause)
+	require.ErrorContains(t, err, "audit ledger finalization failed")
+	require.ErrorContains(t, err, "msgvault build-cache --full-rebuild")
+}
+
+func TestDateRepairUsesAnalyticsCacheOnlyForSQLite(t *testing.T) {
+	assert.True(t, dateRepairUsesAnalyticsCache("/tmp/msgvault.db"))
+	assert.False(t, dateRepairUsesAnalyticsCache("postgres://db.example.com/msgvault"))
+	assert.False(t, dateRepairUsesAnalyticsCache("postgresql://db.example.com/msgvault"))
+}
+
+func TestRunRepairDatesLocalInvalidatesAndUnlocksCacheWhenApplyFails(t *testing.T) {
+	require := require.New(t)
+	dataDir := t.TempDir()
+	savedCfg := cfg
+	cfg = &config.Config{
+		HomeDir: dataDir,
+		Data:    config.DataConfig{DataDir: dataDir},
+	}
+	t.Cleanup(func() { cfg = savedCfg })
+
+	st, err := store.OpenForTest(cfg.DatabaseDSN())
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("gmail", "archive@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversation(
+		source.ID,
+		"failed-date-repair",
+		"Failed date repair",
+	)
+	require.NoError(err)
+	_, err = st.UpsertMessage(&store.Message{
+		ConversationID:  conversationID,
+		SourceID:        source.ID,
+		SourceMessageID: "failed-date-repair-message",
+		MessageType:     "email",
+		SentAt: sql.NullTime{
+			Time:  time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+			Valid: true,
+		},
+		InternalDate: sql.NullTime{
+			Time:  time.Date(2015, 5, 5, 12, 0, 0, 0, time.UTC),
+			Valid: true,
+		},
+	})
+	require.NoError(err)
+	_, err = st.DB().Exec(`
+		CREATE TRIGGER reject_date_repair
+		BEFORE UPDATE OF sent_at ON messages
+		BEGIN
+			SELECT RAISE(ABORT, 'synthetic date repair failure');
+		END
+	`)
+	require.NoError(err)
+	require.NoError(st.Close())
+
+	require.NoError(os.MkdirAll(cfg.AnalyticsDir(), 0o755))
+	statePath := query.CacheStatePath(cfg.AnalyticsDir())
+	require.NoError(os.WriteFile(statePath, []byte("{}\n"), 0o600))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	err = runRepairDatesLocal(
+		cmd,
+		true,
+		time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	)
+	require.ErrorContains(err, "synthetic date repair failure")
+	_, statErr := os.Stat(statePath)
+	require.ErrorIs(statErr, os.ErrNotExist)
+
+	cacheLock, err := cacheBuildFileLock(cfg.AnalyticsDir())
+	require.NoError(err)
+	locked, err := cacheLock.TryLock()
+	require.NoError(err)
+	require.True(locked, "date repair must release the cache lock on failure")
+	require.NoError(cacheLock.Unlock())
+}
+
+func readMessageSentAt(t *testing.T, dsn string, messageID int64) time.Time {
+	t.Helper()
+	st, err := store.OpenForTest(dsn)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, st.Close()) }()
+	var sentAt time.Time
+	require.NoError(t, st.DB().QueryRow(
+		st.Rebind("SELECT sent_at FROM messages WHERE id = ?"),
+		messageID,
+	).Scan(&sentAt))
+	return sentAt.UTC()
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1593,6 +1593,29 @@ msgvault repair-encoding
 
 ---
 
+## repair-dates
+
+Report email messages whose canonical `sent_at` is missing, before 1990, or
+more than 30 days in the future. The command resolves replacements from a
+plausible `Date` header, the oldest plausible `Received` timestamp, or stored
+source metadata, in that order.
+
+The default is a read-only report. Pass `--apply` to update the archive and
+write a JSON audit ledger under the data directory. SQLite archives also
+rebuild the Parquet analytics cache; PostgreSQL archives do not use that cache.
+Original source files and remote servers are never modified.
+
+```bash
+msgvault repair-dates
+msgvault repair-dates --apply
+```
+
+| Flag | Description |
+|---|---|
+| `--apply` | Write repaired dates to the archive |
+
+---
+
 ## update
 
 Update msgvault to the latest version.

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1079,6 +1079,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"list-deletions",
 		"logs",
 		"pack-attachments",
+		"repair-dates",
 		"repack-attachments",
 		"remove-account",
 		"show-deletion",

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1341,6 +1341,7 @@ func TestHandleCLIRunBackupSubcommandAdmission(t *testing.T) {
 		{"logs still allowed", []string{"logs"}, true},
 		{"remove-account still allowed", []string{"remove-account", "alice@example.com", "--yes"}, true},
 		{"pack-attachments allowed", []string{"pack-attachments"}, true},
+		{"repair-dates apply allowed", []string{"repair-dates", "--apply"}, true},
 		{"repack-attachments allowed", []string{"repack-attachments"}, true},
 		{"add-discord allowed", []string{"add-discord"}, true},
 		{"sync-discord allowed", []string{"sync-discord", "113456789012345678"}, true},

--- a/internal/importer/ingest.go
+++ b/internal/importer/ingest.go
@@ -25,7 +25,7 @@ import (
 //   - sourceMsgID: stable dedup key for source_message_id column
 //   - rawHash: sha256 hex of raw bytes, used as thread fallback
 //   - raw: the raw RFC 5322 MIME bytes
-//   - fallbackDate: used when MIME Date header is missing/unparseable
+//   - fallbackDate: source timestamp used when MIME headers have no plausible date
 //   - log: logger (must not be nil)
 func IngestRawMessage(
 	ctx context.Context, st *store.Store,
@@ -40,9 +40,6 @@ func IngestRawMessage(
 		parsed = &mime.Message{
 			Subject:  "(MIME parse error)",
 			BodyText: fmt.Sprintf("[MIME parsing failed: %s]\n\nRaw MIME data is preserved in message_raw table.", errMsg),
-		}
-		if !fallbackDate.IsZero() {
-			parsed.Date = fallbackDate
 		}
 	}
 
@@ -103,11 +100,28 @@ func IngestRawMessage(
 		return fmt.Errorf("ensure conversation: %w", err)
 	}
 
+	now := time.Now().UTC()
+	resolvedDate, dateSource := mime.ResolveMessageDate(
+		parsed.Date,
+		parsed.ReceivedDates,
+		fallbackDate,
+		now,
+	)
+	if !parsed.Date.IsZero() && !mime.IsPlausibleDate(parsed.Date, now) {
+		log.Warn(
+			"ignored implausible email Date header",
+			"source_message_id", sourceMsgID,
+			"header_date", parsed.Date.UTC(),
+			"replacement_source", dateSource,
+		)
+	}
 	var sentAt sql.NullTime
-	if !parsed.Date.IsZero() {
-		sentAt = sql.NullTime{Time: parsed.Date.UTC(), Valid: true}
-	} else if !fallbackDate.IsZero() {
-		sentAt = sql.NullTime{Time: fallbackDate.UTC(), Valid: true}
+	if !resolvedDate.IsZero() {
+		sentAt = sql.NullTime{Time: resolvedDate, Valid: true}
+	}
+	var internalDate sql.NullTime
+	if !fallbackDate.IsZero() {
+		internalDate = sql.NullTime{Time: fallbackDate.UTC(), Valid: true}
 	}
 
 	snippet := snippetFromBody(bodyText)
@@ -120,6 +134,7 @@ func IngestRawMessage(
 		SourceMessageID: sourceMsgID,
 		MessageType:     "email",
 		SentAt:          sentAt,
+		InternalDate:    internalDate,
 		SenderID:        senderID,
 		IsFromMe:        isFromMe,
 		Subject: sql.NullString{

--- a/internal/importer/ingest_test.go
+++ b/internal/importer/ingest_test.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"log/slog"
@@ -195,4 +196,82 @@ func TestIngestRawMessage_InvalidUTF8_RecipientLinkage(t *testing.T) {
 			"invalid UTF-8 in display_name: %q", name)
 	}
 	require.NoError(rows.Err(), "display_name rows")
+}
+
+func TestIngestRawMessage_ResolvesImplausibleDateFromReceivedChain(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(err, "open store")
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchema(), "init schema")
+
+	src, err := st.GetOrCreateSource("test", "owner@example.com")
+	require.NoError(err, "get/create source")
+
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: owner@example.com\r\n" +
+		"Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n" +
+		"Received: from relay.example.net by mx.example.net; Wed, 03 Jan 2007 15:04:05 +0000\r\n" +
+		"Received: from sender.example.net by relay.example.net; Tue, 02 Jan 2007 15:04:05 +0000\r\n" +
+		"Subject: date resolution\r\n\r\nbody\r\n")
+	fallback := time.Date(2015, 5, 5, 12, 0, 0, 0, time.UTC)
+
+	err = IngestRawMessage(
+		context.Background(), st,
+		src.ID, "owner@example.com", "",
+		nil, "source-msg-date", "fakehash",
+		raw, fallback, slog.Default(),
+	)
+	require.NoError(err, "IngestRawMessage")
+
+	var sentAt, internalDate time.Time
+	err = st.DB().QueryRow(
+		`SELECT sent_at, internal_date FROM messages
+		 WHERE source_message_id = ?`,
+		"source-msg-date",
+	).Scan(&sentAt, &internalDate)
+	require.NoError(err, "query dates")
+	assert.Equal(time.Date(2007, 1, 2, 15, 4, 5, 0, time.UTC), sentAt.UTC())
+	assert.Equal(fallback, internalDate.UTC())
+}
+
+func TestIngestRawMessage_LeavesCanonicalDateUnsetWhenNoDateIsPlausible(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(err, "open store")
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchema(), "init schema")
+
+	src, err := st.GetOrCreateSource("test", "owner@example.com")
+	require.NoError(err, "get/create source")
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: owner@example.com\r\n" +
+		"Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n" +
+		"Subject: no plausible date\r\n\r\nbody\r\n")
+	fallback := time.Date(1980, 5, 5, 12, 0, 0, 0, time.UTC)
+	var logs bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logs, nil))
+
+	err = IngestRawMessage(
+		context.Background(), st,
+		src.ID, "owner@example.com", "",
+		nil, "source-msg-no-date", "fakehash",
+		raw, fallback, log,
+	)
+	require.NoError(err, "IngestRawMessage")
+
+	var sentAt, internalDate sql.NullTime
+	err = st.DB().QueryRow(
+		`SELECT sent_at, internal_date FROM messages
+		 WHERE source_message_id = ?`,
+		"source-msg-no-date",
+	).Scan(&sentAt, &internalDate)
+	require.NoError(err, "query dates")
+	assert.False(sentAt.Valid)
+	require.True(internalDate.Valid)
+	assert.Equal(fallback, internalDate.Time.UTC())
+	assert.Contains(logs.String(), "ignored implausible email Date header")
+	assert.Contains(logs.String(), "replacement_source=none")
 }

--- a/internal/mime/date.go
+++ b/internal/mime/date.go
@@ -1,0 +1,79 @@
+package mime
+
+import (
+	"slices"
+	"strings"
+	"time"
+)
+
+var plausibleDateLowerBound = time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+
+const plausibleDateFutureSlack = 30 * 24 * time.Hour
+
+// DateSource identifies the input selected as a message's canonical sent time.
+type DateSource string
+
+const (
+	DateSourceHeader   DateSource = "date-header"
+	DateSourceReceived DateSource = "received-oldest-plausible"
+	DateSourceFallback DateSource = "source-fallback"
+	DateSourceNone     DateSource = "none"
+)
+
+// IsPlausibleDate reports whether t falls inside the accepted range for an
+// email send time. The small amount of future slack permits clock skew and
+// scheduled messages without accepting timestamps decades in the future.
+func IsPlausibleDate(t, now time.Time) bool {
+	if t.IsZero() {
+		return false
+	}
+	utc := t.UTC()
+	return !utc.Before(plausibleDateLowerBound) &&
+		!utc.After(now.UTC().Add(plausibleDateFutureSlack))
+}
+
+// PlausibleDateBounds returns the inclusive date range used by the resolver.
+func PlausibleDateBounds(now time.Time) (time.Time, time.Time) {
+	return plausibleDateLowerBound, now.UTC().Add(plausibleDateFutureSlack)
+}
+
+// ParseReceivedChain extracts the timestamp following the final semicolon in
+// each Received field. The returned slice preserves source order, which is
+// normally newest hop first because receiving MTAs prepend trace fields.
+func ParseReceivedChain(headers []string) []time.Time {
+	dates := make([]time.Time, 0, len(headers))
+	for _, header := range headers {
+		semicolon := strings.LastIndex(header, ";")
+		if semicolon < 0 {
+			continue
+		}
+		if parsed := parseDate(strings.TrimSpace(header[semicolon+1:])); !parsed.IsZero() {
+			dates = append(dates, parsed)
+		}
+	}
+	return dates
+}
+
+// ResolveMessageDate selects a canonical sent time from the Date header, the
+// Received trace, and provider metadata, in that order. Received fields are
+// walked from the oldest hop toward the newest so the first plausible MTA
+// timestamp wins.
+func ResolveMessageDate(
+	headerDate time.Time,
+	receivedDates []time.Time,
+	fallbackDate time.Time,
+	now time.Time,
+) (time.Time, DateSource) {
+	if IsPlausibleDate(headerDate, now) {
+		return headerDate.UTC(), DateSourceHeader
+	}
+	for _, receivedDate := range slices.Backward(receivedDates) {
+		if IsPlausibleDate(receivedDate, now) {
+			return receivedDate.UTC(), DateSourceReceived
+		}
+	}
+	if IsPlausibleDate(fallbackDate, now) {
+		return fallbackDate.UTC(), DateSourceFallback
+	}
+	return time.Time{}, DateSourceNone
+}

--- a/internal/mime/date_test.go
+++ b/internal/mime/date_test.go
@@ -1,0 +1,106 @@
+package mime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPlausibleDate(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		date time.Time
+		want bool
+	}{
+		{name: "zero", date: time.Time{}, want: false},
+		{name: "before lower bound", date: time.Date(1989, 12, 31, 23, 59, 59, 0, time.UTC), want: false},
+		{name: "lower bound", date: time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC), want: true},
+		{name: "current", date: now, want: true},
+		{name: "future slack boundary", date: now.Add(30 * 24 * time.Hour), want: true},
+		{name: "beyond future slack", date: now.Add(30*24*time.Hour + time.Second), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPlausibleDate(tt.date, now))
+		})
+	}
+}
+
+func TestParseReceivedChainPreservesSourceOrder(t *testing.T) {
+	headers := []string{
+		"from relay.example.net by mx.example.net; Wed, 03 Jan 2007 15:04:05 +0000",
+		"from sender.example.net by relay.example.net; Tue, 02 Jan 2007 15:04:05 +0000",
+		"missing semicolon",
+		"from broken.example.net; not-a-date",
+	}
+
+	got := ParseReceivedChain(headers)
+
+	assert.Equal(t, []time.Time{
+		time.Date(2007, 1, 3, 15, 4, 5, 0, time.UTC),
+		time.Date(2007, 1, 2, 15, 4, 5, 0, time.UTC),
+	}, got)
+}
+
+func TestResolveMessageDatePrecedence(t *testing.T) {
+	assert := assert.New(t)
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	header := time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)
+	oldestReceived := time.Date(2018, 1, 1, 1, 0, 0, 0, time.UTC)
+	newestReceived := time.Date(2018, 1, 2, 1, 0, 0, 0, time.UTC)
+	fallback := time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	got, source := ResolveMessageDate(
+		header,
+		[]time.Time{newestReceived, oldestReceived},
+		fallback,
+		now,
+	)
+	assert.Equal(header, got)
+	assert.Equal(DateSourceHeader, source)
+
+	got, source = ResolveMessageDate(
+		time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+		[]time.Time{newestReceived, oldestReceived},
+		fallback,
+		now,
+	)
+	assert.Equal(oldestReceived, got)
+	assert.Equal(DateSourceReceived, source)
+
+	got, source = ResolveMessageDate(
+		time.Date(2039, 1, 1, 0, 0, 0, 0, time.UTC),
+		nil,
+		fallback,
+		now,
+	)
+	assert.Equal(fallback, got)
+	assert.Equal(DateSourceFallback, source)
+
+	got, source = ResolveMessageDate(time.Time{}, nil, time.Time{}, now)
+	assert.True(got.IsZero())
+	assert.Equal(DateSourceNone, source)
+}
+
+func TestParseCollectsReceivedDates(t *testing.T) {
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n" +
+		"Received: from relay.example.net by mx.example.net; Wed, 03 Jan 2007 15:04:05 +0000\r\n" +
+		"Received: from sender.example.net by relay.example.net; Tue, 02 Jan 2007 15:04:05 +0000\r\n" +
+		"Subject: test\r\n\r\nbody\r\n")
+
+	msg, err := Parse(raw)
+
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), msg.Date)
+	assert.Equal(t, []time.Time{
+		time.Date(2007, 1, 3, 15, 4, 5, 0, time.UTC),
+		time.Date(2007, 1, 2, 15, 4, 5, 0, time.UTC),
+	}, msg.ReceivedDates)
+}

--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -16,20 +16,25 @@ import (
 
 // Message represents a parsed email message.
 type Message struct {
-	Subject     string
-	Date        time.Time
-	From        []Address
-	To          []Address
-	Cc          []Address
-	Bcc         []Address
-	ReplyTo     []Address
-	MessageID   string
-	InReplyTo   string
-	References  []string
-	BodyText    string
-	BodyHTML    string
-	Attachments []Attachment
-	Errors      []string // Non-fatal parsing errors
+	Subject string
+	Date    time.Time
+	// RawDateHeader holds the unparsed Date header even when Date could not
+	// be resolved, so callers can distinguish a missing header from one that
+	// failed to parse.
+	RawDateHeader string
+	ReceivedDates []time.Time
+	From          []Address
+	To            []Address
+	Cc            []Address
+	Bcc           []Address
+	ReplyTo       []Address
+	MessageID     string
+	InReplyTo     string
+	References    []string
+	BodyText      string
+	BodyHTML      string
+	Attachments   []Attachment
+	Errors        []string // Non-fatal parsing errors
 }
 
 // Address represents an email address with optional display name.
@@ -67,10 +72,12 @@ func Parse(raw []byte) (*Message, error) {
 
 	// Parse date
 	if dateStr := env.GetHeader("Date"); dateStr != "" {
+		msg.RawDateHeader = dateStr
 		if t := parseDate(dateStr); !t.IsZero() {
 			msg.Date = t
 		}
 	}
+	msg.ReceivedDates = ParseReceivedChain(env.GetHeaderValues("Received"))
 
 	// Parse addresses using enmime's AddressList (handles edge cases better)
 	msg.From = parseAddressList(env, "From")

--- a/internal/mime/parse_test.go
+++ b/internal/mime/parse_test.go
@@ -370,6 +370,7 @@ func TestParse_MalformedContinuationLineAfterDate(t *testing.T) {
 
 	assert.True(t, msg.Date.Equal(time.Date(2004, 5, 27, 22, 6, 42, 0, time.UTC)),
 		"msg.Date = %v", msg.Date)
+	assert.Equal(t, "Thu, 27 May 2004 17:06:42 -0500 .", msg.RawDateHeader)
 }
 
 // TestParse_InvalidCharset verifies enmime handles malformed charsets gracefully.

--- a/internal/store/date_repair.go
+++ b/internal/store/date_repair.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// MessageDateRepairCandidate is an email row whose canonical sent time is
+// missing or outside the configured plausibility range.
+type MessageDateRepairCandidate struct {
+	ID             int64
+	SentAt         sql.NullTime
+	InternalDate   sql.NullTime
+	LastModifiedAt string
+}
+
+// MessageDateRepair updates one message's canonical sent time.
+type MessageDateRepair struct {
+	ID                     int64
+	SentAt                 time.Time
+	ExpectedLastModifiedAt string
+}
+
+// ListMessageDateRepairCandidates returns email rows whose canonical sent time
+// is missing or outside the inclusive bounds.
+func (s *Store) ListMessageDateRepairCandidates(
+	ctx context.Context,
+	lowerBound, upperBound time.Time,
+) ([]MessageDateRepairCandidate, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT m.id, m.sent_at, m.internal_date, CAST(m.last_modified AS TEXT)
+		FROM messages m
+		WHERE m.message_type = 'email'
+		  AND (
+			m.sent_at IS NULL
+			OR m.sent_at < ?
+			OR m.sent_at > ?
+		  )
+		ORDER BY m.id
+	`, lowerBound.UTC(), upperBound.UTC())
+	if err != nil {
+		return nil, fmt.Errorf("query date repair candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var candidates []MessageDateRepairCandidate
+	for rows.Next() {
+		var candidate MessageDateRepairCandidate
+		if err := rows.Scan(
+			&candidate.ID,
+			&candidate.SentAt,
+			&candidate.InternalDate,
+			&candidate.LastModifiedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan date repair candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate date repair candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+// ApplyMessageDateRepairs atomically updates candidates that are still missing
+// or implausible. A row changed after planning aborts the batch instead of
+// overwriting newer data.
+func (s *Store) ApplyMessageDateRepairs(
+	ctx context.Context,
+	repairs []MessageDateRepair,
+	lowerBound, upperBound time.Time,
+) error {
+	return s.withTx(func(tx *loggedTx) error {
+		for _, repair := range repairs {
+			result, err := tx.ExecContext(ctx, `
+				UPDATE messages
+				SET sent_at = ?
+				WHERE id = ?
+				  AND (
+					sent_at IS NULL
+					OR sent_at < ?
+					OR sent_at > ?
+				  )
+				  AND CAST(last_modified AS TEXT) = ?
+			`,
+				repair.SentAt.UTC(),
+				repair.ID,
+				lowerBound.UTC(),
+				upperBound.UTC(),
+				repair.ExpectedLastModifiedAt,
+			)
+			if err != nil {
+				return fmt.Errorf("update message %d sent_at: %w", repair.ID, err)
+			}
+			affected, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("count message %d date repair: %w", repair.ID, err)
+			}
+			if affected != 1 {
+				return fmt.Errorf(
+					"message %d changed after date repair planning",
+					repair.ID,
+				)
+			}
+		}
+		return nil
+	})
+}

--- a/internal/store/date_repair.go
+++ b/internal/store/date_repair.go
@@ -23,23 +23,32 @@ type MessageDateRepair struct {
 	ExpectedLastModifiedAt string
 }
 
+func (s *Store) messageDateOutsideBoundsPredicate(column string) string {
+	boundExpr := "?"
+	if !s.IsPostgreSQL() {
+		column = "julianday(" + column + ")"
+		boundExpr = "julianday(?)"
+	}
+	return column + " < " + boundExpr + " OR " + column + " > " + boundExpr
+}
+
 // ListMessageDateRepairCandidates returns email rows whose canonical sent time
 // is missing or outside the inclusive bounds.
 func (s *Store) ListMessageDateRepairCandidates(
 	ctx context.Context,
 	lowerBound, upperBound time.Time,
 ) ([]MessageDateRepairCandidate, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	query := fmt.Sprintf(`
 		SELECT m.id, m.sent_at, m.internal_date, CAST(m.last_modified AS TEXT)
 		FROM messages m
 		WHERE m.message_type = 'email'
 		  AND (
 			m.sent_at IS NULL
-			OR m.sent_at < ?
-			OR m.sent_at > ?
+			OR %s
 		  )
 		ORDER BY m.id
-	`, lowerBound.UTC(), upperBound.UTC())
+	`, s.messageDateOutsideBoundsPredicate("m.sent_at"))
+	rows, err := s.db.QueryContext(ctx, query, lowerBound.UTC(), upperBound.UTC())
 	if err != nil {
 		return nil, fmt.Errorf("query date repair candidates: %w", err)
 	}
@@ -72,19 +81,22 @@ func (s *Store) ApplyMessageDateRepairs(
 	repairs []MessageDateRepair,
 	lowerBound, upperBound time.Time,
 ) error {
+	updateSQL := fmt.Sprintf(`
+		UPDATE messages
+		SET sent_at = ?
+		WHERE id = ?
+		  AND (
+			sent_at IS NULL
+			OR %s
+		  )
+		  AND CAST(last_modified AS TEXT) = ?
+	`, s.messageDateOutsideBoundsPredicate("sent_at"))
+
 	return s.withTx(func(tx *loggedTx) error {
 		for _, repair := range repairs {
-			result, err := tx.ExecContext(ctx, `
-				UPDATE messages
-				SET sent_at = ?
-				WHERE id = ?
-				  AND (
-					sent_at IS NULL
-					OR sent_at < ?
-					OR sent_at > ?
-				  )
-				  AND CAST(last_modified AS TEXT) = ?
-			`,
+			result, err := tx.ExecContext(
+				ctx,
+				updateSQL,
 				repair.SentAt.UTC(),
 				repair.ID,
 				lowerBound.UTC(),

--- a/internal/store/date_repair_test.go
+++ b/internal/store/date_repair_test.go
@@ -1,0 +1,140 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestMessageDateRepairsListAndApplyCandidates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	lower := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	upper := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+
+	oldID := f.NewMessage().
+		WithSourceMessageID("old").
+		WithSentAt(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)).
+		Create(t, f.Store)
+	goodID := f.NewMessage().
+		WithSourceMessageID("good").
+		WithSentAt(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)).
+		Create(t, f.Store)
+	missingID := f.CreateMessage("missing")
+
+	require.NoError(f.Store.UpsertMessageRaw(oldID, sampleRawMessage), "raw old")
+	require.NoError(f.Store.UpsertMessageRaw(goodID, sampleRawMessage), "raw good")
+	require.NoError(f.Store.UpsertMessageRaw(missingID, sampleRawMessage), "raw missing")
+
+	candidates, err := f.Store.ListMessageDateRepairCandidates(t.Context(), lower, upper)
+	require.NoError(err, "ListMessageDateRepairCandidates")
+	require.Len(candidates, 2)
+	assert.Equal([]int64{oldID, missingID}, []int64{candidates[0].ID, candidates[1].ID})
+	assert.NotEmpty(candidates[0].LastModifiedAt)
+	assert.NotEmpty(candidates[1].LastModifiedAt)
+
+	repairedOld := time.Date(2007, 1, 2, 15, 4, 5, 0, time.UTC)
+	repairedMissing := time.Date(2015, 5, 5, 12, 0, 0, 0, time.UTC)
+	err = f.Store.ApplyMessageDateRepairs(t.Context(), []store.MessageDateRepair{
+		{
+			ID:                     oldID,
+			SentAt:                 repairedOld,
+			ExpectedLastModifiedAt: candidates[0].LastModifiedAt,
+		},
+		{
+			ID:                     missingID,
+			SentAt:                 repairedMissing,
+			ExpectedLastModifiedAt: candidates[1].LastModifiedAt,
+		},
+	}, lower, upper)
+	require.NoError(err, "ApplyMessageDateRepairs")
+
+	for id, want := range map[int64]time.Time{
+		oldID:     repairedOld,
+		missingID: repairedMissing,
+	} {
+		var got time.Time
+		require.NoError(
+			f.Store.DB().QueryRow(
+				f.Store.Rebind("SELECT sent_at FROM messages WHERE id = ?"),
+				id,
+			).Scan(&got),
+			"query repaired sent_at",
+		)
+		assert.Equal(want, got.UTC())
+	}
+}
+
+func TestApplyMessageDateRepairsRejectsChangedRowsAtomically(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	lower := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	upper := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+
+	firstID := f.NewMessage().
+		WithSentAt(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)).
+		Create(t, f.Store)
+	changedID := f.NewMessage().
+		WithSentAt(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC)).
+		Create(t, f.Store)
+
+	candidates, err := f.Store.ListMessageDateRepairCandidates(t.Context(), lower, upper)
+	require.NoError(err)
+	require.Len(candidates, 2)
+
+	concurrentSentAt := time.Date(1972, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err = f.Store.DB().Exec(
+		f.Store.Rebind(`
+			UPDATE messages
+			SET sent_at = ?, last_modified = ?
+			WHERE id = ?
+		`),
+		concurrentSentAt,
+		"2001-02-03 04:05:06",
+		changedID,
+	)
+	require.NoError(err)
+
+	err = f.Store.ApplyMessageDateRepairs(context.Background(), []store.MessageDateRepair{
+		{
+			ID:                     firstID,
+			SentAt:                 time.Date(2007, 1, 2, 0, 0, 0, 0, time.UTC),
+			ExpectedLastModifiedAt: candidates[0].LastModifiedAt,
+		},
+		{
+			ID:                     changedID,
+			SentAt:                 time.Date(2008, 1, 2, 0, 0, 0, 0, time.UTC),
+			ExpectedLastModifiedAt: candidates[1].LastModifiedAt,
+		},
+	}, lower, upper)
+	require.ErrorContains(err, "changed after date repair planning")
+
+	var sentAt sql.NullTime
+	require.NoError(
+		f.Store.DB().QueryRow(
+			f.Store.Rebind("SELECT sent_at FROM messages WHERE id = ?"),
+			firstID,
+		).Scan(&sentAt),
+		"query rolled back sent_at",
+	)
+	require.True(sentAt.Valid)
+	assert.Equal(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), sentAt.Time.UTC())
+
+	require.NoError(
+		f.Store.DB().QueryRow(
+			f.Store.Rebind("SELECT sent_at FROM messages WHERE id = ?"),
+			changedID,
+		).Scan(&sentAt),
+		"query concurrently changed sent_at",
+	)
+	require.True(sentAt.Valid)
+	assert.Equal(concurrentSentAt, sentAt.Time.UTC())
+}

--- a/internal/store/date_repair_test.go
+++ b/internal/store/date_repair_test.go
@@ -72,6 +72,107 @@ func TestMessageDateRepairsListAndApplyCandidates(t *testing.T) {
 	}
 }
 
+func TestMessageDateRepairsCompareOffsetTimestampsByInstant(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	lower := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	upper := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		sourceID string
+		sentAt   string
+	}{
+		{
+			sourceID: "valid-after-lower",
+			sentAt:   "1989-12-31T19:30:00-05:00",
+		},
+		{
+			sourceID: "invalid-before-lower",
+			sentAt:   "1990-01-01 00:30:00+01:00",
+		},
+		{
+			sourceID: "valid-before-upper",
+			sentAt:   "2026-08-22 13:30:00+02:00",
+		},
+		{
+			sourceID: "invalid-after-upper",
+			sentAt:   "2026-08-22 07:30:00-05:00",
+		},
+	}
+
+	ids := make([]int64, 0, len(tests))
+	for _, tc := range tests {
+		id := f.NewMessage().
+			WithSourceMessageID(tc.sourceID).
+			WithSentAt(lower).
+			Create(t, f.Store)
+		_, err := f.Store.DB().Exec(
+			f.Store.Rebind("UPDATE messages SET sent_at = ? WHERE id = ?"),
+			tc.sentAt,
+			id,
+		)
+		require.NoError(err, "store offset timestamp %s", tc.sourceID)
+		ids = append(ids, id)
+	}
+
+	candidates, err := f.Store.ListMessageDateRepairCandidates(t.Context(), lower, upper)
+	require.NoError(err)
+	require.Len(candidates, 2)
+	assert.Equal(
+		[]int64{ids[1], ids[3]},
+		[]int64{candidates[0].ID, candidates[1].ID},
+	)
+
+	err = f.Store.ApplyMessageDateRepairs(t.Context(), []store.MessageDateRepair{
+		{
+			ID:                     candidates[0].ID,
+			SentAt:                 lower.Add(time.Hour),
+			ExpectedLastModifiedAt: candidates[0].LastModifiedAt,
+		},
+		{
+			ID:                     candidates[1].ID,
+			SentAt:                 upper.Add(-time.Hour),
+			ExpectedLastModifiedAt: candidates[1].LastModifiedAt,
+		},
+	}, lower, upper)
+	require.NoError(err)
+
+	var validSentAt time.Time
+	var validLastModified string
+	require.NoError(
+		f.Store.DB().QueryRow(
+			f.Store.Rebind(`
+				SELECT sent_at, CAST(last_modified AS TEXT)
+				FROM messages
+				WHERE id = ?
+			`),
+			ids[0],
+		).Scan(&validSentAt, &validLastModified),
+	)
+
+	err = f.Store.ApplyMessageDateRepairs(t.Context(), []store.MessageDateRepair{{
+		ID:                     ids[0],
+		SentAt:                 lower.Add(2 * time.Hour),
+		ExpectedLastModifiedAt: validLastModified,
+	}}, lower, upper)
+	require.ErrorContains(err, "changed after date repair planning")
+
+	var unchangedSentAt time.Time
+	require.NoError(
+		f.Store.DB().QueryRow(
+			f.Store.Rebind("SELECT sent_at FROM messages WHERE id = ?"),
+			ids[0],
+		).Scan(&unchangedSentAt),
+	)
+	assert.True(
+		validSentAt.Equal(unchangedSentAt),
+		"valid timestamp changed from %v to %v",
+		validSentAt,
+		unchangedSentAt,
+	)
+}
+
 func TestApplyMessageDateRepairsRejectsChangedRowsAtomically(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -508,10 +508,6 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 			Subject:  extractSubjectFromSnippet(raw.Snippet),
 			BodyText: fmt.Sprintf("[MIME parsing failed: %s]\n\nRaw MIME data is preserved in message_raw table.", errMsg),
 		}
-		// Set date from InternalDate if available
-		if raw.InternalDate > 0 {
-			parsed.Date = time.UnixMilli(raw.InternalDate).UTC()
-		}
 		s.logger.Warn("MIME parse failed, storing with placeholder",
 			"id", raw.ID,
 			"error", errMsg)
@@ -595,16 +591,29 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 		AttachmentCount: len(parsed.Attachments),
 	}
 
-	// Set dates - always store in UTC for consistent querying
+	// Set dates - always store in UTC for consistent querying.
+	now := time.Now().UTC()
+	var fallbackDate time.Time
 	if raw.InternalDate > 0 {
-		t := time.UnixMilli(raw.InternalDate).UTC()
-		msg.InternalDate = sql.NullTime{Time: t, Valid: true}
+		fallbackDate = time.UnixMilli(raw.InternalDate).UTC()
+		msg.InternalDate = sql.NullTime{Time: fallbackDate, Valid: true}
 	}
-	if !parsed.Date.IsZero() {
-		msg.SentAt = sql.NullTime{Time: parsed.Date, Valid: true}
-	} else if msg.InternalDate.Valid {
-		// Fall back to InternalDate if Date header couldn't be parsed
-		msg.SentAt = msg.InternalDate
+	resolvedDate, dateSource := mime.ResolveMessageDate(
+		parsed.Date,
+		parsed.ReceivedDates,
+		fallbackDate,
+		now,
+	)
+	if !parsed.Date.IsZero() && !mime.IsPlausibleDate(parsed.Date, now) {
+		s.logger.Warn(
+			"ignored implausible email Date header",
+			"id", raw.ID,
+			"header_date", parsed.Date.UTC(),
+			"replacement_source", dateSource,
+		)
+	}
+	if !resolvedDate.IsZero() {
+		msg.SentAt = sql.NullTime{Time: resolvedDate, Valid: true}
 	}
 
 	return &messageData{

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1044,6 +1044,38 @@ func TestFullSyncDateFallbackToInternalDate(t *testing.T) {
 	assertDateFallback(t, env.Store, "msg-bad-date", "2024-01-15", "12:00:00")
 }
 
+func TestFullSyncImplausibleDateUsesOldestReceivedTimestamp(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n" +
+		"Received: from relay.example.net by mx.example.net; Wed, 03 Jan 2007 15:04:05 +0000\r\n" +
+		"Received: from sender.example.net by relay.example.net; Tue, 02 Jan 2007 15:04:05 +0000\r\n" +
+		"Subject: date resolution\r\n\r\nbody\r\n")
+
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.Messages["msg-implausible-date"] = &gmail.RawMessage{
+		ID:           "msg-implausible-date",
+		ThreadID:     "thread-implausible-date",
+		LabelIDs:     []string{"INBOX"},
+		Raw:          raw,
+		InternalDate: 1430827200000, // 2015-05-05T12:00:00Z
+	}
+	env.Mock.MessagePages = [][]string{{"msg-implausible-date"}}
+
+	runFullSync(t, env)
+
+	sentAt, internalDate, err := env.Store.InspectMessageDates("msg-implausible-date")
+	require.NoError(err, "InspectMessageDates")
+	assert.Contains(sentAt, "2007-01-02", "sent_at")
+	assert.Contains(internalDate, "2015-05-05", "internal_date")
+	assert.NotEqual(internalDate, sentAt)
+}
+
 func TestFullSyncEmptyRawMIME(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)


### PR DESCRIPTION
## Motivation

I imported an older mail archive and found messages appearing decades away
from where they belonged because syntactically valid but implausible `Date:`
headers were treated as authoritative. Those timestamps affect timeline
ordering, date-range searches, statistics, and analytics partitions, and
reimporting would accept the same bad values again.

## Summary

- add one plausibility resolver for email ingestion, bounded from 1990 through
  30 days in the future, using a valid `Date:` header, then the oldest
  plausible `Received:` timestamp, then plausible source metadata
- add `repair-dates`, with a read-only default and explicit `--apply` mode
- apply repairs atomically with changed-row protection and a privacy-safe JSON
  audit ledger
- rebuild the Parquet analytics cache for SQLite archives while correctly
  skipping that SQLite-only cache on PostgreSQL
- route the command through the daemon and document recovery for partial
  failures
- warn when ingestion rejects a nonzero implausible header so genuinely old
  archives do not change silently
- fix a `mime.Parse` bug where a mangled Date header (mbox continuation
  artifact, or US month-day ordering) silently dropped the sent date instead
  of resolving it, recovering 62 of the messages this PR's own audit found
  unresolvable
- report *why* each remaining `repair-dates` candidate is unresolved
  (date header present but unusable, Received headers present but unusable,
  or no date signal at all) instead of a bare count

## Note

This branch currently includes the `mime.Parse` fix (commit `6bf31dc9`) as
its own commit, duplicated from #506, which splits that fix out for
isolated review since it's a general ingestion bug, not specific to
`repair-dates`. Kept here too so this branch builds and tests standalone;
will rebase to drop the duplicate once #506 merges.

## Test plan

- [x] `go test -tags "fts5 sqlite_vec" ./cmd/... ./internal/... ./pkg/... ./tools/...`
- [x] `go vet ./...`
- [x] `make lint-ci`
- [x] verify dry-run, apply, idempotency, audit-ledger failure states, daemon
  admission, SQLite cache rebuilding, and PostgreSQL cache selection with
  synthetic fixtures

Closes #501