### PR TITLE
Add portable field metadata and typed person attributes

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -195,6 +195,159 @@ components:
         - mime_type
         - size_bytes
       type: object
+    AttributeChoice:
+      additionalProperties: false
+      properties:
+        label:
+          type: string
+        value:
+          type: string
+      required:
+        - value
+        - label
+      type: object
+    AttributeDefinition:
+      additionalProperties: true
+      properties:
+        api_mutable:
+          type: boolean
+        cardinality:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        derived_source:
+          type: string
+        description:
+          type: string
+        display_order:
+          format: int64
+          type: integer
+        field_type:
+          type: string
+        history_exempt:
+          type: boolean
+        id:
+          format: int64
+          type: integer
+        is_active:
+          type: boolean
+        is_audited:
+          type: boolean
+        is_deletable:
+          type: boolean
+        is_required:
+          type: boolean
+        is_searchable:
+          type: boolean
+        label:
+          type: string
+        object_type:
+          type: string
+        options:
+          $ref: "#/components/schemas/AttributeOptions"
+        ownership:
+          type: string
+        record_target:
+          type: string
+        revision:
+          format: int64
+          type: integer
+        slug:
+          type: string
+        ui_creatable:
+          type: boolean
+        ui_editable:
+          type: boolean
+        universal_id:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        value_type:
+          type: string
+        vcard_property:
+          type: string
+      required:
+        - id
+        - universal_id
+        - object_type
+        - slug
+        - label
+        - value_type
+        - field_type
+        - cardinality
+        - display_order
+        - is_required
+        - ownership
+        - ui_creatable
+        - ui_editable
+        - api_mutable
+        - is_searchable
+        - is_audited
+        - is_deletable
+        - history_exempt
+        - is_active
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    AttributeDefinitionsResponse:
+      additionalProperties: true
+      properties:
+        definitions:
+          items:
+            $ref: "#/components/schemas/AttributeDefinition"
+          type:
+            - array
+            - "null"
+      required:
+        - definitions
+      type: object
+    AttributeOptions:
+      additionalProperties: false
+      properties:
+        choices:
+          items:
+            $ref: "#/components/schemas/AttributeChoice"
+          type:
+            - array
+            - "null"
+        max_length:
+          format: int64
+          type: integer
+        unit:
+          type: string
+      type: object
+    AttributeValue:
+      additionalProperties: false
+      properties:
+        boolean:
+          type: boolean
+        date:
+          type: string
+        integer:
+          format: int64
+          type: integer
+        json: {}
+        real:
+          format: double
+          type: number
+        record_id:
+          format: int64
+          type: integer
+        record_type:
+          type: string
+        text:
+          type: string
+        timestamp:
+          format: date-time
+          type: string
+        type:
+          type: string
+      required:
+        - type
+      type: object
     BackupFreezeBeginResponse:
       additionalProperties: true
       properties:
@@ -1222,6 +1375,51 @@ components:
         - has_before
         - has_after
         - total
+      type: object
+    CreateAttributeDefinitionRequest:
+      additionalProperties: false
+      properties:
+        cardinality:
+          enum:
+            - single
+            - multi
+          type: string
+        description:
+          type: string
+        display_order:
+          format: int64
+          type: integer
+        field_type:
+          type: string
+        is_audited:
+          type: boolean
+        is_required:
+          type: boolean
+        is_searchable:
+          type: boolean
+        label:
+          type: string
+        object_type:
+          enum:
+            - person
+            - organization
+          type: string
+        options:
+          $ref: "#/components/schemas/AttributeOptions"
+        record_target:
+          type: string
+        slug:
+          type: string
+        value_type:
+          type: string
+        vcard_property:
+          type: string
+      required:
+        - object_type
+        - slug
+        - label
+        - value_type
+        - field_type
       type: object
     CreatePersonRequest:
       additionalProperties: false
@@ -3047,6 +3245,21 @@ components:
       required:
         - busy
       type: object
+    PatchAttributeDefinitionRequest:
+      additionalProperties: false
+      properties:
+        description:
+          type:
+            - string
+            - "null"
+        display_order:
+          format: int64
+          type: integer
+        is_active:
+          type: boolean
+        label:
+          type: string
+      type: object
     PatchPersonRequest:
       additionalProperties: false
       properties:
@@ -3103,6 +3316,106 @@ components:
         - participant_ids
         - created_at
         - updated_at
+      type: object
+    PersonAttributeGroup:
+      additionalProperties: true
+      properties:
+        current:
+          items:
+            $ref: "#/components/schemas/PersonAttributeValue"
+          type:
+            - array
+            - "null"
+        definition:
+          $ref: "#/components/schemas/AttributeDefinition"
+        history:
+          items:
+            $ref: "#/components/schemas/PersonAttributeValue"
+          type:
+            - array
+            - "null"
+      required:
+        - definition
+        - current
+      type: object
+    PersonAttributeValue:
+      additionalProperties: true
+      properties:
+        active_from:
+          format: date-time
+          type: string
+        active_until:
+          format: date-time
+          type: string
+        actor:
+          type: string
+        confidence:
+          format: double
+          type: number
+        created_at:
+          format: date-time
+          type: string
+        definition_id:
+          format: int64
+          type: integer
+        definition_slug:
+          type: string
+        id:
+          format: int64
+          type: integer
+        ordinal:
+          format: int64
+          type: integer
+        person_id:
+          format: int64
+          type: integer
+        source:
+          type: string
+        source_ref:
+          type: string
+        superseded_at:
+          format: date-time
+          type: string
+        value:
+          $ref: "#/components/schemas/AttributeValue"
+      required:
+        - id
+        - person_id
+        - definition_id
+        - definition_slug
+        - ordinal
+        - value
+        - active_from
+        - created_at
+        - source
+      type: object
+    PersonAttributeWrite:
+      additionalProperties: true
+      properties:
+        dry_run:
+          type: boolean
+        superseded:
+          $ref: "#/components/schemas/PersonAttributeValue"
+        value:
+          $ref: "#/components/schemas/PersonAttributeValue"
+      required:
+        - dry_run
+      type: object
+    PersonAttributesResponse:
+      additionalProperties: true
+      properties:
+        attributes:
+          items:
+            $ref: "#/components/schemas/PersonAttributeGroup"
+          type:
+            - array
+            - "null"
+        person_id:
+          format: int64
+          type: integer
+      required:
+        - person_id
+        - attributes
       type: object
     PersonCluster:
       additionalProperties: true
@@ -3865,6 +4178,43 @@ components:
         - auth_mode
         - https
         - plain_http_warning
+      type: object
+    SetPersonAttributeRequest:
+      additionalProperties: false
+      properties:
+        active_from:
+          format: date-time
+          type: string
+        active_until:
+          format: date-time
+          type: string
+        actor:
+          type: string
+        confidence:
+          format: double
+          type: number
+        expected_value_id:
+          format: int64
+          type: integer
+        ordinal:
+          format: int64
+          type: integer
+        source:
+          enum:
+            - user
+            - carddav_import
+            - vcard_import
+            - archive_observation
+            - extraction
+            - enrichment
+            - system
+          type: string
+        source_ref:
+          type: string
+        value:
+          $ref: "#/components/schemas/AttributeValue"
+      required:
+        - value
       type: object
     Setting:
       additionalProperties: true
@@ -4791,7 +5141,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.34.0
+  version: 1.35.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -5233,6 +5583,274 @@ paths:
       security:
         - apiKey: []
       summary: Get attachment metadata
+      tags:
+        - API
+  /api/v1/attribute-definitions:
+    get:
+      operationId: listAttributeDefinitions
+      parameters:
+        - description: Filter by object type
+          in: query
+          name: object_type
+          schema:
+            type: string
+        - description: Include deactivated definitions
+          in: query
+          name: include_hidden
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinitionsResponse"
+          description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List portable attribute definitions
+      tags:
+        - API
+    post:
+      operationId: createAttributeDefinition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAttributeDefinitionRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinition"
+          description: Created
+          headers:
+            ETag:
+              description: Strong attribute definition revision tag
+              schema:
+                type: string
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Create a user attribute definition
+      tags:
+        - API
+  /api/v1/attribute-definitions/{id}:
+    delete:
+      operationId: deleteAttributeDefinition
+      parameters:
+        - description: Attribute definition ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Strong ETag returned by the latest definition read
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "428":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Delete a user attribute definition
+      tags:
+        - API
+    get:
+      operationId: getAttributeDefinition
+      parameters:
+        - description: Attribute definition ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinition"
+          description: OK
+          headers:
+            ETag:
+              description: Strong attribute definition revision tag
+              schema:
+                type: string
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get one attribute definition
+      tags:
+        - API
+    patch:
+      operationId: patchAttributeDefinition
+      parameters:
+        - description: Attribute definition ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Strong ETag returned by the latest definition read
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchAttributeDefinitionRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinition"
+          description: OK
+          headers:
+            ETag:
+              description: Strong attribute definition revision tag
+              schema:
+                type: string
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "428":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Update mutable attribute definition fields
       tags:
         - API
   /api/v1/auth/token/{email}:
@@ -8711,6 +9329,202 @@ paths:
       security:
         - apiKey: []
       summary: Update a durable person's display name
+      tags:
+        - API
+  /api/v1/persons/{id}/attributes:
+    get:
+      operationId: listPersonAttributes
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Include superseded values
+          in: query
+          name: history
+          schema:
+            type: boolean
+        - description: Restrict the response to one definition slug
+          in: query
+          name: slug
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonAttributesResponse"
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List a person's typed attributes
+      tags:
+        - API
+  /api/v1/persons/{id}/attributes/{slug}:
+    delete:
+      operationId: clearPersonAttribute
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Immutable attribute definition slug
+          in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+        - description: Ordinal for a multi-valued definition
+          in: query
+          name: ordinal
+          schema:
+            format: int64
+            type: integer
+        - description: "Compare-and-swap: the current value ID expected to be superseded"
+          in: query
+          name: expected_value_id
+          schema:
+            format: int64
+            type: integer
+        - description: Validate and preview without writing
+          in: query
+          name: dry_run
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonAttributeWrite"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Supersede a person's attribute value
+      tags:
+        - API
+    put:
+      operationId: setPersonAttribute
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Immutable attribute definition slug
+          in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+        - description: Validate and preview without writing
+          in: query
+          name: dry_run
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetPersonAttributeRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonAttributeWrite"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Set a person's attribute value
       tags:
         - API
   /api/v1/query:

--- a/cmd/msgvault/cmd/attribute_definition.go
+++ b/cmd/msgvault/cmd/attribute_definition.go
@@ -1,0 +1,383 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	apiclient "go.kenn.io/msgvault/pkg/client"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+var (
+	attributeDefinitionJSON             bool
+	attributeDefinitionObjectType       string
+	attributeDefinitionIncludeHidden    bool
+	attributeDefinitionDocument         string
+	attributeDefinitionDryRun           bool
+	attributeDefinitionLabel            string
+	attributeDefinitionDescription      string
+	attributeDefinitionClearDescription bool
+)
+
+var attributeDefinitionCmd = &cobra.Command{
+	Use:   "attribute-definition",
+	Short: "Manage portable attribute definitions",
+	Long: "Manage portable attribute definitions. Definitions are metadata rows:\n" +
+		"creating one never changes the database schema. The registry does not\n" +
+		"offer a uniqueness flag, because Msgvault only claims constraints a\n" +
+		"portable database index enforces.",
+}
+
+var attributeDefinitionListCmd = &cobra.Command{
+	Use:   cmdUseList,
+	Short: "List attribute definitions",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		objectType, err := attributeObjectTypeArg(cmd)
+		if err != nil {
+			return err
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+
+		options := &generated.ListAttributeDefinitionsRequestOptions{
+			Query: &generated.ListAttributeDefinitionsQuery{},
+		}
+		if objectType != "" {
+			options.Query.ObjectType = &objectType
+		}
+		if attributeDefinitionIncludeHidden {
+			includeHidden := true
+			options.Query.IncludeHidden = &includeHidden
+		}
+		resp, err := daemonclient.APIResponse(client,
+			func(api *apiclient.Client) (*generated.ListAttributeDefinitionsResp, error) {
+				return api.ListAttributeDefinitionsWithResponse(cmd.Context(), options)
+			})
+		if err != nil {
+			return err
+		}
+		if resp.JSON200 == nil {
+			return errors.New("attribute definitions response was empty")
+		}
+		if attributeDefinitionJSON {
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(resp.JSON200.Definitions)
+		}
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w,
+			"ID\tSLUG\tLABEL\tOBJECT\tVALUE TYPE\tWIDGET\tCARDINALITY\tOWNER\tMODE\tUNIVERSAL ID")
+		for _, definition := range resp.JSON200.Definitions {
+			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				definition.ID, definition.Slug, definition.Label,
+				definition.ObjectType, definition.ValueType, definition.FieldType,
+				definition.Cardinality, definition.Ownership,
+				attributeDefinitionMode(definition), definition.UniversalID)
+		}
+		return w.Flush()
+	},
+}
+
+func attributeDefinitionMode(definition generated.AttributeDefinition) string {
+	if definition.DerivedSource != nil {
+		return "derived (" + *definition.DerivedSource + ")"
+	}
+	if !definition.IsActive {
+		return "inactive"
+	}
+	return "writable"
+}
+
+var attributeDefinitionGetCmd = &cobra.Command{
+	Use:   "get <definition-id>",
+	Short: "Get one attribute definition",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := positivePersonCLIArg(cmd, args[0], "attribute definition")
+		if err != nil {
+			return err
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		resp, err := getCLIAttributeDefinition(cmd, client, id)
+		if err != nil {
+			return err
+		}
+		return writeCLIAttributeDefinition(cmd, resp.JSON200)
+	},
+}
+
+var attributeDefinitionCreateCmd = &cobra.Command{
+	Use:   "create --definition <json|@path|->",
+	Short: "Create a user attribute definition from a JSON document",
+	Long: "Create a user attribute definition from a JSON document. Pass the\n" +
+		"document inline, as @path to read a file, or - to read standard input.\n" +
+		"--dry-run validates the document locally and prints what would be sent.",
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		body, err := decodeCLIAttributeDefinitionDocument(cmd, attributeDefinitionDocument)
+		if err != nil {
+			return err
+		}
+		if attributeDefinitionDryRun {
+			encoded, marshalErr := json.MarshalIndent(body, "", "  ")
+			if marshalErr != nil {
+				return marshalErr
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"Would create attribute definition:\n%s\n", encoded)
+			return nil
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		resp, err := daemonclient.APIResponseWithStatuses(client,
+			[]int{http.StatusCreated},
+			func(api *apiclient.Client) (*generated.CreateAttributeDefinitionResp, error) {
+				return api.CreateAttributeDefinitionWithResponse(cmd.Context(),
+					&generated.CreateAttributeDefinitionRequestOptions{Body: body})
+			})
+		if err != nil {
+			return err
+		}
+		return writeCLIAttributeDefinition(cmd, resp.JSON201)
+	},
+}
+
+var attributeDefinitionRenameCmd = &cobra.Command{
+	Use:   "rename <definition-id> --label <text>",
+	Short: "Change an attribute definition's human label",
+	Long: "Change an attribute definition's human label. The universal identifier\n" +
+		"and slug are immutable, so a rename never breaks a stored reference.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := positivePersonCLIArg(cmd, args[0], "attribute definition")
+		if err != nil {
+			return err
+		}
+		label := strings.TrimSpace(attributeDefinitionLabel)
+		description := strings.TrimSpace(attributeDefinitionDescription)
+		if label == "" && !attributeDefinitionClearDescription && description == "" {
+			return usageErr(cmd, errors.New("--label or --description is required"))
+		}
+		if attributeDefinitionClearDescription && description != "" {
+			return usageErr(cmd, errors.New(
+				"--clear-description cannot be combined with --description"))
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		current, err := getCLIAttributeDefinition(cmd, client, id)
+		if err != nil {
+			return err
+		}
+		if current.JSON200 == nil {
+			return errors.New("attribute definition response was empty")
+		}
+		etag := fmt.Sprintf(`"attribute-definition-%d-r%d"`, id, current.JSON200.Revision)
+		body := generated.PatchAttributeDefinitionBody{}
+		if label != "" {
+			body.Label = &label
+		}
+		switch {
+		case attributeDefinitionClearDescription:
+			empty := ""
+			body.Description = &empty
+		case description != "":
+			body.Description = &description
+		}
+		resp, err := daemonclient.APIResponse(client,
+			func(api *apiclient.Client) (*generated.PatchAttributeDefinitionResp, error) {
+				return api.PatchAttributeDefinitionWithResponse(cmd.Context(),
+					&generated.PatchAttributeDefinitionRequestOptions{
+						PathParams: &generated.PatchAttributeDefinitionPath{ID: id},
+						Header:     &generated.PatchAttributeDefinitionHeaders{IfMatch: etag},
+						Body:       &body,
+					})
+			})
+		if err != nil {
+			return err
+		}
+		return writeCLIAttributeDefinition(cmd, resp.JSON200)
+	},
+}
+
+var attributeDefinitionDeleteCmd = &cobra.Command{
+	Use:   "delete <definition-id>",
+	Short: "Delete a user attribute definition",
+	Long: "Delete a user attribute definition. The daemon refuses definitions that\n" +
+		"ship with Msgvault, definitions marked not deletable, and definitions\n" +
+		"that still have stored values.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := positivePersonCLIArg(cmd, args[0], "attribute definition")
+		if err != nil {
+			return err
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		current, err := getCLIAttributeDefinition(cmd, client, id)
+		if err != nil {
+			return err
+		}
+		if current.JSON200 == nil {
+			return errors.New("attribute definition response was empty")
+		}
+		etag := fmt.Sprintf(`"attribute-definition-%d-r%d"`, id, current.JSON200.Revision)
+		_, err = daemonclient.APIResponseWithStatuses(client,
+			[]int{http.StatusNoContent},
+			func(api *apiclient.Client) (*generated.DeleteAttributeDefinitionResp, error) {
+				return api.DeleteAttributeDefinitionWithResponse(cmd.Context(),
+					&generated.DeleteAttributeDefinitionRequestOptions{
+						PathParams: &generated.DeleteAttributeDefinitionPath{ID: id},
+						Header:     &generated.DeleteAttributeDefinitionHeaders{IfMatch: etag},
+					})
+			})
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Deleted attribute definition %d\n", id)
+		return nil
+	},
+}
+
+func attributeObjectTypeArg(cmd *cobra.Command) (string, error) {
+	value := strings.TrimSpace(attributeDefinitionObjectType)
+	if value == "" || value == "person" || value == "organization" {
+		return value, nil
+	}
+	return "", usageErr(cmd, errors.New("object type must be person or organization"))
+}
+
+func readCLIDocument(cmd *cobra.Command, value string) ([]byte, error) {
+	trimmed := strings.TrimSpace(value)
+	switch {
+	case trimmed == "":
+		return nil, usageErr(cmd, errors.New("a JSON document is required"))
+	case trimmed == "-":
+		data, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, fmt.Errorf("read document from standard input: %w", err)
+		}
+		return data, nil
+	case strings.HasPrefix(trimmed, "@"):
+		filename := strings.TrimPrefix(trimmed, "@")
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("read document %s: %w", filename, err)
+		}
+		return data, nil
+	default:
+		return []byte(trimmed), nil
+	}
+}
+
+func decodeCLIAttributeDefinitionDocument(
+	cmd *cobra.Command, value string,
+) (*generated.CreateAttributeDefinitionBody, error) {
+	data, err := readCLIDocument(cmd, value)
+	if err != nil {
+		return nil, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil || fields == nil {
+		return nil, usageErr(cmd, errors.New(
+			"attribute definition document must be a JSON object"))
+	}
+	for _, reserved := range []string{"is_unique", "unique"} {
+		if _, present := fields[reserved]; present {
+			return nil, usageErr(cmd, errors.New(
+				"attribute definition uniqueness is not supported: a uniqueness claim "+
+					"must be backed by a portable database index"))
+		}
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	var body generated.CreateAttributeDefinitionBody
+	if err := decoder.Decode(&body); err != nil {
+		return nil, usageErr(cmd, fmt.Errorf("invalid attribute definition document: %w", err))
+	}
+	if err := body.Validate(); err != nil {
+		return nil, usageErr(cmd, fmt.Errorf("invalid attribute definition document: %w", err))
+	}
+	return &body, nil
+}
+
+func getCLIAttributeDefinition(
+	cmd *cobra.Command, client *daemonclient.Client, id int64,
+) (*generated.GetAttributeDefinitionResp, error) {
+	return daemonclient.APIResponse(client,
+		func(api *apiclient.Client) (*generated.GetAttributeDefinitionResp, error) {
+			return api.GetAttributeDefinitionWithResponse(cmd.Context(),
+				&generated.GetAttributeDefinitionRequestOptions{
+					PathParams: &generated.GetAttributeDefinitionPath{ID: id},
+				})
+		})
+}
+
+func writeCLIAttributeDefinition(
+	cmd *cobra.Command, definition *generated.AttributeDefinition,
+) error {
+	if definition == nil {
+		return errors.New("attribute definition response was empty")
+	}
+	if attributeDefinitionJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(definition)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"Definition: %d\nSlug: %s\nLabel: %s\nObject: %s\nValue type: %s\n"+
+			"Widget: %s\nCardinality: %s\nOwner: %s\nMode: %s\nUniversal ID: %s\n"+
+			"Revision: %d\n",
+		definition.ID, definition.Slug, definition.Label, definition.ObjectType,
+		definition.ValueType, definition.FieldType, definition.Cardinality,
+		definition.Ownership, attributeDefinitionMode(*definition),
+		definition.UniversalID, definition.Revision)
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(attributeDefinitionCmd)
+	attributeDefinitionCmd.AddCommand(attributeDefinitionListCmd,
+		attributeDefinitionGetCmd, attributeDefinitionCreateCmd,
+		attributeDefinitionRenameCmd, attributeDefinitionDeleteCmd)
+	for _, command := range []*cobra.Command{
+		attributeDefinitionListCmd, attributeDefinitionGetCmd,
+		attributeDefinitionCreateCmd, attributeDefinitionRenameCmd,
+	} {
+		command.Flags().BoolVar(&attributeDefinitionJSON, flagJSON, false, "Output as JSON")
+	}
+	attributeDefinitionListCmd.Flags().StringVar(&attributeDefinitionObjectType,
+		"object-type", "", "Filter by object type: person or organization")
+	attributeDefinitionListCmd.Flags().BoolVar(&attributeDefinitionIncludeHidden,
+		"include-hidden", false, "Include deactivated definitions")
+	attributeDefinitionCreateCmd.Flags().StringVar(&attributeDefinitionDocument,
+		"definition", "", "Definition JSON document, @path, or - for standard input")
+	attributeDefinitionCreateCmd.Flags().BoolVar(&attributeDefinitionDryRun,
+		"dry-run", false, "Validate and print the request without sending it")
+	attributeDefinitionRenameCmd.Flags().StringVar(&attributeDefinitionLabel,
+		"label", "", "New human label")
+	attributeDefinitionRenameCmd.Flags().StringVar(&attributeDefinitionDescription,
+		"description", "", "New description")
+	attributeDefinitionRenameCmd.Flags().BoolVar(&attributeDefinitionClearDescription,
+		"clear-description", false, "Clear the description")
+}

--- a/cmd/msgvault/cmd/attribute_definition.go
+++ b/cmd/msgvault/cmd/attribute_definition.go
@@ -11,7 +11,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/api"
 	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/store"
 	apiclient "go.kenn.io/msgvault/pkg/client"
 	"go.kenn.io/msgvault/pkg/client/generated"
 )
@@ -125,14 +127,18 @@ var attributeDefinitionCreateCmd = &cobra.Command{
 	Short: "Create a user attribute definition from a JSON document",
 	Long: "Create a user attribute definition from a JSON document. Pass the\n" +
 		"document inline, as @path to read a file, or - to read standard input.\n" +
-		"--dry-run validates the document locally and prints what would be sent.",
+		"--dry-run applies the server's definition validation locally (except\n" +
+		"conflicts with existing definitions) and prints what would be sent.",
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		body, err := decodeCLIAttributeDefinitionDocument(cmd, attributeDefinitionDocument)
+		body, raw, err := decodeCLIAttributeDefinitionDocument(cmd, attributeDefinitionDocument)
 		if err != nil {
 			return err
 		}
 		if attributeDefinitionDryRun {
+			if err := validateCLIAttributeDefinition(cmd, raw); err != nil {
+				return err
+			}
 			encoded, marshalErr := json.MarshalIndent(body, "", "  ")
 			if marshalErr != nil {
 				return marshalErr
@@ -294,19 +300,19 @@ func readCLIDocument(cmd *cobra.Command, value string) ([]byte, error) {
 
 func decodeCLIAttributeDefinitionDocument(
 	cmd *cobra.Command, value string,
-) (*generated.CreateAttributeDefinitionBody, error) {
+) (*generated.CreateAttributeDefinitionBody, []byte, error) {
 	data, err := readCLIDocument(cmd, value)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil || fields == nil {
-		return nil, usageErr(cmd, errors.New(
+		return nil, nil, usageErr(cmd, errors.New(
 			"attribute definition document must be a JSON object"))
 	}
 	for _, reserved := range []string{"is_unique", "unique"} {
 		if _, present := fields[reserved]; present {
-			return nil, usageErr(cmd, errors.New(
+			return nil, nil, usageErr(cmd, errors.New(
 				"attribute definition uniqueness is not supported: a uniqueness claim "+
 					"must be backed by a portable database index"))
 		}
@@ -315,12 +321,31 @@ func decodeCLIAttributeDefinitionDocument(
 	decoder.DisallowUnknownFields()
 	var body generated.CreateAttributeDefinitionBody
 	if err := decoder.Decode(&body); err != nil {
-		return nil, usageErr(cmd, fmt.Errorf("invalid attribute definition document: %w", err))
+		return nil, nil, usageErr(cmd, fmt.Errorf("invalid attribute definition document: %w", err))
 	}
 	if err := body.Validate(); err != nil {
-		return nil, usageErr(cmd, fmt.Errorf("invalid attribute definition document: %w", err))
+		return nil, nil, usageErr(cmd, fmt.Errorf("invalid attribute definition document: %w", err))
 	}
-	return &body, nil
+	return &body, data, nil
+}
+
+// validateCLIAttributeDefinition applies the store's full definition
+// validation locally so a dry run rejects what the server would reject
+// (conflicts with existing definitions excepted, which need the database).
+func validateCLIAttributeDefinition(cmd *cobra.Command, data []byte) error {
+	var request api.CreateAttributeDefinitionRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		return usageErr(cmd, fmt.Errorf("invalid attribute definition document: %w", err))
+	}
+	universalID, err := store.NewAttributeUniversalID()
+	if err != nil {
+		return err
+	}
+	if _, err := store.ValidateAttributeDefinitionInput(
+		request.StoreInput(universalID)); err != nil {
+		return usageErr(cmd, err)
+	}
+	return nil
 }
 
 func getCLIAttributeDefinition(

--- a/cmd/msgvault/cmd/attribute_definition_test.go
+++ b/cmd/msgvault/cmd/attribute_definition_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+)
+
+const testAttributeDefinitionJSON = `{
+	"id":3,
+	"universal_id":"93c658a1-2346-4a6e-98c2-abfa29209334",
+	"object_type":"person",
+	"slug":"ask_me_about",
+	"label":"Ask me about",
+	"value_type":"text",
+	"field_type":"text",
+	"cardinality":"multi",
+	"display_order":30,
+	"is_required":false,
+	"ownership":"system",
+	"ui_creatable":true,
+	"ui_editable":true,
+	"api_mutable":true,
+	"is_searchable":true,
+	"is_audited":true,
+	"is_deletable":false,
+	"history_exempt":false,
+	"is_active":true,
+	"revision":7,
+	"created_at":"2026-07-30T12:00:00Z",
+	"updated_at":"2026-07-30T12:00:00Z"
+}`
+
+func runAttributeCommand(
+	t *testing.T, template *cobra.Command, args ...string,
+) (string, error) {
+	t.Helper()
+	var output bytes.Buffer
+	command := &cobra.Command{Use: template.Use, Args: template.Args, RunE: template.RunE}
+	command.Flags().AddFlagSet(template.Flags())
+	command.Flags().VisitAll(func(flag *pflag.Flag) {
+		// Reset the bound package variable too: a previous test's flag value
+		// (e.g. --dry-run) must not leak into this run's request.
+		require.NoError(t, flag.Value.Set(flag.DefValue))
+		flag.Changed = false
+	})
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs(args)
+	err := command.Execute()
+	return output.String(), err
+}
+
+func TestAttributeDefinitionListPrintsRegistryAndForwardsFilter(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var query string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/api/v1/attribute-definitions", r.URL.Path)
+		query = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"definitions":[` + testAttributeDefinitionJSON + `]}`))
+		assert.NoError(err)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	output, err := runAttributeCommand(t, attributeDefinitionListCmd,
+		"--object-type", "person")
+	require.NoError(err)
+	assert.Contains(query, "object_type=person")
+	assert.Contains(output, "ask_me_about")
+	assert.Contains(output, "93c658a1-2346-4a6e-98c2-abfa29209334")
+}
+
+func TestAttributeDefinitionCreateDryRunValidatesLocally(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	output, err := runAttributeCommand(t, attributeDefinitionCreateCmd,
+		"--definition", `{"object_type":"person","slug":"scratch_note",
+			"label":"Scratch note","value_type":"text","field_type":"text"}`,
+		"--dry-run")
+	require.NoError(err)
+	assert.Zero(requests)
+	assert.Contains(output, "Would create")
+	assert.Contains(output, "scratch_note")
+}
+
+func TestAttributeDefinitionCreateRejectsUnsupportedUniqueness(t *testing.T) {
+	_, err := runAttributeCommand(t, attributeDefinitionCreateCmd,
+		"--definition", `{"object_type":"person","slug":"employee_number",
+			"label":"Employee number","value_type":"text","field_type":"text",
+			"is_unique":true}`,
+		"--dry-run")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uniqueness is not supported")
+}
+
+func TestAttributeDefinitionRenameUsesFreshRevisionETag(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var patchIfMatch string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			patchIfMatch = r.Header.Get("If-Match")
+			var body map[string]json.RawMessage
+			assert.NoError(json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(`"Conversation starters"`, string(body["label"]))
+		}
+		_, err := w.Write([]byte(testAttributeDefinitionJSON))
+		assert.NoError(err)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	_, err := runAttributeCommand(t, attributeDefinitionRenameCmd,
+		"3", "--label", "Conversation starters")
+	require.NoError(err)
+	assert.Equal(`"attribute-definition-3-r7"`, patchIfMatch)
+}
+
+func TestAttributeDefinitionClearDescriptionSendsEmptyString(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var description json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			var body map[string]json.RawMessage
+			assert.NoError(json.NewDecoder(r.Body).Decode(&body))
+			description = body["description"]
+		}
+		_, err := w.Write([]byte(testAttributeDefinitionJSON))
+		assert.NoError(err)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	_, err := runAttributeCommand(t, attributeDefinitionRenameCmd,
+		"3", "--clear-description")
+	require.NoError(err)
+	assert.Equal(`""`, string(description))
+}

--- a/cmd/msgvault/cmd/attribute_definition_test.go
+++ b/cmd/msgvault/cmd/attribute_definition_test.go
@@ -107,6 +107,42 @@ func TestAttributeDefinitionCreateDryRunValidatesLocally(t *testing.T) {
 	assert.Contains(output, "scratch_note")
 }
 
+func TestAttributeDefinitionCreateDryRunAppliesServerValidationLocally(t *testing.T) {
+	tests := []struct {
+		name     string
+		document string
+		wantErr  string
+	}{
+		{
+			name: "invalid slug",
+			document: `{"object_type":"person","slug":"Bad Slug","label":"Bad",
+				"value_type":"text","field_type":"text"}`,
+			wantErr: "slug",
+		},
+		{
+			name: "select without choices",
+			document: `{"object_type":"person","slug":"favorite_tea","label":"Favorite tea",
+				"value_type":"text","field_type":"select"}`,
+			wantErr: "choices",
+		},
+		{
+			name: "multiselect on single cardinality",
+			document: `{"object_type":"person","slug":"tags","label":"Tags",
+				"value_type":"text","field_type":"multiselect","cardinality":"single",
+				"options":{"choices":[{"value":"a","label":"A"}]}}`,
+			wantErr: "multi",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := runAttributeCommand(t, attributeDefinitionCreateCmd,
+				"--definition", test.document, "--dry-run")
+			require.Error(t, err, "dry run must reject what the server would reject")
+			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}
+
 func TestAttributeDefinitionCreateRejectsUnsupportedUniqueness(t *testing.T) {
 	_, err := runAttributeCommand(t, attributeDefinitionCreateCmd,
 		"--definition", `{"object_type":"person","slug":"employee_number",

--- a/cmd/msgvault/cmd/create_subset.go
+++ b/cmd/msgvault/cmd/create_subset.go
@@ -26,9 +26,10 @@ and can be used directly:
 }
 
 var (
-	subsetOutput          string
-	subsetRows            int
-	subsetIncludeIdentity bool
+	subsetOutput            string
+	subsetRows              int
+	subsetIncludeIdentity   bool
+	subsetIncludeAttributes bool
 )
 
 func init() {
@@ -45,6 +46,10 @@ func init() {
 		"copy full identity clusters and person profiles for included "+
 			"participants; exposes identifiers (emails, phone numbers) of "+
 			"linked identities that have no messages in the subset",
+	)
+	createSubsetCmd.Flags().BoolVar(
+		&subsetIncludeAttributes, "include-attributes", false,
+		"copy person attribute definitions and all current/history values; may expose sensitive values and provenance metadata",
 	)
 	_ = createSubsetCmd.MarkFlagRequired("output")
 	_ = createSubsetCmd.MarkFlagRequired("rows")
@@ -89,8 +94,16 @@ func runCreateSubset(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stderr,
 		"Copying %d messages from %s...\n", subsetRows, srcDBPath,
 	)
+	if subsetIncludeAttributes {
+		fmt.Fprintln(os.Stderr,
+			"WARNING: --include-attributes copies every included person's current and historical attribute values, including sensitive content, provenance references, and actor metadata.")
+	}
 
-	result, err := store.CopySubset(srcDBPath, dstDir, subsetRows, subsetIncludeIdentity)
+	result, err := store.CopySubsetWithOptions(srcDBPath, dstDir, subsetRows,
+		store.CopySubsetOptions{
+			IncludeIdentity:   subsetIncludeIdentity,
+			IncludeAttributes: subsetIncludeAttributes,
+		})
 	if err != nil {
 		return fmt.Errorf("create subset: %w", err)
 	}

--- a/cmd/msgvault/cmd/person_attributes.go
+++ b/cmd/msgvault/cmd/person_attributes.go
@@ -1,0 +1,428 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	apiclient "go.kenn.io/msgvault/pkg/client"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+var (
+	personAttributesJSONOutput   bool
+	personAttributesHistory      bool
+	personAttributesSlug         string
+	personAttributeValue         string
+	personAttributeValueJSON     string
+	personAttributeOrdinal       int64
+	personAttributeOrdinalSet    bool
+	personAttributeSource        string
+	personAttributeSourceRef     string
+	personAttributeConfidence    float64
+	personAttributeConfidenceSet bool
+	personAttributeActor         string
+	personAttributeExpectedID    int64
+	personAttributeDryRun        bool
+)
+
+var personAttributesCmd = &cobra.Command{
+	Use:   "attributes",
+	Short: "Inspect and set a person's typed attribute values",
+	Long: "Inspect and set a person's typed attribute values. Setting a value\n" +
+		"supersedes the previous one rather than overwriting it, so history stays\n" +
+		"readable. Read-only derived definitions are listed with no value until\n" +
+		"their producing subsystem supplies one.",
+}
+
+var personAttributesListCmd = &cobra.Command{
+	Use:   cmdUseList + " <person-id>",
+	Short: "List a person's attribute definitions and values",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		personID, err := positivePersonCLIArg(cmd, args[0], "person")
+		if err != nil {
+			return err
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		resp, err := listCLIPersonAttributes(cmd, client, personID,
+			personAttributesHistory, personAttributesSlug)
+		if err != nil {
+			return err
+		}
+		if resp.JSON200 == nil {
+			return errors.New("person attributes response was empty")
+		}
+		if personAttributesJSONOutput {
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(resp.JSON200)
+		}
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "SLUG\tORDINAL\tVALUE\tSOURCE\tACTIVE FROM\tACTIVE UNTIL\tMODE")
+		for _, group := range resp.JSON200.Attributes {
+			mode := attributeDefinitionMode(group.Definition)
+			if len(group.Current) == 0 && len(group.History) == 0 {
+				_, _ = fmt.Fprintf(w, "%s\t-\t-\t-\t-\t-\t%s\n", group.Definition.Slug, mode)
+				continue
+			}
+			rows := group.Current
+			if personAttributesHistory {
+				rows = group.History
+			}
+			for _, value := range rows {
+				_, _ = fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
+					value.DefinitionSlug, value.Ordinal,
+					formatCLIAttributeValue(value.Value), value.Source,
+					value.ActiveFrom.Format(time.RFC3339),
+					formatCLIOptionalTime(value.ActiveUntil), mode)
+			}
+		}
+		return w.Flush()
+	},
+}
+
+var personAttributesSetCmd = &cobra.Command{
+	Use:   "set <person-id> <slug>",
+	Short: "Set a person's attribute value",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		personAttributeOrdinalSet = cmd.Flags().Changed("ordinal")
+		personAttributeConfidenceSet = cmd.Flags().Changed("confidence")
+		personID, err := positivePersonCLIArg(cmd, args[0], "person")
+		if err != nil {
+			return err
+		}
+		slug := strings.TrimSpace(args[1])
+		if slug == "" {
+			return usageErr(cmd, errors.New("attribute slug must not be empty"))
+		}
+		hasScalar := cmd.Flags().Changed("value")
+		hasJSON := cmd.Flags().Changed("value-json")
+		expectedValueIDSet := cmd.Flags().Changed("expected-value-id")
+		switch {
+		case hasScalar && hasJSON:
+			return usageErr(cmd, errors.New("--value and --value-json are mutually exclusive"))
+		case !hasScalar && !hasJSON:
+			return usageErr(cmd, errors.New("--value or --value-json is required"))
+		}
+		if expectedValueIDSet && personAttributeExpectedID < 1 {
+			return usageErr(cmd, errors.New("--expected-value-id must be a positive integer"))
+		}
+
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+
+		body := generated.SetPersonAttributeBody{}
+		if hasJSON {
+			document, readErr := readCLIDocument(cmd, personAttributeValueJSON)
+			if readErr != nil {
+				return readErr
+			}
+			decoder := json.NewDecoder(strings.NewReader(string(document)))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&body.Value); err != nil {
+				return usageErr(cmd, fmt.Errorf("invalid --value-json document: %w", err))
+			}
+		} else {
+			definition, defErr := cliPersonAttributeDefinition(cmd, client, personID, slug)
+			if defErr != nil {
+				return defErr
+			}
+			if err := applyCLIScalarAttributeValue(
+				cmd, &body.Value, definition.ValueType, personAttributeValue); err != nil {
+				return err
+			}
+		}
+		source := strings.TrimSpace(personAttributeSource)
+		if source == "" {
+			source = "user"
+		}
+		typedSource := generated.SetPersonAttributeRequestSource(source)
+		body.Source = &typedSource
+		if sourceRef := strings.TrimSpace(personAttributeSourceRef); sourceRef != "" {
+			body.SourceRef = &sourceRef
+		}
+		if personAttributeConfidenceSet {
+			body.Confidence = &personAttributeConfidence
+		}
+		if actor := strings.TrimSpace(personAttributeActor); actor != "" {
+			body.Actor = &actor
+		}
+		if personAttributeOrdinalSet {
+			body.Ordinal = &personAttributeOrdinal
+		}
+		if expectedValueIDSet {
+			body.ExpectedValueID = &personAttributeExpectedID
+		}
+		if err := body.Validate(); err != nil {
+			return usageErr(cmd, fmt.Errorf("invalid person attribute value: %w", err))
+		}
+
+		query := &generated.SetPersonAttributeQuery{}
+		if personAttributeDryRun {
+			dryRun := true
+			query.DryRun = &dryRun
+		}
+		resp, err := daemonclient.APIResponse(client,
+			func(api *apiclient.Client) (*generated.SetPersonAttributeResp, error) {
+				return api.SetPersonAttributeWithResponse(cmd.Context(),
+					&generated.SetPersonAttributeRequestOptions{
+						PathParams: &generated.SetPersonAttributePath{ID: personID, Slug: slug},
+						Query:      query,
+						Body:       &body,
+					})
+			})
+		if err != nil {
+			return err
+		}
+		return writeCLIPersonAttributeWrite(cmd, resp.JSON200)
+	},
+}
+
+var personAttributesClearCmd = &cobra.Command{
+	Use:   "clear <person-id> <slug>",
+	Short: "Supersede a person's current attribute value",
+	Long: "Supersede a person's current attribute value. The historical row is\n" +
+		"retained; this is not a delete.",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		personAttributeOrdinalSet = cmd.Flags().Changed("ordinal")
+		expectedValueIDSet := cmd.Flags().Changed("expected-value-id")
+		personID, err := positivePersonCLIArg(cmd, args[0], "person")
+		if err != nil {
+			return err
+		}
+		slug := strings.TrimSpace(args[1])
+		if slug == "" {
+			return usageErr(cmd, errors.New("attribute slug must not be empty"))
+		}
+		if expectedValueIDSet && personAttributeExpectedID < 1 {
+			return usageErr(cmd, errors.New("--expected-value-id must be a positive integer"))
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+
+		query := &generated.ClearPersonAttributeQuery{}
+		if personAttributeOrdinalSet {
+			query.Ordinal = &personAttributeOrdinal
+		}
+		if expectedValueIDSet {
+			query.ExpectedValueID = &personAttributeExpectedID
+		}
+		if personAttributeDryRun {
+			dryRun := true
+			query.DryRun = &dryRun
+		}
+		resp, err := daemonclient.APIResponse(client,
+			func(api *apiclient.Client) (*generated.ClearPersonAttributeResp, error) {
+				return api.ClearPersonAttributeWithResponse(cmd.Context(),
+					&generated.ClearPersonAttributeRequestOptions{
+						PathParams: &generated.ClearPersonAttributePath{ID: personID, Slug: slug},
+						Query:      query,
+					})
+			})
+		if err != nil {
+			return err
+		}
+		return writeCLIPersonAttributeWrite(cmd, resp.JSON200)
+	},
+}
+
+func listCLIPersonAttributes(
+	cmd *cobra.Command, client *daemonclient.Client,
+	personID int64, history bool, slug string,
+) (*generated.ListPersonAttributesResp, error) {
+	query := &generated.ListPersonAttributesQuery{}
+	if history {
+		includeHistory := true
+		query.History = &includeHistory
+	}
+	if trimmed := strings.TrimSpace(slug); trimmed != "" {
+		query.Slug = &trimmed
+	}
+	return daemonclient.APIResponse(client,
+		func(api *apiclient.Client) (*generated.ListPersonAttributesResp, error) {
+			return api.ListPersonAttributesWithResponse(cmd.Context(),
+				&generated.ListPersonAttributesRequestOptions{
+					PathParams: &generated.ListPersonAttributesPath{ID: personID},
+					Query:      query,
+				})
+		})
+}
+
+func cliPersonAttributeDefinition(
+	cmd *cobra.Command, client *daemonclient.Client, personID int64, slug string,
+) (*generated.AttributeDefinition, error) {
+	resp, err := listCLIPersonAttributes(cmd, client, personID, false, slug)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, errors.New("person attributes response was empty")
+	}
+	for i := range resp.JSON200.Attributes {
+		if resp.JSON200.Attributes[i].Definition.Slug == slug {
+			return &resp.JSON200.Attributes[i].Definition, nil
+		}
+	}
+	return nil, fmt.Errorf("no active attribute definition with slug %q", slug)
+}
+
+func applyCLIScalarAttributeValue(
+	cmd *cobra.Command, value *generated.AttributeValue, valueType, raw string,
+) error {
+	value.Type = valueType
+	trimmed := strings.TrimSpace(raw)
+	switch valueType {
+	case "text":
+		value.Text = &trimmed
+	case "integer":
+		parsed, err := strconv.ParseInt(trimmed, 10, 64)
+		if err != nil {
+			return usageErr(cmd, fmt.Errorf("--value %q must be an integer", trimmed))
+		}
+		value.Integer = &parsed
+	case "real":
+		parsed, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil {
+			return usageErr(cmd, fmt.Errorf("--value %q must be a number", trimmed))
+		}
+		value.Real = &parsed
+	case "boolean":
+		parsed, err := strconv.ParseBool(trimmed)
+		if err != nil {
+			return usageErr(cmd, fmt.Errorf("--value %q must be a boolean", trimmed))
+		}
+		value.Boolean = &parsed
+	case "date":
+		if _, err := time.Parse("2006-01-02", trimmed); err != nil {
+			return usageErr(cmd, fmt.Errorf("--value %q must be a YYYY-MM-DD date", trimmed))
+		}
+		value.Date = &trimmed
+	case "timestamp":
+		parsed, err := time.Parse(time.RFC3339, trimmed)
+		if err != nil {
+			return usageErr(cmd, fmt.Errorf(
+				"--value %q must be an RFC3339 timestamp", trimmed))
+		}
+		utc := parsed.UTC()
+		value.Timestamp = &utc
+	default:
+		return usageErr(cmd, fmt.Errorf(
+			"value type %s needs a structured value; use --value-json", valueType))
+	}
+	return nil
+}
+
+func formatCLIAttributeValue(value generated.AttributeValue) string {
+	switch {
+	case value.Text != nil:
+		return *value.Text
+	case value.Integer != nil:
+		return strconv.FormatInt(*value.Integer, 10)
+	case value.Real != nil:
+		return strconv.FormatFloat(*value.Real, 'g', -1, 64)
+	case value.Boolean != nil:
+		return strconv.FormatBool(*value.Boolean)
+	case value.Date != nil:
+		return *value.Date
+	case value.Timestamp != nil:
+		return value.Timestamp.Format(time.RFC3339)
+	case value.RecordType != nil && value.RecordID != nil:
+		return fmt.Sprintf("%s:%d", *value.RecordType, *value.RecordID)
+	case len(value.JSON) > 0:
+		return string(value.JSON)
+	default:
+		return "-"
+	}
+}
+
+func formatCLIOptionalTime(value *time.Time) string {
+	if value == nil {
+		return "-"
+	}
+	return value.Format(time.RFC3339)
+}
+
+func writeCLIPersonAttributeWrite(
+	cmd *cobra.Command, write *generated.PersonAttributeWrite,
+) error {
+	if write == nil {
+		return errors.New("person attribute response was empty")
+	}
+	if personAttributesJSONOutput {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(write)
+	}
+	prefix := ""
+	if write.DryRun {
+		prefix = "Dry run: "
+	}
+	if write.Superseded != nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"%sSuperseded %s ordinal %d: %s (active until %s)\n",
+			prefix, write.Superseded.DefinitionSlug, write.Superseded.Ordinal,
+			formatCLIAttributeValue(write.Superseded.Value),
+			formatCLIOptionalTime(write.Superseded.ActiveUntil))
+	}
+	if write.Value != nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"%sSet %s ordinal %d: %s (source %s, active from %s)\n",
+			prefix, write.Value.DefinitionSlug, write.Value.Ordinal,
+			formatCLIAttributeValue(write.Value.Value), write.Value.Source,
+			write.Value.ActiveFrom.Format(time.RFC3339))
+	}
+	return nil
+}
+
+func init() {
+	personCmd.AddCommand(personAttributesCmd)
+	personAttributesCmd.AddCommand(personAttributesListCmd,
+		personAttributesSetCmd, personAttributesClearCmd)
+	for _, command := range []*cobra.Command{
+		personAttributesListCmd, personAttributesSetCmd, personAttributesClearCmd,
+	} {
+		command.Flags().BoolVar(&personAttributesJSONOutput, flagJSON, false, "Output as JSON")
+	}
+	personAttributesListCmd.Flags().BoolVar(&personAttributesHistory,
+		"history", false, "Include superseded values")
+	personAttributesListCmd.Flags().StringVar(&personAttributesSlug,
+		"slug", "", "Restrict the listing to one definition slug")
+	personAttributesSetCmd.Flags().StringVar(&personAttributeValue,
+		"value", "", "Scalar value coerced to the definition's storage type")
+	personAttributesSetCmd.Flags().StringVar(&personAttributeValueJSON,
+		"value-json", "", "Typed value envelope as JSON, @path, or - for standard input")
+	personAttributesSetCmd.Flags().StringVar(&personAttributeSource,
+		"source", "", "Provenance: user, carddav_import, vcard_import, "+
+			"archive_observation, extraction, enrichment, or system")
+	personAttributesSetCmd.Flags().StringVar(&personAttributeSourceRef,
+		"source-ref", "", "Reference to the resource or message that produced the value")
+	personAttributesSetCmd.Flags().Float64Var(&personAttributeConfidence,
+		"confidence", 0, "Confidence between 0 and 1; only for derived or suggested values")
+	personAttributesSetCmd.Flags().StringVar(&personAttributeActor,
+		"actor", "", "Actor recorded with the value")
+	for _, command := range []*cobra.Command{personAttributesSetCmd, personAttributesClearCmd} {
+		command.Flags().Int64Var(&personAttributeExpectedID,
+			"expected-value-id", 0,
+			"Compare-and-swap: the current value ID expected to be superseded")
+		command.Flags().Int64Var(&personAttributeOrdinal, "ordinal", 0,
+			"Ordinal for a multi-valued definition")
+		command.Flags().BoolVar(&personAttributeDryRun, "dry-run", false,
+			"Validate and preview without writing")
+	}
+	personAttributesSetCmd.MarkFlagsMutuallyExclusive("value", "value-json")
+}

--- a/cmd/msgvault/cmd/person_attributes_test.go
+++ b/cmd/msgvault/cmd/person_attributes_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+const testPersonAttributesJSON = `{"person_id":7,"attributes":[{
+	"definition":{
+		"id":1,
+		"universal_id":"59e9a7d3-4904-4d0e-97d1-d0680e1e9e55",
+		"object_type":"person",
+		"slug":"primary_channel",
+		"label":"Primary channel",
+		"value_type":"text",
+		"field_type":"select",
+		"cardinality":"single",
+		"display_order":10,
+		"is_required":false,
+		"ownership":"system",
+		"ui_creatable":true,
+		"ui_editable":true,
+		"api_mutable":true,
+		"is_searchable":false,
+		"is_audited":true,
+		"is_deletable":false,
+		"history_exempt":false,
+		"is_active":true,
+		"revision":1,
+		"created_at":"2026-07-30T12:00:00Z",
+		"updated_at":"2026-07-30T12:00:00Z"
+	},
+	"current":[]
+}]}`
+
+func TestApplyCLIScalarAttributeValueCoercesTypedScalars(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	tests := []struct {
+		valueType string
+		raw       string
+		assert    func(*testing.T, generated.AttributeValue)
+	}{
+		{"text", " sailing ", func(t *testing.T, value generated.AttributeValue) {
+			t.Helper()
+			require.NotNil(t, value.Text)
+			assert.Equal(t, "sailing", *value.Text)
+		}},
+		{"integer", "30", func(t *testing.T, value generated.AttributeValue) {
+			t.Helper()
+			require.NotNil(t, value.Integer)
+			assert.Equal(t, int64(30), *value.Integer)
+		}},
+		{"boolean", "true", func(t *testing.T, value generated.AttributeValue) {
+			t.Helper()
+			require.NotNil(t, value.Boolean)
+			assert.True(t, *value.Boolean)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.valueType, func(t *testing.T) {
+			var value generated.AttributeValue
+			require.NoError(t, applyCLIScalarAttributeValue(
+				cmd, &value, test.valueType, test.raw))
+			test.assert(t, value)
+		})
+	}
+}
+
+func TestApplyCLIScalarAttributeValueRequiresJSONForStructuredTypes(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var value generated.AttributeValue
+	err := applyCLIScalarAttributeValue(cmd, &value, "json", `{"kind":"synthetic"}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--value-json")
+}
+
+func TestPersonAttributesSetCoercesScalarAndForwardsMetadata(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var query string
+	var received map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, err := w.Write([]byte(testPersonAttributesJSON))
+			assert.NoError(err)
+		case http.MethodPut:
+			assert.Equal("/api/v1/persons/7/attributes/primary_channel", r.URL.Path)
+			query = r.URL.RawQuery
+			assert.NoError(json.NewDecoder(r.Body).Decode(&received))
+			_, err := w.Write([]byte(`{"dry_run":true,"value":{
+				"id":12,"person_id":7,"definition_id":1,
+				"definition_slug":"primary_channel","ordinal":0,
+				"value":{"type":"text","text":"chat"},
+				"active_from":"2026-07-30T13:00:00Z",
+				"created_at":"2026-07-30T13:00:00Z",
+				"source":"extraction","confidence":0.62}}`))
+			assert.NoError(err)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	output, err := runAttributeCommand(t, personAttributesSetCmd,
+		"7", "primary_channel", "--value", "chat",
+		"--source", "extraction", "--source-ref", "message:1234",
+		"--confidence", "0.62", "--actor", "extractor",
+		"--expected-value-id", "11", "--dry-run")
+	require.NoError(err)
+	assert.Contains(query, "dry_run=true")
+	value, ok := received["value"].(map[string]any)
+	require.True(ok)
+	assert.Equal("text", value["type"])
+	assert.Equal("chat", value["text"])
+	assert.Equal("extraction", received["source"])
+	assert.Equal("message:1234", received["source_ref"])
+	assert.InDelta(0.62, received["confidence"], 0.0001)
+	assert.Equal("extractor", received["actor"])
+	assert.InDelta(11, received["expected_value_id"], 0)
+	assert.Contains(output, "Dry run")
+}
+
+func TestPersonAttributesSetRejectsExplicitNonPositiveExpectedValueID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	for _, expectedID := range []string{"0", "-1"} {
+		t.Run(expectedID, func(t *testing.T) {
+			_, err := runAttributeCommand(t, personAttributesSetCmd,
+				"7", "primary_channel", "--value", "chat",
+				"--expected-value-id", expectedID)
+			require.Error(err)
+			assert.ErrorContains(err, "--expected-value-id must be a positive integer")
+		})
+	}
+	assert.Zero(requests, "invalid compare-and-swap IDs must be rejected before any API request")
+}
+
+func TestPersonAttributesClearForwardsOrdinalAndExpectedValueID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var query string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodDelete, r.Method)
+		assert.Equal("/api/v1/persons/7/attributes/ask_me_about", r.URL.Path)
+		query = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"dry_run":false,"superseded":{
+			"id":11,"person_id":7,"definition_id":3,
+			"definition_slug":"ask_me_about","ordinal":1,
+			"value":{"type":"text","text":"sailing"},
+			"active_from":"2026-07-30T12:00:00Z",
+			"active_until":"2026-07-30T13:00:00Z",
+			"created_at":"2026-07-30T12:00:00Z",
+			"superseded_at":"2026-07-30T13:00:00Z",
+			"source":"user"}}`))
+		assert.NoError(err)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	output, err := runAttributeCommand(t, personAttributesClearCmd,
+		"7", "ask_me_about", "--ordinal", "1", "--expected-value-id", "11")
+	require.NoError(err)
+	assert.Contains(query, "ordinal=1")
+	assert.Contains(query, "expected_value_id=11")
+	assert.NotContains(query, "dry_run",
+		"a prior test's --dry-run must not leak into this run")
+	assert.Contains(output, "Superseded")
+}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -884,6 +884,8 @@ var _ api.CLIDedupDeleteStore = (*storeAPIAdapter)(nil)
 var _ api.ContextCLIDedupDeleteStore = (*storeAPIAdapter)(nil)
 var _ api.IdentityLinkStore = (*storeAPIAdapter)(nil)
 var _ api.PersonProfileStore = (*storeAPIAdapter)(nil)
+var _ api.AttributeDefinitionStore = (*storeAPIAdapter)(nil)
+var _ api.PersonAttributeStore = (*storeAPIAdapter)(nil)
 var _ api.IdentityCacheRefresher = (*storeAPIAdapter)(nil)
 var _ api.ClusterLookupStore = (*storeAPIAdapter)(nil)
 var _ api.ConversationWindowStore = (*storeAPIAdapter)(nil)
@@ -1625,6 +1627,60 @@ func (a *storeAPIAdapter) PersonForParticipantsContext(
 	ctx context.Context, participantIDs []int64,
 ) (*store.Person, error) {
 	return a.store.PersonForParticipantsContext(ctx, participantIDs)
+}
+
+func (a *storeAPIAdapter) ListAttributeDefinitionsContext(
+	ctx context.Context, filter store.AttributeDefinitionFilter,
+) ([]store.AttributeDefinition, error) {
+	return a.store.ListAttributeDefinitionsContext(ctx, filter)
+}
+
+func (a *storeAPIAdapter) GetAttributeDefinitionContext(
+	ctx context.Context, id int64,
+) (*store.AttributeDefinition, error) {
+	return a.store.GetAttributeDefinitionContext(ctx, id)
+}
+
+func (a *storeAPIAdapter) GetAttributeDefinitionBySlugContext(
+	ctx context.Context, objectType store.AttributeObjectType, slug string,
+) (*store.AttributeDefinition, error) {
+	return a.store.GetAttributeDefinitionBySlugContext(ctx, objectType, slug)
+}
+
+func (a *storeAPIAdapter) CreateAttributeDefinitionContext(
+	ctx context.Context, input store.AttributeDefinitionInput,
+) (*store.AttributeDefinition, error) {
+	return a.store.CreateAttributeDefinitionContext(ctx, input)
+}
+
+func (a *storeAPIAdapter) UpdateAttributeDefinitionContext(
+	ctx context.Context, id, expectedRevision int64, update store.AttributeDefinitionUpdate,
+) (*store.AttributeDefinition, error) {
+	return a.store.UpdateAttributeDefinitionContext(ctx, id, expectedRevision, update)
+}
+
+func (a *storeAPIAdapter) DeleteAttributeDefinitionContext(
+	ctx context.Context, id, expectedRevision int64,
+) error {
+	return a.store.DeleteAttributeDefinitionContext(ctx, id, expectedRevision)
+}
+
+func (a *storeAPIAdapter) ListPersonAttributeValuesContext(
+	ctx context.Context, personID int64, query store.PersonAttributeQuery,
+) ([]store.PersonAttributeValue, error) {
+	return a.store.ListPersonAttributeValuesContext(ctx, personID, query)
+}
+
+func (a *storeAPIAdapter) SetPersonAttributeValueContext(
+	ctx context.Context, input store.PersonAttributeValueInput,
+) (*store.PersonAttributeWrite, error) {
+	return a.store.SetPersonAttributeValueContext(ctx, input)
+}
+
+func (a *storeAPIAdapter) SupersedePersonAttributeValueContext(
+	ctx context.Context, input store.PersonAttributeSupersedeInput,
+) (*store.PersonAttributeWrite, error) {
+	return a.store.SupersedePersonAttributeValueContext(ctx, input)
 }
 
 func (a *storeAPIAdapter) ClusterMembers(id int64) ([]int64, error) {

--- a/cmd/msgvault/cmd/store_adapter_test.go
+++ b/cmd/msgvault/cmd/store_adapter_test.go
@@ -30,6 +30,21 @@ func TestStoreAPIAdapterImplementsCtxMessageStore(t *testing.T) {
 	require.True(t, ok, "storeAPIAdapter must implement api.CtxMessageStore")
 }
 
+func TestStoreAPIAdapterServesAttributeDefinitions(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	srv := api.NewServerWithOptions(api.ServerOptions{
+		Config: &config.Config{},
+		Store:  &storeAPIAdapter{store: st},
+		Logger: slog.New(slog.DiscardHandler),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/attribute-definitions", nil)
+	response := httptest.NewRecorder()
+	srv.Router().ServeHTTP(response, req)
+
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+}
+
 var _ api.CtxMessageStore = (*storeAPIAdapter)(nil)
 var _ api.MeetingImporter = (*storeAPIAdapter)(nil)
 

--- a/internal/api/attribute_definitions.go
+++ b/internal/api/attribute_definitions.go
@@ -1,0 +1,440 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const attributeDefinitionsPath = "/api/v1/attribute-definitions"
+
+var attributeReservedRequestKeys = map[string]struct{}{
+	"is_unique": {},
+	"unique":    {},
+}
+
+// AttributeDefinitionStore is the definition capability required by the API.
+type AttributeDefinitionStore interface {
+	ListAttributeDefinitionsContext(
+		ctx context.Context, filter store.AttributeDefinitionFilter,
+	) ([]store.AttributeDefinition, error)
+	GetAttributeDefinitionContext(
+		ctx context.Context, id int64,
+	) (*store.AttributeDefinition, error)
+	GetAttributeDefinitionBySlugContext(
+		ctx context.Context, objectType store.AttributeObjectType, slug string,
+	) (*store.AttributeDefinition, error)
+	CreateAttributeDefinitionContext(
+		ctx context.Context, input store.AttributeDefinitionInput,
+	) (*store.AttributeDefinition, error)
+	UpdateAttributeDefinitionContext(
+		ctx context.Context, id, expectedRevision int64,
+		update store.AttributeDefinitionUpdate,
+	) (*store.AttributeDefinition, error)
+	DeleteAttributeDefinitionContext(ctx context.Context, id, expectedRevision int64) error
+}
+
+// AttributeDefinitionsResponse wraps a definition listing.
+type AttributeDefinitionsResponse struct {
+	Definitions []store.AttributeDefinition `json:"definitions"`
+}
+
+// CreateAttributeDefinitionRequest is the user-creatable definition subset.
+type CreateAttributeDefinitionRequest struct {
+	ObjectType    string                  `json:"object_type" enum:"person,organization"`
+	Slug          string                  `json:"slug"`
+	Label         string                  `json:"label"`
+	Description   *string                 `json:"description,omitempty"`
+	ValueType     string                  `json:"value_type"`
+	FieldType     string                  `json:"field_type"`
+	RecordTarget  *string                 `json:"record_target,omitempty"`
+	Cardinality   string                  `json:"cardinality,omitempty" enum:"single,multi"`
+	DisplayOrder  int64                   `json:"display_order,omitempty"`
+	IsRequired    bool                    `json:"is_required,omitempty"`
+	IsSearchable  bool                    `json:"is_searchable,omitempty"`
+	IsAudited     bool                    `json:"is_audited,omitempty"`
+	Options       *store.AttributeOptions `json:"options,omitempty"`
+	VCardProperty *string                 `json:"vcard_property,omitempty"`
+}
+
+// PatchAttributeDefinitionRequest carries mutable definition fields.
+type PatchAttributeDefinitionRequest struct {
+	Label        *string `json:"label,omitempty"`
+	Description  *string `json:"description,omitempty" nullable:"true"`
+	DisplayOrder *int64  `json:"display_order,omitempty"`
+	IsActive     *bool   `json:"is_active,omitempty"`
+}
+
+func (s *Server) registerAttributeDefinitionRoutes(api huma.API) {
+	list := rawAPIV1Operation("listAttributeDefinitions", http.MethodGet,
+		"/attribute-definitions", "List portable attribute definitions")
+	list.Parameters = append(list.Parameters,
+		queryStringParam("object_type", "Filter by object type", false),
+		queryBooleanParam("include_hidden", "Include deactivated definitions"))
+	list.Responses = jsonResponsesFor[AttributeDefinitionsResponse](api)
+	addErrorResponses(api, list.Responses, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, list, s.handleListAttributeDefinitions)
+
+	create := rawAPIV1Operation("createAttributeDefinition", http.MethodPost,
+		"/attribute-definitions", "Create a user attribute definition")
+	create.RequestBody = jsonRequestBodyFor[CreateAttributeDefinitionRequest](api)
+	create.Responses = jsonResponsesFor[store.AttributeDefinition](api, http.StatusCreated)
+	addAttributeDefinitionETagHeader(create.Responses[httpStatusKey(http.StatusCreated)])
+	addErrorResponses(api, create.Responses, http.StatusBadRequest,
+		http.StatusConflict, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, create, s.handleCreateAttributeDefinition)
+
+	get := rawAPIV1Operation("getAttributeDefinition", http.MethodGet,
+		"/attribute-definitions/{id}", "Get one attribute definition")
+	addAttributeDefinitionIDParameter(&get)
+	get.Responses = jsonResponsesFor[store.AttributeDefinition](api)
+	addAttributeDefinitionETagHeader(get.Responses[httpStatusKey(http.StatusOK)])
+	addErrorResponses(api, get.Responses, http.StatusNotFound, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, get, s.handleGetAttributeDefinition)
+
+	patch := rawAPIV1Operation("patchAttributeDefinition", http.MethodPatch,
+		"/attribute-definitions/{id}", "Update mutable attribute definition fields")
+	addAttributeDefinitionIDParameter(&patch)
+	addAttributeDefinitionIfMatchParameter(&patch)
+	patch.RequestBody = jsonRequestBodyFor[PatchAttributeDefinitionRequest](api)
+	patch.Responses = jsonResponsesFor[store.AttributeDefinition](api)
+	addAttributeDefinitionETagHeader(patch.Responses[httpStatusKey(http.StatusOK)])
+	addErrorResponses(api, patch.Responses, http.StatusBadRequest, http.StatusConflict,
+		http.StatusNotFound, http.StatusPreconditionRequired, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, patch, s.handlePatchAttributeDefinition)
+
+	remove := rawAPIV1Operation("deleteAttributeDefinition", http.MethodDelete,
+		"/attribute-definitions/{id}", "Delete a user attribute definition")
+	addAttributeDefinitionIDParameter(&remove)
+	addAttributeDefinitionIfMatchParameter(&remove)
+	remove.Responses = rawHumaResponses(http.StatusNoContent)
+	remove.Responses["default"] = errorResponseFor(api)
+	addErrorResponses(api, remove.Responses, http.StatusBadRequest, http.StatusConflict,
+		http.StatusNotFound, http.StatusPreconditionRequired, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, remove, s.handleDeleteAttributeDefinition)
+}
+
+func (s *Server) handleListAttributeDefinitions(w http.ResponseWriter, r *http.Request) {
+	definitions, ok := s.attributeDefinitionStore(w)
+	if !ok {
+		return
+	}
+	filter := store.AttributeDefinitionFilter{}
+	if raw := strings.TrimSpace(r.URL.Query().Get("object_type")); raw != "" {
+		if raw != string(store.AttributeObjectPerson) &&
+			raw != string(store.AttributeObjectOrganization) {
+			writeError(w, http.StatusBadRequest, "invalid_object_type",
+				"object_type must be person or organization")
+			return
+		}
+		filter.ObjectType = store.AttributeObjectType(raw)
+	}
+	includeHidden, _, err := queryBool(r, "include_hidden")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	filter.IncludeHidden = includeHidden
+	listed, err := definitions.ListAttributeDefinitionsContext(r.Context(), filter)
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, AttributeDefinitionsResponse{Definitions: listed})
+}
+
+func (s *Server) handleCreateAttributeDefinition(w http.ResponseWriter, r *http.Request) {
+	definitions, ok := s.attributeDefinitionStore(w)
+	if !ok {
+		return
+	}
+	var request CreateAttributeDefinitionRequest
+	if !decodeAttributeRequest(w, r, &request) {
+		return
+	}
+	universalID, err := store.NewAttributeUniversalID()
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	input := store.AttributeDefinitionInput{
+		UniversalID: universalID, ObjectType: store.AttributeObjectType(request.ObjectType),
+		Slug: request.Slug, Label: request.Label, Description: request.Description,
+		ValueType:    store.AttributeValueType(request.ValueType),
+		FieldType:    store.AttributeFieldType(request.FieldType),
+		RecordTarget: request.RecordTarget, Cardinality: store.AttributeCardinality(request.Cardinality),
+		DisplayOrder: request.DisplayOrder, IsRequired: request.IsRequired,
+		Ownership: store.AttributeOwnershipUser, UICreatable: true, UIEditable: true,
+		APIMutable: true, IsSearchable: request.IsSearchable, IsAudited: request.IsAudited,
+		IsDeletable: true, Options: request.Options, VCardProperty: request.VCardProperty,
+	}
+	created, err := definitions.CreateAttributeDefinitionContext(r.Context(), input)
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	w.Header().Set("Location",
+		attributeDefinitionsPath+"/"+strconv.FormatInt(created.ID, 10))
+	writeAttributeDefinition(w, http.StatusCreated, created)
+}
+
+func (s *Server) handleGetAttributeDefinition(w http.ResponseWriter, r *http.Request) {
+	definitions, ok := s.attributeDefinitionStore(w)
+	if !ok {
+		return
+	}
+	id, ok := attributeDefinitionID(w, r)
+	if !ok {
+		return
+	}
+	definition, err := definitions.GetAttributeDefinitionContext(r.Context(), id)
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	writeAttributeDefinition(w, http.StatusOK, definition)
+}
+
+func (s *Server) handlePatchAttributeDefinition(w http.ResponseWriter, r *http.Request) {
+	definitions, ok := s.attributeDefinitionStore(w)
+	if !ok {
+		return
+	}
+	id, ok := attributeDefinitionID(w, r)
+	if !ok {
+		return
+	}
+	revision, ok := attributeDefinitionIfMatch(w, r, id)
+	if !ok {
+		return
+	}
+	var request PatchAttributeDefinitionRequest
+	fields, ok := decodeAttributeRequestFields(w, r, &request)
+	if !ok {
+		return
+	}
+	update := store.AttributeDefinitionUpdate{
+		Label: request.Label, DisplayOrder: request.DisplayOrder, IsActive: request.IsActive,
+	}
+	if raw, present := fields["description"]; present {
+		description := request.Description
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			description = nil
+		}
+		update.Description = &description
+	}
+	updated, err := definitions.UpdateAttributeDefinitionContext(
+		r.Context(), id, revision, update)
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	writeAttributeDefinition(w, http.StatusOK, updated)
+}
+
+func (s *Server) handleDeleteAttributeDefinition(w http.ResponseWriter, r *http.Request) {
+	definitions, ok := s.attributeDefinitionStore(w)
+	if !ok {
+		return
+	}
+	id, ok := attributeDefinitionID(w, r)
+	if !ok {
+		return
+	}
+	revision, ok := attributeDefinitionIfMatch(w, r, id)
+	if !ok {
+		return
+	}
+	if err := definitions.DeleteAttributeDefinitionContext(
+		r.Context(), id, revision); err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) attributeDefinitionStore(
+	w http.ResponseWriter,
+) (AttributeDefinitionStore, bool) {
+	definitions, ok := s.store.(AttributeDefinitionStore)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "attributes_unavailable",
+			"Attribute definitions are unavailable")
+	}
+	return definitions, ok
+}
+
+func (s *Server) writeAttributeError(w http.ResponseWriter, err error) {
+	if s.writeIfContextError(w, err) {
+		return
+	}
+	switch {
+	case errors.Is(err, store.ErrAttributeUniquenessUnsupported):
+		writeError(w, http.StatusBadRequest, "attribute_uniqueness_unsupported", err.Error())
+	case errors.Is(err, store.ErrAttributeDefinitionInvalid),
+		errors.Is(err, store.ErrAttributeValueInvalid):
+		writeError(w, http.StatusBadRequest, "attribute_invalid", err.Error())
+	case errors.Is(err, store.ErrAttributeDefinitionNotFound):
+		writeError(w, http.StatusNotFound, "attribute_definition_not_found",
+			"Attribute definition not found")
+	case errors.Is(err, store.ErrAttributeValueNotFound):
+		writeError(w, http.StatusNotFound, "attribute_value_not_found", "Attribute value not found")
+	case errors.Is(err, store.ErrPersonNotFound):
+		writeError(w, http.StatusNotFound, "person_profile_not_found", "Person profile not found")
+	case errors.Is(err, store.ErrAttributeDefinitionSlugConflict):
+		writeError(w, http.StatusConflict, "attribute_definition_slug_conflict",
+			"An attribute definition with that slug already exists")
+	case errors.Is(err, store.ErrAttributeDefinitionUniversalIDConflict):
+		writeError(w, http.StatusConflict, "attribute_definition_universal_id_conflict",
+			"An attribute definition with that universal identifier already exists")
+	case errors.Is(err, store.ErrAttributeDefinitionRevisionConflict):
+		writeError(w, http.StatusConflict, "attribute_definition_revision_conflict",
+			"Attribute definition changed; reload and retry")
+	case errors.Is(err, store.ErrAttributeDefinitionNotDeletable):
+		writeError(w, http.StatusConflict, "attribute_definition_not_deletable",
+			"This attribute definition cannot be deleted")
+	case errors.Is(err, store.ErrAttributeDefinitionHasValues):
+		writeError(w, http.StatusConflict, "attribute_definition_has_values",
+			"This attribute definition still has stored values, including "+
+				"superseded history; definitions with recorded values cannot be deleted")
+	case errors.Is(err, store.ErrAttributeDefinitionNotWritable):
+		writeError(w, http.StatusConflict, "attribute_definition_not_writable", err.Error())
+	case errors.Is(err, store.ErrAttributeDefinitionInactive):
+		writeError(w, http.StatusConflict, "attribute_definition_inactive", err.Error())
+	case errors.Is(err, store.ErrAttributeValueConflict):
+		writeError(w, http.StatusConflict, "attribute_value_conflict",
+			"Attribute value changed; reload and retry")
+	default:
+		s.logger.Error("attribute operation failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "attribute_failed",
+			"Attribute operation failed")
+	}
+}
+
+func writeAttributeDefinition(
+	w http.ResponseWriter, status int, definition *store.AttributeDefinition,
+) {
+	w.Header().Set("ETag", attributeDefinitionETag(*definition))
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, status, definition)
+}
+
+func attributeDefinitionETag(definition store.AttributeDefinition) string {
+	return fmt.Sprintf(`"attribute-definition-%d-r%d"`, definition.ID, definition.Revision)
+}
+
+func addAttributeDefinitionIDParameter(operation *huma.Operation) {
+	operation.Parameters = append(operation.Parameters, &huma.Param{
+		Name: "id", In: "path", Required: true, Description: "Attribute definition ID",
+		Schema: &huma.Schema{Type: huma.TypeInteger, Format: "int64"},
+	})
+}
+
+func addAttributeDefinitionIfMatchParameter(operation *huma.Operation) {
+	operation.Parameters = append(operation.Parameters, &huma.Param{
+		Name: "If-Match", In: "header", Required: true,
+		Description: "Strong ETag returned by the latest definition read",
+		Schema:      &huma.Schema{Type: huma.TypeString},
+	})
+}
+
+func addAttributeDefinitionETagHeader(response *huma.Response) {
+	response.Headers = map[string]*huma.Param{
+		"ETag": {
+			Description: "Strong attribute definition revision tag",
+			Schema:      &huma.Schema{Type: huma.TypeString},
+		},
+	}
+}
+
+func attributeDefinitionID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "invalid_attribute_definition_id",
+			"Attribute definition ID must be a positive integer")
+		return 0, false
+	}
+	return id, true
+}
+
+func attributeDefinitionIfMatch(
+	w http.ResponseWriter, r *http.Request, id int64,
+) (int64, bool) {
+	values := r.Header.Values("If-Match")
+	if len(values) == 0 || (len(values) == 1 && strings.TrimSpace(values[0]) == "") {
+		writeError(w, http.StatusPreconditionRequired, "if_match_required",
+			"If-Match is required")
+		return 0, false
+	}
+	if len(values) != 1 {
+		writeError(w, http.StatusBadRequest, "invalid_if_match",
+			"If-Match must contain exactly one revision tag")
+		return 0, false
+	}
+	prefix := fmt.Sprintf(`"attribute-definition-%d-r`, id)
+	value := strings.TrimSpace(values[0])
+	if !strings.HasPrefix(value, prefix) || !strings.HasSuffix(value, `"`) {
+		writeError(w, http.StatusBadRequest, "invalid_if_match",
+			"If-Match is not an attribute definition revision tag")
+		return 0, false
+	}
+	revision, err := strconv.ParseInt(
+		strings.TrimSuffix(strings.TrimPrefix(value, prefix), `"`), 10, 64)
+	if err != nil || revision <= 0 {
+		writeError(w, http.StatusBadRequest, "invalid_if_match",
+			"If-Match is not an attribute definition revision tag")
+		return 0, false
+	}
+	return revision, true
+}
+
+func decodeAttributeRequest(w http.ResponseWriter, r *http.Request, target any) bool {
+	_, ok := decodeAttributeRequestFields(w, r, target)
+	return ok
+}
+
+func decodeAttributeRequestFields(
+	w http.ResponseWriter, r *http.Request, target any,
+) (map[string]json.RawMessage, bool) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid attribute request")
+		return nil, false
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil || fields == nil {
+		writeError(w, http.StatusBadRequest, "bad_request",
+			"Attribute request must be a JSON object")
+		return nil, false
+	}
+	for key := range attributeReservedRequestKeys {
+		if _, present := fields[key]; present {
+			writeError(w, http.StatusBadRequest, "attribute_uniqueness_unsupported",
+				store.ErrAttributeUniquenessUnsupported.Error())
+			return nil, false
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request",
+			"Invalid attribute request: "+err.Error())
+		return nil, false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "bad_request",
+			"Attribute request must contain one JSON object")
+		return nil, false
+	}
+	return fields, true
+}

--- a/internal/api/attribute_definitions.go
+++ b/internal/api/attribute_definitions.go
@@ -66,6 +66,25 @@ type CreateAttributeDefinitionRequest struct {
 	VCardProperty *string                 `json:"vcard_property,omitempty"`
 }
 
+// StoreInput maps the request onto the store's input shape, fixing the
+// capability flags the API grants to user-created definitions. The CLI
+// dry-run path reuses it so local validation matches the create path.
+func (r CreateAttributeDefinitionRequest) StoreInput(
+	universalID string,
+) store.AttributeDefinitionInput {
+	return store.AttributeDefinitionInput{
+		UniversalID: universalID, ObjectType: store.AttributeObjectType(r.ObjectType),
+		Slug: r.Slug, Label: r.Label, Description: r.Description,
+		ValueType:    store.AttributeValueType(r.ValueType),
+		FieldType:    store.AttributeFieldType(r.FieldType),
+		RecordTarget: r.RecordTarget, Cardinality: store.AttributeCardinality(r.Cardinality),
+		DisplayOrder: r.DisplayOrder, IsRequired: r.IsRequired,
+		Ownership: store.AttributeOwnershipUser, UICreatable: true, UIEditable: true,
+		APIMutable: true, IsSearchable: r.IsSearchable, IsAudited: r.IsAudited,
+		IsDeletable: true, Options: r.Options, VCardProperty: r.VCardProperty,
+	}
+}
+
 // PatchAttributeDefinitionRequest carries mutable definition fields.
 type PatchAttributeDefinitionRequest struct {
 	Label        *string `json:"label,omitempty"`
@@ -167,18 +186,8 @@ func (s *Server) handleCreateAttributeDefinition(w http.ResponseWriter, r *http.
 		s.writeAttributeError(w, err)
 		return
 	}
-	input := store.AttributeDefinitionInput{
-		UniversalID: universalID, ObjectType: store.AttributeObjectType(request.ObjectType),
-		Slug: request.Slug, Label: request.Label, Description: request.Description,
-		ValueType:    store.AttributeValueType(request.ValueType),
-		FieldType:    store.AttributeFieldType(request.FieldType),
-		RecordTarget: request.RecordTarget, Cardinality: store.AttributeCardinality(request.Cardinality),
-		DisplayOrder: request.DisplayOrder, IsRequired: request.IsRequired,
-		Ownership: store.AttributeOwnershipUser, UICreatable: true, UIEditable: true,
-		APIMutable: true, IsSearchable: request.IsSearchable, IsAudited: request.IsAudited,
-		IsDeletable: true, Options: request.Options, VCardProperty: request.VCardProperty,
-	}
-	created, err := definitions.CreateAttributeDefinitionContext(r.Context(), input)
+	created, err := definitions.CreateAttributeDefinitionContext(
+		r.Context(), request.StoreInput(universalID))
 	if err != nil {
 		s.writeAttributeError(w, err)
 		return

--- a/internal/api/attribute_definitions_test.go
+++ b/internal/api/attribute_definitions_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func attributeRequest(
+	t *testing.T, srv *Server, method, path string, body []byte, ifMatch string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if ifMatch != "" {
+		req.Header.Set("If-Match", ifMatch)
+	}
+	response := httptest.NewRecorder()
+	srv.Router().ServeHTTP(response, req)
+	return response
+}
+
+func TestAttributeDefinitionsHTTPListsSeedsAndRejectsUniqueness(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _ := newIdentityLinkTestServer(t)
+
+	response := attributeRequest(t, srv, http.MethodGet,
+		"/api/v1/attribute-definitions?object_type=person", nil, "")
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	var listed AttributeDefinitionsResponse
+	require.NoError(json.Unmarshal(response.Body.Bytes(), &listed))
+	require.Len(listed.Definitions, 4)
+	assert.NotContains(response.Body.String(), "is_unique")
+
+	rejected := attributeRequest(t, srv, http.MethodPost,
+		"/api/v1/attribute-definitions", []byte(`{
+			"object_type":"person","slug":"employee_number",
+			"label":"Employee number","value_type":"text","field_type":"text",
+			"is_unique":true
+		}`), "")
+	assert.Equal(http.StatusBadRequest, rejected.Code)
+	assert.Contains(rejected.Body.String(), "attribute_uniqueness_unsupported")
+}
+
+func TestAttributeDefinitionsHTTPCreateRenameAndDelete(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _ := newIdentityLinkTestServer(t)
+
+	createdResponse := attributeRequest(t, srv, http.MethodPost,
+		"/api/v1/attribute-definitions", []byte(`{
+			"object_type":"person","slug":"favorite_tea","label":"Favorite tea",
+			"value_type":"text","field_type":"select","cardinality":"multi",
+			"options":{"choices":[{"value":"green","label":"Green"}]}
+		}`), "")
+	require.Equal(http.StatusCreated, createdResponse.Code, createdResponse.Body.String())
+	var created store.AttributeDefinition
+	require.NoError(json.Unmarshal(createdResponse.Body.Bytes(), &created))
+	assert.NotEmpty(created.UniversalID)
+	assert.Equal(store.AttributeOwnershipUser, created.Ownership)
+	assert.Equal(fmt.Sprintf(`"attribute-definition-%d-r1"`, created.ID),
+		createdResponse.Header().Get("ETag"))
+
+	renamedResponse := attributeRequest(t, srv, http.MethodPatch,
+		fmt.Sprintf("/api/v1/attribute-definitions/%d", created.ID),
+		[]byte(`{"label":"Tea preferences"}`), createdResponse.Header().Get("ETag"))
+	require.Equal(http.StatusOK, renamedResponse.Code, renamedResponse.Body.String())
+	var renamed store.AttributeDefinition
+	require.NoError(json.Unmarshal(renamedResponse.Body.Bytes(), &renamed))
+	assert.Equal("Tea preferences", renamed.Label)
+	assert.Equal(created.UniversalID, renamed.UniversalID)
+	assert.Equal(created.Slug, renamed.Slug)
+
+	stale := attributeRequest(t, srv, http.MethodPatch,
+		fmt.Sprintf("/api/v1/attribute-definitions/%d", created.ID),
+		[]byte(`{"label":"Stale"}`), createdResponse.Header().Get("ETag"))
+	assert.Equal(http.StatusConflict, stale.Code)
+
+	removed := attributeRequest(t, srv, http.MethodDelete,
+		fmt.Sprintf("/api/v1/attribute-definitions/%d", created.ID), nil,
+		renamedResponse.Header().Get("ETag"))
+	assert.Equal(http.StatusNoContent, removed.Code, removed.Body.String())
+}
+
+func TestAttributeDefinitionsHTTPProtectsSeedAndRejectsUnknownFields(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, st := newIdentityLinkTestServer(t)
+
+	seeded, err := st.GetAttributeDefinitionBySlugContext(t.Context(),
+		store.AttributeObjectPerson, store.AttributeSlugPrimaryChannel)
+	require.NoError(err)
+	protected := attributeRequest(t, srv, http.MethodDelete,
+		fmt.Sprintf("/api/v1/attribute-definitions/%d", seeded.ID), nil,
+		attributeDefinitionETag(*seeded))
+	assert.Equal(http.StatusConflict, protected.Code)
+
+	unknown := attributeRequest(t, srv, http.MethodPost,
+		"/api/v1/attribute-definitions", []byte(`{
+			"object_type":"person","slug":"scratch","label":"Scratch",
+			"value_type":"text","field_type":"text","ownership":"system"
+		}`), "")
+	assert.Equal(http.StatusBadRequest, unknown.Code)
+}

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -169,7 +169,12 @@ import (
 // this archive is accepted whoever built it. Stores that cannot answer the
 // watermark query, or cannot identify their archive, report 503
 // feature_unavailable. Additive (minor bump): a new path only.
-const APISchemaVersion = "1.34.0"
+// 1.35.0 adds the portable attribute registry and typed person attributes:
+// attribute-definition list/get/create/patch/delete with ETag/If-Match
+// optimistic concurrency, and person attribute list/set/clear with
+// value-level provenance, retained history, and dry-run previews.
+// Additive (minor bump): the major-version compatibility gate stays at 1.
+const APISchemaVersion = "1.35.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -181,14 +181,40 @@ func TestOpenAPIFastSearchDocumentsSourceIDs(t *testing.T) {
 	assert.Fail("source_ids query parameter is not documented for fastSearch")
 }
 
+func TestOpenAPIPersonAttributeContract(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	assert.Equal("1.35.0", APISchemaVersion,
+		"attribute registry and person attributes are an additive schema release")
+
+	doc := OpenAPIDocument()
+	definitions := doc.Paths["/api/v1/attribute-definitions"]
+	require.NotNil(definitions, "attribute definitions path")
+	assert.NotNil(definitions.Get, "attribute definitions list operation")
+	assert.NotNil(definitions.Post, "attribute definitions create operation")
+	definition := doc.Paths["/api/v1/attribute-definitions/{id}"]
+	require.NotNil(definition, "attribute definition path")
+	assert.NotNil(definition.Patch, "attribute definition patch operation")
+	assert.NotNil(definition.Delete, "attribute definition delete operation")
+	values := doc.Paths["/api/v1/persons/{id}/attributes"]
+	require.NotNil(values, "person attributes path")
+	assert.NotNil(values.Get, "person attributes list operation")
+	value := doc.Paths["/api/v1/persons/{id}/attributes/{slug}"]
+	require.NotNil(value, "person attribute value path")
+	assert.NotNil(value.Put, "person attribute set operation")
+	assert.NotNil(value.Delete, "person attribute clear operation")
+}
+
 func TestOpenAPIMeetingImportContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
 	// Pinned so that anyone bumping the schema version has to come here and
 	// confirm the meeting-import contract below still holds. Meeting import
-	// shipped in 1.33.0; the feed added in 1.34.0 did not touch it.
-	assert.Equal("1.34.0", APISchemaVersion, "meeting import is an additive schema release")
+	// shipped in 1.33.0; the feed added in 1.34.0 and the attributes added
+	// in 1.35.0 did not touch it.
+	assert.Equal("1.35.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/person_attributes.go
+++ b/internal/api/person_attributes.go
@@ -1,0 +1,315 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var errPersonsUnavailable = errors.New("person profiles are unavailable")
+
+// PersonAttributeStore is the value capability required by the API.
+type PersonAttributeStore interface {
+	AttributeDefinitionStore
+	ListPersonAttributeValuesContext(
+		ctx context.Context, personID int64, query store.PersonAttributeQuery,
+	) ([]store.PersonAttributeValue, error)
+	SetPersonAttributeValueContext(
+		ctx context.Context, input store.PersonAttributeValueInput,
+	) (*store.PersonAttributeWrite, error)
+	SupersedePersonAttributeValueContext(
+		ctx context.Context, input store.PersonAttributeSupersedeInput,
+	) (*store.PersonAttributeWrite, error)
+}
+
+// PersonAttributeGroup pairs a definition with current and historical values.
+type PersonAttributeGroup struct {
+	Definition store.AttributeDefinition    `json:"definition"`
+	Current    []store.PersonAttributeValue `json:"current"`
+	History    []store.PersonAttributeValue `json:"history,omitempty"`
+}
+
+// PersonAttributesResponse is the grouped attribute read model.
+type PersonAttributesResponse struct {
+	PersonID   int64                  `json:"person_id"`
+	Attributes []PersonAttributeGroup `json:"attributes"`
+}
+
+// SetPersonAttributeRequest carries a typed value and its provenance.
+type SetPersonAttributeRequest struct {
+	Value           store.AttributeValue `json:"value"`
+	Ordinal         *int64               `json:"ordinal,omitempty"`
+	Source          string               `json:"source,omitempty" enum:"user,carddav_import,vcard_import,archive_observation,extraction,enrichment,system"`
+	SourceRef       *string              `json:"source_ref,omitempty"`
+	Confidence      *float64             `json:"confidence,omitempty"`
+	Actor           *string              `json:"actor,omitempty"`
+	ActiveFrom      *time.Time           `json:"active_from,omitempty"`
+	ActiveUntil     *time.Time           `json:"active_until,omitempty"`
+	ExpectedValueID *int64               `json:"expected_value_id,omitempty"`
+}
+
+func (s *Server) registerPersonAttributeRoutes(api huma.API) {
+	list := rawAPIV1Operation("listPersonAttributes", http.MethodGet,
+		"/persons/{id}/attributes", "List a person's typed attributes")
+	addPersonIDParameter(&list)
+	list.Parameters = append(list.Parameters,
+		queryBooleanParam("history", "Include superseded values"),
+		queryStringParam("slug", "Restrict the response to one definition slug", false))
+	list.Responses = jsonResponsesFor[PersonAttributesResponse](api)
+	addErrorResponses(api, list.Responses, http.StatusNotFound, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, list, s.handleListPersonAttributes)
+
+	set := rawAPIV1Operation("setPersonAttribute", http.MethodPut,
+		"/persons/{id}/attributes/{slug}", "Set a person's attribute value")
+	addPersonIDParameter(&set)
+	addAttributeSlugParameter(&set)
+	set.Parameters = append(set.Parameters,
+		queryBooleanParam("dry_run", "Validate and preview without writing"))
+	set.RequestBody = jsonRequestBodyFor[SetPersonAttributeRequest](api)
+	set.Responses = jsonResponsesFor[store.PersonAttributeWrite](api)
+	addErrorResponses(api, set.Responses, http.StatusBadRequest, http.StatusConflict,
+		http.StatusNotFound, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, set, s.handleSetPersonAttribute)
+
+	clearOperation := rawAPIV1Operation("clearPersonAttribute", http.MethodDelete,
+		"/persons/{id}/attributes/{slug}", "Supersede a person's attribute value")
+	addPersonIDParameter(&clearOperation)
+	addAttributeSlugParameter(&clearOperation)
+	clearOperation.Parameters = append(clearOperation.Parameters,
+		queryIntegerParam("ordinal", "Ordinal for a multi-valued definition"),
+		queryIntegerParam("expected_value_id",
+			"Compare-and-swap: the current value ID expected to be superseded"),
+		queryBooleanParam("dry_run", "Validate and preview without writing"))
+	clearOperation.Responses = jsonResponsesFor[store.PersonAttributeWrite](api)
+	addErrorResponses(api, clearOperation.Responses, http.StatusBadRequest, http.StatusConflict,
+		http.StatusNotFound, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, clearOperation, s.handleClearPersonAttribute)
+}
+
+func addAttributeSlugParameter(operation *huma.Operation) {
+	operation.Parameters = append(operation.Parameters, &huma.Param{
+		Name: "slug", In: "path", Required: true,
+		Description: "Immutable attribute definition slug",
+		Schema:      &huma.Schema{Type: huma.TypeString},
+	})
+}
+
+func (s *Server) handleListPersonAttributes(w http.ResponseWriter, r *http.Request) {
+	attributes, ok := s.personAttributeStore(w)
+	if !ok {
+		return
+	}
+	personID, ok := personProfileID(w, r)
+	if !ok {
+		return
+	}
+	includeHistory, _, err := queryBool(r, "history")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	slug := strings.TrimSpace(r.URL.Query().Get("slug"))
+	if slug != "" {
+		if err := store.ValidateAttributeSlug(slug); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_attribute_slug", err.Error())
+			return
+		}
+	}
+	if _, err := s.requirePersonForAttributes(w, r, personID); err != nil {
+		return
+	}
+	definitions, err := attributes.ListAttributeDefinitionsContext(r.Context(),
+		store.AttributeDefinitionFilter{
+			ObjectType: store.AttributeObjectPerson, IncludeHidden: true})
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	values, err := attributes.ListPersonAttributeValuesContext(r.Context(), personID,
+		store.PersonAttributeQuery{DefinitionSlug: slug, IncludeHistory: includeHistory})
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+
+	current := make(map[string][]store.PersonAttributeValue, len(definitions))
+	history := make(map[string][]store.PersonAttributeValue, len(definitions))
+	stored := make(map[string]bool, len(definitions))
+	for _, value := range values {
+		stored[value.DefinitionSlug] = true
+		if value.ActiveUntil == nil && value.SupersededAt == nil {
+			current[value.DefinitionSlug] = append(current[value.DefinitionSlug], value)
+		}
+		if includeHistory {
+			history[value.DefinitionSlug] = append(history[value.DefinitionSlug], value)
+		}
+	}
+
+	response := PersonAttributesResponse{
+		PersonID: personID, Attributes: make([]PersonAttributeGroup, 0, len(definitions)),
+	}
+	for _, definition := range definitions {
+		if slug != "" && definition.Slug != slug {
+			continue
+		}
+		// Inactive definitions appear only while values remain stored under
+		// them; hiding those values entirely would look like data loss.
+		if !definition.IsActive && !stored[definition.Slug] {
+			continue
+		}
+		group := PersonAttributeGroup{
+			Definition: definition, Current: current[definition.Slug],
+		}
+		if group.Current == nil {
+			group.Current = []store.PersonAttributeValue{}
+		}
+		if includeHistory {
+			group.History = history[definition.Slug]
+			if group.History == nil {
+				group.History = []store.PersonAttributeValue{}
+			}
+		}
+		response.Attributes = append(response.Attributes, group)
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) handleSetPersonAttribute(w http.ResponseWriter, r *http.Request) {
+	attributes, ok := s.personAttributeStore(w)
+	if !ok {
+		return
+	}
+	personID, slug, ok := personAttributeTarget(w, r)
+	if !ok {
+		return
+	}
+	dryRun, _, err := queryBool(r, "dry_run")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	var request SetPersonAttributeRequest
+	if !decodeAttributeRequest(w, r, &request) {
+		return
+	}
+	if request.ExpectedValueID != nil && *request.ExpectedValueID < 1 {
+		writeError(w, http.StatusBadRequest, "invalid_expected_value_id",
+			"expected_value_id must be a positive integer")
+		return
+	}
+	source := store.Provenance(strings.TrimSpace(request.Source))
+	if source == "" {
+		source = store.ProvenanceUser
+	}
+	write, err := attributes.SetPersonAttributeValueContext(r.Context(),
+		store.PersonAttributeValueInput{
+			PersonID: personID, DefinitionSlug: slug, Ordinal: request.Ordinal,
+			Value: request.Value, ActiveFrom: request.ActiveFrom,
+			ActiveUntil: request.ActiveUntil, Source: source, SourceRef: request.SourceRef,
+			Confidence: request.Confidence, Actor: request.Actor,
+			ExpectedValueID: request.ExpectedValueID, DryRun: dryRun,
+		})
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, write)
+}
+
+func (s *Server) handleClearPersonAttribute(w http.ResponseWriter, r *http.Request) {
+	attributes, ok := s.personAttributeStore(w)
+	if !ok {
+		return
+	}
+	personID, slug, ok := personAttributeTarget(w, r)
+	if !ok {
+		return
+	}
+	dryRun, _, err := queryBool(r, "dry_run")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	expectedValueID, hasExpectedValueID, err := queryInt64(r, "expected_value_id")
+	if err != nil {
+		s.rejectBadParam(w, err)
+		return
+	}
+	if hasExpectedValueID && expectedValueID < 1 {
+		writeError(w, http.StatusBadRequest, "invalid_expected_value_id",
+			"expected_value_id must be a positive integer")
+		return
+	}
+	var expectedValueIDPtr *int64
+	if hasExpectedValueID {
+		expectedValueIDPtr = &expectedValueID
+	}
+	var ordinal *int64
+	if raw := strings.TrimSpace(r.URL.Query().Get("ordinal")); raw != "" {
+		parsed, parseErr := strconv.ParseInt(raw, 10, 64)
+		if parseErr != nil || parsed < 0 {
+			writeError(w, http.StatusBadRequest, "invalid_ordinal",
+				"ordinal must be a non-negative integer")
+			return
+		}
+		ordinal = &parsed
+	}
+	write, err := attributes.SupersedePersonAttributeValueContext(r.Context(),
+		store.PersonAttributeSupersedeInput{
+			PersonID: personID, DefinitionSlug: slug, Ordinal: ordinal,
+			ExpectedValueID: expectedValueIDPtr, DryRun: dryRun,
+		})
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, write)
+}
+
+func (s *Server) personAttributeStore(w http.ResponseWriter) (PersonAttributeStore, bool) {
+	attributes, ok := s.store.(PersonAttributeStore)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "attributes_unavailable",
+			"Person attributes are unavailable")
+	}
+	return attributes, ok
+}
+
+func personAttributeTarget(w http.ResponseWriter, r *http.Request) (int64, string, bool) {
+	personID, ok := personProfileID(w, r)
+	if !ok {
+		return 0, "", false
+	}
+	slug := strings.TrimSpace(r.PathValue("slug"))
+	if err := store.ValidateAttributeSlug(slug); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_attribute_slug", err.Error())
+		return 0, "", false
+	}
+	return personID, slug, true
+}
+
+func (s *Server) requirePersonForAttributes(
+	w http.ResponseWriter, r *http.Request, personID int64,
+) (*store.Person, error) {
+	profiles, ok := s.store.(PersonProfileStore)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "persons_unavailable",
+			"Person profiles are unavailable")
+		return nil, errPersonsUnavailable
+	}
+	person, err := profiles.GetPersonContext(r.Context(), personID)
+	if err != nil {
+		s.writeAttributeError(w, err)
+		return nil, err
+	}
+	return person, nil
+}

--- a/internal/api/person_attributes_test.go
+++ b/internal/api/person_attributes_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func personAttributesPath(personID int64) string {
+	return fmt.Sprintf("%s/%d/attributes", personsPath, personID)
+}
+
+func newPersonAttributeFixture(t *testing.T) (*Server, int64) {
+	t.Helper()
+	srv, st := newIdentityLinkTestServer(t)
+	participant := st.mustParticipant(t, "alice@example.com", "alice", "example.com")
+	person, _, err := st.CreatePersonFromParticipant(participant)
+	require.NoError(t, err)
+	return srv, person.ID
+}
+
+func decodePersonAttributes(
+	t *testing.T, body []byte,
+) map[string]PersonAttributeGroup {
+	t.Helper()
+	var response PersonAttributesResponse
+	require.NoError(t, json.Unmarshal(body, &response))
+	grouped := make(map[string]PersonAttributeGroup, len(response.Attributes))
+	for _, group := range response.Attributes {
+		grouped[group.Definition.Slug] = group
+	}
+	return grouped
+}
+
+func TestPersonAttributesHTTPListsDefinitionsSetsHistoryAndClears(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, person := newPersonAttributeFixture(t)
+
+	listed := attributeRequest(t, srv, http.MethodGet,
+		personAttributesPath(person), nil, "")
+	require.Equal(http.StatusOK, listed.Code, listed.Body.String())
+	groups := decodePersonAttributes(t, listed.Body.Bytes())
+	require.Len(groups, 4)
+	assert.Empty(groups[store.AttributeSlugLastContacted].Current)
+
+	path := personAttributesPath(person) + "/" + store.AttributeSlugPrimaryChannel
+	first := attributeRequest(t, srv, http.MethodPut, path,
+		[]byte(`{"value":{"type":"text","text":"email"},"source":"user"}`), "")
+	require.Equal(http.StatusOK, first.Code, first.Body.String())
+	var firstWrite store.PersonAttributeWrite
+	require.NoError(json.Unmarshal(first.Body.Bytes(), &firstWrite))
+
+	second := attributeRequest(t, srv, http.MethodPut, path,
+		[]byte(`{"value":{"type":"text","text":"chat"},"source":"user"}`), "")
+	require.Equal(http.StatusOK, second.Code, second.Body.String())
+	var secondWrite store.PersonAttributeWrite
+	require.NoError(json.Unmarshal(second.Body.Bytes(), &secondWrite))
+	require.NotNil(secondWrite.Superseded)
+	assert.Equal(firstWrite.Value.ID, secondWrite.Superseded.ID)
+
+	history := attributeRequest(t, srv, http.MethodGet,
+		personAttributesPath(person)+"?history=true", nil, "")
+	require.Equal(http.StatusOK, history.Code)
+	historyGroups := decodePersonAttributes(t, history.Body.Bytes())
+	assert.Len(historyGroups[store.AttributeSlugPrimaryChannel].History, 2)
+
+	cleared := attributeRequest(t, srv, http.MethodDelete, path, nil, "")
+	require.Equal(http.StatusOK, cleared.Code, cleared.Body.String())
+}
+
+func TestPersonAttributesHTTPClearRejectsStaleExpectedValueID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, person := newPersonAttributeFixture(t)
+	path := personAttributesPath(person) + "/" + store.AttributeSlugPrimaryChannel
+
+	first := attributeRequest(t, srv, http.MethodPut, path,
+		[]byte(`{"value":{"type":"text","text":"email"},"source":"user"}`), "")
+	require.Equal(http.StatusOK, first.Code, first.Body.String())
+	var firstWrite store.PersonAttributeWrite
+	require.NoError(json.Unmarshal(first.Body.Bytes(), &firstWrite))
+
+	second := attributeRequest(t, srv, http.MethodPut, path,
+		[]byte(`{"value":{"type":"text","text":"chat"},"source":"user"}`), "")
+	require.Equal(http.StatusOK, second.Code, second.Body.String())
+	var secondWrite store.PersonAttributeWrite
+	require.NoError(json.Unmarshal(second.Body.Bytes(), &secondWrite))
+
+	staleClear := attributeRequest(t, srv, http.MethodDelete,
+		fmt.Sprintf("%s?expected_value_id=%d", path, firstWrite.Value.ID), nil, "")
+	require.Equal(http.StatusConflict, staleClear.Code, staleClear.Body.String())
+
+	listed := attributeRequest(t, srv, http.MethodGet,
+		personAttributesPath(person), nil, "")
+	require.Equal(http.StatusOK, listed.Code, listed.Body.String())
+	current := decodePersonAttributes(t, listed.Body.Bytes())[store.AttributeSlugPrimaryChannel].Current
+	require.Len(current, 1)
+	assert.Equal(secondWrite.Value.ID, current[0].ID)
+}
+
+func TestPersonAttributesHTTPRejectsDerivedInvalidUnknownAndSupportsDryRun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, person := newPersonAttributeFixture(t)
+
+	derived := attributeRequest(t, srv, http.MethodPut,
+		personAttributesPath(person)+"/"+store.AttributeSlugLastContacted,
+		[]byte(`{"value":{"type":"timestamp","timestamp":"2026-07-30T09:00:00Z"},
+			"source":"system"}`), "")
+	assert.Equal(http.StatusConflict, derived.Code)
+
+	invalid := attributeRequest(t, srv, http.MethodPut,
+		personAttributesPath(person)+"/"+store.AttributeSlugPrimaryChannel,
+		[]byte(`{"value":{"type":"text","text":"carrier_pigeon"},"source":"user"}`), "")
+	assert.Equal(http.StatusBadRequest, invalid.Code)
+
+	for _, malformed := range [][]byte{
+		[]byte(`{"value":{"type":"text","text":"email","record_type":"person"},"source":"user"}`),
+		[]byte(`{"value":{"type":"text","text":"email","record_id":1},"source":"user"}`),
+	} {
+		response := attributeRequest(t, srv, http.MethodPut,
+			personAttributesPath(person)+"/"+store.AttributeSlugPrimaryChannel,
+			malformed, "")
+		assert.Equal(http.StatusBadRequest, response.Code, response.Body.String())
+	}
+
+	unknown := attributeRequest(t, srv, http.MethodPut,
+		personAttributesPath(person)+"/no_such_definition",
+		[]byte(`{"value":{"type":"text","text":"x"},"source":"user"}`), "")
+	assert.Equal(http.StatusNotFound, unknown.Code)
+
+	preview := attributeRequest(t, srv, http.MethodPut,
+		personAttributesPath(person)+"/"+store.AttributeSlugPrimaryChannel+"?dry_run=true",
+		[]byte(`{"value":{"type":"text","text":"email"},"source":"user"}`), "")
+	require.Equal(http.StatusOK, preview.Code, preview.Body.String())
+	var write store.PersonAttributeWrite
+	require.NoError(json.Unmarshal(preview.Body.Bytes(), &write))
+	assert.True(write.DryRun)
+	assert.Zero(write.Value.ID)
+
+	missing := attributeRequest(t, srv, http.MethodGet,
+		personAttributesPath(999_999), nil, "")
+	assert.Equal(http.StatusNotFound, missing.Code)
+
+	badExpected := attributeRequest(t, srv, http.MethodPut,
+		personAttributesPath(person)+"/"+store.AttributeSlugPrimaryChannel,
+		[]byte(`{"value":{"type":"text","text":"email"},"source":"user",
+			"expected_value_id":-5}`), "")
+	assert.Equal(http.StatusBadRequest, badExpected.Code, badExpected.Body.String())
+}
+
+func TestPersonAttributesHTTPKeepsInactiveDefinitionValuesVisibleAndClearable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, st := newIdentityLinkTestServer(t)
+	participant := st.mustParticipant(t, "alice@example.com", "alice", "example.com")
+	person, _, err := st.CreatePersonFromParticipant(participant)
+	require.NoError(err)
+	ctx := t.Context()
+
+	definition, err := st.CreateAttributeDefinitionContext(ctx,
+		store.AttributeDefinitionInput{
+			UniversalID: "test-retired-api-field", ObjectType: store.AttributeObjectPerson,
+			Slug: "retired_api_field", Label: "Retired field",
+			ValueType: store.AttributeValueText, FieldType: store.AttributeFieldText,
+			APIMutable: true, IsDeletable: true,
+		})
+	require.NoError(err)
+	path := personAttributesPath(person.ID) + "/" + definition.Slug
+	set := attributeRequest(t, srv, http.MethodPut, path,
+		[]byte(`{"value":{"type":"text","text":"stale"},"source":"user"}`), "")
+	require.Equal(http.StatusOK, set.Code, set.Body.String())
+
+	inactive := false
+	_, err = st.UpdateAttributeDefinitionContext(ctx, definition.ID, definition.Revision,
+		store.AttributeDefinitionUpdate{IsActive: &inactive})
+	require.NoError(err)
+
+	listed := attributeRequest(t, srv, http.MethodGet,
+		personAttributesPath(person.ID), nil, "")
+	require.Equal(http.StatusOK, listed.Code, listed.Body.String())
+	groups := decodePersonAttributes(t, listed.Body.Bytes())
+	group, ok := groups[definition.Slug]
+	require.True(ok, "values under an inactive definition must stay listed")
+	assert.False(group.Definition.IsActive)
+	require.Len(group.Current, 1)
+
+	cleared := attributeRequest(t, srv, http.MethodDelete, path, nil, "")
+	require.Equal(http.StatusOK, cleared.Code, cleared.Body.String())
+
+	relisted := attributeRequest(t, srv, http.MethodGet,
+		personAttributesPath(person.ID), nil, "")
+	require.Equal(http.StatusOK, relisted.Code)
+	_, ok = decodePersonAttributes(t, relisted.Body.Bytes())[definition.Slug]
+	assert.False(ok,
+		"an inactive definition with no current values must drop out of the listing")
+}

--- a/internal/api/person_profiles.go
+++ b/internal/api/person_profiles.go
@@ -220,6 +220,9 @@ func (s *Server) writePersonError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "person_revision_conflict", "Person profile changed; reload and retry")
 	case errors.Is(err, store.ErrPersonBindingConflict):
 		writeError(w, http.StatusConflict, "person_binding_conflict", "The identity clusters belong to different person profiles")
+	case errors.Is(err, store.ErrPersonReferenced):
+		writeError(w, http.StatusConflict, "person_referenced",
+			"Another profile still references this person")
 	case errors.Is(err, store.ErrParticipantNotFound), errors.Is(err, store.ErrInvalidParticipantID):
 		writeError(w, http.StatusBadRequest, "invalid_participant_id", err.Error())
 	default:

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -213,6 +213,8 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	s.registerExploreRoutes(apiV1)
 	s.registerFilesRoutes(apiV1)
 	s.registerPersonProfileRoutes(apiV1)
+	s.registerAttributeDefinitionRoutes(apiV1)
+	s.registerPersonAttributeRoutes(apiV1)
 	s.registerPeopleRoutes(apiV1)
 	s.registerRelationshipRoutes(apiV1)
 	s.registerIdentityLinkRoutes(apiV1)

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -463,7 +463,7 @@ func TestSettingsOpenAPIContract(t *testing.T) {
 	for _, status := range []string{"400", "409", "412", "422", "428"} {
 		assert.Contains(patch.Responses, status)
 	}
-	assert.Equal("1.34.0", doc.Info.Version)
+	assert.Equal(APISchemaVersion, doc.Info.Version)
 
 	settingValue := doc.Components.Schemas.Map()["SettingValue"]
 	require.NotNil(settingValue)

--- a/internal/codegenfix/cmd/main.go
+++ b/internal/codegenfix/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"go/format"
 	"os"
 
 	"go.kenn.io/msgvault/internal/codegenfix"
@@ -17,6 +18,9 @@ func main() {
 	source, err := os.ReadFile(path)
 	if err == nil {
 		source, err = codegenfix.RewriteGeneratedValidators(source)
+	}
+	if err == nil {
+		source, err = format.Source(source)
 	}
 	if err == nil {
 		// #nosec G703 -- path is the same explicit generated-file argument read above.

--- a/internal/codegenfix/fix.go
+++ b/internal/codegenfix/fix.go
@@ -2,6 +2,7 @@ package codegenfix
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 )
 
@@ -57,5 +58,11 @@ func RewriteGeneratedValidators(source []byte) ([]byte, error) {
 			return nil, fmt.Errorf("generated %s.%s validator shape changed", typeName, field)
 		}
 	}
+	attributeJSON := []byte("*struct{}  `json:\"json,omitempty\"`")
+	if !bytes.Contains(result, attributeJSON) {
+		return nil, errors.New("generated AttributeValue.JSON shape changed")
+	}
+	result = bytes.Replace(result, attributeJSON,
+		[]byte("json.RawMessage `json:\"json,omitempty\"`"), 1)
 	return result, nil
 }

--- a/internal/codegenfix/fix_test.go
+++ b/internal/codegenfix/fix_test.go
@@ -15,6 +15,7 @@ func TestRewriteGeneratedValidatorsMakesRequiredPointersUnconditional(t *testing
 	assertions.NotContains(string(got), "if f.MimeType != nil")
 	assertions.Contains(string(got), `typesValidator.Var(e.Grouping, "required,min=1,max=1")`)
 	assertions.Contains(string(got), `typesValidator.Var(f.Grouping, "required,min=1,max=1")`)
+	assertions.Contains(string(got), "JSON json.RawMessage")
 }
 
 func TestRewriteGeneratedValidatorsRejectsMissingGroupingValidator(t *testing.T) {
@@ -24,7 +25,10 @@ func TestRewriteGeneratedValidatorsRejectsMissingGroupingValidator(t *testing.T)
 }
 
 func generatedValidatorFixture() string {
-	return `func (e ExploreGroupsHTTPRequest) Validate() error {
+	return `type AttributeValue struct {
+	JSON *struct{}  ` + "`json:\"json,omitempty\"`" + `
+}
+func (e ExploreGroupsHTTPRequest) Validate() error {
 	var errors runtime.ValidationErrors
 }
 func (f FileGroupsHTTPRequest) Validate() error {

--- a/internal/store/attribute_definitions.go
+++ b/internal/store/attribute_definitions.go
@@ -1,0 +1,830 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/jsonexact"
+)
+
+var (
+	ErrAttributeDefinitionNotFound     = errors.New("attribute definition not found")
+	ErrAttributeDefinitionInvalid      = errors.New("invalid attribute definition")
+	ErrAttributeDefinitionSlugConflict = errors.New(
+		"attribute definition slug already exists for this object type")
+	ErrAttributeDefinitionUniversalIDConflict = errors.New(
+		"attribute definition universal id already exists")
+	ErrAttributeDefinitionRevisionConflict = errors.New(
+		"attribute definition revision conflict")
+	ErrAttributeDefinitionNotDeletable = errors.New(
+		"attribute definition is not deletable")
+	ErrAttributeDefinitionHasValues = errors.New(
+		"attribute definition still has stored values")
+	// ErrAttributeUniquenessUnsupported rejects decorative uniqueness metadata.
+	ErrAttributeUniquenessUnsupported = errors.New(
+		"attribute definition uniqueness is not supported: " +
+			"a uniqueness claim must be backed by a portable database index")
+)
+
+// AttributeObjectType identifies the kind of record a definition describes.
+type AttributeObjectType string
+
+const (
+	AttributeObjectPerson       AttributeObjectType = "person"
+	AttributeObjectOrganization AttributeObjectType = "organization"
+)
+
+// AttributeValueType identifies a definition's storage type.
+type AttributeValueType string
+
+const (
+	AttributeValueText            AttributeValueType = "text"
+	AttributeValueInteger         AttributeValueType = "integer"
+	AttributeValueReal            AttributeValueType = "real"
+	AttributeValueBoolean         AttributeValueType = "boolean"
+	AttributeValueDate            AttributeValueType = "date"
+	AttributeValueTimestamp       AttributeValueType = "timestamp"
+	AttributeValueJSON            AttributeValueType = "json"
+	AttributeValueRecordReference AttributeValueType = "record_reference"
+)
+
+// AttributeFieldType identifies a definition's presentation widget.
+type AttributeFieldType string
+
+const (
+	AttributeFieldText         AttributeFieldType = "text"
+	AttributeFieldTextarea     AttributeFieldType = "textarea"
+	AttributeFieldSelect       AttributeFieldType = "select"
+	AttributeFieldMultiselect  AttributeFieldType = "multiselect"
+	AttributeFieldCheckbox     AttributeFieldType = "checkbox"
+	AttributeFieldDate         AttributeFieldType = "date"
+	AttributeFieldTimestamp    AttributeFieldType = "timestamp"
+	AttributeFieldDuration     AttributeFieldType = "duration"
+	AttributeFieldPerson       AttributeFieldType = "person"
+	AttributeFieldOrganization AttributeFieldType = "organization"
+	AttributeFieldURL          AttributeFieldType = "url"
+	AttributeFieldEmail        AttributeFieldType = "email"
+	AttributeFieldPhone        AttributeFieldType = "phone"
+	AttributeFieldJSON         AttributeFieldType = "json"
+)
+
+// AttributeCardinality describes whether a definition has one or many values.
+type AttributeCardinality string
+
+const (
+	AttributeCardinalitySingle AttributeCardinality = "single"
+	AttributeCardinalityMulti  AttributeCardinality = "multi"
+)
+
+// AttributeOwnership distinguishes shipped definitions from user definitions.
+type AttributeOwnership string
+
+const (
+	AttributeOwnershipSystem AttributeOwnership = "system"
+	AttributeOwnershipUser   AttributeOwnership = "user"
+)
+
+var attributeObjectTypes = map[AttributeObjectType]bool{
+	AttributeObjectPerson: true, AttributeObjectOrganization: true,
+}
+
+var attributeValueTypes = map[AttributeValueType]bool{
+	AttributeValueText: true, AttributeValueInteger: true, AttributeValueReal: true,
+	AttributeValueBoolean: true, AttributeValueDate: true, AttributeValueTimestamp: true,
+	AttributeValueJSON: true, AttributeValueRecordReference: true,
+}
+
+var attributeFieldTypes = map[AttributeFieldType]bool{
+	AttributeFieldText: true, AttributeFieldTextarea: true, AttributeFieldSelect: true,
+	AttributeFieldMultiselect: true, AttributeFieldCheckbox: true, AttributeFieldDate: true,
+	AttributeFieldTimestamp: true, AttributeFieldDuration: true, AttributeFieldPerson: true,
+	AttributeFieldOrganization: true, AttributeFieldURL: true, AttributeFieldEmail: true,
+	AttributeFieldPhone: true, AttributeFieldJSON: true,
+}
+
+var attributeRecordTargets = map[string]bool{"person": true}
+
+var attributeSlugPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)
+
+var attributeVCardPropertyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9-]{0,62}$`)
+
+// AttributeChoice is one option offered by a select widget.
+type AttributeChoice struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+// AttributeOptions is the closed settings envelope for a definition.
+type AttributeOptions struct {
+	Choices   []AttributeChoice `json:"choices,omitempty"`
+	Unit      string            `json:"unit,omitempty"`
+	MaxLength int               `json:"max_length,omitempty"`
+}
+
+// ChoiceValues returns option values in declaration order.
+func (o *AttributeOptions) ChoiceValues() []string {
+	if o == nil {
+		return nil
+	}
+	values := make([]string, 0, len(o.Choices))
+	for _, choice := range o.Choices {
+		values = append(values, choice.Value)
+	}
+	return values
+}
+
+// AttributeDefinition is portable metadata for one typed field.
+type AttributeDefinition struct {
+	ID            int64                `json:"id"`
+	UniversalID   string               `json:"universal_id"`
+	ObjectType    AttributeObjectType  `json:"object_type"`
+	Slug          string               `json:"slug"`
+	Label         string               `json:"label"`
+	Description   *string              `json:"description,omitempty"`
+	ValueType     AttributeValueType   `json:"value_type"`
+	FieldType     AttributeFieldType   `json:"field_type"`
+	RecordTarget  *string              `json:"record_target,omitempty"`
+	Cardinality   AttributeCardinality `json:"cardinality"`
+	DisplayOrder  int64                `json:"display_order"`
+	IsRequired    bool                 `json:"is_required"`
+	Ownership     AttributeOwnership   `json:"ownership"`
+	UICreatable   bool                 `json:"ui_creatable"`
+	UIEditable    bool                 `json:"ui_editable"`
+	APIMutable    bool                 `json:"api_mutable"`
+	IsSearchable  bool                 `json:"is_searchable"`
+	IsAudited     bool                 `json:"is_audited"`
+	IsDeletable   bool                 `json:"is_deletable"`
+	HistoryExempt bool                 `json:"history_exempt"`
+	DerivedSource *string              `json:"derived_source,omitempty"`
+	Options       *AttributeOptions    `json:"options,omitempty"`
+	VCardProperty *string              `json:"vcard_property,omitempty"`
+	IsActive      bool                 `json:"is_active"`
+	Revision      int64                `json:"revision"`
+	CreatedAt     time.Time            `json:"created_at"`
+	UpdatedAt     time.Time            `json:"updated_at"`
+}
+
+// AttributeDefinitionInput is a complete new definition.
+type AttributeDefinitionInput struct {
+	UniversalID   string
+	ObjectType    AttributeObjectType
+	Slug          string
+	Label         string
+	Description   *string
+	ValueType     AttributeValueType
+	FieldType     AttributeFieldType
+	RecordTarget  *string
+	Cardinality   AttributeCardinality
+	DisplayOrder  int64
+	IsRequired    bool
+	Ownership     AttributeOwnership
+	UICreatable   bool
+	UIEditable    bool
+	APIMutable    bool
+	IsSearchable  bool
+	IsAudited     bool
+	IsDeletable   bool
+	HistoryExempt bool
+	DerivedSource *string
+	Options       *AttributeOptions
+	VCardProperty *string
+}
+
+// AttributeDefinitionUpdate carries only mutable definition fields.
+type AttributeDefinitionUpdate struct {
+	Label        *string
+	Description  **string
+	DisplayOrder *int64
+	IsActive     *bool
+}
+
+// AttributeDefinitionFilter narrows a definition listing.
+type AttributeDefinitionFilter struct {
+	ObjectType    AttributeObjectType
+	IncludeHidden bool
+}
+
+// ValidateAttributeSlug checks the immutable machine-name syntax.
+func ValidateAttributeSlug(slug string) error {
+	if !attributeSlugPattern.MatchString(slug) {
+		return fmt.Errorf(
+			"%w: slug %q must match %s",
+			ErrAttributeDefinitionInvalid, slug, attributeSlugPattern.String())
+	}
+	return nil
+}
+
+func validateAttributeDefinitionInput(
+	input AttributeDefinitionInput,
+) (AttributeDefinitionInput, error) {
+	invalid := func(format string, args ...any) (AttributeDefinitionInput, error) {
+		return AttributeDefinitionInput{}, fmt.Errorf(
+			"%w: %s", ErrAttributeDefinitionInvalid, fmt.Sprintf(format, args...))
+	}
+
+	input.UniversalID = strings.TrimSpace(input.UniversalID)
+	input.Slug = strings.TrimSpace(input.Slug)
+	input.Label = strings.TrimSpace(input.Label)
+	if input.Cardinality == "" {
+		input.Cardinality = AttributeCardinalitySingle
+	}
+	if input.Ownership == "" {
+		input.Ownership = AttributeOwnershipUser
+	}
+
+	if input.UniversalID == "" {
+		return invalid("universal_id is required")
+	}
+	if err := ValidateAttributeSlug(input.Slug); err != nil {
+		return AttributeDefinitionInput{}, err
+	}
+	if input.Label == "" {
+		return invalid("label is required")
+	}
+	if !attributeObjectTypes[input.ObjectType] {
+		return invalid("object_type %q is not supported", input.ObjectType)
+	}
+	if !attributeValueTypes[input.ValueType] {
+		return invalid("value_type %q is not supported", input.ValueType)
+	}
+	if !attributeFieldTypes[input.FieldType] {
+		return invalid("field_type %q is not supported", input.FieldType)
+	}
+	if input.Cardinality != AttributeCardinalitySingle &&
+		input.Cardinality != AttributeCardinalityMulti {
+		return invalid("cardinality %q is not supported", input.Cardinality)
+	}
+	if input.Ownership != AttributeOwnershipSystem &&
+		input.Ownership != AttributeOwnershipUser {
+		return invalid("ownership %q is not supported", input.Ownership)
+	}
+	if input.DisplayOrder < 0 {
+		return invalid("display_order must not be negative")
+	}
+
+	if input.ValueType == AttributeValueRecordReference {
+		if input.RecordTarget == nil || strings.TrimSpace(*input.RecordTarget) == "" {
+			return invalid("record_target is required for value_type record_reference")
+		}
+		target := strings.TrimSpace(*input.RecordTarget)
+		if !attributeRecordTargets[target] {
+			return invalid("record_target %q is not supported yet", target)
+		}
+		input.RecordTarget = &target
+	} else if input.RecordTarget != nil {
+		return invalid("record_target is only valid for value_type record_reference")
+	}
+
+	if err := validateAttributeWidget(input); err != nil {
+		return AttributeDefinitionInput{}, err
+	}
+
+	if input.VCardProperty != nil {
+		property := strings.TrimSpace(*input.VCardProperty)
+		if !attributeVCardPropertyPattern.MatchString(property) {
+			return invalid("vcard_property %q must be an uppercase vCard token", property)
+		}
+		input.VCardProperty = &property
+	}
+	if input.DerivedSource != nil {
+		derived := strings.TrimSpace(*input.DerivedSource)
+		if derived == "" {
+			return invalid("derived_source must not be blank when present")
+		}
+		input.APIMutable = false
+		input.UICreatable = false
+		input.UIEditable = false
+		input.DerivedSource = &derived
+	}
+	if input.Description != nil {
+		description := strings.TrimSpace(*input.Description)
+		if description == "" {
+			input.Description = nil
+		} else {
+			input.Description = &description
+		}
+	}
+	return input, nil
+}
+
+func validateAttributeWidget(input AttributeDefinitionInput) error {
+	invalid := func(format string, args ...any) error {
+		return fmt.Errorf("%w: %s", ErrAttributeDefinitionInvalid,
+			fmt.Sprintf(format, args...))
+	}
+	switch input.FieldType {
+	case AttributeFieldSelect, AttributeFieldMultiselect:
+		if input.Options == nil || len(input.Options.Choices) == 0 {
+			return invalid("field_type %s requires options.choices", input.FieldType)
+		}
+		if !attributeValueTypeHasCanonicalString(input.ValueType) {
+			return invalid("field_type %s value_type %s has no canonical string form",
+				input.FieldType, input.ValueType)
+		}
+	case AttributeFieldCheckbox:
+		if input.ValueType != AttributeValueBoolean {
+			return invalid("field_type checkbox requires value_type boolean")
+		}
+	case AttributeFieldDate:
+		if input.ValueType != AttributeValueDate {
+			return invalid("field_type date requires value_type date")
+		}
+	case AttributeFieldTimestamp:
+		if input.ValueType != AttributeValueTimestamp {
+			return invalid("field_type timestamp requires value_type timestamp")
+		}
+	case AttributeFieldDuration:
+		if input.ValueType != AttributeValueInteger {
+			return invalid("field_type duration requires value_type integer")
+		}
+	case AttributeFieldPerson, AttributeFieldOrganization:
+		if input.ValueType != AttributeValueRecordReference {
+			return invalid("field_type %s requires value_type record_reference",
+				input.FieldType)
+		}
+		expectedTarget := string(input.FieldType)
+		if input.RecordTarget == nil || *input.RecordTarget != expectedTarget {
+			return invalid("field_type %s requires record_target %s",
+				input.FieldType, expectedTarget)
+		}
+	case AttributeFieldJSON:
+		if input.ValueType != AttributeValueJSON {
+			return invalid("field_type json requires value_type json")
+		}
+	case AttributeFieldText, AttributeFieldTextarea:
+		if input.ValueType != AttributeValueText &&
+			input.ValueType != AttributeValueReal {
+			return invalid("field_type %s requires value_type text or real", input.FieldType)
+		}
+	case AttributeFieldURL, AttributeFieldEmail, AttributeFieldPhone:
+		if input.ValueType != AttributeValueText {
+			return invalid("field_type %s requires value_type text", input.FieldType)
+		}
+	}
+	if input.FieldType == AttributeFieldMultiselect &&
+		input.Cardinality != AttributeCardinalityMulti {
+		return invalid("field_type multiselect requires cardinality multi")
+	}
+	if input.Options != nil {
+		seen := make(map[string]bool, len(input.Options.Choices))
+		for i, choice := range input.Options.Choices {
+			value, err := canonicalAttributeChoiceValue(
+				input.ValueType, strings.TrimSpace(choice.Value))
+			if err != nil {
+				return invalid("options.choices[%d].value %q %s", i, choice.Value, err)
+			}
+			label := strings.TrimSpace(choice.Label)
+			if value == "" {
+				return invalid("options.choices[%d].value is required", i)
+			}
+			if label == "" {
+				return invalid("options.choices[%d].label is required", i)
+			}
+			if seen[value] {
+				return invalid("options.choices[%d].value %q is a duplicate", i, value)
+			}
+			seen[value] = true
+			input.Options.Choices[i].Value = value
+			input.Options.Choices[i].Label = label
+		}
+		if input.Options.MaxLength < 0 {
+			return invalid("options.max_length must not be negative")
+		}
+	}
+	return nil
+}
+
+func attributeValueTypeHasCanonicalString(valueType AttributeValueType) bool {
+	switch valueType {
+	case AttributeValueText, AttributeValueInteger, AttributeValueReal,
+		AttributeValueBoolean, AttributeValueDate, AttributeValueTimestamp:
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalAttributeChoiceValue(
+	valueType AttributeValueType, raw string,
+) (string, error) {
+	switch valueType {
+	case AttributeValueText:
+		return AttributeValue{
+			Type: AttributeValueText,
+			Text: &raw,
+		}.CanonicalString()
+	case AttributeValueInteger:
+		value, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return "", errors.New("must be an integer")
+		}
+		return AttributeValue{
+			Type:    AttributeValueInteger,
+			Integer: &value,
+		}.CanonicalString()
+	case AttributeValueReal:
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return "", errors.New("must be a number")
+		}
+		return AttributeValue{
+			Type: AttributeValueReal,
+			Real: &value,
+		}.CanonicalString()
+	case AttributeValueBoolean:
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			return "", errors.New("must be a boolean")
+		}
+		return AttributeValue{
+			Type:    AttributeValueBoolean,
+			Boolean: &value,
+		}.CanonicalString()
+	case AttributeValueDate:
+		value, err := time.Parse("2006-01-02", raw)
+		if err != nil || value.Format("2006-01-02") != raw {
+			return "", errors.New("must be a YYYY-MM-DD calendar date")
+		}
+		return AttributeValue{
+			Type: AttributeValueDate,
+			Date: &raw,
+		}.CanonicalString()
+	case AttributeValueTimestamp:
+		value, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			return "", errors.New("must be an RFC3339 timestamp")
+		}
+		return AttributeValue{
+			Type:      AttributeValueTimestamp,
+			Timestamp: &value,
+		}.CanonicalString()
+	default:
+		return "", fmt.Errorf("uses value_type %s, which has no canonical string form",
+			valueType)
+	}
+}
+
+func marshalAttributeOptions(options *AttributeOptions) (sql.NullString, error) {
+	if options == nil {
+		return sql.NullString{}, nil
+	}
+	encoded, err := json.Marshal(options)
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf(
+			"%w: encode options: %w", ErrAttributeDefinitionInvalid, err)
+	}
+	if err := jsonexact.Validate(encoded, AttributeOptions{}); err != nil {
+		return sql.NullString{}, fmt.Errorf(
+			"%w: options: %w", ErrAttributeDefinitionInvalid, err)
+	}
+	return sql.NullString{String: string(encoded), Valid: true}, nil
+}
+
+func unmarshalAttributeOptions(raw []byte) (*AttributeOptions, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	var options AttributeOptions
+	if err := json.Unmarshal(raw, &options); err != nil {
+		return nil, false, fmt.Errorf("decode attribute options: %w", err)
+	}
+	return &options, true, nil
+}
+
+const attributeDefinitionColumns = `
+	id, universal_id, object_type, slug, label, description,
+	value_type, field_type, record_target, cardinality, display_order,
+	is_required, ownership, ui_creatable, ui_editable, api_mutable,
+	is_searchable, is_audited, is_deletable, history_exempt, derived_source,
+	options, vcard_property, is_active, revision, created_at, updated_at
+`
+
+// CreateAttributeDefinitionContext validates and inserts a definition row.
+func (s *Store) CreateAttributeDefinitionContext(
+	ctx context.Context, input AttributeDefinitionInput,
+) (*AttributeDefinition, error) {
+	validated, err := validateAttributeDefinitionInput(input)
+	if err != nil {
+		return nil, err
+	}
+	options, err := marshalAttributeOptions(validated.Options)
+	if err != nil {
+		return nil, err
+	}
+	var definition *AttributeDefinition
+	err = s.withTxContext(ctx, func(tx *loggedTx) error {
+		query := fmt.Sprintf(`
+			INSERT INTO attribute_definitions (
+			    universal_id, object_type, slug, label, description,
+			    value_type, field_type, record_target, cardinality, display_order,
+			    is_required, ownership, ui_creatable, ui_editable, api_mutable,
+			    is_searchable, is_audited, is_deletable, history_exempt,
+			    derived_source, options, vcard_property
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?)
+			ON CONFLICT DO NOTHING
+			RETURNING %s
+		`, s.dialect.JSONBindExpr(), attributeDefinitionColumns)
+		row := tx.QueryRowContext(ctx, query,
+			validated.UniversalID, string(validated.ObjectType), validated.Slug,
+			validated.Label, validated.Description, string(validated.ValueType),
+			string(validated.FieldType), validated.RecordTarget,
+			string(validated.Cardinality), validated.DisplayOrder,
+			validated.IsRequired, string(validated.Ownership), validated.UICreatable,
+			validated.UIEditable, validated.APIMutable, validated.IsSearchable,
+			validated.IsAudited, validated.IsDeletable, validated.HistoryExempt,
+			validated.DerivedSource, options, validated.VCardProperty)
+		created, scanErr := scanAttributeDefinition(row)
+		if scanErr != nil {
+			return s.attributeDefinitionWriteError(ctx, tx, validated, scanErr)
+		}
+		definition = created
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return definition, nil
+}
+
+func (s *Store) attributeDefinitionWriteError(
+	ctx context.Context, tx *loggedTx, input AttributeDefinitionInput, err error,
+) error {
+	if !errors.Is(err, sql.ErrNoRows) && !s.dialect.IsConflictError(err) {
+		return fmt.Errorf("create attribute definition %q: %w", input.Slug, err)
+	}
+	var existing int
+	if probeErr := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM attribute_definitions WHERE universal_id = ?`,
+		input.UniversalID,
+	).Scan(&existing); probeErr != nil {
+		return fmt.Errorf("classify attribute definition conflict: %w", probeErr)
+	}
+	if existing > 0 {
+		return ErrAttributeDefinitionUniversalIDConflict
+	}
+	return ErrAttributeDefinitionSlugConflict
+}
+
+// GetAttributeDefinitionContext returns one definition by numeric ID.
+func (s *Store) GetAttributeDefinitionContext(
+	ctx context.Context, id int64,
+) (*AttributeDefinition, error) {
+	definition, err := scanAttributeDefinition(s.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s FROM attribute_definitions WHERE id = ?
+	`, attributeDefinitionColumns), id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrAttributeDefinitionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get attribute definition %d: %w", id, err)
+	}
+	return definition, nil
+}
+
+// GetAttributeDefinitionBySlugContext returns a definition by scoped slug.
+func (s *Store) GetAttributeDefinitionBySlugContext(
+	ctx context.Context, objectType AttributeObjectType, slug string,
+) (*AttributeDefinition, error) {
+	definition, err := scanAttributeDefinition(s.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s FROM attribute_definitions WHERE object_type = ? AND slug = ?
+	`, attributeDefinitionColumns), string(objectType), slug))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrAttributeDefinitionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get attribute definition %s/%s: %w", objectType, slug, err)
+	}
+	return definition, nil
+}
+
+// ListAttributeDefinitionsContext lists definitions in display order.
+func (s *Store) ListAttributeDefinitionsContext(
+	ctx context.Context, filter AttributeDefinitionFilter,
+) ([]AttributeDefinition, error) {
+	conditions := make([]string, 0, 2)
+	args := make([]any, 0, 2)
+	if filter.ObjectType != "" {
+		conditions = append(conditions, "object_type = ?")
+		args = append(args, string(filter.ObjectType))
+	}
+	if !filter.IncludeHidden {
+		conditions = append(conditions, s.dialect.BoolTrueExpr("is_active"))
+	}
+	where := ""
+	if len(conditions) > 0 {
+		where = "WHERE " + strings.Join(conditions, " AND ")
+	}
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT %s FROM attribute_definitions
+		%s
+		ORDER BY object_type, display_order, slug, id
+	`, attributeDefinitionColumns, where), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list attribute definitions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	definitions := make([]AttributeDefinition, 0)
+	for rows.Next() {
+		definition, scanErr := scanAttributeDefinition(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan attribute definition: %w", scanErr)
+		}
+		definitions = append(definitions, *definition)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate attribute definitions: %w", err)
+	}
+	return definitions, nil
+}
+
+// UpdateAttributeDefinitionContext applies a revision-guarded mutable update.
+func (s *Store) UpdateAttributeDefinitionContext(
+	ctx context.Context, id, expectedRevision int64, update AttributeDefinitionUpdate,
+) (*AttributeDefinition, error) {
+	assignments := make([]string, 0, 4)
+	args := make([]any, 0, 6)
+	if update.Label != nil {
+		label := strings.TrimSpace(*update.Label)
+		if label == "" {
+			return nil, fmt.Errorf("%w: label must not be blank", ErrAttributeDefinitionInvalid)
+		}
+		assignments = append(assignments, "label = ?")
+		args = append(args, label)
+	}
+	if update.Description != nil {
+		description := *update.Description
+		if description != nil {
+			trimmed := strings.TrimSpace(*description)
+			if trimmed == "" {
+				description = nil
+			} else {
+				description = &trimmed
+			}
+		}
+		assignments = append(assignments, "description = ?")
+		args = append(args, description)
+	}
+	if update.DisplayOrder != nil {
+		if *update.DisplayOrder < 0 {
+			return nil, fmt.Errorf("%w: display_order must not be negative",
+				ErrAttributeDefinitionInvalid)
+		}
+		assignments = append(assignments, "display_order = ?")
+		args = append(args, *update.DisplayOrder)
+	}
+	if update.IsActive != nil {
+		assignments = append(assignments, "is_active = ?")
+		args = append(args, *update.IsActive)
+	}
+	if len(assignments) == 0 {
+		return nil, fmt.Errorf("%w: no mutable field supplied", ErrAttributeDefinitionInvalid)
+	}
+	args = append(args, id, expectedRevision)
+
+	var definition *AttributeDefinition
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		query := fmt.Sprintf(`
+			UPDATE attribute_definitions
+			SET %s, revision = revision + 1, updated_at = %s
+			WHERE id = ? AND revision = ?
+			RETURNING %s
+		`, strings.Join(assignments, ", "), s.dialect.Now(), attributeDefinitionColumns)
+		updated, scanErr := scanAttributeDefinition(tx.QueryRowContext(ctx, query, args...))
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return s.attributeDefinitionCASMissTx(ctx, tx, id)
+		}
+		if scanErr != nil {
+			return fmt.Errorf("update attribute definition %d: %w", id, scanErr)
+		}
+		definition = updated
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return definition, nil
+}
+
+// DeleteAttributeDefinitionContext removes an unused, user-owned definition.
+func (s *Store) DeleteAttributeDefinitionContext(
+	ctx context.Context, id, expectedRevision int64,
+) error {
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		definition, err := scanAttributeDefinition(tx.QueryRowContext(ctx, fmt.Sprintf(`
+			SELECT %s FROM attribute_definitions WHERE id = ?%s
+		`, attributeDefinitionColumns, s.dialect.SelectForUpdate()), id))
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrAttributeDefinitionNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("load attribute definition %d for delete: %w", id, err)
+		}
+		if definition.Revision != expectedRevision {
+			return ErrAttributeDefinitionRevisionConflict
+		}
+		if !definition.IsDeletable || definition.Ownership == AttributeOwnershipSystem {
+			return ErrAttributeDefinitionNotDeletable
+		}
+		var values int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM person_attribute_values WHERE definition_id = ?`, id,
+		).Scan(&values); err != nil {
+			return fmt.Errorf("count values for attribute definition %d: %w", id, err)
+		}
+		if values > 0 {
+			return ErrAttributeDefinitionHasValues
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM attribute_definitions WHERE id = ? AND revision = ?`,
+			id, expectedRevision,
+		); err != nil {
+			return fmt.Errorf("delete attribute definition %d: %w", id, err)
+		}
+		return nil
+	})
+}
+
+func (s *Store) attributeDefinitionCASMissTx(
+	ctx context.Context, tx *loggedTx, id int64,
+) error {
+	var revision int64
+	err := tx.QueryRowContext(ctx,
+		`SELECT revision FROM attribute_definitions WHERE id = ?`, id).Scan(&revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrAttributeDefinitionNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("check attribute definition %d after revision miss: %w", id, err)
+	}
+	return ErrAttributeDefinitionRevisionConflict
+}
+
+func scanAttributeDefinition(row scanner) (*AttributeDefinition, error) {
+	var (
+		definition    AttributeDefinition
+		description   sql.NullString
+		recordTarget  sql.NullString
+		derivedSource sql.NullString
+		options       []byte
+		vcardProperty sql.NullString
+		objectType    string
+		valueType     string
+		fieldType     string
+		cardinality   string
+		ownership     string
+	)
+	if err := row.Scan(
+		&definition.ID, &definition.UniversalID, &objectType, &definition.Slug,
+		&definition.Label, &description, &valueType, &fieldType, &recordTarget,
+		&cardinality, &definition.DisplayOrder, &definition.IsRequired, &ownership,
+		&definition.UICreatable, &definition.UIEditable, &definition.APIMutable,
+		&definition.IsSearchable, &definition.IsAudited, &definition.IsDeletable,
+		&definition.HistoryExempt, &derivedSource, &options, &vcardProperty,
+		&definition.IsActive, &definition.Revision, &definition.CreatedAt,
+		&definition.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	definition.ObjectType = AttributeObjectType(objectType)
+	definition.ValueType = AttributeValueType(valueType)
+	definition.FieldType = AttributeFieldType(fieldType)
+	definition.Cardinality = AttributeCardinality(cardinality)
+	definition.Ownership = AttributeOwnership(ownership)
+	if description.Valid {
+		definition.Description = &description.String
+	}
+	if recordTarget.Valid {
+		definition.RecordTarget = &recordTarget.String
+	}
+	if derivedSource.Valid {
+		definition.DerivedSource = &derivedSource.String
+	}
+	if vcardProperty.Valid {
+		definition.VCardProperty = &vcardProperty.String
+	}
+	parsed, present, err := unmarshalAttributeOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	if present {
+		definition.Options = parsed
+	}
+	return &definition, nil
+}
+
+// NewAttributeUniversalID mints a stable external definition identifier.
+func NewAttributeUniversalID() (string, error) {
+	uid, err := newVCardUID()
+	if err != nil {
+		return "", fmt.Errorf("generate attribute universal id: %w", err)
+	}
+	return uid, nil
+}

--- a/internal/store/attribute_definitions.go
+++ b/internal/store/attribute_definitions.go
@@ -221,6 +221,16 @@ func ValidateAttributeSlug(slug string) error {
 	return nil
 }
 
+// ValidateAttributeDefinitionInput runs the full definition validation
+// without touching a database, so local dry-run previews reject exactly what
+// the server-side create path rejects — except conflicts with existing
+// definitions, which require the database.
+func ValidateAttributeDefinitionInput(
+	input AttributeDefinitionInput,
+) (AttributeDefinitionInput, error) {
+	return validateAttributeDefinitionInput(input)
+}
+
 func validateAttributeDefinitionInput(
 	input AttributeDefinitionInput,
 ) (AttributeDefinitionInput, error) {

--- a/internal/store/attribute_definitions.go
+++ b/internal/store/attribute_definitions.go
@@ -604,6 +604,25 @@ func (s *Store) GetAttributeDefinitionBySlugContext(
 	return definition, nil
 }
 
+// getAttributeDefinitionBySlugTx loads a definition inside tx, locking its
+// row on backends with row locks so writability and option checks stay valid
+// until the transaction commits.
+func (s *Store) getAttributeDefinitionBySlugTx(
+	ctx context.Context, tx *loggedTx, objectType AttributeObjectType, slug string,
+) (*AttributeDefinition, error) {
+	definition, err := scanAttributeDefinition(tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s FROM attribute_definitions WHERE object_type = ? AND slug = ?%s
+	`, attributeDefinitionColumns, s.dialect.SelectForUpdate()),
+		string(objectType), slug))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrAttributeDefinitionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get attribute definition %s/%s: %w", objectType, slug, err)
+	}
+	return definition, nil
+}
+
 // ListAttributeDefinitionsContext lists definitions in display order.
 func (s *Store) ListAttributeDefinitionsContext(
 	ctx context.Context, filter AttributeDefinitionFilter,

--- a/internal/store/attribute_definitions_test.go
+++ b/internal/store/attribute_definitions_test.go
@@ -1,0 +1,527 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func personTextDefinition(slug string) store.AttributeDefinitionInput {
+	return store.AttributeDefinitionInput{
+		UniversalID: "test-" + slug,
+		ObjectType:  store.AttributeObjectPerson,
+		Slug:        slug,
+		Label:       "Test " + slug,
+		ValueType:   store.AttributeValueText,
+		FieldType:   store.AttributeFieldText,
+		Cardinality: store.AttributeCardinalitySingle,
+		Ownership:   store.AttributeOwnershipUser,
+		UICreatable: true,
+		UIEditable:  true,
+		APIMutable:  true,
+		IsAudited:   true,
+		IsDeletable: true,
+	}
+}
+
+func onlyTestDefinitions(
+	definitions []store.AttributeDefinition, slugs ...string,
+) []store.AttributeDefinition {
+	wanted := make(map[string]bool, len(slugs))
+	for _, slug := range slugs {
+		wanted[slug] = true
+	}
+	filtered := make([]store.AttributeDefinition, 0, len(slugs))
+	for _, definition := range definitions {
+		if wanted[definition.Slug] {
+			filtered = append(filtered, definition)
+		}
+	}
+	return filtered
+}
+
+func TestCreateAttributeDefinitionRejectsInvalidVocabularies(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		mutate  func(*store.AttributeDefinitionInput)
+		wantMsg string
+	}{
+		{
+			name:    "unknown object type",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.ObjectType = "household" },
+			wantMsg: "object_type",
+		},
+		{
+			name:    "unknown value type",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.ValueType = "blob" },
+			wantMsg: "value_type",
+		},
+		{
+			name:    "unknown field type",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.FieldType = "slider" },
+			wantMsg: "field_type",
+		},
+		{
+			name:    "unknown cardinality",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.Cardinality = "many" },
+			wantMsg: "cardinality",
+		},
+		{
+			name:    "unknown ownership",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.Ownership = "vendor" },
+			wantMsg: "ownership",
+		},
+		{
+			name:    "uppercase slug",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.Slug = "Ask_Me_About" },
+			wantMsg: "slug",
+		},
+		{
+			name:    "path-unsafe slug",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.Slug = "ask/me" },
+			wantMsg: "slug",
+		},
+		{
+			name:    "empty label",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.Label = "   " },
+			wantMsg: "label",
+		},
+		{
+			name: "record reference without target",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				in.ValueType = store.AttributeValueRecordReference
+				in.FieldType = store.AttributeFieldPerson
+				in.RecordTarget = nil
+			},
+			wantMsg: "record_target",
+		},
+		{
+			name: "organization widget with person target",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				target := "person"
+				in.ValueType = store.AttributeValueRecordReference
+				in.FieldType = store.AttributeFieldOrganization
+				in.RecordTarget = &target
+			},
+			wantMsg: "field_type organization requires record_target organization",
+		},
+		{
+			name: "record target on a scalar value type",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				target := "person"
+				in.RecordTarget = &target
+			},
+			wantMsg: "record_target",
+		},
+		{
+			name: "select widget without choices",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				in.FieldType = store.AttributeFieldSelect
+			},
+			wantMsg: "options.choices",
+		},
+		{
+			name: "multiselect widget on a single-cardinality definition",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				in.FieldType = store.AttributeFieldMultiselect
+				in.Options = &store.AttributeOptions{
+					Choices: []store.AttributeChoice{{Value: "a", Label: "A"}},
+				}
+				in.Cardinality = store.AttributeCardinalitySingle
+			},
+			wantMsg: "multiselect requires cardinality multi",
+		},
+		{
+			name: "checkbox widget on a text value type",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				in.FieldType = store.AttributeFieldCheckbox
+			},
+			wantMsg: "field_type checkbox requires value_type boolean",
+		},
+		{
+			name: "lowercase vCard property",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				property := "x-custom"
+				in.VCardProperty = &property
+			},
+			wantMsg: "vcard_property",
+		},
+		{
+			name:    "negative display order",
+			mutate:  func(in *store.AttributeDefinitionInput) { in.DisplayOrder = -1 },
+			wantMsg: "display_order",
+		},
+		{
+			name: "duplicate choice values",
+			mutate: func(in *store.AttributeDefinitionInput) {
+				in.FieldType = store.AttributeFieldSelect
+				in.Options = &store.AttributeOptions{Choices: []store.AttributeChoice{
+					{Value: "a", Label: "A"},
+					{Value: "a", Label: "Also A"},
+				}}
+			},
+			wantMsg: "duplicate",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			input := personTextDefinition("candidate")
+			test.mutate(&input)
+			_, err := st.CreateAttributeDefinitionContext(ctx, input)
+			require.ErrorIs(err, store.ErrAttributeDefinitionInvalid)
+			assert.ErrorContains(err, test.wantMsg)
+		})
+	}
+}
+
+func TestCreateAttributeDefinitionRejectsSelectTypesWithoutCanonicalChoices(
+	t *testing.T,
+) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		fieldType store.AttributeFieldType
+		valueType store.AttributeValueType
+	}{
+		{
+			name:      "select json",
+			fieldType: store.AttributeFieldSelect,
+			valueType: store.AttributeValueJSON,
+		},
+		{
+			name:      "multiselect record reference",
+			fieldType: store.AttributeFieldMultiselect,
+			valueType: store.AttributeValueRecordReference,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := personTextDefinition("unsupported_choice_type_" + string(rune('a'+i)))
+			input.FieldType = test.fieldType
+			input.ValueType = test.valueType
+			input.Cardinality = store.AttributeCardinalityMulti
+			input.Options = &store.AttributeOptions{Choices: []store.AttributeChoice{
+				{Value: "synthetic", Label: "Synthetic"},
+			}}
+			if test.valueType == store.AttributeValueRecordReference {
+				input.RecordTarget = new("person")
+			}
+
+			_, err := st.CreateAttributeDefinitionContext(ctx, input)
+			require.ErrorIs(t, err, store.ErrAttributeDefinitionInvalid)
+			assert.ErrorContains(t, err, "has no canonical string form")
+		})
+	}
+}
+
+func TestCreateAttributeDefinitionCanonicalizesChoicesForValueType(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		valueType store.AttributeValueType
+		raw       string
+		want      string
+	}{
+		{name: "text", valueType: store.AttributeValueText, raw: " synthetic ", want: "synthetic"},
+		{name: "integer", valueType: store.AttributeValueInteger, raw: "+007", want: "7"},
+		{name: "real", valueType: store.AttributeValueReal, raw: "1.500", want: "1.5"},
+		{name: "boolean", valueType: store.AttributeValueBoolean, raw: "TRUE", want: "true"},
+		{name: "date", valueType: store.AttributeValueDate, raw: " 2026-07-30 ", want: "2026-07-30"},
+		{
+			name:      "timestamp",
+			valueType: store.AttributeValueTimestamp,
+			raw:       "2026-07-30T10:00:00+02:00",
+			want:      "2026-07-30T08:00:00Z",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			input := personTextDefinition("canonical_" + test.name)
+			input.UniversalID = "test-canonical-" + test.name
+			input.ValueType = test.valueType
+			input.FieldType = store.AttributeFieldSelect
+			input.DisplayOrder = int64(i)
+			input.Options = &store.AttributeOptions{Choices: []store.AttributeChoice{
+				{Value: test.raw, Label: " Synthetic label "},
+			}}
+
+			created, err := st.CreateAttributeDefinitionContext(ctx, input)
+			require.NoError(err)
+			require.NotNil(created.Options)
+			require.Len(created.Options.Choices, 1)
+			assert.Equal(test.want, created.Options.Choices[0].Value)
+			assert.Equal("Synthetic label", created.Options.Choices[0].Label)
+		})
+	}
+}
+
+func TestCreateAttributeDefinitionRejectsInvalidAndDuplicateCanonicalChoices(
+	t *testing.T,
+) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		valueType store.AttributeValueType
+		choices   []store.AttributeChoice
+		wantMsg   string
+	}{
+		{
+			name:      "invalid integer",
+			valueType: store.AttributeValueInteger,
+			choices:   []store.AttributeChoice{{Value: "seven", Label: "Seven"}},
+			wantMsg:   "must be an integer",
+		},
+		{
+			name:      "invalid real",
+			valueType: store.AttributeValueReal,
+			choices:   []store.AttributeChoice{{Value: "many", Label: "Many"}},
+			wantMsg:   "must be a number",
+		},
+		{
+			name:      "invalid boolean",
+			valueType: store.AttributeValueBoolean,
+			choices:   []store.AttributeChoice{{Value: "sometimes", Label: "Sometimes"}},
+			wantMsg:   "must be a boolean",
+		},
+		{
+			name:      "invalid date",
+			valueType: store.AttributeValueDate,
+			choices:   []store.AttributeChoice{{Value: "2026-02-30", Label: "Invalid date"}},
+			wantMsg:   "YYYY-MM-DD calendar date",
+		},
+		{
+			name:      "invalid timestamp",
+			valueType: store.AttributeValueTimestamp,
+			choices:   []store.AttributeChoice{{Value: "tomorrow", Label: "Tomorrow"}},
+			wantMsg:   "RFC3339",
+		},
+		{
+			name:      "duplicate canonical integer",
+			valueType: store.AttributeValueInteger,
+			choices: []store.AttributeChoice{
+				{Value: "01", Label: "One"},
+				{Value: "1", Label: "Also one"},
+			},
+			wantMsg: "duplicate",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := personTextDefinition("invalid_choice_" + string(rune('a'+i)))
+			input.UniversalID = "test-invalid-choice-" + test.name
+			input.ValueType = test.valueType
+			input.FieldType = store.AttributeFieldSelect
+			input.Options = &store.AttributeOptions{Choices: test.choices}
+
+			_, err := st.CreateAttributeDefinitionContext(ctx, input)
+			require.ErrorIs(t, err, store.ErrAttributeDefinitionInvalid)
+			assert.ErrorContains(t, err, test.wantMsg)
+		})
+	}
+}
+
+func TestCreateAttributeDefinitionStoresANovelUserDefinition(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	input := personTextDefinition("favorite_tea")
+	input.FieldType = store.AttributeFieldSelect
+	input.Cardinality = store.AttributeCardinalityMulti
+	input.Options = &store.AttributeOptions{Choices: []store.AttributeChoice{
+		{Value: "green", Label: "Green"},
+		{Value: "oolong", Label: "Oolong"},
+	}}
+	input.IsSearchable = true
+	input.DisplayOrder = 100
+
+	created, err := st.CreateAttributeDefinitionContext(ctx, input)
+	require.NoError(err)
+	assert.Positive(created.ID)
+	assert.Equal("favorite_tea", created.Slug)
+	assert.Equal("test-favorite_tea", created.UniversalID)
+	assert.Equal(store.AttributeObjectPerson, created.ObjectType)
+	assert.Equal(store.AttributeCardinalityMulti, created.Cardinality)
+	assert.Equal(store.AttributeOwnershipUser, created.Ownership)
+	assert.Equal(int64(1), created.Revision)
+	assert.True(created.IsActive)
+	require.NotNil(created.Options)
+	assert.Equal([]string{"green", "oolong"}, created.Options.ChoiceValues())
+
+	fetched, err := st.GetAttributeDefinitionBySlugContext(
+		ctx, store.AttributeObjectPerson, "favorite_tea")
+	require.NoError(err)
+	assert.Equal(*created, *fetched)
+}
+
+func TestCreateAttributeDefinitionAllowsOrganizationObjectTypeWithoutAValuePath(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	input := personTextDefinition("industry")
+	input.UniversalID = "test-org-industry"
+	input.ObjectType = store.AttributeObjectOrganization
+
+	created, err := st.CreateAttributeDefinitionContext(ctx, input)
+	require.NoError(err)
+	assert.Equal(store.AttributeObjectOrganization, created.ObjectType)
+
+	personScoped := personTextDefinition("industry")
+	personScoped.UniversalID = "test-person-industry"
+	_, err = st.CreateAttributeDefinitionContext(ctx, personScoped)
+	require.NoError(err)
+
+	listed, err := st.ListAttributeDefinitionsContext(ctx, store.AttributeDefinitionFilter{
+		ObjectType: store.AttributeObjectOrganization,
+	})
+	require.NoError(err)
+	require.Len(listed, 1)
+	assert.Equal("industry", listed[0].Slug)
+}
+
+func TestCreateAttributeDefinitionRejectsDuplicateSlugAndUniversalID(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	_, err := st.CreateAttributeDefinitionContext(ctx, personTextDefinition("nickname_note"))
+	require.NoError(t, err)
+
+	sameSlug := personTextDefinition("nickname_note")
+	sameSlug.UniversalID = "test-other-universal-id"
+	_, err = st.CreateAttributeDefinitionContext(ctx, sameSlug)
+	require.ErrorIs(t, err, store.ErrAttributeDefinitionSlugConflict)
+
+	sameUniversalID := personTextDefinition("other_slug")
+	sameUniversalID.UniversalID = "test-nickname_note"
+	_, err = st.CreateAttributeDefinitionContext(ctx, sameUniversalID)
+	require.ErrorIs(t, err, store.ErrAttributeDefinitionUniversalIDConflict)
+}
+
+func TestUpdateAttributeDefinitionRenamesLabelAndKeepsIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	created, err := st.CreateAttributeDefinitionContext(
+		ctx, personTextDefinition("cadence_note"))
+	require.NoError(err)
+
+	label := "Renamed cadence note"
+	description := "How often to follow up"
+	descriptionPtr := &description
+	updated, err := st.UpdateAttributeDefinitionContext(ctx, created.ID, created.Revision,
+		store.AttributeDefinitionUpdate{Label: &label, Description: &descriptionPtr})
+	require.NoError(err)
+	assert.Equal(label, updated.Label)
+	require.NotNil(updated.Description)
+	assert.Equal(description, *updated.Description)
+	assert.Equal(created.UniversalID, updated.UniversalID)
+	assert.Equal(created.Slug, updated.Slug)
+	assert.Equal(created.Revision+1, updated.Revision)
+
+	_, err = st.UpdateAttributeDefinitionContext(ctx, created.ID, created.Revision,
+		store.AttributeDefinitionUpdate{Label: &label})
+	require.ErrorIs(err, store.ErrAttributeDefinitionRevisionConflict)
+
+	var nilDescription *string
+	cleared, err := st.UpdateAttributeDefinitionContext(ctx, created.ID, updated.Revision,
+		store.AttributeDefinitionUpdate{Description: &nilDescription})
+	require.NoError(err)
+	assert.Nil(cleared.Description)
+
+	_, err = st.UpdateAttributeDefinitionContext(ctx, 999_999, 1,
+		store.AttributeDefinitionUpdate{Label: &label})
+	require.ErrorIs(err, store.ErrAttributeDefinitionNotFound)
+}
+
+func TestDeleteAttributeDefinitionRefusesUndeletableAndAllowsUnused(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	protected := personTextDefinition("protected_note")
+	protected.IsDeletable = false
+	created, err := st.CreateAttributeDefinitionContext(ctx, protected)
+	require.NoError(err)
+	require.ErrorIs(
+		st.DeleteAttributeDefinitionContext(ctx, created.ID, created.Revision),
+		store.ErrAttributeDefinitionNotDeletable,
+	)
+
+	deletable, err := st.CreateAttributeDefinitionContext(
+		ctx, personTextDefinition("scratch_note"))
+	require.NoError(err)
+	require.NoError(st.DeleteAttributeDefinitionContext(
+		ctx, deletable.ID, deletable.Revision))
+	_, err = st.GetAttributeDefinitionContext(ctx, deletable.ID)
+	require.ErrorIs(err, store.ErrAttributeDefinitionNotFound)
+}
+
+func TestListAttributeDefinitionsOrdersByDisplayOrderAndHidesInactiveByDefault(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	first := personTextDefinition("zzz_first")
+	first.DisplayOrder = 1
+	second := personTextDefinition("aaa_second")
+	second.UniversalID = "test-aaa_second"
+	second.DisplayOrder = 2
+	createdFirst, err := st.CreateAttributeDefinitionContext(ctx, first)
+	require.NoError(err)
+	_, err = st.CreateAttributeDefinitionContext(ctx, second)
+	require.NoError(err)
+
+	listed, err := st.ListAttributeDefinitionsContext(ctx, store.AttributeDefinitionFilter{
+		ObjectType: store.AttributeObjectPerson,
+	})
+	require.NoError(err)
+	mine := onlyTestDefinitions(listed, "zzz_first", "aaa_second")
+	require.Len(mine, 2)
+	assert.Equal("zzz_first", mine[0].Slug, "display_order wins over slug ordering")
+
+	inactive := false
+	_, err = st.UpdateAttributeDefinitionContext(ctx, createdFirst.ID, createdFirst.Revision,
+		store.AttributeDefinitionUpdate{IsActive: &inactive})
+	require.NoError(err)
+
+	active, err := st.ListAttributeDefinitionsContext(ctx, store.AttributeDefinitionFilter{
+		ObjectType: store.AttributeObjectPerson,
+	})
+	require.NoError(err)
+	activeMine := onlyTestDefinitions(active, "zzz_first", "aaa_second")
+	require.Len(activeMine, 1)
+	assert.Equal("aaa_second", activeMine[0].Slug)
+
+	all, err := st.ListAttributeDefinitionsContext(ctx, store.AttributeDefinitionFilter{
+		ObjectType: store.AttributeObjectPerson, IncludeHidden: true,
+	})
+	require.NoError(err)
+	assert.Len(onlyTestDefinitions(all, "zzz_first", "aaa_second"), 2)
+}

--- a/internal/store/attribute_seed.go
+++ b/internal/store/attribute_seed.go
@@ -1,0 +1,221 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+const (
+	AttributeUniversalIDPrimaryChannel   = "59e9a7d3-4904-4d0e-97d1-d0680e1e9e55"
+	AttributeUniversalIDContactFrequency = "34b52841-dcf5-40c6-a24e-628b049e85b2"
+	AttributeUniversalIDAskMeAbout       = "93c658a1-2346-4a6e-98c2-abfa29209334"
+	AttributeUniversalIDLastContacted    = "6e843902-1685-4e23-a107-819220c7dd8d"
+)
+
+const (
+	AttributeSlugPrimaryChannel   = "primary_channel"
+	AttributeSlugContactFrequency = "contact_frequency"
+	AttributeSlugAskMeAbout       = "ask_me_about"
+	AttributeSlugLastContacted    = "last_contacted"
+)
+
+// AttributeDerivedSourceActivitySpine names the future last-contacted producer.
+const AttributeDerivedSourceActivitySpine = "activity_spine"
+
+// SeededAttributeDefinitions returns the deliberately small shipped set.
+func SeededAttributeDefinitions() []AttributeDefinitionInput {
+	stringPtr := func(value string) *string { return &value }
+	return []AttributeDefinitionInput{
+		{
+			UniversalID:  AttributeUniversalIDPrimaryChannel,
+			ObjectType:   AttributeObjectPerson,
+			Slug:         AttributeSlugPrimaryChannel,
+			Label:        "Primary channel",
+			Description:  stringPtr("Preferred way to reach this person"),
+			ValueType:    AttributeValueText,
+			FieldType:    AttributeFieldSelect,
+			Cardinality:  AttributeCardinalitySingle,
+			DisplayOrder: 10,
+			Ownership:    AttributeOwnershipSystem,
+			UICreatable:  true,
+			UIEditable:   true,
+			APIMutable:   true,
+			IsAudited:    true,
+			IsDeletable:  false,
+			Options: &AttributeOptions{Choices: []AttributeChoice{
+				{Value: MessageTypeEmail, Label: "Email"},
+				{Value: "phone", Label: "Phone"},
+				{Value: "sms", Label: "SMS"},
+				{Value: "chat", Label: "Chat"},
+				{Value: "in_person", Label: "In person"},
+			}},
+		},
+		{
+			UniversalID:  AttributeUniversalIDContactFrequency,
+			ObjectType:   AttributeObjectPerson,
+			Slug:         AttributeSlugContactFrequency,
+			Label:        "Contact frequency",
+			Description:  stringPtr("Desired number of days between contacts"),
+			ValueType:    AttributeValueInteger,
+			FieldType:    AttributeFieldDuration,
+			Cardinality:  AttributeCardinalitySingle,
+			DisplayOrder: 20,
+			Ownership:    AttributeOwnershipSystem,
+			UICreatable:  true,
+			UIEditable:   true,
+			APIMutable:   true,
+			IsAudited:    true,
+			IsDeletable:  false,
+			Options:      &AttributeOptions{Unit: "days"},
+		},
+		{
+			UniversalID:  AttributeUniversalIDAskMeAbout,
+			ObjectType:   AttributeObjectPerson,
+			Slug:         AttributeSlugAskMeAbout,
+			Label:        "Ask me about",
+			Description:  stringPtr("Topics worth raising with this person"),
+			ValueType:    AttributeValueText,
+			FieldType:    AttributeFieldText,
+			Cardinality:  AttributeCardinalityMulti,
+			DisplayOrder: 30,
+			Ownership:    AttributeOwnershipSystem,
+			UICreatable:  true,
+			UIEditable:   true,
+			APIMutable:   true,
+			IsSearchable: true,
+			IsAudited:    true,
+			IsDeletable:  false,
+			Options:      &AttributeOptions{MaxLength: 120},
+		},
+		{
+			UniversalID:   AttributeUniversalIDLastContacted,
+			ObjectType:    AttributeObjectPerson,
+			Slug:          AttributeSlugLastContacted,
+			Label:         "Last contacted",
+			Description:   stringPtr("Most recent interaction, computed from archive activity"),
+			ValueType:     AttributeValueTimestamp,
+			FieldType:     AttributeFieldTimestamp,
+			Cardinality:   AttributeCardinalitySingle,
+			DisplayOrder:  40,
+			Ownership:     AttributeOwnershipSystem,
+			IsAudited:     false,
+			IsDeletable:   false,
+			HistoryExempt: true,
+			DerivedSource: stringPtr(AttributeDerivedSourceActivitySpine),
+		},
+	}
+}
+
+// EnsureSeededAttributeDefinitions reconciles shipped definitions.
+func (s *Store) EnsureSeededAttributeDefinitions() error {
+	return s.EnsureSeededAttributeDefinitionsContext(context.Background())
+}
+
+// EnsureSeededAttributeDefinitionsContext creates missing seeds and repairs structure.
+func (s *Store) EnsureSeededAttributeDefinitionsContext(ctx context.Context) error {
+	for _, seed := range SeededAttributeDefinitions() {
+		existing, err := s.GetAttributeDefinitionBySlugContext(ctx, seed.ObjectType, seed.Slug)
+		switch {
+		case errors.Is(err, ErrAttributeDefinitionNotFound):
+			if _, err := s.CreateAttributeDefinitionContext(ctx, seed); err != nil &&
+				!errors.Is(err, ErrAttributeDefinitionUniversalIDConflict) &&
+				!errors.Is(err, ErrAttributeDefinitionSlugConflict) {
+				return fmt.Errorf("seed attribute definition %s: %w", seed.Slug, err)
+			}
+			continue
+		case err != nil:
+			return fmt.Errorf("load seeded attribute definition %s: %w", seed.Slug, err)
+		}
+		if err := s.reconcileSeededDefinition(ctx, existing, seed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) reconcileSeededDefinition(
+	ctx context.Context, existing *AttributeDefinition, seed AttributeDefinitionInput,
+) error {
+	validated, err := validateAttributeDefinitionInput(seed)
+	if err != nil {
+		return fmt.Errorf("validate seeded attribute definition %s: %w", seed.Slug, err)
+	}
+	if !seededDefinitionDiffers(existing, validated) {
+		return nil
+	}
+	options, err := marshalAttributeOptions(validated.Options)
+	if err != nil {
+		return err
+	}
+	query := fmt.Sprintf(`
+		UPDATE attribute_definitions
+		SET value_type = ?, field_type = ?, record_target = ?, cardinality = ?,
+		    is_required = ?, ownership = ?, ui_creatable = ?,
+		    ui_editable = ?, api_mutable = ?, is_searchable = ?, is_audited = ?,
+		    is_deletable = ?, history_exempt = ?, derived_source = ?,
+		    options = %s, vcard_property = ?,
+		    revision = revision + 1, updated_at = %s
+		WHERE universal_id = ?
+	`, s.dialect.JSONBindExpr(), s.dialect.Now())
+	if _, err := s.db.ExecContext(ctx, query,
+		string(validated.ValueType), string(validated.FieldType), validated.RecordTarget,
+		string(validated.Cardinality), validated.IsRequired,
+		string(validated.Ownership), validated.UICreatable, validated.UIEditable,
+		validated.APIMutable, validated.IsSearchable, validated.IsAudited,
+		validated.IsDeletable, validated.HistoryExempt, validated.DerivedSource,
+		options, validated.VCardProperty, validated.UniversalID,
+	); err != nil {
+		return fmt.Errorf("reconcile seeded attribute definition %s: %w", seed.Slug, err)
+	}
+	return nil
+}
+
+// seededDefinitionDiffers ignores label, description, and display_order:
+// those are user-adjustable presentation fields that reseeding must preserve.
+func seededDefinitionDiffers(
+	existing *AttributeDefinition, seed AttributeDefinitionInput,
+) bool {
+	if existing.ValueType != seed.ValueType ||
+		existing.FieldType != seed.FieldType ||
+		existing.Cardinality != seed.Cardinality ||
+		existing.Ownership != seed.Ownership ||
+		existing.IsRequired != seed.IsRequired ||
+		existing.UICreatable != seed.UICreatable ||
+		existing.UIEditable != seed.UIEditable ||
+		existing.APIMutable != seed.APIMutable ||
+		existing.IsSearchable != seed.IsSearchable ||
+		existing.IsAudited != seed.IsAudited ||
+		existing.IsDeletable != seed.IsDeletable ||
+		existing.HistoryExempt != seed.HistoryExempt {
+		return true
+	}
+	if !equalOptionalString(existing.RecordTarget, seed.RecordTarget) ||
+		!equalOptionalString(existing.DerivedSource, seed.DerivedSource) ||
+		!equalOptionalString(existing.VCardProperty, seed.VCardProperty) {
+		return true
+	}
+	return !equalAttributeOptions(existing.Options, seed.Options)
+}
+
+func equalOptionalString(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func equalAttributeOptions(a, b *AttributeOptions) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.Unit != b.Unit || a.MaxLength != b.MaxLength || len(a.Choices) != len(b.Choices) {
+		return false
+	}
+	for i := range a.Choices {
+		if a.Choices[i] != b.Choices[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/store/attribute_seed_test.go
+++ b/internal/store/attribute_seed_test.go
@@ -1,0 +1,162 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestInitSchemaSeedsExactlyTheFourSystemDefinitions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	definitions, err := st.ListAttributeDefinitionsContext(ctx,
+		store.AttributeDefinitionFilter{ObjectType: store.AttributeObjectPerson})
+	require.NoError(err)
+
+	slugs := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		slugs = append(slugs, definition.Slug)
+		assert.Equal(store.AttributeOwnershipSystem, definition.Ownership,
+			"seeded definition %s must be system-owned", definition.Slug)
+		assert.False(definition.IsDeletable,
+			"seeded definition %s must not be deletable", definition.Slug)
+	}
+	assert.Equal([]string{
+		store.AttributeSlugPrimaryChannel,
+		store.AttributeSlugContactFrequency,
+		store.AttributeSlugAskMeAbout,
+		store.AttributeSlugLastContacted,
+	}, slugs, "seeding must be minimal and display-ordered")
+
+	organization, err := st.ListAttributeDefinitionsContext(ctx,
+		store.AttributeDefinitionFilter{ObjectType: store.AttributeObjectOrganization})
+	require.NoError(err)
+	assert.Empty(organization)
+}
+
+func TestSeededDefinitionsCarryTheirDocumentedShape(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	primary, err := st.GetAttributeDefinitionBySlugContext(ctx,
+		store.AttributeObjectPerson, store.AttributeSlugPrimaryChannel)
+	require.NoError(err)
+	assert.Equal(store.AttributeUniversalIDPrimaryChannel, primary.UniversalID)
+	assert.Equal(store.AttributeValueText, primary.ValueType)
+	assert.Equal(store.AttributeFieldSelect, primary.FieldType)
+	assert.Equal(store.AttributeCardinalitySingle, primary.Cardinality)
+	require.NotNil(primary.Options)
+	assert.Equal([]string{"email", "phone", "sms", "chat", "in_person"},
+		primary.Options.ChoiceValues())
+	assert.True(primary.APIMutable)
+
+	frequency, err := st.GetAttributeDefinitionBySlugContext(ctx,
+		store.AttributeObjectPerson, store.AttributeSlugContactFrequency)
+	require.NoError(err)
+	assert.Equal(store.AttributeUniversalIDContactFrequency, frequency.UniversalID)
+	assert.Equal(store.AttributeValueInteger, frequency.ValueType)
+	assert.Equal(store.AttributeFieldDuration, frequency.FieldType)
+	require.NotNil(frequency.Options)
+	assert.Equal("days", frequency.Options.Unit)
+
+	askMeAbout, err := st.GetAttributeDefinitionBySlugContext(ctx,
+		store.AttributeObjectPerson, store.AttributeSlugAskMeAbout)
+	require.NoError(err)
+	assert.Equal(store.AttributeUniversalIDAskMeAbout, askMeAbout.UniversalID)
+	assert.Equal(store.AttributeValueText, askMeAbout.ValueType)
+	assert.Equal(store.AttributeCardinalityMulti, askMeAbout.Cardinality)
+	assert.True(askMeAbout.IsSearchable)
+	require.NotNil(askMeAbout.Options)
+	assert.Equal(120, askMeAbout.Options.MaxLength)
+}
+
+func TestSeededLastContactedIsReadOnlyAndDerived(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	derived, err := st.GetAttributeDefinitionBySlugContext(ctx,
+		store.AttributeObjectPerson, store.AttributeSlugLastContacted)
+	require.NoError(err)
+	assert.Equal(store.AttributeUniversalIDLastContacted, derived.UniversalID)
+	assert.Equal(store.AttributeValueTimestamp, derived.ValueType)
+	require.NotNil(derived.DerivedSource)
+	assert.Equal(store.AttributeDerivedSourceActivitySpine, *derived.DerivedSource)
+	assert.False(derived.APIMutable)
+	assert.False(derived.UICreatable)
+	assert.False(derived.UIEditable)
+	assert.True(derived.HistoryExempt)
+}
+
+func TestReSeedingPreservesUserLabelChangesAndRepairsStructure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	original, err := st.GetAttributeDefinitionBySlugContext(ctx,
+		store.AttributeObjectPerson, store.AttributeSlugAskMeAbout)
+	require.NoError(err)
+
+	label := "Conversation starters"
+	description := "Topics this person enjoys"
+	descriptionPtr := &description
+	displayOrder := int64(5)
+	renamed, err := st.UpdateAttributeDefinitionContext(ctx, original.ID, original.Revision,
+		store.AttributeDefinitionUpdate{
+			Label: &label, Description: &descriptionPtr, DisplayOrder: &displayOrder})
+	require.NoError(err)
+
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE attribute_definitions SET field_type = 'textarea' WHERE universal_id = ?
+	`), store.AttributeUniversalIDAskMeAbout)
+	require.NoError(err)
+
+	require.NoError(st.EnsureSeededAttributeDefinitions())
+
+	reseeded, err := st.GetAttributeDefinitionBySlugContext(ctx,
+		store.AttributeObjectPerson, store.AttributeSlugAskMeAbout)
+	require.NoError(err)
+	assert.Equal(label, reseeded.Label)
+	require.NotNil(reseeded.Description)
+	assert.Equal(description, *reseeded.Description)
+	assert.Equal(displayOrder, reseeded.DisplayOrder,
+		"reseeding must preserve a user's display_order override")
+	assert.Equal(original.UniversalID, reseeded.UniversalID)
+	assert.Equal(original.Slug, reseeded.Slug)
+	assert.Equal(store.AttributeFieldText, reseeded.FieldType)
+	assert.Greater(reseeded.Revision, renamed.Revision)
+
+	require.NoError(st.EnsureSeededAttributeDefinitions())
+	idempotent, err := st.GetAttributeDefinitionBySlugContext(ctx,
+		store.AttributeObjectPerson, store.AttributeSlugAskMeAbout)
+	require.NoError(err)
+	assert.Equal(reseeded.Revision, idempotent.Revision)
+
+	all, err := st.ListAttributeDefinitionsContext(ctx,
+		store.AttributeDefinitionFilter{ObjectType: store.AttributeObjectPerson})
+	require.NoError(err)
+	assert.Len(all, 4)
+}
+
+func TestSeededDefinitionsPassTheSameValidationAsUserDefinitions(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+
+	for _, seed := range store.SeededAttributeDefinitions() {
+		t.Run(seed.Slug, func(t *testing.T) {
+			_, err := st.CreateAttributeDefinitionContext(ctx, seed)
+			require.ErrorIs(t, err, store.ErrAttributeDefinitionUniversalIDConflict)
+		})
+	}
+}

--- a/internal/store/attribute_values.go
+++ b/internal/store/attribute_values.go
@@ -1,0 +1,236 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrAttributeValueInvalid          = errors.New("invalid attribute value")
+	ErrAttributeValueNotFound         = errors.New("attribute value not found")
+	ErrAttributeValueConflict         = errors.New("attribute value changed; reload and retry")
+	ErrAttributeDefinitionNotWritable = errors.New(
+		"attribute definition is read-only")
+	ErrAttributeDefinitionInactive = errors.New(
+		"attribute definition is not active; re-activate it to set new values")
+)
+
+var errAttributeDryRun = errors.New("attribute dry run rollback")
+
+const maxAttributeWriteAttempts = 5
+
+// AttributeValue is a typed value union with exactly one populated member.
+type AttributeValue struct {
+	Type       AttributeValueType `json:"type"`
+	Text       *string            `json:"text,omitempty"`
+	Integer    *int64             `json:"integer,omitempty"`
+	Real       *float64           `json:"real,omitempty"`
+	Boolean    *bool              `json:"boolean,omitempty"`
+	Date       *string            `json:"date,omitempty"`
+	Timestamp  *time.Time         `json:"timestamp,omitempty"`
+	JSON       json.RawMessage    `json:"json,omitempty"`
+	RecordType *string            `json:"record_type,omitempty"`
+	RecordID   *int64             `json:"record_id,omitempty"`
+}
+
+// CanonicalString renders scalar values for choice matching.
+func (v AttributeValue) CanonicalString() (string, error) {
+	switch v.Type {
+	case AttributeValueText:
+		if v.Text == nil {
+			return "", fmt.Errorf("%w: text value is required", ErrAttributeValueInvalid)
+		}
+		return *v.Text, nil
+	case AttributeValueInteger:
+		if v.Integer == nil {
+			return "", fmt.Errorf("%w: integer value is required", ErrAttributeValueInvalid)
+		}
+		return strconv.FormatInt(*v.Integer, 10), nil
+	case AttributeValueReal:
+		if v.Real == nil {
+			return "", fmt.Errorf("%w: real value is required", ErrAttributeValueInvalid)
+		}
+		return strconv.FormatFloat(*v.Real, 'g', -1, 64), nil
+	case AttributeValueBoolean:
+		if v.Boolean == nil {
+			return "", fmt.Errorf("%w: boolean value is required", ErrAttributeValueInvalid)
+		}
+		return strconv.FormatBool(*v.Boolean), nil
+	case AttributeValueDate:
+		if v.Date == nil {
+			return "", fmt.Errorf("%w: date value is required", ErrAttributeValueInvalid)
+		}
+		return *v.Date, nil
+	case AttributeValueTimestamp:
+		if v.Timestamp == nil {
+			return "", fmt.Errorf("%w: timestamp value is required", ErrAttributeValueInvalid)
+		}
+		return v.Timestamp.UTC().Format(time.RFC3339Nano), nil
+	default:
+		return "", fmt.Errorf(
+			"%w: value_type %s has no canonical string form", ErrAttributeValueInvalid, v.Type)
+	}
+}
+
+func populatedAttributeValueFields(value AttributeValue) int {
+	count := 0
+	for _, populated := range []bool{
+		value.Text != nil, value.Integer != nil, value.Real != nil,
+		value.Boolean != nil, value.Date != nil, value.Timestamp != nil,
+		len(value.JSON) > 0, value.RecordID != nil,
+	} {
+		if populated {
+			count++
+		}
+	}
+	return count
+}
+
+func normalizeAttributeValue(
+	definition AttributeDefinition, value AttributeValue,
+) (AttributeValue, error) {
+	invalid := func(format string, args ...any) (AttributeValue, error) {
+		return AttributeValue{}, fmt.Errorf(
+			"%w: %s", ErrAttributeValueInvalid, fmt.Sprintf(format, args...))
+	}
+	if value.Type == "" {
+		value.Type = definition.ValueType
+	}
+	if value.Type != definition.ValueType {
+		return invalid("value_type %s does not match definition %s which declares %s",
+			value.Type, definition.Slug, definition.ValueType)
+	}
+	if value.Type != AttributeValueRecordReference &&
+		(value.RecordType != nil || value.RecordID != nil) {
+		return invalid("record_type and record_id are only valid for a record reference")
+	}
+	if populated := populatedAttributeValueFields(value); populated > 1 {
+		return invalid("exactly one typed value must be supplied, got %d", populated)
+	}
+
+	switch value.Type {
+	case AttributeValueText:
+		if value.Text == nil {
+			return invalid("text value is required")
+		}
+		text := strings.TrimSpace(*value.Text)
+		if text == "" {
+			return invalid("text value must not be blank")
+		}
+		if definition.Options != nil && definition.Options.MaxLength > 0 &&
+			len([]rune(text)) > definition.Options.MaxLength {
+			return invalid("text value exceeds options.max_length %d",
+				definition.Options.MaxLength)
+		}
+		value.Text = &text
+	case AttributeValueInteger:
+		if value.Integer == nil {
+			return invalid("integer value is required")
+		}
+	case AttributeValueReal:
+		if value.Real == nil {
+			return invalid("real value is required")
+		}
+	case AttributeValueBoolean:
+		if value.Boolean == nil {
+			return invalid("boolean value is required")
+		}
+	case AttributeValueDate:
+		if value.Date == nil {
+			return invalid("date value is required")
+		}
+		date := strings.TrimSpace(*value.Date)
+		parsed, err := time.Parse("2006-01-02", date)
+		if err != nil || parsed.Format("2006-01-02") != date {
+			return invalid("date value %q must be a YYYY-MM-DD calendar date", date)
+		}
+		value.Date = &date
+	case AttributeValueTimestamp:
+		if value.Timestamp == nil {
+			return invalid("timestamp value is required")
+		}
+		utc := value.Timestamp.UTC()
+		value.Timestamp = &utc
+	case AttributeValueJSON:
+		if len(value.JSON) == 0 {
+			return invalid("json value is required")
+		}
+		trimmed := json.RawMessage(strings.TrimSpace(string(value.JSON)))
+		if !json.Valid(trimmed) || string(trimmed) == "null" {
+			return invalid("json value must be valid and non-null")
+		}
+		value.JSON = trimmed
+	case AttributeValueRecordReference:
+		if value.RecordID == nil || *value.RecordID <= 0 {
+			return invalid("record_id must be a positive integer")
+		}
+		if value.RecordType == nil {
+			return invalid("record_type is required for a record reference")
+		}
+		recordType := strings.TrimSpace(*value.RecordType)
+		if definition.RecordTarget == nil || recordType != *definition.RecordTarget {
+			return invalid("record_type %q does not match the definition record_target",
+				recordType)
+		}
+		value.RecordType = &recordType
+	default:
+		return invalid("value_type %s is not supported", value.Type)
+	}
+
+	if definition.FieldType == AttributeFieldSelect ||
+		definition.FieldType == AttributeFieldMultiselect {
+		canonical, err := value.CanonicalString()
+		if err != nil {
+			return AttributeValue{}, err
+		}
+		if !slices.Contains(definition.Options.ChoiceValues(), canonical) {
+			return invalid("value %q is not one of the definition's options.choices",
+				canonical)
+		}
+	}
+	return value, nil
+}
+
+func validateProvenance(source Provenance, confidence *float64) error {
+	if !source.Valid() {
+		return fmt.Errorf("%w: source %q is not one of %s",
+			ErrAttributeValueInvalid, source, ProvenanceCheckValues())
+	}
+	if confidence == nil {
+		return nil
+	}
+	if source.IsDeclared() {
+		return fmt.Errorf("%w: %w (source %s)",
+			ErrAttributeValueInvalid, ErrConfidenceScope, source)
+	}
+	if *confidence < 0 || *confidence > 1 {
+		return fmt.Errorf("%w: %w: %v is outside [0, 1]",
+			ErrAttributeValueInvalid, ErrConfidenceScope, *confidence)
+	}
+	return nil
+}
+
+func writableAttributeDefinition(definition AttributeDefinition) error {
+	if !definition.IsActive {
+		return fmt.Errorf("%s: %w", definition.Slug, ErrAttributeDefinitionInactive)
+	}
+	return retractableAttributeDefinition(definition)
+}
+
+// retractableAttributeDefinition gates supersession, which stays legal on
+// inactive definitions so stale values can be retired with them.
+func retractableAttributeDefinition(definition AttributeDefinition) error {
+	if definition.DerivedSource != nil {
+		return fmt.Errorf("%s is computed by %s: %w",
+			definition.Slug, *definition.DerivedSource, ErrAttributeDefinitionNotWritable)
+	}
+	if !definition.APIMutable {
+		return fmt.Errorf("%s: %w", definition.Slug, ErrAttributeDefinitionNotWritable)
+	}
+	return nil
+}

--- a/internal/store/attributes_schema_test.go
+++ b/internal/store/attributes_schema_test.go
@@ -1,0 +1,224 @@
+package store_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func insertRawDefinition(t *testing.T, st *store.Store, slug string) int64 {
+	t.Helper()
+	var id int64
+	err := st.DB().QueryRow(st.Rebind(`
+		INSERT INTO attribute_definitions
+		    (universal_id, object_type, slug, label, value_type, field_type)
+		VALUES (?, 'person', ?, ?, 'text', 'text')
+		RETURNING id
+	`), "uid-"+slug, slug, slug).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+func insertRawValue(
+	t *testing.T, st *store.Store, personID, definitionID int64, columns string, args ...any,
+) error {
+	t.Helper()
+	placeholders := strings.TrimSuffix(strings.Repeat("?, ", len(args)), ", ")
+	_, err := st.DB().Exec(st.Rebind(fmt.Sprintf(`
+		INSERT INTO person_attribute_values
+		    (person_id, definition_id, source, %s)
+		VALUES (?, ?, 'user', %s)
+	`, columns, placeholders)), append([]any{personID, definitionID}, args...)...)
+	return err
+}
+
+func TestAttributeSchemaRejectsMultipleTypedValueColumns(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "one_value_only")
+
+	err := insertRawValue(t, st, person, definition,
+		"value_text, value_integer", "alice", 7)
+	require.Error(t, err)
+
+	err = insertRawValue(t, st, person, definition, "value_text", "alice")
+	require.NoError(t, err)
+}
+
+func TestAttributeSchemaRejectsNoTypedValueColumn(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "needs_a_value")
+
+	_, err := st.DB().Exec(st.Rebind(`
+		INSERT INTO person_attribute_values (person_id, definition_id, source)
+		VALUES (?, ?, 'user')
+	`), person, definition)
+	require.Error(t, err)
+}
+
+func TestAttributeSchemaRequiresBothRecordReferenceHalves(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "record_ref")
+
+	err := insertRawValue(t, st, person, definition, "value_record_id", person)
+	require.Error(t, err)
+
+	err = insertRawValue(t, st, person, definition,
+		"value_record_id, value_record_type", person, "person")
+	require.NoError(t, err)
+}
+
+func TestAttributeSchemaRejectsOutOfRangeConfidenceAndOrdinal(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "bounds")
+
+	err := insertRawValue(t, st, person, definition,
+		"value_text, confidence", "alice", 1.5)
+	require.Error(t, err)
+
+	err = insertRawValue(t, st, person, definition,
+		"value_text, ordinal", "alice", -1)
+	require.Error(t, err)
+}
+
+func TestAttributeSchemaPinsValueDateSeparatorPositions(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "date_shape")
+
+	for ordinal, accepted := range []string{"2026-07-30", "abcd-ef-gh"} {
+		err := insertRawValue(t, st, person, definition,
+			"value_date, ordinal", accepted, ordinal)
+		require.NoError(t, err,
+			"%q is positionally valid, so the database accepts it", accepted)
+	}
+
+	for _, rejected := range []string{
+		"abcdefghij", "2026-7-30", "20260730", "2026-07-30T00:00:00Z",
+	} {
+		err := insertRawValue(t, st, person, definition, "value_date", rejected)
+		require.Error(t, err, "%q must violate the separator-position CHECK", rejected)
+	}
+}
+
+func TestAttributeSchemaRejectsInvertedActiveInterval(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "interval")
+
+	from := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	err := insertRawValue(t, st, person, definition,
+		"value_text, active_from, active_until", "alice", from, from.Add(-time.Hour))
+	require.Error(t, err)
+
+	err = insertRawValue(t, st, person, definition,
+		"value_text, active_from, active_until", "alice", from, from.Add(time.Hour))
+	require.NoError(t, err)
+}
+
+func TestAttributeSchemaAllowsOnlyOneCurrentValuePerOrdinal(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "single_current")
+	from := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(insertRawValue(t, st, person, definition,
+		"value_text, ordinal, active_from", "first", 0, from))
+
+	err := insertRawValue(t, st, person, definition,
+		"value_text, ordinal, active_from", "second", 0, from.Add(time.Hour))
+	require.Error(err, "two active rows at the same ordinal must violate the unique index")
+
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_attribute_values
+		SET active_until = ?, superseded_at = ?
+		WHERE person_id = ? AND definition_id = ? AND ordinal = 0 AND active_until IS NULL
+	`), from.Add(time.Hour), from.Add(time.Hour), person, definition)
+	require.NoError(err)
+
+	require.NoError(insertRawValue(t, st, person, definition,
+		"value_text, ordinal, active_from", "second", 0, from.Add(time.Hour)))
+
+	var historyCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM person_attribute_values
+		WHERE person_id = ? AND definition_id = ?
+	`), person, definition).Scan(&historyCount))
+	assert.Equal(2, historyCount, "supersede must preserve the historical row")
+
+	require.NoError(insertRawValue(t, st, person, definition,
+		"value_text, ordinal, active_from", "other slot", 1, from.Add(time.Hour)))
+}
+
+func TestAttributeSchemaAcceptsExactlyTheProvenanceVocabulary(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "provenance_probe")
+
+	for ordinal, provenance := range store.AllProvenances {
+		_, err := st.DB().Exec(st.Rebind(`
+			INSERT INTO person_attribute_values
+			    (person_id, definition_id, ordinal, value_text, source)
+			VALUES (?, ?, ?, ?, ?)
+		`), person, definition, ordinal, "alice", string(provenance))
+		require.NoError(t, err, "provenance %q must be accepted", provenance)
+	}
+
+	_, err := st.DB().Exec(st.Rebind(`
+		INSERT INTO person_attribute_values
+		    (person_id, definition_id, ordinal, value_text, source)
+		VALUES (?, ?, ?, ?, ?)
+	`), person, definition, len(store.AllProvenances), "alice", "guessed")
+	require.Error(t, err, "a source outside the vocabulary must be rejected")
+}
+
+func TestAttributeSchemaRefusesDeletingADefinitionThatHasValues(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "restricted")
+	require.NoError(t, insertRawValue(t, st, person, definition, "value_text", "alice"))
+
+	_, err := st.DB().Exec(st.Rebind(
+		`DELETE FROM attribute_definitions WHERE id = ?`), definition)
+	require.Error(t, err, "ON DELETE RESTRICT must refuse while values exist")
+}
+
+func TestAttributeSchemaCascadesValuesWhenAPersonIsDeleted(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	person := mustSchemaTestPerson(t, st)
+	definition := insertRawDefinition(t, st, "cascades")
+	require.NoError(insertRawValue(t, st, person, definition, "value_text", "alice"))
+
+	var revision int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT revision FROM persons WHERE id = ?`), person).Scan(&revision))
+	require.NoError(st.DeletePerson(person, revision))
+
+	var remaining int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM person_attribute_values WHERE person_id = ?`),
+		person).Scan(&remaining))
+	assert.Equal(0, remaining)
+}
+
+func mustSchemaTestPerson(t *testing.T, st *store.Store) int64 {
+	t.Helper()
+	participant, err := st.EnsureParticipant("alice@example.com", "alice", "example.com")
+	require.NoError(t, err)
+	person, _, err := st.CreatePersonFromParticipant(participant)
+	require.NoError(t, err)
+	return person.ID
+}

--- a/internal/store/person_attributes.go
+++ b/internal/store/person_attributes.go
@@ -122,39 +122,22 @@ func (s *Store) ListPersonAttributeValuesContext(
 	return values, nil
 }
 
-// SetPersonAttributeValueContext supersedes the current value and inserts a replacement.
+// SetPersonAttributeValueContext supersedes the current value and inserts a
+// replacement. Definition-dependent validation runs inside each write
+// attempt's transaction so a concurrent definition change cannot slip
+// between check and insert.
 func (s *Store) SetPersonAttributeValueContext(
 	ctx context.Context, input PersonAttributeValueInput,
 ) (*PersonAttributeWrite, error) {
-	definition, err := s.GetAttributeDefinitionBySlugContext(
-		ctx, AttributeObjectPerson, input.DefinitionSlug)
-	if err != nil {
-		return nil, err
-	}
-	if err := writableAttributeDefinition(*definition); err != nil {
-		return nil, err
-	}
-	value, err := normalizeAttributeValue(*definition, input.Value)
-	if err != nil {
-		return nil, err
-	}
-	input.Value = value
 	if err := validateProvenance(input.Source, input.Confidence); err != nil {
 		return nil, err
-	}
-	if definition.Cardinality == AttributeCardinalitySingle &&
-		input.Ordinal != nil && *input.Ordinal != 0 {
-		return nil, fmt.Errorf(
-			"%w: ordinal %d is not allowed on %s, which declares cardinality single",
-			ErrAttributeValueInvalid, *input.Ordinal, definition.Slug)
 	}
 	if input.Ordinal != nil && *input.Ordinal < 0 {
 		return nil, fmt.Errorf("%w: ordinal must not be negative", ErrAttributeValueInvalid)
 	}
-
 	return s.retryAttributeWrite("set person attribute value",
 		func() (*PersonAttributeWrite, error) {
-			return s.setPersonAttributeValueOnce(ctx, *definition, input)
+			return s.setPersonAttributeValueOnce(ctx, input)
 		})
 }
 
@@ -179,7 +162,7 @@ func (s *Store) retryAttributeWrite(
 }
 
 func (s *Store) setPersonAttributeValueOnce(
-	ctx context.Context, definition AttributeDefinition, input PersonAttributeValueInput,
+	ctx context.Context, input PersonAttributeValueInput,
 ) (*PersonAttributeWrite, error) {
 	activeFrom := time.Now().UTC()
 	if input.ActiveFrom != nil {
@@ -192,6 +175,26 @@ func (s *Store) setPersonAttributeValueOnce(
 
 	write := &PersonAttributeWrite{DryRun: input.DryRun}
 	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		loaded, err := s.getAttributeDefinitionBySlugTx(
+			ctx, tx, AttributeObjectPerson, input.DefinitionSlug)
+		if err != nil {
+			return err
+		}
+		definition := *loaded
+		if err := writableAttributeDefinition(definition); err != nil {
+			return err
+		}
+		value, err := normalizeAttributeValue(definition, input.Value)
+		if err != nil {
+			return err
+		}
+		input.Value = value
+		if definition.Cardinality == AttributeCardinalitySingle &&
+			input.Ordinal != nil && *input.Ordinal != 0 {
+			return fmt.Errorf(
+				"%w: ordinal %d is not allowed on %s, which declares cardinality single",
+				ErrAttributeValueInvalid, *input.Ordinal, definition.Slug)
+		}
 		if input.Value.Type == AttributeValueRecordReference {
 			if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
 				return err
@@ -400,29 +403,13 @@ func (s *Store) insertPersonAttributeValueTx(
 
 // SupersedePersonAttributeValueContext closes a current value without
 // replacement. Unlike Set it also works on inactive definitions: retracting a
-// stale value from a retired definition must stay possible.
+// stale value from a retired definition must stay possible. As in Set, the
+// definition is loaded and checked inside each attempt's transaction.
 func (s *Store) SupersedePersonAttributeValueContext(
 	ctx context.Context, input PersonAttributeSupersedeInput,
 ) (*PersonAttributeWrite, error) {
-	definition, err := s.GetAttributeDefinitionBySlugContext(
-		ctx, AttributeObjectPerson, input.DefinitionSlug)
-	if err != nil {
-		return nil, err
-	}
-	if err := retractableAttributeDefinition(*definition); err != nil {
-		return nil, err
-	}
-	ordinal := int64(0)
-	if input.Ordinal != nil {
-		if *input.Ordinal < 0 {
-			return nil, fmt.Errorf("%w: ordinal must not be negative", ErrAttributeValueInvalid)
-		}
-		if definition.Cardinality == AttributeCardinalitySingle && *input.Ordinal != 0 {
-			return nil, fmt.Errorf(
-				"%w: ordinal %d is not allowed on %s, which declares cardinality single",
-				ErrAttributeValueInvalid, *input.Ordinal, definition.Slug)
-		}
-		ordinal = *input.Ordinal
+	if input.Ordinal != nil && *input.Ordinal < 0 {
+		return nil, fmt.Errorf("%w: ordinal must not be negative", ErrAttributeValueInvalid)
 	}
 	at := time.Now().UTC()
 	if input.At != nil {
@@ -430,18 +417,34 @@ func (s *Store) SupersedePersonAttributeValueContext(
 	}
 	return s.retryAttributeWrite("supersede person attribute value",
 		func() (*PersonAttributeWrite, error) {
-			return s.supersedePersonAttributeValueOnce(ctx, definition.ID, ordinal, at, input)
+			return s.supersedePersonAttributeValueOnce(ctx, at, input)
 		})
 }
 
 func (s *Store) supersedePersonAttributeValueOnce(
-	ctx context.Context, definitionID, ordinal int64, at time.Time,
-	input PersonAttributeSupersedeInput,
+	ctx context.Context, at time.Time, input PersonAttributeSupersedeInput,
 ) (*PersonAttributeWrite, error) {
 	write := &PersonAttributeWrite{DryRun: input.DryRun}
 	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		definition, err := s.getAttributeDefinitionBySlugTx(
+			ctx, tx, AttributeObjectPerson, input.DefinitionSlug)
+		if err != nil {
+			return err
+		}
+		if err := retractableAttributeDefinition(*definition); err != nil {
+			return err
+		}
+		ordinal := int64(0)
+		if input.Ordinal != nil {
+			if definition.Cardinality == AttributeCardinalitySingle && *input.Ordinal != 0 {
+				return fmt.Errorf(
+					"%w: ordinal %d is not allowed on %s, which declares cardinality single",
+					ErrAttributeValueInvalid, *input.Ordinal, definition.Slug)
+			}
+			ordinal = *input.Ordinal
+		}
 		current, hasCurrent, err := s.currentPersonAttributeValueTx(
-			ctx, tx, input.PersonID, definitionID, ordinal)
+			ctx, tx, input.PersonID, definition.ID, ordinal)
 		if err != nil {
 			return err
 		}

--- a/internal/store/person_attributes.go
+++ b/internal/store/person_attributes.go
@@ -1,0 +1,554 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PersonAttributeValue is one typed value and its history metadata.
+type PersonAttributeValue struct {
+	ID             int64          `json:"id"`
+	PersonID       int64          `json:"person_id"`
+	DefinitionID   int64          `json:"definition_id"`
+	DefinitionSlug string         `json:"definition_slug"`
+	Ordinal        int64          `json:"ordinal"`
+	Value          AttributeValue `json:"value"`
+	ActiveFrom     time.Time      `json:"active_from"`
+	ActiveUntil    *time.Time     `json:"active_until,omitempty"`
+	CreatedAt      time.Time      `json:"created_at"`
+	SupersededAt   *time.Time     `json:"superseded_at,omitempty"`
+	Source         Provenance     `json:"source"`
+	SourceRef      *string        `json:"source_ref,omitempty"`
+	Confidence     *float64       `json:"confidence,omitempty"`
+	Actor          *string        `json:"actor,omitempty"`
+}
+
+// PersonAttributeValueInput sets one typed person attribute value.
+type PersonAttributeValueInput struct {
+	PersonID        int64
+	DefinitionSlug  string
+	Ordinal         *int64
+	Value           AttributeValue
+	ActiveFrom      *time.Time
+	ActiveUntil     *time.Time
+	Source          Provenance
+	SourceRef       *string
+	Confidence      *float64
+	Actor           *string
+	ExpectedValueID *int64
+	DryRun          bool
+}
+
+// PersonAttributeSupersedeInput closes one current value without replacement.
+type PersonAttributeSupersedeInput struct {
+	PersonID        int64
+	DefinitionSlug  string
+	Ordinal         *int64
+	At              *time.Time
+	Actor           *string
+	ExpectedValueID *int64
+	DryRun          bool
+}
+
+// PersonAttributeWrite describes a set or supersede result.
+type PersonAttributeWrite struct {
+	Value      *PersonAttributeValue `json:"value,omitempty"`
+	Superseded *PersonAttributeValue `json:"superseded,omitempty"`
+	DryRun     bool                  `json:"dry_run"`
+}
+
+// PersonAttributeQuery filters a person's attribute values.
+type PersonAttributeQuery struct {
+	DefinitionSlug string
+	IncludeHistory bool
+}
+
+const personAttributeValueColumns = `
+	v.id, v.person_id, v.definition_id, d.slug, v.ordinal,
+	d.value_type, v.value_text, v.value_integer, v.value_real, v.value_boolean,
+	v.value_date, v.value_timestamp, v.value_json, v.value_record_type,
+	v.value_record_id, v.active_from, v.active_until, v.created_at,
+	v.superseded_at, v.source, v.source_ref, v.confidence, v.actor
+`
+
+// ListPersonAttributeValuesContext lists current or historical values.
+func (s *Store) ListPersonAttributeValuesContext(
+	ctx context.Context, personID int64, query PersonAttributeQuery,
+) ([]PersonAttributeValue, error) {
+	conditions := []string{"v.person_id = ?"}
+	args := []any{personID}
+	if query.DefinitionSlug != "" {
+		conditions = append(conditions, "d.slug = ?", "d.object_type = ?")
+		args = append(args, query.DefinitionSlug, string(AttributeObjectPerson))
+	}
+	if !query.IncludeHistory {
+		conditions = append(conditions,
+			"v.active_until IS NULL", "v.superseded_at IS NULL")
+	}
+	order := "d.display_order, d.slug, v.ordinal, v.id"
+	if query.IncludeHistory {
+		order = "d.display_order, d.slug, v.ordinal, " +
+			"CASE WHEN v.active_until IS NULL AND v.superseded_at IS NULL " +
+			"THEN 0 ELSE 1 END, v.active_from DESC, v.id DESC"
+	}
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		FROM person_attribute_values v
+		JOIN attribute_definitions d ON d.id = v.definition_id
+		WHERE %s
+		ORDER BY %s
+	`, personAttributeValueColumns, strings.Join(conditions, " AND "), order), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list person %d attribute values: %w", personID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	values := make([]PersonAttributeValue, 0)
+	for rows.Next() {
+		value, scanErr := scanPersonAttributeValue(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan person attribute value: %w", scanErr)
+		}
+		values = append(values, *value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate person attribute values: %w", err)
+	}
+	return values, nil
+}
+
+// SetPersonAttributeValueContext supersedes the current value and inserts a replacement.
+func (s *Store) SetPersonAttributeValueContext(
+	ctx context.Context, input PersonAttributeValueInput,
+) (*PersonAttributeWrite, error) {
+	definition, err := s.GetAttributeDefinitionBySlugContext(
+		ctx, AttributeObjectPerson, input.DefinitionSlug)
+	if err != nil {
+		return nil, err
+	}
+	if err := writableAttributeDefinition(*definition); err != nil {
+		return nil, err
+	}
+	value, err := normalizeAttributeValue(*definition, input.Value)
+	if err != nil {
+		return nil, err
+	}
+	input.Value = value
+	if err := validateProvenance(input.Source, input.Confidence); err != nil {
+		return nil, err
+	}
+	if definition.Cardinality == AttributeCardinalitySingle &&
+		input.Ordinal != nil && *input.Ordinal != 0 {
+		return nil, fmt.Errorf(
+			"%w: ordinal %d is not allowed on %s, which declares cardinality single",
+			ErrAttributeValueInvalid, *input.Ordinal, definition.Slug)
+	}
+	if input.Ordinal != nil && *input.Ordinal < 0 {
+		return nil, fmt.Errorf("%w: ordinal must not be negative", ErrAttributeValueInvalid)
+	}
+
+	return s.retryAttributeWrite("set person attribute value",
+		func() (*PersonAttributeWrite, error) {
+			return s.setPersonAttributeValueOnce(ctx, *definition, input)
+		})
+}
+
+// retryAttributeWrite retries read-then-write transactions that can fail
+// snapshot upgrade (SQLITE_BUSY) or race the current-value unique index.
+func (s *Store) retryAttributeWrite(
+	operation string, attempt func() (*PersonAttributeWrite, error),
+) (*PersonAttributeWrite, error) {
+	var lastErr error
+	for range maxAttributeWriteAttempts {
+		write, err := attempt()
+		if err == nil {
+			return write, nil
+		}
+		if !s.dialect.IsConflictError(err) && !s.dialect.IsBusyError(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("%s: gave up after %d attempts: %w",
+		operation, maxAttributeWriteAttempts, lastErr)
+}
+
+func (s *Store) setPersonAttributeValueOnce(
+	ctx context.Context, definition AttributeDefinition, input PersonAttributeValueInput,
+) (*PersonAttributeWrite, error) {
+	activeFrom := time.Now().UTC()
+	if input.ActiveFrom != nil {
+		activeFrom = input.ActiveFrom.UTC()
+	}
+	if input.ActiveUntil != nil && input.ActiveUntil.Before(activeFrom) {
+		return nil, fmt.Errorf("%w: active_until must not precede active_from",
+			ErrAttributeValueInvalid)
+	}
+
+	write := &PersonAttributeWrite{DryRun: input.DryRun}
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		if input.Value.Type == AttributeValueRecordReference {
+			if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+				return err
+			}
+		}
+		var personExists int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM persons WHERE id = ?`, input.PersonID,
+		).Scan(&personExists); err != nil {
+			return fmt.Errorf("verify person %d: %w", input.PersonID, err)
+		}
+		if personExists == 0 {
+			return ErrPersonNotFound
+		}
+		if err := s.verifyAttributeRecordTargetTx(ctx, tx, input.Value); err != nil {
+			return err
+		}
+		ordinal, err := s.resolveAttributeOrdinalTx(ctx, tx, definition, input)
+		if err != nil {
+			return err
+		}
+		current, hasCurrent, err := s.currentPersonAttributeValueTx(
+			ctx, tx, input.PersonID, definition.ID, ordinal)
+		if err != nil {
+			return err
+		}
+		if input.ExpectedValueID != nil &&
+			(!hasCurrent || current.ID != *input.ExpectedValueID) {
+			return ErrAttributeValueConflict
+		}
+		if hasCurrent {
+			if activeFrom.Before(current.ActiveFrom) {
+				return fmt.Errorf("%w: active_from precedes the current value",
+					ErrAttributeValueInvalid)
+			}
+			closed, err := s.closePersonAttributeValueTx(
+				ctx, tx, current.ID, activeFrom, time.Now().UTC())
+			if err != nil {
+				return err
+			}
+			write.Superseded = closed
+		}
+		inserted, err := s.insertPersonAttributeValueTx(
+			ctx, tx, definition, input, ordinal, activeFrom)
+		if err != nil {
+			return err
+		}
+		write.Value = inserted
+		if input.DryRun {
+			write.Value.ID = 0
+			if write.Superseded != nil {
+				write.Superseded.ID = current.ID
+			}
+			return errAttributeDryRun
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errAttributeDryRun) {
+		return nil, err
+	}
+	return write, nil
+}
+
+func (s *Store) resolveAttributeOrdinalTx(
+	ctx context.Context, tx *loggedTx,
+	definition AttributeDefinition, input PersonAttributeValueInput,
+) (int64, error) {
+	if definition.Cardinality == AttributeCardinalitySingle {
+		return 0, nil
+	}
+	if input.Ordinal != nil {
+		return *input.Ordinal, nil
+	}
+	// Scan historical rows too: reusing a superseded slot's ordinal would
+	// splice an unrelated value into that slot's supersession lineage.
+	var next int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(ordinal) + 1, 0)
+		FROM person_attribute_values
+		WHERE person_id = ? AND definition_id = ?
+	`, input.PersonID, definition.ID).Scan(&next); err != nil {
+		return 0, fmt.Errorf("resolve next ordinal for %s: %w", definition.Slug, err)
+	}
+	return next, nil
+}
+
+func (s *Store) verifyAttributeRecordTargetTx(
+	ctx context.Context, tx *loggedTx, value AttributeValue,
+) error {
+	if value.Type != AttributeValueRecordReference {
+		return nil
+	}
+	switch *value.RecordType {
+	case "person":
+		var exists int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM persons WHERE id = ?`, *value.RecordID,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("verify referenced person %d: %w", *value.RecordID, err)
+		}
+		if exists == 0 {
+			return fmt.Errorf("%w: referenced person %d does not exist",
+				ErrAttributeValueInvalid, *value.RecordID)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: record_type %q is not supported yet",
+			ErrAttributeValueInvalid, *value.RecordType)
+	}
+}
+
+func (s *Store) currentPersonAttributeValueTx(
+	ctx context.Context, tx *loggedTx, personID, definitionID, ordinal int64,
+) (*PersonAttributeValue, bool, error) {
+	value, err := scanPersonAttributeValue(tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		FROM person_attribute_values v
+		JOIN attribute_definitions d ON d.id = v.definition_id
+		WHERE v.person_id = ? AND v.definition_id = ? AND v.ordinal = ?
+		  AND v.active_until IS NULL AND v.superseded_at IS NULL%s
+	`, personAttributeValueColumns, s.dialect.SelectForUpdate()),
+		personID, definitionID, ordinal))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("load current attribute value: %w", err)
+	}
+	return value, true, nil
+}
+
+func (s *Store) closePersonAttributeValueTx(
+	ctx context.Context, tx *loggedTx, valueID int64,
+	activeUntil, supersededAt time.Time,
+) (*PersonAttributeValue, error) {
+	result, err := tx.ExecContext(ctx, `
+		UPDATE person_attribute_values
+		SET active_until = ?, superseded_at = ?
+		WHERE id = ? AND active_until IS NULL AND superseded_at IS NULL
+	`, activeUntil, supersededAt, valueID)
+	if err != nil {
+		return nil, fmt.Errorf("close attribute value %d: %w", valueID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("check close of attribute value %d: %w", valueID, err)
+	}
+	if affected != 1 {
+		return nil, ErrAttributeValueConflict
+	}
+	closed, err := scanPersonAttributeValue(tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		FROM person_attribute_values v
+		JOIN attribute_definitions d ON d.id = v.definition_id
+		WHERE v.id = ?
+	`, personAttributeValueColumns), valueID))
+	if err != nil {
+		return nil, fmt.Errorf("re-read closed attribute value %d: %w", valueID, err)
+	}
+	return closed, nil
+}
+
+func (s *Store) insertPersonAttributeValueTx(
+	ctx context.Context, tx *loggedTx, definition AttributeDefinition,
+	input PersonAttributeValueInput, ordinal int64, activeFrom time.Time,
+) (*PersonAttributeValue, error) {
+	var jsonValue any
+	if len(input.Value.JSON) > 0 {
+		jsonValue = string(input.Value.JSON)
+	}
+	var activeUntil any
+	if input.ActiveUntil != nil {
+		activeUntil = input.ActiveUntil.UTC()
+	}
+	var insertedID int64
+	if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
+		INSERT INTO person_attribute_values (
+		    person_id, definition_id, ordinal,
+		    value_text, value_integer, value_real, value_boolean,
+		    value_date, value_timestamp, value_json,
+		    value_record_type, value_record_id,
+		    active_from, active_until, source, source_ref, confidence, actor
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING id
+	`, s.dialect.JSONBindExpr()),
+		input.PersonID, definition.ID, ordinal,
+		input.Value.Text, input.Value.Integer, input.Value.Real, input.Value.Boolean,
+		input.Value.Date, input.Value.Timestamp, jsonValue,
+		input.Value.RecordType, input.Value.RecordID,
+		activeFrom, activeUntil, string(input.Source), input.SourceRef,
+		input.Confidence, input.Actor,
+	).Scan(&insertedID); err != nil {
+		return nil, fmt.Errorf("insert attribute value for %s: %w", definition.Slug, err)
+	}
+	inserted, err := scanPersonAttributeValue(tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		FROM person_attribute_values v
+		JOIN attribute_definitions d ON d.id = v.definition_id
+		WHERE v.id = ?
+	`, personAttributeValueColumns), insertedID))
+	if err != nil {
+		return nil, fmt.Errorf("re-read inserted attribute value: %w", err)
+	}
+	return inserted, nil
+}
+
+// SupersedePersonAttributeValueContext closes a current value without
+// replacement. Unlike Set it also works on inactive definitions: retracting a
+// stale value from a retired definition must stay possible.
+func (s *Store) SupersedePersonAttributeValueContext(
+	ctx context.Context, input PersonAttributeSupersedeInput,
+) (*PersonAttributeWrite, error) {
+	definition, err := s.GetAttributeDefinitionBySlugContext(
+		ctx, AttributeObjectPerson, input.DefinitionSlug)
+	if err != nil {
+		return nil, err
+	}
+	if err := retractableAttributeDefinition(*definition); err != nil {
+		return nil, err
+	}
+	ordinal := int64(0)
+	if input.Ordinal != nil {
+		if *input.Ordinal < 0 {
+			return nil, fmt.Errorf("%w: ordinal must not be negative", ErrAttributeValueInvalid)
+		}
+		if definition.Cardinality == AttributeCardinalitySingle && *input.Ordinal != 0 {
+			return nil, fmt.Errorf(
+				"%w: ordinal %d is not allowed on %s, which declares cardinality single",
+				ErrAttributeValueInvalid, *input.Ordinal, definition.Slug)
+		}
+		ordinal = *input.Ordinal
+	}
+	at := time.Now().UTC()
+	if input.At != nil {
+		at = input.At.UTC()
+	}
+	return s.retryAttributeWrite("supersede person attribute value",
+		func() (*PersonAttributeWrite, error) {
+			return s.supersedePersonAttributeValueOnce(ctx, definition.ID, ordinal, at, input)
+		})
+}
+
+func (s *Store) supersedePersonAttributeValueOnce(
+	ctx context.Context, definitionID, ordinal int64, at time.Time,
+	input PersonAttributeSupersedeInput,
+) (*PersonAttributeWrite, error) {
+	write := &PersonAttributeWrite{DryRun: input.DryRun}
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		current, hasCurrent, err := s.currentPersonAttributeValueTx(
+			ctx, tx, input.PersonID, definitionID, ordinal)
+		if err != nil {
+			return err
+		}
+		if !hasCurrent {
+			return ErrAttributeValueNotFound
+		}
+		if input.ExpectedValueID != nil && current.ID != *input.ExpectedValueID {
+			return ErrAttributeValueConflict
+		}
+		if at.Before(current.ActiveFrom) {
+			return fmt.Errorf("%w: supersede time precedes active_from",
+				ErrAttributeValueInvalid)
+		}
+		closed, err := s.closePersonAttributeValueTx(
+			ctx, tx, current.ID, at, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		write.Superseded = closed
+		if input.DryRun {
+			return errAttributeDryRun
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errAttributeDryRun) {
+		return nil, err
+	}
+	return write, nil
+}
+
+func scanPersonAttributeValue(row scanner) (*PersonAttributeValue, error) {
+	var (
+		value        PersonAttributeValue
+		valueType    string
+		text         sql.NullString
+		integer      sql.NullInt64
+		realValue    sql.NullFloat64
+		boolean      sql.NullBool
+		date         sql.NullString
+		timestamp    sql.NullTime
+		rawJSON      []byte
+		recordType   sql.NullString
+		recordID     sql.NullInt64
+		activeUntil  sql.NullTime
+		supersededAt sql.NullTime
+		source       string
+		sourceRef    sql.NullString
+		confidence   sql.NullFloat64
+		actor        sql.NullString
+	)
+	if err := row.Scan(
+		&value.ID, &value.PersonID, &value.DefinitionID, &value.DefinitionSlug,
+		&value.Ordinal, &valueType, &text, &integer, &realValue, &boolean, &date,
+		&timestamp, &rawJSON, &recordType, &recordID, &value.ActiveFrom,
+		&activeUntil, &value.CreatedAt, &supersededAt, &source, &sourceRef,
+		&confidence, &actor,
+	); err != nil {
+		return nil, err
+	}
+	value.Value.Type = AttributeValueType(valueType)
+	if text.Valid {
+		value.Value.Text = &text.String
+	}
+	if integer.Valid {
+		value.Value.Integer = &integer.Int64
+	}
+	if realValue.Valid {
+		value.Value.Real = &realValue.Float64
+	}
+	if boolean.Valid {
+		value.Value.Boolean = &boolean.Bool
+	}
+	if date.Valid {
+		value.Value.Date = &date.String
+	}
+	if timestamp.Valid {
+		utc := timestamp.Time.UTC()
+		value.Value.Timestamp = &utc
+	}
+	if len(rawJSON) > 0 {
+		value.Value.JSON = json.RawMessage(append([]byte(nil), rawJSON...))
+	}
+	if recordType.Valid {
+		value.Value.RecordType = &recordType.String
+	}
+	if recordID.Valid {
+		value.Value.RecordID = &recordID.Int64
+	}
+	if activeUntil.Valid {
+		utc := activeUntil.Time.UTC()
+		value.ActiveUntil = &utc
+	}
+	if supersededAt.Valid {
+		utc := supersededAt.Time.UTC()
+		value.SupersededAt = &utc
+	}
+	value.Source = Provenance(source)
+	if sourceRef.Valid {
+		value.SourceRef = &sourceRef.String
+	}
+	if confidence.Valid {
+		value.Confidence = &confidence.Float64
+	}
+	if actor.Valid {
+		value.Actor = &actor.String
+	}
+	value.ActiveFrom = value.ActiveFrom.UTC()
+	value.CreatedAt = value.CreatedAt.UTC()
+	return &value, nil
+}

--- a/internal/store/person_attributes_test.go
+++ b/internal/store/person_attributes_test.go
@@ -1,0 +1,354 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func slugify(name string) string { return strings.ReplaceAll(name, " ", "_") }
+
+func mustAttributePerson(t *testing.T, st *store.Store) int64 {
+	t.Helper()
+	participant, err := st.EnsureParticipant("alice@example.com", "alice", "example.com")
+	require.NoError(t, err)
+	person, _, err := st.CreatePersonFromParticipant(participant)
+	require.NoError(t, err)
+	return person.ID
+}
+
+func TestSetPersonAttributeValueStoresEveryTypedColumn(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+	person := mustAttributePerson(t, st)
+	timestamp := time.Date(2026, 7, 30, 9, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		valueType store.AttributeValueType
+		fieldType store.AttributeFieldType
+		value     store.AttributeValue
+	}{
+		{"text", store.AttributeValueText, store.AttributeFieldText,
+			store.AttributeValue{Type: store.AttributeValueText, Text: new("board games")}},
+		{"integer", store.AttributeValueInteger, store.AttributeFieldDuration,
+			store.AttributeValue{Type: store.AttributeValueInteger, Integer: new(int64(30))}},
+		{"real", store.AttributeValueReal, store.AttributeFieldText,
+			store.AttributeValue{Type: store.AttributeValueReal, Real: new(1.5)}},
+		{"boolean", store.AttributeValueBoolean, store.AttributeFieldCheckbox,
+			store.AttributeValue{Type: store.AttributeValueBoolean, Boolean: new(true)}},
+		{"date", store.AttributeValueDate, store.AttributeFieldDate,
+			store.AttributeValue{Type: store.AttributeValueDate, Date: new("2026-07-30")}},
+		{"timestamp", store.AttributeValueTimestamp, store.AttributeFieldTimestamp,
+			store.AttributeValue{Type: store.AttributeValueTimestamp, Timestamp: &timestamp}},
+		{"json", store.AttributeValueJSON, store.AttributeFieldJSON,
+			store.AttributeValue{Type: store.AttributeValueJSON,
+				JSON: json.RawMessage(`{"kind":"synthetic"}`)}},
+		{"record reference", store.AttributeValueRecordReference, store.AttributeFieldPerson,
+			store.AttributeValue{Type: store.AttributeValueRecordReference,
+				RecordType: new("person"), RecordID: &person}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			definition := personTextDefinition("typed_" + slugify(test.name))
+			definition.UniversalID = "test-typed-" + slugify(test.name)
+			definition.ValueType = test.valueType
+			definition.FieldType = test.fieldType
+			if test.valueType == store.AttributeValueRecordReference {
+				definition.RecordTarget = new("person")
+			}
+			created, err := st.CreateAttributeDefinitionContext(ctx, definition)
+			require.NoError(err)
+
+			write, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+				PersonID: person, DefinitionSlug: created.Slug,
+				Value: test.value, Source: store.ProvenanceUser,
+			})
+			require.NoError(err)
+			require.NotNil(write.Value)
+			assert.Equal(test.valueType, write.Value.Value.Type)
+			assert.Nil(write.Superseded)
+
+			current, err := st.ListPersonAttributeValuesContext(ctx, person,
+				store.PersonAttributeQuery{DefinitionSlug: created.Slug})
+			require.NoError(err)
+			require.Len(current, 1)
+			assert.Equal(write.Value.ID, current[0].ID)
+		})
+	}
+}
+
+func TestDeletePersonRejectsStoredRecordReferences(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+	sourceParticipant, err := st.EnsureParticipant(
+		"source@example.com", "source", "example.com")
+	require.NoError(err)
+	source, _, err := st.CreatePersonFromParticipant(sourceParticipant)
+	require.NoError(err)
+	targetParticipant, err := st.EnsureParticipant(
+		"target@example.com", "target", "example.com")
+	require.NoError(err)
+	target, _, err := st.CreatePersonFromParticipant(targetParticipant)
+	require.NoError(err)
+
+	definition := personTextDefinition("related_person")
+	definition.UniversalID = "test-related-person"
+	definition.ValueType = store.AttributeValueRecordReference
+	definition.FieldType = store.AttributeFieldPerson
+	definition.RecordTarget = new("person")
+	_, err = st.CreateAttributeDefinitionContext(ctx, definition)
+	require.NoError(err)
+	write, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: source.ID, DefinitionSlug: definition.Slug,
+		Value: store.AttributeValue{
+			Type: store.AttributeValueRecordReference, RecordType: new("person"),
+			RecordID: &target.ID,
+		},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+
+	err = st.DeletePersonContext(ctx, target.ID, target.Revision)
+	require.ErrorIs(err, store.ErrPersonReferenced)
+	_, err = st.GetPersonContext(ctx, target.ID)
+	require.NoError(err, "referenced person must remain after a rejected delete")
+
+	_, err = st.SupersedePersonAttributeValueContext(ctx,
+		store.PersonAttributeSupersedeInput{
+			PersonID: source.ID, DefinitionSlug: definition.Slug,
+			ExpectedValueID: &write.Value.ID,
+		})
+	require.NoError(err)
+	err = st.DeletePersonContext(ctx, target.ID, target.Revision)
+	require.NoError(err,
+		"superseded references must not block deletion; only current values do")
+}
+
+func TestSetPersonAttributeValueRejectsInvalidShapes(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+	person := mustAttributePerson(t, st)
+
+	tests := []store.PersonAttributeValueInput{
+		{
+			PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+			Value:  store.AttributeValue{Type: store.AttributeValueInteger, Integer: new(int64(7))},
+			Source: store.ProvenanceUser,
+		},
+		{
+			PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+			Value:  store.AttributeValue{Type: store.AttributeValueText},
+			Source: store.ProvenanceUser,
+		},
+		{
+			PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+			Value: store.AttributeValue{Type: store.AttributeValueText,
+				Text: new("email"), Integer: new(int64(7))},
+			Source: store.ProvenanceUser,
+		},
+		{
+			PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+			Ordinal: new(int64(1)),
+			Value:   store.AttributeValue{Type: store.AttributeValueText, Text: new("email")},
+			Source:  store.ProvenanceUser,
+		},
+		{
+			PersonID: person, DefinitionSlug: store.AttributeSlugAskMeAbout,
+			Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("sailing")},
+			Source: store.ProvenanceUser, Confidence: new(0.9),
+		},
+	}
+	for _, input := range tests {
+		_, err := st.SetPersonAttributeValueContext(ctx, input)
+		require.ErrorIs(t, err, store.ErrAttributeValueInvalid)
+	}
+
+	_, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugLastContacted,
+		Value: store.AttributeValue{Type: store.AttributeValueTimestamp,
+			Timestamp: new(time.Now())},
+		Source: store.ProvenanceSystem,
+	})
+	require.ErrorIs(t, err, store.ErrAttributeDefinitionNotWritable)
+}
+
+func TestPersonAttributeSupersedeHistoryCASAndDryRun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+	person := mustAttributePerson(t, st)
+
+	first, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("email")},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+
+	second, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("chat")},
+		Source: store.ProvenanceUser, ExpectedValueID: &first.Value.ID,
+	})
+	require.NoError(err)
+	require.NotNil(second.Superseded)
+	assert.Equal(first.Value.ID, second.Superseded.ID)
+	require.NotNil(second.Superseded.ActiveUntil)
+	assert.True(second.Superseded.ActiveUntil.Equal(second.Value.ActiveFrom))
+
+	_, err = st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("phone")},
+		Source: store.ProvenanceUser, ExpectedValueID: &first.Value.ID,
+	})
+	require.ErrorIs(err, store.ErrAttributeValueConflict)
+
+	preview, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("sms")},
+		Source: store.ProvenanceUser, DryRun: true,
+	})
+	require.NoError(err)
+	assert.True(preview.DryRun)
+	assert.Zero(preview.Value.ID)
+
+	history, err := st.ListPersonAttributeValuesContext(ctx, person,
+		store.PersonAttributeQuery{
+			DefinitionSlug: store.AttributeSlugPrimaryChannel, IncludeHistory: true})
+	require.NoError(err)
+	require.Len(history, 2)
+	assert.Equal(second.Value.ID, history[0].ID)
+	assert.Equal(first.Value.ID, history[1].ID)
+
+	cleared, err := st.SupersedePersonAttributeValueContext(ctx,
+		store.PersonAttributeSupersedeInput{
+			PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+			ExpectedValueID: &second.Value.ID,
+		})
+	require.NoError(err)
+	assert.Nil(cleared.Value)
+	require.NotNil(cleared.Superseded)
+}
+
+func TestInactiveDefinitionBlocksSetButAllowsSupersede(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+	person := mustAttributePerson(t, st)
+
+	definition := personTextDefinition("retired_field")
+	definition.UniversalID = "test-retired-field"
+	created, err := st.CreateAttributeDefinitionContext(ctx, definition)
+	require.NoError(err)
+	write, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: created.Slug,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("stale")},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+
+	inactive := false
+	_, err = st.UpdateAttributeDefinitionContext(ctx, created.ID, created.Revision,
+		store.AttributeDefinitionUpdate{IsActive: &inactive})
+	require.NoError(err)
+
+	_, err = st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: created.Slug,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("new")},
+		Source: store.ProvenanceUser,
+	})
+	require.ErrorIs(err, store.ErrAttributeDefinitionInactive)
+
+	cleared, err := st.SupersedePersonAttributeValueContext(ctx,
+		store.PersonAttributeSupersedeInput{
+			PersonID: person, DefinitionSlug: created.Slug,
+			ExpectedValueID: &write.Value.ID,
+		})
+	require.NoError(err, "retracting a value from a retired definition must stay possible")
+	require.NotNil(cleared.Superseded)
+}
+
+func TestBackdatedReplacementSeparatesValidityAndAuditTimes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+	person := mustAttributePerson(t, st)
+	originalActiveFrom := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	replacementActiveFrom := time.Date(2021, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	first, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+		Value:      store.AttributeValue{Type: store.AttributeValueText, Text: new("email")},
+		ActiveFrom: &originalActiveFrom, Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+
+	beforeWrite := time.Now().UTC().Add(-time.Second)
+	replacement, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugPrimaryChannel,
+		Value:      store.AttributeValue{Type: store.AttributeValueText, Text: new("chat")},
+		ActiveFrom: &replacementActiveFrom, Source: store.ProvenanceUser,
+		ExpectedValueID: &first.Value.ID,
+	})
+	afterWrite := time.Now().UTC().Add(time.Second)
+	require.NoError(err)
+	require.NotNil(replacement.Superseded)
+	require.NotNil(replacement.Superseded.ActiveUntil)
+	require.NotNil(replacement.Superseded.SupersededAt)
+	assert.Equal(replacementActiveFrom, *replacement.Superseded.ActiveUntil)
+	assert.True(replacement.Superseded.SupersededAt.After(beforeWrite))
+	assert.True(replacement.Superseded.SupersededAt.Before(afterWrite))
+}
+
+func TestMultiCardinalityAppendsPerOrdinalAndDerivedConfidenceIsAllowed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := context.Background()
+	person := mustAttributePerson(t, st)
+
+	first, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugAskMeAbout,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("sailing")},
+		Source: store.ProvenanceExtraction, Confidence: new(0.62),
+	})
+	require.NoError(err)
+	second, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugAskMeAbout,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("ceramics")},
+		Source: store.ProvenanceSystem, Confidence: new(0.5),
+	})
+	require.NoError(err)
+	assert.Equal(int64(0), first.Value.Ordinal)
+	assert.Equal(int64(1), second.Value.Ordinal)
+	assert.InDelta(0.5, *second.Value.Confidence, 0.0001)
+
+	_, err = st.SupersedePersonAttributeValueContext(ctx,
+		store.PersonAttributeSupersedeInput{
+			PersonID: person, DefinitionSlug: store.AttributeSlugAskMeAbout,
+			Ordinal: &second.Value.Ordinal,
+		})
+	require.NoError(err)
+	third, err := st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person, DefinitionSlug: store.AttributeSlugAskMeAbout,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: new("poetry")},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+	assert.Equal(int64(2), third.Value.Ordinal,
+		"appending must not reuse a superseded slot's ordinal and adopt its history")
+}

--- a/internal/store/persons.go
+++ b/internal/store/persons.go
@@ -15,6 +15,7 @@ var (
 	ErrPersonNotFound         = errors.New("person not found")
 	ErrPersonRevisionConflict = errors.New("person revision conflict")
 	ErrPersonBindingConflict  = errors.New("participant clusters belong to different persons")
+	ErrPersonReferenced       = errors.New("person is referenced by another profile")
 )
 
 // PersonBindingConflictError reports the curated people that would be
@@ -162,8 +163,34 @@ func (s *Store) DeletePersonContext(ctx context.Context, id, expectedRevision in
 		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
 			return err
 		}
-		var deletedID int64
+		var revision int64
 		err := tx.QueryRowContext(ctx,
+			`SELECT revision FROM persons WHERE id = ?`+s.dialect.SelectForUpdate(),
+			id).Scan(&revision)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrPersonNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("verify person %d before delete: %w", id, err)
+		}
+		if revision != expectedRevision {
+			return ErrPersonRevisionConflict
+		}
+		var references int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM person_attribute_values
+			WHERE value_record_type = 'person' AND value_record_id = ?
+			  AND person_id <> ?
+			  AND active_until IS NULL AND superseded_at IS NULL
+		`, id, id).Scan(&references); err != nil {
+			return fmt.Errorf("check references to person %d: %w", id, err)
+		}
+		if references > 0 {
+			return fmt.Errorf("delete person %d: %w", id, ErrPersonReferenced)
+		}
+		var deletedID int64
+		err = tx.QueryRowContext(ctx,
 			`DELETE FROM persons WHERE id = ? AND revision = ? RETURNING id`,
 			id, expectedRevision).Scan(&deletedID)
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/store/provenance.go
+++ b/internal/store/provenance.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// ErrInvalidProvenance reports a source value outside the fixed provenance
+// vocabulary. ErrConfidenceScope reports a confidence attached to a declared
+// value, or one outside [0, 1].
+var (
+	ErrInvalidProvenance = errors.New("invalid source")
+	ErrConfidenceScope   = errors.New("confidence is only meaningful for derived or suggested values")
+)
+
+// Provenance records which subsystem asserted a mutable curated fact.
+type Provenance string
+
+const (
+	ProvenanceUser               Provenance = "user"
+	ProvenanceCardDAVImport      Provenance = "carddav_import"
+	ProvenanceVCardImport        Provenance = "vcard_import"
+	ProvenanceArchiveObservation Provenance = "archive_observation"
+	ProvenanceExtraction         Provenance = "extraction"
+	ProvenanceEnrichment         Provenance = "enrichment"
+	ProvenanceSystem             Provenance = "system"
+)
+
+// AllProvenances is the ordered provenance vocabulary.
+var AllProvenances = []Provenance{
+	ProvenanceUser,
+	ProvenanceCardDAVImport,
+	ProvenanceVCardImport,
+	ProvenanceArchiveObservation,
+	ProvenanceExtraction,
+	ProvenanceEnrichment,
+	ProvenanceSystem,
+}
+
+// Valid reports whether p is one of AllProvenances.
+func (p Provenance) Valid() bool {
+	return slices.Contains(AllProvenances, p)
+}
+
+// IsDeclared reports whether a person or curated address book asserted the value.
+func (p Provenance) IsDeclared() bool {
+	switch p {
+	case ProvenanceUser, ProvenanceCardDAVImport, ProvenanceVCardImport:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseProvenance trims whitespace and parses an exact provenance value.
+func ParseProvenance(raw string) (Provenance, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: source is required", ErrInvalidProvenance)
+	}
+	candidate := Provenance(trimmed)
+	if !candidate.Valid() {
+		return "", fmt.Errorf("%w: unknown source %q", ErrInvalidProvenance, trimmed)
+	}
+	return candidate, nil
+}
+
+// ProvenanceCheckValues renders the vocabulary for portable SQL CHECK clauses.
+func ProvenanceCheckValues() string {
+	quoted := make([]string, 0, len(AllProvenances))
+	for _, provenance := range AllProvenances {
+		quoted = append(quoted, "'"+string(provenance)+"'")
+	}
+	return strings.Join(quoted, ", ")
+}

--- a/internal/store/provenance_test.go
+++ b/internal/store/provenance_test.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllProvenancesIsTheSpecVocabulary(t *testing.T) {
+	assert.Equal(t, []Provenance{
+		"user", "carddav_import", "vcard_import", "archive_observation",
+		"extraction", "enrichment", "system",
+	}, AllProvenances)
+}
+
+func TestParseProvenance(t *testing.T) {
+	for _, provenance := range AllProvenances {
+		parsed, err := ParseProvenance("  " + string(provenance) + "  ")
+		require.NoError(t, err)
+		assert.Equal(t, provenance, parsed)
+	}
+
+	for _, raw := range []string{"", "   ", "User", "guessed", "USER"} {
+		_, err := ParseProvenance(raw)
+		require.ErrorIs(t, err, ErrInvalidProvenance)
+	}
+}
+
+func TestProvenanceIsDeclaredSplitsDeclaredFromDerived(t *testing.T) {
+	for _, declared := range []Provenance{
+		ProvenanceUser, ProvenanceCardDAVImport, ProvenanceVCardImport,
+	} {
+		assert.True(t, declared.IsDeclared(), "%s is declared data", declared)
+	}
+	for _, derived := range []Provenance{
+		ProvenanceArchiveObservation, ProvenanceExtraction,
+		ProvenanceEnrichment, ProvenanceSystem,
+	} {
+		assert.False(t, derived.IsDeclared(), "%s is derived or suggested", derived)
+	}
+}
+
+func TestConfidenceScopeSentinelIsDeclared(t *testing.T) {
+	require.Error(t, ErrConfidenceScope)
+	assert.Equal(t,
+		"confidence is only meaningful for derived or suggested values",
+		ErrConfidenceScope.Error())
+}
+
+func TestProvenanceCheckValuesCoversEveryVocabularyEntry(t *testing.T) {
+	clause := ProvenanceCheckValues()
+	for _, provenance := range AllProvenances {
+		assert.Contains(t, clause, "'"+string(provenance)+"'")
+	}
+	assert.Equal(t,
+		"'user', 'carddav_import', 'vcard_import', 'archive_observation', "+
+			"'extraction', 'enrichment', 'system'", clause)
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -634,6 +634,125 @@ CREATE INDEX IF NOT EXISTS idx_participant_links_b
     ON participant_links(participant_b);
 
 -- ============================================================================
+-- PORTABLE FIELD METADATA AND TYPED ATTRIBUTES
+-- ============================================================================
+
+-- Definitions are metadata rows: adding one never issues DDL. universal_id is
+-- the stable external identity, slug is the immutable machine name, and label
+-- is mutable human-facing text. There is deliberately no is_unique column:
+-- only constraints backed by portable database indexes are advertised.
+CREATE TABLE IF NOT EXISTS attribute_definitions (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    universal_id   TEXT NOT NULL UNIQUE,
+    object_type    TEXT NOT NULL,
+    slug           TEXT NOT NULL,
+    label          TEXT NOT NULL,
+    description    TEXT,
+    value_type     TEXT NOT NULL,
+    field_type     TEXT NOT NULL,
+    record_target  TEXT,
+    cardinality    TEXT NOT NULL DEFAULT 'single',
+    display_order  INTEGER NOT NULL DEFAULT 0,
+    is_required    BOOLEAN NOT NULL DEFAULT FALSE,
+    ownership      TEXT NOT NULL DEFAULT 'user',
+    ui_creatable   BOOLEAN NOT NULL DEFAULT TRUE,
+    ui_editable    BOOLEAN NOT NULL DEFAULT TRUE,
+    api_mutable    BOOLEAN NOT NULL DEFAULT TRUE,
+    is_searchable  BOOLEAN NOT NULL DEFAULT FALSE,
+    is_audited     BOOLEAN NOT NULL DEFAULT TRUE,
+    is_deletable   BOOLEAN NOT NULL DEFAULT TRUE,
+    history_exempt BOOLEAN NOT NULL DEFAULT FALSE,
+    derived_source TEXT,
+    options        JSON,
+    vcard_property TEXT,
+    is_active      BOOLEAN NOT NULL DEFAULT TRUE,
+    revision       INTEGER NOT NULL DEFAULT 1,
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (LENGTH(universal_id) > 0),
+    CHECK (LENGTH(slug) > 0),
+    CHECK (LENGTH(label) > 0),
+    CHECK (display_order >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attribute_definitions_object_slug
+    ON attribute_definitions(object_type, slug);
+
+CREATE INDEX IF NOT EXISTS idx_attribute_definitions_active
+    ON attribute_definitions(object_type, display_order, id)
+    WHERE is_active = TRUE;
+
+-- One row is one typed value over one world-time interval. active_from and
+-- active_until describe when the fact was true; created_at and superseded_at
+-- describe when Msgvault knew it. Current means both closing timestamps are
+-- NULL, including future retractions that close only transaction time.
+CREATE TABLE IF NOT EXISTS person_attribute_values (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    person_id         INTEGER NOT NULL REFERENCES persons(id) ON DELETE CASCADE,
+    definition_id     INTEGER NOT NULL
+                          REFERENCES attribute_definitions(id) ON DELETE RESTRICT,
+    ordinal           INTEGER NOT NULL DEFAULT 0,
+    value_text        TEXT,
+    value_integer     BIGINT,
+    value_real        REAL,
+    value_boolean     BOOLEAN,
+    -- A complete YYYY-MM-DD date. Go validates digits and calendar validity;
+    -- the portable CHECK below only pins separator positions and length.
+    value_date        TEXT,
+    value_timestamp   DATETIME,
+    value_json        JSON,
+    value_record_type TEXT,
+    value_record_id   INTEGER,
+    active_from       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    active_until      DATETIME,
+    created_at        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    superseded_at     DATETIME,
+    source            TEXT NOT NULL,
+    source_ref        TEXT,
+    confidence        REAL,
+    actor             TEXT,
+    CHECK (ordinal >= 0),
+    CHECK (source IN ('user', 'carddav_import', 'vcard_import',
+                      'archive_observation', 'extraction', 'enrichment',
+                      'system')),
+    CHECK (active_until IS NULL OR active_until >= active_from),
+    CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
+    CHECK (value_date IS NULL OR value_date LIKE '____-__-__'),
+    CHECK (
+        (CASE WHEN value_text      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_integer   IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_real      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_boolean   IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_date      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_timestamp IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_json      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_record_id IS NOT NULL THEN 1 ELSE 0 END) = 1
+    ),
+    CHECK ((value_record_id IS NULL) = (value_record_type IS NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_person_attribute_values_current
+    ON person_attribute_values(person_id, definition_id, ordinal)
+    WHERE active_until IS NULL AND superseded_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_history
+    ON person_attribute_values(person_id, definition_id, active_from DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_definition
+    ON person_attribute_values(definition_id, active_until);
+
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_current_text
+    ON person_attribute_values(definition_id, value_text)
+    WHERE value_text IS NOT NULL
+      AND active_until IS NULL AND superseded_at IS NULL;
+
+-- Person deletion checks for inbound record references; without this the
+-- check scans the whole value table.
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_record_ref
+    ON person_attribute_values(value_record_type, value_record_id)
+    WHERE value_record_id IS NOT NULL;
+
+-- ============================================================================
 -- APPLIED MIGRATIONS
 -- ============================================================================
 

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -447,7 +447,7 @@ CREATE TABLE IF NOT EXISTS attribute_definitions (
     field_type     TEXT NOT NULL,
     record_target  TEXT,
     cardinality    TEXT NOT NULL DEFAULT 'single',
-    display_order  INTEGER NOT NULL DEFAULT 0,
+    display_order  BIGINT NOT NULL DEFAULT 0,
     is_required    BOOLEAN NOT NULL DEFAULT FALSE,
     ownership      TEXT NOT NULL DEFAULT 'user',
     ui_creatable   BOOLEAN NOT NULL DEFAULT TRUE,

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -429,6 +429,118 @@ CREATE TABLE IF NOT EXISTS participant_links (
 CREATE INDEX IF NOT EXISTS idx_participant_links_b
     ON participant_links(participant_b);
 
+-- ============================================================================
+-- PORTABLE FIELD METADATA AND TYPED ATTRIBUTES
+-- ============================================================================
+
+-- Portable field-definition registry; vocabulary columns intentionally carry
+-- no CHECK so both backends reject growing vocabularies through the same Go
+-- validation. There is deliberately no is_unique column.
+CREATE TABLE IF NOT EXISTS attribute_definitions (
+    id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    universal_id   TEXT NOT NULL UNIQUE,
+    object_type    TEXT NOT NULL,
+    slug           TEXT NOT NULL,
+    label          TEXT NOT NULL,
+    description    TEXT,
+    value_type     TEXT NOT NULL,
+    field_type     TEXT NOT NULL,
+    record_target  TEXT,
+    cardinality    TEXT NOT NULL DEFAULT 'single',
+    display_order  INTEGER NOT NULL DEFAULT 0,
+    is_required    BOOLEAN NOT NULL DEFAULT FALSE,
+    ownership      TEXT NOT NULL DEFAULT 'user',
+    ui_creatable   BOOLEAN NOT NULL DEFAULT TRUE,
+    ui_editable    BOOLEAN NOT NULL DEFAULT TRUE,
+    api_mutable    BOOLEAN NOT NULL DEFAULT TRUE,
+    is_searchable  BOOLEAN NOT NULL DEFAULT FALSE,
+    is_audited     BOOLEAN NOT NULL DEFAULT TRUE,
+    is_deletable   BOOLEAN NOT NULL DEFAULT TRUE,
+    history_exempt BOOLEAN NOT NULL DEFAULT FALSE,
+    derived_source TEXT,
+    options        JSONB,
+    vcard_property TEXT,
+    is_active      BOOLEAN NOT NULL DEFAULT TRUE,
+    revision       BIGINT NOT NULL DEFAULT 1,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (LENGTH(universal_id) > 0),
+    CHECK (LENGTH(slug) > 0),
+    CHECK (LENGTH(label) > 0),
+    CHECK (display_order >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attribute_definitions_object_slug
+    ON attribute_definitions(object_type, slug);
+
+CREATE INDEX IF NOT EXISTS idx_attribute_definitions_active
+    ON attribute_definitions(object_type, display_order, id)
+    WHERE is_active = TRUE;
+
+CREATE TABLE IF NOT EXISTS person_attribute_values (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    person_id         BIGINT NOT NULL REFERENCES persons(id) ON DELETE CASCADE,
+    definition_id     BIGINT NOT NULL
+                          REFERENCES attribute_definitions(id) ON DELETE RESTRICT,
+    ordinal           BIGINT NOT NULL DEFAULT 0,
+    value_text        TEXT,
+    value_integer     BIGINT,
+    value_real        DOUBLE PRECISION,
+    value_boolean     BOOLEAN,
+    value_date        TEXT,
+    value_timestamp   TIMESTAMPTZ,
+    value_json        JSONB,
+    value_record_type TEXT,
+    value_record_id   BIGINT,
+    active_from       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    active_until      TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    superseded_at     TIMESTAMPTZ,
+    source            TEXT NOT NULL,
+    source_ref        TEXT,
+    confidence        DOUBLE PRECISION,
+    actor             TEXT,
+    CHECK (ordinal >= 0),
+    CHECK (source IN ('user', 'carddav_import', 'vcard_import',
+                      'archive_observation', 'extraction', 'enrichment',
+                      'system')),
+    CHECK (active_until IS NULL OR active_until >= active_from),
+    CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
+    CHECK (value_date IS NULL OR value_date LIKE '____-__-__'),
+    CHECK (
+        (CASE WHEN value_text      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_integer   IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_real      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_boolean   IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_date      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_timestamp IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_json      IS NOT NULL THEN 1 ELSE 0 END) +
+        (CASE WHEN value_record_id IS NOT NULL THEN 1 ELSE 0 END) = 1
+    ),
+    CHECK ((value_record_id IS NULL) = (value_record_type IS NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_person_attribute_values_current
+    ON person_attribute_values(person_id, definition_id, ordinal)
+    WHERE active_until IS NULL AND superseded_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_history
+    ON person_attribute_values(person_id, definition_id, active_from DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_definition
+    ON person_attribute_values(definition_id, active_until);
+
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_current_text
+    ON person_attribute_values(definition_id, value_text)
+    WHERE value_text IS NOT NULL
+      AND active_until IS NULL AND superseded_at IS NULL;
+
+-- Person deletion checks for inbound record references; without this the
+-- check scans the whole value table.
+CREATE INDEX IF NOT EXISTS idx_person_attribute_values_record_ref
+    ON person_attribute_values(value_record_type, value_record_id)
+    WHERE value_record_id IS NOT NULL;
+
 -- Marks one-time data migrations that have already run. Schema DDL is
 -- idempotent via IF NOT EXISTS; this table is for *data* migrations
 -- (e.g. moving legacy config into per-account records) that must run

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1316,7 +1316,7 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 	}
 	s.fts5Available = available
 
-	if err := s.EnsureSeededAttributeDefinitions(); err != nil {
+	if err := s.EnsureSeededAttributeDefinitionsContext(ctx); err != nil {
 		return fmt.Errorf("ensure seeded attribute definitions: %w", err)
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1316,6 +1316,10 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 	}
 	s.fts5Available = available
 
+	if err := s.EnsureSeededAttributeDefinitions(); err != nil {
+		return fmt.Errorf("ensure seeded attribute definitions: %w", err)
+	}
+
 	// Ensure the default "All" collection exists and contains every source.
 	if err := s.EnsureDefaultCollectionContext(ctx); err != nil {
 		return fmt.Errorf("ensure default collection: %w", err)

--- a/internal/store/subset.go
+++ b/internal/store/subset.go
@@ -23,6 +23,12 @@ type CopyResult struct {
 	Elapsed       time.Duration
 }
 
+// CopySubsetOptions controls optional sensitive metadata included in a subset.
+type CopySubsetOptions struct {
+	IncludeIdentity   bool
+	IncludeAttributes bool
+}
+
 // CopySubset copies rowCount most recent messages (and all referenced
 // data) from srcDBPath into a new database in dstDir. The destination
 // schema is initialized using the embedded store schema.
@@ -37,12 +43,28 @@ type CopyResult struct {
 // closure instead: participants are expanded through participant_links and
 // shared person bindings until every included cluster and person profile
 // is complete, which exposes identifiers of linked identities that have no
-// messages in the subset.
+// messages in the subset. Person attribute definitions and values are not copied;
+// callers sharing attributes must explicitly use CopySubsetWithOptions with
+// IncludeAttributes. When attributes are included, person-valued references
+// follow the same boundary: references to excluded people are omitted by
+// default, while IncludeIdentity follows references from included people and
+// copies each target's complete identity profile.
 //
 // Security: validates srcDBPath for control characters and canonicalizes
 // it before use in SQL. Callers must validate path containment.
 func CopySubset(
 	srcDBPath, dstDir string, rowCount int, includeIdentity bool,
+) (*CopyResult, error) {
+	return CopySubsetWithOptions(srcDBPath, dstDir, rowCount, CopySubsetOptions{
+		IncludeIdentity: includeIdentity,
+	})
+}
+
+// CopySubsetWithOptions copies a subset with explicitly selected sensitive
+// metadata. IncludeAttributes copies current and historical attribute values,
+// including their value content, provenance references, and actor metadata.
+func CopySubsetWithOptions(
+	srcDBPath, dstDir string, rowCount int, options CopySubsetOptions,
 ) (*CopyResult, error) {
 	if rowCount <= 0 {
 		return nil, fmt.Errorf("rowCount must be positive, got %d", rowCount)
@@ -145,7 +167,7 @@ func CopySubset(
 		return nil, fmt.Errorf("begin transaction: %w", err)
 	}
 
-	result, err := copyData(tx, rowCount, includeIdentity)
+	result, err := copyData(tx, rowCount, options)
 	if err != nil {
 		_ = tx.Rollback()
 		_, _ = db.Exec("DETACH DATABASE src")
@@ -238,7 +260,7 @@ func verifyForeignKeys(db *sql.DB) error {
 }
 
 // copyData executes INSERT INTO ... SELECT in dependency order.
-func copyData(tx *sql.Tx, rowCount int, includeIdentity bool) (*CopyResult, error) {
+func copyData(tx *sql.Tx, rowCount int, options CopySubsetOptions) (*CopyResult, error) {
 	result := &CopyResult{}
 
 	if _, err := tx.Exec(fmt.Sprintf(`
@@ -330,11 +352,11 @@ func copyData(tx *sql.Tx, rowCount int, includeIdentity bool) (*CopyResult, erro
 	// through the closure of link edges and shared person bindings so
 	// every included identity cluster and person profile is complete —
 	// components can pass through participants with no copied messages.
-	if includeIdentity {
+	if options.IncludeIdentity {
 		res, err = tx.Exec(`
 			INSERT INTO participants SELECT * FROM src.participants
 			WHERE id IN (
-				WITH RECURSIVE edge(a, b) AS (
+				WITH RECURSIVE symmetric_edge(a, b) AS (
 					SELECT participant_a, participant_b FROM src.participant_links
 					UNION ALL
 					SELECT pp1.participant_id, pp2.participant_id
@@ -342,17 +364,31 @@ func copyData(tx *sql.Tx, rowCount int, includeIdentity bool) (*CopyResult, erro
 					JOIN src.person_participants pp2
 					  ON pp2.person_id = pp1.person_id
 					 AND pp2.participant_id != pp1.participant_id
+				), reference_edge(a, b) AS (
+					SELECT owner_pp.participant_id, target_pp.participant_id
+					FROM src.person_attribute_values value
+					JOIN src.person_participants owner_pp
+					  ON owner_pp.person_id = value.person_id
+					JOIN src.person_participants target_pp
+					  ON target_pp.person_id = value.value_record_id
+					WHERE value.value_record_type = 'person'
+					  AND ?
 				), identity(id) AS (
 					SELECT id FROM participants
 					UNION
-					SELECT CASE WHEN edge.a = identity.id
-					            THEN edge.b ELSE edge.a END
-					FROM edge
-					JOIN identity ON identity.id IN (edge.a, edge.b)
+					SELECT CASE WHEN symmetric_edge.a = identity.id
+					            THEN symmetric_edge.b ELSE symmetric_edge.a END
+					FROM symmetric_edge
+					JOIN identity
+					  ON identity.id IN (symmetric_edge.a, symmetric_edge.b)
+					UNION
+					SELECT reference_edge.b
+					FROM reference_edge
+					JOIN identity ON identity.id = reference_edge.a
 				)
 				SELECT id FROM identity
 			)
-			  AND id NOT IN (SELECT id FROM participants)`)
+			  AND id NOT IN (SELECT id FROM participants)`, options.IncludeAttributes)
 		if err != nil {
 			return nil, fmt.Errorf("copy identity-closure participants: %w", err)
 		}
@@ -400,6 +436,94 @@ func copyData(tx *sql.Tx, rowCount int, includeIdentity bool) (*CopyResult, erro
 		WHERE person_id IN (SELECT id FROM persons)
 		  AND participant_id IN (SELECT id FROM participants)`); err != nil {
 		return nil, fmt.Errorf("copy person_participants: %w", err)
+	}
+
+	if options.IncludeAttributes {
+		// Definitions are portable by universal_id, not their database-local
+		// numeric key. Reconcile every person definition into the destination,
+		// then map copied values through universal_id below.
+		if _, err := tx.Exec(`
+		INSERT INTO attribute_definitions (
+		    universal_id, object_type, slug, label, description,
+		    value_type, field_type, record_target, cardinality, display_order,
+		    is_required, ownership, ui_creatable, ui_editable, api_mutable,
+		    is_searchable, is_audited, is_deletable, history_exempt,
+		    derived_source, options, vcard_property, is_active, revision,
+		    created_at, updated_at
+		)
+		SELECT
+		    universal_id, object_type, slug, label, description,
+		    value_type, field_type, record_target, cardinality, display_order,
+		    is_required, ownership, ui_creatable, ui_editable, api_mutable,
+		    is_searchable, is_audited, is_deletable, history_exempt,
+		    derived_source, options, vcard_property, is_active, revision,
+		    created_at, updated_at
+		FROM src.attribute_definitions
+		WHERE object_type = 'person'
+		ON CONFLICT(universal_id) DO UPDATE SET
+		    object_type = excluded.object_type,
+		    slug = excluded.slug,
+		    label = excluded.label,
+		    description = excluded.description,
+		    value_type = excluded.value_type,
+		    field_type = excluded.field_type,
+		    record_target = excluded.record_target,
+		    cardinality = excluded.cardinality,
+		    display_order = excluded.display_order,
+		    is_required = excluded.is_required,
+		    ownership = excluded.ownership,
+		    ui_creatable = excluded.ui_creatable,
+		    ui_editable = excluded.ui_editable,
+		    api_mutable = excluded.api_mutable,
+		    is_searchable = excluded.is_searchable,
+		    is_audited = excluded.is_audited,
+		    is_deletable = excluded.is_deletable,
+		    history_exempt = excluded.history_exempt,
+		    derived_source = excluded.derived_source,
+		    options = excluded.options,
+		    vcard_property = excluded.vcard_property,
+		    is_active = excluded.is_active,
+		    revision = excluded.revision,
+		    created_at = excluded.created_at,
+		    updated_at = excluded.updated_at`); err != nil {
+			return nil, fmt.Errorf("copy person attribute definitions: %w", err)
+		}
+
+		// Preserve complete value history for copied people. Record references
+		// only survive when their target person crossed the selected identity
+		// boundary, preventing a subset from containing a dangling private ID.
+		if _, err := tx.Exec(`
+		INSERT INTO person_attribute_values (
+		    id, person_id, definition_id, ordinal,
+		    value_text, value_integer, value_real, value_boolean,
+		    value_date, value_timestamp, value_json,
+		    value_record_type, value_record_id,
+		    active_from, active_until, created_at, superseded_at,
+		    source, source_ref, confidence, actor
+		)
+		SELECT
+		    value.id, value.person_id, destination_definition.id, value.ordinal,
+		    value.value_text, value.value_integer, value.value_real,
+		    value.value_boolean, value.value_date, value.value_timestamp,
+		    value.value_json, value.value_record_type, value.value_record_id,
+		    value.active_from, value.active_until, value.created_at,
+		    value.superseded_at, value.source, value.source_ref,
+		    value.confidence, value.actor
+		FROM src.person_attribute_values value
+		JOIN src.attribute_definitions source_definition
+		  ON source_definition.id = value.definition_id
+		JOIN attribute_definitions destination_definition
+		  ON destination_definition.universal_id = source_definition.universal_id
+		WHERE value.person_id IN (SELECT id FROM persons)
+		  AND (
+		    value.value_record_type IS NULL
+		    OR (
+		      value.value_record_type = 'person'
+		      AND value.value_record_id IN (SELECT id FROM persons)
+		    )
+		  )`); err != nil {
+			return nil, fmt.Errorf("copy person attribute values: %w", err)
+		}
 	}
 
 	if _, err := tx.Exec(`

--- a/internal/store/subset_test.go
+++ b/internal/store/subset_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
@@ -13,6 +14,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func subsetPersonDefinition(slug string) AttributeDefinitionInput {
+	return AttributeDefinitionInput{
+		UniversalID: "test-" + slug,
+		ObjectType:  AttributeObjectPerson,
+		Slug:        slug,
+		Label:       "Test " + slug,
+		ValueType:   AttributeValueText,
+		FieldType:   AttributeFieldText,
+		Cardinality: AttributeCardinalitySingle,
+		Ownership:   AttributeOwnershipUser,
+		UICreatable: true,
+		UIEditable:  true,
+		APIMutable:  true,
+		IsAudited:   true,
+		IsDeletable: true,
+	}
+}
 
 // createTestSourceDB creates a source database with schema and test
 // data. Returns the path to the database.
@@ -292,6 +311,186 @@ func TestCopySubset_PreservesPersonProfiles(t *testing.T) {
 	assert.Equal(person.DisplayName, copied.DisplayName)
 	assert.Equal(person.Revision, copied.Revision)
 	assert.Equal(person.ParticipantIDs, copied.ParticipantIDs)
+}
+
+func TestCopySubset_AttributesRequireExplicitOptIn(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	srcDB := createTestSourceDB(t, t.TempDir(), 5)
+	source, err := Open(srcDB)
+	require.NoError(err)
+	person, _, err := source.CreatePersonFromParticipant(2)
+	require.NoError(err)
+
+	input := subsetPersonDefinition("synthetic_preference")
+	input.UniversalID = "test-synthetic-preference"
+	input.FieldType = AttributeFieldSelect
+	input.Options = &AttributeOptions{Choices: []AttributeChoice{
+		{Value: "alpha", Label: "Alpha"},
+		{Value: "beta", Label: "Beta"},
+	}}
+	definition, err := source.CreateAttributeDefinitionContext(ctx, input)
+	require.NoError(err)
+	_, err = source.db.Exec(
+		`UPDATE attribute_definitions SET id = 42 WHERE id = ?`, definition.ID)
+	require.NoError(err)
+
+	firstAt := time.Date(2026, 7, 29, 8, 0, 0, 0, time.UTC)
+	sourceRef := "fixture:synthetic-preference"
+	actor := "synthetic-agent"
+	confidence := 0.75
+	first, err := source.SetPersonAttributeValueContext(ctx, PersonAttributeValueInput{
+		PersonID: person.ID, DefinitionSlug: input.Slug,
+		Value:      AttributeValue{Type: AttributeValueText, Text: new("alpha")},
+		ActiveFrom: &firstAt, Source: ProvenanceExtraction,
+		SourceRef: &sourceRef, Confidence: &confidence, Actor: &actor,
+	})
+	require.NoError(err)
+	secondAt := firstAt.Add(24 * time.Hour)
+	_, err = source.SetPersonAttributeValueContext(ctx, PersonAttributeValueInput{
+		PersonID: person.ID, DefinitionSlug: input.Slug,
+		Value:      AttributeValue{Type: AttributeValueText, Text: new("beta")},
+		ActiveFrom: &secondAt, Source: ProvenanceUser,
+		ExpectedValueID: &first.Value.ID,
+	})
+	require.NoError(err)
+	require.NoError(source.Close())
+
+	dstDir := filepath.Join(t.TempDir(), "dst")
+	_, err = CopySubset(srcDB, dstDir, 5, false)
+	require.NoError(err)
+	destination, err := Open(filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = destination.Close() })
+
+	_, err = destination.GetAttributeDefinitionBySlugContext(
+		ctx, AttributeObjectPerson, input.Slug)
+	require.ErrorIs(err, ErrAttributeDefinitionNotFound,
+		"shared subsets must not copy person attribute definitions by default")
+
+	history, err := destination.ListPersonAttributeValuesContext(
+		ctx, person.ID, PersonAttributeQuery{
+			DefinitionSlug: input.Slug,
+			IncludeHistory: true,
+		})
+	require.NoError(err)
+	assert.Empty(history,
+		"shared subsets must not copy current or historical person attribute values by default")
+
+	attributesDir := filepath.Join(t.TempDir(), "attributes")
+	_, err = CopySubsetWithOptions(srcDB, attributesDir, 5, CopySubsetOptions{
+		IncludeAttributes: true,
+	})
+	require.NoError(err)
+	withAttributes, err := Open(filepath.Join(attributesDir, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = withAttributes.Close() })
+
+	copiedDefinition, err := withAttributes.GetAttributeDefinitionBySlugContext(
+		ctx, AttributeObjectPerson, input.Slug)
+	require.NoError(err)
+	assert.Equal(input.UniversalID, copiedDefinition.UniversalID)
+	assert.NotEqual(int64(42), copiedDefinition.ID,
+		"destination definition ID must be local rather than copied from the source")
+	assert.Equal(input.Slug, copiedDefinition.Slug)
+	require.NotNil(copiedDefinition.Options)
+	assert.Equal(input.Options.Choices, copiedDefinition.Options.Choices)
+
+	history, err = withAttributes.ListPersonAttributeValuesContext(
+		ctx, person.ID, PersonAttributeQuery{
+			DefinitionSlug: input.Slug,
+			IncludeHistory: true,
+		})
+	require.NoError(err)
+	require.Len(history, 2)
+	assert.Equal(copiedDefinition.ID, history[0].DefinitionID)
+	assert.Equal("beta", *history[0].Value.Text)
+	assert.Equal(copiedDefinition.ID, history[1].DefinitionID)
+	assert.Equal("alpha", *history[1].Value.Text)
+	assert.Equal(ProvenanceExtraction, history[1].Source)
+	assert.Equal(sourceRef, *history[1].SourceRef)
+	assert.InDelta(confidence, *history[1].Confidence, 0)
+	assert.Equal(actor, *history[1].Actor)
+	require.NotNil(history[1].ActiveUntil)
+	require.NotNil(history[1].SupersededAt)
+}
+
+func TestCopySubset_RecordReferencesFollowIdentityPolicy(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	srcDB := createTestSourceDB(t, t.TempDir(), 5)
+	source, err := Open(srcDB)
+	require.NoError(err)
+	owner, _, err := source.CreatePersonFromParticipant(2)
+	require.NoError(err)
+	targetParticipant, err := source.EnsureParticipant(
+		"attribute-target@example.com", "attribute target", "example.com")
+	require.NoError(err)
+	target, _, err := source.CreatePersonFromParticipant(targetParticipant)
+	require.NoError(err)
+
+	input := subsetPersonDefinition("synthetic_person_reference")
+	input.UniversalID = "test-synthetic-person-reference"
+	input.ValueType = AttributeValueRecordReference
+	input.FieldType = AttributeFieldPerson
+	input.RecordTarget = new("person")
+	_, err = source.CreateAttributeDefinitionContext(ctx, input)
+	require.NoError(err)
+	write, err := source.SetPersonAttributeValueContext(ctx, PersonAttributeValueInput{
+		PersonID: owner.ID, DefinitionSlug: input.Slug,
+		Value: AttributeValue{
+			Type:       AttributeValueRecordReference,
+			RecordType: new("person"),
+			RecordID:   &target.ID,
+		},
+		Source: ProvenanceUser,
+	})
+	require.NoError(err)
+	require.NoError(source.Close())
+
+	defaultDir := filepath.Join(t.TempDir(), "default")
+	_, err = CopySubset(srcDB, defaultDir, 5, false)
+	require.NoError(err)
+	defaultSubset, err := Open(filepath.Join(defaultDir, "msgvault.db"))
+	require.NoError(err)
+	defer func() { _ = defaultSubset.Close() }()
+	_, err = defaultSubset.GetPerson(owner.ID)
+	require.NoError(err, "message-derived owner remains included")
+	_, err = defaultSubset.GetPerson(target.ID)
+	require.ErrorIs(err, ErrPersonNotFound,
+		"off-message record target stays outside the default identity boundary")
+	defaultValues, err := defaultSubset.ListPersonAttributeValuesContext(
+		ctx, owner.ID, PersonAttributeQuery{
+			DefinitionSlug: input.Slug,
+			IncludeHistory: true,
+		})
+	require.NoError(err)
+	assert.Empty(defaultValues,
+		"record references to excluded identities must not dangle in the subset")
+
+	identityDir := filepath.Join(t.TempDir(), "identity")
+	_, err = CopySubsetWithOptions(srcDB, identityDir, 5, CopySubsetOptions{
+		IncludeIdentity:   true,
+		IncludeAttributes: true,
+	})
+	require.NoError(err)
+	identitySubset, err := Open(filepath.Join(identityDir, "msgvault.db"))
+	require.NoError(err)
+	defer func() { _ = identitySubset.Close() }()
+	copiedTarget, err := identitySubset.GetPerson(target.ID)
+	require.NoError(err)
+	assert.Equal(target.ParticipantIDs, copiedTarget.ParticipantIDs)
+	identityValues, err := identitySubset.ListPersonAttributeValuesContext(
+		ctx, owner.ID, PersonAttributeQuery{
+			DefinitionSlug: input.Slug,
+			IncludeHistory: true,
+		})
+	require.NoError(err)
+	require.Len(identityValues, 1)
+	assert.Equal(write.Value.ID, identityValues[0].ID)
+	assert.Equal(target.ID, *identityValues[0].Value.RecordID)
 }
 
 // TestCopySubset_IncludeIdentityPreservesClusters covers a promoted linked

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -71,6 +71,26 @@ type ClientInterface interface {
 	GetAttachment(ctx context.Context, options *GetAttachmentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentResponse, error)
 	GetAttachmentWithResponse(ctx context.Context, options *GetAttachmentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttachmentResp, error)
 
+	// ListAttributeDefinitions List portable attribute definitions
+	ListAttributeDefinitions(ctx context.Context, options *ListAttributeDefinitionsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListAttributeDefinitionsResponse, error)
+	ListAttributeDefinitionsWithResponse(ctx context.Context, options *ListAttributeDefinitionsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListAttributeDefinitionsResp, error)
+
+	// CreateAttributeDefinition Create a user attribute definition
+	CreateAttributeDefinition(ctx context.Context, options *CreateAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateAttributeDefinitionResponse, error)
+	CreateAttributeDefinitionWithResponse(ctx context.Context, options *CreateAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateAttributeDefinitionResp, error)
+
+	// DeleteAttributeDefinition Delete a user attribute definition
+	DeleteAttributeDefinition(ctx context.Context, options *DeleteAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*struct{}, error)
+	DeleteAttributeDefinitionWithResponse(ctx context.Context, options *DeleteAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeleteAttributeDefinitionResp, error)
+
+	// GetAttributeDefinition Get one attribute definition
+	GetAttributeDefinition(ctx context.Context, options *GetAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttributeDefinitionResponse, error)
+	GetAttributeDefinitionWithResponse(ctx context.Context, options *GetAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttributeDefinitionResp, error)
+
+	// PatchAttributeDefinition Update mutable attribute definition fields
+	PatchAttributeDefinition(ctx context.Context, options *PatchAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PatchAttributeDefinitionResponse, error)
+	PatchAttributeDefinitionWithResponse(ctx context.Context, options *PatchAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PatchAttributeDefinitionResp, error)
+
 	// UploadToken Upload an OAuth token
 	UploadToken(ctx context.Context, options *UploadTokenRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UploadTokenResponse, error)
 	UploadTokenWithResponse(ctx context.Context, options *UploadTokenRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UploadTokenResp, error)
@@ -394,6 +414,18 @@ type ClientInterface interface {
 	// PatchPerson Update a durable person's display name
 	PatchPerson(ctx context.Context, options *PatchPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PatchPersonResponse, error)
 	PatchPersonWithResponse(ctx context.Context, options *PatchPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PatchPersonResp, error)
+
+	// ListPersonAttributes List a person's typed attributes
+	ListPersonAttributes(ctx context.Context, options *ListPersonAttributesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListPersonAttributesResponse, error)
+	ListPersonAttributesWithResponse(ctx context.Context, options *ListPersonAttributesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListPersonAttributesResp, error)
+
+	// ClearPersonAttribute Supersede a person's attribute value
+	ClearPersonAttribute(ctx context.Context, options *ClearPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ClearPersonAttributeResponse, error)
+	ClearPersonAttributeWithResponse(ctx context.Context, options *ClearPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ClearPersonAttributeResp, error)
+
+	// SetPersonAttribute Set a person's attribute value
+	SetPersonAttribute(ctx context.Context, options *SetPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetPersonAttributeResponse, error)
+	SetPersonAttributeWithResponse(ctx context.Context, options *SetPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetPersonAttributeResp, error)
 
 	// RunQuery Run an aggregate query
 	RunQuery(ctx context.Context, options *RunQueryRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RunQueryResponse, error)
@@ -1101,6 +1133,308 @@ func (c *Client) GetAttachment(ctx context.Context, options *GetAttachmentReques
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attachments/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ListAttributeDefinitions List portable attribute definitions
+func (c *Client) ListAttributeDefinitions(ctx context.Context, options *ListAttributeDefinitionsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListAttributeDefinitionsResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListAttributeDefinitionsResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListAttributeDefinitionsErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListAttributeDefinitionsErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListAttributeDefinitionsResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListAttributeDefinitionsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// CreateAttributeDefinition Create a user attribute definition
+func (c *Client) CreateAttributeDefinition(ctx context.Context, options *CreateAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateAttributeDefinitionResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*CreateAttributeDefinitionResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 201 {
+			target := new(CreateAttributeDefinitionErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "CreateAttributeDefinitionErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(CreateAttributeDefinitionResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateAttributeDefinitionResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// DeleteAttributeDefinition Delete a user attribute definition
+func (c *Client) DeleteAttributeDefinition(ctx context.Context, options *DeleteAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*struct{}, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions/{id}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*struct{}, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 204 {
+			target := new(DeleteAttributeDefinitionErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "DeleteAttributeDefinitionErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		return nil, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// GetAttributeDefinition Get one attribute definition
+func (c *Client) GetAttributeDefinition(ctx context.Context, options *GetAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttributeDefinitionResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions/{id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetAttributeDefinitionResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetAttributeDefinitionErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetAttributeDefinitionErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetAttributeDefinitionResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetAttributeDefinitionResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// PatchAttributeDefinition Update mutable attribute definition fields
+func (c *Client) PatchAttributeDefinition(ctx context.Context, options *PatchAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PatchAttributeDefinitionResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions/{id}",
+		Method:      "PATCH",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*PatchAttributeDefinitionResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(PatchAttributeDefinitionErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "PatchAttributeDefinitionErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(PatchAttributeDefinitionResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "PatchAttributeDefinitionResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions/{id}")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}
@@ -6084,6 +6418,196 @@ func (c *Client) PatchPerson(ctx context.Context, options *PatchPersonRequestOpt
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/persons/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ListPersonAttributes List a person's typed attributes
+func (c *Client) ListPersonAttributes(ctx context.Context, options *ListPersonAttributesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListPersonAttributesResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/persons/{id}/attributes",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListPersonAttributesResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListPersonAttributesErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListPersonAttributesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListPersonAttributesResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListPersonAttributesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/persons/{id}/attributes")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ClearPersonAttribute Supersede a person's attribute value
+func (c *Client) ClearPersonAttribute(ctx context.Context, options *ClearPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ClearPersonAttributeResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/persons/{id}/attributes/{slug}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ClearPersonAttributeResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ClearPersonAttributeErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ClearPersonAttributeErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ClearPersonAttributeResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ClearPersonAttributeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/persons/{id}/attributes/{slug}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// SetPersonAttribute Set a person's attribute value
+func (c *Client) SetPersonAttribute(ctx context.Context, options *SetPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetPersonAttributeResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/persons/{id}/attributes/{slug}",
+		Method:      "PUT",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*SetPersonAttributeResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(SetPersonAttributeErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "SetPersonAttributeErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(SetPersonAttributeResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "SetPersonAttributeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/persons/{id}/attributes/{slug}")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -270,6 +270,253 @@ func (o *GetAttachmentRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// ListAttributeDefinitionsRequestOptions is the options needed to make a request to ListAttributeDefinitions.
+type ListAttributeDefinitionsRequestOptions struct {
+	Query *ListAttributeDefinitionsQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ListAttributeDefinitionsRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ListAttributeDefinitionsRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *ListAttributeDefinitionsRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ListAttributeDefinitionsRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *ListAttributeDefinitionsRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// CreateAttributeDefinitionRequestOptions is the options needed to make a request to CreateAttributeDefinition.
+type CreateAttributeDefinitionRequestOptions struct {
+	Body *CreateAttributeDefinitionBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *CreateAttributeDefinitionRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *CreateAttributeDefinitionRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *CreateAttributeDefinitionRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *CreateAttributeDefinitionRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *CreateAttributeDefinitionRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// DeleteAttributeDefinitionRequestOptions is the options needed to make a request to DeleteAttributeDefinition.
+type DeleteAttributeDefinitionRequestOptions struct {
+	PathParams *DeleteAttributeDefinitionPath
+	Header     *DeleteAttributeDefinitionHeaders
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *DeleteAttributeDefinitionRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Header != nil {
+		if v, ok := any(o.Header).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Header", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *DeleteAttributeDefinitionRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *DeleteAttributeDefinitionRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *DeleteAttributeDefinitionRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *DeleteAttributeDefinitionRequestOptions) GetHeader() (map[string]string, error) {
+	return runtime.AsMap[string](o.Header)
+}
+
+// GetAttributeDefinitionRequestOptions is the options needed to make a request to GetAttributeDefinition.
+type GetAttributeDefinitionRequestOptions struct {
+	PathParams *GetAttributeDefinitionPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetAttributeDefinitionRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetAttributeDefinitionRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetAttributeDefinitionRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetAttributeDefinitionRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetAttributeDefinitionRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// PatchAttributeDefinitionRequestOptions is the options needed to make a request to PatchAttributeDefinition.
+type PatchAttributeDefinitionRequestOptions struct {
+	PathParams *PatchAttributeDefinitionPath
+	Body       *PatchAttributeDefinitionBody
+	Header     *PatchAttributeDefinitionHeaders
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *PatchAttributeDefinitionRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+
+	if o.Header != nil {
+		if v, ok := any(o.Header).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Header", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *PatchAttributeDefinitionRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *PatchAttributeDefinitionRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *PatchAttributeDefinitionRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *PatchAttributeDefinitionRequestOptions) GetHeader() (map[string]string, error) {
+	return runtime.AsMap[string](o.Header)
+}
+
 // UploadTokenRequestOptions is the options needed to make a request to UploadToken.
 type UploadTokenRequestOptions struct {
 	PathParams *UploadTokenPath
@@ -3492,6 +3739,174 @@ func (o *PatchPersonRequestOptions) GetBody() any {
 // GetHeader returns the headers as a map.
 func (o *PatchPersonRequestOptions) GetHeader() (map[string]string, error) {
 	return runtime.AsMap[string](o.Header)
+}
+
+// ListPersonAttributesRequestOptions is the options needed to make a request to ListPersonAttributes.
+type ListPersonAttributesRequestOptions struct {
+	PathParams *ListPersonAttributesPath
+	Query      *ListPersonAttributesQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ListPersonAttributesRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ListPersonAttributesRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ListPersonAttributesRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ListPersonAttributesRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *ListPersonAttributesRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ClearPersonAttributeRequestOptions is the options needed to make a request to ClearPersonAttribute.
+type ClearPersonAttributeRequestOptions struct {
+	PathParams *ClearPersonAttributePath
+	Query      *ClearPersonAttributeQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ClearPersonAttributeRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ClearPersonAttributeRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ClearPersonAttributeRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ClearPersonAttributeRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *ClearPersonAttributeRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// SetPersonAttributeRequestOptions is the options needed to make a request to SetPersonAttribute.
+type SetPersonAttributeRequestOptions struct {
+	PathParams *SetPersonAttributePath
+	Query      *SetPersonAttributeQuery
+	Body       *SetPersonAttributeBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *SetPersonAttributeRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *SetPersonAttributeRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *SetPersonAttributeRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *SetPersonAttributeRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *SetPersonAttributeRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
 }
 
 // RunQueryRequestOptions is the options needed to make a request to RunQuery.

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -578,6 +578,494 @@ func (c *Client) GetAttachmentWithResponse(ctx context.Context, options *GetAtta
 	}
 }
 
+// ListAttributeDefinitions List portable attribute definitions
+func (c *Client) ListAttributeDefinitionsWithResponse(ctx context.Context, options *ListAttributeDefinitionsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListAttributeDefinitionsResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListAttributeDefinitionsResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListAttributeDefinitionsResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListAttributeDefinitionsResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 503:
+		out.JSON503 = new(ListAttributeDefinitionsErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListAttributeDefinitionsErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// CreateAttributeDefinition Create a user attribute definition
+func (c *Client) CreateAttributeDefinitionWithResponse(ctx context.Context, options *CreateAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateAttributeDefinitionResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &CreateAttributeDefinitionResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 201:
+		out.JSON201 = new(CreateAttributeDefinitionResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON201); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateAttributeDefinitionResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers201 = &CreateAttributeDefinitionResp201Headers{
+			ETag: resp.Headers.Get("ETag"),
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(CreateAttributeDefinitionErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateAttributeDefinitionErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(CreateAttributeDefinitionErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateAttributeDefinitionErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(CreateAttributeDefinitionErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateAttributeDefinitionErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// DeleteAttributeDefinition Delete a user attribute definition
+func (c *Client) DeleteAttributeDefinitionWithResponse(ctx context.Context, options *DeleteAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeleteAttributeDefinitionResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions/{id}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &DeleteAttributeDefinitionResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 204:
+		return out, nil
+	case 400:
+		out.JSON400 = new(DeleteAttributeDefinitionErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "DeleteAttributeDefinitionErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(DeleteAttributeDefinitionErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "DeleteAttributeDefinitionErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(DeleteAttributeDefinitionErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "DeleteAttributeDefinitionErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 428:
+		out.JSON428 = new(DeleteAttributeDefinitionErrorResponseJSON428)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON428); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "DeleteAttributeDefinitionErrorResponseJSON428",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(DeleteAttributeDefinitionErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "DeleteAttributeDefinitionErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// GetAttributeDefinition Get one attribute definition
+func (c *Client) GetAttributeDefinitionWithResponse(ctx context.Context, options *GetAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetAttributeDefinitionResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions/{id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetAttributeDefinitionResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetAttributeDefinitionResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttributeDefinitionResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers200 = &GetAttributeDefinitionResp200Headers{
+			ETag: resp.Headers.Get("ETag"),
+		}
+		return out, nil
+	case 404:
+		out.JSON404 = new(GetAttributeDefinitionErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttributeDefinitionErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(GetAttributeDefinitionErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetAttributeDefinitionErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// PatchAttributeDefinition Update mutable attribute definition fields
+func (c *Client) PatchAttributeDefinitionWithResponse(ctx context.Context, options *PatchAttributeDefinitionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PatchAttributeDefinitionResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/attribute-definitions/{id}",
+		Method:      "PATCH",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/attribute-definitions/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &PatchAttributeDefinitionResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(PatchAttributeDefinitionResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PatchAttributeDefinitionResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers200 = &PatchAttributeDefinitionResp200Headers{
+			ETag: resp.Headers.Get("ETag"),
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(PatchAttributeDefinitionErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PatchAttributeDefinitionErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(PatchAttributeDefinitionErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PatchAttributeDefinitionErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(PatchAttributeDefinitionErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PatchAttributeDefinitionErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 428:
+		out.JSON428 = new(PatchAttributeDefinitionErrorResponseJSON428)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON428); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PatchAttributeDefinitionErrorResponseJSON428",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(PatchAttributeDefinitionErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PatchAttributeDefinitionErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // UploadToken Upload an OAuth token
 func (c *Client) UploadTokenWithResponse(ctx context.Context, options *UploadTokenRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UploadTokenResp, error) {
 	var err error
@@ -6640,6 +7128,308 @@ func (c *Client) PatchPersonWithResponse(ctx context.Context, options *PatchPers
 					ContentType:   resp.Headers.Get("Content-Type"),
 					ContentLength: len(bodyBytes),
 					TargetType:    "PatchPersonErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// ListPersonAttributes List a person's typed attributes
+func (c *Client) ListPersonAttributesWithResponse(ctx context.Context, options *ListPersonAttributesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListPersonAttributesResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/persons/{id}/attributes",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/persons/{id}/attributes")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListPersonAttributesResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListPersonAttributesResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListPersonAttributesResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 404:
+		out.JSON404 = new(ListPersonAttributesErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListPersonAttributesErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(ListPersonAttributesErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListPersonAttributesErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// ClearPersonAttribute Supersede a person's attribute value
+func (c *Client) ClearPersonAttributeWithResponse(ctx context.Context, options *ClearPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ClearPersonAttributeResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/persons/{id}/attributes/{slug}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/persons/{id}/attributes/{slug}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ClearPersonAttributeResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ClearPersonAttributeResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ClearPersonAttributeResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(ClearPersonAttributeErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ClearPersonAttributeErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(ClearPersonAttributeErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ClearPersonAttributeErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(ClearPersonAttributeErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ClearPersonAttributeErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(ClearPersonAttributeErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ClearPersonAttributeErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// SetPersonAttribute Set a person's attribute value
+func (c *Client) SetPersonAttributeWithResponse(ctx context.Context, options *SetPersonAttributeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetPersonAttributeResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/persons/{id}/attributes/{slug}",
+		Method:      "PUT",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/persons/{id}/attributes/{slug}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &SetPersonAttributeResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(SetPersonAttributeResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SetPersonAttributeResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(SetPersonAttributeErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SetPersonAttributeErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(SetPersonAttributeErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SetPersonAttributeErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(SetPersonAttributeErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SetPersonAttributeErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(SetPersonAttributeErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SetPersonAttributeErrorResponseJSON503",
 					Body:          bodyBytes,
 					Err:           err,
 				}

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -25,6 +25,40 @@ func (a AddResultCacheState) Validate() error {
 	}
 }
 
+type CreateAttributeDefinitionRequestCardinality string
+
+const (
+	Multi  CreateAttributeDefinitionRequestCardinality = "multi"
+	Single CreateAttributeDefinitionRequestCardinality = "single"
+)
+
+// Validate checks if the CreateAttributeDefinitionRequestCardinality value is valid
+func (c CreateAttributeDefinitionRequestCardinality) Validate() error {
+	switch c {
+	case Multi, Single:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid CreateAttributeDefinitionRequestCardinality value, got: %v", c))
+	}
+}
+
+type CreateAttributeDefinitionRequestObjectType string
+
+const (
+	CreateAttributeDefinitionRequestObjectTypePerson CreateAttributeDefinitionRequestObjectType = "person"
+	Organization                                     CreateAttributeDefinitionRequestObjectType = "organization"
+)
+
+// Validate checks if the CreateAttributeDefinitionRequestObjectType value is valid
+func (c CreateAttributeDefinitionRequestObjectType) Validate() error {
+	switch c {
+	case CreateAttributeDefinitionRequestObjectTypePerson, Organization:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid CreateAttributeDefinitionRequestObjectType value, got: %v", c))
+	}
+}
+
 type ExploreCacheUnavailableResponseReadiness string
 
 const (
@@ -473,6 +507,28 @@ func (s SessionStatusAuthMode) Validate() error {
 		return nil
 	default:
 		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid SessionStatusAuthMode value, got: %v", s))
+	}
+}
+
+type SetPersonAttributeRequestSource string
+
+const (
+	ArchiveObservation SetPersonAttributeRequestSource = "archive_observation"
+	CarddavImport      SetPersonAttributeRequestSource = "carddav_import"
+	Enrichment         SetPersonAttributeRequestSource = "enrichment"
+	Extraction         SetPersonAttributeRequestSource = "extraction"
+	System             SetPersonAttributeRequestSource = "system"
+	User               SetPersonAttributeRequestSource = "user"
+	VcardImport        SetPersonAttributeRequestSource = "vcard_import"
+)
+
+// Validate checks if the SetPersonAttributeRequestSource value is valid
+func (s SetPersonAttributeRequestSource) Validate() error {
+	switch s {
+	case ArchiveObservation, CarddavImport, Enrichment, Extraction, System, User, VcardImport:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid SetPersonAttributeRequestSource value, got: %v", s))
 	}
 }
 

--- a/pkg/client/generated/headers.go
+++ b/pkg/client/generated/headers.go
@@ -6,6 +6,24 @@ import (
 	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
 )
 
+type DeleteAttributeDefinitionHeaders struct {
+	// IfMatch Strong ETag returned by the latest definition read
+	IfMatch string `json:"If-Match" validate:"required"`
+}
+
+func (d DeleteAttributeDefinitionHeaders) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(d))
+}
+
+type PatchAttributeDefinitionHeaders struct {
+	// IfMatch Strong ETag returned by the latest definition read
+	IfMatch string `json:"If-Match" validate:"required"`
+}
+
+func (p PatchAttributeDefinitionHeaders) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(p))
+}
+
 type CreateOrLinkMessageTaskHeaders struct {
 	// XRequestID Browser-generated retry-stable request ID
 	XRequestID string `json:"X-Request-Id" validate:"required"`

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -20,6 +20,21 @@ type GetAttachmentPath struct {
 	ID int64 `json:"id"`
 }
 
+type DeleteAttributeDefinitionPath struct {
+	// ID Attribute definition ID
+	ID int64 `json:"id"`
+}
+
+type GetAttributeDefinitionPath struct {
+	// ID Attribute definition ID
+	ID int64 `json:"id"`
+}
+
+type PatchAttributeDefinitionPath struct {
+	// ID Attribute definition ID
+	ID int64 `json:"id"`
+}
+
 type UploadTokenPath struct {
 	// Email Account email address
 	Email string `json:"email" validate:"required"`
@@ -190,6 +205,35 @@ type GetPersonProfilePath struct {
 type PatchPersonPath struct {
 	// ID Durable person ID
 	ID int64 `json:"id"`
+}
+
+type ListPersonAttributesPath struct {
+	// ID Durable person ID
+	ID int64 `json:"id"`
+}
+
+type ClearPersonAttributePath struct {
+	// ID Durable person ID
+	ID int64 `json:"id"`
+
+	// Slug Immutable attribute definition slug
+	Slug string `json:"slug" validate:"required"`
+}
+
+func (c ClearPersonAttributePath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type SetPersonAttributePath struct {
+	// ID Durable person ID
+	ID int64 `json:"id"`
+
+	// Slug Immutable attribute definition slug
+	Slug string `json:"slug" validate:"required"`
+}
+
+func (s SetPersonAttributePath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(s))
 }
 
 type GetRelationshipTimelinePath struct {

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -6,6 +6,10 @@ type LoginSessionBody = SessionLoginRequest
 
 type AddAccountBody = AddAccountRequest
 
+type CreateAttributeDefinitionBody = CreateAttributeDefinitionRequest
+
+type PatchAttributeDefinitionBody = PatchAttributeDefinitionRequest
+
 type UploadTokenBody = TokenUploadRequest
 
 type EndBackupFreezeBody = BackupFreezeEndRequest
@@ -83,6 +87,8 @@ type GetPersonTimelineBody = ExploreHTTPRequest
 type CreatePersonBody = CreatePersonRequest
 
 type PatchPersonBody = PatchPersonRequest
+
+type SetPersonAttributeBody = SetPersonAttributeRequest
 
 type RunQueryBody = QueryRequest
 

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -113,6 +113,14 @@ func (g GetSubAggregatesQuery) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(g))
 }
 
+type ListAttributeDefinitionsQuery struct {
+	// ObjectType Filter by object type
+	ObjectType *string `json:"object_type,omitempty"`
+
+	// IncludeHidden Include deactivated definitions
+	IncludeHidden *bool `json:"include_hidden,omitempty"`
+}
+
 type GetCLIAttachmentQuery struct {
 	// ContentHash Attachment SHA-256 content hash
 	ContentHash string `json:"content_hash" validate:"required"`
@@ -430,6 +438,30 @@ type GetMessageInlinePartQuery struct {
 
 func (g GetMessageInlinePartQuery) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
+type ListPersonAttributesQuery struct {
+	// History Include superseded values
+	History *bool `json:"history,omitempty"`
+
+	// Slug Restrict the response to one definition slug
+	Slug *string `json:"slug,omitempty"`
+}
+
+type ClearPersonAttributeQuery struct {
+	// Ordinal Ordinal for a multi-valued definition
+	Ordinal *int64 `json:"ordinal,omitempty"`
+
+	// ExpectedValueID Compare-and-swap: the current value ID expected to be superseded
+	ExpectedValueID *int64 `json:"expected_value_id,omitempty"`
+
+	// DryRun Validate and preview without writing
+	DryRun *bool `json:"dry_run,omitempty"`
+}
+
+type SetPersonAttributeQuery struct {
+	// DryRun Validate and preview without writing
+	DryRun *bool `json:"dry_run,omitempty"`
 }
 
 type SearchMessagesQuery struct {

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -59,6 +59,46 @@ type GetAttachmentResponse = AttachmentInfo
 
 type GetAttachmentErrorResponse = ErrorResponse
 
+type ListAttributeDefinitionsResponse = AttributeDefinitionsResponse
+
+type ListAttributeDefinitionsErrorResponse = ErrorResponse
+
+type CreateAttributeDefinitionResponse = AttributeDefinition
+
+type CreateAttributeDefinitionErrorResponse = ErrorResponse
+
+type CreateAttributeDefinitionErrorResponseJSON = ErrorResponse
+
+type CreateAttributeDefinitionErrorResponseJSON503 = ErrorResponse
+
+type DeleteAttributeDefinitionErrorResponse = ErrorResponse
+
+type DeleteAttributeDefinitionErrorResponseJSON = ErrorResponse
+
+type DeleteAttributeDefinitionErrorResponseJSON409 = ErrorResponse
+
+type DeleteAttributeDefinitionErrorResponseJSON428 = ErrorResponse
+
+type DeleteAttributeDefinitionErrorResponseJSON503 = ErrorResponse
+
+type GetAttributeDefinitionResponse = AttributeDefinition
+
+type GetAttributeDefinitionErrorResponse = ErrorResponse
+
+type GetAttributeDefinitionErrorResponseJSON = ErrorResponse
+
+type PatchAttributeDefinitionResponse = AttributeDefinition
+
+type PatchAttributeDefinitionErrorResponse = ErrorResponse
+
+type PatchAttributeDefinitionErrorResponseJSON = ErrorResponse
+
+type PatchAttributeDefinitionErrorResponseJSON409 = ErrorResponse
+
+type PatchAttributeDefinitionErrorResponseJSON428 = ErrorResponse
+
+type PatchAttributeDefinitionErrorResponseJSON503 = ErrorResponse
+
 type UploadTokenResponse = StatusMessageResponse
 
 type UploadTokenErrorResponse = ErrorResponse
@@ -1137,6 +1177,32 @@ type PatchPersonErrorResponseJSON428 = ErrorResponse
 
 type PatchPersonErrorResponseJSON503 = ErrorResponse
 
+type ListPersonAttributesResponse = PersonAttributesResponse
+
+type ListPersonAttributesErrorResponse = ErrorResponse
+
+type ListPersonAttributesErrorResponseJSON = ErrorResponse
+
+type ClearPersonAttributeResponse = PersonAttributeWrite
+
+type ClearPersonAttributeErrorResponse = ErrorResponse
+
+type ClearPersonAttributeErrorResponseJSON = ErrorResponse
+
+type ClearPersonAttributeErrorResponseJSON409 = ErrorResponse
+
+type ClearPersonAttributeErrorResponseJSON503 = ErrorResponse
+
+type SetPersonAttributeResponse = PersonAttributeWrite
+
+type SetPersonAttributeErrorResponse = ErrorResponse
+
+type SetPersonAttributeErrorResponseJSON = ErrorResponse
+
+type SetPersonAttributeErrorResponseJSON409 = ErrorResponse
+
+type SetPersonAttributeErrorResponseJSON503 = ErrorResponse
+
 type RunQueryResponse = QueryResult
 
 type RunQueryErrorResponse = ErrorResponse
@@ -1468,6 +1534,71 @@ type GetAttachmentResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *GetAttachmentResponse
+}
+
+type ListAttributeDefinitionsResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListAttributeDefinitionsResponse
+	JSON503      *ListAttributeDefinitionsErrorResponse
+}
+
+type CreateAttributeDefinitionResp201Headers struct {
+	ETag string `header:"ETag"`
+}
+
+type CreateAttributeDefinitionResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON201      *CreateAttributeDefinitionResponse
+	Headers201   *CreateAttributeDefinitionResp201Headers
+	JSON400      *CreateAttributeDefinitionErrorResponse
+	JSON409      *CreateAttributeDefinitionErrorResponseJSON
+	JSON503      *CreateAttributeDefinitionErrorResponseJSON503
+}
+
+type DeleteAttributeDefinitionResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON400      *DeleteAttributeDefinitionErrorResponse
+	JSON404      *DeleteAttributeDefinitionErrorResponseJSON
+	JSON409      *DeleteAttributeDefinitionErrorResponseJSON409
+	JSON428      *DeleteAttributeDefinitionErrorResponseJSON428
+	JSON503      *DeleteAttributeDefinitionErrorResponseJSON503
+}
+
+type GetAttributeDefinitionResp200Headers struct {
+	ETag string `header:"ETag"`
+}
+
+type GetAttributeDefinitionResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetAttributeDefinitionResponse
+	Headers200   *GetAttributeDefinitionResp200Headers
+	JSON404      *GetAttributeDefinitionErrorResponse
+	JSON503      *GetAttributeDefinitionErrorResponseJSON
+}
+
+type PatchAttributeDefinitionResp200Headers struct {
+	ETag string `header:"ETag"`
+}
+
+type PatchAttributeDefinitionResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *PatchAttributeDefinitionResponse
+	Headers200   *PatchAttributeDefinitionResp200Headers
+	JSON400      *PatchAttributeDefinitionErrorResponse
+	JSON404      *PatchAttributeDefinitionErrorResponseJSON
+	JSON409      *PatchAttributeDefinitionErrorResponseJSON409
+	JSON428      *PatchAttributeDefinitionErrorResponseJSON428
+	JSON503      *PatchAttributeDefinitionErrorResponseJSON503
 }
 
 type UploadTokenResp struct {
@@ -2187,6 +2318,37 @@ type PatchPersonResp struct {
 	JSON409      *PatchPersonErrorResponseJSON
 	JSON428      *PatchPersonErrorResponseJSON428
 	JSON503      *PatchPersonErrorResponseJSON503
+}
+
+type ListPersonAttributesResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListPersonAttributesResponse
+	JSON404      *ListPersonAttributesErrorResponse
+	JSON503      *ListPersonAttributesErrorResponseJSON
+}
+
+type ClearPersonAttributeResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ClearPersonAttributeResponse
+	JSON400      *ClearPersonAttributeErrorResponse
+	JSON404      *ClearPersonAttributeErrorResponseJSON
+	JSON409      *ClearPersonAttributeErrorResponseJSON409
+	JSON503      *ClearPersonAttributeErrorResponseJSON503
+}
+
+type SetPersonAttributeResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *SetPersonAttributeResponse
+	JSON400      *SetPersonAttributeErrorResponse
+	JSON404      *SetPersonAttributeErrorResponseJSON
+	JSON409      *SetPersonAttributeErrorResponseJSON409
+	JSON503      *SetPersonAttributeErrorResponseJSON503
 }
 
 type RunQueryResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -183,6 +183,147 @@ func (a AttachmentInfo) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(a))
 }
 
+type AttributeChoice struct {
+	Label string `json:"label" validate:"required"`
+	Value string `json:"value" validate:"required"`
+}
+
+func (a AttributeChoice) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(a))
+}
+
+type AttributeDefinition struct {
+	APIMutable    bool              `json:"api_mutable"`
+	Cardinality   string            `json:"cardinality" validate:"required"`
+	CreatedAt     time.Time         `json:"created_at" validate:"required"`
+	DerivedSource *string           `json:"derived_source,omitempty"`
+	Description   *string           `json:"description,omitempty"`
+	DisplayOrder  int64             `json:"display_order"`
+	FieldType     string            `json:"field_type" validate:"required"`
+	HistoryExempt bool              `json:"history_exempt"`
+	ID            int64             `json:"id"`
+	IsActive      bool              `json:"is_active"`
+	IsAudited     bool              `json:"is_audited"`
+	IsDeletable   bool              `json:"is_deletable"`
+	IsRequired    bool              `json:"is_required"`
+	IsSearchable  bool              `json:"is_searchable"`
+	Label         string            `json:"label" validate:"required"`
+	ObjectType    string            `json:"object_type" validate:"required"`
+	Options       *AttributeOptions `json:"options,omitempty"`
+	Ownership     string            `json:"ownership" validate:"required"`
+	RecordTarget  *string           `json:"record_target,omitempty"`
+	Revision      int64             `json:"revision"`
+	Slug          string            `json:"slug" validate:"required"`
+	UICreatable   bool              `json:"ui_creatable"`
+	UIEditable    bool              `json:"ui_editable"`
+	UniversalID   string            `json:"universal_id" validate:"required"`
+	UpdatedAt     time.Time         `json:"updated_at" validate:"required"`
+	ValueType     string            `json:"value_type" validate:"required"`
+	VcardProperty *string           `json:"vcard_property,omitempty"`
+}
+
+func (a AttributeDefinition) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(a.Cardinality, "required"); err != nil {
+		errors = errors.Append("Cardinality", err)
+	}
+	if err := typesValidator.Var(a.CreatedAt, "required"); err != nil {
+		errors = errors.Append("CreatedAt", err)
+	}
+	if err := typesValidator.Var(a.FieldType, "required"); err != nil {
+		errors = errors.Append("FieldType", err)
+	}
+	if err := typesValidator.Var(a.Label, "required"); err != nil {
+		errors = errors.Append("Label", err)
+	}
+	if err := typesValidator.Var(a.ObjectType, "required"); err != nil {
+		errors = errors.Append("ObjectType", err)
+	}
+	if a.Options != nil {
+		if v, ok := any(a.Options).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Options", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(a.Ownership, "required"); err != nil {
+		errors = errors.Append("Ownership", err)
+	}
+	if err := typesValidator.Var(a.Slug, "required"); err != nil {
+		errors = errors.Append("Slug", err)
+	}
+	if err := typesValidator.Var(a.UniversalID, "required"); err != nil {
+		errors = errors.Append("UniversalID", err)
+	}
+	if err := typesValidator.Var(a.UpdatedAt, "required"); err != nil {
+		errors = errors.Append("UpdatedAt", err)
+	}
+	if err := typesValidator.Var(a.ValueType, "required"); err != nil {
+		errors = errors.Append("ValueType", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type AttributeDefinitionsResponse struct {
+	Definitions []AttributeDefinition `json:"definitions,omitempty" validate:"required"`
+}
+
+func (a AttributeDefinitionsResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range a.Definitions {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Definitions[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type AttributeOptions struct {
+	Choices   []AttributeChoice `json:"choices,omitempty"`
+	MaxLength *int64            `json:"max_length,omitempty"`
+	Unit      *string           `json:"unit,omitempty"`
+}
+
+func (a AttributeOptions) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range a.Choices {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Choices[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type AttributeValue struct {
+	Boolean    *bool           `json:"boolean,omitempty"`
+	Date       *string         `json:"date,omitempty"`
+	Integer    *int64          `json:"integer,omitempty"`
+	JSON       json.RawMessage `json:"json,omitempty"`
+	Real       *float64        `json:"real,omitempty"`
+	RecordID   *int64          `json:"record_id,omitempty"`
+	RecordType *string         `json:"record_type,omitempty"`
+	Text       *string         `json:"text,omitempty"`
+	Timestamp  *time.Time      `json:"timestamp,omitempty"`
+	Type       string          `json:"type" validate:"required"`
+}
+
+func (a AttributeValue) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(a))
+}
+
 type BackupFreezeBeginResponse struct {
 	Token string `json:"token" validate:"required"`
 }
@@ -995,6 +1136,62 @@ func (c ConversationResponse) Validate() error {
 				errors = errors.Append(fmt.Sprintf("Messages[%d]", i), err)
 			}
 		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type CreateAttributeDefinitionRequest struct {
+	Cardinality   *CreateAttributeDefinitionRequestCardinality `json:"cardinality,omitempty"`
+	Description   *string                                      `json:"description,omitempty"`
+	DisplayOrder  *int64                                       `json:"display_order,omitempty"`
+	FieldType     string                                       `json:"field_type" validate:"required"`
+	IsAudited     *bool                                        `json:"is_audited,omitempty"`
+	IsRequired    *bool                                        `json:"is_required,omitempty"`
+	IsSearchable  *bool                                        `json:"is_searchable,omitempty"`
+	Label         string                                       `json:"label" validate:"required"`
+	ObjectType    CreateAttributeDefinitionRequestObjectType   `json:"object_type" validate:"required"`
+	Options       *AttributeOptions                            `json:"options,omitempty"`
+	RecordTarget  *string                                      `json:"record_target,omitempty"`
+	Slug          string                                       `json:"slug" validate:"required"`
+	ValueType     string                                       `json:"value_type" validate:"required"`
+	VcardProperty *string                                      `json:"vcard_property,omitempty"`
+}
+
+func (c CreateAttributeDefinitionRequest) Validate() error {
+	var errors runtime.ValidationErrors
+	if c.Cardinality != nil {
+		if v, ok := any(c.Cardinality).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Cardinality", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(c.FieldType, "required"); err != nil {
+		errors = errors.Append("FieldType", err)
+	}
+	if err := typesValidator.Var(c.Label, "required"); err != nil {
+		errors = errors.Append("Label", err)
+	}
+	if v, ok := any(c.ObjectType).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("ObjectType", err)
+		}
+	}
+	if c.Options != nil {
+		if v, ok := any(c.Options).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Options", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(c.Slug, "required"); err != nil {
+		errors = errors.Append("Slug", err)
+	}
+	if err := typesValidator.Var(c.ValueType, "required"); err != nil {
+		errors = errors.Append("ValueType", err)
 	}
 	if len(errors) == 0 {
 		return nil
@@ -2736,6 +2933,13 @@ type OperationHealth struct {
 	StartedAt *time.Time `json:"started_at,omitempty"`
 }
 
+type PatchAttributeDefinitionRequest struct {
+	Description  *string `json:"description,omitempty"`
+	DisplayOrder *int64  `json:"display_order,omitempty"`
+	IsActive     *bool   `json:"is_active,omitempty"`
+	Label        *string `json:"label,omitempty"`
+}
+
 type PatchPersonRequest struct {
 	DisplayName *string `json:"display_name" validate:"omitempty"`
 }
@@ -2778,6 +2982,129 @@ type Person struct {
 
 func (p Person) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(p))
+}
+
+type PersonAttributeGroup struct {
+	Current    []PersonAttributeValue `json:"current,omitempty" validate:"required"`
+	Definition AttributeDefinition    `json:"definition"`
+	History    []PersonAttributeValue `json:"history,omitempty"`
+}
+
+func (p PersonAttributeGroup) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range p.Current {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Current[%d]", i), err)
+			}
+		}
+	}
+	if v, ok := any(p.Definition).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Definition", err)
+		}
+	}
+	for i, item := range p.History {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("History[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type PersonAttributeValue struct {
+	ActiveFrom     time.Time      `json:"active_from" validate:"required"`
+	ActiveUntil    *time.Time     `json:"active_until,omitempty"`
+	Actor          *string        `json:"actor,omitempty"`
+	Confidence     *float64       `json:"confidence,omitempty"`
+	CreatedAt      time.Time      `json:"created_at" validate:"required"`
+	DefinitionID   int64          `json:"definition_id"`
+	DefinitionSlug string         `json:"definition_slug" validate:"required"`
+	ID             int64          `json:"id"`
+	Ordinal        int64          `json:"ordinal"`
+	PersonID       int64          `json:"person_id"`
+	Source         string         `json:"source" validate:"required"`
+	SourceRef      *string        `json:"source_ref,omitempty"`
+	SupersededAt   *time.Time     `json:"superseded_at,omitempty"`
+	Value          AttributeValue `json:"value"`
+}
+
+func (p PersonAttributeValue) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(p.ActiveFrom, "required"); err != nil {
+		errors = errors.Append("ActiveFrom", err)
+	}
+	if err := typesValidator.Var(p.CreatedAt, "required"); err != nil {
+		errors = errors.Append("CreatedAt", err)
+	}
+	if err := typesValidator.Var(p.DefinitionSlug, "required"); err != nil {
+		errors = errors.Append("DefinitionSlug", err)
+	}
+	if err := typesValidator.Var(p.Source, "required"); err != nil {
+		errors = errors.Append("Source", err)
+	}
+	if v, ok := any(p.Value).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Value", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type PersonAttributeWrite struct {
+	DryRun     bool                  `json:"dry_run"`
+	Superseded *PersonAttributeValue `json:"superseded,omitempty"`
+	Value      *PersonAttributeValue `json:"value,omitempty"`
+}
+
+func (p PersonAttributeWrite) Validate() error {
+	var errors runtime.ValidationErrors
+	if p.Superseded != nil {
+		if v, ok := any(p.Superseded).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Superseded", err)
+			}
+		}
+	}
+	if p.Value != nil {
+		if v, ok := any(p.Value).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Value", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type PersonAttributesResponse struct {
+	Attributes []PersonAttributeGroup `json:"attributes,omitempty" validate:"required"`
+	PersonID   int64                  `json:"person_id"`
+}
+
+func (p PersonAttributesResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range p.Attributes {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Attributes[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type PersonCluster struct {
@@ -3521,6 +3848,38 @@ func (s SessionStatus) Validate() error {
 	if v, ok := any(s.AuthMode).(runtime.Validator); ok {
 		if err := v.Validate(); err != nil {
 			errors = errors.Append("AuthMode", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type SetPersonAttributeRequest struct {
+	ActiveFrom      *time.Time                       `json:"active_from,omitempty"`
+	ActiveUntil     *time.Time                       `json:"active_until,omitempty"`
+	Actor           *string                          `json:"actor,omitempty"`
+	Confidence      *float64                         `json:"confidence,omitempty"`
+	ExpectedValueID *int64                           `json:"expected_value_id,omitempty"`
+	Ordinal         *int64                           `json:"ordinal,omitempty"`
+	Source          *SetPersonAttributeRequestSource `json:"source,omitempty"`
+	SourceRef       *string                          `json:"source_ref,omitempty"`
+	Value           AttributeValue                   `json:"value"`
+}
+
+func (s SetPersonAttributeRequest) Validate() error {
+	var errors runtime.ValidationErrors
+	if s.Source != nil {
+		if v, ok := any(s.Source).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Source", err)
+			}
+		}
+	}
+	if v, ok := any(s.Value).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Value", err)
 		}
 	}
 	if len(errors) == 0 {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -184,6 +184,155 @@ components:
         - mime_type
         - size_bytes
       type: object
+    AttributeChoice:
+      additionalProperties: false
+      properties:
+        label:
+          type: string
+        value:
+          type: string
+      required:
+        - value
+        - label
+      type: object
+    AttributeDefinition:
+      properties:
+        api_mutable:
+          type: boolean
+        cardinality:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        derived_source:
+          type: string
+        description:
+          type: string
+        display_order:
+          format: int64
+          type: integer
+        field_type:
+          type: string
+        history_exempt:
+          type: boolean
+        id:
+          format: int64
+          type: integer
+        is_active:
+          type: boolean
+        is_audited:
+          type: boolean
+        is_deletable:
+          type: boolean
+        is_required:
+          type: boolean
+        is_searchable:
+          type: boolean
+        label:
+          type: string
+        object_type:
+          type: string
+        options:
+          $ref: "#/components/schemas/AttributeOptions"
+        ownership:
+          type: string
+        record_target:
+          type: string
+        revision:
+          format: int64
+          type: integer
+        slug:
+          type: string
+        ui_creatable:
+          type: boolean
+        ui_editable:
+          type: boolean
+        universal_id:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        value_type:
+          type: string
+        vcard_property:
+          type: string
+      required:
+        - id
+        - universal_id
+        - object_type
+        - slug
+        - label
+        - value_type
+        - field_type
+        - cardinality
+        - display_order
+        - is_required
+        - ownership
+        - ui_creatable
+        - ui_editable
+        - api_mutable
+        - is_searchable
+        - is_audited
+        - is_deletable
+        - history_exempt
+        - is_active
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    AttributeDefinitionsResponse:
+      properties:
+        definitions:
+          items:
+            $ref: "#/components/schemas/AttributeDefinition"
+          nullable: true
+          type: array
+      required:
+        - definitions
+      type: object
+    AttributeOptions:
+      additionalProperties: false
+      properties:
+        choices:
+          items:
+            $ref: "#/components/schemas/AttributeChoice"
+          nullable: true
+          type: array
+        max_length:
+          format: int64
+          type: integer
+        unit:
+          type: string
+      type: object
+    AttributeValue:
+      additionalProperties: false
+      properties:
+        boolean:
+          type: boolean
+        date:
+          type: string
+        integer:
+          format: int64
+          type: integer
+        json: {}
+        real:
+          format: double
+          type: number
+        record_id:
+          format: int64
+          type: integer
+        record_type:
+          type: string
+        text:
+          type: string
+        timestamp:
+          format: date-time
+          type: string
+        type:
+          type: string
+      required:
+        - type
+      type: object
     BackupFreezeBeginResponse:
       properties:
         token:
@@ -1141,6 +1290,51 @@ components:
         - has_before
         - has_after
         - total
+      type: object
+    CreateAttributeDefinitionRequest:
+      additionalProperties: false
+      properties:
+        cardinality:
+          enum:
+            - single
+            - multi
+          type: string
+        description:
+          type: string
+        display_order:
+          format: int64
+          type: integer
+        field_type:
+          type: string
+        is_audited:
+          type: boolean
+        is_required:
+          type: boolean
+        is_searchable:
+          type: boolean
+        label:
+          type: string
+        object_type:
+          enum:
+            - person
+            - organization
+          type: string
+        options:
+          $ref: "#/components/schemas/AttributeOptions"
+        record_target:
+          type: string
+        slug:
+          type: string
+        value_type:
+          type: string
+        vcard_property:
+          type: string
+      required:
+        - object_type
+        - slug
+        - label
+        - value_type
+        - field_type
       type: object
     CreatePersonRequest:
       additionalProperties: false
@@ -2908,6 +3102,20 @@ components:
       required:
         - busy
       type: object
+    PatchAttributeDefinitionRequest:
+      additionalProperties: false
+      properties:
+        description:
+          nullable: true
+          type: string
+        display_order:
+          format: int64
+          type: integer
+        is_active:
+          type: boolean
+        label:
+          type: string
+      type: object
     PatchPersonRequest:
       additionalProperties: false
       properties:
@@ -2964,6 +3172,99 @@ components:
         - participant_ids
         - created_at
         - updated_at
+      type: object
+    PersonAttributeGroup:
+      properties:
+        current:
+          items:
+            $ref: "#/components/schemas/PersonAttributeValue"
+          nullable: true
+          type: array
+        definition:
+          $ref: "#/components/schemas/AttributeDefinition"
+        history:
+          items:
+            $ref: "#/components/schemas/PersonAttributeValue"
+          nullable: true
+          type: array
+      required:
+        - definition
+        - current
+      type: object
+    PersonAttributeValue:
+      properties:
+        active_from:
+          format: date-time
+          type: string
+        active_until:
+          format: date-time
+          type: string
+        actor:
+          type: string
+        confidence:
+          format: double
+          type: number
+        created_at:
+          format: date-time
+          type: string
+        definition_id:
+          format: int64
+          type: integer
+        definition_slug:
+          type: string
+        id:
+          format: int64
+          type: integer
+        ordinal:
+          format: int64
+          type: integer
+        person_id:
+          format: int64
+          type: integer
+        source:
+          type: string
+        source_ref:
+          type: string
+        superseded_at:
+          format: date-time
+          type: string
+        value:
+          $ref: "#/components/schemas/AttributeValue"
+      required:
+        - id
+        - person_id
+        - definition_id
+        - definition_slug
+        - ordinal
+        - value
+        - active_from
+        - created_at
+        - source
+      type: object
+    PersonAttributeWrite:
+      properties:
+        dry_run:
+          type: boolean
+        superseded:
+          $ref: "#/components/schemas/PersonAttributeValue"
+        value:
+          $ref: "#/components/schemas/PersonAttributeValue"
+      required:
+        - dry_run
+      type: object
+    PersonAttributesResponse:
+      properties:
+        attributes:
+          items:
+            $ref: "#/components/schemas/PersonAttributeGroup"
+          nullable: true
+          type: array
+        person_id:
+          format: int64
+          type: integer
+      required:
+        - person_id
+        - attributes
       type: object
     PersonCluster:
       properties:
@@ -3682,6 +3983,43 @@ components:
         - auth_mode
         - https
         - plain_http_warning
+      type: object
+    SetPersonAttributeRequest:
+      additionalProperties: false
+      properties:
+        active_from:
+          format: date-time
+          type: string
+        active_until:
+          format: date-time
+          type: string
+        actor:
+          type: string
+        confidence:
+          format: double
+          type: number
+        expected_value_id:
+          format: int64
+          type: integer
+        ordinal:
+          format: int64
+          type: integer
+        source:
+          enum:
+            - user
+            - carddav_import
+            - vcard_import
+            - archive_observation
+            - extraction
+            - enrichment
+            - system
+          type: string
+        source_ref:
+          type: string
+        value:
+          $ref: "#/components/schemas/AttributeValue"
+      required:
+        - value
       type: object
     Setting:
       properties:
@@ -4557,7 +4895,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.34.0
+  version: 1.35.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -4999,6 +5337,274 @@ paths:
       security:
         - apiKey: []
       summary: Get attachment metadata
+      tags:
+        - API
+  /api/v1/attribute-definitions:
+    get:
+      operationId: listAttributeDefinitions
+      parameters:
+        - description: Filter by object type
+          in: query
+          name: object_type
+          schema:
+            type: string
+        - description: Include deactivated definitions
+          in: query
+          name: include_hidden
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinitionsResponse"
+          description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List portable attribute definitions
+      tags:
+        - API
+    post:
+      operationId: createAttributeDefinition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAttributeDefinitionRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinition"
+          description: Created
+          headers:
+            ETag:
+              description: Strong attribute definition revision tag
+              schema:
+                type: string
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Create a user attribute definition
+      tags:
+        - API
+  /api/v1/attribute-definitions/{id}:
+    delete:
+      operationId: deleteAttributeDefinition
+      parameters:
+        - description: Attribute definition ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Strong ETag returned by the latest definition read
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "428":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Delete a user attribute definition
+      tags:
+        - API
+    get:
+      operationId: getAttributeDefinition
+      parameters:
+        - description: Attribute definition ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinition"
+          description: OK
+          headers:
+            ETag:
+              description: Strong attribute definition revision tag
+              schema:
+                type: string
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get one attribute definition
+      tags:
+        - API
+    patch:
+      operationId: patchAttributeDefinition
+      parameters:
+        - description: Attribute definition ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Strong ETag returned by the latest definition read
+          in: header
+          name: If-Match
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchAttributeDefinitionRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttributeDefinition"
+          description: OK
+          headers:
+            ETag:
+              description: Strong attribute definition revision tag
+              schema:
+                type: string
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "428":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Update mutable attribute definition fields
       tags:
         - API
   /api/v1/auth/token/{email}:
@@ -8477,6 +9083,202 @@ paths:
       security:
         - apiKey: []
       summary: Update a durable person's display name
+      tags:
+        - API
+  /api/v1/persons/{id}/attributes:
+    get:
+      operationId: listPersonAttributes
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Include superseded values
+          in: query
+          name: history
+          schema:
+            type: boolean
+        - description: Restrict the response to one definition slug
+          in: query
+          name: slug
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonAttributesResponse"
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List a person's typed attributes
+      tags:
+        - API
+  /api/v1/persons/{id}/attributes/{slug}:
+    delete:
+      operationId: clearPersonAttribute
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Immutable attribute definition slug
+          in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+        - description: Ordinal for a multi-valued definition
+          in: query
+          name: ordinal
+          schema:
+            format: int64
+            type: integer
+        - description: "Compare-and-swap: the current value ID expected to be superseded"
+          in: query
+          name: expected_value_id
+          schema:
+            format: int64
+            type: integer
+        - description: Validate and preview without writing
+          in: query
+          name: dry_run
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonAttributeWrite"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Supersede a person's attribute value
+      tags:
+        - API
+    put:
+      operationId: setPersonAttribute
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Immutable attribute definition slug
+          in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+        - description: Validate and preview without writing
+          in: query
+          name: dry_run
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetPersonAttributeRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonAttributeWrite"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Set a person's attribute value
       tags:
         - API
   /api/v1/query:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -142,6 +142,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/attribute-definitions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List portable attribute definitions */
+        get: operations["listAttributeDefinitions"];
+        put?: never;
+        /** Create a user attribute definition */
+        post: operations["createAttributeDefinition"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/attribute-definitions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one attribute definition */
+        get: operations["getAttributeDefinition"];
+        put?: never;
+        post?: never;
+        /** Delete a user attribute definition */
+        delete: operations["deleteAttributeDefinition"];
+        options?: never;
+        head?: never;
+        /** Update mutable attribute definition fields */
+        patch: operations["patchAttributeDefinition"];
+        trace?: never;
+    };
     "/api/v1/auth/token/{email}": {
         parameters: {
             query?: never;
@@ -1368,6 +1405,41 @@ export interface paths {
         patch: operations["patchPerson"];
         trace?: never;
     };
+    "/api/v1/persons/{id}/attributes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List a person's typed attributes */
+        get: operations["listPersonAttributes"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/persons/{id}/attributes/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Set a person's attribute value */
+        put: operations["setPersonAttribute"];
+        post?: never;
+        /** Supersede a person's attribute value */
+        delete: operations["clearPersonAttribute"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/query": {
         parameters: {
             query?: never;
@@ -1862,6 +1934,73 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        AttributeChoice: {
+            label: string;
+            value: string;
+        };
+        AttributeDefinition: {
+            api_mutable: boolean;
+            cardinality: string;
+            /** Format: date-time */
+            created_at: string;
+            derived_source?: string;
+            description?: string;
+            /** Format: int64 */
+            display_order: number;
+            field_type: string;
+            history_exempt: boolean;
+            /** Format: int64 */
+            id: number;
+            is_active: boolean;
+            is_audited: boolean;
+            is_deletable: boolean;
+            is_required: boolean;
+            is_searchable: boolean;
+            label: string;
+            object_type: string;
+            options?: components["schemas"]["AttributeOptions"];
+            ownership: string;
+            record_target?: string;
+            /** Format: int64 */
+            revision: number;
+            slug: string;
+            ui_creatable: boolean;
+            ui_editable: boolean;
+            universal_id: string;
+            /** Format: date-time */
+            updated_at: string;
+            value_type: string;
+            vcard_property?: string;
+        } & {
+            [key: string]: unknown;
+        };
+        AttributeDefinitionsResponse: {
+            definitions: components["schemas"]["AttributeDefinition"][] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        AttributeOptions: {
+            choices?: components["schemas"]["AttributeChoice"][] | null;
+            /** Format: int64 */
+            max_length?: number;
+            unit?: string;
+        };
+        AttributeValue: {
+            boolean?: boolean;
+            date?: string;
+            /** Format: int64 */
+            integer?: number;
+            json?: unknown;
+            /** Format: double */
+            real?: number;
+            /** Format: int64 */
+            record_id?: number;
+            record_type?: string;
+            text?: string;
+            /** Format: date-time */
+            timestamp?: string;
+            type: string;
+        };
         BackupFreezeBeginResponse: {
             token: string;
         } & {
@@ -2347,6 +2486,25 @@ export interface components {
             total: number;
         } & {
             [key: string]: unknown;
+        };
+        CreateAttributeDefinitionRequest: {
+            /** @enum {string} */
+            cardinality?: "single" | "multi";
+            description?: string;
+            /** Format: int64 */
+            display_order?: number;
+            field_type: string;
+            is_audited?: boolean;
+            is_required?: boolean;
+            is_searchable?: boolean;
+            label: string;
+            /** @enum {string} */
+            object_type: "person" | "organization";
+            options?: components["schemas"]["AttributeOptions"];
+            record_target?: string;
+            slug: string;
+            value_type: string;
+            vcard_property?: string;
         };
         CreatePersonRequest: {
             /** Format: int64 */
@@ -3086,6 +3244,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        PatchAttributeDefinitionRequest: {
+            description?: string | null;
+            /** Format: int64 */
+            display_order?: number;
+            is_active?: boolean;
+            label?: string;
+        };
         PatchPersonRequest: {
             display_name: string | null;
         };
@@ -3108,6 +3273,54 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
             vcard_uid: string;
+        } & {
+            [key: string]: unknown;
+        };
+        PersonAttributeGroup: {
+            current: components["schemas"]["PersonAttributeValue"][] | null;
+            definition: components["schemas"]["AttributeDefinition"];
+            history?: components["schemas"]["PersonAttributeValue"][] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        PersonAttributeValue: {
+            /** Format: date-time */
+            active_from: string;
+            /** Format: date-time */
+            active_until?: string;
+            actor?: string;
+            /** Format: double */
+            confidence?: number;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: int64 */
+            definition_id: number;
+            definition_slug: string;
+            /** Format: int64 */
+            id: number;
+            /** Format: int64 */
+            ordinal: number;
+            /** Format: int64 */
+            person_id: number;
+            source: string;
+            source_ref?: string;
+            /** Format: date-time */
+            superseded_at?: string;
+            value: components["schemas"]["AttributeValue"];
+        } & {
+            [key: string]: unknown;
+        };
+        PersonAttributeWrite: {
+            dry_run: boolean;
+            superseded?: components["schemas"]["PersonAttributeValue"];
+            value?: components["schemas"]["PersonAttributeValue"];
+        } & {
+            [key: string]: unknown;
+        };
+        PersonAttributesResponse: {
+            attributes: components["schemas"]["PersonAttributeGroup"][] | null;
+            /** Format: int64 */
+            person_id: number;
         } & {
             [key: string]: unknown;
         };
@@ -3444,6 +3657,23 @@ export interface components {
             plain_http_warning: boolean;
         } & {
             [key: string]: unknown;
+        };
+        SetPersonAttributeRequest: {
+            /** Format: date-time */
+            active_from?: string;
+            /** Format: date-time */
+            active_until?: string;
+            actor?: string;
+            /** Format: double */
+            confidence?: number;
+            /** Format: int64 */
+            expected_value_id?: number;
+            /** Format: int64 */
+            ordinal?: number;
+            /** @enum {string} */
+            source?: "user" | "carddav_import" | "vcard_import" | "archive_observation" | "extraction" | "enrichment" | "system";
+            source_ref?: string;
+            value: components["schemas"]["AttributeValue"];
         };
         Setting: {
             /** @enum {string} */
@@ -4269,6 +4499,327 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AttachmentInfo"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listAttributeDefinitions: {
+        parameters: {
+            query?: {
+                /** @description Filter by object type */
+                object_type?: string;
+                /** @description Include deactivated definitions */
+                include_hidden?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttributeDefinitionsResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createAttributeDefinition: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAttributeDefinitionRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    /** @description Strong attribute definition revision tag */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttributeDefinition"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getAttributeDefinition: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Attribute definition ID */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    /** @description Strong attribute definition revision tag */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttributeDefinition"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteAttributeDefinition: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Strong ETag returned by the latest definition read */
+                "If-Match": string;
+            };
+            path: {
+                /** @description Attribute definition ID */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            428: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    patchAttributeDefinition: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Strong ETag returned by the latest definition read */
+                "If-Match": string;
+            };
+            path: {
+                /** @description Attribute definition ID */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PatchAttributeDefinitionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    /** @description Strong attribute definition revision tag */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttributeDefinition"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            428: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Error */
@@ -8243,6 +8794,215 @@ export interface operations {
             };
             /** @description Error */
             428: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listPersonAttributes: {
+        parameters: {
+            query?: {
+                /** @description Include superseded values */
+                history?: boolean;
+                /** @description Restrict the response to one definition slug */
+                slug?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Durable person ID */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PersonAttributesResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    setPersonAttribute: {
+        parameters: {
+            query?: {
+                /** @description Validate and preview without writing */
+                dry_run?: boolean;
+            };
+            header?: never;
+            path: {
+                /** @description Durable person ID */
+                id: number;
+                /** @description Immutable attribute definition slug */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetPersonAttributeRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PersonAttributeWrite"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    clearPersonAttribute: {
+        parameters: {
+            query?: {
+                /** @description Ordinal for a multi-valued definition */
+                ordinal?: number;
+                /** @description Compare-and-swap: the current value ID expected to be superseded */
+                expected_value_id?: number;
+                /** @description Validate and preview without writing */
+                dry_run?: boolean;
+            };
+            header?: never;
+            path: {
+                /** @description Durable person ID */
+                id: number;
+                /** @description Immutable attribute definition slug */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PersonAttributeWrite"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## What changed

- Added a portable field-definition registry with stable universal IDs, immutable slugs, mutable labels, typed storage, cardinality, capabilities, options, vCard mapping, and lifecycle state.
- Added typed, historized person attribute values with value-level provenance, confidence, actor, ordinal, world-time intervals, and transactional supersession.
- Seeded `primary_channel`, `contact_frequency`, `ask_me_about`, and the read-only derived `last_contacted`.
- Added definition and person-attribute API routes, generated clients, and non-interactive CLI workflows with dry-run support.

## Why

A JSON-only profile blob cannot preserve independently addressable values with their own provenance, confidence, actor, ordinal, and active interval. Typed value rows retain that history and keep current-value lookups indexable.

Dynamic per-user DDL would require migration, synchronization, permission, and API machinery for every custom field. Metadata rows plus concrete typed tables keep field creation portable across SQLite and PostgreSQL without issuing runtime DDL.

This is the second implementation slice in #534.

## Usage

- `msgvault attribute-definition list --object-type person`
- `msgvault attribute-definition create --definition @field.json`
- `msgvault person attributes set <person-id> ask_me_about --value sailing`
- `msgvault person attributes list <person-id> --history`
