### PR TITLE
Bootstrap reusable CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_call:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  workflow_call:
   push:
     branches: [main]
     tags:


### PR DESCRIPTION
## Summary

- make the existing CI workflow callable from a later main-pinned dispatcher
- retain the current pull-request trigger and GitHub-hosted execution during the bootstrap phase

This preserves full pull-request validation while the runner-routing change is reviewed and landed separately.
