### PR TITLE
fix: bound message export conversation scans

### DIFF
--- a/internal/store/message_export.go
+++ b/internal/store/message_export.go
@@ -234,6 +234,12 @@ func (s *Store) exportMessageConversations(
 	counts *MessageExportCounts,
 ) error {
 	predicate, args := messageExportPredicate("m", filter, true)
+	var sourcePredicate string
+	if len(filter.SourceIDs) > 0 {
+		clause, sourceArgs := messageExportInClause("c.source_id", filter.SourceIDs)
+		sourcePredicate = " AND " + clause
+		args = append(args, sourceArgs...)
+	}
 	rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(`
 		SELECT s.source_type, s.identifier, c.source_conversation_id,
 		       COALESCE(c.title, ''), c.conversation_type,
@@ -244,7 +250,7 @@ func (s *Store) exportMessageConversations(
 			SELECT 1
 			FROM messages m
 			WHERE m.conversation_id = c.id AND `+predicate+`
-		)
+		)`+sourcePredicate+`
 		ORDER BY s.source_type, s.identifier, c.source_conversation_id
 	`), args...)
 	if err != nil {

--- a/internal/store/message_export_test.go
+++ b/internal/store/message_export_test.go
@@ -216,6 +216,74 @@ func TestExportMessagesFiltersSourcesAndMessageTypes(t *testing.T) {
 	assertions.Equal("first-text", sink.messages[0].ID)
 }
 
+func TestExportMessagesSourceFilterBoundsConversationScan(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	if st.IsPostgreSQL() {
+		t.Skip("SQLite query-plan regression")
+	}
+	requirements := require.New(t)
+	selected, err := st.GetOrCreateSource("text", "selected")
+	requirements.NoError(err)
+	unrelated, err := st.GetOrCreateSource("text", "unrelated")
+	requirements.NoError(err)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	selectedConversation := insertMessageExportConversation(
+		t, st, selected.ID, "selected-conversation", "", "direct_chat", `{}`,
+	)
+
+	tx, err := st.DB().Begin()
+	requirements.NoError(err)
+	conversationStatement, err := tx.Prepare(st.Rebind(`
+		INSERT INTO conversations (
+			source_id, source_conversation_id, conversation_type, title
+		) VALUES (?, ?, 'direct_chat', '')
+	`))
+	requirements.NoError(err)
+	defer func() {
+		requirements.NoError(conversationStatement.Close())
+	}()
+	for i := range 10_000 {
+		_, err = conversationStatement.Exec(unrelated.ID, fmt.Sprintf("unrelated-%d", i))
+		requirements.NoError(err)
+	}
+
+	messageStatement, err := tx.Prepare(st.Rebind(`
+		INSERT INTO messages (
+			conversation_id, source_id, source_message_id, message_type,
+			sent_at, received_at
+		) VALUES (?, ?, ?, 'other', ?, ?)
+	`))
+	requirements.NoError(err)
+	defer func() {
+		requirements.NoError(messageStatement.Close())
+	}()
+	for i := range 1_000 {
+		_, err = messageStatement.Exec(
+			selectedConversation,
+			selected.ID,
+			fmt.Sprintf("selected-%d", i),
+			start,
+			start,
+		)
+		requirements.NoError(err)
+	}
+	requirements.NoError(tx.Commit())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	sink := &collectingMessageExportSink{}
+	counts, err := st.ExportMessages(ctx, store.MessageExportFilter{
+		Start:        start,
+		End:          start.Add(time.Hour),
+		SourceIDs:    []int64{selected.ID},
+		MessageTypes: []string{"wanted"},
+	}, sink)
+	requirements.NoError(err)
+	assert.Equal(t, store.MessageExportCounts{Sources: 1}, counts)
+	assert.Empty(t, sink.conversations)
+	assert.Empty(t, sink.messages)
+}
+
 func TestExportMessagesEmitsExplicitEmptySources(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)


### PR DESCRIPTION
Source-scoped message exports could spend most of their time evaluating unrelated conversations because the source constraint applied only inside a correlated message predicate. That made bounded exports scale with the archive’s total conversation count and could delay stream completion on large mixed-source archives.

Apply the resolved source IDs to the outer conversation query as well, allowing conversation discovery to start from the selected-source index. Export schema, ordering, and filter semantics remain unchanged.

Review focus: confirm the outer constraint remains aligned with the resolved source IDs and backend placeholder rebinding.