### PR TITLE
fix: harden message export reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260706201446-f0a921348800 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260706201446-f0a921348800/go.mod h1:FPk7EXUKMtImne7AmknoYjT4QXqKIzzRbeQIXzLk6fQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 h1:qEHAMpSaUhtD0p3NbEEI83HwNGFxEwaSJ1G9PLnCBZE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/store/discord_export.go
+++ b/internal/store/discord_export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -42,6 +43,14 @@ type discordExportConversationMetadata struct {
 
 type discordExportMessageMetadata struct {
 	AuthorDisplayName string `json:"author_display_name"`
+}
+
+type discordExportMessageRow struct {
+	id                     int64
+	containerID, messageID string
+	rawMetadata            string
+	sentAt                 time.Time
+	deletedFromSource      bool
 }
 
 var discordExportURLPattern = regexp.MustCompile(`https?://[^\s"'<>()]+`)
@@ -91,59 +100,112 @@ func (s *Store) DiscordExport(
 		return nil, fmt.Errorf("close Discord export containers: %w", err)
 	}
 
-	messageRows, err := s.db.QueryContext(ctx, s.dialect.Rebind(`
-		SELECT c.source_conversation_id,
-		       m.source_message_id,
-		       COALESCE(mb.body_text, ''),
-		       COALESCE(m.metadata, '{}'),
-		       COALESCE(m.sent_at, m.received_at, m.internal_date),
-		       m.deleted_from_source_at
-		FROM messages m
-		JOIN conversations c ON c.id = m.conversation_id
-		LEFT JOIN message_bodies mb ON mb.message_id = m.id
-		WHERE m.source_id = ?
-		  AND m.deleted_at IS NULL
-		  AND COALESCE(m.sent_at, m.received_at, m.internal_date) >= ?
-		  AND COALESCE(m.sent_at, m.received_at, m.internal_date) < ?
-		ORDER BY c.source_conversation_id,
-		         COALESCE(m.sent_at, m.received_at, m.internal_date),
-		         m.source_message_id
-	`), sourceID, start, end)
-	if err != nil {
-		return nil, fmt.Errorf("query Discord export messages: %w", err)
-	}
-	defer func() { _ = messageRows.Close() }()
+	var cursor *discordExportMessageRow
+	for {
+		cursorPredicate := ""
+		args := []any{sourceID, start, end}
+		if cursor != nil {
+			cursorPredicate = `
+			  AND (
+			      c.source_conversation_id,
+			      COALESCE(m.sent_at, m.received_at, m.internal_date),
+			      m.source_message_id,
+			      m.id
+			  ) > (?, ?, ?, ?)
+			`
+			args = append(args,
+				cursor.containerID, cursor.sentAt, cursor.messageID, cursor.id,
+			)
+		}
+		args = append(args, messageExportPageSize)
+		messageRows, err := s.db.QueryContext(ctx, s.dialect.Rebind(`
+			SELECT m.id,
+			       c.source_conversation_id,
+			       m.source_message_id,
+			       COALESCE(m.metadata, '{}'),
+			       COALESCE(m.sent_at, m.received_at, m.internal_date),
+			       m.deleted_from_source_at
+			FROM messages m
+			JOIN conversations c ON c.id = m.conversation_id
+			WHERE m.source_id = ?
+			  AND m.deleted_at IS NULL
+			  AND COALESCE(m.sent_at, m.received_at, m.internal_date) >= ?
+			  AND COALESCE(m.sent_at, m.received_at, m.internal_date) < ?
+			`+cursorPredicate+`
+			ORDER BY c.source_conversation_id,
+			         COALESCE(m.sent_at, m.received_at, m.internal_date),
+			         m.source_message_id,
+			         m.id
+			LIMIT ?
+		`), args...)
+		if err != nil {
+			return nil, fmt.Errorf("query Discord export messages: %w", err)
+		}
 
-	for messageRows.Next() {
-		var containerID, id, content, rawMetadata string
-		var sentAt nullableTimestamp
-		var deletedAt sql.NullTime
-		if err := messageRows.Scan(
-			&containerID, &id, &content, &rawMetadata, &sentAt, &deletedAt,
-		); err != nil {
-			return nil, fmt.Errorf("scan Discord export message: %w", err)
+		var page []discordExportMessageRow
+		for messageRows.Next() {
+			var message discordExportMessageRow
+			var sentAt nullableTimestamp
+			var deletedAt sql.NullTime
+			if err := messageRows.Scan(
+				&message.id, &message.containerID, &message.messageID,
+				&message.rawMetadata, &sentAt, &deletedAt,
+			); err != nil {
+				_ = messageRows.Close()
+				return nil, fmt.Errorf("scan Discord export message: %w", err)
+			}
+			message.sentAt = sentAt.Time
+			message.deletedFromSource = deletedAt.Valid
+			page = append(page, message)
 		}
-		index, ok := containerIndex[containerID]
-		if !ok {
-			return nil, fmt.Errorf("discord message %s references unknown container %s", id, containerID)
+		if err := messageRows.Err(); err != nil {
+			_ = messageRows.Close()
+			return nil, fmt.Errorf("iterate Discord export messages: %w", err)
 		}
-		var metadata discordExportMessageMetadata
-		if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
-			return nil, fmt.Errorf("decode Discord message %s metadata: %w", id, err)
+		if err := messageRows.Close(); err != nil {
+			return nil, fmt.Errorf("close Discord export messages: %w", err)
 		}
-		containers[index].Messages = append(containers[index].Messages, DiscordExportMessage{
-			ID:           id,
-			AuthorHandle: metadata.AuthorDisplayName,
-			Content:      content,
-			SentAt:       sentAt.Time.UTC(),
-			Deleted:      deletedAt.Valid,
-			URLs:         discordExportURLs(content),
-		})
+
+		for _, message := range page {
+			index, ok := containerIndex[message.containerID]
+			if !ok {
+				return nil, fmt.Errorf(
+					"discord message %s references unknown container %s",
+					message.messageID, message.containerID,
+				)
+			}
+			var content sql.NullString
+			if err := s.db.QueryRowContext(
+				ctx,
+				s.dialect.Rebind(`SELECT body_text FROM message_bodies WHERE message_id = ?`),
+				message.id,
+			).Scan(&content); err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("load Discord export message body: %w", err)
+			}
+			var metadata discordExportMessageMetadata
+			if err := json.Unmarshal([]byte(message.rawMetadata), &metadata); err != nil {
+				return nil, fmt.Errorf(
+					"decode Discord message %s metadata: %w", message.messageID, err,
+				)
+			}
+			containers[index].Messages = append(
+				containers[index].Messages,
+				DiscordExportMessage{
+					ID:           message.messageID,
+					AuthorHandle: metadata.AuthorDisplayName,
+					Content:      content.String,
+					SentAt:       message.sentAt.UTC(),
+					Deleted:      message.deletedFromSource,
+					URLs:         discordExportURLs(content.String),
+				},
+			)
+		}
+		if len(page) < messageExportPageSize {
+			return containers, nil
+		}
+		last := page[len(page)-1]
+		cursor = &last
 	}
-	if err := messageRows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate Discord export messages: %w", err)
-	}
-	return containers, nil
 }
 
 func discordExportURLs(content string) []string {

--- a/internal/store/discord_export_test.go
+++ b/internal/store/discord_export_test.go
@@ -1,8 +1,13 @@
 package store_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +54,62 @@ func TestDiscordExportReturnsBoundedStableHistory(t *testing.T) {
 	assert.Equal("thread", got[1].Kind)
 	assert.True(got[1].Archived)
 	assert.Equal("20", got[1].ParentID)
+}
+
+func TestDiscordExportPagesMetadataAndLoadsBodiesByPrimaryKey(t *testing.T) {
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("discord", "guild")
+	requirements.NoError(err)
+	conversationID := insertDiscordExportConversation(
+		t, st, source.ID, "100", "general", `{"discord_channel_type":0}`,
+	)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	const messageCount = 257
+	for i := range messageCount {
+		insertDiscordExportMessage(
+			t, st, source.ID, conversationID, fmt.Sprintf("message-%03d", i), start,
+			fmt.Sprintf("Full body %03d", i), "alice", false, false,
+		)
+	}
+
+	store.ConfigureSQLLogging(store.SQLLogOptions{FullTrace: true})
+	t.Cleanup(func() { store.ConfigureSQLLogging(store.SQLLogOptions{}) })
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(
+		&logs, &slog.HandlerOptions{Level: slog.LevelDebug},
+	)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	got, err := st.DiscordExport(
+		context.Background(), source.ID, start, start.Add(time.Hour),
+	)
+	requirements.NoError(err)
+	requirements.Len(got, 1)
+	requirements.Len(got[0].Messages, messageCount)
+	requirements.Equal("Full body 000", got[0].Messages[0].Content)
+	requirements.Equal("Full body 256", got[0].Messages[messageCount-1].Content)
+
+	var messageSelectionStatements []string
+	var bodyLookupStatements []string
+	for line := range strings.SplitSeq(strings.TrimSpace(logs.String()), "\n") {
+		var record map[string]any
+		requirements.NoError(json.Unmarshal([]byte(line), &record))
+		statement, _ := record["stmt"].(string)
+		if strings.Contains(statement, "FROM messages m") {
+			messageSelectionStatements = append(messageSelectionStatements, statement)
+		}
+		if strings.Contains(statement, "FROM message_bodies") {
+			bodyLookupStatements = append(bodyLookupStatements, statement)
+		}
+	}
+	requirements.Len(messageSelectionStatements, 2)
+	for _, statement := range messageSelectionStatements {
+		requirements.NotContains(statement, "message_bodies")
+	}
+	requirements.Len(bodyLookupStatements, messageCount)
+	requirements.Contains(bodyLookupStatements[0], "WHERE message_id =")
 }
 
 func insertDiscordExportConversation(

--- a/internal/store/message_export.go
+++ b/internal/store/message_export.go
@@ -106,6 +106,7 @@ type messageExportMessageRow struct {
 	occurredAt           time.Time
 	deletedFromSource    bool
 	senderID             sql.NullInt64
+	recipientDisplayName string
 	senderDisplayName    string
 	senderAddress        string
 }
@@ -300,25 +301,52 @@ func (s *Store) exportMessageRows(
 	counts *MessageExportCounts,
 ) error {
 	predicate, filterArgs := messageExportPredicate("m", filter, true)
-	for offset := 0; ; offset += messageExportPageSize {
-		args := append(append([]any{}, filterArgs...), messageExportPageSize, offset)
+	var cursor *messageExportMessageRow
+	for {
+		pagePredicate := predicate
+		args := append([]any{}, filterArgs...)
+		if cursor != nil {
+			pagePredicate += `
+				AND (
+					s.source_type, s.identifier, c.source_conversation_id,
+					COALESCE(m.sent_at, m.received_at, m.internal_date),
+					m.source_message_id, m.id
+				) > (?, ?, ?, ?, ?, ?)
+			`
+			args = append(args,
+				cursor.sourceType,
+				cursor.sourceIdentifier,
+				cursor.sourceConversationID,
+				cursor.occurredAt,
+				cursor.sourceMessageID,
+				cursor.id,
+			)
+		}
+		args = append(args, messageExportPageSize)
 		rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(`
 			SELECT m.id, s.source_type, s.identifier, m.source_message_id,
 			       c.source_conversation_id, m.message_type,
 			       COALESCE(m.subject, ''), COALESCE(m.metadata, '{}'),
 			       COALESCE(m.sent_at, m.received_at, m.internal_date),
-			       m.deleted_from_source_at, p.id,
-			       COALESCE(p.display_name, ''),
-			       COALESCE(p.email_address, p.phone_number, '')
+			       m.deleted_from_source_at, p_sender.id,
+			       COALESCE(mr_from.display_name, ''),
+			       COALESCE(p_sender.display_name, ''),
+			       COALESCE(p_sender.email_address, p_sender.phone_number, '')
 			FROM messages m
 			JOIN conversations c ON c.id = m.conversation_id
 			JOIN sources s ON s.id = m.source_id
-			LEFT JOIN participants p ON p.id = m.sender_id
-			WHERE `+predicate+`
+			LEFT JOIN message_recipients mr_from ON mr_from.id = (
+				SELECT mr.id FROM message_recipients mr
+				WHERE mr.message_id = m.id AND mr.recipient_type = 'from'
+				ORDER BY mr.id LIMIT 1
+			)
+			LEFT JOIN participants p_sender
+			       ON p_sender.id = COALESCE(mr_from.participant_id, m.sender_id)
+			WHERE `+pagePredicate+`
 			ORDER BY s.source_type, s.identifier, c.source_conversation_id,
 			         COALESCE(m.sent_at, m.received_at, m.internal_date),
 			         m.source_message_id, m.id
-			LIMIT ? OFFSET ?
+			LIMIT ?
 		`), args...)
 		if err != nil {
 			return fmt.Errorf("query message export page: %w", err)
@@ -362,6 +390,8 @@ func (s *Store) exportMessageRows(
 		if len(page) < messageExportPageSize {
 			return nil
 		}
+		last := page[len(page)-1]
+		cursor = &last
 	}
 }
 
@@ -378,7 +408,7 @@ func scanMessageExportPage(rows *loggedRows) ([]messageExportMessageRow, error) 
 			&row.id, &row.sourceType, &row.sourceIdentifier, &sourceMessageID,
 			&sourceConversationID, &row.messageType, &row.subject, &row.metadata,
 			&occurredAt, &deletedFromSource, &row.senderID,
-			&row.senderDisplayName, &row.senderAddress,
+			&row.recipientDisplayName, &row.senderDisplayName, &row.senderAddress,
 		); err != nil {
 			_ = rows.Close()
 			return nil, fmt.Errorf("scan message export message: %w", err)
@@ -485,25 +515,24 @@ func normalizeMessageExportConversation(
 func normalizeMessageExportAuthor(
 	row messageExportMessageRow,
 ) (*MessageExportAuthor, error) {
-	if row.senderID.Valid {
-		return &MessageExportAuthor{
-			DisplayName: row.senderDisplayName,
-			Address:     row.senderAddress,
-		}, nil
+	displayName := strings.TrimSpace(row.recipientDisplayName)
+	if row.sourceType == "discord" && displayName == "" {
+		var metadata messageExportMessageMetadata
+		if err := json.Unmarshal([]byte(row.metadata), &metadata); err != nil {
+			return nil, fmt.Errorf("decode metadata: %w", err)
+		}
+		displayName = strings.TrimSpace(metadata.AuthorDisplayName)
 	}
-	if row.sourceType != "discord" {
+	if displayName == "" {
+		displayName = row.senderDisplayName
+	}
+	if !row.senderID.Valid && displayName == "" {
 		// A missing normalized sender is represented by a null author.
 		//nolint:nilnil
 		return nil, nil
 	}
-	var metadata messageExportMessageMetadata
-	if err := json.Unmarshal([]byte(row.metadata), &metadata); err != nil {
-		return nil, fmt.Errorf("decode metadata: %w", err)
-	}
-	if metadata.AuthorDisplayName == "" {
-		// Discord archives may lack both a sender relation and display metadata.
-		//nolint:nilnil
-		return nil, nil
-	}
-	return &MessageExportAuthor{DisplayName: metadata.AuthorDisplayName}, nil
+	return &MessageExportAuthor{
+		DisplayName: displayName,
+		Address:     row.senderAddress,
+	}, nil
 }

--- a/internal/store/message_export.go
+++ b/internal/store/message_export.go
@@ -329,7 +329,12 @@ func (s *Store) exportMessageRows(
 			       COALESCE(m.subject, ''), COALESCE(m.metadata, '{}'),
 			       COALESCE(m.sent_at, m.received_at, m.internal_date),
 			       m.deleted_from_source_at, p_sender.id,
-			       COALESCE(mr_from.display_name, ''),
+			       CASE
+			           WHEN m.sender_id IS NULL
+			                OR mr_from.participant_id = m.sender_id
+			           THEN COALESCE(mr_from.display_name, '')
+			           ELSE ''
+			       END,
 			       COALESCE(p_sender.display_name, ''),
 			       COALESCE(p_sender.email_address, p_sender.phone_number, '')
 			FROM messages m
@@ -341,7 +346,7 @@ func (s *Store) exportMessageRows(
 				ORDER BY mr.id LIMIT 1
 			)
 			LEFT JOIN participants p_sender
-			       ON p_sender.id = COALESCE(mr_from.participant_id, m.sender_id)
+			       ON p_sender.id = COALESCE(m.sender_id, mr_from.participant_id)
 			WHERE `+pagePredicate+`
 			ORDER BY s.source_type, s.identifier, c.source_conversation_id,
 			         COALESCE(m.sent_at, m.received_at, m.internal_date),

--- a/internal/store/message_export_test.go
+++ b/internal/store/message_export_test.go
@@ -435,6 +435,45 @@ func TestExportMessagesUsesLegacyFromRecipientAuthor(t *testing.T) {
 	assertions.Equal("author@example.test", sink.messages[0].Author.Address)
 }
 
+func TestExportMessagesPrefersCanonicalSenderOverStaleFromRecipient(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "person@example.test")
+	requirements.NoError(err)
+	conversationID := insertMessageExportConversation(
+		t, st, source.ID, "conversation", "", "email_thread", `{}`,
+	)
+	canonicalID := insertMessageExportParticipant(
+		t, st, "canonical@example.test", "Canonical Author",
+	)
+	staleID := insertMessageExportParticipant(
+		t, st, "stale@example.test", "Stale Participant",
+	)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	messageID := insertMessageExportMessage(
+		t, st, source.ID, conversationID, "message", "email",
+		start, "", "", canonicalID, false, false,
+	)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO message_recipients (
+			message_id, participant_id, recipient_type, display_name
+		) VALUES (?, ?, 'from', ?)
+	`), messageID, staleID, "Stale Message Author")
+	requirements.NoError(err)
+
+	sink := &collectingMessageExportSink{}
+	_, err = st.ExportMessages(context.Background(), store.MessageExportFilter{
+		Start: start,
+		End:   start.Add(time.Hour),
+	}, sink)
+	requirements.NoError(err)
+	requirements.Len(sink.messages, 1)
+	requirements.NotNil(sink.messages[0].Author)
+	assertions.Equal("Canonical Author", sink.messages[0].Author.DisplayName)
+	assertions.Equal("canonical@example.test", sink.messages[0].Author.Address)
+}
+
 type hidingMessageExportSink struct {
 	collectingMessageExportSink
 

--- a/internal/store/message_export_test.go
+++ b/internal/store/message_export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -361,6 +362,137 @@ func TestExportMessagesNormalizesParticipantAuthor(t *testing.T) {
 	assertions.Equal("author@example.test", sink.messages[0].Author.Address)
 }
 
+func TestExportMessagesPrefersDiscordMessageAuthorName(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("discord", "guild")
+	requirements.NoError(err)
+	conversationID := insertMessageExportConversation(
+		t, st, source.ID, "channel", "", "channel", `{}`,
+	)
+	participantID := insertMessageExportParticipant(
+		t, st, "user@example.test", "Stored Participant Name",
+	)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	messageID := insertMessageExportMessage(
+		t, st, source.ID, conversationID, "message", "discord",
+		start, "", "", participantID, false, false,
+	)
+	requirements.NoError(st.SetMessageMetadata(
+		messageID,
+		sql.NullString{
+			String: `{"author_display_name":"Message Author Name"}`,
+			Valid:  true,
+		},
+	))
+
+	sink := &collectingMessageExportSink{}
+	_, err = st.ExportMessages(context.Background(), store.MessageExportFilter{
+		Start: start,
+		End:   start.Add(time.Hour),
+	}, sink)
+	requirements.NoError(err)
+	requirements.Len(sink.messages, 1)
+	requirements.NotNil(sink.messages[0].Author)
+	assertions.Equal("Message Author Name", sink.messages[0].Author.DisplayName)
+	assertions.Equal("user@example.test", sink.messages[0].Author.Address)
+}
+
+func TestExportMessagesUsesLegacyFromRecipientAuthor(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "person@example.test")
+	requirements.NoError(err)
+	conversationID := insertMessageExportConversation(
+		t, st, source.ID, "conversation", "", "email_thread", `{}`,
+	)
+	participantID := insertMessageExportParticipant(
+		t, st, "author@example.test", "Stored Participant Name",
+	)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	messageID := insertMessageExportMessage(
+		t, st, source.ID, conversationID, "message", "email",
+		start, "", "", 0, false, false,
+	)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO message_recipients (
+			message_id, participant_id, recipient_type, display_name
+		) VALUES (?, ?, 'from', ?)
+	`), messageID, participantID, "Message Author Name")
+	requirements.NoError(err)
+
+	sink := &collectingMessageExportSink{}
+	_, err = st.ExportMessages(context.Background(), store.MessageExportFilter{
+		Start: start,
+		End:   start.Add(time.Hour),
+	}, sink)
+	requirements.NoError(err)
+	requirements.Len(sink.messages, 1)
+	requirements.NotNil(sink.messages[0].Author)
+	assertions.Equal("Message Author Name", sink.messages[0].Author.DisplayName)
+	assertions.Equal("author@example.test", sink.messages[0].Author.Address)
+}
+
+type hidingMessageExportSink struct {
+	collectingMessageExportSink
+
+	st             *store.Store
+	sourceID       int64
+	sourceMessage  string
+	hideAfterCount int
+}
+
+func (s *hidingMessageExportSink) Message(message store.MessageExportMessage) error {
+	if err := s.collectingMessageExportSink.Message(message); err != nil {
+		return err
+	}
+	if len(s.messages) != s.hideAfterCount {
+		return nil
+	}
+	_, err := s.st.DB().Exec(s.st.Rebind(`
+		UPDATE messages
+		SET deleted_at = ?
+		WHERE source_id = ? AND source_message_id = ?
+	`), time.Now().UTC(), s.sourceID, s.sourceMessage)
+	return err
+}
+
+func TestExportMessagesKeysetPagingDoesNotSkipAfterPrefixMutation(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("text", "source")
+	requirements.NoError(err)
+	conversationID := insertMessageExportConversation(
+		t, st, source.ID, "conversation", "", "direct_chat", `{}`,
+	)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	const pageSize = 256
+	for i := range pageSize + 1 {
+		insertMessageExportMessage(
+			t, st, source.ID, conversationID, fmt.Sprintf("message-%03d", i), "text",
+			start, "", "", 0, false, false,
+		)
+	}
+
+	sink := &hidingMessageExportSink{
+		st:             st,
+		sourceID:       source.ID,
+		sourceMessage:  "message-000",
+		hideAfterCount: pageSize,
+	}
+	counts, err := st.ExportMessages(context.Background(), store.MessageExportFilter{
+		Start: start,
+		End:   start.Add(time.Hour),
+	}, sink)
+	requirements.NoError(err)
+	assertions.Equal(pageSize+1, counts.Messages)
+	requirements.Len(sink.messages, pageSize+1)
+	assertions.Equal("message-256", sink.messages[pageSize].ID)
+}
+
 type failingMessageExportSink struct {
 	err error
 }
@@ -427,6 +559,20 @@ func insertMessageExportConversation(
 	requirements.NoError(st.SetConversationMetadata(
 		id, sql.NullString{String: metadata, Valid: true},
 	))
+	return id
+}
+
+func insertMessageExportParticipant(
+	t *testing.T, st *store.Store, address, displayName string,
+) int64 {
+	t.Helper()
+	var id int64
+	err := st.DB().QueryRow(st.Rebind(`
+		INSERT INTO participants (email_address, display_name)
+		VALUES (?, ?)
+		RETURNING id
+	`), address, displayName).Scan(&id)
+	require.NoError(t, err)
 	return id
 }
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -13,7 +13,7 @@ buildGoModule {
 
   src = gitignoreSource ../.;
 
-  vendorHash = "sha256-ykrI7CRnfb5jcfaLRXJ0yDrU7GADz2rEJmVq2vUA68E=";
+  vendorHash = "sha256-Bs8ZD/KghCuLrN9EQqvNbjw4t66EZz+BnZfNUQ3f2E4=";
   proxyVendor = true;
 
   subPackages = [ "cmd/msgvault" ];


### PR DESCRIPTION
## Why

Large bounded exports must remain complete and efficient as archives grow. Offset paging repeatedly rescanned the emitted prefix and could skip records when that prefix changed between pages. Author resolution also bypassed the archive’s established per-message sender precedence, producing null legacy authors or stale Discord display names.

This aligns export author identity with the existing message APIs, advances both export paths with stable keyset cursors, and restores the compatibility exporter’s direct-primary-key boundary for large message bodies. The public JSON contracts and command usage remain unchanged.

## Review focus

The main compatibility constraint is deterministic ordering across SQLite and PostgreSQL while preserving the existing half-open window and source-deletion semantics.