### PR TITLE
ci: separate Docker validation from publishing

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,13 +1,15 @@
 name: Docker
 
-# Build and smoke-test the PR image without registry credentials. Keep this
-# branch-defined workflow on a GitHub-hosted runner.
+# Bootstrap the split between validation and publishing on a GitHub-hosted
+# runner. Follow-up PRs can return this dispatcher to docker.yml@main once
+# that read-only reusable workflow is present on the default branch.
 on:
   pull_request:
     paths:
       - 'Dockerfile'
       - '.dockerignore'
       - '.github/workflows/docker.yml'
+      - '.github/workflows/docker-publish.yml'
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,88 @@
+name: Docker publish
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+
+permissions: read-all
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Build browser application
+        run: make web-assets-check
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # latest tag for main branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # version tags (v1.2.3 -> 1.2.3, v1.2.3 -> 1.2, v1.2.3 -> 1)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            # sha tag for traceability
+            type=sha,prefix=sha-
+
+      - name: Prepare build args
+        id: build_args
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="dev-$(printf '%s' "$GITHUB_SHA" | cut -c1-8)"
+          fi
+          {
+            echo "version=$VERSION"
+            echo "commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8)"
+            echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.build_args.outputs.version }}
+            COMMIT=${{ steps.build_args.outputs.commit }}
+            BUILD_DATE=${{ steps.build_args.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,28 +1,20 @@
 name: Docker
 
 on:
-  push:
-    branches: [main]
-    tags:
-      - 'v*'
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  workflow_call:
+
+permissions: read-all
 
 jobs:
-  # Publish: build multi-arch and push to GHCR (main/tags only)
-  publish:
-    runs-on: ${{ github.repository == 'kenn-io/msgvault' && github.ref == 'refs/heads/main' && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+  # PR validation: build and smoke-test only, no registry access
+  validate:
+    runs-on: ${{ github.repository == 'kenn-io/msgvault' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -34,53 +26,32 @@ jobs:
       - name: Build browser application
         run: make web-assets-check
 
-      - name: Log in to Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # latest tag for main branch
-            type=raw,value=latest,enable={{is_default_branch}}
-            # version tags (v1.2.3 -> 1.2.3, v1.2.3 -> 1.2, v1.2.3 -> 1)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            # sha tag for traceability
-            type=sha,prefix=sha-
-
-      - name: Prepare build args
-        id: build_args
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-          else
-            VERSION="dev-$(printf '%s' "$GITHUB_SHA" | cut -c1-8)"
-          fi
-          {
-            echo "version=$VERSION"
-            echo "commit=$(printf '%s' "$GITHUB_SHA" | cut -c1-8)"
-            echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push
+      - name: Build amd64 image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: msgvault:test
           build-args: |
-            VERSION=${{ steps.build_args.outputs.version }}
-            COMMIT=${{ steps.build_args.outputs.commit }}
-            BUILD_DATE=${{ steps.build_args.outputs.build_date }}
+            VERSION=test
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Smoke test (amd64)
+        run: |
+          docker run --rm msgvault:test version
+          docker run --rm msgvault:test --help
+
+          tmpdir="$(mktemp -d)"
+          trap 'sudo rm -rf "$tmpdir"' EXIT
+          sudo chown 1000:1000 "$tmpdir"
+          docker run --rm -v "$tmpdir:/data" msgvault:test init-db
+          sudo test -f "$tmpdir/msgvault.db" || { sudo ls -la "$tmpdir"; echo "FATAL: database not created"; exit 1; }
+
+          # Runtime is binary-only: no frontend toolchain or external asset tree.
+          docker run --rm --entrypoint sh msgvault:test -c \
+            'test ! -e /usr/local/bin/bun && test ! -e /usr/local/bin/node && test ! -d /usr/share/msgvault/web'

--- a/internal/granola/importer_test.go
+++ b/internal/granola/importer_test.go
@@ -923,7 +923,7 @@ func TestImport_RepeatedPageCursorFails(t *testing.T) {
 		cursor:  "same-page",
 	}
 	imp, _ := newTestImporter(t, api)
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	_, err := imp.Import(ctx, ImportOptions{Identifier: "alice@example.com"})


### PR DESCRIPTION
Pull-request Docker validation cannot use a read-only main-pinned caller while the allowlisted reusable workflow also contains the package-writing publisher: GitHub rejects the call before job conditions are evaluated.

Make the allowlisted workflow validation-only and move publishing to trusted main and tag pushes. This prerequisite keeps its own Docker check hosted for one transition; after it lands, #518 can restore the read-only `docker.yml@main` dispatcher and route same-repository validation to the managed runner fleet.

The existing image build, smoke test, and publish steps are preserved. The Granola repeated-page regression also keeps its bounded loop guard while allowing enough time for supported PostgreSQL execution. `actionlint`, formatting, and vet pass; the targeted regression passed repeatedly with SQLite and PostgreSQL 16.