### PR TITLE
fix(query): hydrate direct message senders

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -100,16 +100,17 @@ type searchMessageRow struct {
 }
 
 type getMessageResp struct {
-	ID             int64  `json:"id"`
-	Subject        string `json:"subject"`
-	BodyText       string `json:"body_text"`
-	BodyHTML       string `json:"body_html"`
-	BodyFormat     string `json:"body_format"`
-	BodyLength     int    `json:"body_length"`
-	BodyReturned   int    `json:"body_returned"`
-	Offset         int    `json:"offset"`
-	HasMore        bool   `json:"has_more"`
-	ConversationID int64  `json:"conversation_id"`
+	ID             int64           `json:"id"`
+	Subject        string          `json:"subject"`
+	From           []query.Address `json:"from"`
+	BodyText       string          `json:"body_text"`
+	BodyHTML       string          `json:"body_html"`
+	BodyFormat     string          `json:"body_format"`
+	BodyLength     int             `json:"body_length"`
+	BodyReturned   int             `json:"body_returned"`
+	Offset         int             `json:"offset"`
+	HasMore        bool            `json:"has_more"`
+	ConversationID int64           `json:"conversation_id"`
 }
 
 type paginatedInMessageMatches struct {
@@ -1669,6 +1670,23 @@ func TestGetMessage(t *testing.T) {
 		assert.Equal(11, msg.BodyLength, "body_length")
 		assert.Equal(11, msg.BodyReturned, "body_returned")
 		assert.False(msg.HasMore, "has_more")
+	})
+
+	t.Run("sender-id-only message", func(t *testing.T) {
+		f := storetest.New(t)
+		senderID := f.EnsureParticipant("sender@example.com", "Test Sender", "example.com")
+		messageID := f.NewMessage().
+			WithSourceMessageID("beeper-sender-only").
+			WithSubject("Synthetic Beeper message").
+			Create(t, f.Store)
+		_, err := f.Store.DB().Exec(f.Store.Rebind(
+			`UPDATE messages SET message_type = 'beeper', sender_id = ? WHERE id = ?`,
+		), senderID, messageID)
+		require.NoError(t, err, "set direct sender")
+
+		realHandlers := newTestHandlers(query.NewEngine(f.Store.DB(), f.Store.IsPostgreSQL()))
+		msg := runTool[getMessageResp](t, "get_message", realHandlers.getMessage, map[string]any{"id": float64(messageID)})
+		assert.Equal(t, []query.Address{{Email: "sender@example.com", Name: "Test Sender"}}, msg.From)
 	})
 
 	t.Run("html-only body returns html slice", func(t *testing.T) {

--- a/internal/query/message_detail_sender_test.go
+++ b/internal/query/message_detail_sender_test.go
@@ -1,0 +1,103 @@
+package query
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type messageDetailReader interface {
+	GetMessage(ctx context.Context, id int64) (*MessageDetail, error)
+	GetMessageBySourceID(ctx context.Context, sourceMessageID string) (*MessageDetail, error)
+}
+
+func seedMessageDetailSenderFixture(t *testing.T) (string, *sql.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "msgvault.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err, "open sqlite fixture")
+	schema, err := os.ReadFile("../store/schema.sql")
+	require.NoError(t, err, "read schema")
+	_, err = db.Exec(string(schema))
+	require.NoError(t, err, "create schema")
+	_, err = db.Exec(`
+		INSERT INTO sources (id, source_type, identifier) VALUES
+			(1, 'beeper', 'synthetic-network');
+		INSERT INTO conversations (id, source_id, source_conversation_id, conversation_type, title) VALUES
+			(1, 1, 'synthetic-chat', 'chat', 'Synthetic Chat');
+		INSERT INTO participants (id, email_address, display_name, phone_number, domain) VALUES
+			(1, 'sender@example.com', 'Test Sender', NULL, 'example.com'),
+			(2, 'explicit@example.net', 'Stored Explicit Sender', NULL, 'example.net'),
+			(3, NULL, NULL, '+15550100003', ''),
+			(4, 'email-only@example.org', NULL, NULL, 'example.org'),
+			(5, 'mention@example.com', 'Mentioned User', NULL, 'example.com');
+		INSERT INTO messages (
+			id, conversation_id, source_id, source_message_id, message_type,
+			sent_at, subject, snippet, size_estimate, has_attachments, sender_id
+		) VALUES
+			(1, 1, 1, 'sender-only', 'beeper', '2026-01-01 10:00:00', 'Sender only', '', 10, 0, 1),
+			(2, 1, 1, 'explicit-wins', 'beeper', '2026-01-01 10:01:00', 'Explicit wins', '', 10, 0, 1),
+			(3, 1, 1, 'phone-and-mention', 'beeper', '2026-01-01 10:02:00', 'Phone sender', '', 10, 0, 3),
+			(4, 1, 1, 'email-only', 'beeper', '2026-01-01 10:03:00', 'Email sender', '', 10, 0, 4);
+		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name) VALUES
+			(2, 2, 'from', 'Per-message Sender'),
+			(3, 5, 'mention', 'Mentioned User');
+	`)
+	require.NoError(t, err, "seed sender fixture")
+	return dbPath, db
+}
+
+func assertMessageDetailSenderFallback(t *testing.T, reader messageDetailReader) {
+	t.Helper()
+	ctx := context.Background()
+
+	byID, err := reader.GetMessage(ctx, 1)
+	require.NoError(t, err, "GetMessage sender-only")
+	require.NotNil(t, byID)
+	assert.Equal(t, []Address{{Email: "sender@example.com", Name: "Test Sender"}}, byID.From)
+
+	bySourceID, err := reader.GetMessageBySourceID(ctx, "sender-only")
+	require.NoError(t, err, "GetMessageBySourceID sender-only")
+	require.NotNil(t, bySourceID)
+	assert.Equal(t, byID.From, bySourceID.From)
+
+	explicit, err := reader.GetMessage(ctx, 2)
+	require.NoError(t, err, "GetMessage explicit sender")
+	require.NotNil(t, explicit)
+	assert.Equal(t, []Address{{Email: "explicit@example.net", Name: "Per-message Sender"}}, explicit.From)
+
+	phone, err := reader.GetMessage(ctx, 3)
+	require.NoError(t, err, "GetMessage phone sender")
+	require.NotNil(t, phone)
+	assert.Equal(t, []Address{{Email: "+15550100003", Name: "+15550100003"}}, phone.From)
+
+	emailOnly, err := reader.GetMessage(ctx, 4)
+	require.NoError(t, err, "GetMessage email-only sender")
+	require.NotNil(t, emailOnly)
+	assert.Equal(t, []Address{{Email: "email-only@example.org", Name: "email-only@example.org"}}, emailOnly.From)
+}
+
+func TestSQLiteMessageDetailUsesDirectSenderFallback(t *testing.T) {
+	_, db := seedMessageDetailSenderFixture(t)
+	t.Cleanup(func() { _ = db.Close() })
+	assertMessageDetailSenderFallback(t, NewSQLiteEngine(db))
+}
+
+func TestDuckDBMessageDetailUsesDirectSenderFallback(t *testing.T) {
+	dbPath, db := seedMessageDetailSenderFixture(t)
+	require.NoError(t, db.Close(), "close SQLite writer")
+
+	engine, err := NewDuckDBEngine("", dbPath, nil)
+	require.NoError(t, err, "NewDuckDBEngine")
+	t.Cleanup(func() { _ = engine.Close() })
+	if !engine.hasSQLite() {
+		t.Skip("DuckDB sqlite_scanner extension unavailable")
+	}
+	assertMessageDetailSenderFallback(t, engine)
+}

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -266,11 +266,30 @@ func fetchMessageLabelsDetail(ctx context.Context, db *sql.DB, rebind rebindFunc
 // rebind rewrites the ? placeholders for the driver in use.
 func fetchParticipantsShared(ctx context.Context, db *sql.DB, rebind rebindFunc, tablePrefix string, msg *MessageDetail) error {
 	rows, err := db.QueryContext(ctx, rebind(fmt.Sprintf(`
-		SELECT mr.recipient_type, COALESCE(NULLIF(p.email_address, ''), NULLIF(p.phone_number, ''), ''), %s
+		SELECT mr.recipient_type,
+		       COALESCE(NULLIF(p.email_address, ''), NULLIF(p.phone_number, ''), ''),
+		       %s
 		FROM %smessage_recipients mr
 		JOIN %sparticipants p ON p.id = mr.participant_id
 		WHERE mr.message_id = ?
-	`, recipientNameExpr("mr", "p"), tablePrefix, tablePrefix)), msg.ID)
+		  AND mr.recipient_type IN ('from', 'to', 'cc', 'bcc')
+		UNION ALL
+		SELECT 'from',
+		       COALESCE(NULLIF(p.email_address, ''), NULLIF(p.phone_number, ''), ''),
+		       COALESCE(%s, '')
+		FROM %smessages m
+		JOIN %sparticipants p ON p.id = m.sender_id
+		WHERE m.id = ?
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM %smessage_recipients mr_explicit
+			WHERE mr_explicit.message_id = m.id
+			  AND mr_explicit.recipient_type = 'from'
+		  )
+	`,
+		recipientNameExpr("mr", "p"), tablePrefix, tablePrefix,
+		participantNameExpr("p"), tablePrefix, tablePrefix, tablePrefix,
+	)), msg.ID, msg.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What changed

- hydrate full message details from `messages.sender_id` when no explicit `from` recipient exists
- preserve explicit sender overrides and exclude mention rows from sender results
- add production-path regression coverage for SQLite, DuckDB's attached-SQLite path, and MCP `get_message`

## Root cause

Chat imports store sender attribution directly on `messages.sender_id` without creating a matching `from` recipient row. Message detail hydration only read `message_recipients`, so it omitted a sender that list and search results already displayed.

## Impact

Existing `get_message` clients now receive the stored chat sender in `from`. Explicit email sender rows remain authoritative, and no configuration or schema changes are required.
