### PR TITLE
ci: isolate Playwright tool installs from NodeSource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
         # Mirror hiccups have hung plain apt-get for 15+ minutes; bounded
         # timeouts plus retries turn an outage into a short delay.
         run: |
+          # The pinned Playwright image already provides Node, while its
+          # preconfigured NodeSource repository rejects CI runner traffic.
+          # Bun is installed separately below, so only Ubuntu sources are
+          # needed for the native build toolchain.
+          rm -f /etc/apt/sources.list.d/nodesource.list
           for attempt in 1 2 3; do
             if apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 \
               && apt-get install -y --no-install-recommends -o Acquire::Retries=3 -o Acquire::http::Timeout=30 gcc g++ make unzip; then
@@ -187,6 +192,11 @@ jobs:
         # Mirror hiccups have hung plain apt-get for 15+ minutes; bounded
         # timeouts plus retries turn an outage into a short delay.
         run: |
+          # The pinned Playwright image already provides Node, while its
+          # preconfigured NodeSource repository rejects CI runner traffic.
+          # Bun is installed separately below, so only Ubuntu sources are
+          # needed for the native build toolchain.
+          rm -f /etc/apt/sources.list.d/nodesource.list
           for attempt in 1 2 3; do
             if apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 \
               && apt-get install -y --no-install-recommends -o Acquire::Retries=3 -o Acquire::http::Timeout=30 gcc g++ make unzip; then


### PR DESCRIPTION
The pinned Playwright image bundles a NodeSource APT repository that now rejects CI runner traffic with HTTP 403. Both browser jobs need Ubuntu build packages, but `apt-get update` treats the unrelated NodeSource failure as fatal and stops before any project test runs; retrying cannot recover a policy denial.

Exclude that repository from the ephemeral browser-job containers while retaining the image’s installed Node runtime and the separately managed Bun installation. This keeps native toolchain installation dependent only on Ubuntu sources.

This must land independently because pull-request CI intentionally invokes `ci.yml@main`; a workflow correction carried only by another PR cannot affect its own dispatched jobs. Once this lands, rerunning #524 will exercise the corrected main-pinned workflow.

Review focus: confirm neither browser job installs Node packages through APT and that the exact source-file removal remains scoped to the pinned ephemeral containers.