### PR TITLE
Bound database test concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,7 @@ jobs:
           psql -h localhost -U msgvault_test -d msgvault_test -c "CREATE EXTENSION IF NOT EXISTS vector"
 
       - name: Test (pgvector-tagged)
-        run: go test -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
+        run: go test -p=8 -parallel=8 -timeout=20m -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
 
   nix-build:
     runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
@@ -496,7 +496,7 @@ jobs:
       # against a pgvector/pgvector image. (Run go test directly rather than
       # `make test-pg`, whose PG_TEST_TAGS include pgvector.)
       - name: Test (PostgreSQL)
-        run: go test -tags "fts5 sqlite_vec" ./...
+        run: go test -p=8 -parallel=8 -timeout=20m -tags "fts5 sqlite_vec" ./...
 
       - name: Concurrency tests (-count=5)
         run: |


### PR DESCRIPTION
The self-hosted database lanes inherit 32-way Go test parallelism. Under concurrent CI load, PostgreSQL and SQLite contention makes otherwise healthy packages several times slower and pushes them past Go's default ten-minute timeout.

Cap package and in-package parallelism at eight for the PostgreSQL and pgvector suites, while retaining a twenty-minute timeout as headroom. The dedicated concurrency stress step remains uncapped.

The workflow passes actionlint and all repository hooks.