### PR TITLE
feat(mcp): add bearer authentication to Streamable HTTP

### DIFF
--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -18,6 +18,7 @@ var mcpForceSQL bool
 var mcpNoSQLiteScanner bool
 var mcpHTTPAddr string
 var mcpHTTPAllowInsecure bool
+var serveMCPHTTPWithOptions = mcpserver.ServeHTTPWithOptions
 
 var mcpCmd = &cobra.Command{
 	Use:   "mcp",
@@ -57,11 +58,15 @@ Add to Claude Desktop config:
 		}
 
 		if mcpHTTPAddr != "" {
-			normalized, err := normalizeMCPHTTPAddr(mcpHTTPAddr, mcpHTTPAllowInsecure)
+			normalized, err := normalizeMCPHTTPAddr(
+				mcpHTTPAddr,
+				mcpHTTPAllowInsecure,
+				cfg.Server.APIKey != "",
+			)
 			if err != nil {
 				return usageErr(cmd, err)
 			}
-			return mcpserver.ServeHTTPWithOptions(ctx, opts, normalized)
+			return serveMCPHTTPWithOptions(ctx, opts, normalized, cfg.Server.APIKey)
 		}
 		return mcpserver.ServeWithOptions(ctx, opts)
 	},
@@ -200,12 +205,13 @@ func init() {
 	mcpCmd.Flags().StringVar(&mcpHTTPAddr, "http", "",
 		"Serve over StreamableHTTP on this address (e.g. 127.0.0.1:8080) "+
 			"instead of stdio. Bare port forms (':8080', '8080') bind to "+
-			"loopback only; non-loopback hosts require --http-allow-insecure.")
+			"loopback only; non-loopback hosts require [server].api_key or "+
+			"--http-allow-insecure.")
 	mcpCmd.Flags().BoolVar(&mcpHTTPAllowInsecure, "http-allow-insecure", false,
-		"Allow --http to bind a non-loopback address. The MCP server has no "+
-			"built-in authentication, so any reachable client can read your "+
-			"archive. Only set this on trusted networks (Tailscale, "+
-			"VPN-only) or behind an authenticating reverse proxy.")
+		"Allow --http to bind a non-loopback address without [server].api_key. "+
+			"Any configured key still requires bearer authentication. Without a "+
+			"key, any reachable client can read your archive; only set this behind "+
+			"a trusted network boundary or authenticating reverse proxy.")
 	_ = mcpCmd.Flags().MarkDeprecated("force-sql", "deprecated in 0.17.0; set [analytics].engine = \"sql\" in config.toml")
 	_ = mcpCmd.Flags().MarkDeprecated("no-sqlite-scanner", "deprecated in 0.17.0; cache engine selection is daemon-managed; use [analytics].engine = \"sql\" for live SQL")
 	_ = mcpCmd.Flags().MarkHidden("force-sql")
@@ -213,8 +219,8 @@ func init() {
 }
 
 // normalizeMCPHTTPAddr canonicalises a --http argument and rejects values
-// that would expose the unauthenticated MCP server on a non-loopback
-// interface unless the user has explicitly opted in.
+// that would expose an unauthenticated MCP server on a non-loopback interface
+// unless the user has configured authentication or explicitly opted in.
 //
 // Forms accepted:
 //   - "8080"            → "127.0.0.1:8080" (loopback)
