### PR TITLE
move PostgreSQL test lanes back to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,13 @@ jobs:
   # tag is required; without it these files compile out and ship no tests,
   # so this code would otherwise have zero CI coverage.
   test-pgvector:
-    runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    # Pinned to GitHub-hosted runners. These two lanes are the only ones that
+    # drive the full Go suite against a live PostgreSQL service container, and
+    # that container's disk I/O is roughly 5x slower on the managed public
+    # fleet — enough to push cmd/msgvault/cmd past Go's default 10m per-package
+    # test timeout (1m48s here vs. a timeout panic there). Move back once the
+    # runner-group I/O is addressed.
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -446,7 +452,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-          cache: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
+          cache: 'true'
 
       - name: Install psql client
         run: |
@@ -479,7 +485,10 @@ jobs:
   # unique constraints) surface here rather than slipping past a single
   # pass.
   test-postgres:
-    runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    # Pinned to GitHub-hosted runners for the same reason as test-pgvector
+    # above: the PostgreSQL service container is I/O-bound on the managed
+    # public fleet (5m11s here vs. a 10m timeout panic there).
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:16
@@ -502,7 +511,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-          cache: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
+          cache: 'true'
 
       # This lane uses a stock postgres:16 image (no pgvector extension), so it
       # must NOT build the pgvector tag — those tests CREATE EXTENSION "vector"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
           psql -h localhost -U msgvault_test -d msgvault_test -c "CREATE EXTENSION IF NOT EXISTS vector"
 
       - name: Test (pgvector-tagged)
-        run: go test -p=8 -parallel=8 -timeout=20m -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
+        run: go test -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
 
   nix-build:
     runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
@@ -519,7 +519,7 @@ jobs:
       # against a pgvector/pgvector image. (Run go test directly rather than
       # `make test-pg`, whose PG_TEST_TAGS include pgvector.)
       - name: Test (PostgreSQL)
-        run: go test -p=8 -parallel=8 -timeout=20m -tags "fts5 sqlite_vec" ./...
+        run: go test -tags "fts5 sqlite_vec" ./...
 
       - name: Concurrency tests (-count=5)
         run: |


### PR DESCRIPTION
`test-postgres` and `test-pgvector` have failed on every managed-runner main build since #508. Host telemetry confirms the lanes are storage-bound: PostgreSQL checkpoint syncs take minutes while CPU remains mostly idle.

Move both lanes back to GitHub-hosted runners, restore Actions caching, and restore the test commands from their last known-green hosted configuration. This keeps main reliable without hiding the managed fleet's service-container I/O problem behind longer timeouts.

The workflow passes actionlint and all repository hooks. The fleet storage bottleneck remains a separate infrastructure follow-up.