@@ -223,8 +229,8 @@ func init() {
 //   - "127.0.0.1:8080"  → unchanged (loopback, allowed)
 //   - "[::1]:8080"      → unchanged (loopback, allowed)
 //   - "192.168.1.5:8080", "0.0.0.0:8080", "vault.local:8080" → rejected
-//     unless --http-allow-insecure is set
-func normalizeMCPHTTPAddr(addr string, allowInsecure bool) (string, error) {
+//     unless [server].api_key or --http-allow-insecure is set
+func normalizeMCPHTTPAddr(addr string, allowInsecure, authenticated bool) (string, error) {
 	trimmed := strings.TrimSpace(addr)
 	if trimmed == "" {
 		return "", errors.New("--http requires an address")
@@ -250,12 +256,12 @@ func normalizeMCPHTTPAddr(addr string, allowInsecure bool) (string, error) {
 	if isLoopbackHost(host) {
 		return trimmed, nil
 	}
-	if !allowInsecure {
+	if !authenticated && !allowInsecure {
 		return "", fmt.Errorf(
 			"--http %q: refusing to bind a non-loopback address without "+
-				"--http-allow-insecure (the MCP server has no built-in "+
-				"authentication; only opt in on trusted networks or "+
-				"behind an authenticating reverse proxy)", trimmed)
+				"[server].api_key or --http-allow-insecure (configure an API key "+
+				"for bearer authentication, or only opt into unauthenticated "+
+				"access behind a trusted network boundary)", trimmed)
 	}
 	return trimmed, nil
 }

--- a/cmd/msgvault/cmd/mcp_test.go
+++ b/cmd/msgvault/cmd/mcp_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/daemonclient"
 	"go.kenn.io/msgvault/internal/deletion"
+	mcpserver "go.kenn.io/msgvault/internal/mcp"
 )
 
 func TestMCPCommandUsesDaemonInsteadOfOpeningLocalDatabase(t *testing.T) {
@@ -48,6 +50,59 @@ func TestMCPCommandUsesDaemonInsteadOfOpeningLocalDatabase(t *testing.T) {
 	require.Error(err, "canceled MCP serve should return")
 	require.ErrorIs(err, context.Canceled, "error should preserve context cancellation: %v", err)
 	assert.NotContains(err.Error(), "open database", "MCP command must not open SQLite directly")
+}
+
+func TestMCPCommandForwardsServerAPIKeyToHTTPTransport(t *testing.T) {
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/stats", r.URL.Path)
+		assert.Equal(t, "daemon-key", r.Header.Get("X-Api-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"total_messages": 0,
+			"total_threads": 0,
+			"total_accounts": 0,
+			"total_labels": 0,
+			"total_attachments": 0,
+			"database_size_bytes": 0
+		}`))
+	}))
+	t.Cleanup(daemon.Close)
+
+	withStoreResolverConfig(t, &config.Config{
+		Data:   config.DataConfig{DataDir: t.TempDir()},
+		Server: config.ServerConfig{APIKey: "mcp-http-key"},
+		Remote: config.RemoteConfig{
+			URL:           daemon.URL,
+			APIKey:        "daemon-key",
+			AllowInsecure: true,
+		},
+	})
+
+	savedHTTPAddr := mcpHTTPAddr
+	savedAllowInsecure := mcpHTTPAllowInsecure
+	savedServeHTTP := serveMCPHTTPWithOptions
+	mcpHTTPAddr = "0.0.0.0:8081"
+	mcpHTTPAllowInsecure = true
+	t.Cleanup(func() {
+		mcpHTTPAddr = savedHTTPAddr
+		mcpHTTPAllowInsecure = savedAllowInsecure
+		serveMCPHTTPWithOptions = savedServeHTTP
+	})
+
+	wantErr := errors.New("stop after capture")
+	var gotAddr, gotAPIKey string
+	serveMCPHTTPWithOptions = func(_ context.Context, _ mcpserver.ServeOptions, addr, apiKey string) error {
+		gotAddr = addr
+		gotAPIKey = apiKey
+		return wantErr
+	}
+
+	mcpCmd.SetContext(context.Background())
+	err := mcpCmd.RunE(mcpCmd, nil)
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, "0.0.0.0:8081", gotAddr)
+	assert.Equal(t, "mcp-http-key", gotAPIKey)
 }
 
 func TestDaemonMCPServeOptionsDisablesVectorToolsWhenDaemonVectorUnavailable(t *testing.T) {
@@ -177,13 +232,13 @@ func newMCPDaemonClient(t *testing.T, handler http.HandlerFunc) *daemonclient.Cl
 
 func TestNormalizeMCPHTTPAddr(t *testing.T) {
 	t.Run("bare_port_defaults_to_loopback", func(t *testing.T) {
-		got, err := normalizeMCPHTTPAddr("8080", false)
+		got, err := normalizeMCPHTTPAddr("8080", false, false)
 		require.NoError(t, err)
 		require.Equal(t, "127.0.0.1:8080", got)
 	})
 
 	t.Run("colon_port_defaults_to_loopback", func(t *testing.T) {
-		got, err := normalizeMCPHTTPAddr(":8080", false)
+		got, err := normalizeMCPHTTPAddr(":8080", false, false)
 		require.NoError(t, err)
 		require.Equal(t, "127.0.0.1:8080", got)
 	})
@@ -191,7 +246,7 @@ func TestNormalizeMCPHTTPAddr(t *testing.T) {
 	t.Run("explicit_loopback_passes", func(t *testing.T) {
 		cases := []string{"127.0.0.1:8080", "localhost:8080", "[::1]:8080"}
 		for _, c := range cases {
-			got, err := normalizeMCPHTTPAddr(c, false)
+			got, err := normalizeMCPHTTPAddr(c, false, false)
 			require.NoError(t, err, "%s", c)
 			assert.Equal(t, c, got, "%s: should be unchanged", c)
 		}
@@ -208,25 +263,31 @@ func TestNormalizeMCPHTTPAddr(t *testing.T) {
 			"[]:8080",
 		}
 		for _, c := range cases {
-			_, err := normalizeMCPHTTPAddr(c, false)
+			_, err := normalizeMCPHTTPAddr(c, false, false)
 			require.Error(t, err, "%s: expected refusal", c)
 			assert.ErrorContains(t, err, "--http-allow-insecure", "%s: expected hint", c)
 		}
 	})
 
 	t.Run("non_loopback_allowed_with_optin", func(t *testing.T) {
-		got, err := normalizeMCPHTTPAddr("0.0.0.0:8080", true)
+		got, err := normalizeMCPHTTPAddr("0.0.0.0:8080", true, false)
+		require.NoError(t, err)
+		require.Equal(t, "0.0.0.0:8080", got)
+	})
+
+	t.Run("non_loopback_allowed_with_api_key", func(t *testing.T) {
+		got, err := normalizeMCPHTTPAddr("0.0.0.0:8080", false, true)
 		require.NoError(t, err)
 		require.Equal(t, "0.0.0.0:8080", got)
 	})
 
 	t.Run("empty_rejected", func(t *testing.T) {
-		_, err := normalizeMCPHTTPAddr("", false)
+		_, err := normalizeMCPHTTPAddr("", false, false)
 		require.Error(t, err, "expected error for empty addr")
 	})
 
 	t.Run("garbage_rejected", func(t *testing.T) {
-		_, err := normalizeMCPHTTPAddr("not-a-port", false)
+		_, err := normalizeMCPHTTPAddr("not-a-port", false, false)
 		require.Error(t, err, "expected error for non-port, non-host:port")
 	})
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
+**New features**
+
+- MCP Streamable HTTP can reuse `[server].api_key` for bearer authentication.
+  Authenticated listeners may bind beyond loopback without the insecure
+  override, while keyless non-loopback listeners still require an explicit
+  `--http-allow-insecure` opt-in.
+
 **Bug fixes**
 
 - Daemon-backed CLI, TUI, MCP, statistics, and backup operations now wait for

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1482,8 +1482,8 @@ msgvault mcp [flags]
 |---|---|---|
 | `--force-sql` | `false` | Deprecated in 0.17.0; use `[analytics].engine = "sql"` in `config.toml` instead. See [Configuration: analytics](/configuration/#analytics). |
 | `--no-sqlite-scanner` | `false` | Deprecated in 0.17.0; cache engine selection is daemon-managed. Use `[analytics].engine = "sql"` for live SQL. |
-| `--http` | — | Serve MCP over StreamableHTTP on this address instead of stdio. Bare ports bind to loopback, e.g. `8080` becomes `127.0.0.1:8080`. |
-| `--http-allow-insecure` | `false` | Allow non-loopback HTTP binding. The MCP server has no built-in auth; put it behind a trusted network or authenticated reverse proxy. |
+| `--http` | — | Serve MCP over StreamableHTTP on this address instead of stdio. Bare ports bind to loopback, e.g. `8080` becomes `127.0.0.1:8080`. Non-loopback addresses require `[server].api_key` or `--http-allow-insecure`. |
+| `--http-allow-insecure` | `false` | Allow non-loopback HTTP binding without `[server].api_key`. A configured key is still enforced; without one, use only behind a trusted network boundary or authenticated reverse proxy. |
 
 See [MCP Server](/usage/chat/) for configuration and tool reference.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,13 +248,13 @@ Use `msgvault logs` to view and tail log files from the selected local or remote
 
 ### `[server]`
 
-Settings for the Web UI and API server started by `msgvault serve`. The same HTTP server is used by remote CLI access and by the local background daemon for archive-access CLI commands. See [Web UI & API Server](/api-server/) for endpoint documentation, or fetch `/openapi.json` from a running server for the generated OpenAPI contract.
+Settings for the Web UI and API server started by `msgvault serve`. The same HTTP server is used by remote CLI access and by the local background daemon for archive-access CLI commands. The `api_key` setting is also reused for inbound bearer authentication when `msgvault mcp --http` starts a separate Streamable HTTP listener; that listener's address comes from the `--http` flag. See [Web UI & API Server](/api-server/) for API endpoint documentation and [MCP Server](/usage/chat/#streamablehttp-transport) for MCP client setup, or fetch `/openapi.json` from a running server for the generated OpenAPI contract.
 
 | Key | Default | Description |
 |---|---|---|
 | `api_port` | `0` (auto-select) | Port the server listens on; `0` picks an open port at startup and clients discover it automatically. Set a fixed port for remote/NAS deployments. |
 | `bind_addr` | `127.0.0.1` | Bind address |
-| `api_key` | — | API key for authentication |
+| `api_key` | — | API key for daemon/API authentication and bearer authentication on `msgvault mcp --http` |
 | `allow_insecure` | `false` | Allow non-loopback binding without `api_key` |
 | `cors_origins` | `[]` | Allowed CORS origins |
 | `cors_credentials` | `false` | Allow credentials in CORS requests |
@@ -272,6 +272,11 @@ programmatic clients continue to send the configured key. For remote browser
 access, terminate TLS at a reverse proxy and list that proxy—not arbitrary
 clients—in `trusted_proxies`. See [Web UI](/web-ui/) for the complete security
 model and the plain-HTTP warning.
+
+For MCP Streamable HTTP, send `[server].api_key` as `Authorization: Bearer
+<key>` on every `/mcp` request. This inbound credential is independent of
+`[remote].api_key`, which authenticates `msgvault mcp` when it connects to a
+remote daemon.
 
 ### `[web]`
 

--- a/docs/usage/chat.md
+++ b/docs/usage/chat.md
@@ -39,7 +39,51 @@ msgvault mcp --http 8080
 
 Bare ports and `:port` forms bind to loopback only, so the command above listens on `127.0.0.1:8080`. Explicit loopback addresses such as `127.0.0.1:8080` and `[::1]:8080` are also allowed.
 
-The MCP HTTP server has no built-in authentication. Non-loopback hosts are rejected unless you pass `--http-allow-insecure`; only use that behind a trusted network boundary or an authenticated reverse proxy.
+The endpoint is `http://127.0.0.1:8080/mcp`. To require authentication, set
+the API key in the configuration used by the `msgvault mcp` process:
+
+```toml
+[server]
+api_key = "replace-with-a-long-random-key"
+```
+
+When `[server].api_key` is configured, every HTTP request to `/mcp` must send
+the key as a bearer token, including session `GET` and `DELETE` requests:
+
+```http
+Authorization: Bearer replace-with-a-long-random-key
+```
+
+Missing or incorrect credentials return `401 Unauthorized`. Configure your
+MCP client to send the header on every request. For clients that accept the
+common JSON server configuration shape, that looks like:
+
+```json
+{
+  "mcpServers": {
+    "msgvault": {
+      "url": "http://127.0.0.1:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer replace-with-a-long-random-key"
+      }
+    }
+  }
+}
+```
+
+The key protects loopback and non-loopback listeners alike. A configured key
+also permits a non-loopback `--http` address without
+`--http-allow-insecure`. Without a key, non-loopback addresses remain rejected
+unless you pass `--http-allow-insecure`; use that override only behind an
+authenticating reverse proxy or another trusted network boundary. The built-in
+listener serves plain HTTP, so put non-loopback connections behind TLS or an
+encrypted private network to prevent the bearer token and archive data from
+being exposed in transit.
+
+`[server].api_key` authenticates clients connecting to this MCP HTTP listener.
+It is separate from `[remote].api_key`, which authenticates `msgvault mcp` to a
+selected remote msgvault daemon. Stdio transport does not use bearer
+authentication.
 
 ## Available Tools
 
@@ -178,8 +222,8 @@ msgvault mcp --http 8080
 |---|---|---|
 | `--force-sql` | `false` | Deprecated in 0.17.0; use `[analytics].engine = "sql"` in `config.toml` instead. See [Configuration: analytics](/configuration/#analytics). |
 | `--no-sqlite-scanner` | `false` | Deprecated in 0.17.0; cache engine selection is daemon-managed. Use `[analytics].engine = "sql"` for live SQL. |
-| `--http` | — | Serve over MCP StreamableHTTP instead of stdio. Bare ports bind to `127.0.0.1`. |
-| `--http-allow-insecure` | `false` | Allow non-loopback HTTP binding. Use only behind your own network/auth layer. |
+| `--http` | — | Serve over MCP StreamableHTTP instead of stdio. Bare ports bind to `127.0.0.1`; non-loopback addresses require `[server].api_key` or `--http-allow-insecure`. |
+| `--http-allow-insecure` | `false` | Allow non-loopback HTTP binding without `[server].api_key`. A configured key is still enforced. Without a key, use only behind your own network or authentication layer. |
 
 Deprecated in 0.17.0: MCP analytics behavior moved from per-command flags to daemon configuration. Use `[analytics].engine` and `[analytics].auto_build_cache` in `config.toml` so local and remote daemon behavior stays consistent.
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -188,12 +188,12 @@ func ServeWithOptions(ctx context.Context, opts ServeOptions) error {
 // can complete. Mirrors how ServeWithOptions threads the context through
 // the stdio Listen call.
 func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr, apiKey string) error {
-	httpServer, _ := newMCPHTTPServer(opts, addr, apiKey)
+	_, stdlibServer := newMCPHTTPServer(opts, addr, apiKey)
 	fmt.Fprintf(os.Stderr, "Starting MCP server on %s\n", addr)
 
 	errCh := make(chan error, 1)
 	go func() {
-		if err := httpServer.Start(addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := stdlibServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 			return
 		}
@@ -208,7 +208,7 @@ func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr, apiKey s
 		// usually finish in milliseconds, so 10s is plenty.
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		_ = httpServer.Shutdown(shutdownCtx)
+		_ = stdlibServer.Shutdown(shutdownCtx)
 		return ctx.Err()
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -188,7 +188,7 @@ func ServeWithOptions(ctx context.Context, opts ServeOptions) error {
 // can complete. Mirrors how ServeWithOptions threads the context through
 // the stdio Listen call.
 func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr, apiKey string) error {
-	_, stdlibServer := newMCPHTTPServer(opts, addr, apiKey)
+	stdlibServer := newMCPHTTPServer(opts, addr, apiKey)
 	fmt.Fprintf(os.Stderr, "Starting MCP server on %s\n", addr)
 
 	errCh := make(chan error, 1)
@@ -213,7 +213,7 @@ func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr, apiKey s
 	}
 }
 
-func newMCPHTTPServer(opts ServeOptions, addr, apiKey string) (*server.StreamableHTTPServer, *http.Server) {
+func newMCPHTTPServer(opts ServeOptions, addr, apiKey string) *http.Server {
 	stdlibServer := &http.Server{
 		Addr:              addr,
 		ReadHeaderTimeout: 10 * time.Second,
@@ -225,7 +225,7 @@ func newMCPHTTPServer(opts ServeOptions, addr, apiKey string) (*server.Streamabl
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", bearerAuthHandler(apiKey, httpServer))
 	stdlibServer.Handler = mux
-	return httpServer, stdlibServer
+	return stdlibServer
 }
 
 func bearerAuthHandler(apiKey string, next http.Handler) http.Handler {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,10 +2,13 @@ package mcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -184,9 +187,8 @@ func ServeWithOptions(ctx context.Context, opts ServeOptions) error {
 // is shut down gracefully via httpServer.Shutdown so in-flight requests
 // can complete. Mirrors how ServeWithOptions threads the context through
 // the stdio Listen call.
-func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr string) error {
-	s := newMCPServer(opts)
-	httpServer := server.NewStreamableHTTPServer(s)
+func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr, apiKey string) error {
+	httpServer, _ := newMCPHTTPServer(opts, addr, apiKey)
 	fmt.Fprintf(os.Stderr, "Starting MCP server on %s\n", addr)
 
 	errCh := make(chan error, 1)
@@ -209,6 +211,47 @@ func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, addr string) e
 		_ = httpServer.Shutdown(shutdownCtx)
 		return ctx.Err()
 	}
+}
+
+func newMCPHTTPServer(opts ServeOptions, addr, apiKey string) (*server.StreamableHTTPServer, *http.Server) {
+	stdlibServer := &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	httpServer := server.NewStreamableHTTPServer(
+		newMCPServer(opts),
+		server.WithStreamableHTTPServer(stdlibServer),
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", bearerAuthHandler(apiKey, httpServer))
+	stdlibServer.Handler = mux
+	return httpServer, stdlibServer
+}
+
+func bearerAuthHandler(apiKey string, next http.Handler) http.Handler {
+	if apiKey == "" {
+		return next
+	}
+
+	expected := sha256.Sum256([]byte(apiKey))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		values := r.Header.Values("Authorization")
+		authorized := false
+		if len(values) == 1 {
+			scheme, credential, found := strings.Cut(values[0], " ")
+			if found && credential != "" && strings.EqualFold(scheme, "Bearer") {
+				supplied := sha256.Sum256([]byte(credential))
+				authorized = subtle.ConstantTimeCompare(expected[:], supplied[:]) == 1
+			}
+		}
+
+		if !authorized {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Shared search_metadata schema text. The parser implements a subset of Gmail

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3671,10 +3671,13 @@ func TestServeHTTPWithOptions_ContextCancellation(t *testing.T) {
 }
 
 func TestServeHTTPWithOptionsLiveListenerRequiresBearerAuth(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
 	probe, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+	require.NoError(err)
 	addr := probe.Addr().String()
-	require.NoError(t, probe.Close())
+	require.NoError(probe.Close())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -3694,31 +3697,38 @@ func TestServeHTTPWithOptionsLiveListenerRequiresBearerAuth(t *testing.T) {
 		select {
 		case <-stopped:
 		case <-time.After(15 * time.Second):
-			assert.Fail(t, "ServeHTTPWithOptions did not stop during test cleanup")
+			assert.Fail("ServeHTTPWithOptions did not stop during test cleanup")
 		}
 	})
 
 	client := &http.Client{Timeout: time.Second}
-	var resp *http.Response
-	require.Eventually(t, func() bool {
+	var responseStatus int
+	var responseChallenge string
+	var responseCloseErr error
+	require.Eventually(func() bool {
 		req, requestErr := http.NewRequest(http.MethodPatch, "http://"+addr+"/mcp", nil)
 		if requestErr != nil {
 			return false
 		}
-		resp, requestErr = client.Do(req)
-		return requestErr == nil
+		resp, requestErr := client.Do(req)
+		if requestErr != nil {
+			return false
+		}
+		responseStatus = resp.StatusCode
+		responseChallenge = resp.Header.Get("WWW-Authenticate")
+		responseCloseErr = resp.Body.Close()
+		return true
 	}, 5*time.Second, 10*time.Millisecond)
-	require.NotNil(t, resp)
-	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-	assert.Equal(t, "Bearer", resp.Header.Get("WWW-Authenticate"))
-	require.NoError(t, resp.Body.Close())
+	require.NoError(responseCloseErr)
+	assert.Equal(http.StatusUnauthorized, responseStatus)
+	assert.Equal("Bearer", responseChallenge)
 
 	cancel()
 	select {
 	case serveErr := <-done:
-		require.ErrorIs(t, serveErr, context.Canceled)
+		require.ErrorIs(serveErr, context.Canceled)
 	case <-time.After(15 * time.Second):
-		require.Fail(t, "ServeHTTPWithOptions did not return after context cancellation")
+		require.Fail("ServeHTTPWithOptions did not return after context cancellation")
 	}
 }
 
@@ -3853,7 +3863,7 @@ func TestBearerAuthHandlerCompatibilityAndSchemeCase(t *testing.T) {
 }
 
 func TestMCPHTTPServerMountsProtectedEndpoint(t *testing.T) {
-	_, stdlibServer := newMCPHTTPServer(ServeOptions{
+	stdlibServer := newMCPHTTPServer(ServeOptions{
 		Engine:         &querytest.MockEngine{},
 		AttachmentsDir: t.TempDir(),
 		DataDir:        t.TempDir(),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3664,6 +3665,58 @@ func TestServeHTTPWithOptions_ContextCancellation(t *testing.T) {
 	select {
 	case err := <-done:
 		require.ErrorIs(t, err, context.Canceled, "expected context.Canceled")
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "ServeHTTPWithOptions did not return after context cancellation")
+	}
+}
+
+func TestServeHTTPWithOptionsLiveListenerRequiresBearerAuth(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := probe.Addr().String()
+	require.NoError(t, probe.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	stopped := make(chan struct{})
+	attachmentsDir := t.TempDir()
+	dataDir := t.TempDir()
+	go func() {
+		defer close(stopped)
+		done <- ServeHTTPWithOptions(ctx, ServeOptions{
+			Engine:         &querytest.MockEngine{},
+			AttachmentsDir: attachmentsDir,
+			DataDir:        dataDir,
+		}, addr, "test-api-key")
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-stopped:
+		case <-time.After(15 * time.Second):
+			assert.Fail(t, "ServeHTTPWithOptions did not stop during test cleanup")
+		}
+	})
+
+	client := &http.Client{Timeout: time.Second}
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		req, requestErr := http.NewRequest(http.MethodPatch, "http://"+addr+"/mcp", nil)
+		if requestErr != nil {
+			return false
+		}
+		resp, requestErr = client.Do(req)
+		return requestErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, "Bearer", resp.Header.Get("WWW-Authenticate"))
+	require.NoError(t, resp.Body.Close())
+
+	cancel()
+	select {
+	case serveErr := <-done:
+		require.ErrorIs(t, serveErr, context.Canceled)
 	case <-time.After(15 * time.Second):
 		require.Fail(t, "ServeHTTPWithOptions did not return after context cancellation")
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -3652,7 +3654,7 @@ func TestServeHTTPWithOptions_ContextCancellation(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- ServeHTTPWithOptions(ctx, opts, "127.0.0.1:0")
+		done <- ServeHTTPWithOptions(ctx, opts, "127.0.0.1:0", "test-api-key")
 	}()
 
 	// Give the goroutine a moment to start the listener.
@@ -3665,4 +3667,155 @@ func TestServeHTTPWithOptions_ContextCancellation(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		require.Fail(t, "ServeHTTPWithOptions did not return after context cancellation")
 	}
+}
+
+func TestBearerAuthHandler(t *testing.T) {
+	const apiKey = "test-api-key"
+
+	methods := []string{
+		http.MethodPost,
+		http.MethodGet,
+		http.MethodDelete,
+		http.MethodHead,
+		http.MethodPatch,
+	}
+	tests := []struct {
+		name          string
+		addAuth       func(*http.Request)
+		wantStatus    int
+		wantChallenge string
+		wantCalled    bool
+	}{
+		{
+			name:          "missing",
+			wantStatus:    http.StatusUnauthorized,
+			wantChallenge: "Bearer",
+		},
+		{
+			name: "wrong",
+			addAuth: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer wrong-key")
+			},
+			wantStatus:    http.StatusUnauthorized,
+			wantChallenge: "Bearer",
+		},
+		{
+			name: "valid",
+			addAuth: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+apiKey)
+			},
+			wantStatus: http.StatusNoContent,
+			wantCalled: true,
+		},
+	}
+
+	for _, method := range methods {
+		for _, tt := range tests {
+			t.Run(method+"_"+tt.name, func(t *testing.T) {
+				called := false
+				next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					called = true
+					w.WriteHeader(http.StatusNoContent)
+				})
+				handler := bearerAuthHandler(apiKey, next)
+				req := httptest.NewRequest(method, "/mcp", nil)
+				req.Header.Set("Mcp-Session-Id", "test-session")
+				if tt.addAuth != nil {
+					tt.addAuth(req)
+				}
+				resp := httptest.NewRecorder()
+
+				handler.ServeHTTP(resp, req)
+
+				assert.Equal(t, tt.wantStatus, resp.Code)
+				assert.Equal(t, tt.wantChallenge, resp.Header().Get("WWW-Authenticate"))
+				assert.Equal(t, tt.wantCalled, called)
+			})
+		}
+	}
+}
+
+func TestBearerAuthHandlerRejectsMalformedCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+	}{
+		{name: "wrong scheme", headers: []string{"Basic test-api-key"}},
+		{name: "missing credential", headers: []string{"Bearer"}},
+		{name: "extra field", headers: []string{"Bearer test-api-key extra"}},
+		{name: "duplicate", headers: []string{"Bearer test-api-key", "Bearer test-api-key"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			handler := bearerAuthHandler("test-api-key", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				called = true
+			}))
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			for _, header := range tt.headers {
+				req.Header.Add("Authorization", header)
+			}
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.Code)
+			assert.Equal(t, "Bearer", resp.Header().Get("WWW-Authenticate"))
+			assert.False(t, called)
+		})
+	}
+}
+
+func TestBearerAuthHandlerCompatibilityAndSchemeCase(t *testing.T) {
+	t.Run("empty key passes through", func(t *testing.T) {
+		called := false
+		handler := bearerAuthHandler("", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+
+		assert.Equal(t, http.StatusAccepted, resp.Code)
+		assert.True(t, called)
+	})
+
+	t.Run("bearer scheme is case insensitive", func(t *testing.T) {
+		called := false
+		handler := bearerAuthHandler("test-api-key", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "bEaReR test-api-key")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusAccepted, resp.Code)
+		assert.True(t, called)
+	})
+}
+
+func TestMCPHTTPServerMountsProtectedEndpoint(t *testing.T) {
+	_, stdlibServer := newMCPHTTPServer(ServeOptions{
+		Engine:         &querytest.MockEngine{},
+		AttachmentsDir: t.TempDir(),
+		DataDir:        t.TempDir(),
+	}, "127.0.0.1:0", "test-api-key")
+	assert.Equal(t, 10*time.Second, stdlibServer.ReadHeaderTimeout)
+
+	missing := httptest.NewRecorder()
+	missingRequest := httptest.NewRequest(http.MethodPatch, "/mcp", nil)
+	missingRequest.Header.Set("Mcp-Session-Id", "test-session")
+	stdlibServer.Handler.ServeHTTP(missing, missingRequest)
+	assert.Equal(t, http.StatusUnauthorized, missing.Code)
+
+	authorized := httptest.NewRecorder()
+	authorizedRequest := httptest.NewRequest(http.MethodPatch, "/mcp", nil)
+	authorizedRequest.Header.Set("Authorization", "Bearer test-api-key")
+	stdlibServer.Handler.ServeHTTP(authorized, authorizedRequest)
+	assert.Equal(t, http.StatusNotFound, authorized.Code)
 }


### PR DESCRIPTION
Streamable HTTP MCP currently has no built-in authentication, so operators must keep it on loopback or provide their own authenticated network boundary. msgvault already has an application credential for archive access in `[server].api_key`; this reuses that credential for the HTTP MCP transport instead of introducing a second secret.

When `[server].api_key` is configured, every `/mcp` request must send `Authorization: Bearer <api_key>`. Missing or incorrect credentials return `401 Unauthorized`, including session `GET` and `DELETE` requests. A configured key also permits non-loopback binding without `--http-allow-insecure`.

Usage:

```toml
[server]
api_key = "replace-with-a-long-random-key"
```

Configure the MCP client to send the same value as a bearer token on every request. Without an API key, existing behavior is unchanged: loopback works normally, while non-loopback binding still requires the explicit insecure override. The built-in listener remains plain HTTP, so non-loopback connections still need a TLS proxy or encrypted private network.