### PR TITLE
feat: discover source-scoped email identities

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -81,8 +81,10 @@ components:
           type: string
         signal:
           type: string
+        source_id:
+          format: int64
+          type: integer
       required:
-        - account
         - identifier
         - signal
       type: object
@@ -812,6 +814,55 @@ components:
       required:
         - id
         - status
+      type: object
+    Candidate:
+      additionalProperties: true
+      properties:
+        already_confirmed:
+          type: boolean
+        classification:
+          enum:
+            - confirmed
+            - strong
+            - weak
+          type: string
+        first_seen_at:
+          format: date-time
+          type: string
+        identifier:
+          type: string
+        last_seen_at:
+          format: date-time
+          type: string
+        normalized_identifier:
+          type: string
+        provider_states:
+          items:
+            type: string
+          type: array
+        received_message_count:
+          format: int64
+          type: integer
+        sent_message_count:
+          format: int64
+          type: integer
+        signals:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      required:
+        - identifier
+        - normalized_identifier
+        - classification
+        - already_confirmed
+        - signals
+        - provider_states
+        - sent_message_count
+        - received_message_count
+        - first_seen_at
+        - last_seen_at
       type: object
     ChangedMessageJSON:
       additionalProperties: true
@@ -1556,6 +1607,114 @@ components:
         - description
         - message_count
       type: object
+    DiscoverError:
+      additionalProperties: true
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+      type: object
+    DiscoverEvent:
+      additionalProperties: true
+      properties:
+        error:
+          $ref: "#/components/schemas/DiscoverError"
+        progress:
+          $ref: "#/components/schemas/DiscoverProgress"
+        result:
+          $ref: "#/components/schemas/DiscoverResult"
+        type:
+          enum:
+            - progress
+            - result
+            - error
+          type: string
+      required:
+        - type
+      type: object
+    DiscoverProgress:
+      additionalProperties: true
+      properties:
+        candidates:
+          format: int64
+          type: integer
+        done:
+          format: int64
+          type: integer
+        total:
+          format: int64
+          type: integer
+      required:
+        - done
+        - total
+        - candidates
+      type: object
+    DiscoverRequest:
+      additionalProperties: false
+      properties:
+        account:
+          type: string
+        apply:
+          type: boolean
+        confirm:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        page_size:
+          format: int64
+          type: integer
+        provider:
+          type: boolean
+        source_id:
+          format: int64
+          type: integer
+      type: object
+    DiscoverResult:
+      additionalProperties: true
+      properties:
+        account:
+          type: string
+        applied:
+          items:
+            $ref: "#/components/schemas/IdentityConfirmationOutcome"
+          type:
+            - array
+            - "null"
+        candidates:
+          items:
+            $ref: "#/components/schemas/Candidate"
+          type:
+            - array
+            - "null"
+        rejected:
+          items:
+            $ref: "#/components/schemas/RejectedCandidate"
+          type:
+            - array
+            - "null"
+        scanned_messages:
+          format: int64
+          type: integer
+        source_id:
+          format: int64
+          type: integer
+        source_type:
+          type: string
+      required:
+        - account
+        - source_id
+        - source_type
+        - scanned_messages
+        - candidates
+        - rejected
+        - applied
+      type: object
     DomainContextSummaryHTTPResponse:
       additionalProperties: true
       properties:
@@ -1666,6 +1825,14 @@ components:
           type: string
         match:
           $ref: "#/components/schemas/MatchSummary"
+        matched_recipient_identities:
+          items:
+            type: string
+          type: array
+        matched_sender_identities:
+          items:
+            type: string
+          type: array
         message_count:
           format: int64
           type: integer
@@ -1710,6 +1877,8 @@ components:
         - conversation_type
         - title
         - preview
+        - matched_sender_identities
+        - matched_recipient_identities
         - message_count
         - has_attachments
         - attachment_count
@@ -1894,6 +2063,7 @@ components:
             - after
             - before
             - deletion
+            - identity
           type: string
         values:
           items:
@@ -2781,6 +2951,24 @@ components:
         - took_ms
         - results
       type: object
+    IdentityConfirmationOutcome:
+      additionalProperties: true
+      properties:
+        added:
+          type: boolean
+        identifier:
+          type: string
+        signals:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      required:
+        - identifier
+        - added
+        - signals
+      type: object
     IdentityLinkRequest:
       additionalProperties: false
       properties:
@@ -2846,6 +3034,60 @@ components:
       required:
         - field
         - direction
+      type: object
+    ImportEntry:
+      additionalProperties: false
+      properties:
+        identifier:
+          type: string
+        state:
+          type: string
+      required:
+        - identifier
+      type: object
+    ImportRequest:
+      additionalProperties: false
+      properties:
+        account:
+          type: string
+        apply:
+          type: boolean
+        entries:
+          items:
+            $ref: "#/components/schemas/ImportEntry"
+          type: array
+        signal:
+          type: string
+        source_id:
+          format: int64
+          type: integer
+      required:
+        - entries
+      type: object
+    ImportResult:
+      additionalProperties: true
+      properties:
+        account:
+          type: string
+        applied:
+          items:
+            $ref: "#/components/schemas/IdentityConfirmationOutcome"
+          type: array
+        candidates:
+          items:
+            $ref: "#/components/schemas/Candidate"
+          type: array
+        signal:
+          type: string
+        source_id:
+          format: int64
+          type: integer
+      required:
+        - account
+        - source_id
+        - signal
+        - candidates
+        - applied
       type: object
     ListDeletionsResponse:
       additionalProperties: true
@@ -3662,6 +3904,17 @@ components:
         - rows
         - row_count
       type: object
+    RejectedCandidate:
+      additionalProperties: true
+      properties:
+        identifier:
+          type: string
+        reason:
+          type: string
+      required:
+        - identifier
+        - reason
+      type: object
     RelationshipRow:
       additionalProperties: true
       properties:
@@ -3834,8 +4087,10 @@ components:
           type: string
         identifier:
           type: string
+        source_id:
+          format: int64
+          type: integer
       required:
-        - account
         - identifier
       type: object
     RemoveResult:
@@ -4390,6 +4645,40 @@ components:
       required:
         - source_type
         - count
+      type: object
+    SourceIdentitiesResponse:
+      additionalProperties: true
+      properties:
+        account:
+          type: string
+        identities:
+          items:
+            $ref: "#/components/schemas/SourceIdentityResponse"
+          type: array
+        source_id:
+          format: int64
+          type: integer
+      required:
+        - source_id
+        - account
+        - identities
+      type: object
+    SourceIdentityResponse:
+      additionalProperties: true
+      properties:
+        confirmed_at:
+          format: date-time
+          type: string
+        identifier:
+          type: string
+        signals:
+          items:
+            type: string
+          type: array
+      required:
+        - identifier
+        - signals
+        - confirmed_at
       type: object
     SourceStatus:
       additionalProperties: true
@@ -5141,7 +5430,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.35.0
+  version: 1.36.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -6695,6 +6984,14 @@ paths:
           schema:
             description: Restrict to all member accounts of one collection
             type: string
+        - description: Restrict to one source by numeric ID
+          explode: false
+          in: query
+          name: source_id
+          schema:
+            description: Restrict to one source by numeric ID
+            format: int64
+            type: integer
         - description: For account scope, return only the primary source instead of related sources
           explode: false
           in: query
@@ -6780,6 +7077,78 @@ paths:
       security:
         - apiKey: []
       summary: Add a confirmed identifier to an account identity
+      tags:
+        - CLI
+  /api/v1/cli/identities/discover:
+    post:
+      operationId: discoverCLIIdentities
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DiscoverRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/DiscoverEvent"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Discover source-scoped account identities
+      tags:
+        - API
+  /api/v1/cli/identities/import:
+    post:
+      operationId: importCLIIdentities
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportResult"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Bad Request
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Internal Server Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Service Unavailable
+      security:
+        - apiKey: []
+      summary: Preview or apply parsed source-scoped identities
       tags:
         - CLI
   /api/v1/cli/init-db:
@@ -10573,6 +10942,35 @@ paths:
       security:
         - apiKey: []
       summary: List source sync status
+      tags:
+        - API
+  /api/v1/sources/{source_id}/identities:
+    get:
+      operationId: listSourceIdentities
+      parameters:
+        - description: Source ID
+          in: path
+          name: source_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceIdentitiesResponse"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List confirmed identities for one source
       tags:
         - API
   /api/v1/stats:

--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -747,6 +747,14 @@ func buildCacheLocked(
 		messageSourceAttribution = "COALESCE(m.source_is_from_me, FALSE)"
 	}
 	sourceSnapshot.hasMessageSourceAttribution = messageSourceAttributionColumnCount > 0
+	var recipientEnvelopeColumnCount int
+	if err := sourceSnapshot.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('message_recipients')
+		WHERE name = 'email_address'
+	`).Scan(&recipientEnvelopeColumnCount); err != nil {
+		return nil, fmt.Errorf("inspect recipient envelope schema: %w", err)
+	}
+	sourceSnapshot.hasRecipientEnvelope = recipientEnvelopeColumnCount > 0
 	if err := sourceSnapshot.Prepare(); err != nil {
 		return nil, err
 	}
@@ -813,19 +821,27 @@ func buildCacheLocked(
 		recipientsFilter = fmt.Sprintf(" WHERE message_id > %d", lastMessageID)
 	}
 	recipientsFilter = junctionFilter(recipientsFilter)
+	// Databases from before the envelope snapshot column export '' so the
+	// dataset always carries email_address and identity filters degrade to
+	// participant matching for every legacy row.
+	recipientEnvelopeExpression := "'' as email_address"
+	if sourceSnapshot.hasRecipientEnvelope {
+		recipientEnvelopeExpression = "COALESCE(TRY_CAST(email_address AS VARCHAR), '') as email_address"
+	}
 	if err := runExport("message_recipients", fmt.Sprintf(`
 	COPY (
 		SELECT
 			message_id,
 			participant_id,
 			recipient_type,
-			COALESCE(TRY_CAST(display_name AS VARCHAR), '') as display_name
+			COALESCE(TRY_CAST(display_name AS VARCHAR), '') as display_name,
+			%s
 		FROM sqlite_db.message_recipients%s
 	) TO '%s/%s' (
 		FORMAT PARQUET,
 		COMPRESSION 'zstd'
 	)
-	`, recipientsFilter, escapedRecipientsDir, junctionFile)); err != nil {
+	`, recipientEnvelopeExpression, recipientsFilter, escapedRecipientsDir, junctionFile)); err != nil {
 		return nil, fmt.Errorf("export message_recipients: %w", err)
 	}
 
@@ -1063,6 +1079,26 @@ func buildCacheLocked(
 	messagesDir := filepath.Join(staging.root, tableMessages)
 	escapedMessagesDir := strings.ReplaceAll(messagesDir, "'", "''")
 
+	// Mirrors messageIdentityAttributionMatch (internal/store/messages.go):
+	// after a participant merge a confirmed alias may survive only in the
+	// message's own 'from' envelope snapshot, so deriving attribution from
+	// the sender participant's current fields alone would bake the wrong
+	// message direction into the cache. Guarded because a snapshot from
+	// before the envelope column simply has no alias evidence to read (the
+	// CSV fallback view materializes '' for those rows, excluded here too).
+	identityEnvelopeAttribution := ""
+	if sourceSnapshot.hasRecipientEnvelope {
+		identityEnvelopeAttribution = ` OR EXISTS (
+				SELECT 1 FROM sqlite_db.account_identities ai
+				JOIN sqlite_db.message_recipients smr ON smr.message_id = m.id
+				WHERE ai.source_id = m.source_id
+				  AND smr.recipient_type = 'from'
+				  AND smr.email_address IS NOT NULL
+				  AND smr.email_address != ''
+				  AND lower(smr.email_address) = lower(ai.address)
+			)`
+	}
+
 	if err := runExport(tableMessages, fmt.Sprintf(`
 	COPY (
 		SELECT
@@ -1091,7 +1127,7 @@ func buildCacheLocked(
 				WHERE ai.source_id = m.source_id
 				  AND ((spi.identifier_type = 'email' AND lower(spi.identifier_value) = lower(ai.address))
 				       OR (spi.identifier_type != 'email' AND spi.identifier_value = ai.address))
-			)) AS is_from_me,
+			)%s) AS is_from_me,
 			CAST(EXTRACT(YEAR FROM m.sent_at) AS INTEGER) as year,
 			CAST(EXTRACT(MONTH FROM m.sent_at) AS INTEGER) as month
 		FROM sqlite_db.messages m
@@ -1102,7 +1138,7 @@ func buildCacheLocked(
 		OVERWRITE_OR_IGNORE,
 		COMPRESSION 'zstd'
 	)
-	`, messageSourceAttribution, idFilter, escapedMessagesDir)); err != nil {
+	`, messageSourceAttribution, identityEnvelopeAttribution, idFilter, escapedMessagesDir)); err != nil {
 		return nil, fmt.Errorf("export messages: %w", err)
 	}
 
@@ -1150,12 +1186,12 @@ func buildCacheLocked(
 					WHERE ai.source_id = m.source_id
 					  AND ((spi.identifier_type = 'email' AND lower(spi.identifier_value) = lower(ai.address))
 					       OR (spi.identifier_type != 'email' AND spi.identifier_value = ai.address))
-				)) AS is_from_me,
+				)%s) AS is_from_me,
 				CAST(EXTRACT(MONTH FROM m.sent_at) AS INTEGER) as month
 			FROM sqlite_db.messages m
 			WHERE 1 = 0
 		) TO '%s' (FORMAT PARQUET, COMPRESSION 'zstd')
-		`, messageSourceAttribution, escapedEmptyShard)); err != nil {
+		`, messageSourceAttribution, identityEnvelopeAttribution, escapedEmptyShard)); err != nil {
 			return nil, fmt.Errorf("export empty messages shard: %w", err)
 		}
 	}
@@ -1467,6 +1503,7 @@ type cacheSourceSnapshot struct {
 	tmpDir                      string
 	hasAttachmentMIME           bool
 	hasMessageSourceAttribution bool
+	hasRecipientEnvelope        bool
 }
 
 type cacheSnapshotTable struct {
@@ -1587,6 +1624,10 @@ func (s *cacheSourceSnapshot) tables() []cacheSnapshotTable {
 	if s.hasAttachmentMIME {
 		attachmentQuery = "SELECT id, message_id, size, filename, mime_type FROM attachments"
 	}
+	recipientEnvelopeColumn := "'' AS email_address"
+	if s.hasRecipientEnvelope {
+		recipientEnvelopeColumn = "email_address"
+	}
 	messageColumns := "id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, deleted_from_source_at, deleted_at, sender_id, message_type, is_from_me"
 	messageTypes := "types={'id': 'BIGINT', 'source_id': 'BIGINT', 'source_message_id': 'VARCHAR', 'conversation_id': 'BIGINT', 'subject': 'VARCHAR', 'snippet': 'VARCHAR', 'sent_at': 'TIMESTAMP', 'size_estimate': 'BIGINT', 'has_attachments': 'BOOLEAN', 'attachment_count': 'INTEGER', 'deleted_from_source_at': 'TIMESTAMP', 'deleted_at': 'TIMESTAMP', 'sender_id': 'BIGINT', 'message_type': 'VARCHAR', 'is_from_me': 'BOOLEAN'"
 	if s.hasMessageSourceAttribution {
@@ -1605,8 +1646,8 @@ func (s *cacheSourceSnapshot) tables() []cacheSnapshotTable {
 		// on the sqlite_scanner path; otherwise DuckDB binds against a
 		// CSV view that lacks the column and the export fails on Windows.
 		{tableMessages, "SELECT " + messageColumns + " FROM messages WHERE sent_at IS NOT NULL", messageTypes},
-		{"message_recipients", "SELECT message_id, participant_id, recipient_type, display_name FROM message_recipients",
-			"types={'message_id': 'BIGINT', 'participant_id': 'BIGINT', 'recipient_type': 'VARCHAR', 'display_name': 'VARCHAR'}"},
+		{"message_recipients", "SELECT message_id, participant_id, recipient_type, display_name, " + recipientEnvelopeColumn + " FROM message_recipients",
+			"types={'message_id': 'BIGINT', 'participant_id': 'BIGINT', 'recipient_type': 'VARCHAR', 'display_name': 'VARCHAR', 'email_address': 'VARCHAR'}"},
 		{"message_labels", "SELECT message_id, label_id FROM message_labels",
 			"types={'message_id': 'BIGINT', 'label_id': 'BIGINT'}"},
 		{tableAttachments, attachmentQuery,

--- a/cmd/msgvault/cmd/build_cache_test.go
+++ b/cmd/msgvault/cmd/build_cache_test.go
@@ -86,7 +86,8 @@ func setupTestSQLite(t *testing.T) string {
 			message_id INTEGER NOT NULL REFERENCES messages(id),
 			participant_id INTEGER NOT NULL REFERENCES participants(id),
 			recipient_type TEXT NOT NULL,
-			display_name TEXT
+			display_name TEXT,
+			email_address TEXT
 		);
 
 		CREATE TABLE labels (
@@ -201,11 +202,11 @@ func setupTestSQLite(t *testing.T) string {
 			(5, 1, 'msg5', 104, 'Final', 'Preview 5', '2024-03-01 16:00:00', 500, 0);
 
 		-- Message recipients
-		-- msg1: from alice, to bob+carol
-		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name) VALUES
-			(1, 1, 'from', 'Alice Smith'),
-			(1, 2, 'to', 'Bob Jones'),
-			(1, 3, 'to', 'Carol White');
+		-- msg1: from alice (with envelope snapshot), to bob+carol
+		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name, email_address) VALUES
+			(1, 1, 'from', 'Alice Smith', 'alice-envelope@example.com'),
+			(1, 2, 'to', 'Bob Jones', NULL),
+			(1, 3, 'to', 'Carol White', NULL);
 		-- msg2: from alice, to bob, cc dan
 		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name) VALUES
 			(2, 1, 'from', 'Alice Smith'),
@@ -908,6 +909,43 @@ func TestBuildCache_PublishesConversationParticipants(t *testing.T) {
 	).Scan(&count)
 	require.NoError(err)
 	assert.Equal(t, int64(9), count)
+}
+
+// TestBuildCache_ExportsRecipientEnvelopeAddress verifies the envelope
+// address snapshot reaches the message_recipients Parquet dataset (cache
+// schema v17): identity filters compare against it, so an export that drops
+// the column would silently degrade every filter to participant matching.
+func TestBuildCache_ExportsRecipientEnvelopeAddress(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmpDir := setupTestSQLite(t)
+	dbPath := filepath.Join(tmpDir, "test.db")
+	analyticsDir := filepath.Join(tmpDir, "analytics")
+
+	_, err := buildCache(dbPath, analyticsDir, false)
+	require.NoError(err)
+
+	duckdb, err := sql.Open("duckdb", "")
+	require.NoError(err)
+	defer func() { _ = duckdb.Close() }()
+	glob := filepath.Join(analyticsDir, "message_recipients", "*.parquet")
+
+	var envelope string
+	err = duckdb.QueryRow(
+		`SELECT email_address FROM read_parquet(?)
+		 WHERE message_id = 1 AND recipient_type = 'from'`, glob,
+	).Scan(&envelope)
+	require.NoError(err, "exported message_recipients must carry email_address")
+	assert.Equal("alice-envelope@example.com", envelope)
+
+	var withoutSnapshot int64
+	err = duckdb.QueryRow(
+		`SELECT COUNT(*) FROM read_parquet(?)
+		 WHERE COALESCE(email_address, '') = ''`, glob,
+	).Scan(&withoutSnapshot)
+	require.NoError(err)
+	assert.Equal(int64(11), withoutSnapshot,
+		"rows without a snapshot export as empty, keeping the participant fallback")
 }
 
 // TestBuildCache_DataIntegrity verifies the exported Parquet data matches SQLite.
@@ -2362,7 +2400,8 @@ func setupTestSQLiteEmpty(t *testing.T) string {
 			message_id INTEGER NOT NULL REFERENCES messages(id),
 			participant_id INTEGER NOT NULL REFERENCES participants(id),
 			recipient_type TEXT NOT NULL,
-			display_name TEXT
+			display_name TEXT,
+			email_address TEXT
 		);
 		CREATE TABLE labels (
 			id INTEGER PRIMARY KEY,
@@ -2532,6 +2571,62 @@ func TestBuildCacheCSVSnapshotFallback(t *testing.T) {
 		result, err := buildCache(filepath.Join(tmpDir, "test.db"), filepath.Join(tmpDir, "analytics"), true)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), result.ExportedCount)
+	})
+}
+
+// TestBuildCacheDerivesAttributionFromEnvelopeAliasSnapshot pins the
+// envelope clause of the exported is_from_me derivation: msg1's 'from'
+// envelope snapshot carries alice-envelope@example.com — an address no
+// participant row or identifier holds, exactly the shape a participant merge
+// leaves behind — and its sender_id is NULL, so the participant-based
+// clauses can never match. Confirming that alias (in a different case) must
+// still bake is_from_me=TRUE into the cache, while a message without an
+// envelope snapshot stays FALSE.
+func TestBuildCacheDerivesAttributionFromEnvelopeAliasSnapshot(t *testing.T) {
+	run := func(t *testing.T) {
+		t.Helper()
+		require := require.New(t)
+		assert := assert.New(t)
+		tmpDir := setupTestSQLite(t)
+		dbPath := filepath.Join(tmpDir, "test.db")
+		analyticsDir := filepath.Join(tmpDir, "analytics")
+
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(err)
+		_, err = db.Exec(`
+			INSERT INTO account_identities (source_id, address)
+			VALUES (1, 'Alice-Envelope@Example.com')
+		`)
+		require.NoError(err)
+		require.NoError(db.Close())
+
+		result, err := buildCache(dbPath, analyticsDir, true)
+		require.NoError(err)
+		assert.Positive(result.ExportedCount)
+
+		duckDB, err := sql.Open("duckdb", "")
+		require.NoError(err)
+		defer func() { require.NoError(duckDB.Close()) }()
+
+		pattern := filepath.Join(analyticsDir, "messages", "**", "*.parquet")
+		readIsFromMe := func(messageID int64) bool {
+			var isFromMe bool
+			require.NoError(duckDB.QueryRow(
+				`SELECT is_from_me FROM read_parquet(?, hive_partitioning=true) WHERE id = ?`,
+				pattern, messageID,
+			).Scan(&isFromMe))
+			return isFromMe
+		}
+		assert.True(readIsFromMe(1),
+			"envelope-only alias snapshot must bake identity attribution into the cache")
+		assert.False(readIsFromMe(2),
+			"a message without a matching envelope snapshot must stay unattributed")
+	}
+
+	t.Run("sqlite snapshot", run)
+	t.Run("csv fallback", func(t *testing.T) {
+		t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "1")
+		run(t)
 	})
 }
 
@@ -3189,7 +3284,7 @@ func TestCacheNeedsBuild_IgnoresAlreadyProcessedUpdatedSyncRun(t *testing.T) {
 // schema version other than the current one now forces a full rebuild.
 func TestCacheNeedsBuild_SchemaVersionMismatch(t *testing.T) {
 	require := require.New(t)
-	require.Equal(16, cacheSchemaVersion, "relationship activity has_attachments requires cache v16")
+	require.Equal(17, cacheSchemaVersion, "message_recipients envelope address requires cache v17")
 	tmpDir := setupTestSQLiteEmpty(t)
 
 	dbPath := filepath.Join(tmpDir, "test.db")
@@ -3224,7 +3319,7 @@ func TestCacheNeedsBuild_SchemaVersionMismatch(t *testing.T) {
 	require.False(result.Skipped, "schema mismatch must execute a full rebuild")
 	upgraded, err := query.ReadCacheSyncState(analyticsDir)
 	require.NoError(err, "read upgraded cache state")
-	require.Equal(16, upgraded.SchemaVersion)
+	require.Equal(17, upgraded.SchemaVersion)
 	require.NoFileExists(filepath.Join(analyticsDir, tableParticipantIdentifiers, "data.parquet"),
 		"full rebuild must replace rather than extend the v11 identifier dataset")
 	identifierParquet := filepath.Join(analyticsDir, tableParticipantIdentifiers, "participant_identifiers.parquet")

--- a/cmd/msgvault/cmd/export_discord.go
+++ b/cmd/msgvault/cmd/export_discord.go
@@ -47,7 +47,7 @@ func newExportDiscordCmd(deps discordCommandDeps) *cobra.Command {
 }
 
 func newExportDiscordLocalCmd(deps discordCommandDeps) *cobra.Command {
-	opts := exportDiscordOptions{Format: "json"}
+	opts := exportDiscordOptions{Format: flagJSON}
 	cmd := &cobra.Command{
 		Use:   "export-discord <guild-id-or-name>",
 		Short: "Export bounded Discord history from the local archive",
@@ -58,7 +58,7 @@ func newExportDiscordLocalCmd(deps discordCommandDeps) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.Start, "start", "", "inclusive RFC3339 lower bound")
 	cmd.Flags().StringVar(&opts.End, "end", "", "exclusive RFC3339 upper bound")
-	cmd.Flags().StringVar(&opts.Format, "format", "json", "output format (json)")
+	cmd.Flags().StringVar(&opts.Format, "format", flagJSON, "output format (json)")
 	return cmd
 }
 
@@ -72,7 +72,7 @@ func runExportDiscord(
 	if err != nil {
 		return usageErr(cmd, err)
 	}
-	if opts.Format != "json" {
+	if opts.Format != flagJSON {
 		return usageErr(cmd, fmt.Errorf("unsupported --format %q (expected json)", opts.Format))
 	}
 

--- a/cmd/msgvault/cmd/identity.go
+++ b/cmd/msgvault/cmd/identity.go
@@ -5,20 +5,38 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/identityops"
 )
 
 var (
-	identityListAccount    string
-	identityListCollection string
-	identityListJSON       bool
-	identityShowJSON       bool
-	identityAddSignal      string
+	identityListAccount      string
+	identityListCollection   string
+	identityListSourceID     int64
+	identityListJSON         bool
+	identityShowSourceID     int64
+	identityShowJSON         bool
+	identityAddSourceID      int64
+	identityAddSignal        string
+	identityRemoveSourceID   int64
+	identityDiscoverSourceID int64
+	identityDiscoverApply    bool
+	identityDiscoverProvider bool
+	identityDiscoverConfirm  []string
+	identityDiscoverJSON     bool
+	identityImportSourceID   int64
+	identityImportFile       string
+	identityImportStdin      bool
+	identityImportSignal     string
+	identityImportApply      bool
+	identityImportJSON       bool
 )
 
 // identityCmdUse is the usage/name of the identity command.
@@ -48,8 +66,10 @@ func runIdentityList(cmd *cobra.Command, _ []string) error {
 	rows, err := fetchHTTPIdentityRows(
 		cmd,
 		daemonclient.CLIIdentitiesRequest{
-			Account:    identityListAccount,
-			Collection: identityListCollection,
+			Account:     identityListAccount,
+			Collection:  identityListCollection,
+			SourceID:    identityListSourceID,
+			SourceIDSet: cmd.Flags().Changed("source-id"),
 		},
 	)
 	if err != nil {
@@ -142,21 +162,31 @@ func writeIdentityJSON(w io.Writer, rows []identityRow) error {
 }
 
 var identityShowCmd = &cobra.Command{
-	Use:   "show <account>",
+	Use:   "show [account]",
 	Short: "Show one account's identity in detail",
-	Args:  cobra.ExactArgs(1),
+	Args:  identityShowArgs,
 	RunE:  runIdentityShow,
 }
 
 func runIdentityShow(cmd *cobra.Command, args []string) error {
+	account := ""
+	if len(args) == 1 {
+		account = args[0]
+	}
+	selector, err := identitySourceSelector(cmd, account, identityShowSourceID)
+	if err != nil {
+		return err
+	}
 	rows, err := fetchHTTPIdentityRows(cmd, daemonclient.CLIIdentitiesRequest{
-		Account:     args[0],
-		PrimaryOnly: true,
+		Account:     selector.Account,
+		SourceID:    selector.SourceID,
+		SourceIDSet: cmd.Flags().Changed("source-id"),
+		PrimaryOnly: selector.SourceID == 0,
 	})
 	if err != nil {
 		return err
 	}
-	return renderIdentityShow(cmd.OutOrStdout(), rows, args[0])
+	return renderIdentityShow(cmd.OutOrStdout(), rows, account)
 }
 
 func fetchHTTPIdentityRows(
@@ -214,14 +244,14 @@ func renderIdentityShow(w io.Writer, rows []identityRow, hintAccount string) err
 }
 
 var identityAddCmd = &cobra.Command{
-	Use:   "add <account> <identifier>",
+	Use:   "add [account] <identifier>",
 	Short: "Add a confirmed identifier to an account's identity",
-	Args:  cobra.ExactArgs(2),
+	Args:  identityAddArgs,
 	RunE:  runIdentityAdd,
 }
 
 func runIdentityAdd(cmd *cobra.Command, args []string) error {
-	accountArg, identifierArg := args[0], args[1]
+	accountArg, identifierArg := identityMutationArguments(cmd, args)
 	identifier := strings.TrimSpace(identifierArg)
 	if identifier == "" {
 		return usageErr(cmd, errors.New("identifier cannot be empty"))
@@ -229,10 +259,14 @@ func runIdentityAdd(cmd *cobra.Command, args []string) error {
 	if strings.Contains(identityAddSignal, ",") {
 		return usageErr(cmd, fmt.Errorf("signal names cannot contain commas: %q", identityAddSignal))
 	}
-	return runHTTPIdentityAdd(cmd, accountArg, identifier)
+	selector, err := identitySourceSelector(cmd, accountArg, identityAddSourceID)
+	if err != nil {
+		return err
+	}
+	return runHTTPIdentityAdd(cmd, selector, identifier)
 }
 
-func runHTTPIdentityAdd(cmd *cobra.Command, account string, identifier string) error {
+func runHTTPIdentityAdd(cmd *cobra.Command, selector daemonclient.CLIIdentitySourceSelector, identifier string) error {
 	s, _, err := OpenHTTPStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("open store: %w", err)
@@ -240,9 +274,9 @@ func runHTTPIdentityAdd(cmd *cobra.Command, account string, identifier string) e
 	defer func() { _ = s.Close() }()
 
 	result, err := s.AddCLIIdentity(cmd.Context(), daemonclient.CLIIdentityAddRequest{
-		Account:    account,
-		Identifier: identifier,
-		Signal:     identityAddSignal,
+		SourceSelector: selector,
+		Identifier:     identifier,
+		Signal:         identityAddSignal,
 	})
 	if err != nil {
 		return err
@@ -266,21 +300,270 @@ func renderIdentityAddResult(w io.Writer, result daemonclient.CLIIdentityAddResu
 }
 
 var identityRemoveCmd = &cobra.Command{
-	Use:   "remove <account> <identifier>",
+	Use:   "remove [account] <identifier>",
 	Short: "Remove a confirmed identifier from an account's identity",
-	Args:  cobra.ExactArgs(2),
+	Args:  identityRemoveArgs,
 	RunE:  runIdentityRemove,
 }
 
+var identityDiscoverCmd = &cobra.Command{
+	Use:   "discover [account]",
+	Short: "Preview or apply source-scoped identity evidence",
+	Long: `Scan one ingestion source's archived message metadata for identity
+evidence. The command is read-only unless --apply is present. Strong sent
+evidence is applied automatically with --apply; weak candidates require a
+repeatable --confirm address flag.`,
+	Args: identityDiscoverArgs,
+	RunE: runIdentityDiscover,
+}
+
+var identityImportCmd = &cobra.Command{
+	Use:   "import [account]",
+	Short: "Preview or apply source-scoped identities from text or JSON",
+	Args:  identityImportArgs,
+	RunE:  runIdentityImport,
+}
+
+func runIdentityImport(cmd *cobra.Command, args []string) error {
+	account := ""
+	if len(args) == 1 {
+		account = args[0]
+	}
+	selector, err := identitySourceSelector(cmd, account, identityImportSourceID)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Context().Err(); err != nil {
+		return err
+	}
+
+	var input io.Reader
+	format := ""
+	var file *os.File
+	if identityImportStdin {
+		input = cmd.InOrStdin()
+	} else {
+		file, err = os.Open(identityImportFile)
+		if err != nil {
+			return fmt.Errorf("open identity import file: %w", err)
+		}
+		defer func() { _ = file.Close() }()
+		input = file
+		format = filepath.Ext(identityImportFile)
+	}
+	entries, err := identityops.ParseImport(input, format)
+	if err != nil {
+		return fmt.Errorf("parse identity import: %w", err)
+	}
+
+	client, _, err := OpenHTTPStore(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+	result, err := client.ImportCLIIdentities(cmd.Context(), identityops.ImportRequest{
+		SourceSelector: selector,
+		Entries:        entries,
+		Signal:         identityImportSignal,
+		Apply:          identityImportApply,
+	})
+	if err != nil {
+		return fmt.Errorf("import identities: %w", err)
+	}
+	if result == nil {
+		return errors.New("identity import ended without a result")
+	}
+	return renderIdentityImport(cmd.OutOrStdout(), *result, identityImportJSON)
+}
+
+func renderIdentityImport(w io.Writer, result identityops.ImportResult, jsonOutput bool) error {
+	if jsonOutput {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	}
+	if _, err := fmt.Fprintf(
+		w,
+		"Identity import for %s (source %d)\nSignal: %s\n\nCANDIDATES (%d)\n",
+		result.Account,
+		result.SourceID,
+		result.Signal,
+		len(result.Candidates),
+	); err != nil {
+		return fmt.Errorf("render identity import heading: %w", err)
+	}
+	for _, candidate := range result.Candidates {
+		states := strings.Join(candidate.ProviderStates, ",")
+		if states == "" {
+			states = "-"
+		}
+		if _, err := fmt.Fprintf(
+			w,
+			"  %s\n    classification: %s | states: %s\n",
+			candidate.Identifier,
+			candidate.Classification,
+			states,
+		); err != nil {
+			return fmt.Errorf("render imported identity candidate: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintf(w, "\nApplied %d identity confirmation(s).\n", len(result.Applied)); err != nil {
+		return fmt.Errorf("render imported identity outcomes: %w", err)
+	}
+	return nil
+}
+
+func runIdentityDiscover(cmd *cobra.Command, args []string) error {
+	account := ""
+	if len(args) == 1 {
+		account = args[0]
+	}
+	selector, err := identitySourceSelector(cmd, account, identityDiscoverSourceID)
+	if err != nil {
+		return err
+	}
+	client, _, err := OpenHTTPStore(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	var result *identityops.DiscoverResult
+	err = client.DiscoverCLIIdentities(cmd.Context(), identityops.DiscoverRequest{
+		SourceSelector: selector,
+		Apply:          identityDiscoverApply,
+		Provider:       identityDiscoverProvider,
+		Confirm:        append([]string(nil), identityDiscoverConfirm...),
+	}, func(event identityops.DiscoverEvent) error {
+		switch event.Type {
+		case "progress":
+			if !identityDiscoverJSON && event.Progress != nil {
+				return renderIdentityDiscoverProgress(cmd.ErrOrStderr(), *event.Progress)
+			}
+		case "result":
+			if event.Result != nil {
+				copyResult := *event.Result
+				result = &copyResult
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("discover identities: %w", err)
+	}
+	if result == nil {
+		return errors.New("identity discovery ended without a result")
+	}
+	return renderIdentityDiscover(cmd.OutOrStdout(), *result, identityDiscoverJSON)
+}
+
+func renderIdentityDiscoverProgress(w io.Writer, progress identityops.DiscoverProgress) error {
+	_, err := fmt.Fprintf(
+		w,
+		"Scanning identity evidence: %d/%d messages, %d candidate(s)\n",
+		progress.Done,
+		progress.Total,
+		progress.Candidates,
+	)
+	if err != nil {
+		return fmt.Errorf("render identity discovery progress: %w", err)
+	}
+	return nil
+}
+
+func renderIdentityDiscover(w io.Writer, result identityops.DiscoverResult, jsonOutput bool) error {
+	if jsonOutput {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	}
+
+	if _, err := fmt.Fprintf(
+		w,
+		"Identity discovery for %s (source %d, %s)\nScanned %d message(s).\n",
+		result.Account,
+		result.SourceID,
+		result.SourceType,
+		result.ScannedMessages,
+	); err != nil {
+		return fmt.Errorf("render identity discovery heading: %w", err)
+	}
+	for _, classification := range []string{"confirmed", "strong", "weak"} {
+		if err := renderIdentityDiscoverCandidateGroup(w, classification, result.Candidates); err != nil {
+			return fmt.Errorf("render identity discovery candidates: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintf(w, "\nREJECTED (%d)\n", len(result.Rejected)); err != nil {
+		return fmt.Errorf("render rejected identity candidates: %w", err)
+	}
+	for _, candidate := range result.Rejected {
+		if _, err := fmt.Fprintf(w, "  %s\n    reason: %s\n", candidate.Identifier, candidate.Reason); err != nil {
+			return fmt.Errorf("render rejected identity candidate: %w", err)
+		}
+	}
+	if result.Applied != nil {
+		if _, err := fmt.Fprintf(w, "\nApplied %d identity confirmation(s).\n", len(result.Applied)); err != nil {
+			return fmt.Errorf("render applied identity confirmations: %w", err)
+		}
+	}
+	return nil
+}
+
+func renderIdentityDiscoverCandidateGroup(
+	w io.Writer,
+	classification string,
+	candidates []identityops.Candidate,
+) error {
+	count := 0
+	for _, candidate := range candidates {
+		if candidate.Classification == classification {
+			count++
+		}
+	}
+	if _, err := fmt.Fprintf(w, "\n%s (%d)\n", strings.ToUpper(classification), count); err != nil {
+		return fmt.Errorf("render identity candidate group: %w", err)
+	}
+	for _, candidate := range candidates {
+		if candidate.Classification != classification {
+			continue
+		}
+		signals := strings.Join(candidate.Signals, ",")
+		if signals == "" {
+			signals = "-"
+		}
+		providerStates := strings.Join(candidate.ProviderStates, ",")
+		if providerStates == "" {
+			providerStates = "-"
+		}
+		if _, err := fmt.Fprintf(
+			w,
+			"  %s\n    signals: %s | provider states: %s | sent: %d | received: %d\n",
+			candidate.Identifier,
+			signals,
+			providerStates,
+			candidate.SentMessageCount,
+			candidate.ReceivedMessageCount,
+		); err != nil {
+			return fmt.Errorf("render identity candidate: %w", err)
+		}
+	}
+	return nil
+}
+
 func runIdentityRemove(cmd *cobra.Command, args []string) error {
-	identifier := strings.TrimSpace(args[1])
+	accountArg, identifierArg := identityMutationArguments(cmd, args)
+	identifier := strings.TrimSpace(identifierArg)
 	if identifier == "" {
 		return usageErr(cmd, errors.New("identifier must not be empty"))
 	}
-	return runHTTPIdentityRemove(cmd, args[0], identifier)
+	selector, err := identitySourceSelector(cmd, accountArg, identityRemoveSourceID)
+	if err != nil {
+		return err
+	}
+	return runHTTPIdentityRemove(cmd, selector, identifier)
 }
 
-func runHTTPIdentityRemove(cmd *cobra.Command, account string, identifier string) error {
+func runHTTPIdentityRemove(cmd *cobra.Command, selector daemonclient.CLIIdentitySourceSelector, identifier string) error {
 	s, _, err := OpenHTTPStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("open store: %w", err)
@@ -288,8 +571,8 @@ func runHTTPIdentityRemove(cmd *cobra.Command, account string, identifier string
 	defer func() { _ = s.Close() }()
 
 	result, err := s.RemoveCLIIdentity(cmd.Context(), daemonclient.CLIIdentityRemoveRequest{
-		Account:    account,
-		Identifier: identifier,
+		SourceSelector: selector,
+		Identifier:     identifier,
 	})
 	if err != nil {
 		return err
@@ -317,24 +600,123 @@ func renderIdentityNoIdentityWarning(w io.Writer, account string) {
 		"and SENT label signals only.\n", account)
 }
 
+func identityShowArgs(cmd *cobra.Command, args []string) error {
+	return identitySelectorArgs(cmd, args, 0, 1)
+}
+
+func identityAddArgs(cmd *cobra.Command, args []string) error {
+	return identitySelectorArgs(cmd, args, 1, 2)
+}
+
+func identityRemoveArgs(cmd *cobra.Command, args []string) error {
+	return identitySelectorArgs(cmd, args, 1, 2)
+}
+
+func identityDiscoverArgs(cmd *cobra.Command, args []string) error {
+	return identitySelectorArgs(cmd, args, 0, 1)
+}
+
+func identityImportArgs(cmd *cobra.Command, args []string) error {
+	if err := identitySelectorArgs(cmd, args, 0, 1); err != nil {
+		return err
+	}
+	fileSet := cmd.Flags().Changed("file")
+	if fileSet == identityImportStdin {
+		return errors.New("exactly one of --file or --stdin is required")
+	}
+	if fileSet && strings.TrimSpace(identityImportFile) == "" {
+		return errors.New("identity import file path must not be empty")
+	}
+	if fileSet && identityImportFile == "-" {
+		return errors.New(`--file "-" is not supported; use --stdin to read standard input`)
+	}
+	return nil
+}
+
+func identitySelectorArgs(cmd *cobra.Command, args []string, sourceIDCount, accountCount int) error {
+	if cmd.Flags().Changed("source-id") {
+		if len(args) == sourceIDCount {
+			return nil
+		}
+		if len(args) == accountCount {
+			return errors.New("account and source ID are mutually exclusive")
+		}
+		return cobra.ExactArgs(sourceIDCount)(cmd, args)
+	}
+	return cobra.ExactArgs(accountCount)(cmd, args)
+}
+
+func identityMutationArguments(cmd *cobra.Command, args []string) (account, identifier string) {
+	if cmd.Flags().Changed("source-id") {
+		return "", args[0]
+	}
+	return args[0], args[1]
+}
+
+func identitySourceSelector(
+	cmd *cobra.Command,
+	account string,
+	sourceID int64,
+) (daemonclient.CLIIdentitySourceSelector, error) {
+	if cmd.Flags().Changed("source-id") {
+		if sourceID <= 0 {
+			return daemonclient.CLIIdentitySourceSelector{}, errors.New("source ID must be positive")
+		}
+		return daemonclient.CLIIdentitySourceSelector{SourceID: sourceID}, nil
+	}
+	return daemonclient.CLIIdentitySourceSelector{Account: account}, nil
+}
+
 func init() {
 	rootCmd.AddCommand(identityCmd)
 	identityCmd.AddCommand(identityListCmd)
 	identityCmd.AddCommand(identityShowCmd)
 	identityCmd.AddCommand(identityAddCmd)
 	identityCmd.AddCommand(identityRemoveCmd)
+	identityCmd.AddCommand(identityDiscoverCmd)
+	identityCmd.AddCommand(identityImportCmd)
 
 	identityListCmd.Flags().StringVar(&identityListAccount,
 		"account", "", "Restrict to a single account")
 	identityListCmd.Flags().StringVar(&identityListCollection,
 		"collection", "", "Restrict to all member accounts of one collection")
-	identityListCmd.MarkFlagsMutuallyExclusive("account", "collection")
+	identityListCmd.Flags().Int64Var(&identityListSourceID,
+		"source-id", 0, "Restrict to one source by numeric ID")
+	identityListCmd.MarkFlagsMutuallyExclusive("account", "collection", "source-id")
 	identityListCmd.Flags().BoolVar(&identityListJSON,
 		flagJSON, false, "Output as JSON")
 	identityShowCmd.Flags().BoolVar(&identityShowJSON,
 		flagJSON, false, "Output as JSON")
+	identityShowCmd.Flags().Int64Var(&identityShowSourceID,
+		"source-id", 0, "Select one source by numeric ID")
+	identityAddCmd.Flags().Int64Var(&identityAddSourceID,
+		"source-id", 0, "Select one source by numeric ID")
 	identityAddCmd.Flags().StringVar(&identityAddSignal,
 		"signal", "manual",
 		"Evidence signal name (e.g. manual, account-identifier, phone-e164). "+
 			"Cannot contain commas.")
+	identityRemoveCmd.Flags().Int64Var(&identityRemoveSourceID,
+		"source-id", 0, "Select one source by numeric ID")
+	identityDiscoverCmd.Flags().Int64Var(&identityDiscoverSourceID,
+		"source-id", 0, "Select one source by numeric ID")
+	identityDiscoverCmd.Flags().BoolVar(&identityDiscoverApply,
+		"apply", false, "Confirm strong identity evidence after the preview scan completes")
+	identityDiscoverCmd.Flags().BoolVar(&identityDiscoverProvider,
+		"provider", false, "Include configured provider alias inventory")
+	identityDiscoverCmd.Flags().StringArrayVar(&identityDiscoverConfirm,
+		"confirm", nil, "Explicitly confirm a weak candidate (repeatable; requires --apply)")
+	identityDiscoverCmd.Flags().BoolVar(&identityDiscoverJSON,
+		flagJSON, false, "Output the final result as JSON and suppress progress")
+	identityImportCmd.Flags().Int64Var(&identityImportSourceID,
+		"source-id", 0, "Select one source by numeric ID")
+	identityImportCmd.Flags().StringVar(&identityImportFile,
+		"file", "", "Read identities from a text or JSON file")
+	identityImportCmd.Flags().BoolVar(&identityImportStdin,
+		"stdin", false, "Read identities from standard input")
+	identityImportCmd.Flags().StringVar(&identityImportSignal,
+		"signal", "manual", "Evidence signal name (cannot contain commas)")
+	identityImportCmd.Flags().BoolVar(&identityImportApply,
+		"apply", false, "Confirm all validated imported identities")
+	identityImportCmd.Flags().BoolVar(&identityImportJSON,
+		flagJSON, false, "Output the result as JSON")
 }

--- a/cmd/msgvault/cmd/identity_test.go
+++ b/cmd/msgvault/cmd/identity_test.go
@@ -3,20 +3,395 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/daemon"
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/identityops"
 	"go.kenn.io/msgvault/internal/store"
 )
+
+type identityDiscoverFailingWriter struct {
+	err error
+}
+
+func (w identityDiscoverFailingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func stableIdentityDiscoverResult() identityops.DiscoverResult {
+	return identityops.DiscoverResult{
+		Account:         "primary@example.test",
+		SourceID:        14,
+		SourceType:      "imap",
+		ScannedMessages: 5,
+		Candidates: []identityops.Candidate{
+			{
+				Identifier:           "known@example.test",
+				NormalizedIdentifier: "known@example.test",
+				Classification:       "confirmed",
+				AlreadyConfirmed:     true,
+				Signals:              []string{"is_from_me", "manual"},
+				ProviderStates:       []string{"deleted", "enabled"},
+				SentMessageCount:     2,
+				ReceivedMessageCount: 1,
+				FirstSeenAt:          time.Date(2026, 7, 1, 1, 2, 3, 0, time.UTC),
+				LastSeenAt:           time.Date(2026, 7, 2, 4, 5, 6, 0, time.UTC),
+			},
+			{
+				Identifier:           "strong@example.test",
+				NormalizedIdentifier: "strong@example.test",
+				Classification:       "strong",
+				Signals:              []string{"sent-folder"},
+				ProviderStates:       []string{"enabled"},
+				SentMessageCount:     1,
+				FirstSeenAt:          time.Date(2026, 7, 3, 1, 2, 3, 0, time.UTC),
+				LastSeenAt:           time.Date(2026, 7, 3, 1, 2, 3, 0, time.UTC),
+			},
+			{
+				Identifier:           "weak@example.test",
+				NormalizedIdentifier: "weak@example.test",
+				Classification:       "weak",
+				Signals:              []string{},
+				ProviderStates:       []string{"pending"},
+				ReceivedMessageCount: 2,
+				FirstSeenAt:          time.Date(2026, 7, 4, 1, 2, 3, 0, time.UTC),
+				LastSeenAt:           time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+			},
+		},
+		Rejected: []identityops.RejectedCandidate{{Identifier: "*@example.test", Reason: "wildcard address"}},
+		Applied: []store.IdentityConfirmationOutcome{{
+			Identifier: "strong@example.test", Added: true, Signals: []string{"sent-folder"},
+		}},
+	}
+}
+
+func TestRenderIdentityDiscoverJSONIsStableDocument(t *testing.T) {
+	const expected = `{
+		"account":"primary@example.test",
+		"source_id":14,
+		"source_type":"imap",
+		"scanned_messages":5,
+		"candidates":[
+			{"identifier":"known@example.test","normalized_identifier":"known@example.test","classification":"confirmed","already_confirmed":true,"signals":["is_from_me","manual"],"provider_states":["deleted","enabled"],"sent_message_count":2,"received_message_count":1,"first_seen_at":"2026-07-01T01:02:03Z","last_seen_at":"2026-07-02T04:05:06Z"},
+			{"identifier":"strong@example.test","normalized_identifier":"strong@example.test","classification":"strong","already_confirmed":false,"signals":["sent-folder"],"provider_states":["enabled"],"sent_message_count":1,"received_message_count":0,"first_seen_at":"2026-07-03T01:02:03Z","last_seen_at":"2026-07-03T01:02:03Z"},
+			{"identifier":"weak@example.test","normalized_identifier":"weak@example.test","classification":"weak","already_confirmed":false,"signals":[],"provider_states":["pending"],"sent_message_count":0,"received_message_count":2,"first_seen_at":"2026-07-04T01:02:03Z","last_seen_at":"2026-07-05T01:02:03Z"}
+		],
+		"rejected":[{"identifier":"*@example.test","reason":"wildcard address"}],
+		"applied":[{"identifier":"strong@example.test","added":true,"signals":["sent-folder"]}]
+	}`
+	var out bytes.Buffer
+
+	require.NoError(t, renderIdentityDiscover(&out, stableIdentityDiscoverResult(), true))
+
+	assert.JSONEq(t, expected, out.String())
+	assert.Equal(t, 1, strings.Count(strings.TrimSpace(out.String()), "\n{")+1, "one JSON document")
+}
+
+func TestRenderIdentityDiscoverHumanGroupsCandidatesAndRejected(t *testing.T) {
+	var out bytes.Buffer
+
+	require.NoError(t, renderIdentityDiscover(&out, stableIdentityDiscoverResult(), false))
+
+	text := out.String()
+	for _, want := range []string{
+		"CONFIRMED", "STRONG", "WEAK", "REJECTED",
+		"known@example.test", "signals: is_from_me,manual", "sent: 2", "received: 1",
+		"*@example.test", "wildcard address", "Applied 1 identity confirmation(s).",
+	} {
+		assert.Contains(t, text, want)
+	}
+}
+
+func TestRenderIdentityDiscoverHumanShowsProviderStates(t *testing.T) {
+	var result identityops.DiscoverResult
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"account":"primary@example.test",
+		"source_id":14,
+		"source_type":"imap",
+		"candidates":[{
+			"identifier":"alias@example.test",
+			"normalized_identifier":"alias@example.test",
+			"classification":"strong",
+			"signals":["provider-alias"],
+			"provider_states":["disabled","enabled"]
+		}],
+		"rejected":[],
+		"applied":[]
+	}`), &result))
+
+	var out bytes.Buffer
+	require.NoError(t, renderIdentityDiscover(&out, result, false))
+	assert.Contains(t, out.String(), "provider states: disabled,enabled")
+}
+
+func TestRenderIdentityDiscoverProgressWritesHumanProgress(t *testing.T) {
+	var out bytes.Buffer
+
+	require.NoError(t, renderIdentityDiscoverProgress(&out, identityops.DiscoverProgress{
+		Done: 2, Total: 5, Candidates: 3,
+	}))
+	assert.Equal(t, "Scanning identity evidence: 2/5 messages, 3 candidate(s)\n", out.String())
+}
+
+func TestRenderIdentityDiscoverProgressWrapsWriterError(t *testing.T) {
+	writeErr := errors.New("write progress")
+
+	err := renderIdentityDiscoverProgress(identityDiscoverFailingWriter{err: writeErr}, identityops.DiscoverProgress{})
+
+	require.ErrorIs(t, err, writeErr)
+	assert.ErrorContains(t, err, "render identity discovery progress")
+}
+
+func TestIdentityDiscoverProviderSourceIDApplyConfirmJSONUsesHTTPAndSuppressesProgress(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	dataDir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ping" {
+			daemon.NewPingHandler(daemon.PingHandlerOptions{Service: daemonService, Version: Version}).ServeHTTP(w, r)
+			return
+		}
+		assertions.Equal("/api/v1/cli/identities/discover", r.URL.Path)
+		var req identityops.DiscoverRequest
+		if !assertions.NoError(json.NewDecoder(r.Body).Decode(&req), "decode discovery request") {
+			http.Error(w, "bad discovery request", http.StatusBadRequest)
+			return
+		}
+		assertions.Equal(identityops.SourceSelector{SourceID: 14}, req.SourceSelector)
+		assertions.True(req.Apply)
+		assertions.True(req.Provider)
+		assertions.Equal([]string{"weak@example.test"}, req.Confirm)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		assertions.NoError(json.NewEncoder(w).Encode(identityops.DiscoverEvent{
+			Type: "progress", Progress: &identityops.DiscoverProgress{Done: 2, Total: 2, Candidates: 1},
+		}))
+		result := stableIdentityDiscoverResult()
+		assertions.NoError(json.NewEncoder(w).Encode(identityops.DiscoverEvent{Type: "result", Result: &result}))
+	}))
+	t.Cleanup(srv.Close)
+	writeStatsHTTPDaemonRuntime(t, dataDir, srv)
+
+	savedCfg := cfg
+	savedUseLocal := useLocal
+	savedSourceID := identityDiscoverSourceID
+	savedApply := identityDiscoverApply
+	savedProvider := identityDiscoverProvider
+	savedConfirm := append([]string(nil), identityDiscoverConfirm...)
+	savedJSON := identityDiscoverJSON
+	t.Cleanup(func() {
+		cfg = savedCfg
+		useLocal = savedUseLocal
+		identityDiscoverSourceID = savedSourceID
+		identityDiscoverApply = savedApply
+		identityDiscoverProvider = savedProvider
+		identityDiscoverConfirm = savedConfirm
+		identityDiscoverJSON = savedJSON
+		for _, name := range []string{"source-id", "apply", "provider", "confirm", "json"} {
+			identityDiscoverCmd.Flags().Lookup(name).Changed = false
+		}
+	})
+	cfg = &config.Config{
+		HomeDir: dataDir,
+		Data:    config.DataConfig{DataDir: dataDir},
+		Remote:  config.RemoteConfig{URL: "http://configured-daemonclient.invalid"},
+	}
+	useLocal = true
+
+	var stdout, stderr bytes.Buffer
+	root := newTestRootCmd()
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.AddCommand(identityCmd)
+	root.SetArgs([]string{
+		"identity", "discover", "--source-id", "14", "--apply", "--provider",
+		"--confirm", "weak@example.test", "--json",
+	})
+
+	requirements.NoError(root.Execute())
+	assertions.Empty(stderr.String(), "JSON mode suppresses progress")
+	var got identityops.DiscoverResult
+	requirements.NoError(json.Unmarshal(stdout.Bytes(), &got))
+	assertions.Equal(stableIdentityDiscoverResult(), got)
+}
+
+func TestIdentityDiscoverRejectsExplicitZeroSourceID(t *testing.T) {
+	savedSourceID := identityDiscoverSourceID
+	t.Cleanup(func() { identityDiscoverSourceID = savedSourceID })
+	cmd := &cobra.Command{Use: "discover [account]", Args: identityDiscoverArgs}
+	cmd.Flags().Int64Var(&identityDiscoverSourceID, "source-id", 0, "")
+	require.NoError(t, cmd.Flags().Set("source-id", "0"))
+
+	err := identityDiscoverArgs(cmd, nil)
+	if err == nil {
+		_, err = identitySourceSelector(cmd, "", identityDiscoverSourceID)
+	}
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "source ID must be positive")
+}
+
+func TestIdentityDiscoverRejectsAccountWithSourceID(t *testing.T) {
+	cmd := &cobra.Command{Use: "discover [account]", Args: identityDiscoverArgs}
+	var sourceID int64
+	cmd.Flags().Int64Var(&sourceID, "source-id", 0, "")
+	require.NoError(t, cmd.Flags().Set("source-id", "14"))
+
+	err := identityDiscoverArgs(cmd, []string{"primary@example.test"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestIdentityDiscoverPositionalAccountCompatibility(t *testing.T) {
+	cmd := &cobra.Command{Use: "discover [account]", Args: identityDiscoverArgs}
+	var sourceID int64
+	cmd.Flags().Int64Var(&sourceID, "source-id", 0, "")
+
+	require.NoError(t, identityDiscoverArgs(cmd, []string{"primary@example.test"}))
+	selector, err := identitySourceSelector(cmd, "primary@example.test", sourceID)
+	require.NoError(t, err)
+	assert.Equal(t, daemonclient.CLIIdentitySourceSelector{Account: "primary@example.test"}, selector)
+}
+
+func TestIdentityImportRequiresExactlyOneInputSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		file      string
+		stdin     bool
+		wantError string
+	}{
+		{name: "neither", wantError: "exactly one of --file or --stdin"},
+		{name: "both", file: "aliases.txt", stdin: true, wantError: "exactly one of --file or --stdin"},
+		{name: "dash file", file: "-", wantError: `--file "-" is not supported`},
+		{name: "file", file: "aliases.txt"},
+		{name: "stdin", stdin: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			savedFile, savedStdin := identityImportFile, identityImportStdin
+			t.Cleanup(func() {
+				identityImportFile, identityImportStdin = savedFile, savedStdin
+			})
+			identityImportFile, identityImportStdin = test.file, test.stdin
+			cmd := &cobra.Command{Use: "import [account]"}
+			cmd.Flags().String("file", "", "")
+			cmd.Flags().Bool("stdin", false, "")
+			if test.file != "" {
+				requirements.NoError(cmd.Flags().Set("file", test.file))
+			}
+			if test.stdin {
+				requirements.NoError(cmd.Flags().Set("stdin", "true"))
+			}
+
+			err := identityImportArgs(cmd, []string{"primary@example.test"})
+			if test.wantError == "" {
+				requirements.NoError(err)
+				return
+			}
+			requirements.Error(err)
+			assertions.ErrorContains(err, test.wantError)
+		})
+	}
+}
+
+func TestIdentityImportStdinPreviewShowsHumanStates(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st, root, stdout, stderr := newIdentityCLITest(t)
+	_, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	root.SetIn(strings.NewReader(`{
+		"identities":[
+			{"identifier":"old@example.test","state":"disabled"},
+			{"identifier":"waiting@example.test","state":"pending"}
+		]
+	}`))
+	root.SetArgs([]string{"identity", "import", "primary@example.test", "--stdin"})
+
+	requirements.NoError(root.Execute())
+	assertions.Empty(stderr.String())
+	text := stdout.String()
+	assertions.Contains(text, "Identity import for primary@example.test")
+	assertions.Contains(text, "old@example.test")
+	assertions.Contains(text, "states: disabled")
+	assertions.Contains(text, "waiting@example.test")
+	assertions.Contains(text, "states: pending")
+	assertions.Contains(text, "Applied 0 identity confirmation(s).")
+}
+
+func TestIdentityImportRejectsExplicitZeroSourceID(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	savedSourceID, savedFile, savedStdin := identityImportSourceID, identityImportFile, identityImportStdin
+	t.Cleanup(func() {
+		identityImportSourceID, identityImportFile, identityImportStdin = savedSourceID, savedFile, savedStdin
+	})
+	identityImportStdin = false
+	cmd := &cobra.Command{Use: "import [account]", Args: identityImportArgs}
+	cmd.Flags().Int64Var(&identityImportSourceID, "source-id", 0, "")
+	cmd.Flags().StringVar(&identityImportFile, "file", "", "")
+	cmd.Flags().Bool("stdin", false, "")
+	requirements.NoError(cmd.Flags().Set("source-id", "0"))
+	requirements.NoError(cmd.Flags().Set("file", "aliases.txt"))
+
+	err := identityImportArgs(cmd, nil)
+	if err == nil {
+		_, err = identitySourceSelector(cmd, "", identityImportSourceID)
+	}
+
+	requirements.Error(err)
+	assertions.ErrorContains(err, "source ID must be positive")
+}
+
+func TestIdentityImportJSONFileApplyUsesSourceIDAndStableOutput(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st, root, stdout, stderr := newIdentityCLITest(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	inputFile := filepath.Join(t.TempDir(), "aliases")
+	requirements.NoError(os.WriteFile(inputFile, []byte(`[
+		{"identifier":"Waiting@Example.test","state":"pending"},
+		{"identifier":"active@example.test","state":"enabled"}
+	]`), 0o600))
+	root.SetArgs([]string{
+		"identity", "import", "--source-id", strconv.FormatInt(source.ID, 10),
+		"--file", inputFile, "--signal", "bulk-import", "--apply", "--json",
+	})
+
+	requirements.NoError(root.Execute())
+	assertions.Empty(stderr.String())
+	var result identityops.ImportResult
+	requirements.NoError(json.Unmarshal(stdout.Bytes(), &result))
+	assertions.Equal("bulk-import", result.Signal)
+	assertions.Equal([]string{"active@example.test", "Waiting@Example.test"}, []string{
+		result.Candidates[0].Identifier,
+		result.Candidates[1].Identifier,
+	})
+	assertions.Equal([]store.IdentityConfirmationOutcome{
+		{Identifier: "active@example.test", Added: true, Signals: []string{"bulk-import"}},
+		{Identifier: "Waiting@Example.test", Added: true, Signals: []string{"bulk-import"}},
+	}, result.Applied)
+	assertions.Equal(1, strings.Count(strings.TrimSpace(stdout.String()), "\n{")+1,
+		"JSON mode emits one stable document")
+}
 
 // newIdentityCLITest creates an isolated store and test root command for
 // identity subcommand tests.  Returns (store, root, stdout buffer, stderr buffer).
@@ -38,6 +413,21 @@ func newIdentityCLITest(t *testing.T) (*store.Store, *cobra.Command, *bytes.Buff
 	savedListJSON := identityListJSON
 	savedShowJSON := identityShowJSON
 	savedAddSignal := identityAddSignal
+	savedListSourceID := identityListSourceID
+	savedShowSourceID := identityShowSourceID
+	savedAddSourceID := identityAddSourceID
+	savedRemoveSourceID := identityRemoveSourceID
+	savedDiscoverSourceID := identityDiscoverSourceID
+	savedDiscoverApply := identityDiscoverApply
+	savedDiscoverProvider := identityDiscoverProvider
+	savedDiscoverConfirm := append([]string(nil), identityDiscoverConfirm...)
+	savedDiscoverJSON := identityDiscoverJSON
+	savedImportSourceID := identityImportSourceID
+	savedImportFile := identityImportFile
+	savedImportStdin := identityImportStdin
+	savedImportSignal := identityImportSignal
+	savedImportApply := identityImportApply
+	savedImportJSON := identityImportJSON
 	savedUseLocal := useLocal
 	t.Cleanup(func() {
 		cfg = savedCfg
@@ -47,19 +437,45 @@ func newIdentityCLITest(t *testing.T) (*store.Store, *cobra.Command, *bytes.Buff
 		identityListJSON = savedListJSON
 		identityShowJSON = savedShowJSON
 		identityAddSignal = savedAddSignal
+		identityListSourceID = savedListSourceID
+		identityShowSourceID = savedShowSourceID
+		identityAddSourceID = savedAddSourceID
+		identityRemoveSourceID = savedRemoveSourceID
+		identityDiscoverSourceID = savedDiscoverSourceID
+		identityDiscoverApply = savedDiscoverApply
+		identityDiscoverProvider = savedDiscoverProvider
+		identityDiscoverConfirm = savedDiscoverConfirm
+		identityDiscoverJSON = savedDiscoverJSON
+		identityImportSourceID = savedImportSourceID
+		identityImportFile = savedImportFile
+		identityImportStdin = savedImportStdin
+		identityImportSignal = savedImportSignal
+		identityImportApply = savedImportApply
+		identityImportJSON = savedImportJSON
 		useLocal = savedUseLocal
 		// Reset cobra's "Changed" state so mutually-exclusive flag groups
 		// don't carry over between tests that share the package-level command.
-		for _, name := range []string{"account", "collection", "json"} {
+		for _, name := range []string{"account", "collection", "source-id", "json"} {
 			if f := identityListCmd.Flags().Lookup(name); f != nil {
 				f.Changed = false
 			}
 		}
-		if f := identityShowCmd.Flags().Lookup("json"); f != nil {
-			f.Changed = false
+		for _, cmd := range []*cobra.Command{identityShowCmd, identityAddCmd, identityRemoveCmd} {
+			for _, name := range []string{"source-id", "json", "signal"} {
+				if f := cmd.Flags().Lookup(name); f != nil {
+					f.Changed = false
+				}
+			}
 		}
-		if f := identityAddCmd.Flags().Lookup("signal"); f != nil {
-			f.Changed = false
+		for _, name := range []string{"source-id", "apply", "provider", "confirm", "json"} {
+			if f := identityDiscoverCmd.Flags().Lookup(name); f != nil {
+				f.Changed = false
+			}
+		}
+		for _, name := range []string{"source-id", "file", "stdin", "signal", "apply", "json"} {
+			if f := identityImportCmd.Flags().Lookup(name); f != nil {
+				f.Changed = false
+			}
 		}
 	})
 
@@ -377,6 +793,18 @@ func TestIdentityList_AccountFilter(t *testing.T) {
 	assert.NotContains(t, text, "bob@example.com", "bob leaked into account-filtered output")
 }
 
+func TestIdentityList_RejectsExplicitZeroSourceID(t *testing.T) {
+	s, root, _, _ := newIdentityCLITest(t)
+	_, err := s.GetOrCreateSource("gmail", "alice@example.com")
+	require.NoError(t, err)
+
+	root.SetArgs([]string{"identity", "list", "--source-id", "0"})
+	err = root.Execute()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "source ID must be positive")
+}
+
 func TestIdentityList_AccountWithNoneRow(t *testing.T) {
 	s, root, out, _ := newIdentityCLITest(t)
 	_, _ = s.GetOrCreateSource("mbox", "old-mbox-2018")
@@ -443,6 +871,24 @@ func TestIdentityShow_Empty(t *testing.T) {
 	assert.Contains(t, text, "identity add", "missing hint")
 }
 
+func TestIdentityShow_SourceIDDisambiguatesDuplicateAccounts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	s, root, out, _ := newIdentityCLITest(t)
+	gmail, err := s.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	imap, err := s.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+	require.NoError(s.AddAccountIdentity(gmail.ID, "gmail-alias@example.test", "manual"))
+	require.NoError(s.AddAccountIdentity(imap.ID, "imap-alias@example.test", "manual"))
+
+	root.SetArgs([]string{"identity", "show", "--source-id", strconv.FormatInt(gmail.ID, 10)})
+	require.NoError(root.Execute())
+
+	assert.Contains(out.String(), "gmail-alias@example.test")
+	assert.NotContains(out.String(), "imap-alias@example.test")
+}
+
 func TestIdentityShow_UnknownAccount(t *testing.T) {
 	_, root, _, _ := newIdentityCLITest(t) //nolint:dogsled // helper returns 4 values; test needs only root
 	root.SetArgs([]string{"identity", "show", "ghost@example.com"})
@@ -488,6 +934,43 @@ func TestIdentityAdd_FirstTime(t *testing.T) {
 	root.SetArgs([]string{"identity", "add", "alice@example.com", "extra@example.com"})
 	require.NoError(t, root.Execute())
 	assert.Contains(t, out.String(), "Added extra@example.com", "missing add confirmation")
+}
+
+func TestIdentityAdd_SourceIDDisambiguatesDuplicateAccounts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	s, root, _, _ := newIdentityCLITest(t)
+	gmail, err := s.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	imap, err := s.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+
+	root.SetArgs([]string{
+		"identity", "add", "--source-id", strconv.FormatInt(gmail.ID, 10), "alias@example.test",
+	})
+	require.NoError(root.Execute())
+
+	gmailIdentities, err := s.ListAccountIdentities(gmail.ID)
+	require.NoError(err)
+	assert.Len(gmailIdentities, 1)
+	assert.Equal("alias@example.test", gmailIdentities[0].Address)
+	imapIdentities, err := s.ListAccountIdentities(imap.ID)
+	require.NoError(err)
+	assert.Empty(imapIdentities)
+}
+
+func TestIdentityAdd_RejectsAccountWithSourceID(t *testing.T) {
+	s, root, _, _ := newIdentityCLITest(t)
+	source, err := s.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(t, err)
+
+	root.SetArgs([]string{
+		"identity", "add", "--source-id", strconv.FormatInt(source.ID, 10),
+		"shared@example.test", "alias@example.test",
+	})
+	err = root.Execute()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "mutually exclusive")
 }
 
 func TestIdentityAdd_IdempotentSameSignal(t *testing.T) {
@@ -550,6 +1033,31 @@ func TestIdentityRemove_Hit(t *testing.T) {
 	root.SetArgs([]string{"identity", "remove", "alice@example.com", "extra@example.com"})
 	require.NoError(t, root.Execute())
 	assert.Contains(t, out.String(), "Removed extra@example.com", "missing remove confirmation")
+}
+
+func TestIdentityRemove_SourceIDDisambiguatesDuplicateAccounts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	s, root, _, _ := newIdentityCLITest(t)
+	gmail, err := s.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	imap, err := s.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+	require.NoError(s.AddAccountIdentity(gmail.ID, "shared-alias@example.test", "manual"))
+	require.NoError(s.AddAccountIdentity(imap.ID, "shared-alias@example.test", "manual"))
+
+	root.SetArgs([]string{
+		"identity", "remove", "--source-id", strconv.FormatInt(gmail.ID, 10), "shared-alias@example.test",
+	})
+	require.NoError(root.Execute())
+
+	gmailIdentities, err := s.ListAccountIdentities(gmail.ID)
+	require.NoError(err)
+	assert.Empty(gmailIdentities)
+	imapIdentities, err := s.ListAccountIdentities(imap.ID)
+	require.NoError(err)
+	require.Len(imapIdentities, 1)
+	assert.Equal("shared-alias@example.test", imapIdentities[0].Address)
 }
 
 func TestIdentityRemove_Miss(t *testing.T) {

--- a/cmd/msgvault/cmd/openapi.go
+++ b/cmd/msgvault/cmd/openapi.go
@@ -37,7 +37,7 @@ func renderOpenAPI(version, format string) ([]byte, error) {
 	switch format {
 	case "yaml", "yml":
 		return api.OpenAPIYAMLVersion(version)
-	case "json":
+	case flagJSON:
 		return api.OpenAPIJSONVersion(version)
 	default:
 		return nil, fmt.Errorf("unsupported openapi format %q", format)

--- a/cmd/msgvault/cmd/provider_identity_refresh.go
+++ b/cmd/msgvault/cmd/provider_identity_refresh.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"context"
+
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/provideridentity"
+	"go.kenn.io/msgvault/internal/store"
+	msgsync "go.kenn.io/msgvault/internal/sync"
+)
+
+var fastmailIdentityInventoryFactory provideridentity.Factory = provideridentity.NewFastmailInventory
+
+func newMessageSyncer(client gmail.API, st *store.Store, opts *msgsync.Options) *msgsync.Syncer {
+	return withAutomaticProviderIdentityRefresh(msgsync.New(client, st, opts), st)
+}
+
+func withAutomaticProviderIdentityRefresh(syncer *msgsync.Syncer, st *store.Store) *msgsync.Syncer {
+	return syncer.WithSuccessfulSyncHook(
+		"provider identity refresh",
+		func(ctx context.Context, source *store.Source, mailboxChanged bool) error {
+			// A run that saw mailbox change always refreshes; a no-op run
+			// refreshes only when one is owed, so frequent scheduled no-op
+			// syncs do not each cost a provider round trip.
+			refresh := provideridentity.AutoRefresh
+			if !mailboxChanged {
+				refresh = provideridentity.AutoRefreshIfDue
+			}
+			_, _, err := refresh(
+				ctx,
+				cfg,
+				st,
+				source.ID,
+				fastmailIdentityInventoryFactory,
+			)
+			return err
+		},
+	)
+}

--- a/cmd/msgvault/cmd/provider_identity_refresh_test.go
+++ b/cmd/msgvault/cmd/provider_identity_refresh_test.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/fastmail"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/provideridentity"
+	"go.kenn.io/msgvault/internal/store"
+	msgsync "go.kenn.io/msgvault/internal/sync"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type scheduledProviderInventory struct {
+	records []fastmail.Record
+	calls   int
+}
+
+func (i *scheduledProviderInventory) ListIdentityRecords(context.Context) ([]fastmail.Record, error) {
+	i.calls++
+	return append([]fastmail.Record(nil), i.records...), nil
+}
+
+func TestAutomaticProviderIdentityRefreshIsOptInAndRunsAfterIMAPCompletion(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	const sourceIdentifier = "imaps://user@example.test@imap.example.test:993"
+	source, err := st.GetOrCreateSource(sourceTypeIMAP, sourceIdentifier)
+	require.NoError(t, err)
+
+	savedCfg := cfg
+	savedFactory := fastmailIdentityInventoryFactory
+	t.Cleanup(func() {
+		cfg = savedCfg
+		fastmailIdentityInventoryFactory = savedFactory
+	})
+
+	t.Run("default off", func(t *testing.T) {
+		assertions := assert.New(t)
+		requirements := require.New(t)
+		cfg = &config.Config{Fastmail: []config.FastmailSource{{
+			SourceID: source.ID, APIToken: "not-called-token",
+		}}}
+		calls := 0
+		fastmailIdentityInventoryFactory = func(string) provideridentity.Inventory {
+			calls++
+			return &scheduledProviderInventory{}
+		}
+
+		summary := runAutomaticProviderSync(t, st, sourceIdentifier)
+
+		requirements.NotNil(summary)
+		assertions.Zero(calls)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		assertions := assert.New(t)
+		requirements := require.New(t)
+		cfg = &config.Config{Fastmail: []config.FastmailSource{{
+			SourceID: source.ID, APIToken: "provider-token", AutoConfirmIdentities: true,
+		}}}
+		fastmailIdentityInventoryFactory = func(string) provideridentity.Inventory {
+			return &scheduledProviderInventory{records: []fastmail.Record{
+				{Identifier: "old@example.test", State: "disabled", Kind: "masked-email"},
+				{Identifier: "waiting@example.test", State: "pending", Kind: "masked-email"},
+			}}
+		}
+
+		summary := runAutomaticProviderSync(t, st, sourceIdentifier)
+
+		requirements.NotNil(summary)
+		identities, err := st.ListAccountIdentities(source.ID)
+		requirements.NoError(err)
+		requirements.Len(identities, 1)
+		assertions.Equal("old@example.test", identities[0].Address)
+		assertions.Equal("provider-alias", identities[0].SourceSignal)
+	})
+}
+
+// setUpScheduledProviderIdentityRefresh wires the opt-in automatic refresh for a
+// Gmail source whose cursor sits at history 100, and returns the inventory the
+// post-completion hook would reach for.
+func setUpScheduledProviderIdentityRefresh(
+	t *testing.T,
+	st *store.Store,
+) (*store.Source, *scheduledProviderInventory) {
+	t.Helper()
+	const sourceIdentifier = "gmail-user@example.test"
+	source, err := st.GetOrCreateSource(sourceTypeGmail, sourceIdentifier)
+	require.NoError(t, err)
+	require.NoError(t, st.UpdateSourceSyncCursor(source.ID, "100"))
+	source.SyncCursor = sql.NullString{String: "100", Valid: true}
+
+	savedCfg := cfg
+	savedFactory := fastmailIdentityInventoryFactory
+	t.Cleanup(func() {
+		cfg = savedCfg
+		fastmailIdentityInventoryFactory = savedFactory
+	})
+	cfg = &config.Config{Fastmail: []config.FastmailSource{{
+		SourceID: source.ID, APIToken: "provider-token", AutoConfirmIdentities: true,
+	}}}
+	inventory := &scheduledProviderInventory{records: []fastmail.Record{{
+		Identifier: "historical@example.test", State: "deleted", Kind: "masked-email",
+	}}}
+	fastmailIdentityInventoryFactory = func(string) provideridentity.Inventory {
+		return inventory
+	}
+	return source, inventory
+}
+
+// runNoOpIncrementalProviderSync drives one incremental sync whose cursor
+// already equals the mailbox's current history, so the run is a no-op.
+func runNoOpIncrementalProviderSync(
+	t *testing.T,
+	st *store.Store,
+	source *store.Source,
+) *gmail.SyncSummary {
+	t.Helper()
+	client := gmail.NewMockAPI()
+	client.Profile = &gmail.Profile{EmailAddress: source.Identifier, HistoryID: 100}
+	options := msgsync.DefaultOptions()
+	syncer := newMessageSyncer(client, st, options).WithLogger(slog.New(slog.DiscardHandler))
+	summary, err := syncer.Incremental(t.Context(), source)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	return summary
+}
+
+// TestAutomaticProviderIdentityRefreshSkipsProviderInventoryOnNoOpIncrementalSync
+// pins the cost side of the automatic refresh: scheduled incremental syncs run
+// often and are usually no-ops, and a source whose inventory was refreshed
+// recently must not spend a provider round trip on each of them.
+func TestAutomaticProviderIdentityRefreshSkipsProviderInventoryOnNoOpIncrementalSync(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, inventory := setUpScheduledProviderIdentityRefresh(t, st)
+	requirements.NoError(st.RecordProviderIdentityRefreshOutcomeContext(t.Context(), source.ID, nil),
+		"the previous refresh succeeded recently")
+
+	runNoOpIncrementalProviderSync(t, st, source)
+
+	assertions.Zero(inventory.calls,
+		"an unchanged mailbox with a fresh inventory must not cost a provider round trip")
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	assertions.Empty(identities)
+}
+
+// TestAutomaticProviderIdentityRefreshRunsOnNoOpIncrementalSyncWhenNeverRefreshed
+// pins the coverage side: enabling auto_confirm_identities on an idle mailbox
+// must take effect on the next scheduled sync, not wait for unrelated mail.
+func TestAutomaticProviderIdentityRefreshRunsOnNoOpIncrementalSyncWhenNeverRefreshed(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, inventory := setUpScheduledProviderIdentityRefresh(t, st)
+
+	runNoOpIncrementalProviderSync(t, st, source)
+
+	assertions.Equal(1, inventory.calls,
+		"a source that has never refreshed owes an inventory read even without mailbox history")
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	requirements.Len(identities, 1)
+	assertions.Equal("historical@example.test", identities[0].Address)
+
+	runNoOpIncrementalProviderSync(t, st, source)
+
+	assertions.Equal(1, inventory.calls,
+		"the successful refresh is recorded, so the next no-op sync skips the provider")
+}
+
+// TestAutomaticProviderIdentityRefreshRetriesOnNoOpIncrementalSyncAfterFailure
+// pins failure recovery: a transient provider failure must be retried by the
+// next scheduled sync even when the mailbox itself has not moved.
+func TestAutomaticProviderIdentityRefreshRetriesOnNoOpIncrementalSyncAfterFailure(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, inventory := setUpScheduledProviderIdentityRefresh(t, st)
+	requirements.NoError(st.RecordProviderIdentityRefreshOutcomeContext(
+		t.Context(), source.ID, errors.New("provider unavailable"),
+	), "the previous refresh failed")
+
+	runNoOpIncrementalProviderSync(t, st, source)
+
+	assertions.Equal(1, inventory.calls,
+		"a failed refresh owes a retry on the next sync, no-op or not")
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	requirements.Len(identities, 1)
+	assertions.Equal("historical@example.test", identities[0].Address)
+}
+
+func TestAutomaticProviderIdentityRefreshRunsAfterIncrementalGmailCompletion(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, inventory := setUpScheduledProviderIdentityRefresh(t, st)
+
+	client := gmail.NewMockAPI()
+	client.Profile = &gmail.Profile{EmailAddress: source.Identifier, HistoryID: 200}
+	client.HistoryID = 200
+	options := msgsync.DefaultOptions()
+	syncer := newMessageSyncer(client, st, options).WithLogger(slog.New(slog.DiscardHandler))
+
+	summary, err := syncer.Incremental(t.Context(), source)
+
+	requirements.NoError(err)
+	requirements.NotNil(summary)
+	assertions.Equal(1, inventory.calls, "advanced history refreshes the provider inventory")
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	requirements.Len(identities, 1)
+	assertions.Equal("historical@example.test", identities[0].Address)
+	assertions.Equal("provider-alias", identities[0].SourceSignal)
+}
+
+func runAutomaticProviderSync(
+	t *testing.T,
+	st *store.Store,
+	sourceIdentifier string,
+) *gmail.SyncSummary {
+	t.Helper()
+	client := gmail.NewMockAPI()
+	client.Profile = &gmail.Profile{EmailAddress: "user@example.test", HistoryID: 100}
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	syncer := newMessageSyncer(client, st, options).WithLogger(slog.New(slog.DiscardHandler))
+	summary, err := syncer.Full(t.Context(), sourceIdentifier)
+	require.NoError(t, err)
+	return summary
+}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -871,6 +871,7 @@ type storeAPIAdapter struct {
 
 var _ api.MessageStore = (*storeAPIAdapter)(nil)
 var _ api.CtxMessageStore = (*storeAPIAdapter)(nil)
+var _ api.MessageIdentityStore = (*storeAPIAdapter)(nil)
 var _ api.MeetingImporter = (*storeAPIAdapter)(nil)
 var _ api.SourceStatusStore = (*storeAPIAdapter)(nil)
 var _ api.CLIStore = (*storeAPIAdapter)(nil)
@@ -1575,6 +1576,21 @@ func (a *storeAPIAdapter) ListAccountIdentitiesContext(
 	return a.store.ListAccountIdentitiesContext(ctx, sourceID)
 }
 
+func (a *storeAPIAdapter) ResolveAccountIdentityContext(
+	ctx context.Context,
+	sourceID int64,
+	identifier string,
+) (store.ResolvedAccountIdentity, error) {
+	return a.store.ResolveAccountIdentityContext(ctx, sourceID, identifier)
+}
+
+func (a *storeAPIAdapter) MatchMessageIdentitiesContext(
+	ctx context.Context,
+	messageIDs []int64,
+) (map[int64]store.MessageIdentityMatch, error) {
+	return a.store.MatchMessageIdentitiesContext(ctx, messageIDs)
+}
+
 func (a *storeAPIAdapter) AddAccountIdentity(sourceID int64, address, signal string) error {
 	return a.store.AddAccountIdentity(sourceID, address, signal)
 }
@@ -1597,6 +1613,45 @@ func (a *storeAPIAdapter) RemoveAccountIdentityContext(
 	address string,
 ) (int64, error) {
 	return a.store.RemoveAccountIdentityContext(ctx, sourceID, address)
+}
+
+func (a *storeAPIAdapter) CountIdentityDiscoveryMessagesContext(
+	ctx context.Context,
+	sourceID int64,
+) (int64, error) {
+	return a.store.CountIdentityDiscoveryMessagesContext(ctx, sourceID)
+}
+
+func (a *storeAPIAdapter) ScanIdentityDiscoveryPageContext(
+	ctx context.Context,
+	sourceID, afterID int64,
+	limit int,
+) (store.IdentityDiscoveryPage, error) {
+	return a.store.ScanIdentityDiscoveryPageContext(ctx, sourceID, afterID, limit)
+}
+
+func (a *storeAPIAdapter) ScanIdentityObservationsForSourceMessageIDsContext(
+	ctx context.Context,
+	sourceID int64,
+	sourceMessageIDs []string,
+) ([]store.IdentityObservation, error) {
+	return a.store.ScanIdentityObservationsForSourceMessageIDsContext(ctx, sourceID, sourceMessageIDs)
+}
+
+func (a *storeAPIAdapter) AddAccountIdentitiesBatchContext(
+	ctx context.Context,
+	sourceID int64,
+	candidates []store.IdentityConfirmation,
+) ([]store.IdentityConfirmationOutcome, error) {
+	return a.store.AddAccountIdentitiesBatchContext(ctx, sourceID, candidates)
+}
+
+func (a *storeAPIAdapter) MergeConfirmedAccountIdentitySignalsContext(
+	ctx context.Context,
+	sourceID int64,
+	candidates []store.IdentityConfirmation,
+) ([]store.IdentityConfirmationOutcome, error) {
+	return a.store.MergeConfirmedAccountIdentitySignalsContext(ctx, sourceID, candidates)
 }
 
 func (a *storeAPIAdapter) LinkParticipants(participantA, participantB int64) (int64, error) {
@@ -1998,7 +2053,7 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 	opts := sync.DefaultOptions()
 	opts.AttachmentsDir = cfg.AttachmentsDir()
 
-	syncer := sync.New(client, s, opts).WithLogger(logger)
+	syncer := newMessageSyncer(client, s, opts).WithLogger(logger)
 
 	source, err := s.GetOrCreateSource(sourceTypeGmail, email)
 	if err != nil {
@@ -2052,7 +2107,7 @@ func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store
 	opts.AttachmentsDir = cfg.AttachmentsDir()
 	opts.NoResume = true
 
-	syncer := sync.New(apiClient, s, opts).WithLogger(logger)
+	syncer := newMessageSyncer(apiClient, s, opts).WithLogger(logger)
 
 	// runPostSourceCreateMigrations is keyed off Gmail-only legacy
 	// state, so it's a no-op for fresh IMAP installs; we still call it

--- a/cmd/msgvault/cmd/store_adapter_test.go
+++ b/cmd/msgvault/cmd/store_adapter_test.go
@@ -46,7 +46,42 @@ func TestStoreAPIAdapterServesAttributeDefinitions(t *testing.T) {
 }
 
 var _ api.CtxMessageStore = (*storeAPIAdapter)(nil)
+var _ api.MessageIdentityStore = (*storeAPIAdapter)(nil)
 var _ api.MeetingImporter = (*storeAPIAdapter)(nil)
+
+func TestStoreAPIAdapterPassesThroughMessageIdentityOperations(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversation(source.ID, "thread-identity", "Identity")
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID:  conversationID,
+		SourceID:        source.ID,
+		SourceMessageID: "message-identity",
+		MessageType:     "email",
+	})
+	require.NoError(err)
+	participantID, err := st.EnsureParticipant("masked-shop@example.test", "Masked", "example.test")
+	require.NoError(err)
+	require.NoError(st.ReplaceMessageRecipients(
+		messageID, "to", []int64{participantID}, []string{"Masked"},
+	))
+	require.NoError(st.AddAccountIdentity(source.ID, "Masked-Shop@Example.test", "manual"))
+
+	adapter := &storeAPIAdapter{store: st}
+	resolved, err := adapter.ResolveAccountIdentityContext(
+		t.Context(), source.ID, "masked-shop@example.test",
+	)
+	require.NoError(err)
+	require.Equal("Masked-Shop@Example.test", resolved.Identifier)
+	require.Equal([]int64{participantID}, resolved.ParticipantIDs)
+
+	matches, err := adapter.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	require.Equal([]string{"Masked-Shop@Example.test"}, matches[messageID].Recipients)
+}
 
 type scopedStatsProductionAdapter struct {
 	*storeAPIAdapter

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -255,7 +255,7 @@ func runIncrementalSync(ctx context.Context, s *store.Store, getOAuthMgr func(st
 	opts.AttachmentsDir = cfg.AttachmentsDir()
 
 	// Create syncer with progress reporter
-	syncer := sync.New(client, s, opts).
+	syncer := newMessageSyncer(client, s, opts).
 		WithLogger(logger).
 		WithProgress(&CLIProgress{})
 

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -482,7 +482,7 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	}
 
 	// Create syncer with progress reporter
-	syncer := sync.New(apiClient, s, opts).
+	syncer := newMessageSyncer(apiClient, s, opts).
 		WithLogger(logger).
 		WithProgress(progress)
 

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -19,10 +19,12 @@ import (
 	"go.kenn.io/msgvault/internal/cacheops"
 	"go.kenn.io/msgvault/internal/clirun"
 	"go.kenn.io/msgvault/internal/collectionops"
+	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/deletion"
 	msgexport "go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/identityops"
 	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/provideridentity"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/store"
@@ -86,6 +88,27 @@ type ContextCLIStore interface {
 	ListAccountIdentitiesContext(ctx context.Context, sourceID int64) ([]store.AccountIdentity, error)
 	AddAccountIdentityContext(ctx context.Context, sourceID int64, address, signal string) error
 	RemoveAccountIdentityContext(ctx context.Context, sourceID int64, address string) (int64, error)
+	CountIdentityDiscoveryMessagesContext(ctx context.Context, sourceID int64) (int64, error)
+	ScanIdentityDiscoveryPageContext(
+		ctx context.Context,
+		sourceID, afterID int64,
+		limit int,
+	) (store.IdentityDiscoveryPage, error)
+	ScanIdentityObservationsForSourceMessageIDsContext(
+		ctx context.Context,
+		sourceID int64,
+		sourceMessageIDs []string,
+	) ([]store.IdentityObservation, error)
+	AddAccountIdentitiesBatchContext(
+		ctx context.Context,
+		sourceID int64,
+		candidates []store.IdentityConfirmation,
+	) ([]store.IdentityConfirmationOutcome, error)
+	MergeConfirmedAccountIdentitySignalsContext(
+		ctx context.Context,
+		sourceID int64,
+		candidates []store.IdentityConfirmation,
+	) ([]store.IdentityConfirmationOutcome, error)
 	CountMessagesForSourceContext(ctx context.Context, sourceID int64) (int64, error)
 	CountSourceDeletedMessagesContext(ctx context.Context, sourceIDs ...int64) (int64, error)
 	NeedsFTSBackfillQuickContext(ctx context.Context) bool
@@ -180,6 +203,49 @@ func (s *requestCLIStore) AddAccountIdentity(sourceID int64, address, signal str
 
 func (s *requestCLIStore) RemoveAccountIdentity(sourceID int64, address string) (int64, error) {
 	return s.contextStore.RemoveAccountIdentityContext(s.ctx, sourceID, address)
+}
+
+func (s *requestCLIStore) CountIdentityDiscoveryMessagesContext(
+	_ context.Context,
+	sourceID int64,
+) (int64, error) {
+	return s.contextStore.CountIdentityDiscoveryMessagesContext(s.ctx, sourceID)
+}
+
+func (s *requestCLIStore) ScanIdentityDiscoveryPageContext(
+	_ context.Context,
+	sourceID, afterID int64,
+	limit int,
+) (store.IdentityDiscoveryPage, error) {
+	return s.contextStore.ScanIdentityDiscoveryPageContext(s.ctx, sourceID, afterID, limit)
+}
+
+func (s *requestCLIStore) ScanIdentityObservationsForSourceMessageIDsContext(
+	_ context.Context,
+	sourceID int64,
+	sourceMessageIDs []string,
+) ([]store.IdentityObservation, error) {
+	return s.contextStore.ScanIdentityObservationsForSourceMessageIDsContext(
+		s.ctx,
+		sourceID,
+		sourceMessageIDs,
+	)
+}
+
+func (s *requestCLIStore) AddAccountIdentitiesBatchContext(
+	_ context.Context,
+	sourceID int64,
+	candidates []store.IdentityConfirmation,
+) ([]store.IdentityConfirmationOutcome, error) {
+	return s.contextStore.AddAccountIdentitiesBatchContext(s.ctx, sourceID, candidates)
+}
+
+func (s *requestCLIStore) MergeConfirmedAccountIdentitySignalsContext(
+	_ context.Context,
+	sourceID int64,
+	candidates []store.IdentityConfirmation,
+) ([]store.IdentityConfirmationOutcome, error) {
+	return s.contextStore.MergeConfirmedAccountIdentitySignalsContext(s.ctx, sourceID, candidates)
 }
 
 func (s *requestCLIStore) CountMessagesForSource(sourceID int64) (int64, error) {
@@ -2098,6 +2164,8 @@ func (s *Server) getCLIIdentities(
 	ctx context.Context,
 	account string,
 	collection string,
+	sourceID int64,
+	sourceIDSet bool,
 	primaryOnly bool,
 ) (cliIdentitiesResponse, error) {
 	if s.store == nil {
@@ -2113,16 +2181,30 @@ func (s *Server) getCLIIdentities(
 	}
 	cliStore = bindCLIStoreContext(ctx, cliStore)
 
-	if account != "" && collection != "" {
+	if sourceIDSet && sourceID <= 0 {
 		return cliIdentitiesResponse{}, newAPIHTTPError(
 			http.StatusBadRequest,
 			"invalid_scope",
-			errMutuallyExclusiveScope.Error(),
+			"source ID must be positive",
+		)
+	}
+	if (account != "" && collection != "") ||
+		(sourceIDSet && (account != "" || collection != "")) {
+		return cliIdentitiesResponse{}, newAPIHTTPError(
+			http.StatusBadRequest,
+			"invalid_scope",
+			"account, collection, and source ID selectors are mutually exclusive",
 		)
 	}
 
 	var sourceIDs []int64
 	switch {
+	case sourceIDSet:
+		src, err := identityops.ResolveSource(cliStore, identityops.SourceSelector{SourceID: sourceID})
+		if err != nil {
+			return cliIdentitiesResponse{}, s.cliScopeError(err)
+		}
+		sourceIDs = []int64{src.ID}
 	case primaryOnly:
 		if account == "" || collection != "" {
 			return cliIdentitiesResponse{}, newAPIHTTPError(
@@ -2211,6 +2293,197 @@ func (s *Server) addCLIIdentity(ctx context.Context, req identityops.AddRequest)
 		result.CacheState = s.refreshIdentityCacheState(ctx)
 	}
 	return result, nil
+}
+
+func (s *Server) importCLIIdentities(
+	ctx context.Context,
+	req identityops.ImportRequest,
+) (identityops.ImportResult, error) {
+	cliStore, apiErr := s.cliStore()
+	if apiErr != nil {
+		return identityops.ImportResult{}, apiErr
+	}
+	discoveryStore, ok := bindCLIStoreContext(ctx, cliStore).(identityops.DiscoveryStore)
+	if !ok {
+		return identityops.ImportResult{}, cliStoreUnavailableError()
+	}
+
+	result, err := identityops.Import(ctx, discoveryStore, req)
+	if discoveryAddedIdentity(result.Applied) {
+		s.scheduleAccountIdentityCacheRebuild(ctx)
+	}
+	if err != nil {
+		return result, s.operationError(
+			err,
+			identityOperationErrorPolicy,
+			"Failed to import identities",
+		)
+	}
+	return result, nil
+}
+
+func (s *Server) handleCLIIdentityDiscover(w http.ResponseWriter, r *http.Request) {
+	decoder := json.NewDecoder(r.Body)
+	var rawBody json.RawMessage
+	if err := decoder.Decode(&rawBody); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON request body")
+		return
+	}
+	if !requireSingleJSONValue(w, decoder, "invalid_request") {
+		return
+	}
+	var req identityops.DiscoverRequest
+	if err := json.Unmarshal(rawBody, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON request body")
+		return
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rawBody, &fields); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON request body")
+		return
+	}
+	if _, sourceIDSet := fields["source_id"]; sourceIDSet && req.SourceID <= 0 {
+		writeAPIHTTPError(w, s.operationError(
+			opserr.Invalid(errors.New("source ID must be positive")),
+			identityOperationErrorPolicy,
+			"Failed to discover identities",
+		))
+		return
+	}
+
+	cliStore, apiErr := s.cliStore()
+	if apiErr != nil {
+		writeAPIHTTPError(w, apiErr)
+		return
+	}
+	discoveryStore, ok := bindCLIStoreContext(r.Context(), cliStore).(identityops.DiscoveryStore)
+	if !ok {
+		writeAPIHTTPError(w, cliStoreUnavailableError())
+		return
+	}
+
+	var externalEvidence []identityops.ExternalEvidence
+	if req.Provider {
+		source, resolveErr := identityops.ResolveSource(discoveryStore, req.SourceSelector)
+		if resolveErr != nil {
+			writeAPIHTTPError(w, s.operationError(
+				resolveErr,
+				identityOperationErrorPolicy,
+				"Failed to discover identities",
+			))
+			return
+		}
+		configured, configErr := s.cfg.FastmailSourceFor(cliStore, source.ID)
+		if configErr != nil {
+			wrappedConfigErr := fmt.Errorf("resolve [[fastmail]] configuration for source %d: %w", source.ID, configErr)
+			classifiedConfigErr := opserr.Invalid(wrappedConfigErr)
+			if errors.Is(configErr, config.ErrFastmailSourceLookup) {
+				classifiedConfigErr = opserr.Internal(wrappedConfigErr)
+			}
+			writeAPIHTTPError(w, s.operationError(
+				classifiedConfigErr,
+				identityOperationErrorPolicy,
+				"Failed to discover identities",
+			))
+			return
+		}
+		if configured == nil {
+			account := source.Identifier
+			if source.DisplayName.Valid && strings.TrimSpace(source.DisplayName.String) != "" {
+				account = strings.TrimSpace(source.DisplayName.String)
+			}
+			writeAPIHTTPError(w, s.operationError(
+				opserr.Invalid(fmt.Errorf(
+					"source %d (%s) has no matching [[fastmail]] configuration",
+					source.ID,
+					account,
+				)),
+				identityOperationErrorPolicy,
+				"Failed to discover identities",
+			))
+			return
+		}
+		inventory := s.fastmailInventoryFactory(configured.APIToken)
+		records, inventoryErr := inventory.ListIdentityRecords(r.Context())
+		if inventoryErr != nil {
+			writeAPIHTTPError(w, s.operationError(
+				opserr.Internal(fmt.Errorf("fastmail identity inventory request failed: %w", inventoryErr)),
+				identityOperationErrorPolicy,
+				"Failed to discover identities",
+			))
+			return
+		}
+		externalEvidence = provideridentity.Evidence(records)
+		req.SourceSelector = identityops.SourceSelector{SourceID: source.ID}
+	}
+
+	streamStarted := false
+	writeEvent := newCLINDJSONEventWriter[identityops.DiscoverEvent](w)
+	result, err := identityops.DiscoverWithExternalEvidence(r.Context(), discoveryStore, req, externalEvidence, func(progress identityops.DiscoverProgress) error {
+		streamStarted = true
+		return writeEvent(identityops.DiscoverEvent{Type: "progress", Progress: &progress})
+	})
+	if discoveryAddedIdentity(result.Applied) {
+		s.scheduleAccountIdentityCacheRebuild(r.Context())
+	}
+	if err != nil {
+		if !streamStarted {
+			if s.writeIfContextError(w, err) {
+				return
+			}
+			writeAPIHTTPError(w, s.operationError(
+				err,
+				identityOperationErrorPolicy,
+				"Failed to discover identities",
+			))
+			return
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || r.Context().Err() != nil {
+			return
+		}
+		terminalError := identityDiscoveryTerminalError(err)
+		s.logger.Info("CLI identity discovery stopped before completion", "error_code", terminalError.Code)
+		if writeErr := writeEvent(identityops.DiscoverEvent{Type: "error", Error: &terminalError}); writeErr != nil {
+			s.logger.Error("failed to stream CLI identity discovery error event", "error", writeErr)
+		}
+		return
+	}
+	if err := r.Context().Err(); err != nil {
+		s.logger.Info("CLI identity discovery canceled before result", "error", err)
+		return
+	}
+	if err := writeEvent(identityops.DiscoverEvent{Type: "result", Result: &result}); err != nil {
+		s.logger.Error("failed to stream CLI identity discovery result", "error", err)
+	}
+}
+
+func identityDiscoveryTerminalError(err error) identityops.DiscoverError {
+	switch opserr.KindOf(err) {
+	case opserr.KindInvalid:
+		return identityops.DiscoverError{
+			Code:    identityOperationErrorPolicy.InvalidCode,
+			Message: "Invalid identity discovery request",
+		}
+	case opserr.KindNotFound:
+		return identityops.DiscoverError{
+			Code:    identityOperationErrorPolicy.NotFoundCode,
+			Message: "Identity discovery target was not found",
+		}
+	default:
+		return identityops.DiscoverError{
+			Code:    "internal_error",
+			Message: "Failed to discover identities",
+		}
+	}
+}
+
+func discoveryAddedIdentity(outcomes []store.IdentityConfirmationOutcome) bool {
+	for _, outcome := range outcomes {
+		if outcome.Added {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) removeCLIIdentity(ctx context.Context, req identityops.RemoveRequest) (identityops.RemoveResult, error) {

--- a/internal/api/cli_identity_routes.go
+++ b/internal/api/cli_identity_routes.go
@@ -3,15 +3,34 @@ package api
 import (
 	"context"
 	"net/http"
+	"reflect"
 
 	"github.com/danielgtaylor/huma/v2"
 	"go.kenn.io/msgvault/internal/identityops"
 )
 
 type cliIdentityListInput struct {
-	Account     string `query:"account" doc:"Restrict to a single account"`
-	Collection  string `query:"collection" doc:"Restrict to all member accounts of one collection"`
-	PrimaryOnly bool   `query:"primary_only" doc:"For account scope, return only the primary source instead of related sources"`
+	Account     string                   `query:"account" doc:"Restrict to a single account"`
+	Collection  string                   `query:"collection" doc:"Restrict to all member accounts of one collection"`
+	SourceID    cliIdentitySourceIDParam `query:"source_id" doc:"Restrict to one source by numeric ID"`
+	PrimaryOnly bool                     `query:"primary_only" doc:"For account scope, return only the primary source instead of related sources"`
+}
+
+type cliIdentitySourceIDParam struct {
+	Value int64
+	IsSet bool
+}
+
+func (p *cliIdentitySourceIDParam) Schema(r huma.Registry) *huma.Schema {
+	return huma.SchemaFromType(r, reflect.TypeFor[int64]())
+}
+
+func (p *cliIdentitySourceIDParam) Receiver() reflect.Value {
+	return reflect.ValueOf(p).Elem().Field(0)
+}
+
+func (p *cliIdentitySourceIDParam) OnParamSet(isSet bool, _ any) {
+	p.IsSet = isSet
 }
 
 type cliIdentitiesOutput struct {
@@ -34,6 +53,14 @@ type cliIdentityRemoveOutput struct {
 	Body identityops.RemoveResult
 }
 
+type cliIdentityImportInput struct {
+	Body identityops.ImportRequest
+}
+
+type cliIdentityImportOutput struct {
+	Body identityops.ImportResult
+}
+
 func (s *Server) registerCLIIdentityHumaRoutes(api huma.API) {
 	huma.Register(api, withAPIKeySecurity(huma.Operation{
 		OperationID: "listCLIIdentities",
@@ -43,7 +70,9 @@ func (s *Server) registerCLIIdentityHumaRoutes(api huma.API) {
 		Summary:     "List confirmed account identities",
 		Errors:      []int{http.StatusBadRequest, http.StatusInternalServerError, http.StatusServiceUnavailable},
 	}), func(ctx context.Context, input *cliIdentityListInput) (*cliIdentitiesOutput, error) {
-		resp, err := s.getCLIIdentities(ctx, input.Account, input.Collection, input.PrimaryOnly)
+		resp, err := s.getCLIIdentities(
+			ctx, input.Account, input.Collection, input.SourceID.Value, input.SourceID.IsSet, input.PrimaryOnly,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -81,4 +110,31 @@ func (s *Server) registerCLIIdentityHumaRoutes(api huma.API) {
 		}
 		return &cliIdentityRemoveOutput{Body: result}, nil
 	})
+
+	huma.Register(api, withAPIKeySecurity(huma.Operation{
+		OperationID:      "importCLIIdentities",
+		Method:           http.MethodPost,
+		Path:             "/cli/identities/import",
+		Tags:             []string{cliRouteTag},
+		Summary:          "Preview or apply parsed source-scoped identities",
+		SkipValidateBody: true,
+		Errors:           []int{http.StatusBadRequest, http.StatusInternalServerError, http.StatusServiceUnavailable},
+	}), func(ctx context.Context, input *cliIdentityImportInput) (*cliIdentityImportOutput, error) {
+		result, err := s.importCLIIdentities(ctx, input.Body)
+		if err != nil {
+			return nil, err
+		}
+		return &cliIdentityImportOutput{Body: result}, nil
+	})
+}
+
+func (s *Server) registerCLIIdentityDiscoveryRoute(api huma.API) {
+	registerAPIV1RawHumaNDJSONRouteWithRequest[identityops.DiscoverRequest, identityops.DiscoverEvent](
+		api,
+		"discoverCLIIdentities",
+		http.MethodPost,
+		"/cli/identities/discover",
+		"Discover source-scoped account identities",
+		s.handleCLIIdentityDiscover,
+	)
 }

--- a/internal/api/cli_identity_routes_test.go
+++ b/internal/api/cli_identity_routes_test.go
@@ -1,0 +1,953 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/fastmail"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type cliIdentityProviderInventory struct {
+	records []fastmail.Record
+	err     error
+}
+
+func (i *cliIdentityProviderInventory) ListIdentityRecords(context.Context) ([]fastmail.Record, error) {
+	return append([]fastmail.Record(nil), i.records...), i.err
+}
+
+type cliIdentityDiscoveryTestStore struct {
+	*store.Store
+
+	page             store.IdentityDiscoveryPage
+	countErr         error
+	scanErr          error
+	scanCancel       context.CancelFunc
+	scannedSourceIDs []int64
+	buildCh          chan bool
+	batchFunc        func(
+		context.Context,
+		int64,
+		[]store.IdentityConfirmation,
+	) ([]store.IdentityConfirmationOutcome, error)
+	listSourcesErr error
+}
+
+func (s *cliIdentityDiscoveryTestStore) ListSources(sourceType string) ([]*store.Source, error) {
+	if s.listSourcesErr != nil {
+		return nil, s.listSourcesErr
+	}
+	return s.Store.ListSources(sourceType)
+}
+
+func (s *cliIdentityDiscoveryTestStore) CountIdentityDiscoveryMessagesContext(
+	_ context.Context,
+	_ int64,
+) (int64, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	return s.page.Scanned, nil
+}
+
+func (s *cliIdentityDiscoveryTestStore) ScanIdentityDiscoveryPageContext(
+	ctx context.Context,
+	sourceID, afterID int64,
+	_ int,
+) (store.IdentityDiscoveryPage, error) {
+	s.scannedSourceIDs = append(s.scannedSourceIDs, sourceID)
+	if afterID == 0 {
+		return s.page, nil
+	}
+	if s.scanErr != nil {
+		return store.IdentityDiscoveryPage{}, s.scanErr
+	}
+	if s.scanCancel != nil {
+		s.scanCancel()
+		<-ctx.Done()
+		return store.IdentityDiscoveryPage{}, ctx.Err()
+	}
+	return store.IdentityDiscoveryPage{}, nil
+}
+
+func (s *cliIdentityDiscoveryTestStore) BuildCLICache(
+	_ context.Context,
+	fullRebuild bool,
+	_ func(CLICacheBuildEvent) error,
+) error {
+	s.buildCh <- fullRebuild
+	return nil
+}
+
+func (s *cliIdentityDiscoveryTestStore) AddAccountIdentitiesBatchContext(
+	ctx context.Context,
+	sourceID int64,
+	confirmations []store.IdentityConfirmation,
+) ([]store.IdentityConfirmationOutcome, error) {
+	if s.batchFunc != nil {
+		return s.batchFunc(ctx, sourceID, confirmations)
+	}
+	return s.Store.AddAccountIdentitiesBatchContext(ctx, sourceID, confirmations)
+}
+
+func newCLIIdentityDiscoveryTestServer(
+	t *testing.T,
+) (*Server, *cliIdentityDiscoveryTestStore, *store.Source) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	require.NoError(t, err)
+	wrapped := &cliIdentityDiscoveryTestStore{
+		Store: st,
+		page: store.IdentityDiscoveryPage{
+			Scanned:     2,
+			NextAfterID: 2,
+			Observations: []store.IdentityObservation{
+				{MessageID: 1, Identifier: "strong@example.test", RecipientType: "from", HasSentFolder: true},
+				{MessageID: 2, Identifier: "weak@example.test", RecipientType: "to"},
+			},
+		},
+		buildCh: make(chan bool, 2),
+	}
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, wrapped, nil, testLogger())
+	return srv, wrapped, source
+}
+
+func postDiscoverNDJSON(
+	t *testing.T,
+	srv *Server,
+	body string,
+) []identityops.DiscoverEvent {
+	t.Helper()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/discover",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, "body: %s", resp.Body.String())
+	require.Equal(t, "application/x-ndjson", resp.Header().Get("Content-Type"))
+
+	var events []identityops.DiscoverEvent
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		var event identityops.DiscoverEvent
+		err := decoder.Decode(&event)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		events = append(events, event)
+	}
+	return events
+}
+
+func discoverResultEvent(t *testing.T, events []identityops.DiscoverEvent) identityops.DiscoverResult {
+	t.Helper()
+	require.NotEmpty(t, events)
+	require.Equal(t, "result", events[len(events)-1].Type)
+	require.NotNil(t, events[len(events)-1].Result)
+	return *events[len(events)-1].Result
+}
+
+func postIdentityImport(
+	t *testing.T,
+	srv *Server,
+	body string,
+) (*httptest.ResponseRecorder, identityops.ImportResult) {
+	t.Helper()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/import",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	var result identityops.ImportResult
+	if resp.Code == http.StatusOK {
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	}
+	return resp, result
+}
+
+func requireIdentityDiscoveryCacheBuild(
+	t *testing.T,
+	wrapped *cliIdentityDiscoveryTestStore,
+) {
+	t.Helper()
+	select {
+	case fullRebuild := <-wrapped.buildCh:
+		assert.False(t, fullRebuild)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "no background cache build was scheduled")
+	}
+}
+
+func assertNoIdentityDiscoveryCacheBuild(
+	t *testing.T,
+	wrapped *cliIdentityDiscoveryTestStore,
+) {
+	t.Helper()
+	select {
+	case fullRebuild := <-wrapped.buildCh:
+		assert.Fail(t, "unexpected background cache build", "fullRebuild=%v", fullRebuild)
+	default:
+	}
+}
+
+func TestCLIIdentityDiscoverPreviewAndApplyParity(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+
+	previewEvents := postDiscoverNDJSON(t, srv, fmt.Sprintf(`{"source_id":%d}`, source.ID))
+	preview := discoverResultEvent(t, previewEvents)
+	requirements.GreaterOrEqual(len(previewEvents), 2)
+	assertions.Equal("progress", previewEvents[0].Type)
+	assertions.NotNil(previewEvents[0].Progress)
+	assertions.Equal(int64(2), previewEvents[0].Progress.Done)
+
+	applyEvents := postDiscoverNDJSON(t, srv, fmt.Sprintf(`{"source_id":%d,"apply":true}`, source.ID))
+	apply := discoverResultEvent(t, applyEvents)
+	assertions.Equal(preview.Candidates, apply.Candidates)
+	requirements.NotEmpty(apply.Applied, "apply result: %+v", apply)
+	assertions.True(apply.Applied[0].Added)
+	requireIdentityDiscoveryCacheBuild(t, wrapped)
+
+	repeatEvents := postDiscoverNDJSON(t, srv, fmt.Sprintf(`{"source_id":%d,"apply":true}`, source.ID))
+	repeat := discoverResultEvent(t, repeatEvents)
+	assertions.Empty(repeat.Applied)
+	assertNoIdentityDiscoveryCacheBuild(t, wrapped)
+}
+
+func TestCLIIdentityDiscoverProviderPreviewAndApplyUseOneResolvedSource(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	const token = "do-not-log-provider-token"
+	srv.cfg.Fastmail = []config.FastmailSource{{SourceID: source.ID, APIToken: token}}
+	inventory := &cliIdentityProviderInventory{records: []fastmail.Record{
+		{Identifier: "active@example.test", State: "enabled", Kind: "masked-email"},
+		{Identifier: "ACTIVE@example.test", State: "pending", Kind: "identity"},
+		{Identifier: "old@example.test", State: "disabled", Kind: "masked-email"},
+		{Identifier: "deleted@example.test", State: "deleted", Kind: "masked-email"},
+		{Identifier: "waiting@example.test", State: "pending", Kind: "masked-email"},
+		{Identifier: "*@example.test", State: "enabled", Kind: "identity"},
+		{Identifier: "not an address", State: "enabled", Kind: "identity"},
+	}}
+	srv.fastmailInventoryFactory = func(gotToken string) fastmailIdentityInventory {
+		requirements.Equal(token, gotToken)
+		return inventory
+	}
+
+	preview := discoverResultEvent(t, postDiscoverNDJSON(
+		t, srv, fmt.Sprintf(`{"source_id":%d,"provider":true}`, source.ID),
+	))
+	apply := discoverResultEvent(t, postDiscoverNDJSON(
+		t, srv, fmt.Sprintf(`{"source_id":%d,"provider":true,"apply":true}`, source.ID),
+	))
+
+	assertions.Equal(preview.Candidates, apply.Candidates)
+	encoded, err := json.Marshal(preview)
+	requirements.NoError(err)
+	var reported struct {
+		Candidates []struct {
+			Identifier     string   `json:"identifier"`
+			ProviderStates []string `json:"provider_states"`
+		} `json:"candidates"`
+	}
+	requirements.NoError(json.Unmarshal(encoded, &reported))
+	statesByIdentifier := make(map[string][]string, len(reported.Candidates))
+	for _, candidate := range reported.Candidates {
+		statesByIdentifier[candidate.Identifier] = candidate.ProviderStates
+	}
+	assertions.Equal([]string{"enabled", "pending"}, statesByIdentifier["ACTIVE@example.test"])
+	assertions.Equal([]string{"deleted"}, statesByIdentifier["deleted@example.test"])
+	assertions.Equal([]string{"disabled"}, statesByIdentifier["old@example.test"])
+	assertions.Equal([]string{"pending"}, statesByIdentifier["waiting@example.test"])
+	assertions.Equal([]string{
+		"ACTIVE@example.test",
+		"deleted@example.test",
+		"old@example.test",
+		"strong@example.test",
+	}, identityConfirmationIdentifiers(apply.Applied), "pending and malformed provider rows must not apply")
+	assertions.Equal([]identityops.RejectedCandidate{
+		{Identifier: "*@example.test", Reason: "wildcard identity"},
+		{Identifier: "not an address", Reason: "identifier is not a concrete mailbox address"},
+	}, preview.Rejected)
+	assertions.Equal([]int64{source.ID, source.ID, source.ID, source.ID}, wrapped.scannedSourceIDs)
+	requireIdentityDiscoveryCacheBuild(t, wrapped)
+}
+
+func TestCLIIdentityDiscoverProviderErrorsAreActionableAndRedacted(t *testing.T) {
+	t.Run("missing configuration", func(t *testing.T) {
+		assertions := assert.New(t)
+		requirements := require.New(t)
+		srv, _, source := newCLIIdentityDiscoveryTestServer(t)
+		request := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/cli/identities/discover",
+			strings.NewReader(fmt.Sprintf(`{"source_id":%d,"provider":true}`, source.ID)),
+		)
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+
+		srv.Router().ServeHTTP(response, request)
+
+		requirements.Equal(http.StatusBadRequest, response.Code, "body: %s", response.Body.String())
+		assertions.Contains(response.Body.String(), fmt.Sprintf("source %d", source.ID))
+		assertions.Contains(response.Body.String(), "primary@example.test")
+		assertions.Contains(response.Body.String(), "[[fastmail]]")
+	})
+
+	t.Run("inventory failure", func(t *testing.T) {
+		assertions := assert.New(t)
+		requirements := require.New(t)
+		const (
+			token          = "do-not-log-provider-token"
+			privateAddress = "private-alias@example.test"
+		)
+		srv, _, source := newCLIIdentityDiscoveryTestServer(t)
+		srv.cfg.Fastmail = []config.FastmailSource{{SourceID: source.ID, APIToken: token}}
+		inventory := &cliIdentityProviderInventory{err: fmt.Errorf("inventory failed with %s for %s", token, privateAddress)}
+		srv.fastmailInventoryFactory = func(string) fastmailIdentityInventory { return inventory }
+		var logs bytes.Buffer
+		srv.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+		request := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/cli/identities/discover",
+			strings.NewReader(fmt.Sprintf(`{"source_id":%d,"provider":true}`, source.ID)),
+		)
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+
+		srv.Router().ServeHTTP(response, request)
+
+		requirements.Equal(http.StatusInternalServerError, response.Code, "body: %s", response.Body.String())
+		// The public response payload must stay generic no matter what the
+		// upstream inventory error contains. The internal log intentionally
+		// receives the full diagnostic detail so operators can act on it;
+		// see TestCLIIdentityDiscoverInventoryFailureLogsStatusBearingError.
+		assertions.NotContains(response.Body.String(), token)
+		assertions.NotContains(response.Body.String(), privateAddress)
+	})
+}
+
+// TestCLIIdentityDiscoverStoreFailureIsInternalNotInvalid confirms that an
+// infrastructure failure while resolving [[fastmail]] configuration (e.g. a
+// database error listing archive sources) surfaces as an internal server
+// error, not a user-input error, since the requester did nothing wrong.
+func TestCLIIdentityDiscoverStoreFailureIsInternalNotInvalid(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	srv.cfg.Fastmail = []config.FastmailSource{{SourceID: source.ID, APIToken: "do-not-log-provider-token"}}
+	wrapped.listSourcesErr = errors.New("db unavailable: connection reset")
+	var logs bytes.Buffer
+	srv.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/discover",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d,"provider":true}`, source.ID)),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(response, request)
+
+	requirements.Equal(http.StatusInternalServerError, response.Code, "body: %s", response.Body.String())
+	assertions.NotContains(response.Body.String(), "db unavailable")
+	assertions.NotContains(response.Body.String(), "connection reset")
+	// Pin this test to the [[fastmail]] source-lookup branch specifically,
+	// so it can't keep passing via some other unrelated 500 path after a
+	// future refactor.
+	assertions.Contains(logs.String(), "list sources for Fastmail configuration")
+	assertions.Contains(logs.String(), "[[fastmail]]")
+}
+
+// TestCLIIdentityDiscoverInventoryFailureLogsStatusBearingError confirms that
+// the JMAP inventory error, which safely carries method/host/HTTP status
+// context useful for operators, reaches the internal log record instead of
+// being discarded and replaced with a generic error before logging. The
+// public HTTP response body must stay generic regardless.
+func TestCLIIdentityDiscoverInventoryFailureLogsStatusBearingError(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	const token = "do-not-log-provider-token"
+	srv, _, source := newCLIIdentityDiscoveryTestServer(t)
+	srv.cfg.Fastmail = []config.FastmailSource{{SourceID: source.ID, APIToken: token}}
+	inventory := &cliIdentityProviderInventory{
+		err: errors.New("MaskedEmail/get https://api.fastmail.com/jmap/api/ returned HTTP status 502"),
+	}
+	srv.fastmailInventoryFactory = func(string) fastmailIdentityInventory { return inventory }
+	var logs bytes.Buffer
+	srv.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/discover",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d,"provider":true}`, source.ID)),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(response, request)
+
+	requirements.Equal(http.StatusInternalServerError, response.Code, "body: %s", response.Body.String())
+	assertions.Contains(logs.String(), "502")
+	assertions.NotContains(logs.String(), token)
+	assertions.NotContains(response.Body.String(), "502")
+}
+
+func TestCLIIdentityImportPreviewApplyAndRetryUseParsedEntries(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	body := fmt.Sprintf(`{
+		"source_id":%d,
+		"signal":"bulk-import",
+		"entries":[
+			{"identifier":"Old@Example.test","state":"disabled"},
+			{"identifier":"waiting@example.test","state":"pending"}
+		]
+	}`, source.ID)
+
+	previewResp, preview := postIdentityImport(t, srv, body)
+	requirements.Equal(http.StatusOK, previewResp.Code, previewResp.Body.String())
+	assertions.Empty(preview.Applied)
+	assertNoIdentityDiscoveryCacheBuild(t, wrapped)
+
+	applyResp, apply := postIdentityImport(t, srv, strings.Replace(body, "\n\t}", ",\n\t\t\"apply\":true\n\t}", 1))
+	requirements.Equal(http.StatusOK, applyResp.Code, applyResp.Body.String())
+	assertions.Equal(preview.Candidates, apply.Candidates)
+	assertions.Equal([]store.IdentityConfirmationOutcome{
+		{Identifier: "Old@Example.test", Added: true, Signals: []string{"bulk-import"}},
+		{Identifier: "waiting@example.test", Added: true, Signals: []string{"bulk-import"}},
+	}, apply.Applied)
+	requireIdentityDiscoveryCacheBuild(t, wrapped)
+
+	retryResp, retry := postIdentityImport(t, srv, strings.Replace(body, "\n\t}", ",\n\t\t\"apply\":true\n\t}", 1))
+	requirements.Equal(http.StatusOK, retryResp.Code, retryResp.Body.String())
+	assertions.Empty(retry.Applied)
+	assertNoIdentityDiscoveryCacheBuild(t, wrapped)
+}
+
+func TestCLIIdentityImportRejectsInvalidRowsAndExplicitNonPositiveSourceID(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "invalid later row",
+			body: `{"source_id":14,"apply":true,"entries":[{"identifier":"good@example.test"},{"identifier":"not an address"}]}`,
+			want: "concrete mailbox address",
+		},
+		{
+			name: "explicit zero",
+			body: `{"source_id":0,"entries":[{"identifier":"good@example.test"}]}`,
+			want: "source ID must be positive",
+		},
+		{
+			name: "explicit null",
+			body: `{"source_id":null,"entries":[{"identifier":"good@example.test"}]}`,
+			want: "source ID must be positive",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv, wrapped, _ := newCLIIdentityDiscoveryTestServer(t)
+			resp, _ := postIdentityImport(t, srv, test.body)
+
+			assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
+			assert.Contains(t, resp.Body.String(), test.want)
+			assertNoIdentityDiscoveryCacheBuild(t, wrapped)
+		})
+	}
+}
+
+func TestCLIIdentityImportAccountRequiresUniqueSource(t *testing.T) {
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	_, err := wrapped.GetOrCreateSource("gmail", source.Identifier)
+	require.NoError(t, err)
+
+	resp, _ := postIdentityImport(t, srv, `{
+		"account":"primary@example.test",
+		"entries":[{"identifier":"alias@example.test"}]
+	}`)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
+	assert.Contains(t, resp.Body.String(), "matches multiple sources")
+	assertNoIdentityDiscoveryCacheBuild(t, wrapped)
+}
+
+func TestCLIIdentityImportPartialCommitSchedulesCacheBeforeError(t *testing.T) {
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	wrapped.batchFunc = func(
+		_ context.Context,
+		_ int64,
+		confirmations []store.IdentityConfirmation,
+	) ([]store.IdentityConfirmationOutcome, error) {
+		return []store.IdentityConfirmationOutcome{{
+			Identifier: confirmations[0].Identifier,
+			Added:      true,
+			Signals:    confirmations[0].Signals,
+		}}, errors.New("second chunk failed")
+	}
+
+	resp, _ := postIdentityImport(t, srv, fmt.Sprintf(`{
+		"source_id":%d,
+		"apply":true,
+		"entries":[{"identifier":"first@example.test"},{"identifier":"second@example.test"}]
+	}`, source.ID))
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code, resp.Body.String())
+	requireIdentityDiscoveryCacheBuild(t, wrapped)
+}
+
+func identityConfirmationIdentifiers(outcomes []store.IdentityConfirmationOutcome) []string {
+	identifiers := make([]string, len(outcomes))
+	for i, outcome := range outcomes {
+		identifiers[i] = outcome.Identifier
+	}
+	return identifiers
+}
+
+func TestCLIIdentityDiscoverAccountAndSourceIDSelection(t *testing.T) {
+	assertions := assert.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+
+	byAccount := discoverResultEvent(t, postDiscoverNDJSON(
+		t, srv, `{"account":"primary@example.test"}`,
+	))
+	assertions.Equal(source.ID, byAccount.SourceID)
+	assertions.Equal([]int64{source.ID, source.ID}, wrapped.scannedSourceIDs)
+
+	duplicate, err := wrapped.GetOrCreateSource("gmail", "primary@example.test")
+	require.NoError(t, err)
+	assertions.NotEqual(source.ID, duplicate.ID)
+	wrapped.scannedSourceIDs = nil
+	byID := discoverResultEvent(t, postDiscoverNDJSON(
+		t, srv, fmt.Sprintf(`{"source_id":%d}`, source.ID),
+	))
+	assertions.Equal(source.ID, byID.SourceID)
+	assertions.Equal([]int64{source.ID, source.ID}, wrapped.scannedSourceIDs)
+}
+
+func TestCLIIdentityDiscoverStreamsSanitizedTerminalErrorAfterProgress(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	const secret = "provider-token-private-value"
+	wrapped.scanErr = errors.New("provider request failed with " + secret)
+	var logs bytes.Buffer
+	srv.logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/discover",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d}`, source.ID)),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+
+	requirements.Equal(http.StatusOK, resp.Code, resp.Body.String())
+	requirements.Equal("application/x-ndjson", resp.Header().Get("Content-Type"))
+	var events []struct {
+		Type  string `json:"type"`
+		Error *struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		var event struct {
+			Type  string `json:"type"`
+			Error *struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error,omitempty"`
+		}
+		err := decoder.Decode(&event)
+		if err == io.EOF {
+			break
+		}
+		requirements.NoError(err)
+		events = append(events, event)
+	}
+	requirements.Len(events, 2)
+	assertions.Equal("progress", events[0].Type)
+	assertions.Equal("error", events[1].Type)
+	requirements.NotNil(events[1].Error)
+	assertions.Equal("internal_error", events[1].Error.Code)
+	assertions.Equal("Failed to discover identities", events[1].Error.Message)
+	assertions.NotContains(resp.Body.String(), secret)
+	assertions.NotContains(logs.String(), secret)
+}
+
+func TestCLIIdentityDiscoverRejectsExplicitZeroSourceID(t *testing.T) {
+	tests := []string{
+		`{"source_id":0}`,
+		`{"account":"primary@example.test","source_id":0}`,
+	}
+	for _, body := range tests {
+		t.Run(body, func(t *testing.T) {
+			srv, _, _ := newCLIIdentityDiscoveryTestServer(t)
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/cli/identities/discover",
+				strings.NewReader(body),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+
+			srv.Router().ServeHTTP(resp, req)
+
+			require.Equal(t, http.StatusBadRequest, resp.Code, "body: %s", resp.Body.String())
+			var got ErrorResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+			assert.Contains(t, got.Message, "source ID must be positive")
+		})
+	}
+}
+
+func TestCLIIdentityDiscoverAppliesExplicitWeakConfirmation(t *testing.T) {
+	srv, _, source := newCLIIdentityDiscoveryTestServer(t)
+	events := postDiscoverNDJSON(t, srv, fmt.Sprintf(
+		`{"source_id":%d,"apply":true,"confirm":["weak@example.test"]}`,
+		source.ID,
+	))
+	result := discoverResultEvent(t, events)
+
+	require.Len(t, result.Applied, 2)
+	assert.Equal(t, "weak@example.test", result.Applied[1].Identifier)
+	assert.Equal(t, []string{"manual"}, result.Applied[1].Signals)
+}
+
+func TestCLIIdentityDiscoverClassifiesContextErrorsBeforeStreaming(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{name: "deadline", err: context.DeadlineExceeded, wantCode: "query_timeout"},
+		{name: "canceled", err: context.Canceled, wantCode: "query_canceled"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+			wrapped.countErr = test.err
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/cli/identities/discover",
+				strings.NewReader(fmt.Sprintf(`{"source_id":%d}`, source.ID)),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+
+			srv.Router().ServeHTTP(resp, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, resp.Code, "body: %s", resp.Body.String())
+			var got ErrorResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+			assert.Equal(t, test.wantCode, got.Error)
+		})
+	}
+}
+
+func TestCLIIdentityDiscoverCancellationEmitsNoResult(t *testing.T) {
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	wrapped.scanCancel = cancel
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/discover",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d}`, source.ID)),
+	).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(resp, req)
+
+	assert.Contains(t, resp.Body.String(), `"type":"progress"`)
+	assert.NotContains(t, resp.Body.String(), `"type":"result"`)
+}
+
+func TestCLIIdentityDiscoverPartialApplyErrorSchedulesOneCacheRebuildWithoutResult(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	wrapped.page = store.IdentityDiscoveryPage{
+		Scanned:     2,
+		NextAfterID: 2,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "first@example.test", RecipientType: "from", IsFromMe: true},
+			{MessageID: 2, Identifier: "second@example.test", RecipientType: "from", HasSentFolder: true},
+		},
+	}
+	applyErr := errors.New("apply stopped after committed prefix")
+	wrapped.batchFunc = func(
+		ctx context.Context,
+		sourceID int64,
+		confirmations []store.IdentityConfirmation,
+	) ([]store.IdentityConfirmationOutcome, error) {
+		outcomes, err := wrapped.Store.AddAccountIdentitiesBatchContext(ctx, sourceID, confirmations[:1])
+		requirements.NoError(err)
+		return outcomes, applyErr
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/discover",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d,"apply":true}`, source.ID)),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(resp, req)
+
+	assertions.Contains(resp.Body.String(), `"type":"progress"`)
+	assertions.NotContains(resp.Body.String(), `"type":"result"`)
+	identities, err := wrapped.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	requirements.Len(identities, 1)
+	assertions.Equal("first@example.test", identities[0].Address)
+	requireIdentityDiscoveryCacheBuild(t, wrapped)
+	assertNoIdentityDiscoveryCacheBuild(t, wrapped)
+}
+
+func TestCLIIdentityDiscoverCancellationAfterCommitSchedulesOneCacheRebuildWithoutResult(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv, wrapped, source := newCLIIdentityDiscoveryTestServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	wrapped.batchFunc = func(
+		ctx context.Context,
+		sourceID int64,
+		confirmations []store.IdentityConfirmation,
+	) ([]store.IdentityConfirmationOutcome, error) {
+		outcomes, err := wrapped.Store.AddAccountIdentitiesBatchContext(ctx, sourceID, confirmations)
+		requirements.NoError(err)
+		cancel()
+		return outcomes, nil
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities/discover",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d,"apply":true}`, source.ID)),
+	).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(resp, req)
+
+	assertions.Contains(resp.Body.String(), `"type":"progress"`)
+	assertions.NotContains(resp.Body.String(), `"type":"result"`)
+	identities, err := wrapped.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	requirements.Len(identities, 1)
+	assertions.Equal("strong@example.test", identities[0].Address)
+	requireIdentityDiscoveryCacheBuild(t, wrapped)
+	assertNoIdentityDiscoveryCacheBuild(t, wrapped)
+}
+
+func TestCLIIdentityListSourceIDSelectsOneDuplicateAccount(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, st, nil, testLogger())
+	gmail, err := st.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	imap, err := st.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(gmail.ID, "gmail-alias@example.test", "manual"))
+	require.NoError(st.AddAccountIdentity(imap.ID, "imap-alias@example.test", "manual"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/cli/identities?source_id="+strconv.FormatInt(gmail.ID, 10), nil)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+
+	require.Equal(http.StatusOK, resp.Code, "body: %s", resp.Body.String())
+	var got cliIdentitiesResponse
+	require.NoError(json.NewDecoder(resp.Body).Decode(&got))
+	require.Len(got.Rows, 1)
+	assert.Equal(gmail.ID, got.Rows[0].SourceID)
+	assert.Equal("gmail-alias@example.test", got.Rows[0].Identifier)
+}
+
+func TestCLIIdentityListRejectsSourceIDWithAccount(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, st, nil, testLogger())
+	source, err := st.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/cli/identities?source_id="+strconv.FormatInt(source.ID, 10)+"&account=shared@example.test", nil)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+
+	require.Equal(http.StatusBadRequest, resp.Code, "body: %s", resp.Body.String())
+	var got ErrorResponse
+	require.NoError(json.NewDecoder(resp.Body).Decode(&got))
+	assert.Contains(t, got.Message, "mutually exclusive")
+}
+
+func TestCLIIdentityListRejectsExplicitNonPositiveSourceID(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, st, nil, testLogger())
+	_, err := st.GetOrCreateSource("gmail", "alice@example.test")
+	require.NoError(t, err)
+
+	for _, rawQuery := range []string{
+		"source_id=0",
+		"source_id=0&account=alice@example.test",
+	} {
+		t.Run(rawQuery, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/identities?"+rawQuery, nil)
+			resp := httptest.NewRecorder()
+			srv.Router().ServeHTTP(resp, req)
+
+			require.Equal(t, http.StatusBadRequest, resp.Code, "body: %s", resp.Body.String())
+			var got ErrorResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+			assert.Contains(t, got.Message, "source ID must be positive")
+		})
+	}
+}
+
+func TestCLIIdentityMutationsSourceIDDisambiguateDuplicateAccounts(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, st, nil, testLogger())
+	gmail, err := st.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	imap, err := st.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(imap.ID, "shared-alias@example.test", "manual"))
+
+	addReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/identities",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d,"identifier":"shared-alias@example.test","signal":"manual"}`, gmail.ID)),
+	)
+	addReq.Header.Set("Content-Type", "application/json")
+	addResp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(addResp, addReq)
+	require.Equal(http.StatusOK, addResp.Code, "body: %s", addResp.Body.String())
+
+	gmailIdentities, err := st.ListAccountIdentities(gmail.ID)
+	require.NoError(err)
+	require.Len(gmailIdentities, 1)
+	imapIdentities, err := st.ListAccountIdentities(imap.ID)
+	require.NoError(err)
+	require.Len(imapIdentities, 1)
+
+	removeReq := httptest.NewRequest(
+		http.MethodDelete,
+		"/api/v1/cli/identities",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d,"identifier":"shared-alias@example.test"}`, gmail.ID)),
+	)
+	removeReq.Header.Set("Content-Type", "application/json")
+	removeResp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(removeResp, removeReq)
+	require.Equal(http.StatusOK, removeResp.Code, "body: %s", removeResp.Body.String())
+
+	gmailIdentities, err = st.ListAccountIdentities(gmail.ID)
+	require.NoError(err)
+	assert.Empty(t, gmailIdentities)
+	imapIdentities, err = st.ListAccountIdentities(imap.ID)
+	require.NoError(err)
+	require.Len(imapIdentities, 1)
+}
+
+func TestCLIIdentityMutationsRejectExplicitNonPositiveSourceIDWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		identifier string
+		seed       bool
+	}{
+		{
+			name:       "add zero alone",
+			method:     http.MethodPost,
+			body:       `{"source_id":0,"identifier":"new@example.test","signal":"manual"}`,
+			identifier: "new@example.test",
+		},
+		{
+			name:       "add null with account",
+			method:     http.MethodPost,
+			body:       `{"account":"primary@example.test","source_id":null,"identifier":"new@example.test","signal":"manual"}`,
+			identifier: "new@example.test",
+		},
+		{
+			name:       "remove null alone",
+			method:     http.MethodDelete,
+			body:       `{"source_id":null,"identifier":"existing@example.test"}`,
+			identifier: "existing@example.test",
+			seed:       true,
+		},
+		{
+			name:       "remove zero with account",
+			method:     http.MethodDelete,
+			body:       `{"account":"primary@example.test","source_id":0,"identifier":"existing@example.test"}`,
+			identifier: "existing@example.test",
+			seed:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			st := testutil.NewTestStore(t)
+			source, err := st.GetOrCreateSource("imap", "primary@example.test")
+			requirements.NoError(err)
+			if test.seed {
+				requirements.NoError(st.AddAccountIdentity(source.ID, test.identifier, "manual"))
+			}
+			srv := NewServer(
+				&config.Config{Server: config.ServerConfig{APIPort: 8080}},
+				st,
+				nil,
+				testLogger(),
+			)
+
+			resp := doCLIIdentityRequest(t, srv, test.method, test.body)
+
+			requirements.Equal(http.StatusBadRequest, resp.Code, "body: %s", resp.Body.String())
+			var got ErrorResponse
+			requirements.NoError(json.NewDecoder(resp.Body).Decode(&got))
+			assertions.Contains(got.Message, "source ID must be positive")
+			identities, listErr := st.ListAccountIdentities(source.ID)
+			requirements.NoError(listErr)
+			if test.seed {
+				requirements.Len(identities, 1)
+				assertions.Equal(test.identifier, identities[0].Address)
+			} else {
+				assertions.Empty(identities)
+			}
+		})
+	}
+}

--- a/internal/api/deletions.go
+++ b/internal/api/deletions.go
@@ -319,9 +319,9 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 		writeError(w, http.StatusBadRequest, "invalid_selection", "selection mode must be explicit or all_matching")
 		return nil, nil, false
 	}
-	predicate, err := prepareExplorePredicate(selection.Predicate)
+	predicate, err := s.prepareResolvedExplorePredicate(r.Context(), selection.Predicate)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_selection_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_selection_predicate")
 		return nil, nil, false
 	}
 	if selection.CacheRevision == "" {

--- a/internal/api/deletions_test.go
+++ b/internal/api/deletions_test.go
@@ -36,6 +36,17 @@ type deletionMockStore struct {
 	saveRelease chan struct{} // if non-nil, save blocks until this channel is closed
 }
 
+type deletionIdentityStore struct {
+	*recordingMessageIdentityStore
+
+	saved []*deletion.Manifest
+}
+
+func (s *deletionIdentityStore) SaveCLIDeletionManifest(_ context.Context, manifest *deletion.Manifest) error {
+	s.saved = append(s.saved, manifest)
+	return nil
+}
+
 func (s *deletionMockStore) SaveCLIDeletionManifest(_ context.Context, m *deletion.Manifest) error {
 	if s.saveStarted != nil {
 		s.saveStarted <- struct{}{}
@@ -269,6 +280,47 @@ func TestStageDeletionSelectionRequiresAndConsumesExactPreflightAuthority(t *tes
 	assertions.Equal(http.StatusConflict, reused.Code, reused.Body.String())
 	assertions.Contains(reused.Body.String(), "operation_token_invalid")
 	assertions.Len(st.saved, 1, "one-shot authority must not create another manifest")
+}
+
+func TestStageDeletionReplaysResolvedIdentityFilterOnceAfterPreflight(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+	st := &deletionIdentityStore{recordingMessageIdentityStore: fixture.store}
+	srv := newDeletionTestServer(t, st, fixture.server.engine)
+	filters := `[
+		{"dimension":"source","values":["1"]},
+		{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}
+	]`
+
+	explore := postExploreJSON(t, srv, "/api/v1/explore", `{"filters":`+filters+`}`)
+	requirements.Equal(http.StatusOK, explore.Code, explore.Body.String())
+	var explored ExploreHTTPResponse
+	requirements.NoError(json.Unmarshal(explore.Body.Bytes(), &explored))
+	selection := fmt.Sprintf(
+		`{"mode":"all_matching","predicate":{"filters":%s},"cache_revision":%q}`,
+		filters,
+		explored.CacheRevision,
+	)
+
+	preflight := postExploreJSON(t, srv, "/api/v1/explore/preflight", `{"selection":`+selection+`}`)
+	requirements.Equal(http.StatusOK, preflight.Code, preflight.Body.String())
+	var reviewed ExplorePreflightResponse
+	requirements.NoError(json.Unmarshal(preflight.Body.Bytes(), &reviewed))
+	requirements.NotEmpty(reviewed.OperationToken)
+	assertions.Equal(int64(1), reviewed.Count)
+
+	fixture.store.resolveCalls = 0
+	stage := postDeletions(t, srv, fmt.Sprintf(
+		`{"selection":%s,"operation_token":%q,"description":"identity-filtered batch"}`,
+		selection,
+		reviewed.OperationToken,
+	))
+
+	requirements.Equal(http.StatusCreated, stage.Code, stage.Body.String())
+	requirements.Len(st.saved, 1)
+	assertions.Equal([]string{"m2"}, st.saved[0].GmailIDs)
+	assertions.Equal(1, fixture.store.resolveCalls)
 }
 
 // preflightDeletionSelection runs explore + preflight against the

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/msgvault/internal/explorecatalog"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
 )
@@ -36,7 +37,7 @@ const (
 )
 
 type ExploreFilter struct {
-	Dimension string   `json:"dimension" enum:"source,participant,domain,message_type,after,before,deletion"`
+	Dimension string   `json:"dimension" enum:"source,participant,domain,message_type,after,before,deletion,identity"`
 	Values    []string `json:"values" minItems:"1"`
 }
 
@@ -49,7 +50,19 @@ const (
 	exploreFilterAfter       = "after"
 	exploreFilterBefore      = "before"
 	exploreFilterDeletion    = "deletion"
+	exploreFilterIdentity    = "identity"
 )
+
+var (
+	errInvalidExploreIdentityFilter     = errors.New("invalid identity filter")
+	errExploreIdentityFilterUnavailable = errors.New("identity filter unavailable")
+)
+
+type exploreIdentityFilter struct {
+	sourceID   int64
+	identifier string
+	direction  query.IdentityDirection
+}
 
 type ExploreSort struct {
 	Field     string `json:"field" enum:"occurred_at"`
@@ -311,6 +324,13 @@ func (s *Server) handleExploreWithScope(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 	}
+	if err := s.hydrateExploreIdentityMatches(r.Context(), result.Rows); err != nil {
+		if s.writeIfContextError(w, err) {
+			return
+		}
+		writeError(w, http.StatusServiceUnavailable, "identity_matches_unavailable", "Message identity matches could not be resolved")
+		return
+	}
 	response := ExploreHTTPResponse{
 		Rows: result.Rows, CacheRevision: result.CacheRevision,
 		SearchProvenance: result.SearchProvenance, CandidateSnapshotID: snapshotID,
@@ -338,20 +358,53 @@ func (s *Server) handleExploreWithScope(w http.ResponseWriter, r *http.Request, 
 	writeJSON(w, http.StatusOK, response)
 }
 
+func (s *Server) hydrateExploreIdentityMatches(ctx context.Context, rows []query.EntryRow) error {
+	messageIDs := make([]int64, 0, len(rows))
+	seen := make(map[int64]struct{}, len(rows))
+	for i := range rows {
+		rows[i].MatchedSenderIdentities = make([]string, 0)
+		rows[i].MatchedRecipientIdentities = make([]string, 0)
+		if rows[i].AnchorMessageID == nil || *rows[i].AnchorMessageID < 1 {
+			continue
+		}
+		messageID := *rows[i].AnchorMessageID
+		if _, exists := seen[messageID]; exists {
+			continue
+		}
+		seen[messageID] = struct{}{}
+		messageIDs = append(messageIDs, messageID)
+	}
+	if len(messageIDs) == 0 {
+		return nil
+	}
+	matcher, ok := s.store.(MessageIdentityStore)
+	if !ok {
+		return nil
+	}
+	matches, err := matcher.MatchMessageIdentitiesContext(ctx, messageIDs)
+	if err != nil {
+		return err
+	}
+	for i := range rows {
+		if rows[i].AnchorMessageID == nil {
+			continue
+		}
+		match, found := matches[*rows[i].AnchorMessageID]
+		if !found {
+			continue
+		}
+		rows[i].MatchedSenderIdentities = append(rows[i].MatchedSenderIdentities, match.Sender...)
+		rows[i].MatchedRecipientIdentities = append(rows[i].MatchedRecipientIdentities, match.Recipients...)
+	}
+	return nil
+}
+
 func (s *Server) handleExploreGroups(w http.ResponseWriter, r *http.Request) {
 	var request ExploreGroupsHTTPRequest
 	if !decodeExploreJSON(w, r, &request) {
 		return
 	}
-	for i := range request.Filters {
-		request.Filters[i].Dimension = strings.ToLower(strings.TrimSpace(request.Filters[i].Dimension))
-		for j := range request.Filters[i].Values {
-			request.Filters[i].Values[j] = strings.TrimSpace(request.Filters[i].Values[j])
-		}
-		slices.Sort(request.Filters[i].Values)
-		request.Filters[i].Values = slices.Compact(request.Filters[i].Values)
-	}
-	slices.SortFunc(request.Filters, func(a, b ExploreFilter) int { return strings.Compare(a.Dimension, b.Dimension) })
+	canonicalizeExploreFilters(request.Filters)
 	request.Query = strings.TrimSpace(request.Query)
 	request.SearchMode = strings.ToLower(strings.TrimSpace(request.SearchMode))
 	request.Presentation = strings.ToLower(strings.TrimSpace(request.Presentation))
@@ -378,7 +431,11 @@ func (s *Server) handleExploreGroups(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, err := exploreContext(request.Filters)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_filter", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_filter")
+		return
+	}
+	if err := s.resolveExploreIdentityContext(r.Context(), request.Filters, &ctx); err != nil {
+		s.writeExploreFilterError(w, err, "invalid_filter")
 		return
 	}
 	searchDeletionScope := applySemanticDeletionScope(request.SearchMode, &ctx)
@@ -470,9 +527,9 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "invalid_selection", "selection mode must be explicit or all_matching")
 		return
 	}
-	predicate, err := prepareExplorePredicate(selection.Predicate)
+	predicate, err := s.prepareResolvedExplorePredicate(r.Context(), selection.Predicate)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_selection_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_selection_predicate")
 		return
 	}
 	if selection.CacheRevision == "" {
@@ -597,9 +654,9 @@ func (s *Server) handleExploreMatchCounts(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "invalid_row_keys", fmt.Sprintf("row_keys must contain between 1 and %d entries", exploreMaxLimit))
 		return
 	}
-	predicate, err := prepareExplorePredicate(request.Predicate)
+	predicate, err := s.prepareResolvedExplorePredicate(r.Context(), request.Predicate)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_match_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_match_predicate")
 		return
 	}
 	searchSpec, _, ok := s.resolveExploreSearch(r.Context(), w, predicate.request)
@@ -708,7 +765,11 @@ func (s *Server) prepareExploreRequest(w http.ResponseWriter, r *http.Request, s
 	}
 	ctx, err := exploreContext(request.Filters)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_filter", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_filter")
+		return explorePrepared{}, false
+	}
+	if err := s.resolveExploreIdentityContext(r.Context(), request.Filters, &ctx); err != nil {
+		s.writeExploreFilterError(w, err, "identity_filter_unavailable")
 		return explorePrepared{}, false
 	}
 	searchDeletionScope := applySemanticDeletionScope(request.SearchMode, &ctx)
@@ -731,6 +792,70 @@ func (s *Server) prepareExploreRequest(w http.ResponseWriter, r *http.Request, s
 			Page: query.PageSpec{Limit: request.Limit, Offset: offset},
 		},
 	}, true
+}
+
+func (s *Server) resolveExploreIdentityContext(
+	ctx context.Context,
+	filters []ExploreFilter,
+	result *query.Context,
+) error {
+	if result.Identity == nil {
+		return nil
+	}
+	identity, err := parseExploreIdentityFilter(filters)
+	if err != nil {
+		return err
+	}
+	resolver, ok := s.store.(MessageIdentityStore)
+	if !ok {
+		return errExploreIdentityFilterUnavailable
+	}
+	resolved, err := resolver.ResolveAccountIdentityContext(ctx, identity.sourceID, identity.identifier)
+	if errors.Is(err, store.ErrAccountIdentityNotFound) {
+		return fmt.Errorf("%w: identity is not confirmed for the selected source", errInvalidExploreIdentityFilter)
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return errExploreIdentityFilterUnavailable
+	}
+	if resolved.SourceID != identity.sourceID {
+		return fmt.Errorf("%w: identity does not match the selected source", errInvalidExploreIdentityFilter)
+	}
+	// An email-shaped identity carries its stored address into the predicate
+	// for envelope-first matching, and stays matchable even with zero
+	// resolved participants: the address may survive only in
+	// message_recipients.email_address snapshots after a participant merge.
+	// Identifier types without an envelope surface keep the match-none
+	// short-circuit when no participant carries them.
+	emailIdentifier := ""
+	if resolved.IdentifierIsEmail {
+		emailIdentifier = resolved.Identifier
+	}
+	result.Identity = &query.IdentityPredicate{
+		SourceID:        resolved.SourceID,
+		ParticipantIDs:  slices.Clone(resolved.ParticipantIDs),
+		EmailIdentifier: emailIdentifier,
+		MatchNone:       len(resolved.ParticipantIDs) == 0 && !resolved.IdentifierIsEmail,
+		Direction:       identity.direction,
+	}
+	return nil
+}
+
+func (s *Server) writeExploreFilterError(w http.ResponseWriter, err error, fallbackCode string) {
+	if errors.Is(err, errInvalidExploreIdentityFilter) {
+		writeError(w, http.StatusBadRequest, "invalid_identity_filter", "identity filter is malformed, unconfirmed, or does not match the selected source")
+		return
+	}
+	if errors.Is(err, errExploreIdentityFilterUnavailable) {
+		writeError(w, http.StatusServiceUnavailable, "identity_filter_unavailable", "The identity filter could not be resolved")
+		return
+	}
+	if s.writeIfContextError(w, err) {
+		return
+	}
+	writeError(w, http.StatusBadRequest, fallbackCode, err.Error())
 }
 
 func canonicalScopedExploreHash(request ExploreHTTPRequest, scope *ExploreFilter) string {
@@ -841,6 +966,10 @@ func sameDomainSet(a, b []string) bool {
 // dimension is single-valued per request and rejects a repeat.
 func exploreContext(filters []ExploreFilter) (query.Context, error) {
 	var result query.Context
+	identity, err := parseExploreIdentityFilter(filters)
+	if err != nil {
+		return result, err
+	}
 	seen := map[string]struct{}{}
 	for _, filter := range filters {
 		conjunctive := filter.Dimension == exploreFilterParticipant || filter.Dimension == exploreFilterDomain
@@ -908,11 +1037,72 @@ func exploreContext(filters []ExploreFilter) (query.Context, error) {
 			if result.Deletion != query.DeletionActive && result.Deletion != query.DeletionDeleted && result.Deletion != query.DeletionAny {
 				return result, fmt.Errorf("filter dimension %q accepts active or deleted", exploreFilterDeletion)
 			}
+		case exploreFilterIdentity:
+			result.Identity = &query.IdentityPredicate{
+				SourceID:  identity.sourceID,
+				Direction: identity.direction,
+			}
 		default:
 			return result, fmt.Errorf("unknown filter dimension %q", filter.Dimension)
 		}
 	}
 	return result, nil
+}
+
+func parseExploreIdentityFilter(filters []ExploreFilter) (exploreIdentityFilter, error) {
+	var (
+		identityFilters []ExploreFilter
+		sourceFilters   []ExploreFilter
+	)
+	for _, filter := range filters {
+		switch filter.Dimension {
+		case exploreFilterIdentity:
+			identityFilters = append(identityFilters, filter)
+		case exploreFilterSource:
+			sourceFilters = append(sourceFilters, filter)
+		}
+	}
+	if len(identityFilters) == 0 {
+		return exploreIdentityFilter{}, nil
+	}
+	invalid := func(message string) (exploreIdentityFilter, error) {
+		return exploreIdentityFilter{}, fmt.Errorf("%w: %s", errInvalidExploreIdentityFilter, message)
+	}
+	if len(identityFilters) != 1 {
+		return invalid("exactly one identity filter is required")
+	}
+	if len(sourceFilters) != 1 || len(sourceFilters[0].Values) != 1 {
+		return invalid("identity filter requires exactly one matching source filter")
+	}
+	identityValues := identityFilters[0].Values
+	if len(identityValues) != 3 {
+		return invalid("identity filter requires source ID, identifier, and direction")
+	}
+	identitySourceID, err := strconv.ParseInt(identityValues[0], 10, 64)
+	if err != nil || identitySourceID < 1 {
+		return invalid("identity filter requires a positive source ID")
+	}
+	selectedSourceID, err := strconv.ParseInt(sourceFilters[0].Values[0], 10, 64)
+	if err != nil || selectedSourceID < 1 || selectedSourceID != identitySourceID {
+		return invalid("identity filter requires exactly one matching source filter")
+	}
+	if identityValues[1] == "" {
+		return invalid("identity filter requires a non-empty identifier")
+	}
+	direction := query.IdentityDirection(identityValues[2])
+	if direction == "" {
+		direction = query.IdentityDirectionAny
+	}
+	if direction != query.IdentityDirectionAny &&
+		direction != query.IdentityDirectionSender &&
+		direction != query.IdentityDirectionRecipient {
+		return invalid("identity filter direction must be any, sender, or recipient")
+	}
+	return exploreIdentityFilter{
+		sourceID:   identitySourceID,
+		identifier: identityValues[1],
+		direction:  direction,
+	}, nil
 }
 
 func validateExploreSearchPair(queryText, mode string) error {
@@ -926,15 +1116,7 @@ func validateExploreSearchPair(queryText, mode string) error {
 }
 
 func canonicalizeExploreRequest(request *ExploreHTTPRequest) {
-	for i := range request.Filters {
-		request.Filters[i].Dimension = strings.ToLower(strings.TrimSpace(request.Filters[i].Dimension))
-		for j := range request.Filters[i].Values {
-			request.Filters[i].Values[j] = strings.TrimSpace(request.Filters[i].Values[j])
-		}
-		slices.Sort(request.Filters[i].Values)
-		request.Filters[i].Values = slices.Compact(request.Filters[i].Values)
-	}
-	slices.SortFunc(request.Filters, func(a, b ExploreFilter) int { return strings.Compare(a.Dimension, b.Dimension) })
+	canonicalizeExploreFilters(request.Filters)
 	request.Query = strings.TrimSpace(request.Query)
 	request.SearchMode = strings.ToLower(strings.TrimSpace(request.SearchMode))
 	request.Presentation = strings.ToLower(strings.TrimSpace(request.Presentation))
@@ -945,6 +1127,28 @@ func canonicalizeExploreRequest(request *ExploreHTTPRequest) {
 		request.Sort[i].Field = strings.ToLower(strings.TrimSpace(request.Sort[i].Field))
 		request.Sort[i].Direction = strings.ToLower(strings.TrimSpace(request.Sort[i].Direction))
 	}
+}
+
+func canonicalizeExploreFilters(filters []ExploreFilter) {
+	for i := range filters {
+		filters[i].Dimension = strings.ToLower(strings.TrimSpace(filters[i].Dimension))
+		for j := range filters[i].Values {
+			filters[i].Values[j] = strings.TrimSpace(filters[i].Values[j])
+		}
+		if filters[i].Dimension == exploreFilterIdentity {
+			if len(filters[i].Values) == 3 {
+				direction := strings.ToLower(filters[i].Values[2])
+				if direction == "" {
+					direction = string(query.IdentityDirectionAny)
+				}
+				filters[i].Values[2] = direction
+			}
+			continue
+		}
+		slices.Sort(filters[i].Values)
+		filters[i].Values = slices.Compact(filters[i].Values)
+	}
+	slices.SortFunc(filters, func(a, b ExploreFilter) int { return strings.Compare(a.Dimension, b.Dimension) })
 }
 
 func canonicalExploreHash(request ExploreHTTPRequest) string {
@@ -997,6 +1201,12 @@ func (s *Server) parseExploreCursor(w http.ResponseWriter, encoded, requestHash 
 }
 
 func prepareExplorePredicate(request ExploreHTTPRequest) (explorePrepared, error) {
+	request.Filters = slices.Clone(request.Filters)
+	for i := range request.Filters {
+		request.Filters[i].Values = slices.Clone(request.Filters[i].Values)
+	}
+	request.Grouping = slices.Clone(request.Grouping)
+	request.Sort = slices.Clone(request.Sort)
 	canonicalizeExploreRequest(&request)
 	if err := validateExploreSearchPair(request.Query, request.SearchMode); err != nil {
 		return explorePrepared{}, err
@@ -1031,6 +1241,20 @@ func prepareExplorePredicate(request ExploreHTTPRequest) (explorePrepared, error
 		searchDeletionScope: searchDeletionScope,
 		query:               query.ExploreRequest{Context: ctx},
 	}, nil
+}
+
+func (s *Server) prepareResolvedExplorePredicate(
+	ctx context.Context,
+	request ExploreHTTPRequest,
+) (explorePrepared, error) {
+	prepared, err := prepareExplorePredicate(request)
+	if err != nil {
+		return explorePrepared{}, err
+	}
+	if err := s.resolveExploreIdentityContext(ctx, prepared.request.Filters, &prepared.query.Context); err != nil {
+		return explorePrepared{}, err
+	}
+	return prepared, nil
 }
 
 func (s *Server) resolveExploreSearch(ctx context.Context, w http.ResponseWriter, request ExploreHTTPRequest) (query.SearchSpec, string, bool) {

--- a/internal/api/explore_e2e_test.go
+++ b/internal/api/explore_e2e_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
 )
@@ -376,6 +378,416 @@ func TestExploreSemanticPreflightRequiresAndReusesCandidateSnapshot(t *testing.T
 	assertions.Equal(int64(7), *body.SearchProvenance.VectorGeneration)
 }
 
+func TestExploreIdentityFilterDirectionsAndHydrationAcrossSearchModes(t *testing.T) {
+	fixture := newExploreIdentityAPIFixture(t)
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "base",
+			body: exploreIdentityRequest("any", "", "", 10),
+		},
+		{
+			name: "full text",
+			body: exploreIdentityRequest("any", "alpha", exploreSearchModeFullText, 10),
+		},
+		{
+			name: "semantic",
+			body: exploreIdentityRequest("any", "alpha", exploreSearchModeSemantic, 10),
+		},
+		{
+			name: "hybrid",
+			body: exploreIdentityRequest("any", "alpha", exploreSearchModeHybrid, 10),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			callsBefore := fixture.store.matchCalls
+			response := postExploreJSON(t, fixture.server, "/api/v1/explore", tt.body)
+			require.Equal(http.StatusOK, response.Code, response.Body.String())
+			var body ExploreHTTPResponse
+			require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+			require.Len(body.Rows, 2)
+			assert.Equal(callsBefore+1, fixture.store.matchCalls)
+			assert.ElementsMatch([]int64{1, 2}, fixture.store.matchIDs[len(fixture.store.matchIDs)-1])
+
+			rowsByMessage := make(map[int64]query.EntryRow, len(body.Rows))
+			for _, row := range body.Rows {
+				require.NotNil(row.AnchorMessageID)
+				rowsByMessage[*row.AnchorMessageID] = row
+				assert.NotNil(row.MatchedSenderIdentities)
+				assert.NotNil(row.MatchedRecipientIdentities)
+			}
+			assert.Equal([]string{"Bob@Members.Example"}, rowsByMessage[1].MatchedSenderIdentities)
+			assert.Empty(rowsByMessage[1].MatchedRecipientIdentities)
+			assert.Empty(rowsByMessage[2].MatchedSenderIdentities)
+			assert.Equal([]string{"Bob@Members.Example"}, rowsByMessage[2].MatchedRecipientIdentities)
+			assert.Equal("Older", rowsByMessage[1].Title)
+			assert.Equal([]string{"Bob"}, rowsByMessage[1].ParticipantLabels)
+			assert.Equal("Newest", rowsByMessage[2].Title)
+			assert.Equal([]string{"Alice", "Bob"}, rowsByMessage[2].ParticipantLabels)
+			assert.NotContains(rowsByMessage, int64(3), "the shared participant address must not leak across sources")
+		})
+	}
+
+	directions := []struct {
+		direction string
+		wantIDs   []int64
+	}{
+		{direction: "sender", wantIDs: []int64{1}},
+		{direction: "recipient", wantIDs: []int64{2}},
+		{direction: "any", wantIDs: []int64{1, 2}},
+	}
+	for _, tt := range directions {
+		t.Run(tt.direction, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			response := postExploreJSON(t, fixture.server, "/api/v1/explore", exploreIdentityRequest(tt.direction, "", "", 10))
+			require.Equal(http.StatusOK, response.Code, response.Body.String())
+			var body ExploreHTTPResponse
+			require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+			gotIDs := make([]int64, 0, len(body.Rows))
+			for _, row := range body.Rows {
+				require.NotNil(row.AnchorMessageID)
+				gotIDs = append(gotIDs, *row.AnchorMessageID)
+			}
+			assert.ElementsMatch(tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestExploreIdentityFilterCursorCanonicalizesEmptyDirectionAsAny(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+	emptyDirection := postExploreJSON(t, fixture.server, "/api/v1/explore", exploreIdentityRequest("", "", "", 1))
+	require.Equal(http.StatusOK, emptyDirection.Code, emptyDirection.Body.String())
+	var emptyPage ExploreHTTPResponse
+	require.NoError(json.Unmarshal(emptyDirection.Body.Bytes(), &emptyPage))
+	require.NotEmpty(emptyPage.NextCursor)
+
+	explicitAny := postExploreJSON(t, fixture.server, "/api/v1/explore", exploreIdentityRequest("any", "", "", 1))
+	require.Equal(http.StatusOK, explicitAny.Code, explicitAny.Body.String())
+	var anyPage ExploreHTTPResponse
+	require.NoError(json.Unmarshal(explicitAny.Body.Bytes(), &anyPage))
+	assert.Equal(emptyPage.NextCursor, anyPage.NextCursor)
+
+	secondRequest := fmt.Sprintf(`{
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","any"]}
+		],
+		"limit":1,
+		"cursor":%q
+	}`, emptyPage.NextCursor)
+	second := postExploreJSON(t, fixture.server, "/api/v1/explore", secondRequest)
+	require.Equal(http.StatusOK, second.Code, second.Body.String())
+	var secondPage ExploreHTTPResponse
+	require.NoError(json.Unmarshal(second.Body.Bytes(), &secondPage))
+	require.Len(secondPage.Rows, 1)
+	assert.NotNil(secondPage.Rows[0].MatchedSenderIdentities)
+	assert.NotNil(secondPage.Rows[0].MatchedRecipientIdentities)
+}
+
+func TestExploreFilesIdentityCursorCanonicalizesEmptyDirectionAsAny(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+
+	requestBody := func(direction string) string {
+		return fmt.Sprintf(`{
+			"predicate":{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE",%q]}
+			]},
+			"limit":1
+		}`, direction)
+	}
+	emptyDirection := postExploreJSON(t, fixture.server, "/api/v1/explore/files", requestBody(""))
+	requirements.Equal(http.StatusOK, emptyDirection.Code, emptyDirection.Body.String())
+	var emptyPage ExploreFilesHTTPResponse
+	requirements.NoError(json.Unmarshal(emptyDirection.Body.Bytes(), &emptyPage))
+	requirements.NotEmpty(emptyPage.NextCursor)
+
+	explicitAny := postExploreJSON(t, fixture.server, "/api/v1/explore/files", requestBody("any"))
+	requirements.Equal(http.StatusOK, explicitAny.Code, explicitAny.Body.String())
+	var anyPage ExploreFilesHTTPResponse
+	requirements.NoError(json.Unmarshal(explicitAny.Body.Bytes(), &anyPage))
+	assertions.Equal(emptyPage.NextCursor, anyPage.NextCursor)
+
+	secondRequest := fmt.Sprintf(`{
+		"predicate":{"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","any"]}
+		]},
+		"limit":1,
+		"cursor":%q
+	}`, emptyPage.NextCursor)
+	second := postExploreJSON(t, fixture.server, "/api/v1/explore/files", secondRequest)
+	requirements.Equal(http.StatusOK, second.Code, second.Body.String())
+	var secondPage ExploreFilesHTTPResponse
+	requirements.NoError(json.Unmarshal(second.Body.Bytes(), &secondPage))
+	requirements.Len(secondPage.Files, 1)
+	assertions.Equal("older.txt", secondPage.Files[0].Filename)
+}
+
+func TestExploreIdentityFilterResolvesForGroupsFilesPreflightAndMatchCounts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+	identityFilters := `[
+		{"dimension":"source","values":["1"]},
+		{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","any"]}
+	]`
+
+	groups := postExploreJSON(t, fixture.server, "/api/v1/explore/groups", fmt.Sprintf(`{
+		"grouping":["source"],"filters":%s
+	}`, identityFilters))
+	require.Equal(http.StatusOK, groups.Code, groups.Body.String())
+	var groupsBody ExploreGroupsHTTPResponse
+	require.NoError(json.Unmarshal(groups.Body.Bytes(), &groupsBody))
+	require.Len(groupsBody.Rows, 1)
+	assert.Equal("1", groupsBody.Rows[0].Key)
+	assert.Equal(int64(2), groupsBody.Rows[0].Count)
+
+	files := postExploreJSON(t, fixture.server, "/api/v1/explore/files", fmt.Sprintf(`{
+		"predicate":{"filters":%s},"limit":10
+	}`, identityFilters))
+	require.Equal(http.StatusOK, files.Code, files.Body.String())
+	var filesBody ExploreFilesHTTPResponse
+	require.NoError(json.Unmarshal(files.Body.Bytes(), &filesBody))
+	assert.Equal(int64(2), filesBody.TotalCount)
+	assert.Len(filesBody.Files, 2)
+
+	explore := postExploreJSON(t, fixture.server, "/api/v1/explore", fmt.Sprintf(`{
+		"filters":%s,"limit":10
+	}`, identityFilters))
+	require.Equal(http.StatusOK, explore.Code, explore.Body.String())
+	var exploreBody ExploreHTTPResponse
+	require.NoError(json.Unmarshal(explore.Body.Bytes(), &exploreBody))
+
+	preflight := postExploreJSON(t, fixture.server, "/api/v1/explore/preflight", fmt.Sprintf(`{
+		"selection":{
+			"mode":"all_matching",
+			"predicate":{"filters":%s},
+			"cache_revision":%q
+		}
+	}`, identityFilters, exploreBody.CacheRevision))
+	require.Equal(http.StatusOK, preflight.Code, preflight.Body.String())
+	var preflightBody ExplorePreflightResponse
+	require.NoError(json.Unmarshal(preflight.Body.Bytes(), &preflightBody))
+	assert.Equal(int64(2), preflightBody.Count)
+
+	matchCounts := postExploreJSON(t, fixture.server, "/api/v1/explore/match-counts", fmt.Sprintf(`{
+		"predicate":{"query":"alpha","search_mode":"full_text","filters":%s},
+		"row_keys":["source:1:message:m1","source:1:message:m2"]
+	}`, identityFilters))
+	require.Equal(http.StatusOK, matchCounts.Code, matchCounts.Body.String())
+	var matchCountsBody ExploreMatchCountsResponse
+	require.NoError(json.Unmarshal(matchCounts.Body.Bytes(), &matchCountsBody))
+	assert.Equal([]ExploreRowMatchCount{
+		{RowKey: "source:1:message:m1", Count: 1},
+		{RowKey: "source:1:message:m2", Count: 1},
+	}, matchCountsBody.Counts)
+}
+
+func TestExploreGroupsIdentityFilterPreservesTupleOrderAndNormalizesEmptyDirection(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+	response := postExploreJSON(t, fixture.server, "/api/v1/explore/groups", `{
+		"grouping":["source"],
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","bob@members.example",""]}
+		]
+	}`)
+
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	var body ExploreGroupsHTTPResponse
+	require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	require.Len(body.Rows, 1)
+	assert.Equal("1", body.Rows[0].Key)
+	assert.Equal(int64(2), body.Rows[0].Count)
+}
+
+func TestExploreHydrationUsesEmptyArraysForRowsWithoutAnchors(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	base := newExploreDuckDBFixture(t)
+	engine := &anchorlessExploreEngine{DuckDBEngine: base}
+	srv := newTestServerWithEngine(t, engine)
+
+	response := postExploreJSON(t, srv, "/api/v1/explore", `{"limit":1}`)
+
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	var body ExploreHTTPResponse
+	require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	require.Len(body.Rows, 1)
+	assert.Nil(body.Rows[0].AnchorMessageID)
+	assert.NotNil(body.Rows[0].MatchedSenderIdentities)
+	assert.Empty(body.Rows[0].MatchedSenderIdentities)
+	assert.NotNil(body.Rows[0].MatchedRecipientIdentities)
+	assert.Empty(body.Rows[0].MatchedRecipientIdentities)
+}
+
+type anchorlessExploreEngine struct {
+	*query.DuckDBEngine
+}
+
+func (e *anchorlessExploreEngine) Explore(ctx context.Context, request query.ExploreRequest) (*query.ExploreResponse, error) {
+	result, err := e.DuckDBEngine.Explore(ctx, request)
+	if err == nil && len(result.Rows) > 0 {
+		result.Rows[0].AnchorMessageID = nil
+	}
+	return result, err
+}
+
+type recordingMessageIdentityStore struct {
+	*store.Store
+
+	resolveCalls int
+	matchCalls   int
+	matchIDs     [][]int64
+}
+
+func (s *recordingMessageIdentityStore) ResolveAccountIdentityContext(
+	ctx context.Context,
+	sourceID int64,
+	identifier string,
+) (store.ResolvedAccountIdentity, error) {
+	s.resolveCalls++
+	return s.Store.ResolveAccountIdentityContext(ctx, sourceID, identifier)
+}
+
+func (s *recordingMessageIdentityStore) MatchMessageIdentitiesContext(
+	ctx context.Context,
+	messageIDs []int64,
+) (map[int64]store.MessageIdentityMatch, error) {
+	s.matchCalls++
+	s.matchIDs = append(s.matchIDs, append([]int64(nil), messageIDs...))
+	return s.Store.MatchMessageIdentitiesContext(ctx, messageIDs)
+}
+
+type exploreIdentityAPIFixture struct {
+	server *Server
+	store  *recordingMessageIdentityStore
+}
+
+func newExploreIdentityAPIFixture(t *testing.T) exploreIdentityAPIFixture {
+	t.Helper()
+	requirements := require.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	sourceA, err := st.GetOrCreateSource("gmail", "archive-a@example.com")
+	requirements.NoError(err)
+	sourceB, err := st.GetOrCreateSource("imap", "archive-b@example.com")
+	requirements.NoError(err)
+	requirements.Equal(int64(1), sourceA.ID)
+	requirements.Equal(int64(2), sourceB.ID)
+	conversationA, err := st.EnsureConversation(sourceA.ID, "thread-a", "Thread A")
+	requirements.NoError(err)
+	conversationB, err := st.EnsureConversation(sourceB.ID, "thread-b", "Thread B")
+	requirements.NoError(err)
+	aliceID, err := st.EnsureParticipant("alice@example.com", "Alice", "example.com")
+	requirements.NoError(err)
+	bobID, err := st.EnsureParticipant("BOB@MEMBERS.EXAMPLE", "Bob", "members.example")
+	requirements.NoError(err)
+	requirements.Equal(int64(1), aliceID)
+	requirements.Equal(int64(2), bobID)
+
+	messages := []struct {
+		sourceID       int64
+		conversationID int64
+		sourceMessage  string
+		senderID       int64
+		sentAt         time.Time
+	}{
+		{sourceA.ID, conversationA, "m1", bobID, time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)},
+		{sourceA.ID, conversationA, "m2", aliceID, time.Date(2026, 7, 18, 11, 0, 0, 0, time.UTC)},
+		{sourceB.ID, conversationB, "m3", aliceID, time.Date(2026, 7, 18, 9, 0, 0, 0, time.UTC)},
+	}
+	for i, message := range messages {
+		messageID, err := st.UpsertMessage(&store.Message{
+			ConversationID: message.conversationID, SourceID: message.sourceID,
+			SourceMessageID: message.sourceMessage, MessageType: "email",
+			SentAt:   sql.NullTime{Time: message.sentAt, Valid: true},
+			SenderID: sql.NullInt64{Int64: message.senderID, Valid: true},
+			Subject:  sql.NullString{String: "alpha", Valid: true}, SizeEstimate: 100,
+		})
+		requirements.NoError(err)
+		requirements.Equal(int64(i+1), messageID)
+		requirements.NoError(st.UpsertMessageBody(messageID, sql.NullString{String: "alpha", Valid: true}, sql.NullString{}))
+	}
+	for i := range 10 {
+		requirements.NoError(st.UpsertAttachment(
+			3,
+			fmt.Sprintf("fixture-padding-%d.bin", i),
+			"application/octet-stream",
+			"",
+			fmt.Sprintf("fixture-padding-%d", i),
+			1,
+		))
+	}
+	requirements.NoError(st.UpsertAttachment(1, "older.txt", "text/plain", "", "", 10))
+	requirements.NoError(st.UpsertAttachment(2, "newest.pdf", "application/pdf", "", "", 20))
+	requirements.NoError(st.ReplaceMessageRecipients(1, "from", []int64{bobID}, []string{"Bob"}))
+	requirements.NoError(st.ReplaceMessageRecipients(2, "from", []int64{aliceID}, []string{"Alice"}))
+	requirements.NoError(st.ReplaceMessageRecipients(2, "to", []int64{bobID}, []string{"Bob"}))
+	requirements.NoError(st.ReplaceMessageRecipients(3, "from", []int64{aliceID}, []string{"Alice"}))
+	requirements.NoError(st.ReplaceMessageRecipients(3, "to", []int64{bobID}, []string{"Bob"}))
+	requirements.NoError(st.AddAccountIdentity(sourceA.ID, "Bob@Members.Example", "manual"))
+	requirements.NoError(st.AddAccountIdentity(sourceB.ID, "source-two@example.test", "manual"))
+	_, err = st.BackfillFTS(nil)
+	requirements.NoError(err)
+
+	recipients := `(1::BIGINT, 2::BIGINT, 'from', 'Bob'),
+		(2::BIGINT, 1::BIGINT, 'from', 'Alice'),
+		(2::BIGINT, 2::BIGINT, 'to', 'Bob'),
+		(3::BIGINT, 1::BIGINT, 'from', 'Alice'),
+		(3::BIGINT, 2::BIGINT, 'to', 'Bob')`
+	engine := newExploreDuckDBFixtureWithRecipients(t, recipients)
+	backend := &fakeFusingBackend{
+		fakeVectorBackend: &fakeVectorBackend{
+			active: &vector.Generation{ID: 7, Model: "test", Dimension: 2, Fingerprint: "test:2", State: vector.GenerationActive},
+		},
+		fusedHits: []vector.FusedHit{
+			{MessageID: 1, RRFScore: .9, VectorScore: .9},
+			{MessageID: 2, RRFScore: .8, VectorScore: .8},
+			{MessageID: 3, RRFScore: .7, VectorScore: .7},
+		},
+	}
+	backend.searchHits = []vector.Hit{
+		{MessageID: 1, Score: .9, Rank: 1},
+		{MessageID: 2, Score: .8, Rank: 2},
+		{MessageID: 3, Score: .7, Rank: 3},
+	}
+	hybridEngine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 2}, hybrid.Config{ExpectedFingerprint: "test:2"})
+	recordingStore := &recordingMessageIdentityStore{Store: st}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  recordingStore, Engine: engine, HybridEngine: hybridEngine, Backend: backend, Logger: testLogger(),
+	})
+	return exploreIdentityAPIFixture{server: srv, store: recordingStore}
+}
+
+func exploreIdentityRequest(direction, queryText, searchMode string, limit int) string {
+	search := ""
+	if queryText != "" || searchMode != "" {
+		search = fmt.Sprintf(`,"query":%q,"search_mode":%q`, queryText, searchMode)
+	}
+	return fmt.Sprintf(`{
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE",%q]}
+		],
+		"limit":%d%s
+	}`, direction, limit, search)
+}
+
 func postExploreJSON(t *testing.T, srv *Server, path, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
@@ -411,6 +823,8 @@ const exploreFixtureDefaultMessages = `(1::BIGINT, 1::BIGINT, 'm1', 101::BIGINT,
 	(2::BIGINT, 1::BIGINT, 'm2', 102::BIGINT, 'Newest', 'alpha beta', TIMESTAMP '2026-07-18 11:00:00', 200::BIGINT, true, 1::INTEGER, NULL::TIMESTAMP, NULL::BIGINT, 'email', false, 2026, 7),
 	(3::BIGINT, 2::BIGINT, 'm3', 103::BIGINT, 'Other source', 'beta', TIMESTAMP '2026-07-18 09:00:00', 300::BIGINT, false, 0::INTEGER, NULL::TIMESTAMP, NULL::BIGINT, 'email', false, 2026, 7)`
 
+const exploreFixtureDefaultRecipients = `(1::BIGINT, 1::BIGINT, 'from', 'Alice'), (2::BIGINT, 1::BIGINT, 'from', 'Alice'), (3::BIGINT, 1::BIGINT, 'from', 'Alice'), (3::BIGINT, 2::BIGINT, 'to', 'Bob')`
+
 func newExploreDuckDBFixtureWithDir(t *testing.T) (*query.DuckDBEngine, string) {
 	t.Helper()
 	return newExploreDuckDBFixtureWithMessages(t, exploreFixtureDefaultMessages, 3)
@@ -422,6 +836,23 @@ func newExploreDuckDBFixtureWithDir(t *testing.T) (*query.DuckDBEngine, string) 
 // while sharing the surrounding sources/participants/attachments tables.
 func newExploreDuckDBFixtureWithMessages(
 	t *testing.T, messageValues string, lastMessageID int64,
+) (*query.DuckDBEngine, string) {
+	t.Helper()
+	return newExploreDuckDBFixtureWithMessagesAndRecipients(
+		t, messageValues, exploreFixtureDefaultRecipients, lastMessageID,
+	)
+}
+
+func newExploreDuckDBFixtureWithRecipients(t *testing.T, recipientValues string) *query.DuckDBEngine {
+	t.Helper()
+	engine, _ := newExploreDuckDBFixtureWithMessagesAndRecipients(
+		t, exploreFixtureDefaultMessages, recipientValues, 3,
+	)
+	return engine
+}
+
+func newExploreDuckDBFixtureWithMessagesAndRecipients(
+	t *testing.T, messageValues, recipientValues string, lastMessageID int64,
 ) (*query.DuckDBEngine, string) {
 	t.Helper()
 	analyticsDir := t.TempDir()
@@ -441,7 +872,7 @@ func newExploreDuckDBFixtureWithMessages(
 		{dir: "sources", file: "sources.parquet", columns: "id, account_email, source_type", values: `(1::BIGINT, 'archive-a@example.com', 'gmail'), (2::BIGINT, 'archive-b@example.com', 'imap')`},
 		{dir: "participants", file: "participants.parquet", columns: "id, email_address, domain, display_name, phone_number", values: `(1::BIGINT, 'alice@example.com', 'example.com', 'Alice', ''), (2::BIGINT, 'bob@members.example', 'members.example', 'Bob', '')`},
 		{dir: "participant_identifiers", file: "participant_identifiers.parquet", columns: "participant_id, identifier_type, identifier_value, display_value, is_primary", values: `(1::BIGINT, 'email', 'alice@example.com', 'alice@example.com', true), (2::BIGINT, 'email', 'bob@members.example', 'bob@members.example', true)`},
-		{dir: "message_recipients", file: "message_recipients.parquet", columns: "message_id, participant_id, recipient_type, display_name", values: `(1::BIGINT, 1::BIGINT, 'from', 'Alice'), (2::BIGINT, 1::BIGINT, 'from', 'Alice'), (3::BIGINT, 1::BIGINT, 'from', 'Alice'), (3::BIGINT, 2::BIGINT, 'to', 'Bob')`},
+		{dir: "message_recipients", file: "message_recipients.parquet", columns: "message_id, participant_id, recipient_type, display_name", values: recipientValues},
 		{dir: "labels", file: "labels.parquet", columns: "id, name", values: `(0::BIGINT, '')`, empty: true},
 		{dir: "message_labels", file: "message_labels.parquet", columns: "message_id, label_id", values: `(0::BIGINT, 0::BIGINT)`, empty: true},
 		{dir: "attachments", file: "attachments.parquet", columns: "attachment_id, message_id, size, filename", values: `(11::BIGINT, 1::BIGINT, 10::BIGINT, 'older.txt'), (12::BIGINT, 2::BIGINT, 20::BIGINT, 'newest.pdf')`},

--- a/internal/api/explore_files.go
+++ b/internal/api/explore_files.go
@@ -36,9 +36,9 @@ func (s *Server) handleExploreFiles(w http.ResponseWriter, r *http.Request) {
 	if !decodeExploreJSON(w, r, &request) {
 		return
 	}
-	predicate, err := prepareExplorePredicate(request.Predicate)
+	predicate, err := s.prepareResolvedExplorePredicate(r.Context(), request.Predicate)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_files_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_files_predicate")
 		return
 	}
 	if request.Limit == 0 {
@@ -49,6 +49,7 @@ func (s *Server) handleExploreFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	canonical := request
+	canonical.Predicate = predicate.request
 	canonical.Cursor = ""
 	requestHash := hashCanonicalValue(canonical, false)
 	offset, ok := s.parseExploreCursor(w, request.Cursor, requestHash)

--- a/internal/api/explore_files_test.go
+++ b/internal/api/explore_files_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExploreFilesRejectsUnboundedLimit(t *testing.T) {
@@ -12,4 +13,41 @@ func TestExploreFilesRejectsUnboundedLimit(t *testing.T) {
 	response := postExploreJSON(t, srv, "/api/v1/explore/files", `{"predicate":{},"limit":101}`)
 	assert.Equal(t, http.StatusBadRequest, response.Code)
 	assert.Contains(t, response.Body.String(), "limit must be between")
+}
+
+func TestPrepareExplorePredicateCanonicalizesWithoutMutatingCaller(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	input := ExploreHTTPRequest{
+		Query:      " alpha ",
+		SearchMode: " FULL_TEXT ",
+		Filters: []ExploreFilter{
+			{Dimension: " source ", Values: []string{"1"}},
+			{Dimension: " identity ", Values: []string{"1", " BOB@MEMBERS.EXAMPLE ", ""}},
+		},
+		Grouping: []ExploreGroupDimension{" SOURCE "},
+		Sort:     []ExploreSort{{Field: " OCCURRED_AT ", Direction: " DESC "}},
+	}
+	wantInput := ExploreHTTPRequest{
+		Query:      " alpha ",
+		SearchMode: " FULL_TEXT ",
+		Filters: []ExploreFilter{
+			{Dimension: " source ", Values: []string{"1"}},
+			{Dimension: " identity ", Values: []string{"1", " BOB@MEMBERS.EXAMPLE ", ""}},
+		},
+		Grouping: []ExploreGroupDimension{" SOURCE "},
+		Sort:     []ExploreSort{{Field: " OCCURRED_AT ", Direction: " DESC "}},
+	}
+
+	prepared, err := prepareExplorePredicate(input)
+	requirements.NoError(err)
+	assertions.Equal(wantInput, input, "canonicalization must not mutate the caller through shared slices")
+	assertions.Equal(ExploreFilter{
+		Dimension: "identity",
+		Values:    []string{"1", "BOB@MEMBERS.EXAMPLE", "any"},
+	}, prepared.request.Filters[0])
+	assertions.Equal("alpha", prepared.request.Query)
+	assertions.Equal(exploreSearchModeFullText, prepared.request.SearchMode)
+	assertions.Equal([]ExploreGroupDimension{"source"}, prepared.request.Grouping)
+	assertions.Equal([]ExploreSort{{Field: "occurred_at", Direction: "desc"}}, prepared.request.Sort)
 }

--- a/internal/api/explore_review_test.go
+++ b/internal/api/explore_review_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -33,6 +35,353 @@ func TestExploreRelativeDateRevisionIgnoresParseClock(t *testing.T) {
 	second := (&search.Parser{Now: func() time.Time { return secondNow }}).Parse("alpha newer_than:1d")
 
 	assert.Equal(t, canonicalParsedExploreQuery(first), canonicalParsedExploreQuery(second))
+}
+
+func TestExploreIdentityFilterRequiresMatchingSingleSource(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	tests := []struct {
+		name    string
+		filters []ExploreFilter
+	}{
+		{
+			name: "missing source",
+			filters: []ExploreFilter{
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "recipient"}},
+			},
+		},
+		{
+			name: "multiple selected sources",
+			filters: []ExploreFilter{
+				{Dimension: "source", Values: []string{"14", "15"}},
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "recipient"}},
+			},
+		},
+		{
+			name: "other selected source",
+			filters: []ExploreFilter{
+				{Dimension: "source", Values: []string{"15"}},
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "recipient"}},
+			},
+		},
+		{
+			name: "duplicate source filter",
+			filters: []ExploreFilter{
+				{Dimension: "source", Values: []string{"14"}},
+				{Dimension: "source", Values: []string{"14"}},
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "recipient"}},
+			},
+		},
+		{
+			name: "duplicate identity filter",
+			filters: []ExploreFilter{
+				{Dimension: "source", Values: []string{"14"}},
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "recipient"}},
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "recipient"}},
+			},
+		},
+		{
+			name: "malformed identity tuple",
+			filters: []ExploreFilter{
+				{Dimension: "source", Values: []string{"14"}},
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test"}},
+			},
+		},
+		{
+			name: "empty identifier",
+			filters: []ExploreFilter{
+				{Dimension: "source", Values: []string{"14"}},
+				{Dimension: "identity", Values: []string{"14", "", "recipient"}},
+			},
+		},
+		{
+			name: "invalid direction",
+			filters: []ExploreFilter{
+				{Dimension: "source", Values: []string{"14"}},
+				{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "sideways"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			_, err := exploreContext(tt.filters)
+			assertions.Error(err)
+		})
+	}
+
+	ctx, err := exploreContext([]ExploreFilter{
+		{Dimension: "source", Values: []string{"14"}},
+		{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", "recipient"}},
+	})
+	requirements.NoError(err)
+	requirements.NotNil(ctx.Identity)
+	assertions.Equal(int64(14), ctx.Identity.SourceID)
+	assertions.Equal(query.IdentityDirectionRecipient, ctx.Identity.Direction)
+	assertions.Empty(ctx.Identity.ParticipantIDs)
+}
+
+func TestExploreIdentityFilterEmptyDirectionNormalizesToAny(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	request := ExploreHTTPRequest{Filters: []ExploreFilter{
+		{Dimension: "source", Values: []string{"14"}},
+		{Dimension: "identity", Values: []string{"14", "masked-shop@example.test", ""}},
+	}}
+	canonicalizeExploreRequest(&request)
+
+	require.Len(request.Filters, 2)
+	assert.Equal(ExploreFilter{
+		Dimension: "identity",
+		Values:    []string{"14", "masked-shop@example.test", "any"},
+	}, request.Filters[0])
+	ctx, err := exploreContext(request.Filters)
+	require.NoError(err)
+	require.NotNil(ctx.Identity)
+	assert.Equal(query.IdentityDirectionAny, ctx.Identity.Direction)
+}
+
+func TestExploreIdentityFilterResolvesConfirmedEmailCaseInsensitively(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "archive-a@example.com")
+	requirements.NoError(err)
+	_, err = st.GetOrCreateSource("imap", "archive-b@example.com")
+	requirements.NoError(err)
+	participantID, err := st.EnsureParticipant("alice@example.com", "Alice", "example.com")
+	requirements.NoError(err)
+	requirements.NoError(st.AddAccountIdentity(source.ID, "Alice@Example.com", "manual"))
+	base := newExploreDuckDBFixture(t)
+	engine := &recordingExploreEngine{Engine: base, Explorer: base}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st, Engine: engine, Logger: testLogger(),
+	})
+
+	response := postExploreJSON(t, srv, "/api/v1/explore", `{
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","ALICE@EXAMPLE.COM","sender"]}
+		]
+	}`)
+
+	requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+	requirements.NotNil(engine.request.Context.Identity)
+	assertions.Equal(source.ID, engine.request.Context.Identity.SourceID)
+	assertions.Equal([]int64{participantID}, engine.request.Context.Identity.ParticipantIDs)
+	assertions.Equal("Alice@Example.com", engine.request.Context.Identity.EmailIdentifier,
+		"the stored email identifier must reach the predicate for envelope matching")
+	assertions.Equal(query.IdentityDirectionSender, engine.request.Context.Identity.Direction)
+}
+
+// TestExploreIdentityFilterConfirmedUnseenEmailIdentityKeepsEnvelopePredicate
+// covers the merge edge where a confirmed email address no longer resolves to
+// any participant: the filter must still carry the envelope predicate (the
+// address may survive in message_recipients.email_address snapshots) instead
+// of short-circuiting to match-none.
+func TestExploreIdentityFilterConfirmedUnseenEmailIdentityKeepsEnvelopePredicate(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(source.ID, "unused-mask@example.test", "provider-alias"))
+	base := newExploreDuckDBFixture(t)
+	engine := &recordingExploreEngine{Engine: base, Explorer: base}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st, Engine: engine, Logger: testLogger(),
+	})
+
+	response := postExploreJSON(t, srv, "/api/v1/explore", `{
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","unused-mask@example.test","recipient"]}
+		]
+	}`)
+
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	require.NotNil(engine.request.Context.Identity)
+	assert.Equal(source.ID, engine.request.Context.Identity.SourceID)
+	assert.False(engine.request.Context.Identity.MatchNone,
+		"an email identity stays matchable through envelope snapshots")
+	assert.Equal("unused-mask@example.test", engine.request.Context.Identity.EmailIdentifier)
+	assert.Empty(engine.request.Context.Identity.ParticipantIDs)
+	var body ExploreHTTPResponse
+	require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	require.NotNil(body.TotalCount)
+	assert.Zero(*body.TotalCount)
+}
+
+// TestExploreIdentityFilterAcceptsConfirmedUnseenPhoneIdentityAsMatchNone
+// keeps the match-none short-circuit for identifier types without an envelope
+// surface: a confirmed phone identity with no participant evidence has
+// nothing left to match.
+func TestExploreIdentityFilterAcceptsConfirmedUnseenPhoneIdentityAsMatchNone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(source.ID, "+15550100003", "manual"))
+	base := newExploreDuckDBFixture(t)
+	engine := &recordingExploreEngine{Engine: base, Explorer: base}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st, Engine: engine, Logger: testLogger(),
+	})
+
+	response := postExploreJSON(t, srv, "/api/v1/explore", `{
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","+15550100003","recipient"]}
+		]
+	}`)
+
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	require.NotNil(engine.request.Context.Identity)
+	assert.True(engine.request.Context.Identity.MatchNone)
+	assert.Empty(engine.request.Context.Identity.EmailIdentifier)
+	assert.Empty(engine.request.Context.Identity.ParticipantIDs)
+	var body ExploreHTTPResponse
+	require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	require.NotNil(body.TotalCount)
+	assert.Zero(*body.TotalCount)
+}
+
+func TestExploreIdentityFilterRejectsInvalidAndUnconfirmedIdentitiesWithoutLoggingAddress(t *testing.T) {
+	requirements := require.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	sourceA, err := st.GetOrCreateSource("gmail", "archive-a@example.com")
+	requirements.NoError(err)
+	sourceB, err := st.GetOrCreateSource("imap", "archive-b@example.com")
+	requirements.NoError(err)
+	_, err = st.EnsureParticipant("unconfirmed-private@example.test", "Preview", "example.test")
+	requirements.NoError(err)
+	requirements.NoError(st.AddAccountIdentity(sourceB.ID, "other-source-private@example.test", "manual"))
+
+	tests := []struct {
+		name    string
+		address string
+		body    string
+	}{
+		{
+			name:    "unconfirmed",
+			address: "unconfirmed-private@example.test",
+			body: `{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","unconfirmed-private@example.test","any"]}
+			]}`,
+		},
+		{
+			name:    "confirmed only for another source",
+			address: "other-source-private@example.test",
+			body: `{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","other-source-private@example.test","any"]}
+			]}`,
+		},
+		{
+			name:    "source mismatch",
+			address: "other-source-private@example.test",
+			body: `{"filters":[
+				{"dimension":"source","values":["2"]},
+				{"dimension":"identity","values":["1","other-source-private@example.test","any"]}
+			]}`,
+		},
+		{
+			name: "all sources",
+			body: `{"filters":[
+				{"dimension":"source","values":["1","2"]},
+				{"dimension":"identity","values":["1","unconfirmed-private@example.test","any"]}
+			]}`,
+		},
+		{
+			name: "duplicate source",
+			body: `{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","unconfirmed-private@example.test","any"]}
+			]}`,
+		},
+		{
+			name: "malformed tuple",
+			body: `{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","unconfirmed-private@example.test"]}
+			]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			srv := NewServerWithOptions(ServerOptions{
+				Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+				Store:  st, Engine: newExploreDuckDBFixture(t), Logger: logger,
+			})
+
+			response := postExploreJSON(t, srv, "/api/v1/explore", tt.body)
+
+			assert.Equal(http.StatusBadRequest, response.Code, response.Body.String())
+			var apiErr ErrorResponse
+			require.NoError(json.Unmarshal(response.Body.Bytes(), &apiErr))
+			assert.Equal("invalid_identity_filter", apiErr.Error)
+			if tt.address != "" {
+				assert.NotContains(apiErr.Message, tt.address)
+				assert.NotContains(logs.String(), tt.address)
+			}
+		})
+	}
+
+	assert.New(t).Equal(int64(1), sourceA.ID)
+}
+
+func TestExploreIdentityFilterPreservesResolverContextErrors(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "archive-a@example.com")
+	require.NoError(err)
+	assert.Equal(int64(1), source.ID)
+
+	const identifier = "private-timeout@example.test"
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  &identityResolveErrorStore{Store: st, err: context.DeadlineExceeded},
+		Engine: newExploreDuckDBFixture(t), Logger: testLogger(),
+	})
+	response := postExploreJSON(t, srv, "/api/v1/explore", `{
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","private-timeout@example.test","any"]}
+		]
+	}`)
+
+	assert.Equal(http.StatusServiceUnavailable, response.Code, response.Body.String())
+	var apiErr ErrorResponse
+	require.NoError(json.Unmarshal(response.Body.Bytes(), &apiErr))
+	assert.Equal("query_timeout", apiErr.Error)
+	assert.NotContains(apiErr.Message, identifier)
+}
+
+type identityResolveErrorStore struct {
+	*store.Store
+
+	err error
+}
+
+func (s *identityResolveErrorStore) ResolveAccountIdentityContext(
+	context.Context,
+	int64,
+	string,
+) (store.ResolvedAccountIdentity, error) {
+	return store.ResolvedAccountIdentity{}, s.err
 }
 
 func TestExploreFullTextResolverBoundsCandidateTransfer(t *testing.T) {

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -134,9 +134,9 @@ func (s *Server) handleGroupFiles(w http.ResponseWriter, r *http.Request) {
 	if !decodeExploreJSON(w, r, &request) {
 		return
 	}
-	predicate, err := prepareExplorePredicate(request.Predicate)
+	predicate, err := s.prepareResolvedExplorePredicate(r.Context(), request.Predicate)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_files_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_files_predicate")
 		return
 	}
 	if len(request.Grouping) != 1 {
@@ -278,9 +278,9 @@ func (s *Server) handleSearchFilesWithScope(w http.ResponseWriter, r *http.Reque
 	if !decodeExploreJSON(w, r, &request) {
 		return
 	}
-	predicate, err := prepareExplorePredicate(request.Predicate)
+	predicate, err := s.prepareResolvedExplorePredicate(r.Context(), request.Predicate)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_files_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_files_predicate")
 		return
 	}
 	if request.Limit == 0 {

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -140,6 +140,88 @@ func TestFilesSearchUsesAnalyticalQueryAndOneCatalogBatch(t *testing.T) {
 	assertions.Equal(query.SortSpec{Field: "size", Direction: "asc"}, engine.request.Sort)
 }
 
+func TestFileAdaptersResolveIdentityFilterOncePerRequest(t *testing.T) {
+	t.Run("search", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		fixture := newExploreIdentityAPIFixture(t)
+
+		response := postExploreJSON(t, fixture.server, "/api/v1/files/search", `{
+			"predicate":{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}
+			]}
+		}`)
+
+		requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+		var body FileSearchHTTPResponse
+		requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+		requirements.Len(body.Files, 1)
+		assertions.Equal(int64(2), body.Files[0].MessageID)
+		assertions.Equal(1, fixture.store.resolveCalls)
+	})
+
+	t.Run("groups", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		fixture := newExploreIdentityAPIFixture(t)
+
+		response := postExploreJSON(t, fixture.server, "/api/v1/files/groups", `{
+			"predicate":{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}
+			]},
+			"grouping":["message_type"]
+		}`)
+
+		requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+		var body FileGroupsHTTPResponse
+		requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+		requirements.Len(body.Rows, 1)
+		assertions.Equal("email", body.Rows[0].Key)
+		assertions.Equal(int64(1), body.Rows[0].Count)
+		assertions.Equal(1, fixture.store.resolveCalls)
+	})
+}
+
+func TestFileSearchRejectsUnconfirmedOrSourceMismatchedIdentity(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		filters    string
+	}{
+		{
+			name:       "unconfirmed",
+			identifier: "unconfirmed-private@example.test",
+			filters: `[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","unconfirmed-private@example.test","any"]}
+			]`,
+		},
+		{
+			name:       "source mismatch",
+			identifier: "source-two@example.test",
+			filters: `[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["2","source-two@example.test","any"]}
+			]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newExploreIdentityAPIFixture(t)
+			response := postExploreJSON(t, fixture.server, "/api/v1/files/search", `{
+				"predicate":{"filters":`+tt.filters+`}
+			}`)
+
+			assert.Equal(t, http.StatusBadRequest, response.Code, response.Body.String())
+			assert.Contains(t, response.Body.String(), "invalid_identity_filter")
+			assert.NotContains(t, response.Body.String(), tt.identifier)
+		})
+	}
+}
+
 // TestPersonFilesSearchWidensScopeToIdentityCluster covers the identity
 // consistency between the Relationships hub panes: the person-scoped files
 // search must see the same cluster the person detail header and relationship

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1832,7 +1832,7 @@ func TestHandleCLIIdentityAddPreservesErrorEnvelope(t *testing.T) {
 	var out ErrorResponse
 	require.NoError(json.NewDecoder(resp.Body).Decode(&out), "decode error response")
 	assert.Equal("invalid_identity", out.Error, "error code")
-	assert.Equal("account is required", out.Message, "error message")
+	assert.Equal("account or source ID is required", out.Message, "error message")
 }
 
 func TestHandleCLIIdentityAddMissingAccountUsesNotFoundCode(t *testing.T) {

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -174,7 +174,11 @@ import (
 // optimistic concurrency, and person attribute list/set/clear with
 // value-level provenance, retained history, and dry-run previews.
 // Additive (minor bump): the major-version compatibility gate stays at 1.
-const APISchemaVersion = "1.35.0"
+// 1.36.0 resolves source-scoped identity filters on relationship ranking and
+// timeline routes, and adds a typed terminal error variant to CLI identity
+// discovery NDJSON streams. Additive (minor bump): existing progress/result
+// events and relationship requests without identity filters are unchanged.
+const APISchemaVersion = "1.36.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.
@@ -297,6 +301,7 @@ func hardenExploreSchemas(doc *huma.OpenAPI) {
 		}
 	}
 	for schemaName, properties := range map[string][]string{
+		"EntryRow":                   {"matched_sender_identities", "matched_recipient_identities"},
 		"ExploreFilter":              {"values"},
 		"ExploreHTTPResponse":        {"rows"},
 		"ExploreGroupsHTTPRequest":   {"grouping"},
@@ -541,7 +546,7 @@ func applyClientCodegenExtensions(doc *huma.OpenAPI) {
 			"readiness": {"ExploreCacheUnavailableResponseReadinessAbsent", "ExploreCacheUnavailableResponseReadinessInterrupted", "ExploreCacheUnavailableResponseReadinessStaleSchema", "ExploreCacheUnavailableResponseReadinessDrifted"},
 		},
 		"ExploreFilter": {
-			"dimension": {"ExploreFilterDimensionSource", "ExploreFilterDimensionParticipant", "ExploreFilterDimensionDomain", "ExploreFilterDimensionMessageType", "ExploreFilterDimensionAfter", "ExploreFilterDimensionBefore", "ExploreFilterDimensionDeletion"},
+			"dimension": {"ExploreFilterDimensionSource", "ExploreFilterDimensionParticipant", "ExploreFilterDimensionDomain", "ExploreFilterDimensionMessageType", "ExploreFilterDimensionAfter", "ExploreFilterDimensionBefore", "ExploreFilterDimensionDeletion", "ExploreFilterDimensionIdentity"},
 		},
 		"ExploreGroupSort": {
 			"direction": {"ExploreGroupSortDirectionAsc", "ExploreGroupSortDirectionDesc"},

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/explorecatalog"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 const (
@@ -130,6 +132,84 @@ func TestOpenAPIYAMLDeterministic(t *testing.T) {
 	assert.Equal(t, string(first), string(second), "OpenAPI YAML should be deterministic")
 }
 
+func TestOpenAPIIdentityDiscoveryApplyIsOptional(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	for _, document := range []*huma.OpenAPI{OpenAPIDocument(), openAPIClientDocument()} {
+		schema := document.Components.Schemas.Map()["DiscoverRequest"]
+		requirements.NotNil(schema)
+		assertions.NotContains(schema.Required, "apply", "omitting apply previews discovery")
+		requirements.NotNil(schema.Properties["apply"])
+		assertions.Equal("boolean", schema.Properties["apply"].Type)
+	}
+}
+
+func TestOpenAPIIdentityCandidateRequiresProviderStates(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	for _, document := range []*huma.OpenAPI{OpenAPIDocument(), openAPIClientDocument()} {
+		schema := document.Components.Schemas.Map()["Candidate"]
+		requirements.NotNil(schema)
+		assertions.Contains(schema.Required, "provider_states")
+		property := schema.Properties["provider_states"]
+		requirements.NotNil(property)
+		assertions.Equal("array", property.Type)
+		assertions.False(property.Nullable, "provider_states must always be an array, never null")
+		requirements.NotNil(property.Items)
+		assertions.Equal("string", property.Items.Type)
+	}
+	field, ok := reflect.TypeFor[generated.Candidate]().FieldByName("ProviderStates")
+	requirements.True(ok)
+	assertions.Equal(reflect.Slice, field.Type.Kind())
+	assertions.Equal("provider_states", field.Tag.Get("json"),
+		"generated clients must always serialize provider_states without omitempty")
+}
+
+func TestOpenAPIIdentityImportUsesParsedEntryContract(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	for _, document := range []*huma.OpenAPI{OpenAPIDocument(), openAPIClientDocument()} {
+		path := document.Paths["/api/v1/cli/identities/import"]
+		requirements.NotNil(path)
+		operation := path.Post
+		requirements.NotNil(operation)
+		request := document.Components.Schemas.Map()["ImportRequest"]
+		requirements.NotNil(request)
+		assertions.Contains(request.Required, "entries")
+		assertions.NotContains(request.Properties, "file")
+		assertions.NotContains(request.Properties, "data")
+		entries := request.Properties["entries"]
+		requirements.NotNil(entries)
+		assertions.Equal("array", entries.Type)
+		assertions.False(entries.Nullable, "import entries must never be null")
+
+		result := document.Components.Schemas.Map()["ImportResult"]
+		requirements.NotNil(result)
+		for _, propertyName := range []string{"candidates", "applied"} {
+			assertions.Contains(result.Required, propertyName)
+			property := result.Properties[propertyName]
+			requirements.NotNil(property)
+			assertions.Equal("array", property.Type)
+			assertions.False(property.Nullable, "import result %s must never be null", propertyName)
+		}
+	}
+	for _, test := range []struct {
+		typ       reflect.Type
+		fieldName string
+		jsonTag   string
+	}{
+		{typ: reflect.TypeFor[generated.ImportRequest](), fieldName: "Entries", jsonTag: "entries"},
+		{typ: reflect.TypeFor[generated.ImportResult](), fieldName: "Candidates", jsonTag: "candidates"},
+		{typ: reflect.TypeFor[generated.ImportResult](), fieldName: "Applied", jsonTag: "applied"},
+	} {
+		field, ok := test.typ.FieldByName(test.fieldName)
+		requirements.True(ok)
+		assertions.Equal(reflect.Slice, field.Type.Kind())
+		assertions.Equal(test.jsonTag, field.Tag.Get("json"),
+			"generated import arrays must serialize without omitempty")
+	}
+}
+
 func TestOpenAPITotalStatsDocumentsSearchScope(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -185,8 +265,8 @@ func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("1.35.0", APISchemaVersion,
-		"attribute registry and person attributes are an additive schema release")
+	assert.Equal("1.36.0", APISchemaVersion,
+		"source-scoped identities are additive to the attribute schema release")
 
 	doc := OpenAPIDocument()
 	definitions := doc.Paths["/api/v1/attribute-definitions"]
@@ -212,9 +292,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 
 	// Pinned so that anyone bumping the schema version has to come here and
 	// confirm the meeting-import contract below still holds. Meeting import
-	// shipped in 1.33.0; the feed added in 1.34.0 and the attributes added
-	// in 1.35.0 did not touch it.
-	assert.Equal("1.35.0", APISchemaVersion, "meeting import is an additive schema release")
+	// shipped in 1.33.0; the feed added in 1.34.0, the attributes added in
+	// 1.35.0, and source-scoped identities added in 1.36.0 did not touch it.
+	assert.Equal("1.36.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]
@@ -416,12 +496,21 @@ func TestOpenAPIDocumentsAllExplorationOperations(t *testing.T) {
 	requirements.NotNil(filter)
 	requirements.NotNil(filter.Properties["dimension"])
 	assertions.ElementsMatch(
-		[]any{"source", "participant", "domain", "message_type", "after", "before", "deletion"},
+		[]any{"source", "participant", "domain", "message_type", "after", "before", "deletion", "identity"},
 		filter.Properties["dimension"].Enum,
 	)
+	clientFilter := openAPIClientDocument().Components.Schemas.Map()["ExploreFilter"]
+	requirements.NotNil(clientFilter)
+	requirements.NotNil(clientFilter.Properties["dimension"])
+	assertions.Equal([]any{
+		"ExploreFilterDimensionSource", "ExploreFilterDimensionParticipant", "ExploreFilterDimensionDomain",
+		"ExploreFilterDimensionMessageType", "ExploreFilterDimensionAfter", "ExploreFilterDimensionBefore",
+		"ExploreFilterDimensionDeletion", "ExploreFilterDimensionIdentity",
+	}, clientFilter.Properties["dimension"].Extensions["x-enum-names"])
 	for schemaName, properties := range map[string][]string{
 		"ExploreFilter":              {"values"},
 		"ExploreHTTPResponse":        {"rows"},
+		"EntryRow":                   {"matched_sender_identities", "matched_recipient_identities"},
 		"ExploreGroupsHTTPResponse":  {"rows"},
 		"ExploreFilesHTTPResponse":   {"files"},
 		"ExploreMatchCountsResponse": {"counts"},

--- a/internal/api/people.go
+++ b/internal/api/people.go
@@ -172,9 +172,9 @@ func (s *Server) prepareIdentitySearch(w http.ResponseWriter, r *http.Request, r
 		return identitySearchPrepared{}, false
 	}
 	request.Predicate.Cursor = ""
-	prepared, err := prepareExplorePredicate(request.Predicate)
+	prepared, err := s.prepareResolvedExplorePredicate(r.Context(), request.Predicate)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_identity_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_identity_predicate")
 		return identitySearchPrepared{}, false
 	}
 	if request.Limit == 0 {
@@ -412,9 +412,9 @@ func (s *Server) prepareIdentitySummary(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "invalid_identity_predicate", "identity summary does not accept grouping")
 		return query.ExploreRequest{}, "", false
 	}
-	prepared, err := prepareExplorePredicate(request)
+	prepared, err := s.prepareResolvedExplorePredicate(r.Context(), request)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_identity_predicate", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_identity_predicate")
 		return query.ExploreRequest{}, "", false
 	}
 	searchSpec, snapshotID, ok := s.resolveExploreSearch(r.Context(), w, prepared.request)

--- a/internal/api/people_test.go
+++ b/internal/api/people_test.go
@@ -129,6 +129,47 @@ func TestPeopleSearchResolvesCanonicalFullTextCandidatesAndReturnsAuthority(t *t
 	assertions.Equal(query.SearchProvenance{LexicalIndexRevision: "resolved"}, body.SearchProvenance)
 }
 
+func TestPeopleAdaptersResolveIdentityFilterOncePerRequest(t *testing.T) {
+	t.Run("search", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		fixture := newExploreIdentityAPIFixture(t)
+
+		response := postExploreJSON(t, fixture.server, "/api/v1/people/search", `{
+			"predicate":{"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}
+			]},
+			"limit":25
+		}`)
+
+		requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+		var body PersonSearchHTTPResponse
+		requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+		assertions.Equal(int64(2), body.TotalCount)
+		assertions.Equal(1, fixture.store.resolveCalls)
+	})
+
+	t.Run("summary", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		fixture := newExploreIdentityAPIFixture(t)
+
+		response := postExploreJSON(t, fixture.server, "/api/v1/people/1/summary", `{
+			"filters":[
+				{"dimension":"source","values":["1"]},
+				{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}
+			]
+		}`)
+
+		requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+		var body PersonContextSummaryHTTPResponse
+		requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+		assertions.Equal(int64(1), body.Summary.ActivityCount)
+		assertions.Equal(1, fixture.store.resolveCalls)
+	})
+}
+
 func TestPeopleSearchNamesUnavailableSemanticAuthorityWithoutFallback(t *testing.T) {
 	assertions := assert.New(t)
 	engine := &peopleAPIEngine{MockEngine: &querytest.MockEngine{}, peopleResult: &query.PersonSearchResponse{

--- a/internal/api/relationship_timeline_test.go
+++ b/internal/api/relationship_timeline_test.go
@@ -175,6 +175,66 @@ func TestRelationshipTimelineOverHTTP(t *testing.T) {
 	assert.Equal("event", page.Rows[2].Kind)
 }
 
+func TestRelationshipTimelineResolvesSourceScopedIdentityBeforeAnalyzerWork(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	now := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	duckDB, _ := newRelationshipTimelineDuckDBFixture(t, now)
+	srv, identityStore, engine := newRelationshipIdentityAPIServer(
+		t,
+		duckDB,
+		[]string{
+			relationshipIdentityIdentifier,
+			"pat@example.test",
+			"pat-work@example.test",
+			"bystander@example.test",
+		},
+	)
+	path := fmt.Sprintf("/api/v1/relationships/%d/timeline", rtPatID)
+
+	baseline := postExploreJSON(t, srv, path, `{"timezone":"UTC"}`)
+	requirements.Equal(http.StatusOK, baseline.Code, baseline.Body.String())
+	var baselinePage RelationshipTimelineHTTPResponse
+	requirements.NoError(json.Unmarshal(baseline.Body.Bytes(), &baselinePage))
+	requirements.Len(baselinePage.Rows, 4)
+	assertions.Equal(1, engine.resolveCanonicalCalls)
+	assertions.Equal(1, engine.timelineCalls)
+	assertions.Zero(identityStore.resolveCalls)
+
+	filtered := postExploreJSON(t, srv, path, `{
+		"timezone":"UTC",
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","z-owner@example.test","sender"]}
+		]
+	}`)
+	requirements.Equal(http.StatusOK, filtered.Code, filtered.Body.String())
+	var filteredPage RelationshipTimelineHTTPResponse
+	requirements.NoError(json.Unmarshal(filtered.Body.Bytes(), &filteredPage))
+	requirements.Len(filteredPage.Rows, 1, "the resolved sender identity must retain only the owner-authored meeting")
+	assertions.Equal("event", filteredPage.Rows[0].Kind)
+	assertions.Equal(1, identityStore.resolveCalls, "the shared identity resolver runs once per request")
+	assertions.Equal(2, engine.resolveCanonicalCalls)
+	assertions.Equal(2, engine.timelineCalls)
+
+	invalid := postExploreJSON(t, srv, path, `{
+		"timezone":"UTC",
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","private-provider-token@example.test","sender"]}
+		]
+	}`)
+	requirements.Equal(http.StatusBadRequest, invalid.Code, invalid.Body.String())
+	var apiErr ErrorResponse
+	requirements.NoError(json.Unmarshal(invalid.Body.Bytes(), &apiErr))
+	assertions.Equal("invalid_identity_filter", apiErr.Error)
+	assertions.Equal("identity filter is malformed, unconfirmed, or does not match the selected source", apiErr.Message)
+	assertions.NotContains(invalid.Body.String(), "private-provider-token")
+	assertions.Equal(2, identityStore.resolveCalls)
+	assertions.Equal(2, engine.resolveCanonicalCalls, "invalid identity input must stop before canonical resolution")
+	assertions.Equal(2, engine.timelineCalls, "invalid identity input must stop before timeline analysis")
+}
+
 func TestRelationshipTimelineResolvesAnyMemberIDOverHTTP(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/api/relationships.go
+++ b/internal/api/relationships.go
@@ -3,9 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -51,7 +49,11 @@ func (s *Server) handleRelationships(w http.ResponseWriter, r *http.Request) {
 	canonicalizeRelationshipFilters(request.Filters)
 	analyticalContext, err := exploreContext(request.Filters)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_filter", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_filter")
+		return
+	}
+	if err := s.resolveExploreIdentityContext(r.Context(), request.Filters, &analyticalContext); err != nil {
+		s.writeExploreFilterError(w, err, "invalid_filter")
 		return
 	}
 	if request.Limit == 0 {
@@ -180,7 +182,11 @@ func (s *Server) handleRelationshipTimeline(w http.ResponseWriter, r *http.Reque
 	canonicalizeRelationshipFilters(request.Filters)
 	analyticalContext, err := exploreContext(request.Filters)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_filter", err.Error())
+		s.writeExploreFilterError(w, err, "invalid_filter")
+		return
+	}
+	if err := s.resolveExploreIdentityContext(r.Context(), request.Filters, &analyticalContext); err != nil {
+		s.writeExploreFilterError(w, err, "invalid_filter")
 		return
 	}
 	if request.Limit == 0 {
@@ -246,13 +252,5 @@ func (s *Server) handleRelationshipTimeline(w http.ResponseWriter, r *http.Reque
 }
 
 func canonicalizeRelationshipFilters(filters []ExploreFilter) {
-	for i := range filters {
-		filters[i].Dimension = strings.ToLower(strings.TrimSpace(filters[i].Dimension))
-		for j := range filters[i].Values {
-			filters[i].Values[j] = strings.TrimSpace(filters[i].Values[j])
-		}
-		slices.Sort(filters[i].Values)
-		filters[i].Values = slices.Compact(filters[i].Values)
-	}
-	slices.SortFunc(filters, func(a, b ExploreFilter) int { return strings.Compare(a.Dimension, b.Dimension) })
+	canonicalizeExploreFilters(filters)
 }

--- a/internal/api/relationships_test.go
+++ b/internal/api/relationships_test.go
@@ -15,9 +15,11 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/identityindex"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/query/querytest"
+	"go.kenn.io/msgvault/internal/testutil"
 )
 
 const (
@@ -26,6 +28,69 @@ const (
 	relAlice2ID     = int64(3)
 	relNewsletterID = int64(4)
 )
+
+const relationshipIdentityIdentifier = "z-owner@example.test"
+
+type recordingRelationshipEngine struct {
+	*query.DuckDBEngine
+
+	relationshipsCalls    int
+	timelineCalls         int
+	resolveCanonicalCalls int
+}
+
+func (e *recordingRelationshipEngine) Relationships(
+	ctx context.Context,
+	request query.RelationshipsRequest,
+) (*query.RelationshipsResponse, error) {
+	e.relationshipsCalls++
+	return e.DuckDBEngine.Relationships(ctx, request)
+}
+
+func (e *recordingRelationshipEngine) RelationshipTimeline(
+	ctx context.Context,
+	request query.RelationshipTimelineRequest,
+) (*query.RelationshipTimelineResponse, error) {
+	e.timelineCalls++
+	return e.DuckDBEngine.RelationshipTimeline(ctx, request)
+}
+
+func (e *recordingRelationshipEngine) ResolveCanonicalParticipant(
+	ctx context.Context,
+	participantID int64,
+) (int64, error) {
+	e.resolveCanonicalCalls++
+	return e.DuckDBEngine.ResolveCanonicalParticipant(ctx, participantID)
+}
+
+func newRelationshipIdentityAPIServer(
+	t *testing.T,
+	duckDB *query.DuckDBEngine,
+	participantAddresses []string,
+) (*Server, *recordingMessageIdentityStore, *recordingRelationshipEngine) {
+	t.Helper()
+	requirements := require.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "archive@example.test")
+	requirements.NoError(err)
+	requirements.Equal(int64(1), source.ID)
+	for i, address := range participantAddresses {
+		participantID, err := st.EnsureParticipant(address, fmt.Sprintf("Participant %d", i+1), "example.test")
+		requirements.NoError(err)
+		requirements.Equal(int64(i+1), participantID)
+	}
+	requirements.NoError(st.AddAccountIdentity(source.ID, relationshipIdentityIdentifier, "manual"))
+
+	identityStore := &recordingMessageIdentityStore{Store: st}
+	engine := &recordingRelationshipEngine{DuckDBEngine: duckDB}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  identityStore,
+		Engine: engine,
+		Logger: testLogger(),
+	})
+	return srv, identityStore, engine
+}
 
 // newRelationshipsDuckDBFixture builds a real DuckDB/Parquet engine seeded
 // with: an owner (relOwnerID), a reciprocal counterpart (relAliceID) linked
@@ -203,6 +268,61 @@ func TestRelationshipsRanksAndGatesOverHTTP(t *testing.T) {
 	assert.Len(allPage.Rows, 2, "show_all must include the gated newsletter")
 	ids := []int64{allPage.Rows[0].CanonicalID, allPage.Rows[1].CanonicalID}
 	assert.ElementsMatch([]int64{relAliceID, relNewsletterID}, ids)
+}
+
+func TestRelationshipsResolvesSourceScopedIdentityBeforeRanking(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	now := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	srv, identityStore, engine := newRelationshipIdentityAPIServer(
+		t,
+		newRelationshipsDuckDBFixture(t, now),
+		[]string{
+			relationshipIdentityIdentifier,
+			"alice@example.test",
+			"alice-chat@example.test",
+			"newsletter@example.test",
+		},
+	)
+
+	baseline := postExploreJSON(t, srv, "/api/v1/relationships", `{"show_all":true}`)
+	requirements.Equal(http.StatusOK, baseline.Code, baseline.Body.String())
+	var baselinePage RelationshipsHTTPResponse
+	requirements.NoError(json.Unmarshal(baseline.Body.Bytes(), &baselinePage))
+	requirements.Len(baselinePage.Rows, 2)
+	assertions.Equal(1, engine.relationshipsCalls)
+	assertions.Zero(identityStore.resolveCalls)
+
+	filtered := postExploreJSON(t, srv, "/api/v1/relationships", `{
+		"show_all":true,
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","z-owner@example.test","sender"]}
+		]
+	}`)
+	requirements.Equal(http.StatusOK, filtered.Code, filtered.Body.String())
+	var filteredPage RelationshipsHTTPResponse
+	requirements.NoError(json.Unmarshal(filtered.Body.Bytes(), &filteredPage))
+	requirements.Len(filteredPage.Rows, 1, "the resolved sender identity must remove the inbound-only newsletter")
+	assertions.Equal(relAliceID, filteredPage.Rows[0].CanonicalID)
+	assertions.Equal(1, identityStore.resolveCalls, "the shared identity resolver runs once per request")
+	assertions.Equal(2, engine.relationshipsCalls)
+
+	invalid := postExploreJSON(t, srv, "/api/v1/relationships", `{
+		"show_all":true,
+		"filters":[
+			{"dimension":"source","values":["1"]},
+			{"dimension":"identity","values":["1","private-provider-token@example.test","sender"]}
+		]
+	}`)
+	requirements.Equal(http.StatusBadRequest, invalid.Code, invalid.Body.String())
+	var apiErr ErrorResponse
+	requirements.NoError(json.Unmarshal(invalid.Body.Bytes(), &apiErr))
+	assertions.Equal("invalid_identity_filter", apiErr.Error)
+	assertions.Equal("identity filter is malformed, unconfirmed, or does not match the selected source", apiErr.Message)
+	assertions.NotContains(invalid.Body.String(), "private-provider-token")
+	assertions.Equal(2, identityStore.resolveCalls)
+	assertions.Equal(2, engine.relationshipsCalls, "invalid identity input must stop before ranking")
 }
 
 func TestRelationshipsCursorConflictsOnRevisionDrift(t *testing.T) {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -279,6 +279,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	s.registerCLIAccountHumaRoutes(apiV1)
 	s.registerCLICollectionHumaRoutes(apiV1)
 	s.registerCLIIdentityHumaRoutes(apiV1)
+	s.registerCLIIdentityDiscoveryRoute(apiV1)
 	s.registerCLIDedupHumaRoutes(apiV1)
 	registerAPIV1RawHumaNDJSONRoute[cliRebuildFTSEvent](apiV1, "rebuildCLIFTS", http.MethodPost, "/cli/rebuild-fts", "Rebuild the CLI full-text search index", s.handleCLIRebuildFTS)
 
@@ -389,6 +390,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	registerAPIV1RawHumaJSONRoute[AccountListResponse](apiV1, "listAccounts", http.MethodGet, "/accounts", "List scheduler-configured accounts (with sync schedules); use /cli/accounts for all archived sources", s.handleListAccounts)
 	registerAPIV1RawHumaJSONRouteWithRequest[AddAccountRequest, StatusMessageResponse](apiV1, "addAccount", http.MethodPost, "/accounts", "Add an account", s.handleAddAccount, http.StatusOK, http.StatusCreated)
 	registerAPIV1RawHumaJSONRoute[SourceStatusResponse](apiV1, "listSourceStatus", http.MethodGet, "/sources/status", "List source sync status", s.handleSourceStatus)
+	registerAPIV1RawHumaJSONRoute[SourceIdentitiesResponse](apiV1, "listSourceIdentities", http.MethodGet, "/sources/{source_id}/identities", "List confirmed identities for one source", s.handleSourceIdentities)
 	registerAPIV1RawHumaJSONRoute[StatusMessageResponse](apiV1, "triggerSync", http.MethodPost, "/sync/{account}", "Trigger account sync", s.handleTriggerSync, http.StatusAccepted)
 	registerAPIV1RawHumaJSONRoute[SchedulerStatusResponse](apiV1, "getSchedulerStatus", http.MethodGet, "/scheduler/status", "Get scheduler status", s.handleSchedulerStatus)
 	registerAPIV1RawHumaJSONRouteWithRequest[TokenUploadRequest, StatusMessageResponse](apiV1, "uploadToken", http.MethodPost, "/auth/token/{email}", "Upload an OAuth token", s.handleUploadToken, http.StatusCreated)
@@ -748,6 +750,8 @@ func rawRouteParameters(operationID string) []*huma.Param {
 		}
 	case "listSourceStatus":
 		return []*huma.Param{queryStringParam("source_type", "Restrict to one source type", false)}
+	case "listSourceIdentities":
+		return []*huma.Param{pathNamedIntegerParam("source_id", "Source ID")}
 	case "triggerSync":
 		return []*huma.Param{
 			pathStringParam("account", "Account email or configured source identifier"),
@@ -878,7 +882,11 @@ func pathStringParam(name, doc string) *huma.Param {
 }
 
 func pathIntegerParam(doc string) *huma.Param {
-	p := param("id", "path", huma.TypeInteger, doc, true)
+	return pathNamedIntegerParam("id", doc)
+}
+
+func pathNamedIntegerParam(name, doc string) *huma.Param {
+	p := param(name, "path", huma.TypeInteger, doc, true)
 	p.Schema.Format = "int64"
 	return p
 }

--- a/internal/api/search_coverage.go
+++ b/internal/api/search_coverage.go
@@ -70,6 +70,10 @@ func (s *Server) handleSearchCoverage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_filter", err.Error())
 		return
 	}
+	if err := s.resolveExploreIdentityContext(r.Context(), canonical.Filters, &ctx); err != nil {
+		s.writeExploreFilterError(w, err, "invalid_filter")
+		return
+	}
 	_, backend, cfg := s.vectorComponents()
 	ctx = semanticCoverageContext(ctx, cfg.Embed.Scope.BuildScope())
 	explorer, ok := s.engine.(query.Explorer)
@@ -108,7 +112,7 @@ func (s *Server) handleSearchCoverage(w http.ResponseWriter, r *http.Request) {
 		s.writeExploreError(w, err)
 		return
 	}
-	contextHash := hashCanonicalValue(ctx, false)
+	contextHash := searchCoverageContextHash(ctx)
 	if entry, found := state.getCoverage(searchCoverageCacheKey(contextHash, probe.CacheRevision, *generation)); found {
 		response.EligibleCount, response.EmbeddedCount = entry.EligibleCount, entry.EmbeddedCount
 		response.CacheRevision = probe.CacheRevision
@@ -218,6 +222,35 @@ func searchCoverageCacheKey(contextHash, cacheRevision string, generation vector
 	return fmt.Sprintf("%s|%s|%d|%s|%s|%d",
 		contextHash, cacheRevision,
 		generation.ID, generation.State, generation.Fingerprint, generation.MessageCount)
+}
+
+func searchCoverageContextHash(ctx query.Context) string {
+	type identityKey struct {
+		SourceID       int64   `json:"source_id"`
+		ParticipantIDs []int64 `json:"participant_ids"`
+		// EmailIdentifier participates in the key because envelope-first
+		// filtering makes two aliases with identical resolved participant
+		// sets select different populations.
+		EmailIdentifier string                  `json:"email_identifier,omitempty"`
+		MatchNone       bool                    `json:"match_none"`
+		Direction       query.IdentityDirection `json:"direction"`
+	}
+	var identity *identityKey
+	if ctx.Identity != nil {
+		participantIDs := slices.Clone(ctx.Identity.ParticipantIDs)
+		slices.Sort(participantIDs)
+		identity = &identityKey{
+			SourceID:        ctx.Identity.SourceID,
+			ParticipantIDs:  participantIDs,
+			EmailIdentifier: ctx.Identity.EmailIdentifier,
+			MatchNone:       ctx.Identity.MatchNone,
+			Direction:       ctx.Identity.Direction,
+		}
+	}
+	return hashCanonicalValue(struct {
+		Context  query.Context `json:"context"`
+		Identity *identityKey  `json:"identity,omitempty"`
+	}{Context: ctx, Identity: identity}, false)
 }
 
 func resolveSearchCoverageGeneration(

--- a/internal/api/search_coverage_test.go
+++ b/internal/api/search_coverage_test.go
@@ -251,6 +251,32 @@ func TestSearchCoverageIntersectsCanonicalContextWithEmbeddingScope(t *testing.T
 	assert.Equal(SearchCoverageReady, body.Status)
 }
 
+func TestSearchCoverageResolvesIdentityFilterOnce(t *testing.T) {
+	assertions := assert.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+	backend := &filteredCoverageBackend{
+		active: vector.Generation{
+			ID: 7, Fingerprint: "model:2", State: vector.GenerationActive,
+		},
+		embeddedIDs: map[int64]struct{}{2: {}},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  fixture.store, Engine: fixture.server.engine, Backend: backend,
+		VectorStatus: VectorStatusReady, Logger: testLogger(),
+	})
+
+	body := getSearchCoverage(t, srv, `{"filters":[
+		{"dimension":"source","values":["1"]},
+		{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}
+	]}`)
+
+	assertions.Equal(SearchCoverageReady, body.Status)
+	assertions.Equal(int64(1), body.EligibleCount)
+	assertions.Equal(int64(1), body.EmbeddedCount)
+	assertions.Equal(1, fixture.store.resolveCalls)
+}
+
 func TestSearchCoverageOpenAPIContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -395,6 +421,61 @@ func TestSearchCoverageCachesPerFilterContext(t *testing.T) {
 
 	assert.Equal(int64(3), unfiltered.EligibleCount)
 	assert.Equal(int64(2), filtered.EligibleCount, "a different filter context must not reuse cached counts")
+}
+
+func TestSearchCoverageCacheSeparatesResolvedIdentitiesAndDirections(t *testing.T) {
+	require := require.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+	require.NoError(fixture.store.AddAccountIdentity(1, "alice@example.com", "manual"))
+	engine := &coverageScanEngine{revision: "cache:identity", total: 3}
+	backend := &filteredCoverageBackend{
+		active:   vector.Generation{ID: 7, Fingerprint: "model:2", State: vector.GenerationActive},
+		countAll: true,
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  fixture.store, Engine: engine, Backend: backend,
+		VectorStatus: VectorStatusReady, Logger: testLogger(),
+	})
+	request := func(identifier, direction string) string {
+		return `{"filters":[` +
+			`{"dimension":"source","values":["1"]},` +
+			`{"dimension":"identity","values":["1","` + identifier + `","` + direction + `"]}` +
+			`]}`
+	}
+
+	getSearchCoverage(t, srv, request("BOB@MEMBERS.EXAMPLE", "sender"))
+	require.Equal(1, engine.scanCalls)
+	getSearchCoverage(t, srv, request("BOB@MEMBERS.EXAMPLE", "sender"))
+	require.Equal(1, engine.scanCalls, "an identical resolved identity should hit the cache")
+
+	getSearchCoverage(t, srv, request("BOB@MEMBERS.EXAMPLE", "recipient"))
+	require.Equal(2, engine.scanCalls, "direction must participate in the coverage cache key")
+	getSearchCoverage(t, srv, request("alice@example.com", "sender"))
+	require.Equal(3, engine.scanCalls, "resolved identity must participate in the coverage cache key")
+}
+
+// TestSearchCoverageContextHashSeparatesEmailIdentifier guards the coverage
+// cache key against alias collisions: two confirmed aliases can resolve to
+// the same participant set after a merge, yet envelope-first filtering makes
+// their predicates select different populations.
+func TestSearchCoverageContextHashSeparatesEmailIdentifier(t *testing.T) {
+	assert := assert.New(t)
+	identity := func(emailIdentifier string) query.Context {
+		return query.Context{Identity: &query.IdentityPredicate{
+			SourceID:        1,
+			ParticipantIDs:  []int64{7},
+			EmailIdentifier: emailIdentifier,
+			Direction:       query.IdentityDirectionSender,
+		}}
+	}
+
+	aliasA := searchCoverageContextHash(identity("alias-a@example.test"))
+	aliasARepeat := searchCoverageContextHash(identity("alias-a@example.test"))
+	aliasB := searchCoverageContextHash(identity("alias-b@example.test"))
+	assert.Equal(aliasA, aliasARepeat, "identical contexts must share a cache key")
+	assert.NotEqual(aliasA, aliasB,
+		"aliases resolving to the same participants must not share a cache key")
 }
 
 func TestSearchCoverageRejectsGenerationActivationDuringScan(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/msgvault/internal/apiprotocol"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/daemonauth"
+	"go.kenn.io/msgvault/internal/provideridentity"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/scheduler"
 	"go.kenn.io/msgvault/internal/search"
@@ -41,6 +42,14 @@ type MessageStore interface {
 	GetMessagesSummariesByIDs(ids []int64) ([]APIMessage, error)
 	SearchMessages(query string, offset, limit int) ([]APIMessage, int64, error)
 	SearchMessagesQuery(q *search.Query, offset, limit int) ([]APIMessage, int64, error)
+}
+
+// MessageIdentityStore is the optional source-identity extension used by
+// analytical filters and response hydration. Production stores implement it;
+// keeping it separate preserves lightweight MessageStore test doubles.
+type MessageIdentityStore interface {
+	ResolveAccountIdentityContext(ctx context.Context, sourceID int64, identifier string) (store.ResolvedAccountIdentity, error)
+	MatchMessageIdentitiesContext(ctx context.Context, messageIDs []int64) (map[int64]store.MessageIdentityMatch, error)
 }
 
 type TaskLinkOperations interface {
@@ -204,6 +213,8 @@ type AttachmentBlobStore interface {
 	OpenStream(ctx context.Context, hash string) (io.ReadCloser, int64, error)
 }
 
+type fastmailIdentityInventory = provideridentity.Inventory
+
 // Server represents the HTTP API server.
 type Server struct {
 	cfg            *config.Config
@@ -318,9 +329,10 @@ type Server struct {
 	clock func() time.Time
 	// taskIntegrationProbe performs server-side discovery and capability
 	// validation. It is never exposed to the browser with its credentials.
-	taskIntegrationProbe TaskIntegrationProbe
-	taskLinkOperations   TaskLinkOperations
-	taskIdentityResolver TaskIdentityResolver
+	taskIntegrationProbe     TaskIntegrationProbe
+	taskLinkOperations       TaskLinkOperations
+	taskIdentityResolver     TaskIdentityResolver
+	fastmailInventoryFactory provideridentity.Factory
 	// listenerBound is set true once StartOnListener binds a real listener
 	// (the sole production serve path). It stays false for direct-handler unit
 	// tests that drive s.Router() without starting a listener, leaving the
@@ -416,6 +428,9 @@ type ServerOptions struct {
 	TaskIntegrationProbe TaskIntegrationProbe
 	TaskLinkOperations   TaskLinkOperations
 	TaskIdentityResolver TaskIdentityResolver
+	// FastmailInventoryFactory is the provider-read seam used by identity
+	// discovery. Nil constructs the production JMAP client.
+	FastmailInventoryFactory provideridentity.Factory
 }
 
 // NewServer creates a new API server.
@@ -438,40 +453,45 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 	if taskProbe == nil {
 		taskProbe = taskclient.Evaluate
 	}
+	fastmailInventoryFactory := opts.FastmailInventoryFactory
+	if fastmailInventoryFactory == nil {
+		fastmailInventoryFactory = provideridentity.NewFastmailInventory
+	}
 	s := &Server{
-		cfg:                  opts.Config,
-		store:                opts.Store,
-		savedViewStore:       opts.SavedViewStore,
-		engine:               opts.Engine,
-		sqlQueryRunner:       opts.SQLQueryRunner,
-		shutdownToken:        opts.ShutdownToken,
-		shutdownFunc:         opts.ShutdownFunc,
-		hybridEngine:         opts.HybridEngine,
-		vectorCfg:            opts.VectorCfg,
-		backend:              opts.Backend,
-		scheduler:            opts.Scheduler,
-		logger:               opts.Logger,
-		requestTimeout:       timeout,
-		readTimeout:          daemonReadTimeout,
-		queryTimeout:         QueryEndpointTimeout,
-		inProgressThreshold:  inProgressLogThreshold,
-		inProgressInterval:   inProgressLogInterval,
-		daemonVersion:        opts.DaemonVersion,
-		analyticsMode:        opts.AnalyticsMode,
-		idleTracker:          opts.IdleTracker,
-		operationGate:        opts.OperationGate,
-		blobStore:            opts.BlobStore,
-		remoteImages:         newRemoteImageFetcher(),
-		inlineCache:          newInlineParseCache(inlineCacheMaxEntries, inlineCacheMaxBytes),
-		spaHandler:           opts.SPAHandler,
-		sessions:             newSessionStore(defaultSessionTTL),
-		exploreState:         newExploreServerState(time.Now),
-		exploreCursorKey:     newExploreCursorKey(),
-		trustedProxies:       trustedProxyPrefixes(opts.Config.Server.TrustedProxies),
-		settingsConfigEditor: config.EditConfigFile,
-		taskIntegrationProbe: taskProbe,
-		taskLinkOperations:   opts.TaskLinkOperations,
-		taskIdentityResolver: opts.TaskIdentityResolver,
+		cfg:                      opts.Config,
+		store:                    opts.Store,
+		savedViewStore:           opts.SavedViewStore,
+		engine:                   opts.Engine,
+		sqlQueryRunner:           opts.SQLQueryRunner,
+		shutdownToken:            opts.ShutdownToken,
+		shutdownFunc:             opts.ShutdownFunc,
+		hybridEngine:             opts.HybridEngine,
+		vectorCfg:                opts.VectorCfg,
+		backend:                  opts.Backend,
+		scheduler:                opts.Scheduler,
+		logger:                   opts.Logger,
+		requestTimeout:           timeout,
+		readTimeout:              daemonReadTimeout,
+		queryTimeout:             QueryEndpointTimeout,
+		inProgressThreshold:      inProgressLogThreshold,
+		inProgressInterval:       inProgressLogInterval,
+		daemonVersion:            opts.DaemonVersion,
+		analyticsMode:            opts.AnalyticsMode,
+		idleTracker:              opts.IdleTracker,
+		operationGate:            opts.OperationGate,
+		blobStore:                opts.BlobStore,
+		remoteImages:             newRemoteImageFetcher(),
+		inlineCache:              newInlineParseCache(inlineCacheMaxEntries, inlineCacheMaxBytes),
+		spaHandler:               opts.SPAHandler,
+		sessions:                 newSessionStore(defaultSessionTTL),
+		exploreState:             newExploreServerState(time.Now),
+		exploreCursorKey:         newExploreCursorKey(),
+		trustedProxies:           trustedProxyPrefixes(opts.Config.Server.TrustedProxies),
+		settingsConfigEditor:     config.EditConfigFile,
+		taskIntegrationProbe:     taskProbe,
+		taskLinkOperations:       opts.TaskLinkOperations,
+		taskIdentityResolver:     opts.TaskIdentityResolver,
+		fastmailInventoryFactory: fastmailInventoryFactory,
 	}
 	if s.taskIdentityResolver == nil {
 		s.taskIdentityResolver = s.resolveTaskMessageIdentity
@@ -755,7 +775,8 @@ func cliRequestNeedsProtectiveCeiling(r *http.Request) bool {
 		"GET /api/v1/cli/search",
 		"POST /api/v1/cli/deduplicate/plan",
 		"POST /api/v1/cli/identities",
-		"DELETE /api/v1/cli/identities":
+		"DELETE /api/v1/cli/identities",
+		"POST /api/v1/cli/identities/import":
 		return true
 	default:
 		return false
@@ -782,6 +803,7 @@ func isLongDaemonRequest(path string) bool {
 	case "/api/v1/cli/build-cache",
 		"/api/v1/cli/deduplicate/plan",
 		meetingImportEndpointPath,
+		"/api/v1/cli/identities/discover",
 		"/api/v1/cli/rebuild-fts",
 		"/api/v1/cli/repair-encoding",
 		"/api/v1/cli/run",

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1333,6 +1333,7 @@ func TestMarkedCLIProtectiveCeilingInventory(t *testing.T) {
 		{method: http.MethodPost, path: "/api/v1/cli/deduplicate/plan"},
 		{method: http.MethodPost, path: "/api/v1/cli/identities"},
 		{method: http.MethodDelete, path: "/api/v1/cli/identities"},
+		{method: http.MethodPost, path: "/api/v1/cli/identities/import"},
 	}
 
 	for _, route := range protectiveRoutes {

--- a/internal/api/source_identities.go
+++ b/internal/api/source_identities.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// SourceIdentityCatalogStore is the read-only store capability used by the
+// source identity catalog. Production stores implement it directly; keeping
+// it feature-local avoids expanding lightweight MessageStore test doubles.
+type SourceIdentityCatalogStore interface {
+	GetSourceByIDContext(ctx context.Context, sourceID int64) (*store.Source, error)
+	ListAccountIdentitiesContext(ctx context.Context, sourceID int64) ([]store.AccountIdentity, error)
+}
+
+type SourceIdentityResponse struct {
+	Identifier  string    `json:"identifier"`
+	Signals     []string  `json:"signals" nullable:"false"`
+	ConfirmedAt time.Time `json:"confirmed_at"`
+}
+
+type SourceIdentitiesResponse struct {
+	SourceID   int64                    `json:"source_id"`
+	Account    string                   `json:"account"`
+	Identities []SourceIdentityResponse `json:"identities" nullable:"false"`
+}
+
+func (s *Server) handleSourceIdentities(w http.ResponseWriter, r *http.Request) {
+	sourceID, err := strconv.ParseInt(r.PathValue("source_id"), 10, 64)
+	if err != nil || sourceID <= 0 {
+		writeError(w, http.StatusBadRequest, "invalid_source_id", "Source ID must be a positive integer")
+		return
+	}
+
+	catalog, ok := s.store.(SourceIdentityCatalogStore)
+	if s.store == nil || !ok {
+		writeError(w, http.StatusServiceUnavailable, "store_unavailable", "Database not available")
+		return
+	}
+
+	source, err := catalog.GetSourceByIDContext(r.Context(), sourceID)
+	switch {
+	case errors.Is(err, store.ErrSourceNotFound):
+		writeError(w, http.StatusNotFound, "source_not_found", "Source not found")
+		return
+	case err != nil:
+		s.logger.Error("failed to load source identity catalog", "source_id", sourceID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to retrieve source identities")
+		return
+	}
+
+	stored, err := catalog.ListAccountIdentitiesContext(r.Context(), sourceID)
+	if err != nil {
+		s.logger.Error("failed to list source identities", "source_id", sourceID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to retrieve source identities")
+		return
+	}
+
+	identities := make([]SourceIdentityResponse, 0, len(stored))
+	for _, identity := range stored {
+		identities = append(identities, SourceIdentityResponse{
+			Identifier:  identity.Address,
+			Signals:     identityops.SplitSignalSet(identity.SourceSignal),
+			ConfirmedAt: identity.ConfirmedAt,
+		})
+	}
+	sort.SliceStable(identities, func(i, j int) bool {
+		return identities[i].Identifier < identities[j].Identifier
+	})
+
+	writeJSON(w, http.StatusOK, SourceIdentitiesResponse{
+		SourceID: source.ID, Account: source.Identifier, Identities: identities,
+	})
+}

--- a/internal/api/source_identities_test.go
+++ b/internal/api/source_identities_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type sourceIdentityAPIFixture struct {
+	server      *Server
+	store       *store.Store
+	sourceA     *store.Source
+	sourceB     *store.Source
+	emptySource *store.Source
+}
+
+func newSourceIdentityAPIFixture(t *testing.T) sourceIdentityAPIFixture {
+	t.Helper()
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	sourceA, err := st.GetOrCreateSource("gmail", "account-a@example.test")
+	requirements.NoError(err)
+	sourceB, err := st.GetOrCreateSource("imap", "account-b@example.test")
+	requirements.NoError(err)
+	emptySource, err := st.GetOrCreateSource("mbox", "empty-source")
+	requirements.NoError(err)
+
+	requirements.NoError(st.AddAccountIdentity(sourceA.ID, "Second@Example.test", "manual"))
+	requirements.NoError(st.AddAccountIdentity(sourceA.ID, "Masked-Shop@Example.test", "sent-folder"))
+	requirements.NoError(st.AddAccountIdentity(sourceA.ID, "masked-shop@example.test", "provider-alias"))
+	requirements.NoError(st.AddAccountIdentity(sourceB.ID, "Masked-Shop@Example.test", "other-source"))
+
+	return sourceIdentityAPIFixture{
+		server: NewServer(
+			&config.Config{Server: config.ServerConfig{APIPort: 8080}},
+			st,
+			nil,
+			testLogger(),
+		),
+		store: st, sourceA: sourceA, sourceB: sourceB, emptySource: emptySource,
+	}
+}
+
+func TestSourceIdentitiesListsOnlyRequestedSource(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	fixture := newSourceIdentityAPIFixture(t)
+	response := getSourceIdentities(t, fixture.server, fixture.sourceA.ID)
+	requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+
+	var body SourceIdentitiesResponse
+	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	assertions.Equal(fixture.sourceA.ID, body.SourceID)
+	assertions.Equal("account-a@example.test", body.Account)
+	requirements.Len(body.Identities, 2)
+	assertions.Equal("Masked-Shop@Example.test", body.Identities[0].Identifier, "stored spelling is preserved")
+	assertions.Equal([]string{"provider-alias", "sent-folder"}, body.Identities[0].Signals)
+	assertions.Equal("Second@Example.test", body.Identities[1].Identifier)
+	assertions.Equal([]string{"manual"}, body.Identities[1].Signals)
+
+	stored, err := fixture.store.ListAccountIdentities(fixture.sourceA.ID)
+	requirements.NoError(err)
+	requirements.Len(stored, 2)
+	assertions.True(body.Identities[0].ConfirmedAt.Equal(stored[0].ConfirmedAt), "confirmation instant")
+	for _, identity := range body.Identities {
+		assertions.NotContains(identity.Signals, "other-source", "same identifier on another source must not leak")
+	}
+
+	var wire map[string]json.RawMessage
+	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &wire))
+	assertions.Len(wire, 3)
+	assertions.Contains(wire, "source_id")
+	assertions.Contains(wire, "account")
+	assertions.Contains(wire, "identities")
+}
+
+func TestSourceIdentitiesReturnsStableEmptyArray(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	fixture := newSourceIdentityAPIFixture(t)
+	response := getSourceIdentities(t, fixture.server, fixture.emptySource.ID)
+	requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+
+	var body SourceIdentitiesResponse
+	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	assertions.Equal(fixture.emptySource.ID, body.SourceID)
+	assertions.Equal("empty-source", body.Account)
+	assertions.NotNil(body.Identities)
+	assertions.Empty(body.Identities)
+	assertions.JSONEq(`{"source_id":3,"account":"empty-source","identities":[]}`, response.Body.String())
+}
+
+func TestSourceIdentitiesRejectsInvalidAndUnknownSourceIDs(t *testing.T) {
+	fixture := newSourceIdentityAPIFixture(t)
+	tests := []struct {
+		name       string
+		sourceID   string
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "not numeric", sourceID: "not-a-number", wantStatus: http.StatusBadRequest, wantCode: "invalid_source_id"},
+		{name: "zero", sourceID: "0", wantStatus: http.StatusBadRequest, wantCode: "invalid_source_id"},
+		{name: "negative", sourceID: "-1", wantStatus: http.StatusBadRequest, wantCode: "invalid_source_id"},
+		{name: "unknown", sourceID: "999999", wantStatus: http.StatusNotFound, wantCode: "source_not_found"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/sources/"+test.sourceID+"/identities", nil)
+			response := httptest.NewRecorder()
+			fixture.server.Router().ServeHTTP(response, request)
+			assertions.Equal(test.wantStatus, response.Code, response.Body.String())
+			var body ErrorResponse
+			requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+			assertions.Equal(test.wantCode, body.Error)
+		})
+	}
+}
+
+func TestSourceIdentitiesOpenAPIContract(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	for _, document := range []struct {
+		name string
+		doc  *huma.OpenAPI
+	}{
+		{name: "public", doc: OpenAPIDocument()},
+		{name: "client", doc: openAPIClientDocument()},
+	} {
+		t.Run(document.name, func(t *testing.T) {
+			path := document.doc.Paths["/api/v1/sources/{source_id}/identities"]
+			requirements.NotNil(path)
+			requirements.NotNil(path.Get)
+			assertions.Equal("listSourceIdentities", path.Get.OperationID)
+			requirements.Len(path.Get.Parameters, 1)
+			parameter := path.Get.Parameters[0]
+			assertions.Equal("source_id", parameter.Name)
+			assertions.Equal("path", parameter.In)
+			assertions.True(parameter.Required)
+			requirements.NotNil(parameter.Schema)
+			assertions.Equal("integer", parameter.Schema.Type)
+			assertions.Equal("int64", parameter.Schema.Format)
+
+			responseSchema := document.doc.Components.Schemas.Map()["SourceIdentitiesResponse"]
+			requirements.NotNil(responseSchema)
+			assertions.Contains(responseSchema.Required, "identities")
+			identities := responseSchema.Properties["identities"]
+			requirements.NotNil(identities)
+			assertions.Equal("array", identities.Type)
+			assertions.False(identities.Nullable)
+
+			identitySchema := document.doc.Components.Schemas.Map()["SourceIdentityResponse"]
+			requirements.NotNil(identitySchema)
+			assertions.Contains(identitySchema.Required, "signals")
+			signals := identitySchema.Properties["signals"]
+			requirements.NotNil(signals)
+			assertions.Equal("array", signals.Type)
+			assertions.False(signals.Nullable)
+		})
+	}
+}
+
+func getSourceIdentities(t *testing.T, server *Server, sourceID int64) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/sources/"+strconv.FormatInt(sourceID, 10)+"/identities", nil)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	return response
+}

--- a/internal/circleback/importer.go
+++ b/internal/circleback/importer.go
@@ -221,6 +221,14 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 		return nil, err
 	}
 	sum := &ImportSummary{SourceID: src.ID}
+	if err := imp.store.AddAccountIdentityContext(
+		ctx,
+		src.ID,
+		opts.AccountEmail,
+		"account-email",
+	); err != nil {
+		return nil, fmt.Errorf("confirm Circleback account identity: %w", err)
+	}
 	accountIdentities, err := meetingidentity.ForSource(imp.store, src.ID, opts.AccountEmail)
 	if err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"go.kenn.io/msgvault/internal/fileutil"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/taskclient"
 	"go.kenn.io/msgvault/internal/vector"
 )
@@ -258,6 +260,35 @@ type IdentityConfig struct {
 	Addresses []string `toml:"addresses"`
 }
 
+// FastmailSource configures the optional Fastmail identity inventory for one
+// message source. A source may be selected by its stable source ID or account
+// identifier, but not both.
+type FastmailSource struct {
+	Account               string `toml:"account"`
+	SourceID              int64  `toml:"source_id,omitzero"`
+	APIToken              string `toml:"api_token"`
+	AutoConfirmIdentities bool   `toml:"auto_confirm_identities"`
+
+	sourceIDConfigured bool
+}
+
+// Selector returns the source selector represented by this configuration.
+func (s FastmailSource) Selector() (identityops.SourceSelector, error) {
+	account := strings.TrimSpace(s.Account)
+	switch {
+	case s.SourceID < 0:
+		return identityops.SourceSelector{}, errors.New("source_id must be positive")
+	case s.SourceID > 0 && account != "":
+		return identityops.SourceSelector{}, errors.New("account and source_id are mutually exclusive")
+	case s.SourceID > 0:
+		return identityops.SourceSelector{SourceID: s.SourceID}, nil
+	case account == "":
+		return identityops.SourceSelector{}, errors.New("account or source_id is required")
+	default:
+		return identityops.SourceSelector{Account: account}, nil
+	}
+}
+
 // BackupConfig holds default settings for `msgvault backup` (spec Section
 // 10). Repo lets `--repo` be omitted on every invocation; ZstdLevel tunes
 // the pack compression level (0 keeps kit/pack's own default).
@@ -324,6 +355,7 @@ type Config struct {
 	Remote       RemoteConfig       `toml:"remote"`
 	Vector       vector.Config      `toml:"vector"`
 	Identity     IdentityConfig     `toml:"identity"`
+	Fastmail     []FastmailSource   `toml:"fastmail"`
 	Accounts     []AccountSchedule  `toml:"accounts"`
 	SynctechSMS  SynctechSMSConfig  `toml:"synctech_sms"`
 	GCal         []GCalSource       `toml:"gcal"`
@@ -611,6 +643,9 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 		}
 		return nil, fmt.Errorf("decode config: %w", err)
 	}
+	if err := cfg.validateFastmailSources(fastmailSourceIDConfigured(content)); err != nil {
+		return nil, err
+	}
 
 	// Expand ~ in paths
 	cfg.Data.DataDir = expandPath(cfg.Data.DataDir)
@@ -674,6 +709,134 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	}
 
 	return cfg, nil
+}
+
+func fastmailSourceIDConfigured(content []byte) []bool {
+	var raw struct {
+		Fastmail []struct {
+			SourceID *int64 `toml:"source_id"`
+		} `toml:"fastmail"`
+	}
+	_, _ = toml.Decode(string(content), &raw)
+	configured := make([]bool, len(raw.Fastmail))
+	for i := range raw.Fastmail {
+		configured[i] = raw.Fastmail[i].SourceID != nil
+	}
+	return configured
+}
+
+func (c *Config) validateFastmailSources(sourceIDConfigured []bool) error {
+	seenAccounts := []string{}
+	seenSourceIDs := map[int64]bool{}
+	for i := range c.Fastmail {
+		source := &c.Fastmail[i]
+		source.Account = strings.TrimSpace(source.Account)
+		source.sourceIDConfigured = i < len(sourceIDConfigured) && sourceIDConfigured[i]
+		if source.sourceIDConfigured && source.SourceID <= 0 {
+			return fmt.Errorf("[[fastmail]] entry %d: source_id must be positive", i+1)
+		}
+		if _, err := source.Selector(); err != nil {
+			return fmt.Errorf("[[fastmail]] entry %d: %w", i+1, err)
+		}
+		if source.APIToken == "" {
+			return fmt.Errorf("[[fastmail]] entry %d: api_token is required", i+1)
+		}
+		if source.SourceID > 0 {
+			if seenSourceIDs[source.SourceID] {
+				return fmt.Errorf("[[fastmail]] entry %d: duplicate source_id selector %d", i+1, source.SourceID)
+			}
+			seenSourceIDs[source.SourceID] = true
+			continue
+		}
+		if slices.ContainsFunc(seenAccounts, func(account string) bool {
+			return strings.EqualFold(account, source.Account)
+		}) {
+			return fmt.Errorf("[[fastmail]] entry %d: duplicate account selector %q", i+1, source.Account)
+		}
+		seenAccounts = append(seenAccounts, source.Account)
+	}
+	return nil
+}
+
+// FastmailSourceStore is the complete source-listing surface required to
+// resolve an account selector without losing duplicate-source ambiguity.
+type FastmailSourceStore interface {
+	ListSources(sourceType string) ([]*store.Source, error)
+}
+
+// ErrFastmailSourceLookup marks infrastructure failures while resolving
+// [[fastmail]] configuration, as opposed to configuration errors.
+var ErrFastmailSourceLookup = errors.New("fastmail source lookup failed")
+
+// FastmailSourceFor returns a copy of the optional Fastmail configuration for
+// sourceID. Account selectors are resolved against every archive source so a
+// duplicate identifier or display name cannot silently attach one provider
+// inventory to multiple ingestion sources. Explicit source ID entries take
+// precedence over account matches.
+func (c *Config) FastmailSourceFor(st FastmailSourceStore, sourceID int64) (*FastmailSource, error) {
+	if st == nil {
+		return nil, errors.New("fastmail source lookup requires a source store")
+	}
+	if sourceID <= 0 {
+		return nil, errors.New("fastmail source lookup requires a positive source ID")
+	}
+	sources, err := st.ListSources("")
+	if err != nil {
+		return nil, fmt.Errorf("%w: list sources for Fastmail configuration: %w", ErrFastmailSourceLookup, err)
+	}
+	var source *store.Source
+	for _, candidate := range sources {
+		if candidate != nil && candidate.ID == sourceID {
+			source = candidate
+			break
+		}
+	}
+	if source == nil {
+		return nil, fmt.Errorf("fastmail source lookup: source %d not found", sourceID)
+	}
+	for i := range c.Fastmail {
+		configured := c.Fastmail[i]
+		if configured.SourceID > 0 && configured.SourceID == sourceID {
+			return &configured, nil
+		}
+	}
+
+	var matched *FastmailSource
+	for i := range c.Fastmail {
+		configured := c.Fastmail[i]
+		if configured.SourceID > 0 {
+			continue
+		}
+		account := strings.TrimSpace(configured.Account)
+		if account == "" {
+			continue
+		}
+		if !fastmailAccountMatchesSource(account, source) {
+			continue
+		}
+		matchingSources := 0
+		for _, candidate := range sources {
+			if candidate != nil && fastmailAccountMatchesSource(account, candidate) {
+				matchingSources++
+			}
+		}
+		if matchingSources > 1 {
+			return nil, fmt.Errorf(
+				"fastmail account selector %q matches multiple sources; configure source_id",
+				account,
+			)
+		}
+		if matched != nil {
+			return nil, fmt.Errorf("ambiguous Fastmail configuration for source %d", sourceID)
+		}
+		matched = &configured
+	}
+	return matched, nil
+}
+
+func fastmailAccountMatchesSource(account string, source *store.Source) bool {
+	return strings.EqualFold(account, source.Identifier) ||
+		(source.DisplayName.Valid && strings.EqualFold(account, source.DisplayName.String))
 }
 
 func (c *Config) applySynctechSMSDefaults() {

--- a/internal/config/config_fastmail_test.go
+++ b/internal/config/config_fastmail_test.go
@@ -1,0 +1,407 @@
+package config
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func loadConfigText(t *testing.T, content string) *Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	cfg, err := Load(path, "")
+	require.NoError(t, err)
+	return cfg
+}
+
+func loadConfigTextError(t *testing.T, content string) error {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	_, err := Load(path, "")
+	return err
+}
+
+func TestFastmailConfigAcceptsAccountOrSourceID(t *testing.T) {
+	assert := assert.New(t)
+	cfg := loadConfigText(t, `
+[[fastmail]]
+account = "primary@example.test"
+api_token = "fm_test_account"
+
+[[fastmail]]
+source_id = 14
+api_token = "fm_test_id"
+auto_confirm_identities = true
+`)
+	require.Len(t, cfg.Fastmail, 2)
+	assert.Equal("primary@example.test", cfg.Fastmail[0].Account)
+	assert.Equal(int64(14), cfg.Fastmail[1].SourceID)
+	assert.True(cfg.Fastmail[1].AutoConfirmIdentities)
+}
+
+func TestFastmailConfigRejectsBothSelectors(t *testing.T) {
+	err := loadConfigTextError(t, `[[fastmail]]
+account="primary@example.test"
+source_id=14
+api_token="fm_test"
+`)
+	require.ErrorContains(t, err, "account and source_id are mutually exclusive")
+}
+
+func TestFastmailConfigRejectsInvalidEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "missing selector",
+			content: `[[fastmail]]
+api_token = "fm_test_missing_selector"
+`,
+			wantErr: "account or source_id is required",
+		},
+		{
+			name: "zero source ID",
+			content: `[[fastmail]]
+source_id = 0
+api_token = "fm_test_zero_id"
+`,
+			wantErr: "source_id must be positive",
+		},
+		{
+			name: "negative source ID",
+			content: `[[fastmail]]
+source_id = -1
+api_token = "fm_test_negative_id"
+`,
+			wantErr: "source_id must be positive",
+		},
+		{
+			name: "empty token",
+			content: `[[fastmail]]
+account = "primary@example.test"
+api_token = ""
+`,
+			wantErr: "api_token is required",
+		},
+		{
+			name: "duplicate account selector",
+			content: `[[fastmail]]
+account = " primary@example.test "
+api_token = "fm_test_first"
+
+[[fastmail]]
+account = "PRIMARY@example.test"
+api_token = "fm_test_second"
+`,
+			wantErr: "duplicate account selector",
+		},
+		{
+			name: "Unicode fold-equivalent account selectors",
+			content: `[[fastmail]]
+account = "s@example.test"
+api_token = "fm_test_first"
+
+[[fastmail]]
+account = "ſ@example.test"
+api_token = "fm_test_second"
+`,
+			wantErr: "duplicate account selector",
+		},
+		{
+			name: "duplicate source ID selector",
+			content: `[[fastmail]]
+source_id = 14
+api_token = "fm_test_first"
+
+[[fastmail]]
+source_id = 14
+api_token = "fm_test_second"
+`,
+			wantErr: "duplicate source_id selector",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := loadConfigTextError(t, tt.content)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestFastmailSourceSelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  FastmailSource
+		want    identityops.SourceSelector
+		wantErr string
+	}{
+		{
+			name:   "account",
+			source: FastmailSource{Account: " primary@example.test "},
+			want:   identityops.SourceSelector{Account: "primary@example.test"},
+		},
+		{
+			name:   "source ID",
+			source: FastmailSource{SourceID: 14},
+			want:   identityops.SourceSelector{SourceID: 14},
+		},
+		{
+			name:    "missing selector",
+			source:  FastmailSource{},
+			wantErr: "account or source_id is required",
+		},
+		{
+			name:    "both selectors",
+			source:  FastmailSource{Account: "primary@example.test", SourceID: 14},
+			wantErr: "account and source_id are mutually exclusive",
+		},
+		{
+			name:    "negative source ID",
+			source:  FastmailSource{SourceID: -1},
+			wantErr: "source_id must be positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			got, err := tt.source.Selector()
+			if tt.wantErr != "" {
+				require.ErrorContains(err, tt.wantErr)
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestFastmailSourceForMatchesIDBeforeAccountAndReturnsCopy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	require.NoError(err)
+	cfg := &Config{Fastmail: []FastmailSource{
+		{Account: "primary@example.test", APIToken: "fm_test_account"},
+		{SourceID: source.ID, APIToken: "fm_test_id"},
+	}}
+
+	got, err := cfg.FastmailSourceFor(st, source.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(source.ID, got.SourceID)
+
+	got.APIToken = "modified"
+	assert.Equal("fm_test_id", cfg.Fastmail[1].APIToken)
+}
+
+func TestFastmailSourceForMatchesIdentifierOrDisplayName(t *testing.T) {
+	tests := []struct {
+		name   string
+		source *store.Source
+	}{
+		{
+			name:   "identifier",
+			source: &store.Source{ID: 14, SourceType: "imap", Identifier: "PRIMARY@example.test"},
+		},
+		{
+			name: "display name",
+			source: &store.Source{
+				ID:          14,
+				SourceType:  "imap",
+				Identifier:  "imap://primary",
+				DisplayName: sql.NullString{String: "PRIMARY@example.test", Valid: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			st := testutil.NewTestStore(t)
+			source, err := st.GetOrCreateSource(tt.source.SourceType, tt.source.Identifier)
+			require.NoError(err)
+			if tt.source.DisplayName.Valid {
+				require.NoError(st.UpdateSourceDisplayName(source.ID, tt.source.DisplayName.String))
+			}
+			cfg := loadConfigText(t, `
+[[fastmail]]
+account = " primary@example.test "
+api_token = "fm_test_account"
+`)
+
+			got, err := cfg.FastmailSourceFor(st, source.ID)
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(t, "primary@example.test", got.Account)
+		})
+	}
+}
+
+func TestFastmailSourceForRejectsAmbiguousAccountMatchesWithoutToken(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "PRIMARY@example.test")
+	require.NoError(err)
+	require.NoError(st.UpdateSourceDisplayName(source.ID, "primary mailbox"))
+	cfg := &Config{Fastmail: []FastmailSource{
+		{Account: "primary@example.test", APIToken: "fm_test_identifier"},
+		{Account: "Primary Mailbox", APIToken: "fm_test_display"},
+	}}
+	got, err := cfg.FastmailSourceFor(st, source.ID)
+	require.ErrorContains(err, "ambiguous Fastmail configuration")
+	assert.Nil(got)
+	assert.NotContains(err.Error(), "fm_test_identifier")
+	assert.NotContains(err.Error(), "fm_test_display")
+}
+
+func TestFastmailSourceForRejectsAccountMatchingMultipleArchiveSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		display    string
+	}{
+		{name: "identifier", identifier: "primary@example.test"},
+		{name: "display name", identifier: "imap://primary", display: "primary@example.test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			st := testutil.NewTestStore(t)
+			first, err := st.GetOrCreateSource("imap", tt.identifier)
+			require.NoError(err)
+			second, err := st.GetOrCreateSource("gmail", tt.identifier)
+			require.NoError(err)
+			if tt.display != "" {
+				require.NoError(st.UpdateSourceDisplayName(first.ID, tt.display))
+				require.NoError(st.UpdateSourceDisplayName(second.ID, tt.display))
+			}
+
+			cfg := &Config{Fastmail: []FastmailSource{{
+				Account:  "PRIMARY@example.test",
+				APIToken: "fm_test_must_not_leak",
+			}}}
+			for _, sourceID := range []int64{first.ID, second.ID} {
+				got, lookupErr := cfg.FastmailSourceFor(st, sourceID)
+				require.ErrorContains(lookupErr, "matches multiple sources")
+				assert.Nil(got)
+				require.ErrorContains(lookupErr, "source_id")
+				assert.NotContains(lookupErr.Error(), "fm_test_must_not_leak")
+			}
+		})
+	}
+}
+
+// TestFastmailSourceForWrapsStoreFailure confirms that infrastructure
+// failures while listing archive sources are distinguishable from
+// configuration/selector errors, so callers can classify them as internal
+// server errors instead of user-input errors.
+func TestFastmailSourceForWrapsStoreFailure(t *testing.T) {
+	t.Run("store failure is wrapped", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		cfg := &Config{Fastmail: []FastmailSource{{Account: "primary@example.test", APIToken: "fm_test"}}}
+		st := failingFastmailSourceStore{err: errors.New("db unavailable")}
+
+		got, err := cfg.FastmailSourceFor(st, 14)
+
+		require.Error(err)
+		assert.Nil(got)
+		assert.ErrorIs(err, ErrFastmailSourceLookup)
+	})
+
+	t.Run("misconfiguration is not wrapped", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		st := testutil.NewTestStore(t)
+		source, err := st.GetOrCreateSource("imap", "PRIMARY@example.test")
+		require.NoError(err)
+		require.NoError(st.UpdateSourceDisplayName(source.ID, "primary mailbox"))
+		cfg := &Config{Fastmail: []FastmailSource{
+			{Account: "primary@example.test", APIToken: "fm_test_identifier"},
+			{Account: "Primary Mailbox", APIToken: "fm_test_display"},
+		}}
+
+		got, lookupErr := cfg.FastmailSourceFor(st, source.ID)
+
+		require.Error(lookupErr)
+		assert.Nil(got)
+		assert.NotErrorIs(lookupErr, ErrFastmailSourceLookup)
+	})
+}
+
+type failingFastmailSourceStore struct {
+	err error
+}
+
+func (f failingFastmailSourceStore) ListSources(string) ([]*store.Source, error) {
+	return nil, f.err
+}
+
+func TestFastmailSourceForReturnsNilWhenSourceIsNotConfigured(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "other@example.test")
+	require.NoError(t, err)
+	cfg := &Config{Fastmail: []FastmailSource{{
+		Account:  "primary@example.test",
+		APIToken: "fm_test_account",
+	}}}
+
+	got, err := cfg.FastmailSourceFor(st, source.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestFastmailConfigSurvivesSaveAndLoad(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cfg := NewDefaultConfig()
+	cfg.HomeDir = t.TempDir()
+	cfg.Fastmail = []FastmailSource{
+		{
+			Account:               "primary@example.test",
+			APIToken:              "fm_test_account",
+			AutoConfirmIdentities: true,
+		},
+		{
+			SourceID:              14,
+			APIToken:              "fm_test_source_id",
+			AutoConfirmIdentities: true,
+		},
+	}
+
+	require.NoError(cfg.Save())
+	content, err := os.ReadFile(cfg.ConfigFilePath())
+	require.NoError(err)
+	assert.NotContains(string(content), "source_id = 0")
+
+	loaded, err := Load(cfg.ConfigFilePath(), "")
+	require.NoError(err)
+	require.Len(loaded.Fastmail, 2)
+	assert.Equal("primary@example.test", loaded.Fastmail[0].Account)
+	assert.Equal("fm_test_account", loaded.Fastmail[0].APIToken)
+	assert.True(loaded.Fastmail[0].AutoConfirmIdentities)
+	assert.False(loaded.Fastmail[0].sourceIDConfigured)
+	assert.Equal(int64(14), loaded.Fastmail[1].SourceID)
+	assert.Equal("fm_test_source_id", loaded.Fastmail[1].APIToken)
+	assert.True(loaded.Fastmail[1].AutoConfirmIdentities)
+	assert.True(loaded.Fastmail[1].sourceIDConfigured)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1098,21 +1098,25 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	assert.Equal("user@gmail.com", loaded.Accounts[0].Email)
 }
 
-func TestSave_CreatesFileWithSecurePermissions(t *testing.T) {
+func TestConfigFileModeOnSave(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	cfg := NewDefaultConfig()
 	cfg.HomeDir = tmpDir
+	cfg.Fastmail = []FastmailSource{{
+		SourceID: 14,
+		APIToken: "fm_test_file_mode",
+	}}
 
 	require.NoError(t, cfg.Save(), "Save()")
 
 	info, err := os.Stat(cfg.ConfigFilePath())
 	require.NoError(t, err, "Stat config")
 
-	// Should have no group/other permissions (0600 or stricter)
+	// The config may contain provider API tokens, so its Unix mode must be exact.
 	// Windows doesn't support Unix file permissions.
 	if runtime.GOOS != "windows" {
-		assert.Zero(t, info.Mode().Perm()&0077, "config perm = %04o, want no group/other access", info.Mode().Perm())
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 	}
 }
 

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -291,13 +291,25 @@ type CLIIdentityRow struct {
 type CLIIdentitiesRequest struct {
 	Account     string
 	Collection  string
+	SourceID    int64
+	SourceIDSet bool
 	PrimaryOnly bool
 }
 
+type CLIIdentitySourceSelector = identityops.SourceSelector
 type CLIIdentityAddRequest = identityops.AddRequest
 type CLIIdentityAddResult = identityops.AddResult
 type CLIIdentityRemoveRequest = identityops.RemoveRequest
 type CLIIdentityRemoveResult = identityops.RemoveResult
+type CLIIdentityImportRequest = identityops.ImportRequest
+type CLIIdentityImportResult = identityops.ImportResult
+
+func optionalCLIIdentitySourceID(sourceID int64, isSet bool) *int64 {
+	if sourceID == 0 && !isSet {
+		return nil
+	}
+	return &sourceID
+}
 
 type CLIDeleteDedupedRequest struct {
 	BatchIDs           []string
@@ -438,6 +450,69 @@ func (c *Client) RunCLICommand(
 ) error {
 	body := generated.RunCLIBody{Args: req.Args, Env: req.Env, Cwd: optionalString(req.Cwd)}
 	return c.runCLIStream(ctx, "/api/v1/cli/run", "run", &generated.RunCLIRequestOptions{Body: &body}, output)
+}
+
+func (c *Client) DiscoverCLIIdentities(
+	ctx context.Context,
+	req identityops.DiscoverRequest,
+	onEvent func(identityops.DiscoverEvent) error,
+) error {
+	resp, err := c.openCLIStream(
+		ctx,
+		"/api/v1/cli/identities/discover",
+		&generated.DiscoverCLIIdentitiesRequestOptions{Body: cliIdentityDiscoverBodyFromRequest(req)},
+	)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	seenResult := false
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		var generatedEvent generated.DiscoverEvent
+		err := decoder.Decode(&generatedEvent)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("decode CLI identity discovery stream: %w", err)
+		}
+		event := cliIdentityDiscoverEventFromGenerated(generatedEvent)
+		switch event.Type {
+		case "progress":
+			if seenResult {
+				return errors.New("identity discovery progress arrived after result")
+			}
+		case "result":
+			if seenResult {
+				return errors.New("identity discovery stream returned multiple results")
+			}
+			if event.Result == nil {
+				return errors.New("identity discovery result event has no result")
+			}
+			seenResult = true
+		case "error":
+			if seenResult {
+				return errors.New("identity discovery error arrived after result")
+			}
+			if event.Error == nil || event.Error.Code == "" || event.Error.Message == "" {
+				return errors.New("identity discovery error event is malformed")
+			}
+			return event.Error
+		default:
+			return fmt.Errorf("unknown identity discovery event type %q", event.Type)
+		}
+		if onEvent != nil {
+			if err := onEvent(event); err != nil {
+				return err
+			}
+		}
+	}
+	if !seenResult {
+		return errors.New("identity discovery stream ended without result")
+	}
+	return nil
 }
 
 func (c *Client) PlanCLIAddCalendar(
@@ -852,6 +927,7 @@ func (c *Client) GetCLIIdentities(
 			Query: &generated.ListCLIIdentitiesQuery{
 				Account:     optionalString(req.Account),
 				Collection:  optionalString(req.Collection),
+				SourceID:    optionalCLIIdentitySourceID(req.SourceID, req.SourceIDSet),
 				PrimaryOnly: optionalBool(req.PrimaryOnly),
 			},
 		})
@@ -869,7 +945,8 @@ func (c *Client) AddCLIIdentity(
 	resp, err := CLIResponse(c, func(client *apiclient.Client) (*generated.AddCLIIdentityResp, error) {
 		return client.AddCLIIdentityWithResponse(ctx, &generated.AddCLIIdentityRequestOptions{
 			Body: &generated.AddCLIIdentityBody{
-				Account:    req.Account,
+				Account:    optionalString(req.Account),
+				SourceID:   optionalCLIIdentitySourceID(req.SourceID, req.SourceID != 0),
 				Identifier: req.Identifier,
 				Signal:     req.Signal,
 			},
@@ -881,6 +958,21 @@ func (c *Client) AddCLIIdentity(
 	return cliIdentityAddResultFromGenerated(resp.JSON200), nil
 }
 
+func (c *Client) ImportCLIIdentities(
+	ctx context.Context,
+	req CLIIdentityImportRequest,
+) (*CLIIdentityImportResult, error) {
+	resp, err := CLIResponse(c, func(client *apiclient.Client) (*generated.ImportCLIIdentitiesResp, error) {
+		return client.ImportCLIIdentitiesWithResponse(ctx, &generated.ImportCLIIdentitiesRequestOptions{
+			Body: cliIdentityImportBodyFromRequest(req),
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cliIdentityImportResultFromGenerated(resp.JSON200), nil
+}
+
 func (c *Client) RemoveCLIIdentity(
 	ctx context.Context,
 	req CLIIdentityRemoveRequest,
@@ -888,7 +980,8 @@ func (c *Client) RemoveCLIIdentity(
 	resp, err := CLIResponse(c, func(client *apiclient.Client) (*generated.RemoveCLIIdentityResp, error) {
 		return client.RemoveCLIIdentityWithResponse(ctx, &generated.RemoveCLIIdentityRequestOptions{
 			Body: &generated.RemoveCLIIdentityBody{
-				Account:    req.Account,
+				Account:    optionalString(req.Account),
+				SourceID:   optionalCLIIdentitySourceID(req.SourceID, req.SourceID != 0),
 				Identifier: req.Identifier,
 			},
 		})

--- a/internal/daemonclient/client_test.go
+++ b/internal/daemonclient/client_test.go
@@ -17,8 +17,190 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/msgvault/internal/apiprotocol"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/pkg/client/generated"
 )
+
+func TestCLIIdentityDiscoverProviderStreamsConvertedEventsAndRequest(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(http.MethodPost, r.Method)
+		assertions.Equal("/api/v1/cli/identities/discover", r.URL.Path)
+		var req identityops.DiscoverRequest
+		if !assertions.NoError(json.NewDecoder(r.Body).Decode(&req), "decode discovery request") {
+			http.Error(w, "bad discovery request", http.StatusBadRequest)
+			return
+		}
+		assertions.Equal(identityops.SourceSelector{SourceID: 14}, req.SourceSelector)
+		assertions.True(req.Apply)
+		assertions.True(req.Provider)
+		assertions.Equal([]string{"weak@example.test"}, req.Confirm)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, err := w.Write([]byte(
+			`{"type":"progress","progress":{"done":2,"total":2,"candidates":1}}` + "\n" +
+				`{"type":"result","result":{"account":"primary@example.test","source_id":14,"source_type":"imap","scanned_messages":2,"candidates":[{"identifier":"alias@example.test","normalized_identifier":"alias@example.test","classification":"strong","already_confirmed":false,"signals":["provider-alias"],"provider_states":["disabled","enabled"],"sent_message_count":0,"received_message_count":0,"first_seen_at":"0001-01-01T00:00:00Z","last_seen_at":"0001-01-01T00:00:00Z"}],"rejected":[],"applied":[]}}` + "\n",
+		))
+		assertions.NoError(err)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := New(Config{URL: srv.URL, AllowInsecure: true})
+	requirements.NoError(err)
+	var events []identityops.DiscoverEvent
+	err = client.DiscoverCLIIdentities(t.Context(), identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Apply:          true,
+		Provider:       true,
+		Confirm:        []string{"weak@example.test"},
+	}, func(event identityops.DiscoverEvent) error {
+		events = append(events, event)
+		return nil
+	})
+
+	requirements.NoError(err)
+	requirements.Len(events, 2)
+	assertions.Equal("progress", events[0].Type)
+	requirements.NotNil(events[0].Progress)
+	assertions.Equal(int64(2), events[0].Progress.Done)
+	assertions.Equal("result", events[1].Type)
+	requirements.NotNil(events[1].Result)
+	assertions.Equal(int64(14), events[1].Result.SourceID)
+	encoded, err := json.Marshal(events[1].Result.Candidates[0])
+	requirements.NoError(err)
+	var reported struct {
+		ProviderStates []string `json:"provider_states"`
+	}
+	requirements.NoError(json.Unmarshal(encoded, &reported))
+	assertions.Equal([]string{"disabled", "enabled"}, reported.ProviderStates,
+		"generated-client conversion must retain provider state metadata")
+}
+
+func TestCLIIdentityDiscoverRejectsStreamWithoutResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, err := w.Write([]byte(
+			`{"type":"progress","progress":{"done":1,"total":2,"candidates":1}}` + "\n",
+		))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	client, err := New(Config{URL: srv.URL, AllowInsecure: true})
+	require.NoError(t, err)
+
+	err = client.DiscoverCLIIdentities(t.Context(), identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+	}, nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "without result")
+}
+
+func TestCLIIdentityDiscoverConsumesSanitizedTerminalError(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	const secret = "provider-token-private-value"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, err := w.Write([]byte(
+			`{"type":"progress","progress":{"done":1,"total":2,"candidates":1}}` + "\n" +
+				`{"type":"error","error":{"code":"internal_error","message":"Failed to discover identities"}}` + "\n",
+		))
+		assertions.NoError(err)
+	}))
+	t.Cleanup(srv.Close)
+	client, err := New(Config{URL: srv.URL, AllowInsecure: true})
+	requirements.NoError(err)
+
+	var events []identityops.DiscoverEvent
+	err = client.DiscoverCLIIdentities(t.Context(), identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+	}, func(event identityops.DiscoverEvent) error {
+		events = append(events, event)
+		return nil
+	})
+
+	requirements.Error(err)
+	requirements.ErrorContains(err, "Failed to discover identities")
+	assertions.NotContains(err.Error(), secret)
+	var discoverErr *identityops.DiscoverError
+	requirements.ErrorAs(err, &discoverErr)
+	assertions.Equal("internal_error", discoverErr.Code)
+	assertions.Equal("Failed to discover identities", discoverErr.Message)
+	requirements.Len(events, 1)
+	assertions.Equal("progress", events[0].Type)
+}
+
+func TestCLIIdentityImportSendsParsedEntriesAndConvertsResult(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(http.MethodPost, r.Method)
+		assertions.Equal("/api/v1/cli/identities/import", r.URL.Path)
+		var raw map[string]json.RawMessage
+		if !assertions.NoError(json.NewDecoder(r.Body).Decode(&raw), "decode import request") {
+			http.Error(w, "bad import request", http.StatusBadRequest)
+			return
+		}
+		assertions.NotContains(raw, "file")
+		assertions.NotContains(raw, "data")
+		encoded, err := json.Marshal(raw)
+		if !assertions.NoError(err) {
+			http.Error(w, "encode import request", http.StatusInternalServerError)
+			return
+		}
+		var req identityops.ImportRequest
+		if !assertions.NoError(json.Unmarshal(encoded, &req)) {
+			http.Error(w, "decode import request", http.StatusBadRequest)
+			return
+		}
+		assertions.Empty(req.Account)
+		assertions.Equal(int64(14), req.SourceID)
+		assertions.Equal("bulk-import", req.Signal)
+		assertions.True(req.Apply)
+		assertions.Equal([]identityops.ImportEntry{{
+			Identifier: "alias@example.test", State: "disabled",
+		}}, req.Entries)
+
+		w.Header().Set("Content-Type", "application/json")
+		assertions.NoError(json.NewEncoder(w).Encode(identityops.ImportResult{
+			Account:  "primary@example.test",
+			SourceID: 14,
+			Signal:   "bulk-import",
+			Candidates: []identityops.Candidate{{
+				Identifier:           "alias@example.test",
+				NormalizedIdentifier: "alias@example.test",
+				Classification:       "strong",
+				Signals:              []string{"bulk-import"},
+				ProviderStates:       []string{"disabled"},
+			}},
+			Applied: []store.IdentityConfirmationOutcome{{
+				Identifier: "alias@example.test", Added: true, Signals: []string{"bulk-import"},
+			}},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := New(Config{URL: srv.URL, AllowInsecure: true})
+	requirements.NoError(err)
+	result, err := client.ImportCLIIdentities(t.Context(), identityops.ImportRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Entries: []identityops.ImportEntry{{
+			Identifier: "alias@example.test", State: "disabled",
+		}},
+		Signal: "bulk-import",
+		Apply:  true,
+	})
+
+	requirements.NoError(err)
+	requirements.NotNil(result)
+	assertions.Equal("primary@example.test", result.Account)
+	assertions.Equal([]string{"disabled"}, result.Candidates[0].ProviderStates)
+	assertions.Equal([]store.IdentityConfirmationOutcome{{
+		Identifier: "alias@example.test", Added: true, Signals: []string{"bulk-import"},
+	}}, result.Applied)
+}
 
 func TestNewRejectsHTTPWithoutAllowInsecure(t *testing.T) {
 	_, err := New(Config{URL: "http://nas:8080", APIKey: "key"})

--- a/internal/daemonclient/convert.go
+++ b/internal/daemonclient/convert.go
@@ -7,6 +7,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/cacheops"
 	"go.kenn.io/msgvault/internal/deletion"
+	"go.kenn.io/msgvault/internal/identityops"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/pkg/client/generated"
@@ -513,6 +514,148 @@ func cliIdentityRemoveResultFromGenerated(resp *generated.RemoveResult) *CLIIden
 		Identifier: resp.Identifier,
 		Removed:    resp.Removed,
 		NoIdentity: boolValue(resp.NoIdentity),
+	}
+}
+
+func cliIdentityDiscoverBodyFromRequest(
+	req identityops.DiscoverRequest,
+) *generated.DiscoverCLIIdentitiesBody {
+	body := &generated.DiscoverCLIIdentitiesBody{
+		Account:  optionalString(req.Account),
+		Apply:    optionalBool(req.Apply),
+		Confirm:  append([]string(nil), req.Confirm...),
+		Provider: optionalBool(req.Provider),
+		SourceID: optionalCLIIdentitySourceID(req.SourceID, req.SourceID != 0),
+	}
+	if req.PageSize != 0 {
+		pageSize := int64(req.PageSize)
+		body.PageSize = &pageSize
+	}
+	return body
+}
+
+func cliIdentityDiscoverEventFromGenerated(event generated.DiscoverEvent) identityops.DiscoverEvent {
+	out := identityops.DiscoverEvent{Type: string(event.Type)}
+	if event.ErrorData != nil {
+		out.Error = &identityops.DiscoverError{
+			Code:    event.ErrorData.Code,
+			Message: event.ErrorData.Message,
+		}
+	}
+	if event.Progress != nil {
+		out.Progress = &identityops.DiscoverProgress{
+			Done:       event.Progress.Done,
+			Total:      event.Progress.Total,
+			Candidates: int(event.Progress.Candidates),
+		}
+	}
+	if event.Result != nil {
+		out.Result = cliIdentityDiscoverResultFromGenerated(event.Result)
+	}
+	return out
+}
+
+func cliIdentityDiscoverResultFromGenerated(result *generated.DiscoverResult) *identityops.DiscoverResult {
+	if result == nil {
+		return nil
+	}
+	candidates := make([]identityops.Candidate, len(result.Candidates))
+	for i, candidate := range result.Candidates {
+		candidates[i] = identityops.Candidate{
+			Identifier:           candidate.Identifier,
+			NormalizedIdentifier: candidate.NormalizedIdentifier,
+			Classification:       string(candidate.Classification),
+			AlreadyConfirmed:     candidate.AlreadyConfirmed,
+			Signals:              append([]string{}, candidate.Signals...),
+			ProviderStates:       append([]string{}, candidate.ProviderStates...),
+			SentMessageCount:     candidate.SentMessageCount,
+			ReceivedMessageCount: candidate.ReceivedMessageCount,
+			FirstSeenAt:          candidate.FirstSeenAt,
+			LastSeenAt:           candidate.LastSeenAt,
+		}
+	}
+	rejected := make([]identityops.RejectedCandidate, len(result.Rejected))
+	for i, candidate := range result.Rejected {
+		rejected[i] = identityops.RejectedCandidate{
+			Identifier: candidate.Identifier,
+			Reason:     candidate.Reason,
+		}
+	}
+	applied := make([]store.IdentityConfirmationOutcome, len(result.Applied))
+	for i, outcome := range result.Applied {
+		applied[i] = store.IdentityConfirmationOutcome{
+			Identifier: outcome.Identifier,
+			Added:      outcome.Added,
+			Signals:    append([]string{}, outcome.Signals...),
+		}
+	}
+	return &identityops.DiscoverResult{
+		Account:         result.Account,
+		SourceID:        result.SourceID,
+		SourceType:      result.SourceType,
+		ScannedMessages: result.ScannedMessages,
+		Candidates:      candidates,
+		Rejected:        rejected,
+		Applied:         applied,
+	}
+}
+
+func cliIdentityImportBodyFromRequest(
+	req identityops.ImportRequest,
+) *generated.ImportCLIIdentitiesBody {
+	entries := make([]generated.ImportEntry, len(req.Entries))
+	for i, entry := range req.Entries {
+		entries[i] = generated.ImportEntry{
+			Identifier: entry.Identifier,
+			State:      optionalString(entry.State),
+		}
+	}
+	return &generated.ImportCLIIdentitiesBody{
+		Account:  optionalString(req.Account),
+		Apply:    optionalBool(req.Apply),
+		Entries:  entries,
+		Signal:   optionalString(req.Signal),
+		SourceID: optionalCLIIdentitySourceID(req.SourceID, req.SourceID != 0),
+	}
+}
+
+func cliIdentityImportResultFromGenerated(result *generated.ImportResult) *identityops.ImportResult {
+	if result == nil {
+		return &identityops.ImportResult{}
+	}
+	candidates := make([]identityops.Candidate, len(result.Candidates))
+	for i, candidate := range result.Candidates {
+		candidates[i] = cliIdentityCandidateFromGenerated(candidate)
+	}
+	applied := make([]store.IdentityConfirmationOutcome, len(result.Applied))
+	for i, outcome := range result.Applied {
+		applied[i] = store.IdentityConfirmationOutcome{
+			Identifier: outcome.Identifier,
+			Added:      outcome.Added,
+			Signals:    append([]string{}, outcome.Signals...),
+		}
+	}
+	return &identityops.ImportResult{
+		Account:    result.Account,
+		SourceID:   result.SourceID,
+		Signal:     result.Signal,
+		Candidates: candidates,
+		Applied:    applied,
+	}
+}
+
+func cliIdentityCandidateFromGenerated(candidate generated.Candidate) identityops.Candidate {
+	return identityops.Candidate{
+		Identifier:           candidate.Identifier,
+		NormalizedIdentifier: candidate.NormalizedIdentifier,
+		Classification:       string(candidate.Classification),
+		AlreadyConfirmed:     candidate.AlreadyConfirmed,
+		Signals:              append([]string{}, candidate.Signals...),
+		ProviderStates:       append([]string{}, candidate.ProviderStates...),
+		SentMessageCount:     candidate.SentMessageCount,
+		ReceivedMessageCount: candidate.ReceivedMessageCount,
+		FirstSeenAt:          candidate.FirstSeenAt,
+		LastSeenAt:           candidate.LastSeenAt,
 	}
 }
 

--- a/internal/dedup/dedup_test.go
+++ b/internal/dedup/dedup_test.go
@@ -662,3 +662,63 @@ func TestEngine_PerSourceIdentity(t *testing.T) {
 		"survivor (%s), want source A, matched identity",
 		survivor.SourceIdentifier)
 }
+
+func TestEngine_AliasOnlyAfterDiscoveryConfirmation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	st := f.Store
+	source := f.Source
+
+	const alias = "masked-shop@example.test"
+	const rfc822ID = "rfc-alias-confirmation"
+	aliasMessageID := addMessageWithFrom(
+		t,
+		st,
+		source,
+		"alias-copy",
+		rfc822ID,
+		alias,
+	)
+	_ = addMessageWithFrom(
+		t,
+		st,
+		source,
+		"other-copy",
+		rfc822ID,
+		"other-sender@example.test",
+	)
+
+	plan := func(identityAddresses map[int64]map[string]struct{}) dedup.DuplicateMessage {
+		t.Helper()
+		engine := dedup.NewEngine(st, dedup.Config{
+			AccountSourceIDs:          []int64{source.ID},
+			Account:                   source.Identifier,
+			IdentityAddressesBySource: identityAddresses,
+		}, nil)
+		report, err := engine.Scan(context.Background())
+		require.NoError(err, "Scan")
+		require.Len(report.Groups, 1, "duplicate groups")
+		for _, message := range report.Groups[0].Messages {
+			if message.ID == aliasMessageID {
+				return message
+			}
+		}
+		require.Fail("alias message missing from duplicate plan")
+		return dedup.DuplicateMessage{}
+	}
+
+	before := plan(nil)
+	assert.False(before.MatchedIdentity, "unconfirmed alias must not count as sender identity")
+	require.NoError(st.AddAccountIdentity(source.ID, "MASKED-SHOP@EXAMPLE.TEST", "sent-folder"),
+		"confirm discovered alias")
+	confirmed, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	identityAddresses := map[int64]map[string]struct{}{source.ID: {}}
+	for _, identity := range confirmed {
+		identityAddresses[source.ID][store.NormalizeIdentifierForCompare(identity.Address)] = struct{}{}
+	}
+
+	after := plan(identityAddresses)
+	assert.True(after.MatchedIdentity, "confirmed alias counts as sender identity")
+}

--- a/internal/fastmail/client.go
+++ b/internal/fastmail/client.go
@@ -1,0 +1,446 @@
+package fastmail
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultSessionURL     = "https://api.fastmail.com/jmap/session"
+	defaultRequestTimeout = 30 * time.Second
+	maxResponseBytes      = 8 << 20
+	maskedEmailGet        = "MaskedEmail/get"
+
+	maskedCallID   = "masked"
+	identityCallID = "identity"
+)
+
+// Client reads identity inventory metadata from Fastmail's JMAP endpoint.
+type Client struct {
+	apiToken   string
+	httpClient *http.Client
+	sessionURL string
+}
+
+// NewClient creates a client that discovers the Fastmail JMAP session at the
+// standard endpoint. A nil HTTP client uses http.DefaultClient.
+func NewClient(apiToken string, httpClient *http.Client) *Client {
+	return newClient(apiToken, httpClient, defaultSessionURL)
+}
+
+func newClient(apiToken string, httpClient *http.Client, sessionURL string) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	clientCopy := *httpClient
+	if clientCopy.Timeout == 0 || clientCopy.Timeout > defaultRequestTimeout {
+		clientCopy.Timeout = defaultRequestTimeout
+	}
+	clientCopy.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &Client{
+		apiToken:   apiToken,
+		httpClient: &clientCopy,
+		sessionURL: sessionURL,
+	}
+}
+
+// ListIdentityRecords reads all Masked Email records and, when available,
+// standard JMAP submission identities. It performs one JMAP method request.
+//
+// The MaskedEmail extension defines only /get and /set, so records cannot be
+// enumerated in chunks bounded by the session's maxObjectsInGet. Accounts with
+// more records than that limit (Fastmail advertises 4096) fail with a typed
+// *ObjectLimitError instead of an opaque method error.
+func (c *Client) ListIdentityRecords(ctx context.Context) ([]Record, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	sessionURL, err := parseEndpoint(c.sessionURL)
+	if err != nil {
+		return nil, errors.New("invalid JMAP session endpoint")
+	}
+	session, err := c.fetchSession(ctx, sessionURL)
+	if err != nil {
+		return nil, err
+	}
+	if !hasCapability(session.Capabilities, CoreCapability) {
+		return nil, &CapabilityError{Capability: CoreCapability}
+	}
+	if !hasCapability(session.Capabilities, MaskedEmailCapability) {
+		return nil, &CapabilityError{Capability: MaskedEmailCapability}
+	}
+
+	maskedAccountID, err := selectCapabilityAccount(session, MaskedEmailCapability)
+	if err != nil {
+		return nil, err
+	}
+
+	using := []string{CoreCapability, MaskedEmailCapability}
+	methods := []methodExpectation{{
+		method:    maskedEmailGet,
+		callID:    maskedCallID,
+		accountID: maskedAccountID,
+	}}
+	if hasCapability(session.Capabilities, SubmissionCapability) {
+		if submissionAccountID, selectErr := selectCapabilityAccount(session, SubmissionCapability); selectErr == nil {
+			using = append(using, SubmissionCapability)
+			methods = append(methods, methodExpectation{
+				method:    "Identity/get",
+				callID:    identityCallID,
+				accountID: submissionAccountID,
+			})
+		}
+	}
+
+	apiURL, err := resolveAPIURL(sessionURL, session.APIURL)
+	if err != nil {
+		return nil, err
+	}
+	requestBody, err := buildJMAPRequest(using, methods)
+	if err != nil {
+		return nil, errors.New("encode JMAP identity request")
+	}
+	response, err := c.callMethods(ctx, apiURL, requestBody, methods)
+	if err != nil {
+		return nil, err
+	}
+	records, err := parseMethodResponses(apiURL, response, methods, coreObjectLimit(session.Capabilities))
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(records, func(i, j int) bool {
+		left := strings.ToLower(strings.TrimSpace(records[i].Identifier))
+		right := strings.ToLower(strings.TrimSpace(records[j].Identifier))
+		if left != right {
+			return left < right
+		}
+		if records[i].Kind != records[j].Kind {
+			return records[i].Kind < records[j].Kind
+		}
+		if records[i].State != records[j].State {
+			return records[i].State < records[j].State
+		}
+		return records[i].Identifier < records[j].Identifier
+	})
+	return records, nil
+}
+
+func (c *Client) fetchSession(ctx context.Context, endpoint *url.URL) (sessionResponse, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return sessionResponse{}, errors.New("create JMAP session request")
+	}
+	setRequestHeaders(request, c.apiToken, false)
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return sessionResponse{}, ctxErr
+		}
+		return sessionResponse{}, fmt.Errorf("request JMAP session from %s: transport failure", endpoint.Host)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return sessionResponse{}, fmt.Errorf(
+			"JMAP session at %s returned HTTP status %d",
+			endpoint.Host,
+			response.StatusCode,
+		)
+	}
+
+	var session sessionResponse
+	if err := decodeJSON(response.Body, &session); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return sessionResponse{}, ctxErr
+		}
+		return sessionResponse{}, fmt.Errorf("decode JMAP session from %s", endpoint.Host)
+	}
+	return session, nil
+}
+
+func (c *Client) callMethods(
+	ctx context.Context,
+	endpoint *url.URL,
+	body []byte,
+	methods []methodExpectation,
+) (jmapResponse, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return jmapResponse{}, errors.New("create JMAP method request")
+	}
+	setRequestHeaders(request, c.apiToken, true)
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return jmapResponse{}, ctxErr
+		}
+		return jmapResponse{}, fmt.Errorf(
+			"request %s from %s: transport failure",
+			methodNames(methods),
+			endpoint.Host,
+		)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return jmapResponse{}, fmt.Errorf(
+			"%s at %s returned HTTP status %d",
+			methodNames(methods),
+			endpoint.Host,
+			response.StatusCode,
+		)
+	}
+
+	var result jmapResponse
+	if err := decodeJSON(response.Body, &result); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return jmapResponse{}, ctxErr
+		}
+		return jmapResponse{}, fmt.Errorf("decode %s response from %s", methodNames(methods), endpoint.Host)
+	}
+	return result, nil
+}
+
+func setRequestHeaders(request *http.Request, token string, hasBody bool) {
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Accept", "application/json")
+	if hasBody {
+		request.Header.Set("Content-Type", "application/json")
+	}
+}
+
+func decodeJSON(reader io.Reader, target any) error {
+	limited := io.LimitReader(reader, maxResponseBytes+1)
+	decoder := json.NewDecoder(limited)
+	return decoder.Decode(target)
+}
+
+func parseEndpoint(rawURL string) (*url.URL, error) {
+	endpoint, err := url.Parse(rawURL)
+	if err != nil || !endpoint.IsAbs() || endpoint.Host == "" || endpoint.User != nil {
+		return nil, errors.New("invalid endpoint")
+	}
+	if endpoint.Scheme != "https" && endpoint.Scheme != "http" {
+		return nil, errors.New("invalid endpoint")
+	}
+	return endpoint, nil
+}
+
+func resolveAPIURL(sessionURL *url.URL, rawAPIURL string) (*url.URL, error) {
+	reference, err := url.Parse(rawAPIURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JMAP API endpoint from %s", sessionURL.Host)
+	}
+	endpoint := sessionURL.ResolveReference(reference)
+	if _, err := parseEndpoint(endpoint.String()); err != nil {
+		return nil, fmt.Errorf("invalid JMAP API endpoint from %s", sessionURL.Host)
+	}
+	if !sameOrigin(sessionURL, endpoint) {
+		return nil, fmt.Errorf("cross-origin JMAP API endpoint rejected for %s", sessionURL.Host)
+	}
+	return endpoint, nil
+}
+
+func sameOrigin(left, right *url.URL) bool {
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) &&
+		effectivePort(left) == effectivePort(right)
+}
+
+func effectivePort(endpoint *url.URL) string {
+	if port := endpoint.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(endpoint.Scheme, "https") {
+		return "443"
+	}
+	if strings.EqualFold(endpoint.Scheme, "http") {
+		return "80"
+	}
+	return ""
+}
+
+func hasCapability(capabilities map[string]json.RawMessage, capability string) bool {
+	_, ok := capabilities[capability]
+	return ok
+}
+
+func selectCapabilityAccount(session sessionResponse, capability string) (string, error) {
+	if accountID := session.PrimaryAccounts[capability]; accountID != "" {
+		account, ok := session.Accounts[accountID]
+		if !ok || !hasCapability(account.AccountCapabilities, capability) {
+			return "", fmt.Errorf("primary account does not advertise JMAP capability %s", capability)
+		}
+		return accountID, nil
+	}
+
+	var matches []string
+	for accountID, account := range session.Accounts {
+		if hasCapability(account.AccountCapabilities, capability) {
+			matches = append(matches, accountID)
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no account advertises JMAP capability %s", capability)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("ambiguous account selection for JMAP capability %s", capability)
+	}
+	return matches[0], nil
+}
+
+type methodExpectation struct {
+	method    string
+	callID    string
+	accountID string
+}
+
+func buildJMAPRequest(using []string, methods []methodExpectation) ([]byte, error) {
+	request := jmapRequest{Using: using, MethodCalls: make([][]json.RawMessage, 0, len(methods))}
+	for _, method := range methods {
+		name, err := json.Marshal(method.method)
+		if err != nil {
+			return nil, err
+		}
+		arguments, err := json.Marshal(struct {
+			AccountID string `json:"accountId"`
+		}{AccountID: method.accountID})
+		if err != nil {
+			return nil, err
+		}
+		callID, err := json.Marshal(method.callID)
+		if err != nil {
+			return nil, err
+		}
+		request.MethodCalls = append(request.MethodCalls, []json.RawMessage{name, arguments, callID})
+	}
+	return json.Marshal(request)
+}
+
+func coreObjectLimit(capabilities map[string]json.RawMessage) int64 {
+	raw, ok := capabilities[CoreCapability]
+	if !ok {
+		return 0
+	}
+	var settings struct {
+		MaxObjectsInGet int64 `json:"maxObjectsInGet"`
+	}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return 0
+	}
+	return settings.MaxObjectsInGet
+}
+
+func methodErrorType(arguments json.RawMessage) string {
+	var payload struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(arguments, &payload); err != nil {
+		return ""
+	}
+	return payload.Type
+}
+
+func parseMethodResponses(
+	endpoint *url.URL,
+	response jmapResponse,
+	methods []methodExpectation,
+	maxObjectsInGet int64,
+) ([]Record, error) {
+	expected := make(map[string]methodExpectation, len(methods))
+	for _, method := range methods {
+		expected[method.callID] = method
+	}
+	seen := make(map[string]bool, len(methods))
+	var records []Record
+	for _, rawResponse := range response.MethodResponses {
+		var tuple []json.RawMessage
+		if err := json.Unmarshal(rawResponse, &tuple); err != nil || len(tuple) != 3 {
+			return nil, fmt.Errorf("decode JMAP method response from %s", endpoint.Host)
+		}
+		var methodName, callID string
+		if err := json.Unmarshal(tuple[0], &methodName); err != nil {
+			return nil, fmt.Errorf("decode JMAP method name from %s", endpoint.Host)
+		}
+		if err := json.Unmarshal(tuple[2], &callID); err != nil {
+			return nil, fmt.Errorf("decode JMAP call ID from %s", endpoint.Host)
+		}
+		method, ok := expected[callID]
+		if !ok {
+			return nil, fmt.Errorf("unexpected JMAP call ID from %s", endpoint.Host)
+		}
+		if seen[callID] {
+			return nil, fmt.Errorf("duplicate JMAP call ID for %s from %s", method.method, endpoint.Host)
+		}
+		seen[callID] = true
+		if methodName == "error" {
+			if methodErrorType(tuple[1]) == "requestTooLarge" {
+				return nil, &ObjectLimitError{Method: method.method, MaxObjectsInGet: maxObjectsInGet}
+			}
+			return nil, fmt.Errorf("%s at %s returned a JMAP method error", method.method, endpoint.Host)
+		}
+		if methodName != method.method {
+			return nil, fmt.Errorf("unexpected JMAP method for %s from %s", method.method, endpoint.Host)
+		}
+
+		switch callID {
+		case maskedCallID:
+			var result maskedEmailGetResponse
+			if err := json.Unmarshal(tuple[1], &result); err != nil {
+				return nil, fmt.Errorf("decode %s response from %s", method.method, endpoint.Host)
+			}
+			if result.AccountID != method.accountID {
+				return nil, fmt.Errorf("unexpected account in %s response from %s", method.method, endpoint.Host)
+			}
+			for _, item := range result.List {
+				records = append(records, Record{
+					Identifier: item.Email,
+					State:      item.State,
+					Kind:       "masked-email",
+				})
+			}
+		case identityCallID:
+			var result identityGetResponse
+			if err := json.Unmarshal(tuple[1], &result); err != nil {
+				return nil, fmt.Errorf("decode %s response from %s", method.method, endpoint.Host)
+			}
+			if result.AccountID != method.accountID {
+				return nil, fmt.Errorf("unexpected account in %s response from %s", method.method, endpoint.Host)
+			}
+			for _, item := range result.List {
+				records = append(records, Record{
+					Identifier: item.Email,
+					State:      "enabled",
+					Kind:       "identity",
+				})
+			}
+		}
+	}
+
+	for _, method := range methods {
+		if !seen[method.callID] {
+			return nil, fmt.Errorf("missing %s response from %s", method.method, endpoint.Host)
+		}
+	}
+	return records, nil
+}
+
+func methodNames(methods []methodExpectation) string {
+	names := make([]string, 0, len(methods))
+	for _, method := range methods {
+		names = append(names, method.method)
+	}
+	return strings.Join(names, " and ")
+}

--- a/internal/fastmail/client_test.go
+++ b/internal/fastmail/client_test.go
@@ -1,0 +1,709 @@
+package fastmail
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testToken = "fm_synthetic_token_never_log"
+
+func TestListIdentityRecordsIncludesHistoricalMaskedAliases(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	methodRequests := make(chan requestCapture, 1)
+	srv := newTestServer(t, func(baseURL string) sessionResponse {
+		return sessionResponse{
+			APIURL: baseURL + "/jmap",
+			Capabilities: capabilitySet(
+				CoreCapability,
+				MaskedEmailCapability,
+				SubmissionCapability,
+			),
+			Accounts: map[string]sessionAccount{
+				"masked-account": {
+					AccountCapabilities: capabilitySet(MaskedEmailCapability),
+				},
+				"submission-account": {
+					AccountCapabilities: capabilitySet(SubmissionCapability),
+				},
+			},
+			PrimaryAccounts: map[string]string{
+				MaskedEmailCapability: "masked-account",
+				SubmissionCapability:  "submission-account",
+			},
+		}
+	}, func(w http.ResponseWriter, r *http.Request) {
+		var request jmapRequest
+		err := json.NewDecoder(r.Body).Decode(&request)
+		methodRequests <- requestCapture{request: request, err: err}
+		if err != nil {
+			http.Error(w, "invalid JMAP request", http.StatusBadRequest)
+			return
+		}
+		assert.NoError(writeJSON(w, map[string]any{
+			"methodResponses": []any{
+				[]any{"MaskedEmail/get", map[string]any{
+					"accountId": "masked-account",
+					"state":     "masked-state",
+					"list": []any{
+						map[string]any{"id": "4", "email": "waiting@example.test", "state": "pending"},
+						map[string]any{"id": "2", "email": "old@example.test", "state": "disabled"},
+						map[string]any{"id": "1", "email": "Active@example.test", "state": "enabled"},
+						map[string]any{"id": "3", "email": "deleted@example.test", "state": "deleted"},
+					},
+				}, "masked"},
+				[]any{"Identity/get", map[string]any{
+					"accountId": "submission-account",
+					"state":     "identity-state",
+					"list": []any{
+						map[string]any{"id": "identity-2", "email": "send-as@example.test", "name": "Send As"},
+						map[string]any{"id": "identity-1", "email": "*@example.test", "name": "Wildcard"},
+					},
+				}, "identity"},
+			},
+		}))
+	})
+
+	got, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+	require.NoError(err)
+	methodRequest := <-methodRequests
+	require.NoError(methodRequest.err)
+	assert.Equal([]Record{
+		{Identifier: "*@example.test", State: "enabled", Kind: "identity"},
+		{Identifier: "Active@example.test", State: "enabled", Kind: "masked-email"},
+		{Identifier: "deleted@example.test", State: "deleted", Kind: "masked-email"},
+		{Identifier: "old@example.test", State: "disabled", Kind: "masked-email"},
+		{Identifier: "send-as@example.test", State: "enabled", Kind: "identity"},
+		{Identifier: "waiting@example.test", State: "pending", Kind: "masked-email"},
+	}, got)
+
+	require.Len(methodRequest.request.MethodCalls, 2)
+	assert.Equal([]string{
+		CoreCapability,
+		MaskedEmailCapability,
+		SubmissionCapability,
+	}, methodRequest.request.Using)
+	assertMethodCall(t, methodRequest.request.MethodCalls[0], "MaskedEmail/get", "masked-account", "masked")
+	assertMethodCall(t, methodRequest.request.MethodCalls[1], "Identity/get", "submission-account", "identity")
+}
+
+func TestListIdentityRecordsWorksWithMaskedEmailCapabilityOnly(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	methodRequests := make(chan requestCapture, 1)
+	srv := newTestServer(t, func(baseURL string) sessionResponse {
+		return sessionResponse{
+			APIURL:       baseURL + "/jmap",
+			Capabilities: capabilitySet(CoreCapability, MaskedEmailCapability),
+			Accounts: map[string]sessionAccount{
+				"masked-only": {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+			},
+			PrimaryAccounts: map[string]string{MaskedEmailCapability: "masked-only"},
+		}
+	}, func(w http.ResponseWriter, r *http.Request) {
+		var request jmapRequest
+		err := json.NewDecoder(r.Body).Decode(&request)
+		methodRequests <- requestCapture{request: request, err: err}
+		if err != nil {
+			http.Error(w, "invalid JMAP request", http.StatusBadRequest)
+			return
+		}
+		assert.NoError(writeJSON(w, map[string]any{
+			"methodResponses": []any{
+				[]any{"MaskedEmail/get", map[string]any{
+					"accountId": "masked-only",
+					"list": []any{
+						map[string]any{"id": "1", "email": "masked@example.test", "state": "enabled"},
+					},
+				}, "masked"},
+			},
+		}))
+	})
+
+	got, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+	require.NoError(err)
+	methodRequest := <-methodRequests
+	require.NoError(methodRequest.err)
+	assert.Equal([]Record{
+		{Identifier: "masked@example.test", State: "enabled", Kind: "masked-email"},
+	}, got)
+	require.Len(methodRequest.request.MethodCalls, 1)
+	assert.Equal([]string{CoreCapability, MaskedEmailCapability}, methodRequest.request.Using)
+	assertMethodCall(t, methodRequest.request.MethodCalls[0], "MaskedEmail/get", "masked-only", "masked")
+}
+
+func TestListIdentityRecordsSkipsSubmissionWithoutAccessibleAccount(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	methodRequests := make(chan requestCapture, 1)
+	srv := newTestServer(t, func(baseURL string) sessionResponse {
+		return sessionResponse{
+			APIURL: baseURL + "/jmap",
+			Capabilities: capabilitySet(
+				CoreCapability,
+				MaskedEmailCapability,
+				SubmissionCapability,
+			),
+			Accounts: map[string]sessionAccount{
+				"masked-only": {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+			},
+			PrimaryAccounts: map[string]string{MaskedEmailCapability: "masked-only"},
+		}
+	}, func(w http.ResponseWriter, r *http.Request) {
+		var request jmapRequest
+		err := json.NewDecoder(r.Body).Decode(&request)
+		methodRequests <- requestCapture{request: request, err: err}
+		if err != nil {
+			http.Error(w, "invalid JMAP request", http.StatusBadRequest)
+			return
+		}
+		assert.NoError(writeJSON(w, map[string]any{
+			"methodResponses": []any{
+				[]any{"MaskedEmail/get", map[string]any{
+					"accountId": "masked-only",
+					"list": []any{
+						map[string]any{"id": "1", "email": "historical@example.test", "state": "disabled"},
+					},
+				}, "masked"},
+			},
+		}))
+	})
+
+	got, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+	require.NoError(err)
+	assert.Equal([]Record{
+		{Identifier: "historical@example.test", State: "disabled", Kind: "masked-email"},
+	}, got)
+	methodRequest := <-methodRequests
+	require.NoError(methodRequest.err)
+	require.Len(methodRequest.request.MethodCalls, 1)
+	assert.Equal([]string{CoreCapability, MaskedEmailCapability}, methodRequest.request.Using)
+	assertMethodCall(t, methodRequest.request.MethodCalls[0], "MaskedEmail/get", "masked-only", "masked")
+}
+
+func TestListIdentityRecordsUsesUniqueAccountCapabilityFallback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	methodRequests := make(chan requestCapture, 1)
+	srv := newTestServer(t, func(baseURL string) sessionResponse {
+		return sessionResponse{
+			APIURL:       baseURL + "/jmap",
+			Capabilities: capabilitySet(CoreCapability, MaskedEmailCapability, SubmissionCapability),
+			Accounts: map[string]sessionAccount{
+				"mail-account": {AccountCapabilities: capabilitySet("urn:ietf:params:jmap:mail")},
+				"masked-account": {
+					AccountCapabilities: capabilitySet(MaskedEmailCapability),
+				},
+				"submission-account": {
+					AccountCapabilities: capabilitySet(SubmissionCapability),
+				},
+			},
+		}
+	}, func(w http.ResponseWriter, r *http.Request) {
+		var request jmapRequest
+		err := json.NewDecoder(r.Body).Decode(&request)
+		methodRequests <- requestCapture{request: request, err: err}
+		if err != nil {
+			http.Error(w, "invalid JMAP request", http.StatusBadRequest)
+			return
+		}
+		assert.NoError(writeJSON(w, map[string]any{
+			"methodResponses": []any{
+				[]any{"MaskedEmail/get", map[string]any{"accountId": "masked-account", "list": []any{}}, "masked"},
+				[]any{"Identity/get", map[string]any{"accountId": "submission-account", "list": []any{}}, "identity"},
+			},
+		}))
+	})
+
+	got, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+	require.NoError(err)
+	assert.Empty(got)
+	methodRequest := <-methodRequests
+	require.NoError(methodRequest.err)
+	require.Len(methodRequest.request.MethodCalls, 2)
+	assertMethodCall(t, methodRequest.request.MethodCalls[0], "MaskedEmail/get", "masked-account", "masked")
+	assertMethodCall(t, methodRequest.request.MethodCalls[1], "Identity/get", "submission-account", "identity")
+}
+
+func TestListIdentityRecordsReturnsTypedCapabilityError(t *testing.T) {
+	var methodRequests atomic.Int32
+	srv := newTestServer(t, func(baseURL string) sessionResponse {
+		return sessionResponse{
+			APIURL:          baseURL + "/jmap",
+			Capabilities:    capabilitySet(CoreCapability),
+			Accounts:        map[string]sessionAccount{},
+			PrimaryAccounts: map[string]string{},
+		}
+	}, func(w http.ResponseWriter, _ *http.Request) {
+		methodRequests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+	var capabilityErr *CapabilityError
+	require.ErrorAs(t, err, &capabilityErr)
+	assert.Equal(t, MaskedEmailCapability, capabilityErr.Capability)
+	assert.Equal(t, int32(0), methodRequests.Load())
+}
+
+func TestListIdentityRecordsRejectsAmbiguousCapabilityAccount(t *testing.T) {
+	var methodRequests atomic.Int32
+	srv := newTestServer(t, func(baseURL string) sessionResponse {
+		return sessionResponse{
+			APIURL:       baseURL + "/jmap",
+			Capabilities: capabilitySet(CoreCapability, MaskedEmailCapability),
+			Accounts: map[string]sessionAccount{
+				"masked-a": {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+				"masked-b": {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+			},
+		}
+	}, func(w http.ResponseWriter, _ *http.Request) {
+		methodRequests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+	require.ErrorContains(t, err, "ambiguous")
+	assert.NotContains(t, err.Error(), testToken)
+	assert.Equal(t, int32(0), methodRequests.Load())
+}
+
+func TestListIdentityRecordsRejectsCrossOriginAPIURLBeforeSendingToken(t *testing.T) {
+	var crossOriginRequests atomic.Int32
+	crossOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		crossOriginRequests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(crossOrigin.Close)
+
+	session := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !assertBearer(t, r) {
+			http.Error(w, "missing bearer token", http.StatusUnauthorized)
+			return
+		}
+		assert.NoError(t, writeJSON(w, sessionResponse{
+			APIURL:       crossOrigin.URL + "/jmap",
+			Capabilities: capabilitySet(CoreCapability, MaskedEmailCapability),
+			Accounts: map[string]sessionAccount{
+				"masked": {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+			},
+			PrimaryAccounts: map[string]string{MaskedEmailCapability: "masked"},
+		}))
+	}))
+	t.Cleanup(session.Close)
+
+	_, err := newClient(testToken, session.Client(), session.URL+"/session").ListIdentityRecords(context.Background())
+	require.ErrorContains(t, err, "cross-origin")
+	assert.Equal(t, int32(0), crossOriginRequests.Load())
+	assert.NotContains(t, err.Error(), testToken)
+}
+
+func TestListIdentityRecordsDoesNotFollowAuthenticatedRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	session := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusFound)
+	}))
+	t.Cleanup(session.Close)
+
+	_, err := newClient(testToken, session.Client(), session.URL+"/session").ListIdentityRecords(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, int32(0), redirectedRequests.Load())
+	assert.NotContains(t, err.Error(), testToken)
+}
+
+func TestJMAPHTTPErrorsRedactTokenAndBody(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv := newTestServer(t, func(baseURL string) sessionResponse {
+		return sessionResponse{
+			APIURL:       baseURL + "/jmap",
+			Capabilities: capabilitySet(CoreCapability, MaskedEmailCapability),
+			Accounts: map[string]sessionAccount{
+				"masked": {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+			},
+			PrimaryAccounts: map[string]string{MaskedEmailCapability: "masked"},
+		}
+	}, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"detail":"private-address@example.test","token":"fm_body_secret"}`))
+	})
+
+	_, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+	require.Error(err)
+	require.ErrorContains(err, "MaskedEmail/get")
+	require.ErrorContains(err, "502")
+	assert.NotContains(err.Error(), testToken)
+	assert.NotContains(err.Error(), "private-address@example.test")
+	assert.NotContains(err.Error(), "fm_body_secret")
+}
+
+func TestListIdentityRecordsFailsClosedForInvalidMethodResponses(t *testing.T) {
+	tests := []struct {
+		name            string
+		methodResponses []any
+		wantError       string
+	}{
+		{
+			name: "method error",
+			methodResponses: []any{
+				[]any{"error", map[string]any{"type": "serverFail", "description": "private@example.test"}, "masked"},
+			},
+			wantError: "MaskedEmail/get",
+		},
+		{
+			name: "wrong call id",
+			methodResponses: []any{
+				[]any{"MaskedEmail/get", map[string]any{"accountId": "masked", "list": []any{}}, "other"},
+			},
+			wantError: "unexpected JMAP call ID",
+		},
+		{
+			name: "wrong method",
+			methodResponses: []any{
+				[]any{"Identity/get", map[string]any{"accountId": "masked", "list": []any{}}, "masked"},
+			},
+			wantError: "unexpected JMAP method",
+		},
+		{
+			name: "mismatched response account",
+			methodResponses: []any{
+				[]any{"MaskedEmail/get", map[string]any{"accountId": "private-account@example.test", "list": []any{}}, "masked"},
+			},
+			wantError: "unexpected account in MaskedEmail/get response",
+		},
+		{
+			name: "duplicate expected call id",
+			methodResponses: []any{
+				[]any{"MaskedEmail/get", map[string]any{"accountId": "masked", "list": []any{}}, "masked"},
+				[]any{"MaskedEmail/get", map[string]any{"accountId": "masked", "list": []any{}}, "masked"},
+			},
+			wantError: "duplicate JMAP call ID for MaskedEmail/get",
+		},
+		{
+			name: "missing expected response",
+			methodResponses: []any{
+				[]any{"MaskedEmail/get", map[string]any{"accountId": "masked", "list": []any{}}, "masked"},
+			},
+			wantError: "missing Identity/get response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			srv := newTestServer(t, func(baseURL string) sessionResponse {
+				return sessionResponse{
+					APIURL: baseURL + "/jmap",
+					Capabilities: capabilitySet(
+						CoreCapability,
+						MaskedEmailCapability,
+						SubmissionCapability,
+					),
+					Accounts: map[string]sessionAccount{
+						"masked":     {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+						"submission": {AccountCapabilities: capabilitySet(SubmissionCapability)},
+					},
+					PrimaryAccounts: map[string]string{
+						MaskedEmailCapability: "masked",
+						SubmissionCapability:  "submission",
+					},
+				}
+			}, func(w http.ResponseWriter, _ *http.Request) {
+				assert.NoError(writeJSON(w, map[string]any{"methodResponses": tt.methodResponses}))
+			})
+
+			_, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+			require.Error(err)
+			require.ErrorContains(err, tt.wantError)
+			assert.NotContains(err.Error(), "private@example.test")
+			assert.NotContains(err.Error(), "private-account@example.test")
+			assert.NotContains(err.Error(), testToken)
+		})
+	}
+}
+
+func TestListIdentityRecordsClassifiesObjectLimitErrors(t *testing.T) {
+	tests := []struct {
+		name            string
+		coreCapability  json.RawMessage
+		methodResponses []any
+		wantMethod      string
+		wantLimit       int64
+	}{
+		{
+			name:           "masked email inventory over limit",
+			coreCapability: json.RawMessage(`{"maxObjectsInGet": 2}`),
+			methodResponses: []any{
+				[]any{"error", map[string]any{
+					"type":        "requestTooLarge",
+					"description": "private@example.test",
+				}, "masked"},
+			},
+			wantMethod: "MaskedEmail/get",
+			wantLimit:  2,
+		},
+		{
+			name:           "identity inventory over limit",
+			coreCapability: json.RawMessage(`{"maxObjectsInGet": 3}`),
+			methodResponses: []any{
+				[]any{"MaskedEmail/get", map[string]any{"accountId": "masked", "list": []any{}}, "masked"},
+				[]any{"error", map[string]any{
+					"type":        "requestTooLarge",
+					"description": "private@example.test",
+				}, "identity"},
+			},
+			wantMethod: "Identity/get",
+			wantLimit:  3,
+		},
+		{
+			name:           "limit not advertised",
+			coreCapability: json.RawMessage(`{}`),
+			methodResponses: []any{
+				[]any{"error", map[string]any{"type": "requestTooLarge"}, "masked"},
+			},
+			wantMethod: "MaskedEmail/get",
+			wantLimit:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			srv := newTestServer(t, func(baseURL string) sessionResponse {
+				capabilities := capabilitySet(CoreCapability, MaskedEmailCapability, SubmissionCapability)
+				capabilities[CoreCapability] = tt.coreCapability
+				return sessionResponse{
+					APIURL:       baseURL + "/jmap",
+					Capabilities: capabilities,
+					Accounts: map[string]sessionAccount{
+						"masked":     {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+						"submission": {AccountCapabilities: capabilitySet(SubmissionCapability)},
+					},
+					PrimaryAccounts: map[string]string{
+						MaskedEmailCapability: "masked",
+						SubmissionCapability:  "submission",
+					},
+				}
+			}, func(w http.ResponseWriter, _ *http.Request) {
+				assert.NoError(writeJSON(w, map[string]any{"methodResponses": tt.methodResponses}))
+			})
+
+			_, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(context.Background())
+			var limitErr *ObjectLimitError
+			require.ErrorAs(err, &limitErr)
+			assert.Equal(tt.wantMethod, limitErr.Method)
+			assert.Equal(tt.wantLimit, limitErr.MaxObjectsInGet)
+			require.ErrorContains(err, "requestTooLarge")
+			assert.NotContains(err.Error(), "private@example.test")
+			assert.NotContains(err.Error(), testToken)
+		})
+	}
+}
+
+func TestListIdentityRecordsReturnsContextCancellation(t *testing.T) {
+	t.Run("session request", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			close(started)
+			select {
+			case <-r.Context().Done():
+			case <-release:
+			}
+		}))
+		t.Cleanup(srv.Close)
+		t.Cleanup(func() { close(release) })
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			_, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(ctx)
+			done <- err
+		}()
+		waitForRequest(t, started)
+		cancel()
+		assert.ErrorIs(t, waitForError(t, done), context.Canceled)
+	})
+
+	t.Run("method request", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		methodRequests := make(chan requestCapture, 1)
+		srv := newTestServer(t, func(baseURL string) sessionResponse {
+			return sessionResponse{
+				APIURL:       baseURL + "/jmap",
+				Capabilities: capabilitySet(CoreCapability, MaskedEmailCapability),
+				Accounts: map[string]sessionAccount{
+					"masked": {AccountCapabilities: capabilitySet(MaskedEmailCapability)},
+				},
+				PrimaryAccounts: map[string]string{MaskedEmailCapability: "masked"},
+			}
+		}, func(w http.ResponseWriter, r *http.Request) {
+			var request jmapRequest
+			err := json.NewDecoder(r.Body).Decode(&request)
+			methodRequests <- requestCapture{request: request, err: err}
+			if err != nil {
+				http.Error(w, "invalid JMAP request", http.StatusBadRequest)
+				return
+			}
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			close(started)
+			select {
+			case <-r.Context().Done():
+			case <-release:
+			}
+		})
+		t.Cleanup(func() { close(release) })
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			_, err := newClient(testToken, srv.Client(), srv.URL+"/session").ListIdentityRecords(ctx)
+			done <- err
+		}()
+		waitForRequest(t, started)
+		cancel()
+		require.ErrorIs(t, waitForError(t, done), context.Canceled)
+		require.NoError(t, (<-methodRequests).err)
+	})
+}
+
+func TestNewClientDefaultsNilHTTPClient(t *testing.T) {
+	client := NewClient(testToken, nil)
+	require.NotNil(t, client)
+	assert.NotNil(t, client.httpClient)
+	assert.Equal(t, defaultRequestTimeout, client.httpClient.Timeout)
+}
+
+func TestNewClientCapsRequestTimeoutWithoutLengtheningShorterCustomTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     time.Duration
+		wantTimeout time.Duration
+	}{
+		{name: "unset", timeout: 0, wantTimeout: defaultRequestTimeout},
+		{name: "shorter", timeout: 2 * time.Second, wantTimeout: 2 * time.Second},
+		{name: "longer", timeout: 2 * defaultRequestTimeout, wantTimeout: defaultRequestTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := &http.Client{Timeout: tt.timeout}
+
+			client := NewClient(testToken, original)
+
+			require.NotNil(t, client)
+			assert.Equal(t, tt.wantTimeout, client.httpClient.Timeout)
+			assert.Equal(t, tt.timeout, original.Timeout, "caller-owned client must not be mutated")
+		})
+	}
+}
+
+type testSessionFactory func(baseURL string) sessionResponse
+
+type requestCapture struct {
+	request jmapRequest
+	err     error
+}
+
+func newTestServer(
+	t *testing.T,
+	session testSessionFactory,
+	methodHandler func(w http.ResponseWriter, r *http.Request),
+) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/session":
+			if !assertBearer(t, r) {
+				http.Error(w, "missing bearer token", http.StatusUnauthorized)
+				return
+			}
+			assert.NoError(t, writeJSON(w, session(srv.URL)))
+		case "/jmap":
+			if !assertBearer(t, r) {
+				http.Error(w, "missing bearer token", http.StatusUnauthorized)
+				return
+			}
+			methodHandler(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func assertBearer(t *testing.T, r *http.Request) bool {
+	t.Helper()
+	return assert.Equal(t, "Bearer "+testToken, r.Header.Get("Authorization"))
+}
+
+func assertMethodCall(t *testing.T, call []json.RawMessage, method, accountID, callID string) {
+	t.Helper()
+	require.Len(t, call, 3)
+	var gotMethod string
+	require.NoError(t, json.Unmarshal(call[0], &gotMethod))
+	assert.Equal(t, method, gotMethod)
+	var args struct {
+		AccountID string `json:"accountId"`
+	}
+	require.NoError(t, json.Unmarshal(call[1], &args))
+	assert.Equal(t, accountID, args.AccountID)
+	var gotCallID string
+	require.NoError(t, json.Unmarshal(call[2], &gotCallID))
+	assert.Equal(t, callID, gotCallID)
+}
+
+func capabilitySet(capabilities ...string) map[string]json.RawMessage {
+	set := make(map[string]json.RawMessage, len(capabilities))
+	for _, capability := range capabilities {
+		set[capability] = json.RawMessage(`{}`)
+	}
+	return set
+}
+
+func writeJSON[T any](w http.ResponseWriter, value T) error {
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(value)
+}
+
+func waitForRequest(t *testing.T, started <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timed out waiting for request")
+	}
+}
+
+func waitForError(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timed out waiting for client result")
+		return nil
+	}
+}

--- a/internal/fastmail/types.go
+++ b/internal/fastmail/types.go
@@ -1,0 +1,86 @@
+package fastmail
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	CoreCapability        = "urn:ietf:params:jmap:core"
+	SubmissionCapability  = "urn:ietf:params:jmap:submission"
+	MaskedEmailCapability = "https://www.fastmail.com/dev/maskedemail"
+)
+
+// Record is one provider-reported address that can supply identity evidence.
+type Record struct {
+	Identifier string
+	State      string
+	Kind       string
+}
+
+// CapabilityError reports that an explicit provider operation cannot proceed
+// because the JMAP session does not advertise a required capability.
+type CapabilityError struct {
+	Capability string
+}
+
+func (e *CapabilityError) Error() string {
+	return "Fastmail JMAP capability unavailable: " + e.Capability
+}
+
+// ObjectLimitError reports that a JMAP /get call covered more objects than the
+// server allows in one method call (RFC 8620 "requestTooLarge"). The
+// MaskedEmail extension has no /query or /changes method, so the inventory
+// cannot be enumerated in chunks; accounts with more records than the
+// session's maxObjectsInGet cannot be listed. MaxObjectsInGet is zero when the
+// session did not advertise the limit.
+type ObjectLimitError struct {
+	Method          string
+	MaxObjectsInGet int64
+}
+
+func (e *ObjectLimitError) Error() string {
+	if e.MaxObjectsInGet > 0 {
+		return fmt.Sprintf(
+			"%s exceeded the JMAP server limit of %d objects per call (requestTooLarge)",
+			e.Method,
+			e.MaxObjectsInGet,
+		)
+	}
+	return e.Method + " exceeded the JMAP server object limit (requestTooLarge)"
+}
+
+type sessionResponse struct {
+	APIURL          string                     `json:"apiUrl"`
+	Capabilities    map[string]json.RawMessage `json:"capabilities"`
+	Accounts        map[string]sessionAccount  `json:"accounts"`
+	PrimaryAccounts map[string]string          `json:"primaryAccounts"`
+}
+
+type sessionAccount struct {
+	AccountCapabilities map[string]json.RawMessage `json:"accountCapabilities"`
+}
+
+type jmapRequest struct {
+	Using       []string            `json:"using"`
+	MethodCalls [][]json.RawMessage `json:"methodCalls"`
+}
+
+type jmapResponse struct {
+	MethodResponses []json.RawMessage `json:"methodResponses"`
+}
+
+type maskedEmailGetResponse struct {
+	AccountID string `json:"accountId"`
+	List      []struct {
+		Email string `json:"email"`
+		State string `json:"state"`
+	} `json:"list"`
+}
+
+type identityGetResponse struct {
+	AccountID string `json:"accountId"`
+	List      []struct {
+		Email string `json:"email"`
+	} `json:"list"`
+}

--- a/internal/gmail/api.go
+++ b/internal/gmail/api.go
@@ -1,7 +1,11 @@
 // Package gmail provides a Gmail API client with rate limiting and retry logic.
 package gmail
 
-import "context"
+import (
+	"context"
+
+	"go.kenn.io/msgvault/internal/store"
+)
 
 // AccountReader provides read access to account-level Gmail data.
 type AccountReader interface {
@@ -65,10 +69,20 @@ type Label struct {
 	ID                    string
 	Name                  string
 	Type                  string // "system" or "user"
+	SystemRole            string
 	MessagesTotal         int64
 	MessagesUnread        int64
 	MessageListVisibility string
 	LabelListVisibility   string
+}
+
+// SystemRoleForLabelID returns roles Gmail identifies canonically, never by
+// the localized label name returned to users.
+func SystemRoleForLabelID(sourceLabelID string) string {
+	if sourceLabelID == "SENT" {
+		return store.LabelSystemRoleSent
+	}
+	return ""
 }
 
 // MessageListResponse contains a page of message IDs.

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -341,6 +341,7 @@ func (c *Client) ListLabels(ctx context.Context) ([]*Label, error) {
 			ID:                    l.ID,
 			Name:                  l.Name,
 			Type:                  l.Type,
+			SystemRole:            SystemRoleForLabelID(l.ID),
 			MessagesTotal:         l.MessagesTotal,
 			MessagesUnread:        l.MessagesUnread,
 			MessageListVisibility: l.MessageListVisibility,

--- a/internal/gmail/mock.go
+++ b/internal/gmail/mock.go
@@ -91,7 +91,7 @@ func (m *MockAPI) ListLabels(ctx context.Context) ([]*Label, error) {
 	if m.Labels == nil {
 		return []*Label{
 			{ID: "INBOX", Name: "INBOX", Type: "system"},
-			{ID: "SENT", Name: "SENT", Type: "system"},
+			{ID: "SENT", Name: "SENT", Type: "system", SystemRole: SystemRoleForLabelID("SENT")},
 			{ID: "STARRED", Name: "STARRED", Type: "system"},
 			{ID: "TRASH", Name: "TRASH", Type: "system"},
 			{ID: "UNREAD", Name: "UNREAD", Type: "system"},
@@ -100,7 +100,13 @@ func (m *MockAPI) ListLabels(ctx context.Context) ([]*Label, error) {
 			{ID: "DRAFT", Name: "DRAFT", Type: "system"},
 		}, nil
 	}
-	return m.Labels, nil
+	labels := make([]*Label, len(m.Labels))
+	for i, source := range m.Labels {
+		label := *source
+		label.SystemRole = SystemRoleForLabelID(label.ID)
+		labels[i] = &label
+	}
+	return labels, nil
 }
 
 // ListMessages returns mock message IDs with pagination.

--- a/internal/granola/importer.go
+++ b/internal/granola/importer.go
@@ -77,6 +77,14 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 		return nil, err
 	}
 	sum := &ImportSummary{SourceID: src.ID}
+	if err := imp.store.AddAccountIdentityContext(
+		ctx,
+		src.ID,
+		opts.AccountEmail,
+		"account-email",
+	); err != nil {
+		return nil, fmt.Errorf("confirm Granola account identity: %w", err)
+	}
 	accountIdentities, err := meetingidentity.ForSource(imp.store, src.ID, opts.AccountEmail)
 	if err != nil {
 		return nil, err

--- a/internal/identityops/discovery.go
+++ b/internal/identityops/discovery.go
@@ -1,0 +1,894 @@
+package identityops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/mail"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	SignalIsFromMe      = "is_from_me"
+	SignalProviderAlias = "provider-alias"
+	SignalSentFolder    = "sent-folder"
+	SignalSentLabel     = "sent-label"
+
+	classificationConfirmed = "confirmed"
+	classificationStrong    = "strong"
+	classificationWeak      = "weak"
+
+	defaultDiscoveryPageSize = 1000
+	maxDiscoveryPageSize     = 5000
+)
+
+// DiscoveryStore is the source-resolution, metadata-scan, and bounded-write
+// surface used by identity discovery.
+type DiscoveryStore interface {
+	Store
+	CountIdentityDiscoveryMessagesContext(ctx context.Context, sourceID int64) (int64, error)
+	ScanIdentityDiscoveryPageContext(ctx context.Context, sourceID, afterID int64, limit int) (store.IdentityDiscoveryPage, error)
+	ScanIdentityObservationsForSourceMessageIDsContext(ctx context.Context, sourceID int64, sourceMessageIDs []string) ([]store.IdentityObservation, error)
+	AddAccountIdentitiesBatchContext(ctx context.Context, sourceID int64, candidates []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error)
+	MergeConfirmedAccountIdentitySignalsContext(ctx context.Context, sourceID int64, candidates []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error)
+}
+
+// ExternalEvidenceStore is the bounded identity-write service used by
+// provider refreshes that do not need to rescan archived messages.
+type ExternalEvidenceStore interface {
+	ListAccountIdentities(sourceID int64) ([]store.AccountIdentity, error)
+	AddAccountIdentitiesBatchContext(ctx context.Context, sourceID int64, candidates []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error)
+}
+
+type Candidate struct {
+	Identifier           string    `json:"identifier"`
+	NormalizedIdentifier string    `json:"normalized_identifier"`
+	Classification       string    `json:"classification" enum:"confirmed,strong,weak"`
+	AlreadyConfirmed     bool      `json:"already_confirmed"`
+	Signals              []string  `json:"signals"`
+	ProviderStates       []string  `json:"provider_states" nullable:"false"`
+	SentMessageCount     int64     `json:"sent_message_count"`
+	ReceivedMessageCount int64     `json:"received_message_count"`
+	FirstSeenAt          time.Time `json:"first_seen_at"`
+	LastSeenAt           time.Time `json:"last_seen_at"`
+
+	strongSignals []string
+}
+
+type RejectedCandidate struct {
+	Identifier string `json:"identifier"`
+	Reason     string `json:"reason"`
+}
+
+type DiscoverRequest struct {
+	SourceSelector
+
+	Apply    bool     `json:"apply,omitempty"`
+	Provider bool     `json:"provider,omitempty"`
+	Confirm  []string `json:"confirm,omitempty"`
+	PageSize int      `json:"page_size,omitempty"`
+}
+
+// ExternalEvidence is provider- or import-supplied identity evidence. State is
+// reporting metadata only; Strong controls whether the signal may be applied.
+type ExternalEvidence struct {
+	Identifier     string
+	Signal         string
+	State          string
+	Strong         bool
+	RejectedReason string
+}
+
+type DiscoverProgress struct {
+	Done       int64 `json:"done"`
+	Total      int64 `json:"total"`
+	Candidates int   `json:"candidates"`
+}
+
+type DiscoverResult struct {
+	Account         string                              `json:"account"`
+	SourceID        int64                               `json:"source_id"`
+	SourceType      string                              `json:"source_type"`
+	ScannedMessages int64                               `json:"scanned_messages"`
+	Candidates      []Candidate                         `json:"candidates"`
+	Rejected        []RejectedCandidate                 `json:"rejected"`
+	Applied         []store.IdentityConfirmationOutcome `json:"applied"`
+}
+
+// DiscoverError is the stable, sanitized terminal failure carried by a
+// discovery stream after progress has already committed the NDJSON response.
+// Provider and storage details remain on the daemon side of the boundary.
+type DiscoverError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *DiscoverError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return e.Code
+}
+
+type DiscoverEvent struct {
+	Type     string            `json:"type" enum:"progress,result,error"`
+	Progress *DiscoverProgress `json:"progress,omitempty"`
+	Result   *DiscoverResult   `json:"result,omitempty"`
+	Error    *DiscoverError    `json:"error,omitempty"`
+}
+
+type candidateAccumulator struct {
+	identifier       string
+	normalized       string
+	signals          map[string]struct{}
+	strongSignals    map[string]struct{}
+	existingSignals  map[string]struct{}
+	alreadyConfirmed bool
+	sentMessages     map[int64]struct{}
+	receivedMessages map[int64]struct{}
+	firstSeenAt      time.Time
+	lastSeenAt       time.Time
+}
+
+type classifiedDiscovery struct {
+	candidates    []Candidate
+	rejected      []RejectedCandidate
+	confirmations []store.IdentityConfirmation
+}
+
+// Discover scans one source completely before optionally applying strong or
+// explicitly confirmed evidence. No write occurs during the scan.
+func Discover(
+	ctx context.Context,
+	st DiscoveryStore,
+	req DiscoverRequest,
+	progress func(DiscoverProgress) error,
+) (DiscoverResult, error) {
+	return DiscoverWithExternalEvidence(ctx, st, req, nil, progress)
+}
+
+// DiscoverWithExternalEvidence merges normalized external evidence before
+// deriving the optional write plan, so preview and apply expose one result.
+func DiscoverWithExternalEvidence(
+	ctx context.Context,
+	st DiscoveryStore,
+	req DiscoverRequest,
+	evidence []ExternalEvidence,
+	progress func(DiscoverProgress) error,
+) (DiscoverResult, error) {
+	if err := ctx.Err(); err != nil {
+		return DiscoverResult{}, err
+	}
+	if len(req.Confirm) > 0 && !req.Apply {
+		return DiscoverResult{}, opserr.Invalid(errors.New("explicit confirmation requires apply"))
+	}
+	pageSize, err := discoveryPageSize(req.PageSize)
+	if err != nil {
+		return DiscoverResult{}, err
+	}
+	src, err := ResolveSource(st, req.SourceSelector)
+	if err != nil {
+		return DiscoverResult{}, err
+	}
+	total, err := st.CountIdentityDiscoveryMessagesContext(ctx, src.ID)
+	if err != nil {
+		return DiscoverResult{}, opserr.Internal(fmt.Errorf("count identity discovery messages: %w", err))
+	}
+	existing, err := listAccountIdentities(st, src.ID)
+	if err != nil {
+		return DiscoverResult{}, err
+	}
+
+	accumulators := make(map[string]*candidateAccumulator)
+	rejected := make(map[RejectedCandidate]struct{})
+	done, err := scanIdentityObservationPages(
+		ctx, st, src.ID, pageSize, accumulators, rejected,
+		func(done int64, candidates int) error {
+			if progress == nil {
+				return nil
+			}
+			return progress(DiscoverProgress{Done: done, Total: total, Candidates: candidates})
+		},
+	)
+	if err != nil {
+		return DiscoverResult{}, err
+	}
+
+	classified := classifyDiscovery(accumulators, rejected, existing)
+	result := DiscoverResult{
+		Account:         src.Identifier,
+		SourceID:        src.ID,
+		SourceType:      src.SourceType,
+		ScannedMessages: done,
+		Candidates:      classified.candidates,
+		Rejected:        classified.rejected,
+		Applied:         []store.IdentityConfirmationOutcome{},
+	}
+	seedExistingExternalCandidates(&result, evidence, existing)
+	MergeExternalEvidence(&result, evidence)
+	if !req.Apply {
+		return result, nil
+	}
+	classified.candidates = result.Candidates
+	classified.confirmations = strongConfirmations(result.Candidates, existing)
+	if err := addExplicitWeakConfirmations(&classified, req.Confirm); err != nil {
+		return DiscoverResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return DiscoverResult{}, err
+	}
+	if len(classified.confirmations) == 0 {
+		return result, nil
+	}
+	result.Applied, err = st.AddAccountIdentitiesBatchContext(ctx, src.ID, classified.confirmations)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func seedExistingExternalCandidates(
+	result *DiscoverResult,
+	evidence []ExternalEvidence,
+	existing []store.AccountIdentity,
+) {
+	if len(evidence) == 0 || len(existing) == 0 {
+		return
+	}
+	candidateNormalized := make(map[string]struct{}, len(result.Candidates))
+	for _, candidate := range result.Candidates {
+		candidateNormalized[candidate.NormalizedIdentifier] = struct{}{}
+	}
+	existingByNormalized := make(map[string]store.AccountIdentity, len(existing))
+	for _, identity := range existing {
+		normalized := store.NormalizeIdentifierForCompare(strings.TrimSpace(identity.Address))
+		existingByNormalized[normalized] = identity
+	}
+	seeded := make(map[string]struct{})
+	for _, item := range evidence {
+		if item.RejectedReason != "" {
+			continue
+		}
+		identifier, reason := validateDiscoveredIdentifier(item.Identifier)
+		if reason != "" {
+			continue
+		}
+		normalized := store.NormalizeIdentifierForCompare(identifier)
+		if _, present := candidateNormalized[normalized]; present {
+			continue
+		}
+		if _, present := seeded[normalized]; present {
+			continue
+		}
+		identity, confirmed := existingByNormalized[normalized]
+		if !confirmed {
+			continue
+		}
+		result.Candidates = append(result.Candidates, Candidate{
+			Identifier:           strings.TrimSpace(identity.Address),
+			NormalizedIdentifier: normalized,
+			Classification:       classificationConfirmed,
+			AlreadyConfirmed:     true,
+			Signals:              SplitSignalSet(identity.SourceSignal),
+			ProviderStates:       []string{},
+			strongSignals:        []string{},
+		})
+		seeded[normalized] = struct{}{}
+	}
+}
+
+// MergeExternalEvidence case-folds concrete mailbox addresses, preserves
+// existing confirmation metadata, and deterministically merges signals and
+// rejections. It never removes or unconfirms an identity based on State.
+func MergeExternalEvidence(result *DiscoverResult, evidence []ExternalEvidence) {
+	if result == nil || len(evidence) == 0 {
+		return
+	}
+
+	candidates := make(map[string]*Candidate, len(result.Candidates)+len(evidence))
+	for i := range result.Candidates {
+		candidate := result.Candidates[i]
+		normalized := candidate.NormalizedIdentifier
+		if normalized == "" {
+			normalized = store.NormalizeIdentifierForCompare(strings.TrimSpace(candidate.Identifier))
+			candidate.NormalizedIdentifier = normalized
+		}
+		candidate.Signals = sortedUnique(candidate.Signals)
+		candidate.ProviderStates = sortedUnique(candidate.ProviderStates)
+		candidate.strongSignals = sortedUnique(candidate.strongSignals)
+		copyCandidate := candidate
+		candidates[normalized] = &copyCandidate
+	}
+	rejected := make(map[RejectedCandidate]struct{}, len(result.Rejected)+len(evidence))
+	for _, candidate := range result.Rejected {
+		rejected[candidate] = struct{}{}
+	}
+
+	ordered := append([]ExternalEvidence(nil), evidence...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		leftIdentifier := strings.TrimSpace(ordered[i].Identifier)
+		rightIdentifier := strings.TrimSpace(ordered[j].Identifier)
+		leftNormalized := store.NormalizeIdentifierForCompare(leftIdentifier)
+		rightNormalized := store.NormalizeIdentifierForCompare(rightIdentifier)
+		if leftNormalized != rightNormalized {
+			return leftNormalized < rightNormalized
+		}
+		if leftIdentifier != rightIdentifier {
+			return leftIdentifier < rightIdentifier
+		}
+		if ordered[i].Signal != ordered[j].Signal {
+			return ordered[i].Signal < ordered[j].Signal
+		}
+		if ordered[i].State != ordered[j].State {
+			return ordered[i].State < ordered[j].State
+		}
+		if ordered[i].Strong != ordered[j].Strong {
+			return ordered[i].Strong
+		}
+		return ordered[i].RejectedReason < ordered[j].RejectedReason
+	})
+
+	for _, item := range ordered {
+		identifier := strings.TrimSpace(item.Identifier)
+		if item.RejectedReason != "" {
+			rejected[RejectedCandidate{Identifier: identifier, Reason: item.RejectedReason}] = struct{}{}
+			continue
+		}
+		validated, reason := validateDiscoveredIdentifier(identifier)
+		if reason != "" {
+			rejected[RejectedCandidate{Identifier: identifier, Reason: reason}] = struct{}{}
+			continue
+		}
+		normalized := store.NormalizeIdentifierForCompare(validated)
+		candidate, ok := candidates[normalized]
+		if !ok {
+			candidate = &Candidate{
+				Identifier:           validated,
+				NormalizedIdentifier: normalized,
+				Classification:       classificationWeak,
+				Signals:              []string{},
+				ProviderStates:       []string{},
+				strongSignals:        []string{},
+			}
+			candidates[normalized] = candidate
+		}
+		if signal := strings.TrimSpace(item.Signal); signal != "" {
+			candidate.Signals = appendUnique(candidate.Signals, signal)
+			if item.Strong {
+				candidate.strongSignals = appendUnique(candidate.strongSignals, signal)
+			}
+		}
+		if state := strings.TrimSpace(item.State); state != "" {
+			candidate.ProviderStates = appendUnique(candidate.ProviderStates, state)
+		}
+		switch {
+		case candidate.AlreadyConfirmed || candidate.Classification == classificationConfirmed:
+			candidate.AlreadyConfirmed = true
+			candidate.Classification = classificationConfirmed
+		case item.Strong || candidate.Classification == classificationStrong:
+			candidate.Classification = classificationStrong
+		default:
+			candidate.Classification = classificationWeak
+		}
+	}
+
+	result.Candidates = make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate.Signals = sortedUnique(candidate.Signals)
+		candidate.ProviderStates = sortedUnique(candidate.ProviderStates)
+		candidate.strongSignals = sortedUnique(candidate.strongSignals)
+		result.Candidates = append(result.Candidates, *candidate)
+	}
+	sort.Slice(result.Candidates, func(i, j int) bool {
+		left, right := result.Candidates[i], result.Candidates[j]
+		if left.NormalizedIdentifier == right.NormalizedIdentifier {
+			return left.Identifier < right.Identifier
+		}
+		return left.NormalizedIdentifier < right.NormalizedIdentifier
+	})
+	result.Rejected = make([]RejectedCandidate, 0, len(rejected))
+	for candidate := range rejected {
+		result.Rejected = append(result.Rejected, candidate)
+	}
+	sort.Slice(result.Rejected, func(i, j int) bool {
+		if result.Rejected[i].Identifier == result.Rejected[j].Identifier {
+			return result.Rejected[i].Reason < result.Rejected[j].Reason
+		}
+		return result.Rejected[i].Identifier < result.Rejected[j].Identifier
+	})
+}
+
+// ApplyExternalEvidence confirms only strong normalized evidence through the
+// store's bounded batch service. Weak and rejected rows never write.
+func ApplyExternalEvidence(
+	ctx context.Context,
+	st ExternalEvidenceStore,
+	sourceID int64,
+	evidence []ExternalEvidence,
+) ([]store.IdentityConfirmationOutcome, error) {
+	if sourceID <= 0 {
+		return nil, opserr.Invalid(errors.New("source ID must be positive"))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	existing, err := listAccountIdentities(st, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	result := DiscoverResult{SourceID: sourceID}
+	MergeExternalEvidence(&result, evidence)
+	confirmations := strongConfirmations(result.Candidates, existing)
+	if len(confirmations) == 0 {
+		return []store.IdentityConfirmationOutcome{}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	outcomes, err := st.AddAccountIdentitiesBatchContext(ctx, sourceID, confirmations)
+	if err != nil {
+		return outcomes, err
+	}
+	return outcomes, nil
+}
+
+// DiscoverStrongForSourceMessageIDs refreshes one bounded ingestion batch's
+// authoritative From evidence into the source's already-confirmed identities.
+// It never confirms a first-time identity: placement in Sent is evidence about
+// a message, and claiming an address from it during sync would let one
+// mis-filed message silently take ownership. New identities are confirmed only
+// through the reviewed discovery path.
+func DiscoverStrongForSourceMessageIDs(
+	ctx context.Context,
+	st DiscoveryStore,
+	sourceID int64,
+	sourceMessageIDs []string,
+) ([]store.IdentityConfirmationOutcome, error) {
+	if sourceID <= 0 {
+		return nil, opserr.Invalid(errors.New("source ID must be positive"))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(sourceMessageIDs) == 0 {
+		return []store.IdentityConfirmationOutcome{}, nil
+	}
+	existing, err := listAccountIdentities(st, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) == 0 {
+		return []store.IdentityConfirmationOutcome{}, nil
+	}
+	observations, err := st.ScanIdentityObservationsForSourceMessageIDsContext(
+		ctx, sourceID, sourceMessageIDs,
+	)
+	if err != nil {
+		return nil, opserr.Internal(fmt.Errorf("scan identity observations for source message IDs: %w", err))
+	}
+	accumulators := make(map[string]*candidateAccumulator)
+	rejected := make(map[RejectedCandidate]struct{})
+	mergeIdentityObservations(accumulators, rejected, observations)
+	return mergeConfirmedIdentitySignals(ctx, st, sourceID, existing, accumulators, rejected)
+}
+
+// RefreshConfirmedForSource re-derives strong signals for a source's
+// already-confirmed identities from the full archived evidence. It never
+// confirms new identities.
+func RefreshConfirmedForSource(ctx context.Context, st DiscoveryStore, sourceID int64) error {
+	if sourceID <= 0 {
+		return opserr.Invalid(errors.New("source ID must be positive"))
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	existing, err := listAccountIdentities(st, sourceID)
+	if err != nil {
+		return err
+	}
+	if len(existing) == 0 {
+		return nil
+	}
+
+	accumulators := make(map[string]*candidateAccumulator)
+	rejected := make(map[RejectedCandidate]struct{})
+	if _, err := scanIdentityObservationPages(
+		ctx, st, sourceID, defaultDiscoveryPageSize, accumulators, rejected, nil,
+	); err != nil {
+		return err
+	}
+
+	_, err = mergeConfirmedIdentitySignals(ctx, st, sourceID, existing, accumulators, rejected)
+	return err
+}
+
+// scanIdentityObservationPages walks one source's messages in keyset pages,
+// merging each page's envelope observations into accumulators. onPage, when
+// set, reports cumulative progress and may abort the scan. It returns the
+// number of messages scanned.
+func scanIdentityObservationPages(
+	ctx context.Context,
+	st DiscoveryStore,
+	sourceID int64,
+	pageSize int,
+	accumulators map[string]*candidateAccumulator,
+	rejected map[RejectedCandidate]struct{},
+	onPage func(done int64, candidates int) error,
+) (int64, error) {
+	var done, afterID int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return done, err
+		}
+		page, scanErr := st.ScanIdentityDiscoveryPageContext(ctx, sourceID, afterID, pageSize)
+		if scanErr != nil {
+			return done, opserr.Internal(fmt.Errorf("scan identity discovery page: %w", scanErr))
+		}
+		if page.Scanned == 0 {
+			return done, nil
+		}
+		if page.NextAfterID <= afterID {
+			return done, opserr.Internal(errors.New("identity discovery page did not advance"))
+		}
+		mergeIdentityObservations(accumulators, rejected, page.Observations)
+		done += page.Scanned
+		afterID = page.NextAfterID
+		if onPage != nil {
+			if err := onPage(done, len(accumulators)); err != nil {
+				return done, err
+			}
+		}
+	}
+}
+
+// mergeConfirmedIdentitySignals writes only the new strong signals belonging to
+// identities the source has already confirmed. Unconfirmed candidates are
+// classified for their signal contribution but never reach the write path.
+// Filtering here is an optimization; the merge-only store call is the boundary
+// that makes confirming a new identity impossible, including when the confirmed
+// set went stale during a long scan.
+func mergeConfirmedIdentitySignals(
+	ctx context.Context,
+	st DiscoveryStore,
+	sourceID int64,
+	existing []store.AccountIdentity,
+	accumulators map[string]*candidateAccumulator,
+	rejected map[RejectedCandidate]struct{},
+) ([]store.IdentityConfirmationOutcome, error) {
+	classified := classifyDiscovery(accumulators, rejected, existing)
+	confirmed := make(map[string]struct{}, len(classified.candidates))
+	for _, candidate := range classified.candidates {
+		if candidate.AlreadyConfirmed {
+			confirmed[candidate.NormalizedIdentifier] = struct{}{}
+		}
+	}
+	confirmations := make([]store.IdentityConfirmation, 0, len(confirmed))
+	for _, confirmation := range classified.confirmations {
+		if _, ok := confirmed[store.NormalizeIdentifierForCompare(confirmation.Identifier)]; ok {
+			confirmations = append(confirmations, confirmation)
+		}
+	}
+	if len(confirmations) == 0 {
+		return []store.IdentityConfirmationOutcome{}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	outcomes, err := st.MergeConfirmedAccountIdentitySignalsContext(ctx, sourceID, confirmations)
+	if err != nil {
+		return outcomes, err
+	}
+	return outcomes, nil
+}
+
+// accountIdentityLister is the confirmed-identity read shared by the discovery
+// and external-evidence entry points.
+type accountIdentityLister interface {
+	ListAccountIdentities(sourceID int64) ([]store.AccountIdentity, error)
+}
+
+func listAccountIdentities(st accountIdentityLister, sourceID int64) ([]store.AccountIdentity, error) {
+	existing, err := st.ListAccountIdentities(sourceID)
+	if err != nil {
+		return nil, opserr.Internal(fmt.Errorf("list account identities: %w", err))
+	}
+	return existing, nil
+}
+
+func discoveryPageSize(requested int) (int, error) {
+	if requested < 0 {
+		return 0, opserr.Invalid(errors.New("identity discovery page size must not be negative"))
+	}
+	if requested == 0 {
+		return defaultDiscoveryPageSize, nil
+	}
+	return min(requested, maxDiscoveryPageSize), nil
+}
+
+func mergeIdentityObservations(
+	accumulators map[string]*candidateAccumulator,
+	rejected map[RejectedCandidate]struct{},
+	observations []store.IdentityObservation,
+) {
+	fromCounts := make(map[int64]int)
+	for _, observation := range observations {
+		if observation.RecipientType == "from" {
+			fromCounts[observation.MessageID]++
+		}
+	}
+	for _, observation := range observations {
+		identifier, reason := validateDiscoveredIdentifier(observation.Identifier)
+		if reason != "" {
+			rejected[RejectedCandidate{Identifier: strings.TrimSpace(observation.Identifier), Reason: reason}] = struct{}{}
+			continue
+		}
+		normalized := store.NormalizeIdentifierForCompare(identifier)
+		candidate, ok := accumulators[normalized]
+		if !ok {
+			candidate = &candidateAccumulator{
+				identifier:       identifier,
+				normalized:       normalized,
+				signals:          make(map[string]struct{}),
+				strongSignals:    make(map[string]struct{}),
+				existingSignals:  make(map[string]struct{}),
+				sentMessages:     make(map[int64]struct{}),
+				receivedMessages: make(map[int64]struct{}),
+			}
+			accumulators[normalized] = candidate
+		}
+		candidate.observe(observation, fromCounts[observation.MessageID])
+	}
+}
+
+func validateDiscoveredIdentifier(input string) (string, string) {
+	if strings.IndexFunc(input, unicode.IsControl) >= 0 {
+		return "", "identifier contains control characters"
+	}
+	identifier := strings.TrimSpace(input)
+	if identifier == "" {
+		return "", "identifier is empty"
+	}
+	if strings.Contains(identifier, "*") {
+		return "", "identifier is not a concrete mailbox address"
+	}
+	parsed, err := mail.ParseAddress(identifier)
+	if err != nil || !strings.EqualFold(parsed.Address, identifier) {
+		return "", "identifier is not a concrete mailbox address"
+	}
+	at := strings.LastIndex(identifier, "@")
+	if at <= 0 || at == len(identifier)-1 || !strings.Contains(identifier[at+1:], ".") {
+		return "", "identifier is not a concrete mailbox address"
+	}
+	return identifier, ""
+}
+
+func (candidate *candidateAccumulator) observe(observation store.IdentityObservation, fromCount int) {
+	if !observation.ObservedAt.IsZero() {
+		observedAt := observation.ObservedAt.UTC()
+		if candidate.firstSeenAt.IsZero() || observedAt.Before(candidate.firstSeenAt) {
+			candidate.firstSeenAt = observedAt
+		}
+		if candidate.lastSeenAt.IsZero() || observedAt.After(candidate.lastSeenAt) {
+			candidate.lastSeenAt = observedAt
+		}
+	}
+	if observation.RecipientType != "from" {
+		candidate.receivedMessages[observation.MessageID] = struct{}{}
+		return
+	}
+	candidate.sentMessages[observation.MessageID] = struct{}{}
+	// Sent placement and is_from_me describe the message, not an individual
+	// author. With multiple From addresses, none is attributable without
+	// separate address-specific evidence such as a provider alias inventory.
+	if fromCount != 1 {
+		return
+	}
+	if observation.IsFromMe {
+		candidate.addStrongSignal(SignalIsFromMe)
+	}
+	if observation.HasSentFolder {
+		candidate.addStrongSignal(SignalSentFolder)
+	}
+	if observation.HasSentLabel {
+		candidate.addStrongSignal(SignalSentLabel)
+	}
+}
+
+func (candidate *candidateAccumulator) addStrongSignal(signal string) {
+	candidate.signals[signal] = struct{}{}
+	candidate.strongSignals[signal] = struct{}{}
+}
+
+func classifyDiscovery(
+	accumulators map[string]*candidateAccumulator,
+	rejectedSet map[RejectedCandidate]struct{},
+	existing []store.AccountIdentity,
+) classifiedDiscovery {
+	for _, identity := range existing {
+		normalized := store.NormalizeIdentifierForCompare(strings.TrimSpace(identity.Address))
+		candidate, ok := accumulators[normalized]
+		if !ok {
+			continue
+		}
+		candidate.alreadyConfirmed = true
+		for _, signal := range SplitSignalSet(identity.SourceSignal) {
+			candidate.signals[signal] = struct{}{}
+			candidate.existingSignals[signal] = struct{}{}
+		}
+	}
+
+	classified := classifiedDiscovery{
+		candidates:    make([]Candidate, 0, len(accumulators)),
+		rejected:      make([]RejectedCandidate, 0, len(rejectedSet)),
+		confirmations: make([]store.IdentityConfirmation, 0, len(accumulators)),
+	}
+	for _, candidate := range accumulators {
+		signals := setKeys(candidate.signals)
+		classification := classificationWeak
+		switch {
+		case candidate.alreadyConfirmed:
+			classification = classificationConfirmed
+		case len(candidate.strongSignals) > 0:
+			classification = classificationStrong
+		}
+		classified.candidates = append(classified.candidates, Candidate{
+			Identifier:           candidate.identifier,
+			NormalizedIdentifier: candidate.normalized,
+			Classification:       classification,
+			AlreadyConfirmed:     candidate.alreadyConfirmed,
+			Signals:              signals,
+			ProviderStates:       []string{},
+			SentMessageCount:     int64(len(candidate.sentMessages)),
+			ReceivedMessageCount: int64(len(candidate.receivedMessages)),
+			FirstSeenAt:          candidate.firstSeenAt,
+			LastSeenAt:           candidate.lastSeenAt,
+			strongSignals:        setKeys(candidate.strongSignals),
+		})
+
+		newStrongSignals := make([]string, 0, len(candidate.strongSignals))
+		for signal := range candidate.strongSignals {
+			if _, exists := candidate.existingSignals[signal]; !exists {
+				newStrongSignals = append(newStrongSignals, signal)
+			}
+		}
+		slices.Sort(newStrongSignals)
+		if len(newStrongSignals) > 0 {
+			classified.confirmations = append(classified.confirmations, store.IdentityConfirmation{
+				Identifier: candidate.identifier,
+				Signals:    newStrongSignals,
+			})
+		}
+	}
+	for rejected := range rejectedSet {
+		classified.rejected = append(classified.rejected, rejected)
+	}
+	sort.Slice(classified.candidates, func(i, j int) bool {
+		left, right := classified.candidates[i], classified.candidates[j]
+		if left.NormalizedIdentifier == right.NormalizedIdentifier {
+			return left.Identifier < right.Identifier
+		}
+		return left.NormalizedIdentifier < right.NormalizedIdentifier
+	})
+	sort.Slice(classified.rejected, func(i, j int) bool {
+		if classified.rejected[i].Identifier == classified.rejected[j].Identifier {
+			return classified.rejected[i].Reason < classified.rejected[j].Reason
+		}
+		return classified.rejected[i].Identifier < classified.rejected[j].Identifier
+	})
+	sort.Slice(classified.confirmations, func(i, j int) bool {
+		left := store.NormalizeIdentifierForCompare(classified.confirmations[i].Identifier)
+		right := store.NormalizeIdentifierForCompare(classified.confirmations[j].Identifier)
+		if left == right {
+			return classified.confirmations[i].Identifier < classified.confirmations[j].Identifier
+		}
+		return left < right
+	})
+	return classified
+}
+
+func strongConfirmations(
+	candidates []Candidate,
+	existing []store.AccountIdentity,
+) []store.IdentityConfirmation {
+	existingSignals := make(map[string]map[string]struct{}, len(existing))
+	for _, identity := range existing {
+		normalized := store.NormalizeIdentifierForCompare(strings.TrimSpace(identity.Address))
+		set := existingSignals[normalized]
+		if set == nil {
+			set = make(map[string]struct{})
+			existingSignals[normalized] = set
+		}
+		for _, signal := range SplitSignalSet(identity.SourceSignal) {
+			set[signal] = struct{}{}
+		}
+	}
+
+	confirmations := make([]store.IdentityConfirmation, 0, len(candidates))
+	for _, candidate := range candidates {
+		known := existingSignals[candidate.NormalizedIdentifier]
+		newSignals := make([]string, 0, len(candidate.strongSignals))
+		for _, signal := range candidate.strongSignals {
+			if _, exists := known[signal]; !exists {
+				newSignals = append(newSignals, signal)
+			}
+		}
+		if len(newSignals) == 0 {
+			continue
+		}
+		confirmations = append(confirmations, store.IdentityConfirmation{
+			Identifier: candidate.Identifier,
+			Signals:    sortedUnique(newSignals),
+		})
+	}
+	return confirmations
+}
+
+func addExplicitWeakConfirmations(classified *classifiedDiscovery, requested []string) error {
+	weakByNormalized := make(map[string]Candidate)
+	for _, candidate := range classified.candidates {
+		if candidate.Classification == classificationWeak {
+			weakByNormalized[candidate.NormalizedIdentifier] = candidate
+		}
+	}
+	manual := make(map[string]store.IdentityConfirmation)
+	for _, input := range requested {
+		identifier := strings.TrimSpace(input)
+		normalized := store.NormalizeIdentifierForCompare(identifier)
+		candidate, ok := weakByNormalized[normalized]
+		if !ok {
+			return opserr.Invalid(fmt.Errorf("explicit confirmation %q does not match a weak candidate from the completed scan", identifier))
+		}
+		manual[normalized] = store.IdentityConfirmation{
+			Identifier: candidate.Identifier,
+			Signals:    []string{"manual"},
+		}
+	}
+	for _, confirmation := range manual {
+		classified.confirmations = append(classified.confirmations, confirmation)
+	}
+	sort.Slice(classified.confirmations, func(i, j int) bool {
+		left := store.NormalizeIdentifierForCompare(classified.confirmations[i].Identifier)
+		right := store.NormalizeIdentifierForCompare(classified.confirmations[j].Identifier)
+		if left == right {
+			return classified.confirmations[i].Identifier < classified.confirmations[j].Identifier
+		}
+		return left < right
+	})
+	return nil
+}
+
+func setKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func appendUnique(values []string, value string) []string {
+	if slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
+}
+
+func sortedUnique(values []string) []string {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	return setKeys(set)
+}

--- a/internal/identityops/discovery_test.go
+++ b/internal/identityops/discovery_test.go
@@ -1,0 +1,911 @@
+package identityops_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type discoveryFakeStore struct {
+	identityops.Store
+
+	source            *store.Source
+	identities        []store.AccountIdentity
+	pages             []store.IdentityDiscoveryPage
+	pageCalls         int
+	batchCalls        [][]store.IdentityConfirmation
+	batchSourceIDs    []int64
+	idObservations    []store.IdentityObservation
+	scannedSourceID   int64
+	scannedMessageIDs []string
+	batchFunc         func(context.Context, []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error)
+}
+
+func newDiscoveryFakeStore() *discoveryFakeStore {
+	return &discoveryFakeStore{source: &store.Source{
+		ID: 14, SourceType: "imap", Identifier: "primary@example.test",
+	}}
+}
+
+func (s *discoveryFakeStore) GetSourceByID(id int64) (*store.Source, error) {
+	return s.source, nil
+}
+
+func (s *discoveryFakeStore) ListAccountIdentities(sourceID int64) ([]store.AccountIdentity, error) {
+	return s.identities, nil
+}
+
+func (s *discoveryFakeStore) CountIdentityDiscoveryMessagesContext(context.Context, int64) (int64, error) {
+	var total int64
+	for _, page := range s.pages {
+		total += page.Scanned
+	}
+	return total, nil
+}
+
+func (s *discoveryFakeStore) ScanIdentityDiscoveryPageContext(
+	context.Context,
+	int64,
+	int64,
+	int,
+) (store.IdentityDiscoveryPage, error) {
+	if s.pageCalls >= len(s.pages) {
+		return store.IdentityDiscoveryPage{}, nil
+	}
+	page := s.pages[s.pageCalls]
+	s.pageCalls++
+	return page, nil
+}
+
+func (s *discoveryFakeStore) ScanIdentityObservationsForSourceMessageIDsContext(
+	_ context.Context,
+	sourceID int64,
+	sourceMessageIDs []string,
+) ([]store.IdentityObservation, error) {
+	s.scannedSourceID = sourceID
+	s.scannedMessageIDs = append([]string(nil), sourceMessageIDs...)
+	return s.idObservations, nil
+}
+
+func (s *discoveryFakeStore) AddAccountIdentitiesBatchContext(
+	ctx context.Context,
+	sourceID int64,
+	confirmations []store.IdentityConfirmation,
+) ([]store.IdentityConfirmationOutcome, error) {
+	s.batchSourceIDs = append(s.batchSourceIDs, sourceID)
+	s.batchCalls = append(s.batchCalls, confirmations)
+	if s.batchFunc != nil {
+		return s.batchFunc(ctx, confirmations)
+	}
+	outcomes := make([]store.IdentityConfirmationOutcome, len(confirmations))
+	for i, confirmation := range confirmations {
+		outcomes[i] = store.IdentityConfirmationOutcome{
+			Identifier: confirmation.Identifier,
+			Added:      true,
+			Signals:    confirmation.Signals,
+		}
+	}
+	return outcomes, nil
+}
+
+// MergeConfirmedAccountIdentitySignalsContext mirrors the store's merge-only
+// boundary: a candidate without a confirmed row is dropped rather than created.
+// Writes are recorded alongside the insert-capable batch so tests can assert on
+// either path.
+func (s *discoveryFakeStore) MergeConfirmedAccountIdentitySignalsContext(
+	_ context.Context,
+	sourceID int64,
+	confirmations []store.IdentityConfirmation,
+) ([]store.IdentityConfirmationOutcome, error) {
+	confirmed := make(map[string]struct{}, len(s.identities))
+	for _, identity := range s.identities {
+		confirmed[store.NormalizeIdentifierForCompare(strings.TrimSpace(identity.Address))] = struct{}{}
+	}
+	outcomes := make([]store.IdentityConfirmationOutcome, 0, len(confirmations))
+	merged := make([]store.IdentityConfirmation, 0, len(confirmations))
+	for _, confirmation := range confirmations {
+		if _, ok := confirmed[store.NormalizeIdentifierForCompare(confirmation.Identifier)]; !ok {
+			continue
+		}
+		merged = append(merged, confirmation)
+		outcomes = append(outcomes, store.IdentityConfirmationOutcome{
+			Identifier: confirmation.Identifier,
+			Added:      false,
+			Signals:    confirmation.Signals,
+		})
+	}
+	if len(merged) == 0 {
+		return []store.IdentityConfirmationOutcome{}, nil
+	}
+	s.batchSourceIDs = append(s.batchSourceIDs, sourceID)
+	s.batchCalls = append(s.batchCalls, merged)
+	return outcomes, nil
+}
+
+func classificationsByStableOrder(candidates []identityops.Candidate) []string {
+	classifications := make([]string, len(candidates))
+	for i, candidate := range candidates {
+		classifications[i] = candidate.Classification
+	}
+	return classifications
+}
+
+func TestMergeProviderExternalEvidenceKeepsHistoricalAndReviewsPending(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	result := identityops.DiscoverResult{
+		SourceID: 14,
+		Candidates: []identityops.Candidate{{
+			Identifier:           "Known@Example.test",
+			NormalizedIdentifier: "known@example.test",
+			Classification:       "confirmed",
+			AlreadyConfirmed:     true,
+			Signals:              []string{"manual"},
+		}},
+	}
+
+	identityops.MergeExternalEvidence(&result, []identityops.ExternalEvidence{
+		{Identifier: "active@example.test", Signal: identityops.SignalProviderAlias, State: "enabled", Strong: true},
+		{Identifier: "old@example.test", Signal: identityops.SignalProviderAlias, State: "disabled", Strong: true},
+		{Identifier: "KNOWN@example.test", Signal: identityops.SignalProviderAlias, State: "deleted", Strong: true},
+		{Identifier: "waiting@example.test", Signal: identityops.SignalProviderAlias, State: "pending"},
+		{Identifier: "*@example.test", Signal: identityops.SignalProviderAlias, State: "enabled", RejectedReason: "wildcard identity"},
+		{Identifier: "not an address", Signal: identityops.SignalProviderAlias, State: "enabled", Strong: true},
+	})
+
+	requirements.Len(result.Candidates, 4)
+	assertions.Equal([]string{"strong", "confirmed", "strong", "weak"}, classificationsByStableOrder(result.Candidates))
+	assertions.Equal("Known@Example.test", result.Candidates[1].Identifier, "confirmed spelling must win case folding")
+	assertions.Equal([]string{"manual", "provider-alias"}, result.Candidates[1].Signals)
+	assertions.True(result.Candidates[1].AlreadyConfirmed)
+	assertions.Equal([]identityops.RejectedCandidate{
+		{Identifier: "*@example.test", Reason: "wildcard identity"},
+		{Identifier: "not an address", Reason: "identifier is not a concrete mailbox address"},
+	}, result.Rejected)
+}
+
+func TestMergeProviderExternalEvidenceIsDeterministicAcrossInputOrder(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	evidence := []identityops.ExternalEvidence{
+		{Identifier: "ALIAS@example.test", Signal: identityops.SignalProviderAlias, State: "pending"},
+		{Identifier: "alias@example.test", Signal: identityops.SignalProviderAlias, State: "enabled", Strong: true},
+		{Identifier: "Alias@example.test", Signal: "provider-send-as", State: "disabled", Strong: true},
+		{Identifier: "other@example.test", Signal: "manual", Strong: true},
+	}
+	reversed := append([]identityops.ExternalEvidence(nil), evidence...)
+	slices.Reverse(reversed)
+	left := identityops.DiscoverResult{SourceID: 14}
+	right := identityops.DiscoverResult{SourceID: 14}
+
+	identityops.MergeExternalEvidence(&left, evidence)
+	identityops.MergeExternalEvidence(&right, reversed)
+
+	assertions.Equal(left, right)
+	requirements.Len(left.Candidates, 2)
+	assertions.Equal("ALIAS@example.test", left.Candidates[0].Identifier)
+	assertions.Equal("strong", left.Candidates[0].Classification)
+	assertions.Equal([]string{"provider-alias", "provider-send-as"}, left.Candidates[0].Signals)
+
+	encoded, err := json.Marshal(left)
+	requirements.NoError(err)
+	var reported struct {
+		Candidates []struct {
+			Identifier     string   `json:"identifier"`
+			ProviderStates []string `json:"provider_states"`
+		} `json:"candidates"`
+	}
+	requirements.NoError(json.Unmarshal(encoded, &reported))
+	assertions.Equal([]string{"disabled", "enabled", "pending"}, reported.Candidates[0].ProviderStates)
+}
+
+func TestDiscoverWithProviderExternalEvidencePreviewAndApplyUseSameMergedCandidates(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	evidence := []identityops.ExternalEvidence{
+		{Identifier: "known@example.test", Signal: identityops.SignalProviderAlias, State: "deleted", Strong: true},
+		{Identifier: "old@example.test", Signal: identityops.SignalProviderAlias, State: "deleted", Strong: true},
+		{Identifier: "waiting@example.test", Signal: identityops.SignalProviderAlias, State: "pending"},
+		{Identifier: "OBSERVED@example.test", Signal: identityops.SignalProviderAlias, State: "pending"},
+		{Identifier: "observed@example.test", Signal: identityops.SignalProviderAlias, State: "enabled", Strong: true},
+	}
+	previewStore := newDiscoveryFakeStore()
+	previewStore.identities = []store.AccountIdentity{{
+		SourceID: 14, Address: "Known@Example.test", SourceSignal: "manual",
+	}}
+	previewStore.pages = []store.IdentityDiscoveryPage{{
+		Scanned: 1, NextAfterID: 1,
+		Observations: []store.IdentityObservation{{
+			MessageID: 1, Identifier: "observed@example.test", RecipientType: "from", HasSentFolder: true,
+		}},
+	}}
+
+	preview, err := identityops.DiscoverWithExternalEvidence(t.Context(), previewStore, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+	}, evidence, nil)
+	requirements.NoError(err)
+
+	applyStore := newDiscoveryFakeStore()
+	applyStore.pages = previewStore.pages
+	applyStore.identities = previewStore.identities
+	apply, err := identityops.DiscoverWithExternalEvidence(t.Context(), applyStore, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true,
+	}, evidence, nil)
+	requirements.NoError(err)
+
+	assertions.Equal(preview.Candidates, apply.Candidates)
+	requirements.Len(preview.Candidates, 4)
+	assertions.Equal("Known@Example.test", preview.Candidates[0].Identifier)
+	assertions.Equal("confirmed", preview.Candidates[0].Classification)
+	assertions.True(preview.Candidates[0].AlreadyConfirmed)
+	assertions.Equal([]string{"manual", "provider-alias"}, preview.Candidates[0].Signals)
+	encoded, err := json.Marshal(preview)
+	requirements.NoError(err)
+	var reported struct {
+		Candidates []struct {
+			Identifier     string   `json:"identifier"`
+			Signals        []string `json:"signals"`
+			ProviderStates []string `json:"provider_states"`
+		} `json:"candidates"`
+	}
+	requirements.NoError(json.Unmarshal(encoded, &reported))
+	assertions.Equal([]string{"deleted"}, reported.Candidates[0].ProviderStates,
+		"provider-only confirmed identity retains its inventory state")
+	assertions.Equal("observed@example.test", reported.Candidates[1].Identifier,
+		"archive observation spelling wins case-folded provider duplicates")
+	assertions.Equal([]string{"provider-alias", "sent-folder"}, reported.Candidates[1].Signals)
+	assertions.Equal([]string{"enabled", "pending"}, reported.Candidates[1].ProviderStates)
+	requirements.Len(applyStore.batchCalls, 1)
+	assertions.Equal([]store.IdentityConfirmation{
+		{Identifier: "Known@Example.test", Signals: []string{"provider-alias"}},
+		{Identifier: "observed@example.test", Signals: []string{"provider-alias", "sent-folder"}},
+		{Identifier: "old@example.test", Signals: []string{"provider-alias"}},
+	}, applyStore.batchCalls[0], "pending provider evidence must remain preview-only")
+}
+
+func TestApplyProviderExternalEvidenceUsesBoundedStoreServiceAndIsRetryIdempotent(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	other, err := st.GetOrCreateSource("imap", "other@example.test")
+	requirements.NoError(err)
+	requirements.NoError(st.AddAccountIdentity(other.ID, "other-alias@example.test", "manual"))
+	evidence := []identityops.ExternalEvidence{
+		{Identifier: "active@example.test", Signal: identityops.SignalProviderAlias, State: "enabled", Strong: true},
+		{Identifier: "old@example.test", Signal: identityops.SignalProviderAlias, State: "disabled", Strong: true},
+		{Identifier: "deleted@example.test", Signal: identityops.SignalProviderAlias, State: "deleted", Strong: true},
+		{Identifier: "waiting@example.test", Signal: identityops.SignalProviderAlias, State: "pending"},
+		{Identifier: "*@example.test", Signal: identityops.SignalProviderAlias, State: "enabled", Strong: true},
+	}
+	beforeRevision, err := st.AccountIdentityRevision()
+	requirements.NoError(err)
+
+	first, err := identityops.ApplyExternalEvidence(t.Context(), st, source.ID, evidence)
+	requirements.NoError(err)
+	assertions.Equal([]string{
+		"active@example.test", "deleted@example.test", "old@example.test",
+	}, identityConfirmationIdentifiers(first))
+	afterFirstRevision, err := st.AccountIdentityRevision()
+	requirements.NoError(err)
+	assertions.Equal(beforeRevision+1, afterFirstRevision)
+
+	retry, err := identityops.ApplyExternalEvidence(t.Context(), st, source.ID, evidence)
+	requirements.NoError(err)
+	assertions.Empty(retry)
+	afterRetryRevision, err := st.AccountIdentityRevision()
+	requirements.NoError(err)
+	assertions.Equal(afterFirstRevision, afterRetryRevision)
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	assertions.Equal([]string{
+		"active@example.test", "deleted@example.test", "old@example.test",
+	}, accountIdentityAddresses(identities))
+	otherIdentities, err := st.ListAccountIdentities(other.ID)
+	requirements.NoError(err)
+	assertions.Equal([]string{"other-alias@example.test"}, accountIdentityAddresses(otherIdentities))
+}
+
+func identityConfirmationIdentifiers(outcomes []store.IdentityConfirmationOutcome) []string {
+	identifiers := make([]string, len(outcomes))
+	for i, outcome := range outcomes {
+		identifiers[i] = outcome.Identifier
+	}
+	return identifiers
+}
+
+func accountIdentityAddresses(identities []store.AccountIdentity) []string {
+	addresses := make([]string, len(identities))
+	for i, identity := range identities {
+		addresses[i] = identity.Address
+	}
+	return addresses
+}
+
+func TestDiscoverClassifiesStrongWeakConfirmedAndCaseVariants(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.identities = []store.AccountIdentity{{
+		SourceID: 14, Address: "Known@Example.test", SourceSignal: "manual",
+	}}
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned:     4,
+		NextAfterID: 4,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "masked-shop@example.test", RecipientType: "from", HasSentFolder: true, ObservedAt: time.Unix(10, 0).UTC()},
+			{MessageID: 2, Identifier: "MASKED-SHOP@example.test", RecipientType: "to", ObservedAt: time.Unix(20, 0).UTC()},
+			{MessageID: 3, Identifier: "Known@example.test", RecipientType: "from", IsFromMe: true, ObservedAt: time.Unix(30, 0).UTC()},
+			{MessageID: 4, Identifier: "list@example.test", RecipientType: "cc", ObservedAt: time.Unix(40, 0).UTC()},
+		},
+	}}
+
+	got, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+	}, nil)
+	require.NoError(err)
+	require.Len(got.Candidates, 3)
+	assert.Equal([]string{"confirmed", "weak", "strong"}, classificationsByStableOrder(got.Candidates))
+	assert.Equal([]string{"is_from_me", "manual"}, got.Candidates[0].Signals)
+	assert.Equal("masked-shop@example.test", got.Candidates[2].Identifier, "first spelling must win")
+	assert.Equal(int64(1), got.Candidates[2].SentMessageCount)
+	assert.Equal(int64(1), got.Candidates[2].ReceivedMessageCount)
+}
+
+func TestDiscoverApplyNeverConfirmsRecipientOnlyCandidate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned:     2,
+		NextAfterID: 2,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "masked-shop@example.test", RecipientType: "from", HasSentFolder: true},
+			{MessageID: 2, Identifier: "list@example.test", RecipientType: "to"},
+		},
+	}}
+
+	_, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Apply:          true,
+	}, nil)
+	require.NoError(err)
+	assert.Equal([]int64{14}, st.batchSourceIDs)
+	require.Len(st.batchCalls, 1)
+	require.Len(st.batchCalls[0], 1)
+	assert.Equal("masked-shop@example.test", st.batchCalls[0][0].Identifier)
+	assert.Equal([]string{"sent-folder"}, st.batchCalls[0][0].Signals)
+}
+
+func TestDiscoverApplyDoesNotConfirmAmbiguousFromAddresses(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned:     1,
+		NextAfterID: 1,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "author@example.test", RecipientType: "from", IsFromMe: true, HasSentFolder: true, HasSentLabel: true},
+			{MessageID: 1, Identifier: "coauthor@example.test", RecipientType: "from", IsFromMe: true, HasSentFolder: true, HasSentLabel: true},
+		},
+	}}
+
+	got, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Apply:          true,
+	}, nil)
+	require.NoError(err)
+	require.Len(got.Candidates, 2)
+	for _, candidate := range got.Candidates {
+		assert.Equal("weak", candidate.Classification)
+		assert.Empty(candidate.Signals)
+		assert.Equal(int64(1), candidate.SentMessageCount)
+	}
+	assert.Empty(got.Applied)
+	assert.Empty(st.batchCalls)
+}
+
+func TestDiscoverApplyMergesOnlyNewStrongSignalsIntoConfirmedCandidate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.identities = []store.AccountIdentity{{
+		SourceID: 14, Address: "Known@Example.test", SourceSignal: "manual,sent-folder",
+	}}
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned: 1, NextAfterID: 1,
+		Observations: []store.IdentityObservation{{
+			MessageID: 1, Identifier: "known@example.test", RecipientType: "from",
+			IsFromMe: true, HasSentFolder: true,
+		}},
+	}}
+
+	_, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true,
+	}, nil)
+	require.NoError(err)
+	assert.Equal([]int64{14}, st.batchSourceIDs)
+	require.Len(st.batchCalls, 1)
+	require.Len(st.batchCalls[0], 1)
+	assert.Equal("known@example.test", st.batchCalls[0][0].Identifier)
+	assert.Equal([]string{"is_from_me"}, st.batchCalls[0][0].Signals)
+
+	st = newDiscoveryFakeStore()
+	st.identities = []store.AccountIdentity{{
+		SourceID: 14, Address: "known@example.test", SourceSignal: "is_from_me",
+	}}
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned: 1, NextAfterID: 1,
+		Observations: []store.IdentityObservation{{
+			MessageID: 1, Identifier: "KNOWN@example.test", RecipientType: "from", IsFromMe: true,
+		}},
+	}}
+	_, err = identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true,
+	}, nil)
+	require.NoError(err)
+	assert.Empty(st.batchCalls, "unchanged evidence must not start an empty write batch")
+}
+
+func TestDiscoverExplicitlyConfirmsOnlyCompletedWeakCandidate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned:     2,
+		NextAfterID: 2,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "weak@example.test", RecipientType: "to"},
+			{MessageID: 2, Identifier: "strong@example.test", RecipientType: "from", IsFromMe: true},
+		},
+	}}
+
+	got, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Apply:          true,
+		Confirm:        []string{"WEAK@example.test", "weak@example.test"},
+	}, nil)
+	require.NoError(err)
+	require.Len(got.Applied, 2)
+	assert.Equal("strong@example.test", got.Applied[0].Identifier)
+	assert.Equal([]string{"is_from_me"}, got.Applied[0].Signals)
+	assert.Equal("weak@example.test", got.Applied[1].Identifier)
+	assert.Equal([]string{"manual"}, got.Applied[1].Signals)
+
+	st = newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned:     1,
+		NextAfterID: 1,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "strong@example.test", RecipientType: "from", IsFromMe: true},
+		},
+	}}
+	_, err = identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Apply:          true,
+		Confirm:        []string{"strong@example.test"},
+	}, nil)
+	require.ErrorContains(err, "weak candidate")
+	assert.Empty(st.batchCalls, "all explicit confirmations must validate before writing")
+}
+
+func TestDiscoverConfirmRequiresApply(t *testing.T) {
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned: 1, NextAfterID: 1,
+		Observations: []store.IdentityObservation{{
+			MessageID: 1, Identifier: "weak@example.test", RecipientType: "to",
+		}},
+	}}
+
+	_, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Confirm:        []string{"weak@example.test"},
+	}, nil)
+	require.ErrorContains(t, err, "requires apply")
+	assert.Empty(t, st.batchCalls)
+}
+
+func TestDiscoverStrongForSourceMessageIDsAppliesOnlyMergedStrongEvidence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.identities = []store.AccountIdentity{
+		{SourceID: 14, Address: "alias@example.test", SourceSignal: "manual"},
+		{SourceID: 14, Address: "recipient@example.test", SourceSignal: "manual"},
+	}
+	st.idObservations = []store.IdentityObservation{
+		{MessageID: 3, Identifier: "Alias@Example.test", RecipientType: "from", HasSentFolder: true},
+		{MessageID: 4, Identifier: "alias@example.test", RecipientType: "from", IsFromMe: true, HasSentLabel: true},
+		{MessageID: 4, Identifier: "recipient@example.test", RecipientType: "to", IsFromMe: true, HasSentLabel: true},
+	}
+
+	got, err := identityops.DiscoverStrongForSourceMessageIDs(
+		t.Context(), st, 14, []string{"provider-2", "provider-1", "provider-2"},
+	)
+	require.NoError(err)
+	assert.Equal(int64(14), st.scannedSourceID)
+	assert.Equal([]string{"provider-2", "provider-1", "provider-2"}, st.scannedMessageIDs)
+	assert.Equal([]int64{14}, st.batchSourceIDs)
+	require.Len(got, 1)
+	assert.Equal("Alias@Example.test", got[0].Identifier)
+	assert.Equal([]string{"is_from_me", "sent-folder", "sent-label"}, got[0].Signals)
+}
+
+// newSentEvidenceStore returns a real store holding one Gmail source, so the
+// refresh-only tests below exercise the production discovery scan rather than a
+// hand-built observation list.
+func newSentEvidenceStore(t *testing.T) (*store.Store, *store.Source) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "primary@example.test")
+	require.NoError(t, err, "create source")
+	return st, source
+}
+
+// archiveSentMessage archives one Sent-labelled message carrying
+// provider-native attribution whose only From address is sender.
+func archiveSentMessage(t *testing.T, st *store.Store, source *store.Source, sourceMessageID, sender string) {
+	t.Helper()
+	convID, err := st.EnsureConversation(source.ID, "thread-"+sourceMessageID, "Thread")
+	require.NoError(t, err, "create conversation")
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID:  convID,
+		SourceID:        source.ID,
+		SourceMessageID: sourceMessageID,
+		MessageType:     "email",
+		IsFromMe:        true,
+		SizeEstimate:    100,
+	})
+	require.NoError(t, err, "archive message")
+	participantID, err := st.EnsureParticipant(sender, "Test User", "example.test")
+	require.NoError(t, err, "create participant")
+	require.NoError(t,
+		st.ReplaceMessageRecipients(messageID, "from", []int64{participantID}, []string{"Test User"}),
+		"add From participant")
+	sentLabelID, err := st.EnsureLabel(source.ID, "SENT", "Sent Mail", "system")
+	require.NoError(t, err, "create Gmail sent label")
+	require.NoError(t, st.ReplaceMessageLabels(messageID, []int64{sentLabelID}), "label sent message")
+}
+
+func TestDiscoverStrongForSourceMessageIDsNeverConfirmsFirstTimeIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source := newSentEvidenceStore(t)
+	archiveSentMessage(t, st, source, "fresh-sent", "newcomer@example.test")
+
+	outcomes, err := identityops.DiscoverStrongForSourceMessageIDs(
+		t.Context(), st, source.ID, []string{"fresh-sent"},
+	)
+	require.NoError(err)
+	assert.Empty(outcomes, "sync-time discovery must not confirm a first-time identity")
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err)
+	assert.Empty(identities, "a single Sent-placed message must not create an identity")
+}
+
+func TestDiscoverStrongForSourceMessageIDsMergesSignalsIntoConfirmed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source := newSentEvidenceStore(t)
+	require.NoError(st.AddAccountIdentity(source.ID, "owner@example.test", "manual"), "pre-confirm identity")
+	archiveSentMessage(t, st, source, "confirmed-sent", "owner@example.test")
+
+	_, err := identityops.DiscoverStrongForSourceMessageIDs(
+		t.Context(), st, source.ID, []string{"confirmed-sent"},
+	)
+	require.NoError(err)
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err)
+	require.Len(identities, 1)
+	assert.Equal("owner@example.test", identities[0].Address)
+	assert.Equal([]string{"is_from_me", "manual", "sent-label"},
+		identityops.SplitSignalSet(identities[0].SourceSignal),
+		"new strong signals must merge into the already-confirmed identity")
+}
+
+func TestDiscoverStrongForSourceMessageIDsDoesNotReAddRemovedIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source := newSentEvidenceStore(t)
+	require.NoError(st.AddAccountIdentity(source.ID, "retired@example.test", "manual"), "confirm identity")
+	removed, err := st.RemoveAccountIdentity(source.ID, "retired@example.test")
+	require.NoError(err, "remove identity")
+	require.Equal(int64(1), removed)
+	archiveSentMessage(t, st, source, "post-removal-sent", "retired@example.test")
+
+	_, err = identityops.DiscoverStrongForSourceMessageIDs(
+		t.Context(), st, source.ID, []string{"post-removal-sent"},
+	)
+	require.NoError(err)
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err)
+	assert.Empty(identities, "sync-time discovery must not resurrect a removed identity")
+}
+
+func TestRefreshConfirmedForSourceMergesOnlyConfirmed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source := newSentEvidenceStore(t)
+	require.NoError(st.AddAccountIdentity(source.ID, "owner@example.test", "manual"), "pre-confirm identity")
+	archiveSentMessage(t, st, source, "confirmed-sent", "owner@example.test")
+	archiveSentMessage(t, st, source, "unconfirmed-sent", "stranger@example.test")
+
+	require.NoError(identityops.RefreshConfirmedForSource(t.Context(), st, source.ID))
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err)
+	require.Len(identities, 1, "refresh must never confirm an unconfirmed address")
+	assert.Equal("owner@example.test", identities[0].Address)
+	assert.Equal([]string{"is_from_me", "manual", "sent-label"},
+		identityops.SplitSignalSet(identities[0].SourceSignal),
+		"refresh must merge full-archive strong signals into the confirmed identity")
+}
+
+func TestRefreshConfirmedForSourceSkipsScanWithoutConfirmedIdentities(t *testing.T) {
+	assert := assert.New(t)
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned: 1, NextAfterID: 1,
+		Observations: []store.IdentityObservation{{
+			MessageID: 1, Identifier: "stranger@example.test", RecipientType: "from", IsFromMe: true,
+		}},
+	}}
+
+	require.NoError(t, identityops.RefreshConfirmedForSource(t.Context(), st, 14))
+	assert.Zero(st.pageCalls, "a source with no confirmed identities must not be scanned")
+	assert.Empty(st.batchCalls)
+}
+
+func TestDiscoverRejectsUnsafeAddressesAndCountsDistinctMessages(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned:     3,
+		NextAfterID: 3,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: " Alias@Example.test ", RecipientType: "from", HasSentFolder: true, ObservedAt: time.Unix(30, 0).UTC()},
+			{MessageID: 1, Identifier: "alias@example.test", RecipientType: "from", IsFromMe: true, ObservedAt: time.Unix(20, 0).UTC()},
+			{MessageID: 2, Identifier: "ALIAS@example.test", RecipientType: "to", ObservedAt: time.Unix(40, 0).UTC()},
+			{MessageID: 2, Identifier: "alias@example.test", RecipientType: "cc", ObservedAt: time.Unix(40, 0).UTC()},
+			{MessageID: 3, Identifier: "Display Name <display@example.test>", RecipientType: "from", IsFromMe: true},
+			{MessageID: 3, Identifier: "*@example.test", RecipientType: "from", IsFromMe: true},
+			{MessageID: 3, Identifier: "line@example.test\n", RecipientType: "from", IsFromMe: true},
+			{MessageID: 3, Identifier: "user@localhost", RecipientType: "from", IsFromMe: true},
+			{MessageID: 3, Identifier: "@Synthetic:example.test", RecipientType: "from", IsFromMe: true},
+			{MessageID: 3, Identifier: "@synthetic:example.test", RecipientType: "from", IsFromMe: true},
+		},
+	}}
+
+	got, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+	}, nil)
+	require.NoError(err)
+	require.Len(got.Candidates, 1)
+	assert.Equal("Alias@Example.test", got.Candidates[0].Identifier)
+	assert.Equal(int64(1), got.Candidates[0].SentMessageCount)
+	assert.Equal(int64(1), got.Candidates[0].ReceivedMessageCount)
+	assert.Equal(time.Unix(20, 0).UTC(), got.Candidates[0].FirstSeenAt)
+	assert.Equal(time.Unix(40, 0).UTC(), got.Candidates[0].LastSeenAt)
+	assert.Len(got.Rejected, 6)
+	assert.Contains(got.Rejected, identityops.RejectedCandidate{
+		Identifier: "user@localhost",
+		Reason:     "identifier is not a concrete mailbox address",
+	})
+	assert.Contains(rejectedIdentifiers(got.Rejected), "@Synthetic:example.test")
+	assert.Contains(rejectedIdentifiers(got.Rejected), "@synthetic:example.test")
+}
+
+func TestDiscoverCancellationAfterPageWritesNothing(t *testing.T) {
+	assert := assert.New(t)
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{
+		{
+			Scanned: 1, NextAfterID: 1,
+			Observations: []store.IdentityObservation{{
+				MessageID: 1, Identifier: "first@example.test", RecipientType: "from", IsFromMe: true,
+			}},
+		},
+		{
+			Scanned: 1, NextAfterID: 2,
+			Observations: []store.IdentityObservation{{
+				MessageID: 2, Identifier: "second@example.test", RecipientType: "from", IsFromMe: true,
+			}},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+
+	got, err := identityops.Discover(ctx, st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true, PageSize: 1,
+	}, func(identityops.DiscoverProgress) error {
+		cancel()
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(identityops.DiscoverResult{}, got, "canceled scan must not return a preview result")
+	assert.Empty(st.batchCalls)
+}
+
+func TestDiscoverInterruptedApplyRerunMatchesOneShot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	pages := []store.IdentityDiscoveryPage{{
+		Scanned: 2, NextAfterID: 2,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "first@example.test", RecipientType: "from", IsFromMe: true},
+			{MessageID: 2, Identifier: "second@example.test", RecipientType: "from", HasSentFolder: true},
+		},
+	}}
+
+	resumedState := make(map[string]map[string]struct{})
+	resumed := newDiscoveryFakeStore()
+	resumed.pages = pages
+	resumed.batchFunc = func(_ context.Context, confirmations []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error) {
+		outcomes := mergeConfirmationState(resumedState, confirmations[:1])
+		return outcomes, context.Canceled
+	}
+	_, err := identityops.Discover(t.Context(), resumed, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true,
+	}, nil)
+	require.ErrorIs(err, context.Canceled)
+
+	resumed.pageCalls = 0
+	resumed.batchFunc = func(_ context.Context, confirmations []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error) {
+		return mergeConfirmationState(resumedState, confirmations), nil
+	}
+	_, err = identityops.Discover(t.Context(), resumed, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true,
+	}, nil)
+	require.NoError(err)
+
+	cleanState := make(map[string]map[string]struct{})
+	clean := newDiscoveryFakeStore()
+	clean.pages = pages
+	clean.batchFunc = func(_ context.Context, confirmations []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error) {
+		return mergeConfirmationState(cleanState, confirmations), nil
+	}
+	_, err = identityops.Discover(t.Context(), clean, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true,
+	}, nil)
+	require.NoError(err)
+	assert.Equal(cleanState, resumedState)
+}
+
+func TestDiscoverApplyErrorReturnsCommittedPrefix(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := newDiscoveryFakeStore()
+	st.pages = []store.IdentityDiscoveryPage{{
+		Scanned: 2, NextAfterID: 2,
+		Observations: []store.IdentityObservation{
+			{MessageID: 1, Identifier: "first@example.test", RecipientType: "from", IsFromMe: true},
+			{MessageID: 2, Identifier: "second@example.test", RecipientType: "from", HasSentFolder: true},
+		},
+	}}
+	applyErr := errors.New("apply stopped after committed prefix")
+	st.batchFunc = func(_ context.Context, confirmations []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error) {
+		return []store.IdentityConfirmationOutcome{{
+			Identifier: confirmations[0].Identifier,
+			Added:      true,
+			Signals:    append([]string(nil), confirmations[0].Signals...),
+		}}, applyErr
+	}
+
+	got, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14}, Apply: true,
+	}, nil)
+
+	requirements.ErrorIs(err, applyErr)
+	requirements.Len(got.Applied, 1)
+	assertions.Equal("first@example.test", got.Applied[0].Identifier)
+	assertions.True(got.Applied[0].Added)
+	assertions.Equal([]string{"is_from_me"}, got.Applied[0].Signals)
+}
+
+func rejectedIdentifiers(rejected []identityops.RejectedCandidate) []string {
+	identifiers := make([]string, len(rejected))
+	for i, candidate := range rejected {
+		identifiers[i] = candidate.Identifier
+	}
+	return identifiers
+}
+
+func mergeConfirmationState(
+	state map[string]map[string]struct{},
+	confirmations []store.IdentityConfirmation,
+) []store.IdentityConfirmationOutcome {
+	outcomes := make([]store.IdentityConfirmationOutcome, 0, len(confirmations))
+	for _, confirmation := range confirmations {
+		key := strings.ToLower(confirmation.Identifier)
+		if state[key] == nil {
+			state[key] = make(map[string]struct{})
+		}
+		for _, signal := range confirmation.Signals {
+			state[key][signal] = struct{}{}
+		}
+		signals := make([]string, 0, len(state[key]))
+		for signal := range state[key] {
+			signals = append(signals, signal)
+		}
+		sort.Strings(signals)
+		outcomes = append(outcomes, store.IdentityConfirmationOutcome{
+			Identifier: confirmation.Identifier, Signals: signals,
+		})
+	}
+	return outcomes
+}
+
+func TestDiscoverApplyAfterParticipantMergeConfirmsOnlyEnvelopeAddress(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "owner@example.test")
+	require.NoError(err, "create source")
+	convID, err := st.EnsureConversation(source.ID, "merge-thread", "Merge Thread")
+	require.NoError(err, "create conversation")
+	aliceID, err := st.EnsureParticipant("alice@example.test", "Alice", "example.test")
+	require.NoError(err, "create alice")
+	bobID, err := st.EnsureParticipant("bob@example.test", "Bob", "example.test")
+	require.NoError(err, "create bob")
+
+	_, err = st.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID:  convID,
+			SourceID:        source.ID,
+			SourceMessageID: "native-sent-from-alice",
+			MessageType:     "email",
+			SentAt:          sql.NullTime{Time: time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC), Valid: true},
+			SenderID:        sql.NullInt64{Int64: aliceID, Valid: true},
+			IsFromMe:        true,
+			SizeEstimate:    100,
+		},
+		Recipients: []store.RecipientSet{{
+			Type:           "from",
+			ParticipantIDs: []int64{aliceID},
+			DisplayNames:   []string{"Alice"},
+			EmailAddresses: []string{"alice@example.test"},
+		}},
+	})
+	require.NoError(err, "persist source-native sent message")
+	require.NoError(st.MergeParticipants(aliceID, bobID), "merge alice into bob")
+
+	result, err := identityops.Discover(t.Context(), st, identityops.DiscoverRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: source.ID},
+		Apply:          true,
+	}, nil)
+	require.NoError(err, "discover with apply")
+
+	for _, candidate := range result.Candidates {
+		if candidate.NormalizedIdentifier != "bob@example.test" {
+			continue
+		}
+		assert.NotEqual("strong", candidate.Classification,
+			"the merge survivor's primary email must not become strong evidence")
+		assert.False(candidate.AlreadyConfirmed,
+			"apply must not confirm an address the provider never emitted as the sender")
+	}
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err, "list confirmed identities")
+	require.Len(identities, 1, "apply must confirm exactly the envelope address")
+	assert.Equal("alice@example.test", identities[0].Address)
+	assert.Equal("is_from_me", identities[0].SourceSignal)
+}

--- a/internal/identityops/identityops.go
+++ b/internal/identityops/identityops.go
@@ -1,6 +1,7 @@
 package identityops
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -20,15 +21,38 @@ const (
 
 type Store interface {
 	collectionops.AccountResolverStore
+	GetSourceByID(id int64) (*store.Source, error)
 	ListAccountIdentities(sourceID int64) ([]store.AccountIdentity, error)
 	AddAccountIdentity(sourceID int64, address, signal string) error
 	RemoveAccountIdentity(sourceID int64, address string) (int64, error)
 }
 
+type SourceSelector struct {
+	Account     string `json:"account,omitempty"`
+	SourceID    int64  `json:"source_id,omitempty"`
+	sourceIDSet bool
+}
+
 type AddRequest struct {
-	Account    string `json:"account"`
+	SourceSelector
+
 	Identifier string `json:"identifier"`
 	Signal     string `json:"signal"`
+}
+
+func (r *AddRequest) UnmarshalJSON(data []byte) error {
+	type addRequest AddRequest
+	var decoded addRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	set, err := jsonFieldPresent(data, "source_id")
+	if err != nil {
+		return err
+	}
+	decoded.sourceIDSet = set
+	*r = AddRequest(decoded)
+	return nil
 }
 
 type AddResult struct {
@@ -45,8 +69,33 @@ type AddResult struct {
 }
 
 type RemoveRequest struct {
-	Account    string `json:"account"`
+	SourceSelector
+
 	Identifier string `json:"identifier"`
+}
+
+func (r *RemoveRequest) UnmarshalJSON(data []byte) error {
+	type removeRequest RemoveRequest
+	var decoded removeRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	set, err := jsonFieldPresent(data, "source_id")
+	if err != nil {
+		return err
+	}
+	decoded.sourceIDSet = set
+	*r = RemoveRequest(decoded)
+	return nil
+}
+
+func jsonFieldPresent(data []byte, field string) (bool, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return false, err
+	}
+	_, ok := fields[field]
+	return ok, nil
 }
 
 type RemoveResult struct {
@@ -71,7 +120,7 @@ func Add(st Store, req AddRequest) (AddResult, error) {
 		return AddResult{}, opserr.Invalid(fmt.Errorf("signal names cannot contain commas: %q", req.Signal))
 	}
 
-	src, err := resolveAccountSource(st, req.Account)
+	src, err := ResolveSource(st, req.SourceSelector)
 	if err != nil {
 		return AddResult{}, err
 	}
@@ -114,7 +163,7 @@ func Remove(st Store, req RemoveRequest) (RemoveResult, error) {
 		return RemoveResult{}, opserr.Invalid(errors.New("identifier must not be empty"))
 	}
 
-	src, err := resolveAccountSource(st, req.Account)
+	src, err := ResolveSource(st, req.SourceSelector)
 	if err != nil {
 		return RemoveResult{}, err
 	}
@@ -156,11 +205,30 @@ func Remove(st Store, req RemoveRequest) (RemoveResult, error) {
 	return result, nil
 }
 
-func resolveAccountSource(st Store, input string) (*store.Source, error) {
-	if input == "" {
-		return nil, opserr.Invalid(errors.New("account is required"))
+func ResolveSource(st Store, selector SourceSelector) (*store.Source, error) {
+	account := strings.TrimSpace(selector.Account)
+	switch {
+	case selector.SourceID < 0 || (selector.sourceIDSet && selector.SourceID == 0):
+		return nil, opserr.Invalid(errors.New("source ID must be positive"))
+	case selector.SourceID > 0 && account != "":
+		return nil, opserr.Invalid(errors.New("account and source ID are mutually exclusive"))
+	case selector.SourceID > 0:
+		src, err := st.GetSourceByID(selector.SourceID)
+		if errors.Is(err, store.ErrSourceNotFound) {
+			return nil, opserr.NotFound(err)
+		}
+		if err != nil {
+			return nil, opserr.Internal(err)
+		}
+		return src, nil
+	case account == "":
+		return nil, opserr.Invalid(errors.New("account or source ID is required"))
+	default:
+		return resolveAccountSource(st, account)
 	}
+}
 
+func resolveAccountSource(st Store, input string) (*store.Source, error) {
 	scope, err := collectionops.ResolveAccount(st, input)
 	if err != nil {
 		return nil, err

--- a/internal/identityops/import.go
+++ b/internal/identityops/import.go
@@ -1,0 +1,284 @@
+package identityops
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// ImportEntry is one provider-neutral identity supplied by a user-owned file.
+// State is report-only metadata and never requests removal.
+type ImportEntry struct {
+	Identifier string `json:"identifier"`
+	State      string `json:"state,omitempty"`
+}
+
+type ImportRequest struct {
+	SourceSelector
+
+	Entries []ImportEntry `json:"entries" nullable:"false"`
+	Signal  string        `json:"signal,omitempty"`
+	Apply   bool          `json:"apply,omitempty"`
+}
+
+func (r *ImportRequest) UnmarshalJSON(data []byte) error {
+	type importRequest ImportRequest
+	var decoded importRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	set, err := jsonFieldPresent(data, "source_id")
+	if err != nil {
+		return err
+	}
+	decoded.sourceIDSet = set
+	*r = ImportRequest(decoded)
+	return nil
+}
+
+type ImportResult struct {
+	Account    string                              `json:"account"`
+	SourceID   int64                               `json:"source_id"`
+	Signal     string                              `json:"signal"`
+	Candidates []Candidate                         `json:"candidates" nullable:"false"`
+	Applied    []store.IdentityConfirmationOutcome `json:"applied" nullable:"false"`
+}
+
+var errTrailingImportJSON = errors.New("identity import must contain a single JSON document")
+
+// ParseImport reads text or strict JSON identity input, validates every row,
+// merges case-folded duplicates, and returns stable normalized ordering.
+func ParseImport(r io.Reader, format string) ([]ImportEntry, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read identity import: %w", err)
+	}
+	resolved, err := resolveImportFormat(format, data)
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []ImportEntry
+	switch resolved {
+	case "text":
+		entries = parseTextImport(data)
+	case "json":
+		entries, err = parseJSONImport(data)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported identity import format %q", format)
+	}
+	return normalizeImportEntries(entries)
+}
+
+// Import validates one complete parsed request, previews every entry, and
+// optionally confirms it through the same bounded source-scoped write path as
+// discovery. State is copied into the report but never affects confirmation.
+func Import(
+	ctx context.Context,
+	st DiscoveryStore,
+	req ImportRequest,
+) (ImportResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ImportResult{}, err
+	}
+	signal := strings.TrimSpace(req.Signal)
+	if signal == "" {
+		signal = "manual"
+	}
+	if strings.Contains(signal, ",") {
+		return ImportResult{}, opserr.Invalid(fmt.Errorf("signal names cannot contain commas: %q", signal))
+	}
+	entries, err := normalizeImportEntries(req.Entries)
+	if err != nil {
+		return ImportResult{}, opserr.Invalid(err)
+	}
+
+	src, err := ResolveSource(st, req.SourceSelector)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	existing, err := st.ListAccountIdentities(src.ID)
+	if err != nil {
+		return ImportResult{}, opserr.Internal(fmt.Errorf("list account identities: %w", err))
+	}
+	evidence := make([]ExternalEvidence, len(entries))
+	for i, entry := range entries {
+		evidence[i] = ExternalEvidence{
+			Identifier: entry.Identifier,
+			Signal:     signal,
+			State:      entry.State,
+			Strong:     true,
+		}
+	}
+	result := ImportResult{
+		Account:    src.Identifier,
+		SourceID:   src.ID,
+		Signal:     signal,
+		Candidates: []Candidate{},
+		Applied:    []store.IdentityConfirmationOutcome{},
+	}
+	discovery := DiscoverResult{SourceID: src.ID, Candidates: result.Candidates}
+	seedExistingExternalCandidates(&discovery, evidence, existing)
+	MergeExternalEvidence(&discovery, evidence)
+	result.Candidates = discovery.Candidates
+	if !req.Apply {
+		return result, nil
+	}
+
+	confirmations := strongConfirmations(result.Candidates, existing)
+	if len(confirmations) == 0 {
+		return result, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	result.Applied, err = st.AddAccountIdentitiesBatchContext(ctx, src.ID, confirmations)
+	return result, err
+}
+
+func resolveImportFormat(hint string, data []byte) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(hint))
+	switch normalized {
+	case "", "auto":
+		trimmed := bytes.TrimSpace(data)
+		if len(trimmed) > 0 && (trimmed[0] == '[' || trimmed[0] == '{') {
+			return "json", nil
+		}
+		return "text", nil
+	case "text", "txt", ".txt", ".text":
+		return "text", nil
+	case "json", ".json":
+		return "json", nil
+	}
+	switch strings.ToLower(filepath.Ext(normalized)) {
+	case ".txt", ".text":
+		return "text", nil
+	case ".json":
+		return "json", nil
+	default:
+		return "", fmt.Errorf("unsupported identity import format %q", hint)
+	}
+}
+
+func parseTextImport(data []byte) []ImportEntry {
+	lines := strings.Split(string(data), "\n")
+	entries := make([]ImportEntry, 0, len(lines))
+	for _, line := range lines {
+		identifier := strings.TrimSpace(line)
+		if identifier == "" || strings.HasPrefix(identifier, "#") {
+			continue
+		}
+		entries = append(entries, ImportEntry{Identifier: identifier})
+	}
+	return entries
+}
+
+func parseJSONImport(data []byte) ([]ImportEntry, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("identity import contains no identities")
+	}
+	switch trimmed[0] {
+	case '[':
+		var identifiers []string
+		stringErr := decodeStrictImportJSON(trimmed, &identifiers)
+		if stringErr == nil {
+			entries := make([]ImportEntry, len(identifiers))
+			for i, identifier := range identifiers {
+				entries[i] = ImportEntry{Identifier: identifier}
+			}
+			return entries, nil
+		}
+		if errors.Is(stringErr, errTrailingImportJSON) {
+			return nil, stringErr
+		}
+		var entries []ImportEntry
+		entryErr := decodeStrictImportJSON(trimmed, &entries)
+		if entryErr == nil {
+			return entries, nil
+		}
+		if errors.Is(entryErr, errTrailingImportJSON) {
+			return nil, entryErr
+		}
+		if strings.Contains(entryErr.Error(), "unknown field") {
+			return nil, fmt.Errorf("decode identity import JSON: %w", entryErr)
+		}
+		return nil, fmt.Errorf("identity import JSON must be an array of strings or identity entries: %w", entryErr)
+	case '{':
+		var envelope struct {
+			Identities []ImportEntry `json:"identities"`
+		}
+		if err := decodeStrictImportJSON(trimmed, &envelope); err != nil {
+			return nil, fmt.Errorf("decode identity import JSON: %w", err)
+		}
+		return envelope.Identities, nil
+	default:
+		return nil, errors.New("identity import JSON must be an array or identities object")
+	}
+}
+
+func decodeStrictImportJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errTrailingImportJSON
+		}
+		return fmt.Errorf("%w: %w", errTrailingImportJSON, err)
+	}
+	return nil
+}
+
+func normalizeImportEntries(entries []ImportEntry) ([]ImportEntry, error) {
+	byNormalized := make(map[string]ImportEntry, len(entries))
+	for _, entry := range entries {
+		identifier, reason := validateDiscoveredIdentifier(entry.Identifier)
+		if reason != "" {
+			return nil, fmt.Errorf("invalid imported identity %q: %s", strings.TrimSpace(entry.Identifier), reason)
+		}
+		normalized := store.NormalizeIdentifierForCompare(identifier)
+		entry = ImportEntry{Identifier: identifier, State: strings.TrimSpace(entry.State)}
+		if existing, ok := byNormalized[normalized]; ok {
+			if existing.State != entry.State {
+				return nil, fmt.Errorf(
+					"duplicate imported identity %q has conflicting states %q and %q",
+					existing.Identifier,
+					existing.State,
+					entry.State,
+				)
+			}
+			continue
+		}
+		byNormalized[normalized] = entry
+	}
+	if len(byNormalized) == 0 {
+		return nil, errors.New("identity import contains no identities")
+	}
+
+	normalized := make([]string, 0, len(byNormalized))
+	for identifier := range byNormalized {
+		normalized = append(normalized, identifier)
+	}
+	sort.Strings(normalized)
+	out := make([]ImportEntry, len(normalized))
+	for i, identifier := range normalized {
+		out[i] = byNormalized[identifier]
+	}
+	return out, nil
+}

--- a/internal/identityops/import_test.go
+++ b/internal/identityops/import_test.go
@@ -1,0 +1,327 @@
+package identityops_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestParseIdentityImportSupportsTextAndStrictJSONShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		format string
+		want   []identityops.ImportEntry
+	}{
+		{
+			name:   "text comments blanks and extension",
+			input:  "  # exported aliases\nOld@Example.test\n\nactive@example.test\n",
+			format: "aliases.txt",
+			want: []identityops.ImportEntry{
+				{Identifier: "active@example.test"},
+				{Identifier: "Old@Example.test"},
+			},
+		},
+		{
+			name:   "auto detects string array",
+			input:  "  [\"Old@Example.test\",\"active@example.test\"]",
+			format: "",
+			want: []identityops.ImportEntry{
+				{Identifier: "active@example.test"},
+				{Identifier: "Old@Example.test"},
+			},
+		},
+		{
+			name:   "entry array",
+			input:  `[{"identifier":"old@example.test","state":"disabled"}]`,
+			format: "json",
+			want: []identityops.ImportEntry{
+				{Identifier: "old@example.test", State: "disabled"},
+			},
+		},
+		{
+			name:   "object",
+			input:  `{"identities":[{"identifier":"waiting@example.test","state":"pending"}]}`,
+			format: ".json",
+			want: []identityops.ImportEntry{
+				{Identifier: "waiting@example.test", State: "pending"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := identityops.ParseImport(strings.NewReader(test.input), test.format)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestIdentityImportPreviewAndApplyShareDeterministicCandidates(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	entries := []identityops.ImportEntry{
+		{Identifier: "Waiting@Example.test", State: "pending"},
+		{Identifier: "known@example.test", State: "deleted"},
+		{Identifier: "alias@example.test", State: "enabled"},
+	}
+	previewStore := newDiscoveryFakeStore()
+	previewStore.identities = []store.AccountIdentity{{
+		SourceID: 14, Address: "Known@Example.test", SourceSignal: "manual",
+	}}
+
+	preview, err := identityops.Import(t.Context(), previewStore, identityops.ImportRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Entries:        entries,
+	})
+	requirements.NoError(err)
+	assertions.Empty(previewStore.batchCalls)
+	assertions.Equal("manual", preview.Signal)
+	encoded, err := json.Marshal(preview.Candidates)
+	requirements.NoError(err)
+	assertions.JSONEq(`[
+		{"identifier":"alias@example.test","normalized_identifier":"alias@example.test","classification":"strong","already_confirmed":false,"signals":["manual"],"provider_states":["enabled"],"sent_message_count":0,"received_message_count":0,"first_seen_at":"0001-01-01T00:00:00Z","last_seen_at":"0001-01-01T00:00:00Z"},
+		{"identifier":"Known@Example.test","normalized_identifier":"known@example.test","classification":"confirmed","already_confirmed":true,"signals":["manual"],"provider_states":["deleted"],"sent_message_count":0,"received_message_count":0,"first_seen_at":"0001-01-01T00:00:00Z","last_seen_at":"0001-01-01T00:00:00Z"},
+		{"identifier":"Waiting@Example.test","normalized_identifier":"waiting@example.test","classification":"strong","already_confirmed":false,"signals":["manual"],"provider_states":["pending"],"sent_message_count":0,"received_message_count":0,"first_seen_at":"0001-01-01T00:00:00Z","last_seen_at":"0001-01-01T00:00:00Z"}
+	]`, string(encoded))
+
+	applyStore := newDiscoveryFakeStore()
+	applyStore.identities = previewStore.identities
+	apply, err := identityops.Import(t.Context(), applyStore, identityops.ImportRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Entries:        entries,
+		Apply:          true,
+	})
+	requirements.NoError(err)
+	assertions.Equal(preview.Candidates, apply.Candidates)
+	requirements.Len(applyStore.batchCalls, 1)
+	assertions.Equal([]store.IdentityConfirmation{
+		{Identifier: "alias@example.test", Signals: []string{"manual"}},
+		{Identifier: "Waiting@Example.test", Signals: []string{"manual"}},
+	}, applyStore.batchCalls[0], "pending and historical states are report-only")
+}
+
+func TestIdentityImportValidatesEveryRowAndSignalBeforeWriting(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []identityops.ImportEntry
+		signal  string
+		want    string
+	}{
+		{
+			name: "invalid later row",
+			entries: []identityops.ImportEntry{
+				{Identifier: "good@example.test"},
+				{Identifier: "not an address"},
+			},
+			want: "concrete mailbox address",
+		},
+		{
+			name:    "conflicting duplicate state",
+			entries: []identityops.ImportEntry{{Identifier: "Alias@example.test", State: "enabled"}, {Identifier: "alias@example.test", State: "deleted"}},
+			want:    "conflicting states",
+		},
+		{
+			name:    "comma signal",
+			entries: []identityops.ImportEntry{{Identifier: "good@example.test"}},
+			signal:  "manual,provider",
+			want:    "cannot contain commas",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			st := newDiscoveryFakeStore()
+			_, err := identityops.Import(t.Context(), st, identityops.ImportRequest{
+				SourceSelector: identityops.SourceSelector{SourceID: 14},
+				Entries:        test.entries,
+				Signal:         test.signal,
+				Apply:          true,
+			})
+
+			require.ErrorContains(t, err, test.want)
+			assert.Empty(t, st.batchCalls)
+		})
+	}
+}
+
+func TestIdentityImportApplyIsSourceScopedStateIndependentAndIdempotent(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	other, err := st.GetOrCreateSource("imap", "other@example.test")
+	requirements.NoError(err)
+	requirements.NoError(st.AddAccountIdentity(source.ID, "Old@Example.test", "manual"))
+	requirements.NoError(st.AddAccountIdentity(other.ID, "other-alias@example.test", "manual"))
+	req := identityops.ImportRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: source.ID},
+		Entries: []identityops.ImportEntry{
+			{Identifier: "old@example.test", State: "deleted"},
+			{Identifier: "waiting@example.test", State: "pending"},
+		},
+		Apply: true,
+	}
+
+	first, err := identityops.Import(t.Context(), st, req)
+	requirements.NoError(err)
+	assertions.Equal([]store.IdentityConfirmationOutcome{{
+		Identifier: "waiting@example.test", Added: true, Signals: []string{"manual"},
+	}}, first.Applied)
+	retry, err := identityops.Import(t.Context(), st, req)
+	requirements.NoError(err)
+	assertions.Empty(retry.Applied)
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	assertions.Equal([]string{"Old@Example.test", "waiting@example.test"}, accountIdentityAddresses(identities))
+	otherIdentities, err := st.ListAccountIdentities(other.ID)
+	requirements.NoError(err)
+	assertions.Equal([]string{"other-alias@example.test"}, accountIdentityAddresses(otherIdentities))
+}
+
+func TestIdentityImportMergesAdditionalSignalIdempotently(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	requirements.NoError(st.AddAccountIdentity(source.ID, "Alias@Example.test", "manual"))
+	req := identityops.ImportRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: source.ID},
+		Entries:        []identityops.ImportEntry{{Identifier: "alias@example.test", State: "deleted"}},
+		Signal:         "bulk-import",
+		Apply:          true,
+	}
+
+	first, err := identityops.Import(t.Context(), st, req)
+	requirements.NoError(err)
+	assertions.Equal([]store.IdentityConfirmationOutcome{{
+		Identifier: "Alias@Example.test", Added: false, Signals: []string{"bulk-import"},
+	}}, first.Applied)
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	requirements.Len(identities, 1)
+	assertions.Equal("Alias@Example.test", identities[0].Address)
+	assertions.Equal("bulk-import,manual", identities[0].SourceSignal)
+
+	retry, err := identityops.Import(t.Context(), st, req)
+	requirements.NoError(err)
+	assertions.Empty(retry.Applied)
+}
+
+func TestIdentityImportCancellationPreventsWrites(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	st := newDiscoveryFakeStore()
+
+	_, err := identityops.Import(ctx, st, identityops.ImportRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Entries:        []identityops.ImportEntry{{Identifier: "alias@example.test"}},
+		Apply:          true,
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, st.batchCalls)
+}
+
+func TestIdentityImportReturnsCommittedPrefixOnBatchError(t *testing.T) {
+	st := newDiscoveryFakeStore()
+	commitErr := errors.New("second chunk failed")
+	st.batchFunc = func(_ context.Context, confirmations []store.IdentityConfirmation) ([]store.IdentityConfirmationOutcome, error) {
+		return []store.IdentityConfirmationOutcome{{
+			Identifier: confirmations[0].Identifier,
+			Added:      true,
+			Signals:    confirmations[0].Signals,
+		}}, commitErr
+	}
+
+	result, err := identityops.Import(t.Context(), st, identityops.ImportRequest{
+		SourceSelector: identityops.SourceSelector{SourceID: 14},
+		Entries: []identityops.ImportEntry{
+			{Identifier: "first@example.test"},
+			{Identifier: "second@example.test"},
+		},
+		Apply: true,
+	})
+
+	require.ErrorIs(t, err, commitErr)
+	assert.Equal(t, []store.IdentityConfirmationOutcome{{
+		Identifier: "first@example.test", Added: true, Signals: []string{"manual"},
+	}}, result.Applied)
+}
+
+func TestIdentityImportJSONTracksExplicitNullSourceID(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var req identityops.ImportRequest
+	requirements.NoError(json.Unmarshal([]byte(`{
+		"source_id":null,
+		"entries":[{"identifier":"alias@example.test"}]
+	}`), &req))
+
+	st := newDiscoveryFakeStore()
+	_, err := identityops.Import(t.Context(), st, req)
+
+	requirements.Error(err)
+	requirements.ErrorContains(err, "source ID must be positive")
+	assertions.Empty(st.batchCalls)
+}
+
+func TestParseIdentityImportPreservesFirstSpellingAndRejectsConflictingStates(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	got, err := identityops.ParseImport(strings.NewReader(`[
+		{"identifier":"Alias@Example.test","state":"disabled"},
+		{"identifier":"alias@example.test","state":"disabled"},
+		{"identifier":"zeta@example.test"}
+	]`), "json")
+
+	requirements.NoError(err)
+	assertions.Equal([]identityops.ImportEntry{
+		{Identifier: "Alias@Example.test", State: "disabled"},
+		{Identifier: "zeta@example.test"},
+	}, got)
+
+	_, err = identityops.ParseImport(strings.NewReader(`[
+		{"identifier":"Alias@Example.test","state":"disabled"},
+		{"identifier":"alias@example.test","state":"enabled"}
+	]`), "json")
+	requirements.Error(err)
+	assertions.ErrorContains(err, "conflicting states")
+}
+
+func TestParseIdentityImportRejectsMalformedOrUnsafeInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		format string
+		want   string
+	}{
+		{name: "unknown format", input: "alias@example.test", format: "csv", want: "unsupported identity import format"},
+		{name: "empty", input: " # only a comment\n", format: "text", want: "no identities"},
+		{name: "invalid text address", input: "not an address\n", format: "text", want: "concrete mailbox address"},
+		{name: "wildcard", input: "*@example.test\n", format: "text", want: "concrete mailbox address"},
+		{name: "unknown envelope field", input: `{"identities":[],"extra":true}`, format: "json", want: "unknown field"},
+		{name: "unknown entry field", input: `[{"identifier":"alias@example.test","extra":true}]`, format: "json", want: "unknown field"},
+		{name: "trailing document", input: `["alias@example.test"] {}`, format: "json", want: "single JSON document"},
+		{name: "mixed array", input: `["alias@example.test",{"identifier":"other@example.test"}]`, format: "json", want: "array of strings or identity entries"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := identityops.ParseImport(strings.NewReader(test.input), test.format)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, test.want)
+		})
+	}
+}

--- a/internal/identityops/selector_test.go
+++ b/internal/identityops/selector_test.go
@@ -1,0 +1,42 @@
+package identityops_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestResolveSourceRequiresExactlyOneSelector(t *testing.T) {
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	_, err := st.GetOrCreateSource("gmail", "shared@example.test")
+	requirements.NoError(err)
+
+	_, err = identityops.ResolveSource(st, identityops.SourceSelector{})
+	requirements.ErrorContains(err, "account or source ID is required")
+	_, err = identityops.ResolveSource(st, identityops.SourceSelector{SourceID: -1})
+	requirements.ErrorContains(err, "source ID must be positive")
+	_, err = identityops.ResolveSource(st, identityops.SourceSelector{
+		Account: "shared@example.test", SourceID: 1,
+	})
+	requirements.ErrorContains(err, "mutually exclusive")
+}
+
+func TestResolveSourceIDDisambiguatesDuplicateIdentifiers(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	providerSource, err := st.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	_, err = st.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+
+	_, err = identityops.ResolveSource(st, identityops.SourceSelector{Account: "shared@example.test"})
+	require.ErrorContains(err, "ambiguous")
+	got, err := identityops.ResolveSource(st, identityops.SourceSelector{SourceID: providerSource.ID})
+	require.NoError(err)
+	assert.Equal(providerSource.ID, got.ID)
+}

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -269,6 +269,16 @@ func (c *Client) selectMailbox(mailbox string) error {
 	return nil
 }
 
+// listOptionsLocked requests RFC 6154 special-use attributes only when the
+// server advertises support. Sending extended LIST options to legacy servers
+// can make otherwise valid mailbox enumeration fail.
+func (c *Client) listOptionsLocked() *imap.ListOptions {
+	if !c.conn.Caps().Has(imap.CapSpecialUse) {
+		return nil
+	}
+	return &imap.ListOptions{ReturnSpecialUse: true}
+}
+
 // listMailboxesLocked returns all selectable mailboxes, caching the result.
 // Also detects special-use attributes (\Trash, \All) for later use.
 // Caller must hold mu.
@@ -277,7 +287,7 @@ func (c *Client) listMailboxesLocked() ([]string, error) {
 		return c.mailboxCache, nil
 	}
 
-	items, err := c.conn.List("", "*", nil).Collect()
+	items, err := c.conn.List("", "*", c.listOptionsLocked()).Collect()
 	if err != nil {
 		return nil, fmt.Errorf("LIST: %w", err)
 	}
@@ -900,16 +910,17 @@ func (c *Client) GetProfile(ctx context.Context) (*gmailapi.Profile, error) {
 func (c *Client) ListLabels(ctx context.Context) ([]*gmailapi.Label, error) {
 	var labels []*gmailapi.Label
 	err := c.withConn(ctx, func(conn *imapclient.Client) error {
-		items, err := conn.List("", "*", nil).Collect()
+		items, err := conn.List("", "*", c.listOptionsLocked()).Collect()
 		if err != nil {
 			return fmt.Errorf("LIST: %w", err)
 		}
 		for _, item := range items {
 			labelType := classifyLabelType(item.Mailbox, item.Attrs)
 			labels = append(labels, &gmailapi.Label{
-				ID:   item.Mailbox,
-				Name: item.Mailbox,
-				Type: labelType,
+				ID:         item.Mailbox,
+				Name:       item.Mailbox,
+				Type:       labelType,
+				SystemRole: systemRoleForMailbox(item.Attrs),
 			})
 		}
 		return nil

--- a/internal/imap/client_test.go
+++ b/internal/imap/client_test.go
@@ -1,14 +1,161 @@
 package imap
 
 import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	imapapi "github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type specialUseListSession struct {
+	imapserver.Session
+
+	returnSpecialUse *atomic.Bool
+}
+
+type legacyListSession struct {
+	imapserver.Session
+}
+
+func (s *legacyListSession) List(
+	w *imapserver.ListWriter,
+	_ string,
+	_ []string,
+	options *imapapi.ListOptions,
+) error {
+	if options.ReturnSpecialUse {
+		return errors.New("extended LIST is unsupported")
+	}
+	if err := w.WriteList(&imapapi.ListData{
+		Delim:   '/',
+		Mailbox: "INBOX",
+	}); err != nil {
+		return fmt.Errorf("write LIST response: %w", err)
+	}
+	return nil
+}
+
+func (s *specialUseListSession) List(
+	w *imapserver.ListWriter,
+	_ string,
+	_ []string,
+	options *imapapi.ListOptions,
+) error {
+	s.returnSpecialUse.Store(options.ReturnSpecialUse)
+	attrs := []imapapi.MailboxAttr(nil)
+	if options.ReturnSpecialUse {
+		attrs = append(attrs, imapapi.MailboxAttrSent)
+	}
+	if err := w.WriteList(&imapapi.ListData{
+		Attrs:   attrs,
+		Delim:   '/',
+		Mailbox: "Envoyes",
+	}); err != nil {
+		return fmt.Errorf("write LIST response: %w", err)
+	}
+	return nil
+}
+
+func TestListLabelsRequestsSpecialUseForLocalizedSentMailbox(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	user := imapmemserver.NewUser("owner@example.test", "test-password")
+	memServer := imapmemserver.New()
+	memServer.AddUser(user)
+	var returnSpecialUse atomic.Bool
+	server := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return &specialUseListSession{
+				Session:          memServer.NewSession(),
+				returnSpecialUse: &returnSpecialUse,
+			}, nil, nil
+		},
+		Caps: imapapi.CapSet{
+			imapapi.CapIMAP4rev1:    {},
+			imapapi.CapListExtended: {},
+			imapapi.CapSpecialUse:   {},
+		},
+		InsecureAuth: true,
+	})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	host, portText, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(err)
+	client := NewClient(&Config{
+		Host:     host,
+		Port:     port,
+		Username: "owner@example.test",
+	}, "test-password")
+	t.Cleanup(func() { _ = client.Close() })
+
+	labels, err := client.ListLabels(t.Context())
+	require.NoError(err)
+	require.Len(labels, 1)
+	assert.True(returnSpecialUse.Load(), "LIST must explicitly request RETURN (SPECIAL-USE)")
+	assert.Equal("Envoyes", labels[0].Name)
+	assert.Equal("sent", labels[0].SystemRole)
+}
+
+func TestListMailboxesUsesBasicListWithoutSpecialUseCapability(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	user := imapmemserver.NewUser("owner@example.test", "test-password")
+	memServer := imapmemserver.New()
+	memServer.AddUser(user)
+	server := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return &legacyListSession{Session: memServer.NewSession()}, nil, nil
+		},
+		Caps: imapapi.CapSet{
+			imapapi.CapIMAP4rev1: {},
+		},
+		InsecureAuth: true,
+	})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	host, portText, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(err)
+	client := NewClient(&Config{
+		Host:     host,
+		Port:     port,
+		Username: "owner@example.test",
+	}, "test-password")
+	t.Cleanup(func() { _ = client.Close() })
+
+	labels, err := client.ListLabels(t.Context())
+	require.NoError(err, "legacy label listing")
+	require.Len(labels, 1)
+	assert.Equal("INBOX", labels[0].Name)
+
+	var mailboxes []string
+	err = client.withConn(t.Context(), func(*imapclient.Client) error {
+		var listErr error
+		mailboxes, listErr = client.listMailboxesLocked()
+		return listErr
+	})
+	require.NoError(err, "legacy mailbox listing")
+	assert.Equal([]string{"INBOX"}, mailboxes)
+}
 
 func TestEnumerateMailboxSearchCriteriaConstrainsUIDRange(t *testing.T) {
 	require := require.New(t)

--- a/internal/imap/labels.go
+++ b/internal/imap/labels.go
@@ -1,9 +1,11 @@
 package imap
 
 import (
+	"slices"
 	"strings"
 
 	imap "github.com/emersion/go-imap/v2"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 // systemAttrs maps RFC 6154 special-use attributes to system labels.
@@ -39,6 +41,16 @@ var systemNames = map[string]bool{
 
 // labelTypeSystem is the label_type value for standard IMAP folders.
 const labelTypeSystem = "system"
+
+// systemRoleForMailbox returns roles only when RFC 6154 special-use metadata
+// confirms them. Mailbox display names are deliberately not classification
+// input because they are localized and user-editable.
+func systemRoleForMailbox(attrs []imap.MailboxAttr) string {
+	if slices.Contains(attrs, imap.MailboxAttrSent) {
+		return store.LabelSystemRoleSent
+	}
+	return ""
+}
 
 // classifyLabelType returns "system" for standard IMAP folders
 // (detected via RFC 6154 attributes or well-known folder names)

--- a/internal/imap/labels_test.go
+++ b/internal/imap/labels_test.go
@@ -99,3 +99,8 @@ func TestClassifyLabelType(t *testing.T) {
 		})
 	}
 }
+
+func TestSystemRoleForMailboxTrustsSpecialUseNotName(t *testing.T) {
+	assert.Equal(t, "sent", systemRoleForMailbox([]imap.MailboxAttr{imap.MailboxAttrSent}))
+	assert.Empty(t, systemRoleForMailbox(nil), "a folder name is not part of role classification")
+}

--- a/internal/importer/ingest.go
+++ b/internal/importer/ingest.go
@@ -277,7 +277,10 @@ func buildRecipientSet(recipientType string, addresses []mime.Address, participa
 		return rs
 	}
 
+	// The envelope email is pinned at first occurrence, matching
+	// display-name dedup.
 	idToName := make(map[int64]string)
+	idToEmail := make(map[int64]string)
 	var orderedIDs []int64
 
 	for _, addr := range addresses {
@@ -292,6 +295,7 @@ func buildRecipientSet(recipientType string, addresses []mime.Address, participa
 		if _, seen := idToName[id]; !seen {
 			orderedIDs = append(orderedIDs, id)
 			idToName[id] = name
+			idToEmail[id] = addr.Email
 			continue
 		}
 		if idToName[id] == "" && name != "" {
@@ -301,8 +305,10 @@ func buildRecipientSet(recipientType string, addresses []mime.Address, participa
 
 	rs.ParticipantIDs = orderedIDs
 	rs.DisplayNames = make([]string, len(orderedIDs))
+	rs.EmailAddresses = make([]string, len(orderedIDs))
 	for i, id := range orderedIDs {
 		rs.DisplayNames[i] = idToName[id]
+		rs.EmailAddresses[i] = idToEmail[id]
 	}
 	return rs
 }

--- a/internal/provideridentity/provider.go
+++ b/internal/provideridentity/provider.go
@@ -1,0 +1,149 @@
+// Package provideridentity maps external provider inventory into the shared
+// identity evidence contract without giving provider clients store access.
+package provideridentity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/fastmail"
+	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// Inventory is the credential-bearing provider read seam. Tests inject an
+// in-memory implementation; the production implementation is the JMAP client.
+type Inventory interface {
+	ListIdentityRecords(ctx context.Context) ([]fastmail.Record, error)
+}
+
+// Factory binds one provider token to an inventory client.
+type Factory func(apiToken string) Inventory
+
+// Store is the complete source lookup and bounded identity-write surface used
+// by automatic provider refresh.
+type Store interface {
+	config.FastmailSourceStore
+	identityops.ExternalEvidenceStore
+	RecordProviderIdentityRefreshOutcomeContext(ctx context.Context, sourceID int64, refreshErr error) error
+	ProviderIdentityRefreshStateContext(ctx context.Context, sourceID int64) (store.ProviderIdentityRefreshState, bool, error)
+}
+
+// RefreshStaleAfter bounds how long a successful automatic refresh lets no-op
+// syncs skip the provider round trip. Provider inventory can change while a
+// mailbox is idle, so freshness expires even without mailbox history.
+const RefreshStaleAfter = 24 * time.Hour
+
+// NewFastmailInventory constructs the production Fastmail JMAP inventory.
+func NewFastmailInventory(apiToken string) Inventory {
+	return fastmail.NewClient(apiToken, nil)
+}
+
+// Evidence maps provider states to confirmation strength. Historical disabled
+// and deleted aliases remain authoritative; pending aliases stay review-only.
+func Evidence(records []fastmail.Record) []identityops.ExternalEvidence {
+	evidence := make([]identityops.ExternalEvidence, 0, len(records))
+	for _, record := range records {
+		state := strings.ToLower(strings.TrimSpace(record.State))
+		item := identityops.ExternalEvidence{
+			Identifier: record.Identifier,
+			Signal:     identityops.SignalProviderAlias,
+			State:      state,
+			Strong:     state == "enabled" || state == "disabled" || state == "deleted",
+		}
+		if strings.Contains(record.Identifier, "*") {
+			item.RejectedReason = "wildcard identity"
+		}
+		evidence = append(evidence, item)
+	}
+	return evidence
+}
+
+// AutoRefresh applies a configured provider inventory only when the source has
+// explicitly opted in. The bool reports whether provider reads were enabled.
+func AutoRefresh(
+	ctx context.Context,
+	cfg *config.Config,
+	st Store,
+	sourceID int64,
+	factory Factory,
+) ([]store.IdentityConfirmationOutcome, bool, error) {
+	return autoRefresh(ctx, cfg, st, sourceID, factory, false)
+}
+
+// AutoRefreshIfDue is AutoRefresh for syncs that observed no mailbox change:
+// the provider round trip is skipped while the recorded refresh state is
+// fresh, and made when the source has never refreshed, the last attempt
+// failed, or the last success is older than RefreshStaleAfter — the cases
+// where provider inventory may have moved independently of mailbox history.
+func AutoRefreshIfDue(
+	ctx context.Context,
+	cfg *config.Config,
+	st Store,
+	sourceID int64,
+	factory Factory,
+) ([]store.IdentityConfirmationOutcome, bool, error) {
+	return autoRefresh(ctx, cfg, st, sourceID, factory, true)
+}
+
+func autoRefresh(
+	ctx context.Context,
+	cfg *config.Config,
+	st Store,
+	sourceID int64,
+	factory Factory,
+	skipIfFresh bool,
+) ([]store.IdentityConfirmationOutcome, bool, error) {
+	if cfg == nil {
+		return nil, false, errors.New("provider identity refresh requires configuration")
+	}
+	configured, err := cfg.FastmailSourceFor(st, sourceID)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve Fastmail identity refresh configuration: %w", err)
+	}
+	if configured == nil || !configured.AutoConfirmIdentities {
+		return []store.IdentityConfirmationOutcome{}, false, nil
+	}
+	if skipIfFresh {
+		state, found, stateErr := st.ProviderIdentityRefreshStateContext(ctx, sourceID)
+		if stateErr != nil {
+			return nil, true, fmt.Errorf("read provider identity refresh state: %w", stateErr)
+		}
+		if found && state.Fresh(time.Now(), RefreshStaleAfter) {
+			return []store.IdentityConfirmationOutcome{}, true, nil
+		}
+	}
+	if factory == nil {
+		factory = NewFastmailInventory
+	}
+	inventory := factory(configured.APIToken)
+	if inventory == nil {
+		return nil, true, errors.New("fastmail identity inventory unavailable")
+	}
+	records, err := inventory.ListIdentityRecords(ctx)
+	if err == nil {
+		var outcomes []store.IdentityConfirmationOutcome
+		outcomes, err = identityops.ApplyExternalEvidence(ctx, st, sourceID, Evidence(records))
+		if err == nil {
+			return outcomes, true, recordRefreshOutcome(ctx, st, sourceID, nil)
+		}
+	}
+	if recordErr := recordRefreshOutcome(ctx, st, sourceID, err); recordErr != nil {
+		err = errors.Join(err, recordErr)
+	}
+	return nil, true, err
+}
+
+// recordRefreshOutcome persists the attempt result so no-op syncs know whether
+// a retry is owed. A recording failure surfaces to the caller: it means the
+// next no-op sync will re-poll the provider, which the operator should see.
+func recordRefreshOutcome(ctx context.Context, st Store, sourceID int64, refreshErr error) error {
+	if err := st.RecordProviderIdentityRefreshOutcomeContext(ctx, sourceID, refreshErr); err != nil {
+		return fmt.Errorf("record provider identity refresh outcome: %w", err)
+	}
+	return nil
+}

--- a/internal/provideridentity/provider_test.go
+++ b/internal/provideridentity/provider_test.go
@@ -1,0 +1,162 @@
+package provideridentity_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/fastmail"
+	"go.kenn.io/msgvault/internal/provideridentity"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type fakeInventory struct {
+	records []fastmail.Record
+}
+
+func (i *fakeInventory) ListIdentityRecords(context.Context) ([]fastmail.Record, error) {
+	return append([]fastmail.Record(nil), i.records...), nil
+}
+
+func TestAutoRefreshDefaultOffMakesNoProviderCall(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	cfg := &config.Config{Fastmail: []config.FastmailSource{{
+		SourceID: source.ID, APIToken: "not-called-token",
+	}}}
+	calls := 0
+
+	outcomes, enabled, err := provideridentity.AutoRefresh(
+		t.Context(), cfg, st, source.ID,
+		func(string) provideridentity.Inventory {
+			calls++
+			return &fakeInventory{}
+		},
+	)
+
+	requirements.NoError(err)
+	assertions.False(enabled)
+	assertions.Zero(calls)
+	assertions.Empty(outcomes)
+}
+
+func TestAutoRefreshAppliesOnlyStrongEvidenceAndRetryIsIdempotent(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	cfg := &config.Config{Fastmail: []config.FastmailSource{{
+		SourceID: source.ID, APIToken: "provider-token", AutoConfirmIdentities: true,
+	}}}
+	inventory := &fakeInventory{records: []fastmail.Record{
+		{Identifier: "active@example.test", State: "enabled", Kind: "masked-email"},
+		{Identifier: "old@example.test", State: "disabled", Kind: "masked-email"},
+		{Identifier: "deleted@example.test", State: "deleted", Kind: "masked-email"},
+		{Identifier: "waiting@example.test", State: "pending", Kind: "masked-email"},
+		{Identifier: "*@example.test", State: "enabled", Kind: "identity"},
+	}}
+	factory := func(string) provideridentity.Inventory { return inventory }
+
+	first, enabled, err := provideridentity.AutoRefresh(t.Context(), cfg, st, source.ID, factory)
+	requirements.NoError(err)
+	assertions.True(enabled)
+	requirements.Len(first, 3)
+	for _, outcome := range first {
+		assertions.True(outcome.Added)
+		assertions.Equal([]string{"provider-alias"}, outcome.Signals)
+	}
+
+	retry, enabled, err := provideridentity.AutoRefresh(t.Context(), cfg, st, source.ID, factory)
+	requirements.NoError(err)
+	assertions.True(enabled)
+	assertions.Empty(retry)
+	identities, err := st.ListAccountIdentities(source.ID)
+	requirements.NoError(err)
+	assertions.Len(identities, 3)
+}
+
+type countingInventory struct {
+	records []fastmail.Record
+	err     error
+	calls   int
+}
+
+func (i *countingInventory) ListIdentityRecords(context.Context) ([]fastmail.Record, error) {
+	i.calls++
+	if i.err != nil {
+		return nil, i.err
+	}
+	return append([]fastmail.Record(nil), i.records...), nil
+}
+
+func TestAutoRefreshIfDueSkipsFreshStateAndRefreshesWhenOwed(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	cfg := &config.Config{Fastmail: []config.FastmailSource{{
+		SourceID: source.ID, APIToken: "provider-token", AutoConfirmIdentities: true,
+	}}}
+	inventory := &countingInventory{records: []fastmail.Record{
+		{Identifier: "old@example.test", State: "disabled", Kind: "masked-email"},
+	}}
+	factory := func(string) provideridentity.Inventory { return inventory }
+
+	// Never refreshed: the provider read is owed even without mailbox change.
+	outcomes, enabled, err := provideridentity.AutoRefreshIfDue(t.Context(), cfg, st, source.ID, factory)
+	requirements.NoError(err)
+	assertions.True(enabled)
+	assertions.Equal(1, inventory.calls)
+	requirements.Len(outcomes, 1)
+
+	// The success was recorded, so a fresh state skips the provider entirely.
+	outcomes, enabled, err = provideridentity.AutoRefreshIfDue(t.Context(), cfg, st, source.ID, factory)
+	requirements.NoError(err)
+	assertions.True(enabled)
+	assertions.Equal(1, inventory.calls, "a fresh refresh state must skip the provider round trip")
+	assertions.Empty(outcomes)
+
+	// AutoRefresh (mailbox changed) ignores freshness.
+	_, enabled, err = provideridentity.AutoRefresh(t.Context(), cfg, st, source.ID, factory)
+	requirements.NoError(err)
+	assertions.True(enabled)
+	assertions.Equal(2, inventory.calls, "a changed mailbox always refreshes")
+}
+
+func TestAutoRefreshRecordsFailureSoNoOpSyncsRetry(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "primary@example.test")
+	requirements.NoError(err)
+	cfg := &config.Config{Fastmail: []config.FastmailSource{{
+		SourceID: source.ID, APIToken: "provider-token", AutoConfirmIdentities: true,
+	}}}
+	inventory := &countingInventory{err: errors.New("provider unavailable")}
+	factory := func(string) provideridentity.Inventory { return inventory }
+
+	_, enabled, err := provideridentity.AutoRefreshIfDue(t.Context(), cfg, st, source.ID, factory)
+	requirements.Error(err)
+	assertions.True(enabled)
+	assertions.Equal(1, inventory.calls)
+
+	// The failure was recorded, so the next no-op sync retries instead of
+	// treating the source as fresh.
+	inventory.err = nil
+	inventory.records = []fastmail.Record{
+		{Identifier: "old@example.test", State: "disabled", Kind: "masked-email"},
+	}
+	outcomes, enabled, err := provideridentity.AutoRefreshIfDue(t.Context(), cfg, st, source.ID, factory)
+	requirements.NoError(err)
+	assertions.True(enabled)
+	assertions.Equal(2, inventory.calls, "a recorded failure owes a retry")
+	requirements.Len(outcomes, 1)
+}

--- a/internal/query/cache_state.go
+++ b/internal/query/cache_state.go
@@ -17,8 +17,11 @@ import (
 // CacheSchemaVersion is the sole schema compatibility version shared by the
 // cache publisher and analytical readers. Version 15 adds the compact
 // relationship activity, people, domain, and daily read model; version 16
-// adds has_attachments to the relationship activity dataset.
-const CacheSchemaVersion = 16
+// adds has_attachments to the relationship activity dataset; version 17 adds
+// the envelope address snapshot (email_address) to message_recipients. The
+// bump forces a full rebuild so committed caches never mix recipient shards
+// with and without the column.
+const CacheSchemaVersion = 17
 
 // CacheSyncState is the commit marker written after a complete analytics
 // cache publication. SQLite remains authoritative; these watermarks only

--- a/internal/query/explore.go
+++ b/internal/query/explore.go
@@ -128,6 +128,8 @@ func (e *DuckDBEngine) Explore(ctx context.Context, request ExploreRequest) (*Ex
 		if err := json.Unmarshal([]byte(participantLabelsJSON), &row.ParticipantLabels); err != nil {
 			return nil, fmt.Errorf("decode analytical participant labels: %w", err)
 		}
+		row.MatchedSenderIdentities = make([]string, 0)
+		row.MatchedRecipientIdentities = make([]string, 0)
 		response.Rows = append(response.Rows, row)
 	}
 	if err := rows.Err(); err != nil {
@@ -306,6 +308,10 @@ func buildExploreConditions(request ExploreRequest) (string, []any) {
 		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
 	}
 	appendIntAnyOf(request.Context.SourceIDs, "source_id = ?")
+	if identityCondition, identityArgs := buildIdentityPredicateCondition(request.Context.Identity, ""); identityCondition != "" {
+		conditions = append(conditions, identityCondition)
+		args = append(args, identityArgs...)
+	}
 	if len(request.Context.ParticipantIDs) > 0 {
 		parts := make([]string, len(request.Context.ParticipantIDs))
 		for i := range parts {
@@ -398,6 +404,98 @@ func buildExploreConditions(request ExploreRequest) (string, []any) {
 		return "true", args
 	}
 	return strings.Join(conditions, " AND "), args
+}
+
+func buildIdentityPredicateCondition(identity *IdentityPredicate, prefix string) (string, []any) {
+	if identity == nil {
+		return "", nil
+	}
+	if identity.MatchNone {
+		return "false", nil
+	}
+	outerPrefix := prefix
+	if outerPrefix == "" {
+		// Correlated subqueries below also read message_recipients.message_id.
+		// Qualify the outer reference so SQL name resolution cannot bind both
+		// sides of the correlation to the inner table and turn it into a
+		// tautology.
+		outerPrefix = "analytical_entries."
+	}
+	args := []any{identity.SourceID}
+	participantMatch := func(column string) string {
+		// An email identity may legitimately resolve zero participants (a
+		// merge absorbed the alias's participant row and dropped the
+		// address); the envelope comparison still applies, so this branch
+		// renders as unmatchable instead of invalid SQL.
+		if len(identity.ParticipantIDs) == 0 {
+			return "false"
+		}
+		parts := make([]string, len(identity.ParticipantIDs))
+		for i, participantID := range identity.ParticipantIDs {
+			parts[i] = column + " = ?"
+			args = append(args, participantID)
+		}
+		return "(" + strings.Join(parts, " OR ") + ")"
+	}
+	// recipientRowMatch renders the identity comparison for one
+	// message_recipients row. For an email-shaped identity the envelope
+	// snapshot (message_recipients.email_address, written at email ingest)
+	// is authoritative: it is immutable under participant merges, so
+	// comparing it keeps one alias's filter from selecting mail sent
+	// through another alias that the merge survivor now also carries.
+	// Rows without a snapshot (legacy ingests, non-email writers) fall
+	// back to the resolved participant IDs, and non-email identifier
+	// types (phone, matrix, handles) have no envelope column at all, so
+	// they keep the participant rules that mirror baked is_from_me
+	// attribution (see ResolveAccountIdentityContext). Email comparison
+	// stays case-insensitive, matching attribution's email rule.
+	recipientRowMatch := func(alias string) string {
+		if identity.EmailIdentifier == "" {
+			return participantMatch(alias + ".participant_id")
+		}
+		args = append(args, identity.EmailIdentifier)
+		envelope := "(COALESCE(" + alias + ".email_address, '') <> '' AND LOWER(" + alias + ".email_address) = LOWER(?))"
+		if len(identity.ParticipantIDs) == 0 {
+			return envelope
+		}
+		return "(" + envelope + " OR (COALESCE(" + alias + ".email_address, '') = '' AND " +
+			participantMatch(alias+".participant_id") + "))"
+	}
+	senderCondition := func() string {
+		explicitFrom := `EXISTS (
+			SELECT 1 FROM message_recipients identity_mr_sender
+			WHERE identity_mr_sender.message_id = ` + outerPrefix + `message_id
+			  AND identity_mr_sender.recipient_type = 'from'
+			  AND ` + recipientRowMatch("identity_mr_sender") + `
+		)`
+		directFallback := `(
+			NOT EXISTS (
+				SELECT 1 FROM message_recipients identity_mr_from
+				WHERE identity_mr_from.message_id = ` + outerPrefix + `message_id
+				  AND identity_mr_from.recipient_type = 'from'
+			)
+			AND ` + participantMatch(outerPrefix+"sender_id") + `
+		)`
+		return "(" + explicitFrom + " OR " + directFallback + ")"
+	}
+	recipientCondition := func() string {
+		return `EXISTS (
+			SELECT 1 FROM message_recipients identity_mr_recipient
+			WHERE identity_mr_recipient.message_id = ` + outerPrefix + `message_id
+			  AND identity_mr_recipient.recipient_type IN ('to', 'cc', 'bcc')
+			  AND ` + recipientRowMatch("identity_mr_recipient") + `
+		)`
+	}
+	var directionCondition string
+	switch identity.Direction {
+	case IdentityDirectionAny:
+		directionCondition = "(" + senderCondition() + " OR " + recipientCondition() + ")"
+	case IdentityDirectionSender:
+		directionCondition = senderCondition()
+	case IdentityDirectionRecipient:
+		directionCondition = recipientCondition()
+	}
+	return "(" + outerPrefix + "source_id = ? AND " + directionCondition + ")", args
 }
 
 // buildExploreSQL builds the entry-row page query. counterpart_participant_id

--- a/internal/query/explore_analysis.go
+++ b/internal/query/explore_analysis.go
@@ -267,6 +267,9 @@ func exploreGroupExpressions(dimension, activityGlob, peopleGlob string) (groupE
 // unknown) IDs pass through unchanged, so archives without identity links
 // keep their exact pre-cluster filter semantics.
 func (e *DuckDBEngine) expandParticipantFilterClusters(ctx context.Context, explore ExploreRequest) (ExploreRequest, error) {
+	if err := validateIdentityPredicate(explore.Context); err != nil {
+		return explore, err
+	}
 	expanded, err := e.expandParticipantClusterMembers(ctx, explore.Context.ParticipantIDs)
 	if err != nil {
 		return explore, err
@@ -285,6 +288,43 @@ func (e *DuckDBEngine) expandParticipantFilterClusters(ctx context.Context, expl
 		explore.Context.AdditionalParticipantGroups[i] = expandedGroup
 	}
 	return explore, nil
+}
+
+func validateIdentityPredicate(analyticalContext Context) error {
+	identity := analyticalContext.Identity
+	if identity == nil {
+		return nil
+	}
+	if identity.SourceID <= 0 {
+		return fmt.Errorf("%w: identity source ID must be positive", ErrInvalidExploreRequest)
+	}
+	if identity.MatchNone && len(identity.ParticipantIDs) > 0 {
+		return fmt.Errorf("%w: identity match-none predicate cannot include participant IDs", ErrInvalidExploreRequest)
+	}
+	if identity.MatchNone && identity.EmailIdentifier != "" {
+		return fmt.Errorf("%w: identity match-none predicate cannot carry an email identifier", ErrInvalidExploreRequest)
+	}
+	// An email identity is matchable through the envelope snapshot alone,
+	// so it does not require resolved participant IDs (see
+	// IdentityPredicate.EmailIdentifier).
+	if !identity.MatchNone && len(identity.ParticipantIDs) == 0 && identity.EmailIdentifier == "" {
+		return fmt.Errorf("%w: identity participant IDs are required", ErrInvalidExploreRequest)
+	}
+	for _, participantID := range identity.ParticipantIDs {
+		if participantID <= 0 {
+			return fmt.Errorf("%w: identity participant ID must be positive", ErrInvalidExploreRequest)
+		}
+	}
+	switch identity.Direction {
+	case IdentityDirectionAny, IdentityDirectionSender, IdentityDirectionRecipient:
+	default:
+		return fmt.Errorf("%w: unknown identity direction %q", ErrInvalidExploreRequest, identity.Direction)
+	}
+	if len(analyticalContext.SourceIDs) > 0 &&
+		(len(analyticalContext.SourceIDs) != 1 || analyticalContext.SourceIDs[0] != identity.SourceID) {
+		return fmt.Errorf("%w: identity source ID must agree with context source IDs", ErrInvalidExploreRequest)
+	}
+	return nil
 }
 
 // expandParticipantClusterMembers widens a set of participant IDs to every

--- a/internal/query/explore_fastpath_test.go
+++ b/internal/query/explore_fastpath_test.go
@@ -288,6 +288,11 @@ func TestExploreParticipantContextKeepsLegacyPath(t *testing.T) {
 	assert.False(exploreConditionsTouchParticipantLists(ExploreRequest{
 		Context: Context{SourceIDs: []int64{1}, MessageTypes: []string{"email"}},
 	}))
+	assert.False(exploreConditionsTouchParticipantLists(ExploreRequest{
+		Context: Context{Identity: &IdentityPredicate{
+			SourceID: 1, ParticipantIDs: []int64{7}, Direction: IdentityDirectionAny,
+		}},
+	}), "identity predicates use bounded header-row existence checks, not participant lists")
 	assert.True(exploreConditionsTouchParticipantLists(ExploreRequest{
 		Context: Context{ParticipantIDs: []int64{7}},
 	}))

--- a/internal/query/explore_models.go
+++ b/internal/query/explore_models.go
@@ -13,11 +13,47 @@ type ExploreRequest struct {
 	Page         PageSpec     `json:"page"`
 }
 
+// IdentityDirection selects which exact address-header side an identity must match.
+type IdentityDirection string
+
+const (
+	IdentityDirectionAny       IdentityDirection = "any"
+	IdentityDirectionSender    IdentityDirection = "sender"
+	IdentityDirectionRecipient IdentityDirection = "recipient"
+)
+
+// IdentityPredicate is a source-pinned, internal analytical filter resolved
+// from confirmed account identities by the API layer.
+type IdentityPredicate struct {
+	SourceID       int64
+	ParticipantIDs []int64
+	// EmailIdentifier carries the confirmed address when it is email-shaped.
+	// Non-empty, it switches recipient-row matching to the immutable
+	// envelope snapshot (message_recipients.email_address, compared
+	// case-insensitively like every email rule): participant merges repoint
+	// recipient rows onto a survivor that may carry several aliases, so a
+	// participant-only match would let one alias's filter select another
+	// alias's mail. ParticipantIDs stay as the fallback for rows without a
+	// snapshot (legacy ingests, direct chat senders). Empty means the
+	// confirmed identifier has no envelope surface (phone, matrix, handle)
+	// and matching uses ParticipantIDs alone, mirroring baked is_from_me
+	// attribution.
+	EmailIdentifier string
+	// MatchNone represents a confirmed non-email identity that has not
+	// appeared in message metadata yet. It is valid but must return an
+	// empty result. Email identities never short-circuit this way: their
+	// envelope snapshot can match even when no participant carries the
+	// address any more.
+	MatchNone bool
+	Direction IdentityDirection
+}
+
 // Context narrows the archive before logical chat rows are aggregated.
 type Context struct {
-	SourceIDs      []int64  `json:"source_ids,omitempty"`
-	ParticipantIDs []int64  `json:"participant_ids,omitempty"`
-	Domains        []string `json:"domains,omitempty"`
+	SourceIDs      []int64            `json:"source_ids,omitempty"`
+	ParticipantIDs []int64            `json:"participant_ids,omitempty"`
+	Domains        []string           `json:"domains,omitempty"`
+	Identity       *IdentityPredicate `json:"-"`
 	// AdditionalParticipantGroups holds extra participant filters beyond the
 	// primary ParticipantIDs group. Each inner slice is OR'd internally (any
 	// member matches) but the groups themselves are AND'd together, and
@@ -122,21 +158,23 @@ type SearchProvenance struct {
 // EntryRow is one logical archive row. Chat/text rows aggregate messages only
 // after Context has been applied; other modalities retain durable item units.
 type EntryRow struct {
-	Key               string       `json:"key"`
-	Kind              EntryKind    `json:"kind"`
-	AnchorMessageID   *int64       `json:"anchor_message_id,omitempty"`
-	ConversationID    *int64       `json:"conversation_id,omitempty"`
-	OccurredAt        time.Time    `json:"occurred_at"`
-	Match             MatchSummary `json:"match"`
-	SourceID          int64        `json:"source_id"`
-	SourceType        string       `json:"source_type"`
-	SourceIdentifier  string       `json:"source_identifier"`
-	MessageType       string       `json:"message_type"`
-	ConversationType  string       `json:"conversation_type"`
-	Title             string       `json:"title"`
-	Preview           string       `json:"preview"`
-	ParticipantIDs    []int64      `json:"participant_ids,omitempty"`
-	ParticipantLabels []string     `json:"participant_labels,omitempty"`
+	Key                        string       `json:"key"`
+	Kind                       EntryKind    `json:"kind"`
+	AnchorMessageID            *int64       `json:"anchor_message_id,omitempty"`
+	ConversationID             *int64       `json:"conversation_id,omitempty"`
+	OccurredAt                 time.Time    `json:"occurred_at"`
+	Match                      MatchSummary `json:"match"`
+	SourceID                   int64        `json:"source_id"`
+	SourceType                 string       `json:"source_type"`
+	SourceIdentifier           string       `json:"source_identifier"`
+	MessageType                string       `json:"message_type"`
+	ConversationType           string       `json:"conversation_type"`
+	Title                      string       `json:"title"`
+	Preview                    string       `json:"preview"`
+	ParticipantIDs             []int64      `json:"participant_ids,omitempty"`
+	ParticipantLabels          []string     `json:"participant_labels,omitempty"`
+	MatchedSenderIdentities    []string     `json:"matched_sender_identities" nullable:"false"`
+	MatchedRecipientIdentities []string     `json:"matched_recipient_identities" nullable:"false"`
 	// StrongestMatchedMessageID is bounded internal semantic-ranking state.
 	// It is never serialized and is nil for no-search and full-text rows.
 	StrongestMatchedMessageID *int64 `json:"-"`

--- a/internal/query/explore_test.go
+++ b/internal/query/explore_test.go
@@ -362,6 +362,488 @@ func TestExploreAppliesContextBeforeChatAggregation(t *testing.T) {
 	assert.Equal(int64(2), response.Rows[0].MessageCount, "chat facts must be computed after context filtering")
 }
 
+func TestExploreIdentityDirectionSeparatesSenderAndRecipientWithinSource(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	sourceA := b.AddSource("archive-a@example.com")
+	sourceB := b.AddSource("archive-b@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	sent := b.AddMessage(MessageOpt{SourceID: sourceA, Subject: "sent", SentAt: base})
+	b.AddFrom(sent, otherID, "Other")
+	b.AddFrom(sent, identityID, "Identity")
+	b.AddTo(sent, otherID, "Other")
+	received := b.AddMessage(MessageOpt{SourceID: sourceA, Subject: "received", SentAt: base.Add(-time.Hour)})
+	b.AddFrom(received, otherID, "Other")
+	b.AddTo(received, identityID, "Identity")
+	otherSource := b.AddMessage(MessageOpt{SourceID: sourceB, Subject: "other source", SentAt: base.Add(time.Hour)})
+	b.AddFrom(otherSource, identityID, "Identity")
+
+	engine := b.BuildEngine()
+	explore := func(direction IdentityDirection) *ExploreResponse {
+		result, err := engine.Explore(context.Background(), ExploreRequest{
+			Context: Context{Identity: &IdentityPredicate{
+				SourceID: sourceA, ParticipantIDs: []int64{identityID}, Direction: direction,
+			}},
+			Page: PageSpec{Limit: 10},
+		})
+		requirements.NoError(err)
+		return result
+	}
+
+	sender := explore(IdentityDirectionSender)
+	requirements.Len(sender.Rows, 1)
+	assertions.Equal("sent", sender.Rows[0].Title)
+	assertions.Equal(sourceA, sender.Rows[0].SourceID)
+	assertions.Equal(int64(1), sender.TotalCount)
+
+	recipient := explore(IdentityDirectionRecipient)
+	requirements.Len(recipient.Rows, 1)
+	assertions.Equal("received", recipient.Rows[0].Title)
+	assertions.Equal(sourceA, recipient.Rows[0].SourceID)
+	assertions.Equal(int64(1), recipient.TotalCount)
+
+	anyDirection := explore(IdentityDirectionAny)
+	requirements.Len(anyDirection.Rows, 2)
+	assertions.Equal([]string{"sent", "received"}, []string{anyDirection.Rows[0].Title, anyDirection.Rows[1].Title})
+	for _, row := range anyDirection.Rows {
+		assertions.Equal(sourceA, row.SourceID, "identity predicate must not leak to another source")
+	}
+}
+
+func TestExploreIdentitySenderUsesDirectSenderOnlyWithoutFromRows(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	explicitFromID := b.AddParticipant("explicit@example.net", "example.net", "Explicit")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	multiFrom := b.AddMessage(MessageOpt{SourceID: source, Subject: "multi from", SenderID: &explicitFromID, SentAt: base})
+	b.AddFrom(multiFrom, explicitFromID, "Explicit")
+	b.AddFrom(multiFrom, identityID, "Identity")
+	directConflict := b.AddMessage(MessageOpt{SourceID: source, Subject: "direct conflict", SenderID: &identityID, SentAt: base.Add(-time.Hour)})
+	b.AddFrom(directConflict, explicitFromID, "Explicit")
+	b.AddMessage(MessageOpt{SourceID: source, Subject: "direct fallback", SenderID: &identityID, SentAt: base.Add(-2 * time.Hour)})
+
+	result, err := b.BuildEngine().Explore(context.Background(), ExploreRequest{
+		Context: Context{Identity: &IdentityPredicate{
+			SourceID: source, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionSender,
+		}},
+		Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err)
+	requirements.Len(result.Rows, 2)
+	assertions.Equal([]string{"multi from", "direct fallback"}, []string{result.Rows[0].Title, result.Rows[1].Title})
+	assertions.Equal(int64(2), result.TotalCount)
+}
+
+func TestExploreIdentityPredicateAppliesBeforeChatAggregation(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSourceWithType("+15550000000", messageTypeIMessage)
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	const conversationID = int64(812)
+
+	sent := b.AddMessage(MessageOpt{SourceID: source, ConversationID: conversationID, MessageType: messageTypeIMessage, ConversationType: "direct_chat", SenderID: &identityID})
+	b.AddFrom(sent, identityID, "Identity")
+	b.AddTo(sent, otherID, "Other")
+	received := b.AddMessage(MessageOpt{SourceID: source, ConversationID: conversationID, MessageType: messageTypeIMessage, ConversationType: "direct_chat", SenderID: &otherID})
+	b.AddFrom(received, otherID, "Other")
+	b.AddCc(received, identityID, "Identity")
+
+	engine := b.BuildEngine()
+	for _, test := range []struct {
+		direction IdentityDirection
+		wantCount int64
+	}{
+		{direction: IdentityDirectionSender, wantCount: 1},
+		{direction: IdentityDirectionRecipient, wantCount: 1},
+		{direction: IdentityDirectionAny, wantCount: 2},
+	} {
+		result, err := engine.Explore(context.Background(), ExploreRequest{
+			Context: Context{Identity: &IdentityPredicate{
+				SourceID: source, ParticipantIDs: []int64{identityID}, Direction: test.direction,
+			}},
+			Page: PageSpec{Limit: 10},
+		})
+		requirements.NoError(err, test.direction)
+		requirements.Len(result.Rows, 1, test.direction)
+		assertions.Equal(EntryConversation, result.Rows[0].Kind, test.direction)
+		assertions.Equal(test.wantCount, result.Rows[0].MessageCount, test.direction)
+	}
+}
+
+func TestExploreIdentityPredicateValidatesSourceIDsParticipantsAndDirection(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	messageID := b.AddMessage(MessageOpt{SourceID: source})
+	b.AddFrom(messageID, identityID, "Identity")
+	engine := b.BuildEngine()
+
+	tests := []struct {
+		name      string
+		context   Context
+		wantError string
+	}{
+		{name: "missing source", context: Context{Identity: &IdentityPredicate{ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionAny}}, wantError: "source ID"},
+		{name: "missing participant IDs", context: Context{Identity: &IdentityPredicate{SourceID: source, Direction: IdentityDirectionAny}}, wantError: "participant IDs"},
+		{name: "match none with participant IDs", context: Context{Identity: &IdentityPredicate{SourceID: source, ParticipantIDs: []int64{identityID}, MatchNone: true, Direction: IdentityDirectionAny}}, wantError: "match-none"},
+		{name: "zero participant ID", context: Context{Identity: &IdentityPredicate{SourceID: source, ParticipantIDs: []int64{0}, Direction: IdentityDirectionAny}}, wantError: "participant ID"},
+		{name: "invalid direction", context: Context{Identity: &IdentityPredicate{SourceID: source, ParticipantIDs: []int64{identityID}, Direction: "sideways"}}, wantError: "identity direction"},
+		{name: "mismatched source", context: Context{SourceIDs: []int64{source + 1}, Identity: &IdentityPredicate{SourceID: source, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionAny}}, wantError: "source IDs"},
+		{name: "multiple sources", context: Context{SourceIDs: []int64{source, source + 1}, Identity: &IdentityPredicate{SourceID: source, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionAny}}, wantError: "source IDs"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			_, err := engine.Explore(context.Background(), ExploreRequest{Context: test.context})
+			requirements.Error(err)
+			requirements.ErrorContains(err, test.wantError)
+			assertions.ErrorIs(err, ErrInvalidExploreRequest)
+		})
+	}
+
+	valid, err := engine.Explore(context.Background(), ExploreRequest{Context: Context{
+		Identity: &IdentityPredicate{SourceID: source, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionAny},
+	}})
+	requirements.NoError(err, "the source-pinned predicate is valid without a redundant SourceIDs field")
+	assertions.Equal(int64(1), valid.TotalCount)
+
+	matchingSource, err := engine.Explore(context.Background(), ExploreRequest{Context: Context{
+		SourceIDs: []int64{source},
+		Identity:  &IdentityPredicate{SourceID: source, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionAny},
+	}})
+	requirements.NoError(err)
+	assertions.Equal(int64(1), matchingSource.TotalCount)
+
+	matchNone, err := engine.Explore(context.Background(), ExploreRequest{Context: Context{
+		Identity: &IdentityPredicate{SourceID: source, MatchNone: true, Direction: IdentityDirectionAny},
+	}})
+	requirements.NoError(err, "a confirmed identity without observed participants is a valid empty filter")
+	assertions.Zero(matchNone.TotalCount)
+	assertions.Empty(matchNone.Rows)
+}
+
+// TestExploreIdentityFilterPrefersEnvelopeAddressOverMergedParticipant models
+// the post-merge archive: one surviving participant row backs mail sent
+// through two different envelope addresses. Filtering on one alias must
+// select only that alias's envelope rows, not everything the survivor
+// participant touches.
+func TestExploreIdentityFilterPrefersEnvelopeAddressOverMergedParticipant(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.com")
+	survivorID := b.AddParticipant("alias-b@example.com", "example.com", "Survivor")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	sentViaA := b.AddMessage(MessageOpt{SourceID: source, Subject: "sent via a", SentAt: base})
+	b.AddRecipientWithEnvelope(sentViaA, survivorID, "from", "Survivor", "alias-a@example.com")
+	b.AddTo(sentViaA, otherID, "Other")
+	sentViaB := b.AddMessage(MessageOpt{SourceID: source, Subject: "sent via b", SentAt: base.Add(-time.Hour)})
+	b.AddRecipientWithEnvelope(sentViaB, survivorID, "from", "Survivor", "alias-b@example.com")
+	receivedAtA := b.AddMessage(MessageOpt{SourceID: source, Subject: "received at a", SentAt: base.Add(-2 * time.Hour)})
+	b.AddFrom(receivedAtA, otherID, "Other")
+	b.AddRecipientWithEnvelope(receivedAtA, survivorID, "to", "Survivor", "alias-a@example.com")
+	receivedAtB := b.AddMessage(MessageOpt{SourceID: source, Subject: "received at b", SentAt: base.Add(-3 * time.Hour)})
+	b.AddFrom(receivedAtB, otherID, "Other")
+	b.AddRecipientWithEnvelope(receivedAtB, survivorID, "cc", "Survivor", "alias-b@example.com")
+
+	engine := b.BuildEngine()
+	explore := func(direction IdentityDirection, emailIdentifier string) *ExploreResponse {
+		result, err := engine.Explore(context.Background(), ExploreRequest{
+			Context: Context{Identity: &IdentityPredicate{
+				SourceID:        source,
+				ParticipantIDs:  []int64{survivorID},
+				EmailIdentifier: emailIdentifier,
+				Direction:       direction,
+			}},
+			Page: PageSpec{Limit: 10},
+		})
+		requirements.NoError(err)
+		return result
+	}
+
+	sender := explore(IdentityDirectionSender, "alias-a@example.com")
+	requirements.Len(sender.Rows, 1, "alias A sender filter must not match alias B's envelope")
+	assertions.Equal("sent via a", sender.Rows[0].Title)
+
+	recipient := explore(IdentityDirectionRecipient, "alias-a@example.com")
+	requirements.Len(recipient.Rows, 1, "alias A recipient filter must not match alias B's envelope")
+	assertions.Equal("received at a", recipient.Rows[0].Title)
+
+	anyDirection := explore(IdentityDirectionAny, "ALIAS-A@EXAMPLE.COM")
+	requirements.Len(anyDirection.Rows, 2, "envelope comparison stays case-insensitive for emails")
+	assertions.Equal(int64(2), anyDirection.TotalCount)
+
+	participantOnly := explore(IdentityDirectionAny, "")
+	assertions.Equal(int64(4), participantOnly.TotalCount,
+		"without an email identifier the participant rules stay in force")
+}
+
+// TestExploreIdentityFilterFallsBackToParticipantForRowsWithoutEnvelope locks
+// in the legacy contract on the analytical path: recipient rows whose
+// envelope snapshot is empty keep matching through the resolved participant
+// IDs even when the filter carries an email identifier.
+func TestExploreIdentityFilterFallsBackToParticipantForRowsWithoutEnvelope(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	legacySent := b.AddMessage(MessageOpt{SourceID: source, Subject: "legacy sent", SentAt: base})
+	b.AddFrom(legacySent, identityID, "Identity")
+	unrelated := b.AddMessage(MessageOpt{SourceID: source, Subject: "unrelated", SentAt: base.Add(-time.Hour)})
+	b.AddFrom(unrelated, otherID, "Other")
+	directChat := b.AddMessage(MessageOpt{SourceID: source, Subject: "direct chat", SenderID: &identityID, SentAt: base.Add(-2 * time.Hour)})
+	_ = directChat
+
+	result, err := b.BuildEngine().Explore(context.Background(), ExploreRequest{
+		Context: Context{Identity: &IdentityPredicate{
+			SourceID:        source,
+			ParticipantIDs:  []int64{identityID},
+			EmailIdentifier: "identity@example.com",
+			Direction:       IdentityDirectionSender,
+		}},
+		Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err)
+	requirements.Len(result.Rows, 2)
+	assertions.Equal([]string{"legacy sent", "direct chat"},
+		[]string{result.Rows[0].Title, result.Rows[1].Title},
+		"empty-envelope rows and direct senders keep the participant fallback")
+}
+
+// TestExploreIdentityFilterMatchesEnvelopeWithoutParticipantEvidence covers
+// the merge edge where no participant row carries the alias any more (the
+// absorbed email vanished from every participant surface): the envelope
+// snapshot alone must still select the alias's mail.
+func TestExploreIdentityFilterMatchesEnvelopeWithoutParticipantEvidence(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.com")
+	survivorID := b.AddParticipant("alias-b@example.com", "example.com", "Survivor")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	sentViaA := b.AddMessage(MessageOpt{SourceID: source, Subject: "sent via a", SentAt: base})
+	b.AddRecipientWithEnvelope(sentViaA, survivorID, "from", "Survivor", "alias-a@example.com")
+	sentViaB := b.AddMessage(MessageOpt{SourceID: source, Subject: "sent via b", SentAt: base.Add(-time.Hour)})
+	b.AddRecipientWithEnvelope(sentViaB, survivorID, "from", "Survivor", "alias-b@example.com")
+	directOnly := b.AddMessage(MessageOpt{SourceID: source, Subject: "direct only", SenderID: &survivorID, SentAt: base.Add(-2 * time.Hour)})
+	_ = directOnly
+
+	result, err := b.BuildEngine().Explore(context.Background(), ExploreRequest{
+		Context: Context{Identity: &IdentityPredicate{
+			SourceID:        source,
+			EmailIdentifier: "alias-a@example.com",
+			Direction:       IdentityDirectionAny,
+		}},
+		Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err, "an envelope-only email identity is a valid predicate without participant IDs")
+	requirements.Len(result.Rows, 1)
+	assertions.Equal("sent via a", result.Rows[0].Title,
+		"only the alias's own envelope rows match; no participant fallback exists to widen the result")
+}
+
+// TestExploreIdentityFilterLegacyCacheWithoutEnvelopeColumnFallsBack proves a
+// committed cache written before the envelope column existed keeps serving
+// identity filters with the participant semantics instead of erroring.
+func TestExploreIdentityFilterLegacyCacheWithoutEnvelopeColumnFallsBack(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	b.SetLegacyRecipientSchema()
+	source := b.AddSource("archive@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	sent := b.AddMessage(MessageOpt{SourceID: source, Subject: "legacy cache sent", SentAt: base})
+	b.AddFrom(sent, identityID, "Identity")
+	unrelated := b.AddMessage(MessageOpt{SourceID: source, Subject: "unrelated", SentAt: base.Add(-time.Hour)})
+	b.AddFrom(unrelated, otherID, "Other")
+
+	result, err := b.BuildEngine().Explore(context.Background(), ExploreRequest{
+		Context: Context{Identity: &IdentityPredicate{
+			SourceID:        source,
+			ParticipantIDs:  []int64{identityID},
+			EmailIdentifier: "identity@example.com",
+			Direction:       IdentityDirectionSender,
+		}},
+		Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err, "a pre-v17 cache without the envelope column must not error")
+	requirements.Len(result.Rows, 1)
+	assertions.Equal("legacy cache sent", result.Rows[0].Title)
+}
+
+func TestExploreIdentityPredicateScopesCountsGroupsSelectionAndSearchCandidates(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	matchingFirst := b.AddMessage(MessageOpt{SourceID: source, Subject: "matching first", SentAt: base})
+	b.AddFrom(matchingFirst, identityID, "Identity")
+	b.AddAttachment(matchingFirst, 10, "first.txt")
+	matchingSecond := b.AddMessage(MessageOpt{SourceID: source, Subject: "matching second", SentAt: base.Add(-time.Hour)})
+	b.AddFrom(matchingSecond, identityID, "Identity")
+	nonmatching := b.AddMessage(MessageOpt{SourceID: source, Subject: "nonmatching", SentAt: base.Add(-2 * time.Hour)})
+	b.AddFrom(nonmatching, otherID, "Other")
+	b.AddAttachment(nonmatching, 20, "other.txt")
+	engine := b.BuildEngine()
+	identityContext := Context{Identity: &IdentityPredicate{
+		SourceID: source, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionSender,
+	}}
+
+	page, err := engine.Explore(context.Background(), ExploreRequest{Context: identityContext, Page: PageSpec{Limit: 1}})
+	requirements.NoError(err)
+	requirements.Len(page.Rows, 1)
+	assertions.Equal("matching first", page.Rows[0].Title)
+	assertions.Equal(int64(2), page.TotalCount)
+
+	offset, err := engine.Explore(context.Background(), ExploreRequest{Context: identityContext, Page: PageSpec{Limit: 1, Offset: 1}})
+	requirements.NoError(err)
+	requirements.Len(offset.Rows, 1)
+	assertions.Equal("matching second", offset.Rows[0].Title)
+	assertions.Equal(int64(2), offset.TotalCount)
+
+	grouped, err := engine.ExploreGroups(context.Background(), ExploreGroupRequest{
+		Explore: ExploreRequest{Context: identityContext}, Dimension: "year",
+		Sort: SortSpec{Field: "count", Direction: "desc"}, Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err)
+	requirements.Len(grouped.Rows, 1)
+	assertions.Equal(int64(2), grouped.Rows[0].Count)
+
+	selection, err := engine.ExploreSelectionStats(context.Background(), ExploreSelectionRequest{
+		Explore: ExploreRequest{Context: identityContext},
+	})
+	requirements.NoError(err)
+	assertions.Equal(int64(2), selection.Count)
+	assertions.Equal(int64(1), selection.FileCount)
+
+	exploreFiles, err := engine.ExploreFiles(context.Background(), ExploreFilesRequest{
+		Explore: ExploreRequest{Context: identityContext}, Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err)
+	requirements.Len(exploreFiles.Files, 1)
+	assertions.Equal("first.txt", exploreFiles.Files[0].Filename)
+	assertions.Equal(int64(1), exploreFiles.TotalCount)
+
+	generation := int64(7)
+	for _, test := range []struct {
+		name   string
+		search SearchSpec
+	}{
+		{name: "full text", search: SearchSpec{Mode: SearchFullText, Query: "match", CandidateMessageIDs: []int64{matchingFirst, nonmatching}, LexicalIndexRevision: "fts5:test"}},
+		{name: "semantic", search: SearchSpec{Mode: SearchSemantic, Query: "match", CandidateMessageIDs: []int64{matchingFirst, nonmatching}, VectorGeneration: &generation}},
+		{name: "hybrid", search: SearchSpec{Mode: SearchHybrid, Query: "match", CandidateMessageIDs: []int64{matchingFirst, nonmatching}, LexicalIndexRevision: "fts5:test", VectorGeneration: &generation}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, searchErr := engine.Explore(context.Background(), ExploreRequest{
+				Context: identityContext, Search: test.search, Page: PageSpec{Limit: 10},
+			})
+			require.NoError(t, searchErr)
+			require.Len(t, result.Rows, 1)
+			assert.Equal(t, matchingFirst, *result.Rows[0].AnchorMessageID)
+		})
+	}
+
+	matchCounts, err := engine.ExploreMatchCounts(context.Background(), ExploreMatchCountsRequest{
+		Explore: ExploreRequest{Context: identityContext, Search: SearchSpec{
+			Mode: SearchFullText, Query: "match", CandidateMessageIDs: []int64{matchingFirst, nonmatching}, LexicalIndexRevision: "fts5:test",
+		}},
+		RowKeys: []string{"source:1:message:msg1", "source:1:message:msg3"},
+	})
+	requirements.NoError(err)
+	assertions.Equal(map[string]int64{"source:1:message:msg1": 1, "source:1:message:msg3": 0}, matchCounts.Counts)
+	assertions.NotEqual(matchingSecond, nonmatching)
+}
+
+func TestExploreIdentityPredicateScopesRelationshipTimeline(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	sourceA := b.AddSource("archive-a@example.com")
+	sourceB := b.AddSource("archive-b@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	counterpartID := b.AddParticipant("counterpart@example.org", "example.org", "Counterpart")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	matching := b.AddMessage(MessageOpt{SourceID: sourceA, Subject: "matching", SentAt: base})
+	b.AddFrom(matching, identityID, "Identity")
+	b.AddTo(matching, counterpartID, "Counterpart")
+	nonmatching := b.AddMessage(MessageOpt{SourceID: sourceA, Subject: "nonmatching", SentAt: base.Add(-time.Hour)})
+	b.AddFrom(nonmatching, otherID, "Other")
+	b.AddTo(nonmatching, counterpartID, "Counterpart")
+	otherSource := b.AddMessage(MessageOpt{SourceID: sourceB, Subject: "other source", SentAt: base.Add(time.Hour)})
+	b.AddFrom(otherSource, identityID, "Identity")
+	b.AddTo(otherSource, counterpartID, "Counterpart")
+
+	result, err := b.BuildEngine().RelationshipTimeline(context.Background(), RelationshipTimelineRequest{
+		CanonicalID: counterpartID,
+		Context: Context{SourceIDs: []int64{sourceA}, Identity: &IdentityPredicate{
+			SourceID: sourceA, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionSender,
+		}},
+		Limit: 10,
+	})
+	requirements.NoError(err)
+	requirements.Len(result.Rows, 1)
+	assertions.Equal("matching", result.Rows[0].Title)
+	assertions.Equal(sourceA, result.Rows[0].SourceID)
+	assertions.Equal(int64(1), result.TotalCount)
+}
+
+func TestExploreIdentityPredicateScopesPeopleGrouping(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	counterpartID := b.AddParticipant("counterpart@example.org", "example.org", "Counterpart")
+
+	matching := b.AddMessage(MessageOpt{SourceID: source, Subject: "matching"})
+	b.AddFrom(matching, identityID, "Identity")
+	b.AddTo(matching, counterpartID, "Counterpart")
+	nonmatching := b.AddMessage(MessageOpt{SourceID: source, Subject: "nonmatching"})
+	b.AddFrom(nonmatching, otherID, "Other")
+	b.AddTo(nonmatching, counterpartID, "Counterpart")
+
+	result, err := b.BuildEngine().SearchPeople(context.Background(), PersonSearchRequest{
+		Explore: ExploreRequest{Context: Context{Identity: &IdentityPredicate{
+			SourceID: source, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionSender,
+		}}},
+		Sort: SortSpec{Field: "activity_count", Direction: "desc"}, Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err)
+	requirements.Len(result.Rows, 2)
+	assertions.ElementsMatch([]int64{identityID, counterpartID}, []int64{result.Rows[0].ID, result.Rows[1].ID})
+	assertions.NotContains([]int64{result.Rows[0].ID, result.Rows[1].ID}, otherID)
+	assertions.Equal(int64(2), result.TotalCount)
+}
+
 func TestExploreKeepsDurableCallsAsIndividualItemsInsideChatConversations(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/query/files_test.go
+++ b/internal/query/files_test.go
@@ -54,6 +54,69 @@ func TestSearchFilesAppliesCanonicalContextAndFileFilters(t *testing.T) {
 	assertions.NotEmpty(result.CacheRevision)
 }
 
+func TestFilesIdentityPredicateSeparatesDirectionsAndSources(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	b := NewTestDataBuilder(t)
+	sourceA := b.AddSource("archive-a@example.com")
+	sourceB := b.AddSource("archive-b@example.com")
+	identityID := b.AddParticipant("identity@example.com", "example.com", "Identity")
+	otherID := b.AddParticipant("other@example.net", "example.net", "Other")
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	sent := b.AddMessage(MessageOpt{SourceID: sourceA, Subject: "sent", SentAt: base})
+	b.AddFrom(sent, identityID, "Identity")
+	b.AddTo(sent, otherID, "Other")
+	b.AddAttachmentWithMIME(801, sent, 10, "sent.pdf", "application/pdf")
+	received := b.AddMessage(MessageOpt{SourceID: sourceA, Subject: "received", SentAt: base.Add(-time.Hour)})
+	b.AddFrom(received, otherID, "Other")
+	b.AddRecipient(received, identityID, "bcc", "Identity")
+	b.AddAttachmentWithMIME(802, received, 20, "received.pdf", "application/pdf")
+	otherSource := b.AddMessage(MessageOpt{SourceID: sourceB, Subject: "other source", SentAt: base.Add(time.Hour)})
+	b.AddFrom(otherSource, identityID, "Identity")
+	b.AddAttachmentWithMIME(803, otherSource, 30, "other-source.pdf", "application/pdf")
+
+	engine := b.BuildEngine()
+	search := func(direction IdentityDirection) *FileSearchResponse {
+		result, err := engine.SearchFiles(context.Background(), FileSearchRequest{
+			Explore: ExploreRequest{Context: Context{Identity: &IdentityPredicate{
+				SourceID: sourceA, ParticipantIDs: []int64{identityID}, Direction: direction,
+			}}},
+			Sort: SortSpec{Field: sortFieldOccurredAt, Direction: "desc"}, Page: PageSpec{Limit: 10},
+		})
+		requirements.NoError(err)
+		return result
+	}
+
+	sender := search(IdentityDirectionSender)
+	requirements.Len(sender.Files, 1)
+	assertions.Equal("sent.pdf", sender.Files[0].Filename)
+	assertions.Equal(sourceA, sender.Files[0].SourceID)
+	assertions.Equal(int64(1), sender.TotalCount)
+
+	recipient := search(IdentityDirectionRecipient)
+	requirements.Len(recipient.Files, 1)
+	assertions.Equal("received.pdf", recipient.Files[0].Filename)
+	assertions.Equal(sourceA, recipient.Files[0].SourceID)
+	assertions.Equal(int64(1), recipient.TotalCount)
+
+	anyDirection := search(IdentityDirectionAny)
+	requirements.Len(anyDirection.Files, 2)
+	assertions.Equal([]string{"sent.pdf", "received.pdf"}, []string{anyDirection.Files[0].Filename, anyDirection.Files[1].Filename})
+	assertions.Equal(int64(2), anyDirection.TotalCount)
+
+	grouped, err := engine.GroupFiles(context.Background(), FileGroupRequest{
+		Explore: ExploreRequest{Context: Context{Identity: &IdentityPredicate{
+			SourceID: sourceA, ParticipantIDs: []int64{identityID}, Direction: IdentityDirectionAny,
+		}}},
+		Dimension: "source", Sort: SortSpec{Field: "count", Direction: "desc"}, Page: PageSpec{Limit: 10},
+	})
+	requirements.NoError(err)
+	requirements.Len(grouped.Rows, 1)
+	assertions.Equal("1", grouped.Rows[0].Key)
+	assertions.Equal(int64(2), grouped.Rows[0].Count)
+}
+
 func TestSearchFilesFlattensSnippetMarkupInContainingTitle(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)

--- a/internal/query/identity_activity.go
+++ b/internal/query/identity_activity.go
@@ -12,6 +12,7 @@ import (
 func identityRequestIsUnfiltered(request ExploreRequest) bool {
 	context := request.Context
 	return len(context.SourceIDs) == 0 &&
+		context.Identity == nil &&
 		len(context.ParticipantIDs) == 0 &&
 		len(context.Domains) == 0 &&
 		len(context.AdditionalParticipantGroups) == 0 &&
@@ -269,6 +270,14 @@ func buildIdentityFactConditions(request ExploreRequest, activityPath string) (s
 		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
 	}
 	appendIntGroup(request.Context.SourceIDs, "f.source_id = ?")
+	if identityCondition, identityArgs := buildIdentityPredicateCondition(request.Context.Identity, "identity_entry."); identityCondition != "" {
+		conditions = append(conditions, `(EXISTS (
+			SELECT 1 FROM analytical_entries identity_entry
+			WHERE identity_entry.message_id = f.message_id
+			  AND `+identityCondition+`
+		))`)
+		args = append(args, identityArgs...)
+	}
 	participantPredicate := `(EXISTS (
 		SELECT 1
 		FROM read_parquet('` + activityPath + `',

--- a/internal/query/mixed_archive_fixture_test.go
+++ b/internal/query/mixed_archive_fixture_test.go
@@ -26,6 +26,8 @@ func TestWriteMixedArchiveBrowserFixture(t *testing.T) {
 
 	kinds := make(map[EntryKind]int)
 	for _, row := range fixture.LogicalRows {
+		require.NotNil(row.MatchedSenderIdentities)
+		require.NotNil(row.MatchedRecipientIdentities)
 		kinds[row.Kind]++
 	}
 	require.Equal(100, kinds[EntryConversation])

--- a/internal/query/testfixtures_test.go
+++ b/internal/query/testfixtures_test.go
@@ -89,6 +89,10 @@ type RecipientFixture struct {
 	ParticipantID int64
 	Type          string // "from", "to", "cc", "bcc"
 	DisplayName   string
+	// EmailAddress is the envelope address snapshot written at email
+	// ingest. Empty models rows without a snapshot (legacy ingests,
+	// non-email writers).
+	EmailAddress string
 }
 
 // LabelFixture defines a label row for Parquet test data.
@@ -169,6 +173,9 @@ type TestDataBuilder struct {
 	participantClusters      []ParticipantClusterFixture
 
 	emptyAttachments bool // if true, write empty attachments file
+	// legacyRecipientSchema writes message_recipients without the
+	// email_address envelope column, modeling a pre-v17 cache.
+	legacyRecipientSchema bool
 }
 
 // NewTestDataBuilder creates a new typed test data builder.
@@ -321,11 +328,17 @@ func (b *TestDataBuilder) AddMessage(opt MessageOpt) int64 {
 	return id
 }
 
-// AddRecipient adds a message_recipients row.
+// AddRecipient adds a message_recipients row without an envelope snapshot.
 func (b *TestDataBuilder) AddRecipient(messageID, participantID int64, recipientType, displayName string) {
+	b.AddRecipientWithEnvelope(messageID, participantID, recipientType, displayName, "")
+}
+
+// AddRecipientWithEnvelope adds a message_recipients row carrying the
+// envelope address as it appeared in the message.
+func (b *TestDataBuilder) AddRecipientWithEnvelope(messageID, participantID int64, recipientType, displayName, emailAddress string) {
 	b.recipients = append(b.recipients, RecipientFixture{
 		MessageID: messageID, ParticipantID: participantID,
-		Type: recipientType, DisplayName: displayName,
+		Type: recipientType, DisplayName: displayName, EmailAddress: emailAddress,
 	})
 }
 
@@ -423,6 +436,12 @@ func (b *TestDataBuilder) SetEmptyAttachments() {
 	b.emptyAttachments = true
 }
 
+// SetLegacyRecipientSchema writes message_recipients without the
+// email_address envelope column, modeling a pre-v17 cache.
+func (b *TestDataBuilder) SetLegacyRecipientSchema() {
+	b.legacyRecipientSchema = true
+}
+
 // ---------------------------------------------------------------------------
 // SQL generation
 // ---------------------------------------------------------------------------
@@ -511,9 +530,15 @@ func (b *TestDataBuilder) participantIdentifiersSQL() string {
 }
 
 func (b *TestDataBuilder) recipientsSQL() string {
+	if b.legacyRecipientSchema {
+		return joinRows(b.recipients, func(r RecipientFixture) string {
+			return fmt.Sprintf("(%d::BIGINT, %d::BIGINT, %s, %s)",
+				r.MessageID, r.ParticipantID, sqlStr(r.Type), sqlStr(r.DisplayName))
+		})
+	}
 	return joinRows(b.recipients, func(r RecipientFixture) string {
-		return fmt.Sprintf("(%d::BIGINT, %d::BIGINT, %s, %s)",
-			r.MessageID, r.ParticipantID, sqlStr(r.Type), sqlStr(r.DisplayName))
+		return fmt.Sprintf("(%d::BIGINT, %d::BIGINT, %s, %s, %s)",
+			r.MessageID, r.ParticipantID, sqlStr(r.Type), sqlStr(r.DisplayName), sqlStr(r.EmailAddress))
 	})
 }
 
@@ -567,19 +592,23 @@ func (b *TestDataBuilder) participantClustersSQL() string {
 
 // column definitions (coupled to SQL generation methods above).
 const (
-	messagesCols                 = "id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, deleted_from_source_at, sender_id, message_type, is_from_me, year, month"
-	messagesColsWithDeletedAt    = "id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, deleted_at, deleted_from_source_at, sender_id, message_type, is_from_me, year, month"
-	sourcesCols                  = "id, account_email, source_type"
-	participantsCols             = "id, email_address, domain, display_name, phone_number"
-	participantIdentifiersCols   = "participant_id, identifier_type, identifier_value, display_value, is_primary"
-	messageRecipientsCols        = "message_id, participant_id, recipient_type, display_name"
-	labelsCols                   = "id, name"
-	messageLabelsCols            = "message_id, label_id"
-	attachmentsCols              = "attachment_id, message_id, size, filename, mime_type"
-	conversationsCols            = "id, source_conversation_id, title, conversation_type"
-	conversationParticipantsCols = "conversation_id, participant_id"
-	ownerParticipantsCols        = "source_id, participant_id"
-	participantClustersCols      = "participant_id, canonical_id"
+	messagesCols               = "id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, deleted_from_source_at, sender_id, message_type, is_from_me, year, month"
+	messagesColsWithDeletedAt  = "id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, deleted_at, deleted_from_source_at, sender_id, message_type, is_from_me, year, month"
+	sourcesCols                = "id, account_email, source_type"
+	participantsCols           = "id, email_address, domain, display_name, phone_number"
+	participantIdentifiersCols = "participant_id, identifier_type, identifier_value, display_value, is_primary"
+	messageRecipientsCols      = "message_id, participant_id, recipient_type, display_name"
+	// messageRecipientsColsWithEnvelope adds the envelope address snapshot
+	// (cache schema v17). messageRecipientsCols stays for fixtures that
+	// model pre-v17 caches without the column.
+	messageRecipientsColsWithEnvelope = "message_id, participant_id, recipient_type, display_name, email_address"
+	labelsCols                        = "id, name"
+	messageLabelsCols                 = "message_id, label_id"
+	attachmentsCols                   = "attachment_id, message_id, size, filename, mime_type"
+	conversationsCols                 = "id, source_conversation_id, title, conversation_type"
+	conversationParticipantsCols      = "conversation_id, participant_id"
+	ownerParticipantsCols             = "source_id, participant_id"
+	participantClustersCols           = "participant_id, canonical_id"
 )
 
 // Build generates Parquet files from the accumulated data and returns the
@@ -620,6 +649,23 @@ func (b *TestDataBuilder) addMessageTables(pb *parquetBuilder) {
 	}
 }
 
+// recipientCols returns the message_recipients column list for this
+// builder's schema mode.
+func (b *TestDataBuilder) recipientCols() string {
+	if b.legacyRecipientSchema {
+		return messageRecipientsCols
+	}
+	return messageRecipientsColsWithEnvelope
+}
+
+// recipientDummyRow returns the schema-only dummy row matching recipientCols.
+func (b *TestDataBuilder) recipientDummyRow() string {
+	if b.legacyRecipientSchema {
+		return "(0::BIGINT, 0::BIGINT, '', '')"
+	}
+	return "(0::BIGINT, 0::BIGINT, '', '', '')"
+}
+
 // addAuxiliaryTables adds sources, participants, recipients, labels, message_labels, and conversations.
 func (b *TestDataBuilder) addAuxiliaryTables(pb *parquetBuilder) {
 	auxTables := []struct {
@@ -629,7 +675,7 @@ func (b *TestDataBuilder) addAuxiliaryTables(pb *parquetBuilder) {
 		{"sources", "sources", "sources.parquet", sourcesCols, "(0::BIGINT, '', 'gmail')", b.sourcesSQL(), len(b.sources) == 0},
 		{"participants", "participants", "participants.parquet", participantsCols, "(0::BIGINT, '', '', '', '')", b.participantsSQL(), len(b.participants) == 0},
 		{"participant_identifiers", "participant_identifiers", "participant_identifiers.parquet", participantIdentifiersCols, "(0::BIGINT, '', '', '', false)", b.participantIdentifiersSQL(), len(b.participantIdentifiers) == 0},
-		{"message_recipients", "message_recipients", "message_recipients.parquet", messageRecipientsCols, "(0::BIGINT, 0::BIGINT, '', '')", b.recipientsSQL(), len(b.recipients) == 0},
+		{"message_recipients", "message_recipients", "message_recipients.parquet", b.recipientCols(), b.recipientDummyRow(), b.recipientsSQL(), len(b.recipients) == 0},
 		{"labels", "labels", "labels.parquet", labelsCols, "(0::BIGINT, '')", b.labelsSQL(), len(b.labels) == 0},
 		{"message_labels", "message_labels", "message_labels.parquet", messageLabelsCols, "(0::BIGINT, 0::BIGINT)", b.messageLabelsSQL(), len(b.msgLabels) == 0},
 		{"conversations", "conversations", "conversations.parquet", conversationsCols, "(0::BIGINT, '', '', 'email')", b.conversationsSQL(), len(b.conversations) == 0},

--- a/internal/query/views.go
+++ b/internal/query/views.go
@@ -127,6 +127,7 @@ func probeAllOptionalColumns(db *sql.DB, analyticsDir string) map[string]map[str
 		datasetConversations: probeColumns(db, tablePath(datasetConversations), false),
 		"attachments":        probeColumns(db, tablePath("attachments"), false),
 		"sources":            probeColumns(db, tablePath("sources"), false),
+		"message_recipients": probeColumns(db, tablePath("message_recipients"), false),
 	}
 }
 
@@ -244,7 +245,18 @@ func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[str
 					"CAST(recipient_type AS VARCHAR) AS recipient_type",
 					"CAST(display_name AS VARCHAR) AS display_name",
 				},
+				optionalCols: []optionalCol{{
+					// Envelope address snapshot (cache schema v17). The ''
+					// default keeps pre-v17 caches readable: an empty
+					// envelope makes identity filters fall back to
+					// participant matching (see
+					// buildIdentityPredicateCondition).
+					name:        "email_address",
+					replaceExpr: "COALESCE(CAST(email_address AS VARCHAR), '') AS email_address",
+					defaultExpr: "'' AS email_address",
+				}},
 			},
+			probe: colsFor("message_recipients"),
 		},
 		{
 			def: viewDef{

--- a/internal/store/account_identities.go
+++ b/internal/store/account_identities.go
@@ -223,24 +223,11 @@ func (s *Store) addAccountIdentityOnce(
 		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
 			return err
 		}
-
-		whereAddr := match.WhereClause("address")
-		var existing string
-		selectSQL := `SELECT source_signal FROM account_identities
-			WHERE source_id = ? AND ` + whereAddr + s.dialect.SelectForUpdate()
-		err := tx.QueryRowContext(ctx, selectSQL, sourceID, match.BindValue()).Scan(&existing)
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-			if _, err := tx.ExecContext(ctx,
-				`INSERT INTO account_identities (source_id, address, source_signal)
-					VALUES (?, ?, ?)`,
-				sourceID, addr, signal,
-			); err != nil {
-				return fmt.Errorf("insert account identity: %w", err)
-			}
-			// A brand new (source_id, address) pair changes owner_participants;
-			// merging a signal into an existing row (the default case below)
-			// does not, so only this branch bumps the revisions.
+		added, err := s.mergeAccountIdentitySignalsTx(ctx, tx, sourceID, addr, []string{signal}, match)
+		if err != nil {
+			return err
+		}
+		if added {
 			if _, err := s.bumpIdentityRevisionContext(ctx, tx); err != nil {
 				return err
 			}
@@ -252,22 +239,174 @@ func (s *Store) addAccountIdentityOnce(
 					return err
 				}
 			}
-		case err != nil:
-			return fmt.Errorf("read existing source_signal: %w", err)
-		default:
-			merged := mergeSignalSet(existing, signal)
-			if merged != existing {
-				if _, err := tx.ExecContext(ctx,
-					`UPDATE account_identities SET source_signal = ?
-						WHERE source_id = ? AND `+whereAddr,
-					merged, sourceID, match.BindValue(),
-				); err != nil {
-					return fmt.Errorf("update source_signal: %w", err)
-				}
-			}
 		}
 		return nil
 	})
+}
+
+// mergeAccountIdentitySignalsTx applies the row-level insert/signal-merge
+// semantics shared by the single and batched confirmation paths. The caller
+// must already hold lockIdentityMutationTxContext's writer lock. It reports
+// whether a new ownership row was inserted; revision policy stays with the
+// transaction owner so a batch can bump once per chunk.
+func (s *Store) mergeAccountIdentitySignalsTx(
+	ctx context.Context,
+	tx *loggedTx,
+	sourceID int64,
+	addr string,
+	signals []string,
+	match identifierMatch,
+) (bool, error) {
+	inserted, _, err := s.mergeAccountIdentitySignalsTxWith(ctx, tx, sourceID, addr, signals, match, true)
+	return inserted, err
+}
+
+// mergeAccountIdentitySignalsTxWith is the row-level merge. When allowInsert is
+// false an absent row is left alone rather than created, which is what makes
+// the refresh paths incapable of confirming ownership: the check happens inside
+// the same writer-locked transaction as the write, so a removal that lands
+// after the caller read the confirmed set cannot be undone. It reports whether
+// a row was inserted and whether one was present to merge into.
+func (s *Store) mergeAccountIdentitySignalsTxWith(
+	ctx context.Context,
+	tx *loggedTx,
+	sourceID int64,
+	addr string,
+	signals []string,
+	match identifierMatch,
+	allowInsert bool,
+) (inserted, present bool, err error) {
+	whereAddr := match.WhereClause("address")
+	var existing string
+	selectSQL := `SELECT source_signal FROM account_identities
+		WHERE source_id = ? AND ` + whereAddr + s.dialect.SelectForUpdate()
+	err = tx.QueryRowContext(ctx, selectSQL, sourceID, match.BindValue()).Scan(&existing)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		if !allowInsert {
+			return false, false, nil
+		}
+		merged := ""
+		for _, signal := range signals {
+			merged = mergeSignalSet(merged, signal)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO account_identities (source_id, address, source_signal)
+				VALUES (?, ?, ?)`,
+			sourceID, addr, merged,
+		); err != nil {
+			return false, false, fmt.Errorf("insert account identity: %w", err)
+		}
+		return true, true, nil
+	case err != nil:
+		return false, false, fmt.Errorf("read existing source_signal: %w", err)
+	default:
+		merged := existing
+		for _, signal := range signals {
+			merged = mergeSignalSet(merged, signal)
+		}
+		if merged != existing {
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE account_identities SET source_signal = ?
+					WHERE source_id = ? AND `+whereAddr,
+				merged, sourceID, match.BindValue(),
+			); err != nil {
+				return false, true, fmt.Errorf("update source_signal: %w", err)
+			}
+		}
+		return false, true, nil
+	}
+}
+
+// MergeConfirmedAccountIdentitySignalsContext merges evidence into identities
+// the source has already confirmed and never creates one. Candidates whose
+// ownership row is absent are skipped, so a refresh that scanned the archive
+// against a stale confirmed set cannot resurrect an identity removed while it
+// ran. Signal-only merges preserve revisions and confirmed_at, so no revision
+// is bumped and message attribution is left untouched.
+func (s *Store) MergeConfirmedAccountIdentitySignalsContext(
+	ctx context.Context,
+	sourceID int64,
+	candidates []IdentityConfirmation,
+) ([]IdentityConfirmationOutcome, error) {
+	normalized, err := normalizeIdentityConfirmations(candidates)
+	if err != nil {
+		return nil, err
+	}
+	outcomes := make([]IdentityConfirmationOutcome, 0, len(normalized))
+	for start := 0; start < len(normalized); start += identityConfirmationChunkSize {
+		if err := ctx.Err(); err != nil {
+			return outcomes, err
+		}
+		end := min(start+identityConfirmationChunkSize, len(normalized))
+		chunkOutcomes, err := s.mergeConfirmedAccountIdentityChunk(ctx, sourceID, normalized[start:end])
+		if err != nil {
+			return outcomes, err
+		}
+		outcomes = append(outcomes, chunkOutcomes...)
+	}
+	return outcomes, nil
+}
+
+func (s *Store) mergeConfirmedAccountIdentityChunk(
+	ctx context.Context,
+	sourceID int64,
+	confirmations []normalizedIdentityConfirmation,
+) ([]IdentityConfirmationOutcome, error) {
+	const maxAttempts = 5
+	for range maxAttempts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		outcomes, err := s.mergeConfirmedAccountIdentityChunkOnce(ctx, sourceID, confirmations)
+		if err == nil {
+			return outcomes, nil
+		}
+		if !s.dialect.IsConflictError(err) && !s.dialect.IsBusyError(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("merge confirmed account identity signals: gave up after %d retries", maxAttempts)
+}
+
+func (s *Store) mergeConfirmedAccountIdentityChunkOnce(
+	ctx context.Context,
+	sourceID int64,
+	confirmations []normalizedIdentityConfirmation,
+) ([]IdentityConfirmationOutcome, error) {
+	outcomes := make([]IdentityConfirmationOutcome, 0, len(confirmations))
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		for _, confirmation := range confirmations {
+			_, present, err := s.mergeAccountIdentitySignalsTxWith(
+				ctx,
+				tx,
+				sourceID,
+				confirmation.identifier,
+				confirmation.signals,
+				newIdentifierMatch(confirmation.identifier),
+				false,
+			)
+			if err != nil {
+				return err
+			}
+			if !present {
+				continue
+			}
+			outcomes = append(outcomes, IdentityConfirmationOutcome{
+				Identifier: confirmation.identifier,
+				Added:      false,
+				Signals:    confirmation.signals,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return outcomes, nil
 }
 
 // mergeSignalSet returns the comma-joined sorted union of the existing

--- a/internal/store/account_identities_test.go
+++ b/internal/store/account_identities_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
@@ -619,4 +620,66 @@ func TestRemoveAccountIdentity_NonEmailIsCaseSensitive(t *testing.T) {
 	removed, err := st.RemoveAccountIdentity(f.Source.ID, "alicehandle")
 	require.NoError(t, err, "RemoveAccountIdentity")
 	require.Equal(t, int64(0), removed, "removed on case-mismatch for non-email identifier")
+}
+
+// TestMergeConfirmedAccountIdentitySignalsSkipsUnconfirmedAddresses pins the
+// merge-only write boundary: refresh paths pass candidates they believe are
+// confirmed, and the store must refuse to create ownership for any address
+// whose row is absent.
+func TestMergeConfirmedAccountIdentitySignalsSkipsUnconfirmedAddresses(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+	st := f.Store
+	require.NoError(st.AddAccountIdentity(f.Source.ID, "Owner@Example.test", "manual"), "confirm identity")
+	beforeIdentityRevision, err := st.IdentityRevision()
+	require.NoError(err)
+	beforeAccountRevision, err := st.AccountIdentityRevision()
+	require.NoError(err)
+
+	outcomes, err := st.MergeConfirmedAccountIdentitySignalsContext(
+		t.Context(), f.Source.ID, []store.IdentityConfirmation{
+			{Identifier: "owner@example.test", Signals: []string{"sent-label"}},
+			{Identifier: "stranger@example.test", Signals: []string{"is_from_me", "sent-label"}},
+		})
+	require.NoError(err)
+	assert.Equal([]store.IdentityConfirmationOutcome{{
+		Identifier: "owner@example.test", Added: false, Signals: []string{"sent-label"},
+	}}, outcomes, "only the already-confirmed identity may merge")
+
+	identities, err := st.ListAccountIdentities(f.Source.ID)
+	require.NoError(err)
+	require.Len(identities, 1, "a merge must never create an ownership row")
+	assert.Equal("Owner@Example.test", identities[0].Address, "existing spelling wins case folding")
+	assert.Equal("manual,sent-label", identities[0].SourceSignal, "confirmed identity still merges signals")
+
+	afterIdentityRevision, err := st.IdentityRevision()
+	require.NoError(err)
+	afterAccountRevision, err := st.AccountIdentityRevision()
+	require.NoError(err)
+	assert.Equal(beforeIdentityRevision, afterIdentityRevision, "signal-only merge must not bump")
+	assert.Equal(beforeAccountRevision, afterAccountRevision, "signal-only merge must not bump")
+}
+
+// TestMergeConfirmedAccountIdentitySignalsDoesNotResurrectRemovedIdentity
+// covers the race the merge-only boundary exists for: a refresh reads the
+// confirmed set, the identity is removed, and the stale write arrives after.
+func TestMergeConfirmedAccountIdentitySignalsDoesNotResurrectRemovedIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+	st := f.Store
+	require.NoError(st.AddAccountIdentity(f.Source.ID, "retired@example.test", "manual"), "confirm identity")
+	stale := []store.IdentityConfirmation{{Identifier: "retired@example.test", Signals: []string{"sent-label"}}}
+	removed, err := st.RemoveAccountIdentity(f.Source.ID, "retired@example.test")
+	require.NoError(err, "remove identity after the refresh read its candidate set")
+	require.Equal(int64(1), removed)
+
+	outcomes, err := st.MergeConfirmedAccountIdentitySignalsContext(t.Context(), f.Source.ID, stale)
+	require.NoError(err)
+	assert.Empty(outcomes)
+
+	identities, err := st.ListAccountIdentities(f.Source.ID)
+	require.NoError(err)
+	assert.Empty(identities, "a stale refresh write must not resurrect a removed identity")
 }

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -257,7 +257,6 @@ func (s *Store) GetMessageContext(ctx context.Context, id int64) (*APIMessage, e
 	if err != nil {
 		return nil, err
 	}
-
 	// Get body (single PK lookup — only place we touch message_bodies)
 	var bodyText, bodyHTML sql.NullString
 	err = s.db.QueryRowContext(ctx, "SELECT body_text, body_html FROM message_bodies WHERE message_id = ?", id).Scan(&bodyText, &bodyHTML)
@@ -319,7 +318,7 @@ func (s *Store) GetMessageContext(ctx context.Context, id int64) (*APIMessage, e
 // have already filtered for live messages, and a missing row in the
 // summary set is just "ignore this hit". Recipients and labels are
 // batch-loaded with the same shape as SearchMessages, so the worst
-// case is 5 SQL round-trips regardless of len(ids). This is the
+// case remains bounded regardless of len(ids). This is the
 // designated hydration path for vector/hybrid search hits, where
 // callers loop over many MessageIDs and never need body or
 // attachments — calling GetMessage in that loop costs ~7 queries per

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -598,6 +598,7 @@ func (d *PostgreSQLDialect) LegacyColumnMigrations() []ColumnMigration {
 		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS delete_batch_id TEXT`, "delete_batch_id"},
 		{`ALTER TABLE conversations ADD COLUMN IF NOT EXISTS title TEXT`, "title"},
 		{`ALTER TABLE conversations ADD COLUMN IF NOT EXISTS conversation_type TEXT NOT NULL DEFAULT 'email_thread'`, "conversation_type"},
+		{`ALTER TABLE labels ADD COLUMN IF NOT EXISTS system_role TEXT`, "labels.system_role"},
 		// FTS tsvector column for legacy PG databases created before FTS
 		// support. Inline in schema_pg.sql's CREATE TABLE (a no-op on a
 		// pre-existing table), so without this an upgraded DB never gets the
@@ -621,6 +622,10 @@ func (d *PostgreSQLDialect) LegacyColumnMigrations() []ColumnMigration {
 		// schema.sql stamps inserts from a column DEFAULT and gets no INSERT
 		// trigger at all (SQLiteDialect.EnsureTriggers).
 		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS content_changed_at TIMESTAMPTZ`, "content_changed_at"},
+		// email_address: immutable envelope address for identity discovery.
+		// Legacy rows stay NULL (unfillable without re-parsing raw MIME) and
+		// discovery falls back to the participant's email for them.
+		{`ALTER TABLE message_recipients ADD COLUMN IF NOT EXISTS email_address TEXT`, "message_recipients.email_address"},
 	}
 }
 

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -774,6 +774,7 @@ func (d *SQLiteDialect) LegacyColumnMigrations() []ColumnMigration {
 		{`ALTER TABLE messages ADD COLUMN delete_batch_id TEXT`, "delete_batch_id"},
 		{`ALTER TABLE conversations ADD COLUMN title TEXT`, "title"},
 		{`ALTER TABLE conversations ADD COLUMN conversation_type TEXT NOT NULL DEFAULT 'email_thread'`, "conversation_type"},
+		{`ALTER TABLE labels ADD COLUMN system_role TEXT`, "labels.system_role"},
 		// embed_gen: per-message vector-embedding watermark. NULL default
 		// means every legacy row reads as "needs embedding", which is
 		// correct — the scan-and-fill worker (and backstop) will embed and
@@ -797,6 +798,10 @@ func (d *SQLiteDialect) LegacyColumnMigrations() []ColumnMigration {
 		// "now", which would make an existing archive look like every message
 		// changed at upgrade time.
 		{`ALTER TABLE messages ADD COLUMN content_changed_at DATETIME`, "content_changed_at"},
+		// email_address: immutable envelope address for identity discovery.
+		// Legacy rows stay NULL (unfillable without re-parsing raw MIME) and
+		// discovery falls back to the participant's email for them.
+		{`ALTER TABLE message_recipients ADD COLUMN email_address TEXT`, "message_recipients.email_address"},
 	}
 }
 

--- a/internal/store/identity_backlog.go
+++ b/internal/store/identity_backlog.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// identityDiscoveryBacklogKeyPrefix namespaces the per-source backlog rows in
+// archive_metadata. The row does not participate in the identity-revision lock
+// ordering documented in participant_links.go: it is only ever read and written
+// on its own, never alongside an account_identities write.
+const identityDiscoveryBacklogKeyPrefix = "identity_discovery_backlog:"
+
+// identityDiscoveryBacklogMarker records that a source owes identity discovery
+// a refresh. Discovery evidence is recomputable from the archived messages, so
+// a failed sync page parks the debt here instead of failing (and thereby
+// unwinding) an otherwise-successful sync run.
+type identityDiscoveryBacklogMarker struct {
+	LastError string `json:"last_error"`
+	FailedAt  string `json:"failed_at"`
+	Attempts  int    `json:"attempts"`
+}
+
+func identityDiscoveryBacklogKey(sourceID int64) string {
+	return identityDiscoveryBacklogKeyPrefix + strconv.FormatInt(sourceID, 10)
+}
+
+var errIdentityBacklogSourceID = errors.New("source ID must be positive")
+
+// SetIdentityDiscoveryBacklogContext marks sourceID as owing an identity
+// discovery refresh, recording cause and bumping the consecutive-failure count.
+func (s *Store) SetIdentityDiscoveryBacklogContext(
+	ctx context.Context,
+	sourceID int64,
+	cause error,
+) error {
+	if sourceID <= 0 {
+		return fmt.Errorf("set identity discovery backlog: %w", errIdentityBacklogSourceID)
+	}
+	message := ""
+	if cause != nil {
+		message = cause.Error()
+	}
+	key := identityDiscoveryBacklogKey(sourceID)
+
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		if _, err := tx.ExecContext(ctx, s.dialect.InsertOrIgnore(
+			`INSERT OR IGNORE INTO archive_metadata (key, value) VALUES (?, '')`), key,
+		); err != nil {
+			return fmt.Errorf("seed identity discovery backlog: %w", err)
+		}
+		// Read the previous value back through an UPDATE so the row is locked
+		// before the attempt count is derived from it: two concurrent syncs of
+		// the same source failing discovery at once must not both read the
+		// same count and both store count+1.
+		var previous string
+		if err := tx.QueryRowContext(ctx,
+			`UPDATE archive_metadata SET value = value WHERE key = ? RETURNING value`, key,
+		).Scan(&previous); err != nil {
+			return fmt.Errorf("lock identity discovery backlog: %w", err)
+		}
+
+		marker := identityDiscoveryBacklogMarker{
+			LastError: message,
+			FailedAt:  time.Now().UTC().Format(time.RFC3339),
+			Attempts:  1,
+		}
+		// An unreadable previous value restarts the count instead of failing
+		// the caller: the marker is a repair hint, not a ledger. The seeded
+		// empty string takes this path on the first failure.
+		var prior identityDiscoveryBacklogMarker
+		if json.Unmarshal([]byte(previous), &prior) == nil && prior.Attempts > 0 {
+			marker.Attempts = prior.Attempts + 1
+		}
+		encoded, err := json.Marshal(marker)
+		if err != nil {
+			return fmt.Errorf("encode identity discovery backlog: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE archive_metadata SET value = ? WHERE key = ?`, string(encoded), key,
+		); err != nil {
+			return fmt.Errorf("update identity discovery backlog: %w", err)
+		}
+		return nil
+	})
+}
+
+// IdentityDiscoveryBacklogContext reports whether sourceID owes an identity
+// discovery refresh, along with the error text that parked it. A source with no
+// marker is not an error condition.
+func (s *Store) IdentityDiscoveryBacklogContext(
+	ctx context.Context,
+	sourceID int64,
+) (found bool, lastError string, err error) {
+	if sourceID <= 0 {
+		return false, "", fmt.Errorf("read identity discovery backlog: %w", errIdentityBacklogSourceID)
+	}
+	var value string
+	err = s.db.QueryRowContext(ctx,
+		`SELECT value FROM archive_metadata WHERE key = ?`, identityDiscoveryBacklogKey(sourceID),
+	).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("read identity discovery backlog: %w", err)
+	}
+	// The debt is real even if the payload is not decodable, so a decode miss
+	// is a formatting question rather than a read failure: surface the raw
+	// value so the drain still runs and the operator sees what is stored.
+	var marker identityDiscoveryBacklogMarker
+	decodable := json.Unmarshal([]byte(value), &marker) == nil
+	if !decodable {
+		return true, value, nil
+	}
+	return true, marker.LastError, nil
+}
+
+// ClearIdentityDiscoveryBacklogContext drops the marker after a successful
+// refresh. Clearing an absent marker is a no-op.
+func (s *Store) ClearIdentityDiscoveryBacklogContext(ctx context.Context, sourceID int64) error {
+	if sourceID <= 0 {
+		return fmt.Errorf("clear identity discovery backlog: %w", errIdentityBacklogSourceID)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM archive_metadata WHERE key = ?`, identityDiscoveryBacklogKey(sourceID),
+	); err != nil {
+		return fmt.Errorf("clear identity discovery backlog: %w", err)
+	}
+	return nil
+}

--- a/internal/store/identity_backlog_test.go
+++ b/internal/store/identity_backlog_test.go
@@ -1,0 +1,209 @@
+package store_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type backlogMarker struct {
+	LastError string `json:"last_error"`
+	FailedAt  string `json:"failed_at"`
+	Attempts  int    `json:"attempts"`
+}
+
+// readBacklogMarker reads the raw archive_metadata row so the tests pin the
+// durable on-disk contract, not just what the accessor chooses to return.
+// The key is interpolated rather than bound because *sql.DB skips the store's
+// dialect rebinding.
+func readBacklogMarker(t *testing.T, st *store.Store, sourceID int64) backlogMarker {
+	t.Helper()
+	key := "identity_discovery_backlog:" + strconv.FormatInt(sourceID, 10)
+	var value string
+	require.NoError(t,
+		st.DB().QueryRow(`SELECT value FROM archive_metadata WHERE key = '`+key+`'`).Scan(&value),
+		"read backlog metadata row")
+	var marker backlogMarker
+	require.NoError(t, json.Unmarshal([]byte(value), &marker), "decode backlog marker JSON")
+	return marker
+}
+
+// writeRawBacklogValue plants a marker value the production writer would never
+// produce, so the tests can exercise what happens when the row has been
+// hand-edited or written by an older format. The value is interpolated rather
+// than bound because *sql.DB skips the store's dialect rebinding.
+func writeRawBacklogValue(t *testing.T, st *store.Store, sourceID int64, value string) {
+	t.Helper()
+	key := "identity_discovery_backlog:" + strconv.FormatInt(sourceID, 10)
+	_, err := st.DB().Exec(
+		`INSERT INTO archive_metadata (key, value) VALUES ('` + key + `', '` + value + `')`)
+	require.NoError(t, err, "seed raw backlog metadata row")
+}
+
+func newBacklogTestSource(t *testing.T) (*store.Store, int64) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "alice@example.test")
+	require.NoError(t, err, "GetOrCreateSource")
+	return st, source.ID
+}
+
+func TestIdentityDiscoveryBacklogSetRecordsCause(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, sourceID := newBacklogTestSource(t)
+	ctx := t.Context()
+
+	require.NoError(
+		st.SetIdentityDiscoveryBacklogContext(ctx, sourceID, errors.New("forced discovery failure")),
+		"SetIdentityDiscoveryBacklogContext")
+
+	found, lastError, err := st.IdentityDiscoveryBacklogContext(ctx, sourceID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.True(found, "marker is found after being set")
+	assert.Equal("forced discovery failure", lastError)
+
+	marker := readBacklogMarker(t, st, sourceID)
+	assert.Equal("forced discovery failure", marker.LastError)
+	assert.Equal(1, marker.Attempts, "first failure records one attempt")
+	_, parseErr := time.Parse(time.RFC3339, marker.FailedAt)
+	assert.NoError(parseErr, "failed_at is RFC3339")
+}
+
+func TestIdentityDiscoveryBacklogSetTwiceIncrementsAttempts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, sourceID := newBacklogTestSource(t)
+	ctx := t.Context()
+
+	require.NoError(
+		st.SetIdentityDiscoveryBacklogContext(ctx, sourceID, errors.New("first failure")),
+		"first SetIdentityDiscoveryBacklogContext")
+	require.NoError(
+		st.SetIdentityDiscoveryBacklogContext(ctx, sourceID, errors.New("second failure")),
+		"second SetIdentityDiscoveryBacklogContext")
+
+	marker := readBacklogMarker(t, st, sourceID)
+	assert.Equal(2, marker.Attempts, "repeated failure increments attempts")
+	assert.Equal("second failure", marker.LastError, "the most recent cause replaces the previous one")
+
+	found, lastError, err := st.IdentityDiscoveryBacklogContext(ctx, sourceID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.True(found, "marker stays set")
+	assert.Equal("second failure", lastError)
+}
+
+func TestIdentityDiscoveryBacklogClearRemovesMarker(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, sourceID := newBacklogTestSource(t)
+	ctx := t.Context()
+	require.NoError(
+		st.SetIdentityDiscoveryBacklogContext(ctx, sourceID, errors.New("forced discovery failure")),
+		"SetIdentityDiscoveryBacklogContext")
+
+	require.NoError(st.ClearIdentityDiscoveryBacklogContext(ctx, sourceID),
+		"ClearIdentityDiscoveryBacklogContext")
+
+	found, lastError, err := st.IdentityDiscoveryBacklogContext(ctx, sourceID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext after clear")
+	assert.False(found, "cleared marker is not found")
+	assert.Empty(lastError, "cleared marker reports no error text")
+
+	var rows int
+	key := "identity_discovery_backlog:" + strconv.FormatInt(sourceID, 10)
+	require.NoError(
+		st.DB().QueryRow(`SELECT COUNT(*) FROM archive_metadata WHERE key = '`+key+`'`).Scan(&rows),
+		"count backlog metadata rows")
+	assert.Equal(0, rows, "clear deletes the metadata row")
+}
+
+func TestIdentityDiscoveryBacklogReportsNotFoundWhenNeverSet(t *testing.T) {
+	st, sourceID := newBacklogTestSource(t)
+
+	found, lastError, err := st.IdentityDiscoveryBacklogContext(t.Context(), sourceID)
+
+	require.NoError(t, err, "reading an absent marker is not an error")
+	assert.False(t, found, "never-set marker is not found")
+	assert.Empty(t, lastError)
+}
+
+// TestIdentityDiscoveryBacklogSurfacesUndecodableMarker pins the deliberate
+// fallback in the getter: the debt is real whether or not its payload parses,
+// so refusing to read it would strand the very repair the marker exists for.
+func TestIdentityDiscoveryBacklogSurfacesUndecodableMarker(t *testing.T) {
+	st, sourceID := newBacklogTestSource(t)
+	writeRawBacklogValue(t, st, sourceID, "not-a-json-marker")
+
+	found, lastError, err := st.IdentityDiscoveryBacklogContext(t.Context(), sourceID)
+
+	require.NoError(t, err, "an undecodable marker is a debt to drain, not a read failure")
+	assert.True(t, found, "the drain must still run")
+	assert.Equal(t, "not-a-json-marker", lastError,
+		"the raw value is surfaced so the operator sees what is actually stored")
+}
+
+// TestIdentityDiscoveryBacklogRestartsAttemptsFromUnusablePriorValue pins the
+// matching fallback in the writer: a prior value that yields no usable count
+// restarts at one rather than failing the sync that is trying to record a
+// failure.
+func TestIdentityDiscoveryBacklogRestartsAttemptsFromUnusablePriorValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		prior string
+	}{
+		{name: "undecodable", prior: "not-a-json-marker"},
+		{
+			// A non-positive count must not be incremented into a still-wrong
+			// one; zero would be indistinguishable from restarting, so the
+			// case that actually pins the guard is a negative count.
+			name:  "negative attempts",
+			prior: `{"last_error":"old","failed_at":"2026-01-01T00:00:00Z","attempts":-5}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, sourceID := newBacklogTestSource(t)
+			writeRawBacklogValue(t, st, sourceID, tt.prior)
+
+			require.NoError(t,
+				st.SetIdentityDiscoveryBacklogContext(t.Context(), sourceID, errors.New("fresh failure")),
+				"SetIdentityDiscoveryBacklogContext")
+
+			marker := readBacklogMarker(t, st, sourceID)
+			assert.Equal(t, 1, marker.Attempts, "an unusable prior count restarts at one")
+			assert.Equal(t, "fresh failure", marker.LastError, "the new cause replaces the unusable value")
+		})
+	}
+}
+
+func TestIdentityDiscoveryBacklogIsPerSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, sourceID := newBacklogTestSource(t)
+	other, err := st.GetOrCreateSource("gmail", "bob@example.test")
+	require.NoError(err, "GetOrCreateSource")
+	ctx := t.Context()
+
+	require.NoError(
+		st.SetIdentityDiscoveryBacklogContext(ctx, sourceID, errors.New("alice failure")),
+		"SetIdentityDiscoveryBacklogContext")
+
+	found, _, err := st.IdentityDiscoveryBacklogContext(ctx, other.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext for the other source")
+	assert.False(found, "one source's backlog must not shadow another's")
+
+	require.NoError(st.ClearIdentityDiscoveryBacklogContext(ctx, other.ID),
+		"clearing an absent marker is a no-op")
+	found, _, err = st.IdentityDiscoveryBacklogContext(ctx, sourceID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext after unrelated clear")
+	assert.True(found, "clearing another source leaves this marker intact")
+}

--- a/internal/store/identity_discovery.go
+++ b/internal/store/identity_discovery.go
@@ -1,0 +1,522 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// IdentityObservation is one address occurrence in message envelope metadata.
+// Sent evidence is repeated on every participant row so callers can classify
+// From observations without loading message content or labels separately.
+type IdentityObservation struct {
+	MessageID     int64
+	Identifier    string
+	RecipientType string
+	// IsFromMe carries provider-native attribution only. Identity-derived
+	// attribution is excluded: it is computed from confirmed identities, so
+	// feeding it back would let a confirmation act as evidence for itself.
+	IsFromMe      bool
+	HasSentFolder bool
+	HasSentLabel  bool
+	ObservedAt    time.Time
+}
+
+// IdentityDiscoveryPage is one keyset-bounded page of source messages and
+// their envelope observations.
+type IdentityDiscoveryPage struct {
+	Observations []IdentityObservation
+	NextAfterID  int64
+	Scanned      int64
+}
+
+// IdentityConfirmation is one source-scoped identifier and the evidence
+// signals to merge into account_identities.
+type IdentityConfirmation struct {
+	Identifier string
+	Signals    []string
+}
+
+// IdentityConfirmationOutcome reports the deterministic input spelling and
+// signals for one normalized confirmation, plus whether this call created a
+// new source-to-identifier ownership row.
+type IdentityConfirmationOutcome struct {
+	Identifier string   `json:"identifier"`
+	Added      bool     `json:"added"`
+	Signals    []string `json:"signals"`
+}
+
+type identityDiscoveryMessage struct {
+	id         int64
+	isFromMe   bool
+	observedAt time.Time
+}
+
+// CountIdentityDiscoveryMessagesContext counts source messages rather than
+// participant or label join rows. It is used only as a progress denominator;
+// pages remain the authoritative scan unit.
+func (s *Store) CountIdentityDiscoveryMessagesContext(ctx context.Context, sourceID int64) (int64, error) {
+	var count int64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT m.id) FROM messages m WHERE m.source_id = ?`, sourceID,
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count identity discovery messages: %w", err)
+	}
+	return count, nil
+}
+
+// ScanIdentityDiscoveryPageContext reads one messages.id keyset page and then
+// loads participant/label metadata for only those message IDs.
+func (s *Store) ScanIdentityDiscoveryPageContext(
+	ctx context.Context,
+	sourceID, afterID int64,
+	limit int,
+) (IdentityDiscoveryPage, error) {
+	if limit <= 0 {
+		return IdentityDiscoveryPage{}, fmt.Errorf("identity discovery page limit must be positive: %d", limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT m.id,
+		       COALESCE(m.source_is_from_me, FALSE),
+		       COALESCE(m.sent_at, m.received_at, m.internal_date, m.archived_at)
+		FROM messages m
+		WHERE m.source_id = ? AND m.id > ?
+		ORDER BY m.id
+		LIMIT ?
+	`, sourceID, afterID, limit)
+	if err != nil {
+		return IdentityDiscoveryPage{}, fmt.Errorf("query identity discovery page: %w", err)
+	}
+
+	messages, err := scanIdentityDiscoveryMessages(rows)
+	if err != nil {
+		return IdentityDiscoveryPage{}, err
+	}
+	page := IdentityDiscoveryPage{
+		NextAfterID: afterID,
+		Scanned:     int64(len(messages)),
+	}
+	if len(messages) == 0 {
+		return page, nil
+	}
+	page.NextAfterID = messages[len(messages)-1].id
+	page.Observations, err = s.scanIdentityObservationsContext(ctx, sourceID, messages)
+	if err != nil {
+		return IdentityDiscoveryPage{}, err
+	}
+	return page, nil
+}
+
+// ScanIdentityObservationsForSourceMessageIDsContext loads the same metadata
+// observations for a bounded ingestion batch. Requested IDs are deduplicated
+// and chunked before querying so retries and oversized provider pages do not
+// duplicate observations or exceed SQLite's bind limit.
+func (s *Store) ScanIdentityObservationsForSourceMessageIDsContext(
+	ctx context.Context,
+	sourceID int64,
+	sourceMessageIDs []string,
+) ([]IdentityObservation, error) {
+	if len(sourceMessageIDs) == 0 {
+		return []IdentityObservation{}, nil
+	}
+
+	unique := make(map[string]struct{}, len(sourceMessageIDs))
+	for _, sourceMessageID := range sourceMessageIDs {
+		unique[sourceMessageID] = struct{}{}
+	}
+	deduped := make([]string, 0, len(unique))
+	for sourceMessageID := range unique {
+		deduped = append(deduped, sourceMessageID)
+	}
+	sort.Strings(deduped)
+
+	messageByID := make(map[int64]identityDiscoveryMessage)
+	err := queryInChunksContext(ctx, s.db, deduped, []any{sourceID}, `
+		SELECT m.id,
+		       COALESCE(m.source_is_from_me, FALSE),
+		       COALESCE(m.sent_at, m.received_at, m.internal_date, m.archived_at)
+		FROM messages m
+		WHERE m.source_id = ? AND m.source_message_id IN (%s)
+		ORDER BY m.id
+	`, func(rows *loggedRows) error {
+		message, scanErr := scanIdentityDiscoveryMessage(rows)
+		if scanErr != nil {
+			return scanErr
+		}
+		messageByID[message.id] = message
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query identity discovery source message IDs: %w", err)
+	}
+
+	messages := make([]identityDiscoveryMessage, 0, len(messageByID))
+	for _, message := range messageByID {
+		messages = append(messages, message)
+	}
+	sort.Slice(messages, func(i, j int) bool { return messages[i].id < messages[j].id })
+	return s.scanIdentityObservationsContext(ctx, sourceID, messages)
+}
+
+func scanIdentityDiscoveryMessages(rows *loggedRows) ([]identityDiscoveryMessage, error) {
+	defer func() { _ = rows.Close() }()
+	var messages []identityDiscoveryMessage
+	for rows.Next() {
+		message, err := scanIdentityDiscoveryMessage(rows)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate identity discovery messages: %w", err)
+	}
+	return messages, nil
+}
+
+func scanIdentityDiscoveryMessage(row scanner) (identityDiscoveryMessage, error) {
+	var message identityDiscoveryMessage
+	var observedAt nullableTimestamp
+	if err := row.Scan(&message.id, &message.isFromMe, &observedAt); err != nil {
+		return identityDiscoveryMessage{}, fmt.Errorf("scan identity discovery message: %w", err)
+	}
+	if observedAt.Valid {
+		message.observedAt = observedAt.Time.UTC()
+	}
+	return message, nil
+}
+
+func (s *Store) scanIdentityObservationsContext(
+	ctx context.Context,
+	sourceID int64,
+	messages []identityDiscoveryMessage,
+) ([]IdentityObservation, error) {
+	if len(messages) == 0 {
+		return []IdentityObservation{}, nil
+	}
+
+	messageByID := make(map[int64]identityDiscoveryMessage, len(messages))
+	messageIDs := make([]int64, len(messages))
+	for i, message := range messages {
+		messageByID[message.id] = message
+		messageIDs[i] = message.id
+	}
+
+	// The identifier is the recipient row's envelope address: it is written
+	// at ingest and never changes, so a later participant merge cannot turn
+	// one address's provider-native evidence into evidence for the merge
+	// survivor's primary email. Legacy rows ingested before the column
+	// existed fall back to the participant's current email, which remains
+	// mutable under merges; routine re-sync skips already-archived messages,
+	// so those rows keep the fallback until the message is re-ingested (a
+	// future repair command could backfill from the stored raw MIME).
+	observations := make([]IdentityObservation, 0)
+	err := queryInChunksContext(ctx, s.db, messageIDs, []any{sourceID}, `
+		SELECT m.id,
+		       COALESCE(NULLIF(mr.email_address, ''), p.email_address),
+		       mr.recipient_type,
+		       EXISTS (
+		           SELECT 1
+		           FROM message_labels ml
+		           JOIN labels l ON l.id = ml.label_id
+		           WHERE ml.message_id = m.id
+		             AND l.source_id = m.source_id
+		             AND l.system_role = 'sent'
+		       ) AS has_sent_folder,
+		       EXISTS (
+		           SELECT 1
+		           FROM message_labels ml
+		           JOIN labels l ON l.id = ml.label_id
+		           WHERE ml.message_id = m.id
+		             AND l.source_id = m.source_id
+		             AND src.source_type = 'gmail'
+		             AND l.source_label_id = 'SENT'
+		       ) AS has_sent_label
+		FROM messages m
+		JOIN sources src ON src.id = m.source_id
+		JOIN message_recipients mr ON mr.message_id = m.id
+		JOIN participants p ON p.id = mr.participant_id
+		WHERE m.source_id = ?
+		  AND m.id IN (%s)
+		  AND mr.recipient_type IN ('from', 'to', 'cc', 'bcc')
+		  AND COALESCE(NULLIF(mr.email_address, ''), p.email_address) IS NOT NULL
+		ORDER BY m.id, mr.id
+	`, func(rows *loggedRows) error {
+		var observation IdentityObservation
+		if err := rows.Scan(
+			&observation.MessageID,
+			&observation.Identifier,
+			&observation.RecipientType,
+			&observation.HasSentFolder,
+			&observation.HasSentLabel,
+		); err != nil {
+			return fmt.Errorf("scan identity observation: %w", err)
+		}
+		message := messageByID[observation.MessageID]
+		observation.IsFromMe = message.isFromMe
+		observation.ObservedAt = message.observedAt
+		observations = append(observations, observation)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query identity observations: %w", err)
+	}
+	return observations, nil
+}
+
+type normalizedIdentityConfirmation struct {
+	identifier string
+	normalized string
+	signals    []string
+}
+
+const identityConfirmationChunkSize = 500
+
+// AddAccountIdentitiesBatchContext deterministically deduplicates candidates,
+// then confirms them in short writer-locked transactions. Each chunk bumps
+// identity revisions once when it creates at least one new ownership row;
+// signal-only merges preserve both revisions and confirmed_at.
+func (s *Store) AddAccountIdentitiesBatchContext(
+	ctx context.Context,
+	sourceID int64,
+	candidates []IdentityConfirmation,
+) ([]IdentityConfirmationOutcome, error) {
+	normalized, err := normalizeIdentityConfirmations(candidates)
+	if err != nil {
+		return nil, err
+	}
+	outcomes := make([]IdentityConfirmationOutcome, 0, len(normalized))
+	for start := 0; start < len(normalized); start += identityConfirmationChunkSize {
+		if err := ctx.Err(); err != nil {
+			return outcomes, err
+		}
+		end := min(start+identityConfirmationChunkSize, len(normalized))
+		chunkOutcomes, err := s.addAccountIdentityConfirmationChunk(ctx, sourceID, normalized[start:end])
+		if err != nil {
+			return outcomes, err
+		}
+		outcomes = append(outcomes, chunkOutcomes...)
+	}
+	return outcomes, nil
+}
+
+func normalizeIdentityConfirmations(candidates []IdentityConfirmation) ([]normalizedIdentityConfirmation, error) {
+	type accumulator struct {
+		identifier string
+		signals    map[string]struct{}
+	}
+	byNormalized := make(map[string]*accumulator, len(candidates))
+	for _, candidate := range candidates {
+		identifier := strings.TrimSpace(candidate.Identifier)
+		if identifier == "" {
+			continue
+		}
+		normalized := NormalizeIdentifierForCompare(identifier)
+		entry, ok := byNormalized[normalized]
+		if !ok {
+			entry = &accumulator{identifier: identifier, signals: make(map[string]struct{})}
+			byNormalized[normalized] = entry
+		}
+		for _, signal := range candidate.Signals {
+			if strings.Contains(signal, ",") {
+				return nil, fmt.Errorf("signal names cannot contain commas: %q", signal)
+			}
+			if signal != "" {
+				entry.signals[signal] = struct{}{}
+			}
+		}
+	}
+
+	normalized := make([]normalizedIdentityConfirmation, 0, len(byNormalized))
+	for key, entry := range byNormalized {
+		signals := make([]string, 0, len(entry.signals))
+		for signal := range entry.signals {
+			signals = append(signals, signal)
+		}
+		sort.Strings(signals)
+		normalized = append(normalized, normalizedIdentityConfirmation{
+			identifier: entry.identifier,
+			normalized: key,
+			signals:    signals,
+		})
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if normalized[i].normalized == normalized[j].normalized {
+			return normalized[i].identifier < normalized[j].identifier
+		}
+		return normalized[i].normalized < normalized[j].normalized
+	})
+	return normalized, nil
+}
+
+func (s *Store) addAccountIdentityConfirmationChunk(
+	ctx context.Context,
+	sourceID int64,
+	confirmations []normalizedIdentityConfirmation,
+) ([]IdentityConfirmationOutcome, error) {
+	const maxAttempts = 5
+	for range maxAttempts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		outcomes, err := s.addAccountIdentityConfirmationChunkOnce(ctx, sourceID, confirmations)
+		if err == nil {
+			return outcomes, nil
+		}
+		if !s.dialect.IsConflictError(err) && !s.dialect.IsBusyError(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("add account identities batch: gave up after %d retries", maxAttempts)
+}
+
+func (s *Store) addAccountIdentityConfirmationChunkOnce(
+	ctx context.Context,
+	sourceID int64,
+	confirmations []normalizedIdentityConfirmation,
+) ([]IdentityConfirmationOutcome, error) {
+	outcomes := make([]IdentityConfirmationOutcome, 0, len(confirmations))
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+
+		inserted := false
+		for _, confirmation := range confirmations {
+			added, err := s.mergeAccountIdentitySignalsTx(
+				ctx,
+				tx,
+				sourceID,
+				confirmation.identifier,
+				confirmation.signals,
+				newIdentifierMatch(confirmation.identifier),
+			)
+			if err != nil {
+				return err
+			}
+			inserted = inserted || added
+			outcomes = append(outcomes, IdentityConfirmationOutcome{
+				Identifier: confirmation.identifier,
+				Added:      added,
+				Signals:    confirmation.signals,
+			})
+		}
+		if !inserted {
+			return nil
+		}
+		if _, err := s.bumpIdentityRevisionContext(ctx, tx); err != nil {
+			return err
+		}
+		if err := s.bumpAccountIdentityRevisionContext(ctx, tx); err != nil {
+			return err
+		}
+		participantIDs, err := participantIDsForConfirmationsContext(ctx, tx, sourceID, confirmations)
+		if err != nil {
+			return err
+		}
+		if len(participantIDs) == 0 {
+			return nil
+		}
+		return refreshParticipantMessageAttributionContext(ctx, tx, participantIDs...)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return outcomes, nil
+}
+
+// participantIDsForConfirmationsContext resolves the participants matched by
+// a confirmation chunk's identifiers, using the same case-sensitivity rules
+// as messageIdentityAttributionMatch: participants.email_address and
+// email-typed participant_identifiers match case-insensitively, and every
+// other identifier type matches the raw stored value. Scoping the
+// attribution refresh that follows a chunk's inserts to just these
+// participants replaces a full-source UPDATE with one bounded to the
+// senders the chunk could actually affect.
+//
+// Current identifiers alone are not enough: after a participant merge a
+// confirmed alias may survive only in message_recipients.email_address
+// snapshots, matching no participant row at all — yet the merge survivor's
+// sent messages still carry that alias in their 'from' envelope and must be
+// re-attributed. The envelope pass below resolves those senders. It walks
+// the confirming source's messages once per chunk (probing the 'from'
+// snapshot per message through idx_message_recipients_message) rather than
+// scanning message_recipients by address, which no index serves; a source
+// walk per chunk is the same order of work the single-identity
+// AddAccountIdentity path already spends on its full-source refresh.
+func participantIDsForConfirmationsContext(
+	ctx context.Context,
+	tx *loggedTx,
+	sourceID int64,
+	confirmations []normalizedIdentityConfirmation,
+) ([]int64, error) {
+	addresses := make([]string, 0, len(confirmations))
+	loweredAddresses := make([]string, 0, len(confirmations))
+	loweredEmailAddresses := make([]string, 0, len(confirmations))
+	seenLowered := make(map[string]struct{}, len(confirmations))
+	for _, confirmation := range confirmations {
+		addresses = append(addresses, confirmation.identifier)
+		lowered := strings.ToLower(confirmation.identifier)
+		if _, ok := seenLowered[lowered]; !ok {
+			seenLowered[lowered] = struct{}{}
+			loweredAddresses = append(loweredAddresses, lowered)
+			if looksLikeEmail(confirmation.identifier) {
+				loweredEmailAddresses = append(loweredEmailAddresses, lowered)
+			}
+		}
+	}
+
+	participantIDs := make(map[int64]struct{})
+	scanParticipantID := func(rows *loggedRows) error {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("scan confirmation participant id: %w", err)
+		}
+		participantIDs[id] = struct{}{}
+		return nil
+	}
+
+	if err := queryInChunksContext(ctx, tx, loweredAddresses, nil, `
+		SELECT p.id FROM participants p
+		WHERE p.email_address IS NOT NULL AND LOWER(p.email_address) IN (%s)
+	`, scanParticipantID); err != nil {
+		return nil, fmt.Errorf("resolve confirmation participants by email: %w", err)
+	}
+	if err := queryInChunksContext(ctx, tx, loweredAddresses, nil, `
+		SELECT pi.participant_id FROM participant_identifiers pi
+		WHERE pi.identifier_type = 'email' AND LOWER(pi.identifier_value) IN (%s)
+	`, scanParticipantID); err != nil {
+		return nil, fmt.Errorf("resolve confirmation participants by email identifier: %w", err)
+	}
+	if err := queryInChunksContext(ctx, tx, addresses, nil, `
+		SELECT pi.participant_id FROM participant_identifiers pi
+		WHERE pi.identifier_type <> 'email' AND pi.identifier_value IN (%s)
+	`, scanParticipantID); err != nil {
+		return nil, fmt.Errorf("resolve confirmation participants by non-email identifier: %w", err)
+	}
+	if len(loweredEmailAddresses) > 0 {
+		if err := queryInChunksContext(ctx, tx, loweredEmailAddresses, []any{sourceID}, `
+			SELECT m.sender_id FROM messages m
+			WHERE m.source_id = ?
+			  AND m.sender_id IS NOT NULL
+			  AND EXISTS (
+			      SELECT 1 FROM message_recipients mr
+			      WHERE mr.message_id = m.id
+			        AND mr.recipient_type = 'from'
+			        AND mr.email_address IS NOT NULL
+			        AND LOWER(mr.email_address) IN (%s)
+			  )
+		`, scanParticipantID); err != nil {
+			return nil, fmt.Errorf("resolve confirmation senders by envelope address: %w", err)
+		}
+	}
+
+	ids := make([]int64, 0, len(participantIDs))
+	for id := range participantIDs {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/internal/store/identity_discovery_test.go
+++ b/internal/store/identity_discovery_test.go
@@ -1,0 +1,812 @@
+package store_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+type identityDiscoveryFixture struct {
+	Store       *store.Store
+	SourceID    int64
+	SentID      int64
+	InboundID   int64
+	GmailSentID int64
+	When        time.Time
+}
+
+func newIdentityDiscoveryFixture(t *testing.T) identityDiscoveryFixture {
+	t.Helper()
+	f := storetest.New(t)
+	when := time.Date(2026, 7, 31, 12, 30, 0, 0, time.UTC)
+
+	createMessage := func(sourceMessageID string, sentAt, receivedAt sql.NullTime, isFromMe bool) int64 {
+		t.Helper()
+		id, err := f.Store.UpsertMessage(&store.Message{
+			ConversationID:  f.ConvID,
+			SourceID:        f.Source.ID,
+			SourceMessageID: sourceMessageID,
+			MessageType:     "email",
+			SentAt:          sentAt,
+			ReceivedAt:      receivedAt,
+			IsFromMe:        isFromMe,
+			SizeEstimate:    100,
+		})
+		require.NoError(t, err, "create discovery message")
+		return id
+	}
+
+	sentID := createMessage("sent-folder-message", sql.NullTime{Time: when, Valid: true}, sql.NullTime{}, false)
+	inboundID := createMessage("inbound-message", sql.NullTime{}, sql.NullTime{Time: when.Add(time.Hour), Valid: true}, false)
+	gmailSentID := createMessage("gmail-sent-message", sql.NullTime{}, sql.NullTime{}, true)
+	_, err := f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET archived_at = ? WHERE id = ?`), when.Add(2*time.Hour), gmailSentID)
+	require.NoError(t, err, "fix archived-at fallback")
+
+	sentLabelID, err := f.Store.EnsureLabel(f.Source.ID, "imap-sent", "Sent Mail", "system")
+	require.NoError(t, err, "create canonical sent folder")
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE labels SET system_role = 'sent' WHERE id = ?`), sentLabelID)
+	require.NoError(t, err, "set canonical sent role")
+	require.NoError(t, f.Store.ReplaceMessageLabels(sentID, []int64{sentLabelID}), "label sent message")
+
+	gmailSentLabelID, err := f.Store.EnsureLabel(f.Source.ID, "SENT", "Gmail Sent Mail", "system")
+	require.NoError(t, err, "create Gmail sent label")
+	require.NoError(t, f.Store.ReplaceMessageLabels(gmailSentID, []int64{gmailSentLabelID}), "label Gmail sent message")
+
+	nameOnlySentID, err := f.Store.EnsureLabel(f.Source.ID, "mailbox-42", "Sent", "user")
+	require.NoError(t, err, "create name-only sent label")
+	require.NoError(t, f.Store.ReplaceMessageLabels(inboundID, []int64{nameOnlySentID}), "label inbound message")
+
+	addRecipients := func(messageID int64, recipientType string, addresses ...string) {
+		t.Helper()
+		participantIDs := make([]int64, 0, len(addresses))
+		displayNames := make([]string, 0, len(addresses))
+		for _, address := range addresses {
+			participantID, participantErr := f.Store.EnsureParticipant(address, "Test User", "example.test")
+			require.NoError(t, participantErr, "create discovery participant")
+			participantIDs = append(participantIDs, participantID)
+			displayNames = append(displayNames, "Test User")
+		}
+		require.NoError(t,
+			f.Store.ReplaceMessageRecipients(messageID, recipientType, participantIDs, displayNames),
+			"add discovery recipients")
+	}
+
+	addRecipients(sentID, "from", "Masked-Shop@Example.test", "second-from@example.test")
+	addRecipients(sentID, "to", "sent-to@example.test")
+	addRecipients(sentID, "cc", "sent-cc@example.test")
+	addRecipients(sentID, "bcc", "sent-bcc@example.test")
+	addRecipients(inboundID, "to", "inbound-only@example.test")
+	addRecipients(gmailSentID, "from", "gmail-sender@example.test")
+
+	return identityDiscoveryFixture{
+		Store:       f.Store,
+		SourceID:    f.Source.ID,
+		SentID:      sentID,
+		InboundID:   inboundID,
+		GmailSentID: gmailSentID,
+		When:        when,
+	}
+}
+
+func TestIdentityDiscoveryPageReadsStrongWeakAndAllRecipientMetadata(t *testing.T) {
+	assert := assert.New(t)
+	fx := newIdentityDiscoveryFixture(t)
+
+	page, err := fx.Store.ScanIdentityDiscoveryPageContext(t.Context(), fx.SourceID, 0, 100)
+	require.NoError(t, err)
+
+	assert.Equal(int64(3), page.Scanned)
+	assert.Equal(fx.GmailSentID, page.NextAfterID)
+	assert.ElementsMatch([]store.IdentityObservation{
+		{MessageID: fx.SentID, Identifier: "Masked-Shop@Example.test", RecipientType: "from", HasSentFolder: true, ObservedAt: fx.When},
+		{MessageID: fx.SentID, Identifier: "second-from@example.test", RecipientType: "from", HasSentFolder: true, ObservedAt: fx.When},
+		{MessageID: fx.SentID, Identifier: "sent-to@example.test", RecipientType: "to", HasSentFolder: true, ObservedAt: fx.When},
+		{MessageID: fx.SentID, Identifier: "sent-cc@example.test", RecipientType: "cc", HasSentFolder: true, ObservedAt: fx.When},
+		{MessageID: fx.SentID, Identifier: "sent-bcc@example.test", RecipientType: "bcc", HasSentFolder: true, ObservedAt: fx.When},
+		{MessageID: fx.InboundID, Identifier: "inbound-only@example.test", RecipientType: "to", ObservedAt: fx.When.Add(time.Hour)},
+		{MessageID: fx.GmailSentID, Identifier: "gmail-sender@example.test", RecipientType: "from", IsFromMe: true, HasSentLabel: true, ObservedAt: fx.When.Add(2 * time.Hour)},
+	}, page.Observations)
+}
+
+func TestIdentityDiscoveryScanReadsOnlySourceNativeAttribution(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+
+	senderID := f.EnsureParticipant("owner@example.com", "Owner", "example.com")
+	require.NoError(
+		f.Store.AddAccountIdentity(f.Source.ID, "owner@example.com", "manual"),
+		"confirm identity before ingestion",
+	)
+	messageID, err := f.Store.UpsertMessage(&store.Message{
+		ConversationID:  f.ConvID,
+		SourceID:        f.Source.ID,
+		SourceMessageID: "identity-derived-message",
+		MessageType:     "email",
+		SenderID:        sql.NullInt64{Int64: senderID, Valid: true},
+		SizeEstimate:    100,
+	})
+	require.NoError(err, "persist identity-derived message")
+	require.NoError(
+		f.Store.ReplaceMessageRecipients(messageID, "from", []int64{senderID}, []string{"Owner"}),
+		"add From participant",
+	)
+
+	var isFromMe, sourceIsFromMe, identityIsFromMe bool
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT is_from_me, source_is_from_me, identity_is_from_me
+		FROM messages
+		WHERE id = ?
+	`), messageID).Scan(&isFromMe, &sourceIsFromMe, &identityIsFromMe))
+	require.True(isFromMe, "fixture must carry effective attribution")
+	require.False(sourceIsFromMe, "fixture must not carry provider-native attribution")
+	require.True(identityIsFromMe, "fixture attribution must be identity-derived")
+
+	page, err := f.Store.ScanIdentityDiscoveryPageContext(t.Context(), f.Source.ID, 0, 100)
+	require.NoError(err, "scan identity discovery page")
+	require.NotEmpty(page.Observations)
+	for _, observation := range page.Observations {
+		assert.False(observation.IsFromMe,
+			"page scan must not treat identity-derived attribution as evidence")
+	}
+
+	batch, err := f.Store.ScanIdentityObservationsForSourceMessageIDsContext(
+		t.Context(), f.Source.ID, []string{"identity-derived-message"})
+	require.NoError(err, "scan identity observations for source message IDs")
+	require.NotEmpty(batch)
+	for _, observation := range batch {
+		assert.False(observation.IsFromMe,
+			"batch scan must not treat identity-derived attribution as evidence")
+	}
+}
+
+func TestIdentityDiscoveryScanReportsEnvelopeAddressAfterParticipantMerge(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+
+	aliceID := f.EnsureParticipant("alice@example.test", "Alice", "example.test")
+	bobID := f.EnsureParticipant("bob@example.test", "Bob", "example.test")
+
+	messageID, err := f.Store.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID:  f.ConvID,
+			SourceID:        f.Source.ID,
+			SourceMessageID: "native-sent-from-alice",
+			MessageType:     "email",
+			SentAt:          sql.NullTime{Time: time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC), Valid: true},
+			SenderID:        sql.NullInt64{Int64: aliceID, Valid: true},
+			IsFromMe:        true,
+			SizeEstimate:    100,
+		},
+		Recipients: []store.RecipientSet{{
+			Type:           "from",
+			ParticipantIDs: []int64{aliceID},
+			DisplayNames:   []string{"Alice"},
+			EmailAddresses: []string{"alice@example.test"},
+		}},
+	})
+	require.NoError(err, "persist source-native sent message")
+
+	require.NoError(f.Store.MergeParticipants(aliceID, bobID), "merge alice into bob")
+
+	page, err := f.Store.ScanIdentityDiscoveryPageContext(t.Context(), f.Source.ID, 0, 100)
+	require.NoError(err, "scan identity discovery page")
+	require.Len(page.Observations, 1)
+	observation := page.Observations[0]
+	assert.Equal(messageID, observation.MessageID)
+	assert.Equal("from", observation.RecipientType)
+	assert.True(observation.IsFromMe, "provider-native attribution must survive the merge")
+	assert.Equal("alice@example.test", observation.Identifier,
+		"discovery must report the envelope address, not the merge survivor's primary email")
+
+	batch, err := f.Store.ScanIdentityObservationsForSourceMessageIDsContext(
+		t.Context(), f.Source.ID, []string{"native-sent-from-alice"})
+	require.NoError(err, "scan identity observations for source message IDs")
+	require.Len(batch, 1)
+	assert.Equal("alice@example.test", batch[0].Identifier,
+		"the ingestion-batch scan must report the envelope address after a merge")
+}
+
+// TestParticipantMergeKeepsDistinctEnvelopeAliasRows pins the merge collision
+// rule to the full unique key: an absorbed participant's recipient row whose
+// envelope address differs from every surviving row's must survive the
+// repoint, while a row that matches a surviving snapshot (case-insensitively)
+// is still deduplicated. Without this, merging an alias participant into the
+// primary one destroyed the alias's envelope evidence, and identity discovery
+// could no longer observe the alias at all.
+func TestParticipantMergeKeepsDistinctEnvelopeAliasRows(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+
+	aliasID := f.EnsureParticipant("alias@example.test", "Alias", "example.test")
+	primaryID := f.EnsureParticipant("primary@example.test", "Primary", "example.test")
+
+	persist := func(sourceMessageID string, emails ...string) int64 {
+		t.Helper()
+		participantIDs := []int64{aliasID, primaryID}
+		id, err := f.Store.PersistMessage(&store.MessagePersistData{
+			Message: &store.Message{
+				ConversationID:  f.ConvID,
+				SourceID:        f.Source.ID,
+				SourceMessageID: sourceMessageID,
+				MessageType:     "email",
+				SentAt:          sql.NullTime{Time: time.Date(2026, 8, 2, 9, 0, 0, 0, time.UTC), Valid: true},
+				SizeEstimate:    100,
+			},
+			Recipients: []store.RecipientSet{{
+				Type:           "to",
+				ParticipantIDs: participantIDs,
+				DisplayNames:   []string{"Alias", "Primary"},
+				EmailAddresses: emails,
+			}},
+		})
+		require.NoError(err, "persist %s", sourceMessageID)
+		return id
+	}
+
+	// Both addresses appear in one To: header as distinct participants.
+	distinctID := persist("distinct-envelopes", "alias@example.test", "primary@example.test")
+	// Both participants snapshot the same address (case variant): the
+	// absorbed row must be deduplicated by the merge, not duplicated.
+	sharedID := persist("shared-envelope", "Shared@Example.test", "shared@example.test")
+
+	require.NoError(f.Store.MergeParticipants(aliasID, primaryID), "merge alias into primary")
+
+	readEnvelopes := func(messageID int64) []string {
+		t.Helper()
+		rows, err := f.Store.DB().Query(f.Store.Rebind(`
+			SELECT participant_id, email_address FROM message_recipients
+			WHERE message_id = ? AND recipient_type = 'to' ORDER BY id
+		`), messageID)
+		require.NoError(err, "read recipient rows")
+		defer func() { _ = rows.Close() }()
+		var emails []string
+		for rows.Next() {
+			var participantID int64
+			var email string
+			require.NoError(rows.Scan(&participantID, &email), "scan recipient row")
+			assert.Equal(primaryID, participantID, "every surviving row must point at the merge survivor")
+			emails = append(emails, email)
+		}
+		require.NoError(rows.Err(), "iterate recipient rows")
+		return emails
+	}
+
+	assert.ElementsMatch(
+		[]string{"alias@example.test", "primary@example.test"},
+		readEnvelopes(distinctID),
+		"distinct envelope snapshots must both survive the merge")
+	assert.Len(readEnvelopes(sharedID), 1,
+		"case-variant duplicates of one envelope address must still collapse to a single row")
+
+	page, err := f.Store.ScanIdentityDiscoveryPageContext(t.Context(), f.Source.ID, 0, 100)
+	require.NoError(err, "scan identity discovery page")
+	observed := make([]string, 0, len(page.Observations))
+	for _, observation := range page.Observations {
+		if observation.MessageID == distinctID {
+			observed = append(observed, observation.Identifier)
+		}
+	}
+	assert.ElementsMatch([]string{"alias@example.test", "primary@example.test"}, observed,
+		"discovery must still observe both envelope addresses after the merge")
+}
+
+// mergedAliasEnvelopeFixture persists a non-source-native sent message whose
+// sender is an alias participant, then merges that participant into the
+// primary one — after which the alias survives ONLY in the message's 'from'
+// envelope snapshot. Confirming the alias afterwards must still repair the
+// message's identity attribution.
+func mergedAliasEnvelopeFixture(t *testing.T) (*storetest.Fixture, int64) {
+	t.Helper()
+	f := storetest.New(t)
+
+	aliasID := f.EnsureParticipant("alias@example.test", "Alias", "example.test")
+	primaryID := f.EnsureParticipant("primary@example.test", "Primary", "example.test")
+
+	messageID, err := f.Store.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID:  f.ConvID,
+			SourceID:        f.Source.ID,
+			SourceMessageID: "sent-from-merged-alias",
+			MessageType:     "email",
+			SentAt:          sql.NullTime{Time: time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC), Valid: true},
+			SenderID:        sql.NullInt64{Int64: aliasID, Valid: true},
+			SizeEstimate:    100,
+		},
+		Recipients: []store.RecipientSet{{
+			Type:           "from",
+			ParticipantIDs: []int64{aliasID},
+			DisplayNames:   []string{"Alias"},
+			EmailAddresses: []string{"alias@example.test"},
+		}},
+	})
+	require.NoError(t, err, "persist message sent from alias")
+
+	require.NoError(t, f.Store.MergeParticipants(aliasID, primaryID), "merge alias into primary")
+
+	var isFromMe, identityIsFromMe bool
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT is_from_me, identity_is_from_me FROM messages WHERE id = ?
+	`), messageID).Scan(&isFromMe, &identityIsFromMe), "read pre-confirmation attribution")
+	require.False(t, isFromMe, "fixture message must start unattributed")
+	require.False(t, identityIsFromMe, "fixture message must start without identity attribution")
+
+	return f, messageID
+}
+
+func assertMessageIdentityAttributed(t *testing.T, f *storetest.Fixture, messageID int64) {
+	t.Helper()
+	var isFromMe, sourceIsFromMe, identityIsFromMe bool
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT is_from_me, source_is_from_me, identity_is_from_me FROM messages WHERE id = ?
+	`), messageID).Scan(&isFromMe, &sourceIsFromMe, &identityIsFromMe), "read attribution")
+	assert.True(t, identityIsFromMe,
+		"confirming the alias must attribute the message through its envelope snapshot")
+	assert.True(t, isFromMe, "effective attribution must follow the identity repair")
+	assert.False(t, sourceIsFromMe, "source-native provenance must stay untouched")
+}
+
+func TestBatchConfirmationAttributesMergedAliasEnvelopeMessages(t *testing.T) {
+	require := require.New(t)
+	f, messageID := mergedAliasEnvelopeFixture(t)
+
+	outcomes, err := f.Store.AddAccountIdentitiesBatchContext(
+		t.Context(), f.Source.ID,
+		[]store.IdentityConfirmation{{Identifier: "alias@example.test", Signals: []string{"sent-folder"}}},
+	)
+	require.NoError(err, "confirm merged alias in batch")
+	require.Len(outcomes, 1)
+	require.True(outcomes[0].Added, "batch confirmation must insert the alias identity")
+
+	assertMessageIdentityAttributed(t, f, messageID)
+}
+
+func TestAddAccountIdentityAttributesMergedAliasEnvelopeMessages(t *testing.T) {
+	require := require.New(t)
+	f, messageID := mergedAliasEnvelopeFixture(t)
+
+	require.NoError(f.Store.AddAccountIdentity(f.Source.ID, "alias@example.test", "manual"),
+		"confirm merged alias")
+
+	assertMessageIdentityAttributed(t, f, messageID)
+}
+
+// TestPersistMessageAttributesEnvelopeOnlyIdentity pins the persist-time
+// ordering: the message upsert computes attribution from the sender
+// participant before this transaction writes the 'from' envelope snapshot,
+// so a confirmed identity represented only in that snapshot must still come
+// out attributed once the recipient rows are final.
+func TestPersistMessageAttributesEnvelopeOnlyIdentity(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+
+	primaryID := f.EnsureParticipant("primary@example.test", "Primary", "example.test")
+	require.NoError(f.Store.AddAccountIdentity(f.Source.ID, "alias@example.test", "manual"),
+		"confirm alias no participant carries")
+
+	messageID, err := f.Store.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID:  f.ConvID,
+			SourceID:        f.Source.ID,
+			SourceMessageID: "envelope-only-identity",
+			MessageType:     "email",
+			SentAt:          sql.NullTime{Time: time.Date(2026, 8, 4, 9, 0, 0, 0, time.UTC), Valid: true},
+			SenderID:        sql.NullInt64{Int64: primaryID, Valid: true},
+			SizeEstimate:    100,
+		},
+		Recipients: []store.RecipientSet{{
+			Type:           "from",
+			ParticipantIDs: []int64{primaryID},
+			DisplayNames:   []string{"Primary"},
+			EmailAddresses: []string{"alias@example.test"},
+		}},
+	})
+	require.NoError(err, "persist message with envelope-only identity")
+
+	assertMessageIdentityAttributed(t, f, messageID)
+}
+
+// TestRepersistKeepsMergedAliasEnvelopeAttribution re-persists a repaired
+// message the way a repair re-sync would — sender resolved to the merge
+// survivor, the 'from' envelope still carrying the confirmed alias — and
+// requires the repaired attribution to survive: the upsert's ON CONFLICT
+// recomputation cannot see envelope rows and would otherwise clear it.
+func TestRepersistKeepsMergedAliasEnvelopeAttribution(t *testing.T) {
+	require := require.New(t)
+	f, messageID := mergedAliasEnvelopeFixture(t)
+
+	require.NoError(f.Store.AddAccountIdentity(f.Source.ID, "alias@example.test", "manual"),
+		"confirm merged alias")
+	assertMessageIdentityAttributed(t, f, messageID)
+
+	primaryID := f.EnsureParticipant("primary@example.test", "Primary", "example.test")
+	repersistedID, err := f.Store.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID:  f.ConvID,
+			SourceID:        f.Source.ID,
+			SourceMessageID: "sent-from-merged-alias",
+			MessageType:     "email",
+			SentAt:          sql.NullTime{Time: time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC), Valid: true},
+			SenderID:        sql.NullInt64{Int64: primaryID, Valid: true},
+			SizeEstimate:    100,
+		},
+		Recipients: []store.RecipientSet{{
+			Type:           "from",
+			ParticipantIDs: []int64{primaryID},
+			DisplayNames:   []string{"Primary"},
+			EmailAddresses: []string{"alias@example.test"},
+		}},
+	})
+	require.NoError(err, "re-persist repaired message")
+	require.Equal(messageID, repersistedID, "re-persist must land on the same message row")
+
+	assertMessageIdentityAttributed(t, f, messageID)
+}
+
+func TestIdentityDiscoveryCountAndPageUseDistinctMessageKeyset(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fx := newIdentityDiscoveryFixture(t)
+
+	count, err := fx.Store.CountIdentityDiscoveryMessagesContext(t.Context(), fx.SourceID)
+	require.NoError(err)
+	assert.Equal(int64(3), count, "count must not multiply messages by recipients or labels")
+
+	first, err := fx.Store.ScanIdentityDiscoveryPageContext(t.Context(), fx.SourceID, 0, 2)
+	require.NoError(err)
+	assert.Equal(int64(2), first.Scanned)
+	assert.Equal(fx.InboundID, first.NextAfterID)
+	assert.NotEmpty(first.Observations)
+	for _, observation := range first.Observations {
+		assert.LessOrEqual(observation.MessageID, fx.InboundID)
+	}
+
+	second, err := fx.Store.ScanIdentityDiscoveryPageContext(t.Context(), fx.SourceID, first.NextAfterID, 2)
+	require.NoError(err)
+	assert.Equal(int64(1), second.Scanned)
+	assert.Equal(fx.GmailSentID, second.NextAfterID)
+	require.Len(second.Observations, 1)
+	assert.Equal(fx.GmailSentID, second.Observations[0].MessageID)
+}
+
+func TestIdentityDiscoverySourceMessageIDsAreSourceScopedAndBounded(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fx := newIdentityDiscoveryFixture(t)
+	other, err := fx.Store.GetOrCreateSource("imap", "other@example.test")
+	require.NoError(err)
+	otherConv, err := fx.Store.EnsureConversation(other.ID, "other-thread", "Other")
+	require.NoError(err)
+	otherMessageID, err := fx.Store.UpsertMessage(&store.Message{
+		ConversationID: otherConv, SourceID: other.ID, SourceMessageID: "sent-folder-message",
+		MessageType: "email", SizeEstimate: 100,
+	})
+	require.NoError(err)
+	otherParticipant, err := fx.Store.EnsureParticipant("other-source@example.test", "Other", "example.test")
+	require.NoError(err)
+	require.NoError(
+		fx.Store.ReplaceMessageRecipients(otherMessageID, "from", []int64{otherParticipant}, []string{"Other"}))
+	imapUpperSentLabel, err := fx.Store.EnsureLabel(other.ID, "SENT", "Uppercase mailbox", "system")
+	require.NoError(err)
+	require.NoError(fx.Store.ReplaceMessageLabels(otherMessageID, []int64{imapUpperSentLabel}))
+
+	sourceMessageIDs := make([]string, 0, 503)
+	for i := range 501 {
+		sourceMessageIDs = append(sourceMessageIDs, fmt.Sprintf("missing-%03d", i))
+	}
+	sourceMessageIDs = append(sourceMessageIDs, "sent-folder-message", "inbound-message")
+
+	observations, err := fx.Store.ScanIdentityObservationsForSourceMessageIDsContext(
+		t.Context(), fx.SourceID, sourceMessageIDs)
+	require.NoError(err)
+	assert.NotEmpty(observations)
+	for _, observation := range observations {
+		assert.Contains([]int64{fx.SentID, fx.InboundID}, observation.MessageID)
+		assert.NotEqual("other-source@example.test", observation.Identifier)
+	}
+
+	otherObservations, err := fx.Store.ScanIdentityObservationsForSourceMessageIDsContext(
+		t.Context(), other.ID, []string{"sent-folder-message"})
+	require.NoError(err)
+	require.Len(otherObservations, 1)
+	assert.False(otherObservations[0].HasSentLabel,
+		"an IMAP mailbox ID named SENT is not canonical Gmail sent evidence")
+}
+
+func TestIdentityDiscoveryDoesNotReadContentTables(t *testing.T) {
+	fx := newIdentityDiscoveryFixture(t)
+	store.ConfigureSQLLogging(store.SQLLogOptions{FullTrace: true, MaxStmtChars: 10_000})
+	t.Cleanup(func() { store.ConfigureSQLLogging(store.SQLLogOptions{}) })
+
+	var logBuffer bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	_, err := fx.Store.ScanIdentityDiscoveryPageContext(context.Background(), fx.SourceID, 0, 100)
+	require.NoError(t, err)
+
+	statements := strings.ToLower(logBuffer.String())
+	assert.Contains(t, statements, "message_recipients", "trace must observe the production metadata query")
+	for _, forbidden := range []string{"message_bodies", "message_raw", "attachments", "snippet"} {
+		assert.NotContains(t, statements, forbidden)
+	}
+}
+
+func TestAccountIdentityBatchDeterministicallyMergesCaseAndSignals(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+	beforeIdentityRevision, err := f.Store.IdentityRevision()
+	require.NoError(err)
+	beforeAccountRevision, err := f.Store.AccountIdentityRevision()
+	require.NoError(err)
+
+	outcomes, err := f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{
+		{Identifier: "Zulu@example.test", Signals: []string{"sent-label"}},
+		{Identifier: "Alias@Example.test", Signals: []string{"sent-folder", "is_from_me"}},
+		{Identifier: "alias@example.test", Signals: []string{"sent-label", "is_from_me"}},
+		{Identifier: "zulu@example.test", Signals: []string{"is_from_me"}},
+	})
+	require.NoError(err)
+	assert.Equal([]store.IdentityConfirmationOutcome{
+		{Identifier: "Alias@Example.test", Added: true, Signals: []string{"is_from_me", "sent-folder", "sent-label"}},
+		{Identifier: "Zulu@example.test", Added: true, Signals: []string{"is_from_me", "sent-label"}},
+	}, outcomes)
+
+	identities, err := f.Store.ListAccountIdentities(f.Source.ID)
+	require.NoError(err)
+	require.Len(identities, 2)
+	assert.Equal("Alias@Example.test", identities[0].Address, "first spelling must win case-folded batching")
+	assert.Equal("is_from_me,sent-folder,sent-label", identities[0].SourceSignal)
+	assert.Equal("Zulu@example.test", identities[1].Address)
+	assert.Equal("is_from_me,sent-label", identities[1].SourceSignal)
+
+	afterIdentityRevision, err := f.Store.IdentityRevision()
+	require.NoError(err)
+	afterAccountRevision, err := f.Store.AccountIdentityRevision()
+	require.NoError(err)
+	assert.Equal(beforeIdentityRevision+1, afterIdentityRevision, "one chunk with two inserts bumps once")
+	assert.Equal(beforeAccountRevision+1, afterAccountRevision, "one chunk with two inserts bumps once")
+}
+
+func TestAccountIdentityBatchRefreshesExistingMessageAttribution(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+
+	senderID := f.EnsureParticipant("masked-shop@example.test", "Masked Shop", "example.test")
+	message := f.NewMessage().WithSourceMessageID("sent-before-alias-confirmation").Build()
+	message.SenderID = sql.NullInt64{Int64: senderID, Valid: true}
+	messageID, err := f.Store.UpsertMessage(message)
+	require.NoError(err, "persist message before alias confirmation")
+
+	before, err := f.Store.GetMessageIsFromMe(messageID)
+	require.NoError(err, "read initial attribution")
+	assert.False(before)
+
+	_, err = f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{{
+		Identifier: "MASKED-SHOP@EXAMPLE.TEST",
+		Signals:    []string{"sent-folder"},
+	}})
+	require.NoError(err, "confirm alias in batch")
+
+	var isFromMe, sourceIsFromMe, identityIsFromMe bool
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT is_from_me, source_is_from_me, identity_is_from_me
+		FROM messages
+		WHERE id = ?
+	`), messageID).Scan(&isFromMe, &sourceIsFromMe, &identityIsFromMe))
+	assert.True(isFromMe, "batch confirmation must repair the existing message")
+	assert.False(sourceIsFromMe, "message did not carry source-native attribution")
+	assert.True(identityIsFromMe, "batch confirmation must retain identity provenance")
+}
+
+func TestAccountIdentityBatchBoundsLargeWritesAndKeepsRetryIdempotent(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	f := storetest.New(t)
+	confirmations := make([]store.IdentityConfirmation, 501)
+	for i := range confirmations {
+		confirmations[i] = store.IdentityConfirmation{
+			Identifier: fmt.Sprintf("masked-%03d@example.test", i),
+			Signals:    []string{"sent-folder"},
+		}
+	}
+	beforeIdentityRevision, err := f.Store.IdentityRevision()
+	requirements.NoError(err)
+	beforeAccountRevision, err := f.Store.AccountIdentityRevision()
+	requirements.NoError(err)
+
+	first, err := f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, confirmations)
+	requirements.NoError(err)
+	requirements.Len(first, 501)
+	afterFirstIdentityRevision, err := f.Store.IdentityRevision()
+	requirements.NoError(err)
+	afterFirstAccountRevision, err := f.Store.AccountIdentityRevision()
+	requirements.NoError(err)
+	assertions.Equal(beforeIdentityRevision+2, afterFirstIdentityRevision,
+		"501 inserts must commit as one 500-row chunk and one 1-row chunk")
+	assertions.Equal(beforeAccountRevision+2, afterFirstAccountRevision,
+		"each insert-bearing chunk must bump the account identity revision once")
+
+	retry, err := f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, confirmations)
+	requirements.NoError(err)
+	requirements.Len(retry, 501)
+	for _, outcome := range retry {
+		assertions.False(outcome.Added, outcome.Identifier)
+	}
+	afterRetryIdentityRevision, err := f.Store.IdentityRevision()
+	requirements.NoError(err)
+	afterRetryAccountRevision, err := f.Store.AccountIdentityRevision()
+	requirements.NoError(err)
+	assertions.Equal(afterFirstIdentityRevision, afterRetryIdentityRevision,
+		"an identical retry must not bump identity revision")
+	assertions.Equal(afterFirstAccountRevision, afterRetryAccountRevision,
+		"an identical retry must not bump account identity revision")
+}
+
+func TestAccountIdentityBatchPreservesExistingSpellingTimestampAndRevisions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+	require.NoError(f.Store.AddAccountIdentity(f.Source.ID, "First@Example.test", "manual"))
+	beforeRows, err := f.Store.ListAccountIdentities(f.Source.ID)
+	require.NoError(err)
+	require.Len(beforeRows, 1)
+	beforeIdentityRevision, err := f.Store.IdentityRevision()
+	require.NoError(err)
+	beforeAccountRevision, err := f.Store.AccountIdentityRevision()
+	require.NoError(err)
+
+	outcomes, err := f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{
+		{Identifier: "first@example.test", Signals: []string{"sent-folder", "manual"}},
+		{Identifier: "FIRST@example.test", Signals: []string{"is_from_me"}},
+	})
+	require.NoError(err)
+	assert.Equal([]store.IdentityConfirmationOutcome{{
+		Identifier: "first@example.test", Added: false, Signals: []string{"is_from_me", "manual", "sent-folder"},
+	}}, outcomes)
+
+	afterRows, err := f.Store.ListAccountIdentities(f.Source.ID)
+	require.NoError(err)
+	require.Len(afterRows, 1)
+	assert.Equal("First@Example.test", afterRows[0].Address)
+	assert.Equal("is_from_me,manual,sent-folder", afterRows[0].SourceSignal)
+	assert.True(afterRows[0].ConfirmedAt.Equal(beforeRows[0].ConfirmedAt), "confirmed_at must stay at first confirmation")
+	afterIdentityRevision, err := f.Store.IdentityRevision()
+	require.NoError(err)
+	afterAccountRevision, err := f.Store.AccountIdentityRevision()
+	require.NoError(err)
+	assert.Equal(beforeIdentityRevision, afterIdentityRevision, "signal-only merge must not bump")
+	assert.Equal(beforeAccountRevision, afterAccountRevision, "signal-only merge must not bump")
+}
+
+func TestAccountIdentityBatchRejectsInvalidSignalBeforeWriting(t *testing.T) {
+	f := storetest.New(t)
+
+	_, err := f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{
+		{Identifier: "safe@example.test", Signals: []string{"sent-folder"}},
+		{Identifier: "invalid@example.test", Signals: []string{"sent,label"}},
+	})
+	require.ErrorContains(t, err, "comma")
+
+	identities, listErr := f.Store.ListAccountIdentities(f.Source.ID)
+	require.NoError(t, listErr)
+	assert.Empty(t, identities, "validation must finish before committing any chunk")
+}
+
+func TestAccountIdentityBatchRefreshesOnlyAffectedSenders(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+
+	aliceID := f.EnsureParticipant("alice@example.test", "Alice", "example.test")
+	bobID := f.EnsureParticipant("bob@example.test", "Bob", "example.test")
+
+	aliceMessage := f.NewMessage().WithSourceMessageID("alice-message").Build()
+	aliceMessage.SenderID = sql.NullInt64{Int64: aliceID, Valid: true}
+	aliceMessageID, err := f.Store.UpsertMessage(aliceMessage)
+	require.NoError(err, "persist alice message")
+
+	bobMessage := f.NewMessage().WithSourceMessageID("bob-message").Build()
+	bobMessage.SenderID = sql.NullInt64{Int64: bobID, Valid: true}
+	bobMessageID, err := f.Store.UpsertMessage(bobMessage)
+	require.NoError(err, "persist bob message")
+
+	// Confirm Bob first so his message starts out correctly attributed.
+	_, err = f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{
+		{Identifier: "bob@example.test", Signals: []string{"sent-folder"}},
+	})
+	require.NoError(err, "confirm bob")
+
+	bobIsFromMe, err := f.Store.GetMessageIsFromMe(bobMessageID)
+	require.NoError(err)
+	require.True(bobIsFromMe, "bob's own confirmation must repair his message first")
+
+	// Remove Bob's identity row directly, leaving his message row untouched
+	// (stale). A full-source refresh triggered by Alice's confirmation below
+	// would recompute Bob's attribution from scratch, find no matching
+	// identity, and flip his message back to false. A refresh scoped to
+	// Alice's own participant must never visit Bob's row.
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`DELETE FROM account_identities WHERE source_id = ? AND address = ?`),
+		f.Source.ID, "bob@example.test")
+	require.NoError(err, "simulate a stale bob identity")
+
+	_, err = f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{
+		{Identifier: "alice@example.test", Signals: []string{"sent-folder"}},
+	})
+	require.NoError(err, "confirm alice")
+
+	aliceIsFromMe, err := f.Store.GetMessageIsFromMe(aliceMessageID)
+	require.NoError(err)
+	assert.True(aliceIsFromMe, "alice's message must be repaired by her own confirmation")
+
+	bobIsFromMeAfter, err := f.Store.GetMessageIsFromMe(bobMessageID)
+	require.NoError(err)
+	assert.True(bobIsFromMeAfter,
+		"a refresh scoped to alice's chunk must not touch bob's message, even though "+
+			"a full-source refresh would have flipped it back to false")
+}
+
+func TestAccountIdentityBatchWithUnseenAliasSkipsRefresh(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+
+	// A message exists but was never observed under the alias being confirmed.
+	knownSenderID := f.EnsureParticipant("known@example.test", "Known", "example.test")
+	message := f.NewMessage().WithSourceMessageID("preexisting-message").Build()
+	message.SenderID = sql.NullInt64{Int64: knownSenderID, Valid: true}
+	messageID, err := f.Store.UpsertMessage(message)
+	require.NoError(err, "persist message from an unrelated sender")
+
+	// Confirm the known sender first so his message starts out attributed,
+	// then remove his identity row directly, leaving his message row stale
+	// (true). Confirming the unseen alias below must succeed but skip the
+	// refresh entirely: if it triggered ANY broader refresh — even one
+	// correctly scoped but accidentally reaching this unrelated sender —
+	// recomputing from the now-empty identity set would flip his message
+	// back to false. A false-before/false-after version of this test would
+	// pass even under a full-source refresh and would not prove anything.
+	_, err = f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{
+		{Identifier: "known@example.test", Signals: []string{"sent-folder"}},
+	})
+	require.NoError(err, "confirm known sender")
+	before, err := f.Store.GetMessageIsFromMe(messageID)
+	require.NoError(err)
+	require.True(before, "known sender's own confirmation must repair his message first")
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`DELETE FROM account_identities WHERE source_id = ? AND address = ?`),
+		f.Source.ID, "known@example.test")
+	require.NoError(err, "simulate a stale known-sender identity")
+
+	outcomes, err := f.Store.AddAccountIdentitiesBatchContext(t.Context(), f.Source.ID, []store.IdentityConfirmation{
+		{Identifier: "never-seen@example.test", Signals: []string{"manual"}},
+	})
+	require.NoError(err, "confirming an identity with no matching participant must succeed")
+	require.Len(outcomes, 1)
+	assert.True(outcomes[0].Added)
+
+	after, err := f.Store.GetMessageIsFromMe(messageID)
+	require.NoError(err)
+	assert.True(after,
+		"no participant matches the confirmed alias, so the refresh must be skipped entirely — "+
+			"even a full-source refresh would have flipped the known sender's stale message back to false")
+}

--- a/internal/store/message_export.go
+++ b/internal/store/message_export.go
@@ -504,7 +504,7 @@ func normalizeMessageExportConversation(
 		return conversationType, parentID, nil
 	}
 	switch rawType {
-	case "email", "email_thread":
+	case string(AttributeFieldEmail), "email_thread":
 		return MessageExportConversationEmailThread, nil, nil
 	case "channel":
 		return MessageExportConversationChannel, nil, nil

--- a/internal/store/message_identity_matches.go
+++ b/internal/store/message_identity_matches.go
@@ -1,0 +1,382 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// ErrAccountIdentityNotFound is returned when an identifier is not confirmed
+// for the requested source.
+var ErrAccountIdentityNotFound = errors.New("account identity not found")
+
+// MessageIdentityMatch is the source-scoped intersection between one
+// message's envelope participants and its source's confirmed identities.
+type MessageIdentityMatch struct {
+	MessageID  int64
+	SourceID   int64
+	Sender     []string
+	Recipients []string
+}
+
+// ResolvedAccountIdentity is one confirmed source identity and every
+// participant row that carries the same identifier.
+type ResolvedAccountIdentity struct {
+	SourceID   int64
+	Identifier string
+	// IdentifierIsEmail reports whether Identifier is email-shaped
+	// (looksLikeEmail). Email identities can be compared against the
+	// immutable envelope snapshot message_recipients.email_address; other
+	// identifier types (phone, matrix, handles) have no envelope column and
+	// match through participants only.
+	IdentifierIsEmail bool
+	ParticipantIDs    []int64
+}
+
+// ResolveAccountIdentityContext verifies that identifier is confirmed for
+// sourceID, then resolves every participant row carrying that identifier.
+func (s *Store) ResolveAccountIdentityContext(
+	ctx context.Context,
+	sourceID int64,
+	identifier string,
+) (ResolvedAccountIdentity, error) {
+	identities, err := s.ListAccountIdentitiesContext(ctx, sourceID)
+	if err != nil {
+		return ResolvedAccountIdentity{}, err
+	}
+
+	var storedIdentifier string
+	for _, identity := range identities {
+		if EqualIdentifier(identity.Address, identifier) {
+			storedIdentifier = identity.Address
+			break
+		}
+	}
+	if storedIdentifier == "" {
+		return ResolvedAccountIdentity{}, fmt.Errorf(
+			"source %d identity %q: %w", sourceID, identifier, ErrAccountIdentityNotFound)
+	}
+
+	// Mirrors messageIdentityAttributionMatch (messages.go) exactly: the
+	// email column compares case-insensitively, participant_identifiers rows
+	// compare per their own identifier_type (case-insensitive only when
+	// type = 'email'), and participants.phone_number is never consulted —
+	// EnsureParticipantByPhone always backs a phone identity with a
+	// participant_identifiers row, so that row is the parity-correct match
+	// surface. Do not reintroduce identifierMatch/EqualIdentifier here: their
+	// global, shape-based case rule is what this query replaces.
+	const query = `
+		SELECT p.id FROM participants p
+		WHERE p.email_address IS NOT NULL AND LOWER(p.email_address) = LOWER(?)
+		UNION
+		SELECT pi.participant_id FROM participant_identifiers pi
+		WHERE (pi.identifier_type = 'email' AND LOWER(pi.identifier_value) = LOWER(?))
+		   OR (pi.identifier_type <> 'email' AND pi.identifier_value = ?)
+		ORDER BY 1
+	`
+	rows, err := s.db.QueryContext(
+		ctx,
+		query,
+		storedIdentifier,
+		storedIdentifier,
+		storedIdentifier,
+	)
+	if err != nil {
+		return ResolvedAccountIdentity{}, fmt.Errorf("resolve account identity participants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	participantIDs := make([]int64, 0)
+	for rows.Next() {
+		var participantID int64
+		if err := rows.Scan(&participantID); err != nil {
+			return ResolvedAccountIdentity{}, fmt.Errorf("scan account identity participant: %w", err)
+		}
+		participantIDs = append(participantIDs, participantID)
+	}
+	if err := rows.Err(); err != nil {
+		return ResolvedAccountIdentity{}, fmt.Errorf("iterate account identity participants: %w", err)
+	}
+
+	return ResolvedAccountIdentity{
+		SourceID:          sourceID,
+		Identifier:        storedIdentifier,
+		IdentifierIsEmail: looksLikeEmail(storedIdentifier),
+		ParticipantIDs:    participantIDs,
+	}, nil
+}
+
+type messageIdentityCandidates struct {
+	messageID  int64
+	sourceID   int64
+	sender     *identityCandidateSet
+	recipients *identityCandidateSet
+}
+
+// identityCandidateSet keeps one key set per comparison rule so the
+// intersection can mirror messageIdentityAttributionMatch: envelope and
+// participant-email candidates compare by identifier shape (case-insensitive
+// only when email-shaped, preserving synthetic-address exactness),
+// email-typed identifier rows compare case-insensitively, and every other
+// identifier type compares verbatim.
+type identityCandidateSet struct {
+	shape map[string]struct{}
+	lower map[string]struct{}
+	raw   map[string]struct{}
+}
+
+func newIdentityCandidateSet() *identityCandidateSet {
+	return &identityCandidateSet{
+		shape: make(map[string]struct{}),
+		lower: make(map[string]struct{}),
+		raw:   make(map[string]struct{}),
+	}
+}
+
+// MatchMessageIdentitiesContext resolves requested messages in bounded batch
+// queries. It reads envelope metadata only; bodies, raw messages, and
+// attachments are never involved.
+func (s *Store) MatchMessageIdentitiesContext(
+	ctx context.Context,
+	messageIDs []int64,
+) (map[int64]MessageIdentityMatch, error) {
+	candidatesByMessage := make(map[int64]*messageIdentityCandidates, len(messageIDs))
+	sourceSet := make(map[int64]struct{})
+
+	err := queryInChunksContext(ctx, s.db, messageIDs, nil, `
+		WITH requested_messages AS (
+			SELECT m.id, m.source_id, m.sender_id
+			FROM messages m
+			WHERE m.id IN (%s)
+		), candidate_links AS (
+			SELECT rm.id AS message_id,
+			       rm.source_id,
+			       mr.recipient_type,
+			       mr.participant_id,
+			       mr.email_address AS envelope_address
+			FROM requested_messages rm
+			LEFT JOIN message_recipients mr
+			  ON mr.message_id = rm.id
+			 AND mr.recipient_type IN ('from', 'to', 'cc', 'bcc')
+			UNION ALL
+			SELECT rm.id AS message_id,
+			       rm.source_id,
+			       'from' AS recipient_type,
+			       rm.sender_id AS participant_id,
+			       NULL AS envelope_address
+			FROM requested_messages rm
+			WHERE rm.sender_id IS NOT NULL
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM message_recipients sender_row
+				WHERE sender_row.message_id = rm.id
+				  AND sender_row.recipient_type = 'from'
+			  )
+		)
+		SELECT cl.message_id,
+		       cl.source_id,
+		       cl.recipient_type,
+		       cl.envelope_address,
+		       p.email_address,
+		       pi.identifier_type,
+		       pi.identifier_value
+		FROM candidate_links cl
+		LEFT JOIN participants p ON p.id = cl.participant_id
+		LEFT JOIN participant_identifiers pi ON pi.participant_id = p.id
+		ORDER BY cl.message_id, cl.recipient_type, cl.participant_id, pi.id
+	`, func(rows *loggedRows) error {
+		var (
+			messageID       int64
+			sourceID        int64
+			recipientType   sql.NullString
+			envelopeAddress sql.NullString
+			emailAddress    sql.NullString
+			identifierType  sql.NullString
+			identifierValue sql.NullString
+		)
+		if err := rows.Scan(
+			&messageID,
+			&sourceID,
+			&recipientType,
+			&envelopeAddress,
+			&emailAddress,
+			&identifierType,
+			&identifierValue,
+		); err != nil {
+			return fmt.Errorf("scan message identity candidate: %w", err)
+		}
+
+		candidates := candidatesByMessage[messageID]
+		if candidates == nil {
+			candidates = &messageIdentityCandidates{
+				messageID:  messageID,
+				sourceID:   sourceID,
+				sender:     newIdentityCandidateSet(),
+				recipients: newIdentityCandidateSet(),
+			}
+			candidatesByMessage[messageID] = candidates
+			sourceSet[sourceID] = struct{}{}
+		}
+
+		var target *identityCandidateSet
+		switch recipientType.String {
+		case "from":
+			target = candidates.sender
+		case "to", "cc", "bcc":
+			target = candidates.recipients
+		default:
+			return nil
+		}
+		target.addRow(envelopeAddress, emailAddress, identifierType, identifierValue)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query message identity candidates: %w", err)
+	}
+
+	sourceIDs := make([]int64, 0, len(sourceSet))
+	for sourceID := range sourceSet {
+		sourceIDs = append(sourceIDs, sourceID)
+	}
+	slices.Sort(sourceIDs)
+
+	identitiesBySource := make(map[int64]*storedIdentityIndex, len(sourceIDs))
+	err = queryInChunksContext(ctx, s.db, sourceIDs, nil, `
+		SELECT source_id, address
+		FROM account_identities
+		WHERE source_id IN (%s)
+		ORDER BY source_id, address
+	`, func(rows *loggedRows) error {
+		var sourceID int64
+		var address string
+		if err := rows.Scan(&sourceID, &address); err != nil {
+			return fmt.Errorf("scan message account identity: %w", err)
+		}
+		index := identitiesBySource[sourceID]
+		if index == nil {
+			index = newStoredIdentityIndex()
+			identitiesBySource[sourceID] = index
+		}
+		index.add(address)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query message account identities: %w", err)
+	}
+
+	matches := make(map[int64]MessageIdentityMatch, len(candidatesByMessage))
+	for messageID, candidates := range candidatesByMessage {
+		identities := identitiesBySource[candidates.sourceID]
+		matches[messageID] = MessageIdentityMatch{
+			MessageID:  candidates.messageID,
+			SourceID:   candidates.sourceID,
+			Sender:     intersectStoredIdentities(candidates.sender, identities),
+			Recipients: intersectStoredIdentities(candidates.recipients, identities),
+		}
+	}
+	return matches, nil
+}
+
+// addRow records one candidate-link row's identifier under the comparison
+// rule messageIdentityAttributionMatch applies to that column.
+//
+// The envelope snapshot (message_recipients.email_address) is the
+// message's own record of the address on this recipient row. It is
+// immutable under participant merges, so when present it is the only
+// candidate: falling through to the participant's current fields would
+// badge one alias's mail with every alias the merge survivor carries.
+// Rows without a snapshot (legacy ingests, non-email writers) keep the
+// participant-derived candidates: the participant's email plus its non-email
+// identifier rows compared per their own identifier_type. Email-typed
+// identifiers are considered case-insensitively only when no primary email is
+// present, so alternate email aliases remain suppressed while preserved phone
+// and chat identifiers survive participant merges, exactly as attribution
+// does. participants.phone_number is deliberately NOT a candidate:
+// attribution never consults it (EnsureParticipantByPhone always backs a
+// phone identity with a participant_identifiers row), so badging through
+// it would keep matching a phone identity after its identifier mapping
+// was removed.
+func (set *identityCandidateSet) addRow(
+	envelopeAddress sql.NullString,
+	emailAddress sql.NullString,
+	identifierType sql.NullString,
+	identifierValue sql.NullString,
+) {
+	if addCandidateKey(set.shape, envelopeAddress, NormalizeIdentifierForCompare) {
+		return
+	}
+	hasPrimaryEmail := addCandidateKey(set.shape, emailAddress, NormalizeIdentifierForCompare)
+	if identifierType.Valid && identifierType.String == string(AttributeFieldEmail) {
+		if !hasPrimaryEmail {
+			addCandidateKey(set.lower, identifierValue, strings.ToLower)
+		}
+		return
+	}
+	addCandidateKey(set.raw, identifierValue, func(value string) string { return value })
+}
+
+func addCandidateKey(
+	target map[string]struct{},
+	value sql.NullString,
+	normalize func(string) string,
+) bool {
+	if !value.Valid || strings.TrimSpace(value.String) == "" {
+		return false
+	}
+	target[normalize(strings.TrimSpace(value.String))] = struct{}{}
+	return true
+}
+
+// storedIdentityIndex holds one source's confirmed identities keyed per
+// comparison rule, so each candidate key set intersects under the semantics
+// its column carries in messageIdentityAttributionMatch.
+type storedIdentityIndex struct {
+	byShape map[string][]string // NormalizeIdentifierForCompare(address)
+	byLower map[string][]string // LOWER(address), for email-typed identifier rows
+	byRaw   map[string][]string // address verbatim, for non-email identifier rows
+}
+
+func newStoredIdentityIndex() *storedIdentityIndex {
+	return &storedIdentityIndex{
+		byShape: make(map[string][]string),
+		byLower: make(map[string][]string),
+		byRaw:   make(map[string][]string),
+	}
+}
+
+func (index *storedIdentityIndex) add(address string) {
+	shapeKey := NormalizeIdentifierForCompare(address)
+	index.byShape[shapeKey] = append(index.byShape[shapeKey], address)
+	lowerKey := strings.ToLower(address)
+	index.byLower[lowerKey] = append(index.byLower[lowerKey], address)
+	index.byRaw[address] = append(index.byRaw[address], address)
+}
+
+func intersectStoredIdentities(
+	candidates *identityCandidateSet,
+	identities *storedIdentityIndex,
+) []string {
+	matchedSet := make(map[string]struct{})
+	if identities != nil {
+		collect := func(keys map[string]struct{}, byKey map[string][]string) {
+			for candidate := range keys {
+				for _, stored := range byKey[candidate] {
+					matchedSet[stored] = struct{}{}
+				}
+			}
+		}
+		collect(candidates.shape, identities.byShape)
+		collect(candidates.lower, identities.byLower)
+		collect(candidates.raw, identities.byRaw)
+	}
+	matched := make([]string, 0, len(matchedSet))
+	for stored := range matchedSet {
+		matched = append(matched, stored)
+	}
+	sort.Strings(matched)
+	return matched
+}

--- a/internal/store/message_identity_matches_test.go
+++ b/internal/store/message_identity_matches_test.go
@@ -1,0 +1,635 @@
+package store_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+type messageIdentityFixture struct {
+	Store    *store.Store
+	SourceA  int64
+	SourceB  int64
+	MessageA int64
+	MessageB int64
+}
+
+func newMessageIdentityFixture(t *testing.T) messageIdentityFixture {
+	t.Helper()
+
+	fx := storetest.New(t)
+	other, err := fx.Store.GetOrCreateSource("gmail", "other-source@example.test")
+	require.NoError(t, err, "create second source")
+	otherConversationID, err := fx.Store.EnsureConversation(other.ID, "other-thread", "Other Thread")
+	require.NoError(t, err, "create second-source conversation")
+
+	sendAs := fx.EnsureParticipant("send-as@example.test", "Send As", "example.test")
+	otherFrom := fx.EnsureParticipant("outside@example.test", "Outside", "example.test")
+	maskedRecipient := fx.EnsureParticipant("MASKED-SHOP@EXAMPLE.TEST", "Masked Shop", "example.test")
+	ccRecipient := fx.EnsureParticipant("cc-owner@example.test", "CC Owner", "example.test")
+	bccRecipient := fx.EnsureParticipant("bcc-owner@example.test", "BCC Owner", "example.test")
+	directSender := fx.EnsureParticipant("direct-owner@example.test", "Direct Owner", "example.test")
+
+	messageA := fx.NewMessage().WithSubject("identity intersection").Build()
+	messageA.SenderID = sql.NullInt64{Int64: directSender, Valid: true}
+	messageAID, err := fx.Store.UpsertMessage(messageA)
+	require.NoError(t, err, "create source-A message")
+	require.NoError(t, fx.Store.ReplaceMessageRecipients(
+		messageAID, "from", []int64{otherFrom, sendAs}, []string{"Outside", "Send As"}),
+		"add every From row")
+	require.NoError(t, fx.Store.ReplaceMessageRecipients(
+		messageAID, "to", []int64{maskedRecipient}, []string{"Masked Shop"}),
+		"add To row")
+	require.NoError(t, fx.Store.ReplaceMessageRecipients(
+		messageAID, "cc", []int64{ccRecipient}, []string{"CC Owner"}),
+		"add Cc row")
+	require.NoError(t, fx.Store.ReplaceMessageRecipients(
+		messageAID, "bcc", []int64{bccRecipient}, []string{"BCC Owner"}),
+		"add Bcc row")
+
+	messageB := storetest.NewMessage(other.ID, otherConversationID).
+		WithSubject("other source identity").Build()
+	messageB.SenderID = sql.NullInt64{Int64: sendAs, Valid: true}
+	messageBID, err := fx.Store.UpsertMessage(messageB)
+	require.NoError(t, err, "create source-B message")
+	require.NoError(t, fx.Store.ReplaceMessageRecipients(
+		messageBID, "from", []int64{sendAs}, []string{"Send As"}),
+		"add source-B From row")
+
+	return messageIdentityFixture{
+		Store:    fx.Store,
+		SourceA:  fx.Source.ID,
+		SourceB:  other.ID,
+		MessageA: messageAID,
+		MessageB: messageBID,
+	}
+}
+
+func TestMatchMessageIdentitiesUsesEveryFromAndRecipientWithinSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := newMessageIdentityFixture(t)
+	require.NoError(fx.Store.AddAccountIdentity(fx.SourceA, "Send-As@Example.test", "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.SourceA, "masked-shop@example.test", "provider-alias"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.SourceA, "cc-owner@example.test", "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.SourceA, "bcc-owner@example.test", "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.SourceA, "direct-owner@example.test", "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.SourceB, "other@example.test", "manual"))
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{fx.MessageA})
+	require.NoError(err)
+	match := matches[fx.MessageA]
+	assert.Equal(fx.MessageA, match.MessageID)
+	assert.Equal(fx.SourceA, match.SourceID)
+	assert.Equal([]string{"Send-As@Example.test"}, match.Sender)
+	assert.Equal([]string{
+		"bcc-owner@example.test",
+		"cc-owner@example.test",
+		"masked-shop@example.test",
+	}, match.Recipients)
+	assert.NotContains(match.Sender, "direct-owner@example.test",
+		"sender_id must not supplement an existing From row")
+}
+
+func TestMatchMessageIdentitiesCannotLeakAcrossSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := newMessageIdentityFixture(t)
+	require.NoError(fx.Store.AddAccountIdentity(fx.SourceA, "send-as@example.test", "manual"))
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{fx.MessageB})
+	require.NoError(err)
+	assert.Empty(matches[fx.MessageB].Sender)
+	assert.NotNil(matches[fx.MessageB].Sender)
+	assert.NotNil(matches[fx.MessageB].Recipients)
+}
+
+func TestMatchMessageIdentitiesPreservesSyntheticExactness(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	synthetic := fx.EnsureParticipant("@me:example.test", "Synthetic", "")
+	message := fx.NewMessage().Build()
+	message.SenderID = sql.NullInt64{Int64: synthetic, Valid: true}
+	messageID, err := fx.Store.UpsertMessage(message)
+	require.NoError(err)
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "from", []int64{synthetic}, []string{"Synthetic"}))
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "@Me:example.test", "manual"))
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Empty(matches[messageID].Sender)
+
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "@me:example.test", "manual"))
+	matches, err = fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Equal([]string{"@me:example.test"}, matches[messageID].Sender)
+}
+
+func TestMatchMessageIdentitiesUsesDirectSenderOnlyWithoutFromRow(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	direct := fx.EnsureParticipant("direct@example.test", "Direct", "example.test")
+	message := fx.NewMessage().Build()
+	message.SenderID = sql.NullInt64{Int64: direct, Valid: true}
+	messageID, err := fx.Store.UpsertMessage(message)
+	require.NoError(err)
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "Direct@Example.test", "manual"))
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Equal([]string{"Direct@Example.test"}, matches[messageID].Sender)
+	assert.NotNil(matches[messageID].Recipients)
+}
+
+func TestMatchMessageIdentitiesDoesNotReplaceHeaderAddressWithAlternateIdentifier(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	sender := fx.EnsureParticipant("header-address@example.test", "Sender", "example.test")
+	require.NoError(fx.Store.SetParticipantIdentifier(
+		sender, "email", "confirmed-alias@example.test"))
+	messageID := fx.NewMessage().Create(t, fx.Store)
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "from", []int64{sender}, []string{"Sender"}))
+	require.NoError(fx.Store.AddAccountIdentity(
+		fx.Source.ID, "confirmed-alias@example.test", "manual"))
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Empty(matches[messageID].Sender,
+		"an alternate participant identifier is not the message's exact From address")
+}
+
+func TestMatchMessageIdentitiesChunksAndReturnsStableEmptyMatches(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	messageIDs := fx.CreateMessages(501)
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), messageIDs)
+	require.NoError(err)
+	require.Len(matches, len(messageIDs))
+	for _, messageID := range messageIDs {
+		match := matches[messageID]
+		assert.Equal(fx.Source.ID, match.SourceID)
+		assert.NotNil(match.Sender)
+		assert.NotNil(match.Recipients)
+	}
+}
+
+func TestResolveAccountIdentityContextReturnsStoredIdentityAndAllParticipants(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	primary := fx.EnsureParticipant("owner@example.test", "Primary", "example.test")
+	alias := fx.EnsureParticipant("alias@example.test", "Alias", "example.test")
+	require.NoError(fx.Store.SetParticipantIdentifier(alias, "email", "OWNER@EXAMPLE.TEST"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "Owner@Example.test", "manual"))
+
+	resolved, err := fx.Store.ResolveAccountIdentityContext(
+		t.Context(), fx.Source.ID, "owner@example.test")
+	require.NoError(err)
+	assert.Equal(fx.Source.ID, resolved.SourceID)
+	assert.Equal("Owner@Example.test", resolved.Identifier)
+	assert.Equal([]int64{primary, alias}, resolved.ParticipantIDs)
+}
+
+func TestResolveAccountIdentityContextRequiresExactSourceConfirmation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	other, err := fx.Store.GetOrCreateSource("gmail", "identity-other@example.test")
+	require.NoError(err)
+	require.NoError(fx.Store.AddAccountIdentity(other.ID, "owner@example.test", "manual"))
+
+	_, err = fx.Store.ResolveAccountIdentityContext(
+		context.Background(), fx.Source.ID, "OWNER@example.test")
+	require.ErrorIs(err, store.ErrAccountIdentityNotFound)
+
+	_, err = fx.Store.ResolveAccountIdentityContext(
+		context.Background(), other.ID, "missing@example.test")
+	require.ErrorIs(err, store.ErrAccountIdentityNotFound)
+
+	require.NoError(fx.Store.AddAccountIdentity(other.ID, "@Me:example.test", "manual"))
+	_, err = fx.Store.ResolveAccountIdentityContext(
+		context.Background(), other.ID, "@me:example.test")
+	require.ErrorIs(err, store.ErrAccountIdentityNotFound)
+	resolved, err := fx.Store.ResolveAccountIdentityContext(
+		context.Background(), other.ID, "@Me:example.test")
+	require.NoError(err)
+	assert.Equal("@Me:example.test", resolved.Identifier)
+	assert.NotNil(resolved.ParticipantIDs)
+}
+
+// TestMatchMessageIdentitiesMatchesAttributionForPhoneIdentity guards
+// hydration parity with messageIdentityAttributionMatch: a phone identity
+// badges through the participant_identifiers row EnsureParticipantByPhone
+// creates, never through participants.phone_number directly. If that row
+// disappears (the MergeParticipants edge, simulated here with a direct
+// delete) the badge must vanish, exactly as attribution stops matching.
+func TestMatchMessageIdentitiesMatchesAttributionForPhoneIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	const phone = "+15550100001"
+
+	participantID, err := fx.Store.EnsureParticipantByPhone(phone, "Phone Owner", "whatsapp")
+	require.NoError(err, "EnsureParticipantByPhone")
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, phone, "manual"))
+
+	message := fx.NewMessage().WithSubject("phone identity parity").Build()
+	message.SenderID = sql.NullInt64{Int64: participantID, Valid: true}
+	messageID, err := fx.Store.UpsertMessage(message)
+	require.NoError(err, "create phone-sender message")
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "from", []int64{participantID}, []string{"Phone Owner"}),
+		"add phone From row")
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Equal([]string{phone}, matches[messageID].Sender,
+		"identifier-backed phone identity must badge the sender")
+
+	_, err = fx.Store.DB().Exec(
+		fx.Store.Rebind("DELETE FROM participant_identifiers WHERE participant_id = ?"),
+		participantID,
+	)
+	require.NoError(err, "simulate MergeParticipants edge: identifier row gone, phone_number still set")
+
+	matchesAfter, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Empty(matchesAfter[messageID].Sender,
+		"participants.phone_number alone must not badge; attribution never consults it")
+}
+
+// TestMatchMessageIdentitiesNonEmailIdentifierIsCaseSensitive guards
+// hydration parity with messageIdentityAttributionMatch's per-row rule: a
+// participant_identifiers row whose type is not "email" compares
+// case-sensitively based on identifier_type, not on whether the value looks
+// email-shaped — the old shape-based normalization would case-fold an
+// email-looking bridge handle and badge a differently cased identity that
+// attribution rejects.
+func TestMatchMessageIdentitiesNonEmailIdentifierIsCaseSensitive(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+
+	// Neither participant carries an email of its own, so hydration falls
+	// back to the identifier rows; the values are deliberately email-shaped.
+	newBridgeSender := func(name, identifierValue, sourceMessageID string) int64 {
+		t.Helper()
+		var senderID int64
+		require.NoError(fx.Store.DB().QueryRow(fx.Store.Rebind(`
+			INSERT INTO participants (display_name, created_at, updated_at)
+			VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+			RETURNING id
+		`), name).Scan(&senderID), "create email-less participant")
+		require.NoError(fx.Store.SetParticipantIdentifier(senderID, "matrix", identifierValue))
+		message := fx.NewMessage().WithSubject("bridge identifier parity").Build()
+		message.SourceMessageID = sourceMessageID
+		message.SenderID = sql.NullInt64{Int64: senderID, Valid: true}
+		messageID, err := fx.Store.UpsertMessage(message)
+		require.NoError(err, "create bridge-sender message")
+		require.NoError(fx.Store.ReplaceMessageRecipients(
+			messageID, "from", []int64{senderID}, []string{name}),
+			"add bridge From row")
+		return messageID
+	}
+	exactCaseMessage := newBridgeSender("Bridge Exact", "User@Example.Test", "bridge-exact")
+	differentCaseMessage := newBridgeSender("Bridge Diff", "user@example.test", "bridge-diff")
+
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "User@Example.Test", "manual"))
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(
+		t.Context(), []int64{exactCaseMessage, differentCaseMessage})
+	require.NoError(err)
+	assert.Equal([]string{"User@Example.Test"}, matches[exactCaseMessage].Sender,
+		"exact-case match against a non-email identifier row must badge")
+	assert.Empty(matches[differentCaseMessage].Sender,
+		"non-email identifier types must compare case-sensitively even for email-shaped values")
+}
+
+// TestMatchMessageIdentitiesEmailTypedIdentifierIsCaseInsensitive locks in
+// the email-typed half of the per-row rule: identifier rows of type "email"
+// keep badging case-insensitively, same as attribution.
+func TestMatchMessageIdentitiesEmailTypedIdentifierIsCaseInsensitive(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+
+	var senderID int64
+	require.NoError(fx.Store.DB().QueryRow(fx.Store.Rebind(`
+		INSERT INTO participants (display_name, created_at, updated_at)
+		VALUES ('Alias User', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		RETURNING id
+	`)).Scan(&senderID), "create email-less participant")
+	require.NoError(fx.Store.SetParticipantIdentifier(senderID, "email", "Send-As@Example.Test"))
+
+	message := fx.NewMessage().WithSubject("email identifier parity").Build()
+	message.SenderID = sql.NullInt64{Int64: senderID, Valid: true}
+	messageID, err := fx.Store.UpsertMessage(message)
+	require.NoError(err, "create alias-sender message")
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "from", []int64{senderID}, []string{"Alias User"}),
+		"add alias From row")
+
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "send-as@example.test", "manual"))
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Equal([]string{"send-as@example.test"}, matches[messageID].Sender,
+		"email-typed identifier rows must badge case-insensitively")
+}
+
+// TestResolveAccountIdentityMatchesAttributionForPhoneIdentity guards parity
+// with messageIdentityAttributionMatch: a phone identity resolves through the
+// participant_identifiers row EnsureParticipantByPhone creates, not through
+// participants.phone_number directly. If that row disappears (the
+// MergeParticipants edge, simulated here with a direct delete) the resolver
+// must stop matching, exactly as attribution would.
+func TestResolveAccountIdentityMatchesAttributionForPhoneIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	const phone = "+15550100001"
+
+	participantID, err := fx.Store.EnsureParticipantByPhone(phone, "Phone Owner", "whatsapp")
+	require.NoError(err, "EnsureParticipantByPhone")
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, phone, "manual"))
+
+	resolved, err := fx.Store.ResolveAccountIdentityContext(t.Context(), fx.Source.ID, phone)
+	require.NoError(err)
+	assert.Contains(resolved.ParticipantIDs, participantID,
+		"participant_identifiers row for the phone must resolve, matching attribution")
+
+	_, err = fx.Store.DB().Exec(
+		fx.Store.Rebind("DELETE FROM participant_identifiers WHERE participant_id = ?"),
+		participantID,
+	)
+	require.NoError(err, "simulate MergeParticipants edge: identifier row gone, phone_number still set")
+
+	resolvedAfter, err := fx.Store.ResolveAccountIdentityContext(t.Context(), fx.Source.ID, phone)
+	require.NoError(err)
+	assert.NotContains(resolvedAfter.ParticipantIDs, participantID,
+		"participants.phone_number alone must not resolve; attribution never consults it")
+}
+
+// TestResolveAccountIdentityNonEmailIdentifierIsCaseSensitive guards parity
+// with messageIdentityAttributionMatch's per-row rule: a participant_identifiers
+// row whose type is not "email" compares case-sensitively, based on the
+// row's identifier_type column — not on whether the confirmed identity
+// address happens to look email-shaped. The confirmed identity here is
+// deliberately email-shaped (e.g. a chat bridge that issues email-looking
+// handles) so the old global "does the searched string look like an email"
+// rule would apply LOWER() everywhere and over-match a differently cased,
+// non-email-typed row; the per-row rule must not.
+func TestResolveAccountIdentityNonEmailIdentifierIsCaseSensitive(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	exactCase := fx.EnsureParticipant("matrix-exact@example.test", "Matrix Exact", "example.test")
+	require.NoError(fx.Store.SetParticipantIdentifier(exactCase, "matrix", "User@Example.Test"))
+	differentCase := fx.EnsureParticipant("matrix-diff@example.test", "Matrix Diff", "example.test")
+	require.NoError(fx.Store.SetParticipantIdentifier(differentCase, "matrix", "user@example.test"))
+
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "User@Example.Test", "manual"))
+
+	resolved, err := fx.Store.ResolveAccountIdentityContext(
+		t.Context(), fx.Source.ID, "User@Example.Test")
+	require.NoError(err)
+	assert.Contains(resolved.ParticipantIDs, exactCase,
+		"exact-case match against a non-email identifier row must resolve")
+	assert.NotContains(resolved.ParticipantIDs, differentCase,
+		"non-email identifier types compare case-sensitively even when the value looks email-shaped")
+}
+
+// TestResolveAccountIdentityEmailRemainsCaseInsensitive locks in existing
+// behavior: participant_identifiers rows of type "email" keep comparing
+// case-insensitively, same as attribution.
+func TestResolveAccountIdentityEmailRemainsCaseInsensitive(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	owner := fx.EnsureParticipant("owner@example.test", "Owner", "example.test")
+	alias := fx.EnsureParticipant("alias@example.test", "Alias", "example.test")
+	require.NoError(fx.Store.SetParticipantIdentifier(alias, "email", "User@Example.Com"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "user@example.com", "manual"))
+
+	resolved, err := fx.Store.ResolveAccountIdentityContext(
+		t.Context(), fx.Source.ID, "user@example.com")
+	require.NoError(err)
+	assert.Contains(resolved.ParticipantIDs, alias,
+		"email identifier type must match case-insensitively")
+	assert.NotContains(resolved.ParticipantIDs, owner,
+		"unrelated participant must not resolve")
+}
+
+// persistEnvelopeMessage stores one email message through the production
+// PersistMessage path with an envelope address snapshot on its single
+// recipient row, mirroring what email ingest writes.
+func persistEnvelopeMessage(
+	t *testing.T,
+	fx *storetest.Fixture,
+	sourceMessageID, recipientType string,
+	participantID int64,
+	envelopeAddress string,
+) int64 {
+	t.Helper()
+	message := &store.Message{
+		ConversationID:  fx.ConvID,
+		SourceID:        fx.Source.ID,
+		SourceMessageID: sourceMessageID,
+		MessageType:     "email",
+		SentAt:          sql.NullTime{Time: time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC), Valid: true},
+		SizeEstimate:    100,
+	}
+	if recipientType == "from" {
+		message.SenderID = sql.NullInt64{Int64: participantID, Valid: true}
+	}
+	messageID, err := fx.Store.PersistMessage(&store.MessagePersistData{
+		Message: message,
+		Recipients: []store.RecipientSet{{
+			Type:           recipientType,
+			ParticipantIDs: []int64{participantID},
+			DisplayNames:   []string{"Envelope Participant"},
+			EmailAddresses: []string{envelopeAddress},
+		}},
+	})
+	require.NoError(t, err, "persist envelope message %s", sourceMessageID)
+	return messageID
+}
+
+// TestMatchMessageIdentitiesPrefersEnvelopeAddressAfterParticipantMerge is
+// the badge-hydration half of envelope-accurate identity matching: after a
+// participant merge repoints recipient rows onto the survivor, each message
+// must keep badging the alias that actually appeared in its envelope, not
+// every alias the merged participant now carries.
+func TestMatchMessageIdentitiesPrefersEnvelopeAddressAfterParticipantMerge(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	aliasA := fx.EnsureParticipant("alias-a@example.test", "Alias A", "example.test")
+	aliasB := fx.EnsureParticipant("alias-b@example.test", "Alias B", "example.test")
+
+	sentViaA := persistEnvelopeMessage(t, fx, "sent-via-a", "from", aliasA, "alias-a@example.test")
+	sentViaB := persistEnvelopeMessage(t, fx, "sent-via-b", "from", aliasB, "alias-b@example.test")
+	receivedAtA := persistEnvelopeMessage(t, fx, "received-at-a", "to", aliasA, "alias-a@example.test")
+
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "alias-a@example.test", "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "alias-b@example.test", "manual"))
+	require.NoError(fx.Store.MergeParticipants(aliasA, aliasB), "merge alias A into alias B")
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(
+		t.Context(), []int64{sentViaA, sentViaB, receivedAtA})
+	require.NoError(err)
+	assert.Equal([]string{"alias-a@example.test"}, matches[sentViaA].Sender,
+		"a merge must not rebadge alias A's sent mail as alias B")
+	assert.Equal([]string{"alias-b@example.test"}, matches[sentViaB].Sender,
+		"alias B's own sent mail keeps its envelope badge")
+	assert.Equal([]string{"alias-a@example.test"}, matches[receivedAtA].Recipients,
+		"a merge must not rebadge alias A's received mail as alias B")
+}
+
+// TestMatchMessageIdentitiesFallsBackToParticipantEmailWithoutEnvelope locks
+// in the legacy contract: recipient rows written before the envelope snapshot
+// existed (email_address NULL) keep matching through the current participant
+// fields.
+func TestMatchMessageIdentitiesFallsBackToParticipantEmailWithoutEnvelope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	legacy := fx.EnsureParticipant("legacy-owner@example.test", "Legacy", "example.test")
+	message := fx.NewMessage().Build()
+	message.SenderID = sql.NullInt64{Int64: legacy, Valid: true}
+	messageID, err := fx.Store.UpsertMessage(message)
+	require.NoError(err)
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "from", []int64{legacy}, []string{"Legacy"}),
+		"legacy write path leaves the envelope snapshot NULL")
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "Legacy-Owner@example.test", "manual"))
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Equal([]string{"Legacy-Owner@example.test"}, matches[messageID].Sender,
+		"NULL-envelope rows must keep matching via the participant email")
+}
+
+// TestMatchMessageIdentitiesKeepsNonEmailIdentifierAfterParticipantMerge
+// guards legacy and non-email recipient rows after an email participant
+// absorbs a phone participant. The survivor's primary email suppresses
+// alternate email aliases, but must not hide the preserved phone identifier.
+func TestMatchMessageIdentitiesKeepsNonEmailIdentifierAfterParticipantMerge(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	const (
+		email = "owner@example.test"
+		phone = "+15550100003"
+	)
+
+	emailParticipant := fx.EnsureParticipant(email, "Email Owner", "example.test")
+	phoneParticipant, err := fx.Store.EnsureParticipantByPhone(phone, "Phone Owner", "whatsapp")
+	require.NoError(err, "create phone participant")
+
+	message := fx.NewMessage().WithSubject("merged email and phone identity").Build()
+	message.SenderID = sql.NullInt64{Int64: emailParticipant, Valid: true}
+	messageID, err := fx.Store.UpsertMessage(message)
+	require.NoError(err, "create email-sender message")
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "from", []int64{emailParticipant}, []string{"Email Owner"}),
+		"add legacy From row without an envelope snapshot")
+
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, email, "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, phone, "manual"))
+	require.NoError(fx.Store.MergeParticipants(phoneParticipant, emailParticipant),
+		"merge phone participant into email participant")
+
+	matches, err := fx.Store.MatchMessageIdentitiesContext(t.Context(), []int64{messageID})
+	require.NoError(err)
+	assert.Equal([]string{phone, email}, matches[messageID].Sender,
+		"the survivor must badge both its primary email and preserved phone identifier")
+}
+
+// TestResolveAccountIdentityContextReportsEmailIdentifierShape verifies the
+// resolver classifies the stored identifier's shape so consumers know whether
+// the envelope snapshot column applies (emails) or participant matching is
+// the only surface (phones, matrix IDs, handles).
+func TestResolveAccountIdentityContextReportsEmailIdentifierShape(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "shape-owner@example.test", "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(fx.Source.ID, "+15550100002", "manual"))
+
+	email, err := fx.Store.ResolveAccountIdentityContext(
+		t.Context(), fx.Source.ID, "shape-owner@example.test")
+	require.NoError(err)
+	assert.True(email.IdentifierIsEmail, "email-shaped identifier must be classified as email")
+
+	phone, err := fx.Store.ResolveAccountIdentityContext(
+		t.Context(), fx.Source.ID, "+15550100002")
+	require.NoError(err)
+	assert.False(phone.IdentifierIsEmail, "phone identifier must not be classified as email")
+}
+
+func TestGenericAPIMessagePathsDoNotHydrateIdentityMatches(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fx := storetest.New(t)
+	from := fx.EnsureParticipant("STORED-SENDER@EXAMPLE.TEST", "Header Sender", "example.test")
+	to := fx.EnsureParticipant("STORED-RECIPIENT@EXAMPLE.TEST", "Header To", "example.test")
+	message := fx.NewMessage().WithSubject("identity hydration subject").Build()
+	message.SenderID = sql.NullInt64{Int64: from, Valid: true}
+	messageID, err := fx.Store.UpsertMessage(message)
+	require.NoError(err)
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "from", []int64{from}, []string{"Header Sender"}))
+	require.NoError(fx.Store.ReplaceMessageRecipients(
+		messageID, "to", []int64{to}, []string{"Header To"}))
+	require.NoError(fx.Store.AddAccountIdentity(
+		fx.Source.ID, "Stored-Sender@Example.test", "manual"))
+	require.NoError(fx.Store.AddAccountIdentity(
+		fx.Source.ID, "stored-recipient@example.test", "manual"))
+	store.ConfigureSQLLogging(store.SQLLogOptions{FullTrace: true, MaxStmtChars: 10_000})
+	t.Cleanup(func() { store.ConfigureSQLLogging(store.SQLLogOptions{}) })
+	var logBuffer bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	detail, err := fx.Store.GetMessage(messageID)
+	require.NoError(err)
+	assert.Equal("Header Sender <STORED-SENDER@EXAMPLE.TEST>", detail.From)
+	assert.Equal([]string{"Header To <STORED-RECIPIENT@EXAMPLE.TEST>"}, detail.To)
+
+	listed, total, err := fx.Store.ListMessages(0, 10)
+	require.NoError(err)
+	require.Equal(int64(1), total)
+	require.Len(listed, 1)
+
+	summaries, err := fx.Store.GetMessagesSummariesByIDs([]int64{messageID})
+	require.NoError(err)
+	require.Len(summaries, 1)
+
+	searched, total, err := fx.Store.SearchMessagesQuery(
+		&search.Query{SubjectTerms: []string{"identity hydration"}}, 0, 10)
+	require.NoError(err)
+	require.Equal(int64(1), total)
+	require.Len(searched, 1)
+
+	trace := strings.ToLower(logBuffer.String())
+	assert.NotContains(trace, "account_identities",
+		"generic message paths must leave identity matching to explicit API consumers")
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -47,12 +47,16 @@ type contextQuerier interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
-// RecipientSet groups participant IDs and display names for one
-// recipient type (from, to, cc, bcc).
+// RecipientSet groups participant IDs, display names, and envelope
+// addresses for one recipient type (from, to, cc, bcc). EmailAddresses
+// carries the address as it appeared in the message envelope; unlike the
+// participant row it resolves to, it never changes under participant
+// merges. Writers without envelope addresses may leave it empty.
 type RecipientSet struct {
 	Type           string
 	ParticipantIDs []int64
 	DisplayNames   []string
+	EmailAddresses []string
 }
 
 // ParticipantPersistData describes one email participant to resolve inside a
@@ -981,6 +985,15 @@ func (s *Store) GetMessageIsFromMe(messageID int64) (bool, error) {
 	return isFromMe, err
 }
 
+// messageIdentityAttributionMatch derives identity_is_from_me for one
+// messages row. The first two clauses match the sender participant's current
+// email and identifier rows. The third matches the message's own 'from'
+// envelope snapshot (message_recipients.email_address): after a participant
+// merge a confirmed alias may survive ONLY there — the survivor's email is
+// the primary address and no identifier row carries the alias — so without
+// it, confirming that alias would leave the alias's sent messages
+// unattributed. Envelope snapshots exist only for email addresses, so a
+// non-email identity (phone, matrix) can never match the clause.
 const messageIdentityAttributionMatch = `(
 	EXISTS (
 	  SELECT 1
@@ -999,6 +1012,15 @@ const messageIdentityAttributionMatch = `(
 	      (pi.identifier_type = 'email' AND LOWER(pi.identifier_value) = LOWER(ai.address))
 	      OR (pi.identifier_type <> 'email' AND pi.identifier_value = ai.address)
 	    )
+	)
+	OR EXISTS (
+	  SELECT 1
+	  FROM account_identities ai
+	  JOIN message_recipients mr ON mr.message_id = messages.id
+	  WHERE ai.source_id = messages.source_id
+	    AND mr.recipient_type = 'from'
+	    AND mr.email_address IS NOT NULL
+	    AND LOWER(mr.email_address) = LOWER(ai.address)
 	)
 )`
 
@@ -1066,6 +1088,33 @@ func refreshParticipantMessageAttributionContext(
 	`, messageSourceAttribution, messageIdentityAttributionMatch), args...)
 	if err != nil {
 		return fmt.Errorf("refresh participant message attribution: %w", err)
+	}
+	return nil
+}
+
+// refreshMessageAttributionWith recomputes one message's identity attribution
+// against its final recipient rows. persistMessageWith calls it after
+// replacing recipients because the attribution CTE inside the message upsert
+// runs before this transaction writes the 'from' envelope snapshot: a
+// confirmed identity represented only there — the shape a participant merge
+// leaves behind — would otherwise persist as unattributed, and re-persisting
+// an already-repaired message would clear the flag its envelope had earned.
+// The change guard keeps the common agreeing case write-free, so it fires no
+// last_modified triggers.
+func refreshMessageAttributionWith(q querier, messageID int64) error {
+	_, err := q.Exec(fmt.Sprintf(`
+		UPDATE messages
+		SET identity_is_from_me = %[2]s,
+		    is_from_me = (%[1]s OR %[2]s)
+		WHERE id = ?
+		  AND (
+		    identity_is_from_me <> %[2]s
+		    OR is_from_me IS NULL
+		    OR is_from_me <> (%[1]s OR %[2]s)
+		  )
+	`, messageSourceAttribution, messageIdentityAttributionMatch), messageID)
+	if err != nil {
+		return fmt.Errorf("refresh message attribution: %w", err)
 	}
 	return nil
 }
@@ -1206,6 +1255,14 @@ func (s *Store) persistMessageWith(
 		if err := replaceMessageRecipientsTx(q, messageID, rs); err != nil {
 			return 0, fmt.Errorf("store %s recipients: %w", rs.Type, err)
 		}
+	}
+
+	// Unconditional, not gated on data.Recipients carrying a 'from' set: even
+	// a persist that touches no recipients re-ran the upsert's attribution
+	// CTE, which cannot see the envelope rows already in the table, so the
+	// recompute must settle attribution against them either way.
+	if err := refreshMessageAttributionWith(q, messageID); err != nil {
+		return 0, err
 	}
 
 	if !data.PreserveLabels {
@@ -1358,38 +1415,50 @@ func replaceMessageRecipientsTx(tx querier, messageID int64, rs RecipientSet) er
 		return nil
 	}
 
-	// Collapse duplicate participants within this set. The table holds at most
-	// one row per (message_id, participant_id, recipient_type), so a participant
-	// repeated in one call — a calendar event listing the same attendee twice, or
-	// two address forms that resolve to the same participant — is redundant and
-	// would otherwise trip the UNIQUE constraint and abort the entire write. The
-	// first occurrence's display name wins.
-	seen := make(map[int64]struct{}, len(rs.ParticipantIDs))
+	// Collapse duplicates within this set. The table holds at most one row
+	// per (message_id, participant_id, recipient_type, normalized envelope
+	// address) — idx_message_recipients_envelope — so an exact repeat in one
+	// call (a calendar event listing the same attendee twice) is redundant
+	// and would otherwise trip the unique index and abort the entire write,
+	// while the same participant under two envelope aliases keeps one row
+	// per alias. The first occurrence's display name wins per row.
+	type recipientRowKey struct {
+		participantID int64
+		email         string
+	}
+	seen := make(map[recipientRowKey]struct{}, len(rs.ParticipantIDs))
 	ids := make([]int64, 0, len(rs.ParticipantIDs))
 	names := make([]string, 0, len(rs.ParticipantIDs))
+	emails := make([]string, 0, len(rs.ParticipantIDs))
 	for i, pid := range rs.ParticipantIDs {
-		if _, dup := seen[pid]; dup {
+		email := ""
+		if i < len(rs.EmailAddresses) {
+			email = rs.EmailAddresses[i]
+		}
+		key := recipientRowKey{participantID: pid, email: strings.ToLower(email)}
+		if _, dup := seen[key]; dup {
 			continue
 		}
-		seen[pid] = struct{}{}
+		seen[key] = struct{}{}
 		ids = append(ids, pid)
 		name := ""
 		if i < len(rs.DisplayNames) {
 			name = rs.DisplayNames[i]
 		}
 		names = append(names, name)
+		emails = append(emails, email)
 	}
 
 	return insertInChunks(tx, chunkInsert{
 		totalRows:    len(ids),
-		valuesPerRow: 4,
-		prefix:       "INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name) VALUES ",
+		valuesPerRow: 5,
+		prefix:       "INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name, email_address) VALUES ",
 	}, func(start, end int) ([]string, []any) {
 		values := make([]string, end-start)
-		args := make([]any, 0, (end-start)*4)
+		args := make([]any, 0, (end-start)*5)
 		for i := start; i < end; i++ {
-			values[i-start] = "(?, ?, ?, ?)"
-			args = append(args, messageID, ids[i], rs.Type, names[i])
+			values[i-start] = "(?, ?, ?, ?, ?)"
+			args = append(args, messageID, ids[i], rs.Type, names[i], nullIfEmpty(emails[i]))
 		}
 		return values, args
 	})
@@ -1402,7 +1471,12 @@ type Label struct {
 	SourceLabelID sql.NullString
 	Name          string
 	LabelType     sql.NullString
+	SystemRole    sql.NullString
 }
+
+// LabelSystemRoleSent identifies a label whose provider metadata confirms it
+// represents sent mail. It is deliberately independent of the display name.
+const LabelSystemRoleSent = "sent"
 
 // EnsureLabel gets or creates a label, handling renames and ID changes.
 // For batch operations prefer EnsureLabelsBatch which runs in a single
@@ -1415,7 +1489,7 @@ func (s *Store) EnsureLabel(
 	err := s.withTx(func(tx *loggedTx) error {
 		var txErr error
 		id, txErr = ensureLabelWith(
-			tx, sourceID, sourceLabelID, name, labelType,
+			tx, sourceID, sourceLabelID, name, labelType, nil,
 		)
 		return txErr
 	})
@@ -1436,19 +1510,31 @@ func ensureLabelWith(
 	q querier,
 	sourceID int64,
 	sourceLabelID, name, labelType string,
+	systemRole *string,
 ) (int64, error) {
 	// Look up by canonical identifier (Gmail label ID).
 	var id int64
 	var existingName string
 	var existingType sql.NullString
+	var existingRole sql.NullString
 	err := q.QueryRow(`
-		SELECT id, name, label_type FROM labels
+		SELECT id, name, label_type, system_role FROM labels
 		WHERE source_id = ? AND source_label_id = ?
-	`, sourceID, sourceLabelID).Scan(&id, &existingName, &existingType)
+	`, sourceID, sourceLabelID).Scan(&id, &existingName, &existingType, &existingRole)
 
 	if err == nil {
 		if existingName == name {
-			if !existingType.Valid || existingType.String != labelType {
+			if !existingType.Valid || existingType.String != labelType ||
+				(systemRole != nil && !labelSystemRoleMatches(existingRole, *systemRole)) {
+				if systemRole != nil {
+					if _, err = q.Exec(`
+						UPDATE labels SET label_type = ?, system_role = ?
+						WHERE id = ?
+					`, labelType, labelSystemRoleValue(*systemRole), id); err != nil {
+						return 0, fmt.Errorf("update label type and role: %w", err)
+					}
+					return id, nil
+				}
 				if _, err = q.Exec(`
 					UPDATE labels SET label_type = ?
 					WHERE id = ?
@@ -1464,7 +1550,14 @@ func ensureLabelWith(
 		if err = mergeLabelByName(q, sourceID, name, id); err != nil {
 			return 0, err
 		}
-		if _, err = q.Exec(`
+		if systemRole != nil {
+			if _, err = q.Exec(`
+				UPDATE labels SET name = ?, label_type = ?, system_role = ?
+				WHERE id = ?
+			`, name, labelType, labelSystemRoleValue(*systemRole), id); err != nil {
+				return 0, fmt.Errorf("update label name and role: %w", err)
+			}
+		} else if _, err = q.Exec(`
 			UPDATE labels SET name = ?, label_type = ?
 			WHERE id = ?
 		`, name, labelType, id); err != nil {
@@ -1479,7 +1572,18 @@ func ensureLabelWith(
 	// Not found by source_label_id — upsert by name. Handles the case
 	// where a label with this name exists from a previous import or
 	// with a stale/NULL source_label_id.
-	if _, err = q.Exec(`
+	if systemRole != nil {
+		if _, err = q.Exec(`
+			INSERT INTO labels (source_id, source_label_id, name, label_type, system_role)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(source_id, name) DO UPDATE SET
+				source_label_id = excluded.source_label_id,
+				label_type = excluded.label_type,
+				system_role = excluded.system_role
+		`, sourceID, sourceLabelID, name, labelType, labelSystemRoleValue(*systemRole)); err != nil {
+			return 0, err
+		}
+	} else if _, err = q.Exec(`
 		INSERT INTO labels (source_id, source_label_id, name, label_type)
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT(source_id, name) DO UPDATE SET
@@ -1496,6 +1600,20 @@ func ensureLabelWith(
 		return 0, err
 	}
 	return id, nil
+}
+
+func labelSystemRoleValue(systemRole string) any {
+	if systemRole == "" {
+		return nil
+	}
+	return systemRole
+}
+
+func labelSystemRoleMatches(existing sql.NullString, systemRole string) bool {
+	if systemRole == "" {
+		return !existing.Valid
+	}
+	return existing.Valid && existing.String == systemRole
 }
 
 // mergeLabelByName finds a label with the given name (excluding keepID)
@@ -1544,8 +1662,9 @@ func mergeLabelByName(
 
 // LabelInfo holds the name and type for a label to be ensured.
 type LabelInfo struct {
-	Name string
-	Type string // "system" or "user"
+	Name       string
+	Type       string // "system" or "user"
+	SystemRole string // trusted canonical role; empty clears any stale value
 }
 
 // IsSystemLabel returns true if the given Gmail label ID represents a system label.
@@ -1607,7 +1726,7 @@ func (s *Store) EnsureLabelsBatch(
 		// is safe to merge (dead/imported label).
 		for sourceLabelID, info := range labels {
 			id, err := ensureLabelWith(
-				tx, sourceID, sourceLabelID, info.Name, info.Type,
+				tx, sourceID, sourceLabelID, info.Name, info.Type, &info.SystemRole,
 			)
 			if err != nil {
 				return err
@@ -2699,10 +2818,17 @@ func (s *Store) MergeParticipants(oldID, newID int64) error {
 		if _, err := tx.Exec(`UPDATE reactions SET participant_id = ? WHERE participant_id = ?`, newID, oldID); err != nil {
 			return err
 		}
+		// Collide on the full unique key including the normalized envelope
+		// address (idx_message_recipients_envelope), not just (message_id,
+		// recipient_type): a row of the absorbed participant whose envelope
+		// snapshot differs from every surviving row's must survive the
+		// repoint, or the merge would destroy the immutable alias evidence
+		// identity discovery classifies from.
 		if _, err := tx.Exec(`
 			DELETE FROM message_recipients WHERE participant_id = ? AND EXISTS (
 				SELECT 1 FROM message_recipients m2 WHERE m2.message_id = message_recipients.message_id
-				  AND m2.participant_id = ? AND m2.recipient_type = message_recipients.recipient_type)`, oldID, newID); err != nil {
+				  AND m2.participant_id = ? AND m2.recipient_type = message_recipients.recipient_type
+				  AND LOWER(COALESCE(m2.email_address, '')) = LOWER(COALESCE(message_recipients.email_address, '')))`, oldID, newID); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(`UPDATE message_recipients SET participant_id = ? WHERE participant_id = ?`, newID, oldID); err != nil {

--- a/internal/store/migrate_phone_unique.go
+++ b/internal/store/migrate_phone_unique.go
@@ -149,7 +149,12 @@ func (s *Store) mergeParticipant(ctx context.Context, tx *loggedTx, winner, lose
 	if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
 		return err
 	}
-	// (1) message_recipients UNIQUE(message_id, participant_id, recipient_type)
+	// (1) message_recipients UNIQUE(message_id, participant_id, recipient_type).
+	// Deliberately NOT the envelope-aware collision rule MergeParticipants
+	// uses: this one-shot migration runs before the legacy ADD COLUMN loop in
+	// InitSchemaContext, so whenever it actually merges rows the
+	// email_address column does not exist yet — there is no envelope
+	// evidence to preserve, and referencing the column here would fail.
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM message_recipients
 		 WHERE participant_id = ?

--- a/internal/store/migrate_recipient_envelope.go
+++ b/internal/store/migrate_recipient_envelope.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+const migrationRecipientEnvelopeUnique = "message_recipients_envelope_unique_index"
+
+// ensureRecipientEnvelopeUniqueIndex relaxes message_recipients uniqueness
+// from (message_id, participant_id, recipient_type) to that triple plus the
+// normalized envelope address. Under the old table-level UNIQUE one
+// participant could snapshot only a single envelope address per message and
+// type, so two aliases of an already-merged participant in one To: header
+// collapsed onto the first-seen address, and a participant merge had to
+// delete colliding recipient rows outright — both silently destroying the
+// immutable envelope evidence identity discovery classifies from. The new
+// unique index keeps writer idempotency (one row per participant AND
+// address) while letting distinct alias snapshots coexist.
+//
+// PostgreSQL drops the table-level constraint by catalog-discovered name.
+// SQLite enforces a table-level UNIQUE through an undroppable
+// sqlite_autoindex, so a legacy table is rebuilt: copy into a
+// constraint-free twin, swap, and recreate the plain indexes the DROP TABLE
+// took with it. The copy preserves ids, so mr.id-based ordering is stable
+// across the rebuild. A fresh database — created by the current schema files,
+// which no longer declare the table-level UNIQUE — has no autoindex and
+// skips the rebuild; it only needs the unique index built here, because on
+// upgraded databases email_address is a late ADD COLUMN that does not exist
+// yet when the schema files run (so the index cannot live there), and this
+// migration must therefore run after the legacy ADD COLUMN loop.
+//
+// Everything runs in one runMaintenance transaction: the copy and the
+// unique-index build over the archive's largest-row-count table exceed the
+// pool-wide 30s statement_timeout on PostgreSQL (finding S1), and a
+// cancelled or failed run rolls back whole — the ledger entry is written
+// only after success, so the next open retries.
+func (s *Store) ensureRecipientEnvelopeUniqueIndex(ctx context.Context) error {
+	return s.runOnceMigration(
+		ctx, migrationRecipientEnvelopeUnique, false,
+		func(ctx context.Context) error {
+			return s.runMaintenance(ctx, func(ctx context.Context, tx *loggedTx) error {
+				if s.IsPostgreSQL() {
+					if err := dropRecipientTableUniqueConstraintsPG(ctx, tx); err != nil {
+						return err
+					}
+				} else if err := rebuildRecipientTableWithoutUniqueSQLite(ctx, tx); err != nil {
+					return err
+				}
+				if _, err := tx.ExecContext(ctx, `
+					CREATE UNIQUE INDEX IF NOT EXISTS idx_message_recipients_envelope
+					    ON message_recipients(message_id, participant_id, recipient_type,
+					                          LOWER(COALESCE(email_address, '')))
+				`); err != nil {
+					return fmt.Errorf("create idx_message_recipients_envelope: %w", err)
+				}
+				return nil
+			})
+		},
+	)
+}
+
+// dropRecipientTableUniqueConstraintsPG drops every UNIQUE constraint on
+// message_recipients by its catalog name. Discovery instead of a hardcoded
+// name: the default constraint name is derived (and 63-byte truncated) by
+// the server, so trusting pg_constraint is what guarantees the drop matches
+// whatever an existing archive actually carries. regclass resolves through
+// search_path, consistent with every unqualified statement here.
+func dropRecipientTableUniqueConstraintsPG(ctx context.Context, tx *loggedTx) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT conname FROM pg_constraint
+		WHERE conrelid = 'message_recipients'::regclass AND contype = 'u'
+	`)
+	if err != nil {
+		return fmt.Errorf("list message_recipients unique constraints: %w", err)
+	}
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan message_recipients unique constraint: %w", err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate message_recipients unique constraints: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close message_recipients unique constraints: %w", err)
+	}
+	for _, name := range names {
+		if _, err := tx.ExecContext(ctx,
+			`ALTER TABLE message_recipients DROP CONSTRAINT `+quoteIdentifier(name),
+		); err != nil {
+			return fmt.Errorf("drop message_recipients constraint %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// rebuildRecipientTableWithoutUniqueSQLite swaps a legacy message_recipients
+// table for one without the table-level UNIQUE. Detection is the presence of
+// a sqlite_autoindex on the table: only a table-level UNIQUE creates one
+// (INTEGER PRIMARY KEY does not), so its absence means the table already has
+// the current shape and there is nothing to rebuild — robust against
+// comments in the stored DDL, unlike matching sqlite_master.sql text.
+//
+// No trigger or view references message_recipients and no foreign key points
+// at it, so DROP TABLE plus RENAME inside the transaction is a complete
+// swap; only the two plain indexes the DROP took along need recreating (the
+// unique index is built by the caller for the rebuilt and fresh paths
+// alike). The whole-table copy writes the table once through the WAL — a
+// one-time upgrade cost on the order of the table's size.
+func rebuildRecipientTableWithoutUniqueSQLite(ctx context.Context, tx *loggedTx) error {
+	var hasTableUnique bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM sqlite_master
+			WHERE type = 'index'
+			  AND tbl_name = 'message_recipients'
+			  AND name LIKE 'sqlite_autoindex%'
+		)
+	`).Scan(&hasTableUnique); err != nil {
+		return fmt.Errorf("check message_recipients table-level unique: %w", err)
+	}
+	if !hasTableUnique {
+		return nil
+	}
+
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS message_recipients_new`,
+		`CREATE TABLE message_recipients_new (
+			id INTEGER PRIMARY KEY,
+			message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+			participant_id INTEGER NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+			recipient_type TEXT NOT NULL,
+			display_name TEXT,
+			email_address TEXT
+		)`,
+		`INSERT INTO message_recipients_new
+			(id, message_id, participant_id, recipient_type, display_name, email_address)
+			SELECT id, message_id, participant_id, recipient_type, display_name, email_address
+			FROM message_recipients`,
+		`DROP TABLE message_recipients`,
+		`ALTER TABLE message_recipients_new RENAME TO message_recipients`,
+		`CREATE INDEX IF NOT EXISTS idx_message_recipients_message
+			ON message_recipients(message_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_message_recipients_participant
+			ON message_recipients(participant_id, recipient_type)`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("rebuild message_recipients without table-level unique: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/store/migrate_recipient_envelope_test.go
+++ b/internal/store/migrate_recipient_envelope_test.go
@@ -1,0 +1,231 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureRecipientEnvelopeUniqueIndex_LegacyTableRebuild simulates an
+// upgraded SQLite archive whose message_recipients still carries the
+// table-level UNIQUE(message_id, participant_id, recipient_type) — enforced
+// through an undroppable sqlite_autoindex — and proves the migration:
+//
+//  1. rebuilds the table without the table-level constraint, preserving
+//     rows and ids,
+//  2. recreates the plain indexes the DROP TABLE removed,
+//  3. creates idx_message_recipients_envelope, under which the same
+//     participant may carry several alias snapshots per message while an
+//     exact (case-insensitive) repeat is still rejected,
+//  4. marks the migration applied so the next run is a no-op.
+func TestEnsureRecipientEnvelopeUniqueIndex_LegacyTableRebuild(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	// SQLite-only: this test rebuilds the legacy table shape through
+	// sqlite_master-visible DDL. On PostgreSQL the migration only drops a
+	// nameable table constraint, and the alias-row behavior it enables is
+	// covered by the merge and discovery tests on both backends.
+	dbPath := filepath.Join(t.TempDir(), "envelope_unique.db")
+	st, err := Open(dbPath)
+	require.NoError(err, "Open")
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchema(), "InitSchema")
+
+	// Seed rows the rebuilt table's foreign keys will point at.
+	source, err := st.GetOrCreateSource("gmail", "owner@example.test")
+	require.NoError(err, "GetOrCreateSource")
+	convID, err := st.EnsureConversation(source.ID, "thread-envelope", "")
+	require.NoError(err, "EnsureConversation")
+	msgID, err := st.UpsertMessage(&Message{
+		ConversationID:  convID,
+		SourceID:        source.ID,
+		SourceMessageID: "msg-envelope",
+		MessageType:     "email",
+		SizeEstimate:    100,
+	})
+	require.NoError(err, "UpsertMessage")
+	participantID, err := st.EnsureParticipant("primary@example.test", "Primary", "example.test")
+	require.NoError(err, "EnsureParticipant")
+
+	// Roll back to the legacy shape: clear the ledger entry, then swap the
+	// table for one declaring the old table-level UNIQUE. The plain indexes
+	// vanish with the dropped table, exactly as they do during the real
+	// migration's swap, so their recreation is exercised too.
+	_, err = st.db.Exec(`DELETE FROM applied_migrations WHERE name = ?`, migrationRecipientEnvelopeUnique)
+	require.NoError(err, "clear migration sentinel")
+	for _, stmt := range []string{
+		`ALTER TABLE message_recipients RENAME TO message_recipients_current`,
+		`CREATE TABLE message_recipients (
+			id INTEGER PRIMARY KEY,
+			message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+			participant_id INTEGER NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+			recipient_type TEXT NOT NULL,
+			display_name TEXT,
+			email_address TEXT,
+			UNIQUE(message_id, participant_id, recipient_type)
+		)`,
+		`INSERT INTO message_recipients (id, message_id, participant_id, recipient_type, display_name, email_address)
+			SELECT id, message_id, participant_id, recipient_type, display_name, email_address
+			FROM message_recipients_current`,
+		`DROP TABLE message_recipients_current`,
+	} {
+		_, err = st.db.Exec(stmt)
+		require.NoError(err, "rebuild legacy table: %q", stmt)
+	}
+
+	var seededID int64
+	require.NoError(st.db.QueryRow(`
+		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name, email_address)
+		VALUES (?, ?, 'to', 'Primary', 'primary@example.test')
+		RETURNING id
+	`, msgID, participantID).Scan(&seededID), "seed legacy recipient row")
+
+	// Prove the reconstructed constraint behaves like the legacy one: a
+	// second envelope address for the same participant is rejected.
+	_, err = st.db.Exec(`
+		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name, email_address)
+		VALUES (?, ?, 'to', 'Primary', 'alias@example.test')
+	`, msgID, participantID)
+	require.Error(err, "legacy table-level UNIQUE must reject an alias row")
+
+	// Run the migration we are testing.
+	require.NoError(st.ensureRecipientEnvelopeUniqueIndex(context.Background()),
+		"ensureRecipientEnvelopeUniqueIndex")
+
+	// 1) The table-level UNIQUE (its autoindex) is gone and the expected
+	//    indexes exist.
+	var autoindexCount int
+	require.NoError(st.db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'index' AND tbl_name = 'message_recipients' AND name LIKE 'sqlite_autoindex%'
+	`).Scan(&autoindexCount), "count autoindexes")
+	assert.Equal(0, autoindexCount, "table-level UNIQUE must be rebuilt away")
+	for _, index := range []string{
+		"idx_message_recipients_message",
+		"idx_message_recipients_participant",
+		"idx_message_recipients_envelope",
+	} {
+		var indexCount int
+		require.NoError(st.db.QueryRow(`
+			SELECT COUNT(*) FROM sqlite_master
+			WHERE type = 'index' AND tbl_name = 'message_recipients' AND name = ?
+		`, index).Scan(&indexCount), "count index %s", index)
+		assert.Equal(1, indexCount, "index %s must exist after the rebuild", index)
+	}
+
+	// 2) The seeded row survived the rebuild with its id and data intact.
+	var email string
+	require.NoError(st.db.QueryRow(
+		`SELECT email_address FROM message_recipients WHERE id = ?`, seededID,
+	).Scan(&email), "read seeded row")
+	assert.Equal("primary@example.test", email, "seeded row must survive the rebuild")
+
+	// 3) An alias snapshot for the same participant now inserts, while a
+	//    case variant of an existing snapshot is still rejected.
+	_, err = st.db.Exec(`
+		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name, email_address)
+		VALUES (?, ?, 'to', 'Primary', 'alias@example.test')
+	`, msgID, participantID)
+	require.NoError(err, "alias envelope row must insert after the migration")
+	_, err = st.db.Exec(`
+		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name, email_address)
+		VALUES (?, ?, 'to', 'Primary', 'ALIAS@example.test')
+	`, msgID, participantID)
+	require.Error(err, "case variant of an existing snapshot must still be rejected")
+
+	// 4) Ledger marked; a second run is a no-op that changes nothing.
+	applied, err := st.IsMigrationApplied(migrationRecipientEnvelopeUnique)
+	require.NoError(err, "read migration ledger")
+	assert.True(applied, "migration must be marked applied")
+	require.NoError(st.ensureRecipientEnvelopeUniqueIndex(context.Background()),
+		"second run must be a no-op")
+	var rowCount int
+	require.NoError(st.db.QueryRow(
+		`SELECT COUNT(*) FROM message_recipients WHERE message_id = ?`, msgID,
+	).Scan(&rowCount), "count recipient rows")
+	assert.Equal(2, rowCount, "no-op rerun must not change row count")
+}
+
+// TestEnsureRecipientEnvelopeUniqueIndex_PGLegacyConstraintDrop simulates an
+// upgraded PostgreSQL archive whose message_recipients still carries the
+// table-level UNIQUE constraint, and proves the migration discovers it by
+// catalog name, drops it, and creates idx_message_recipients_envelope — after
+// which one participant may carry several alias snapshots per message while a
+// case variant of an existing snapshot is still rejected.
+func TestEnsureRecipientEnvelopeUniqueIndex_PGLegacyConstraintDrop(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := skipUnlessPostgresInternal(t)
+	st := newPGStoreInternal(t, dbURL)
+
+	// Roll back to the legacy shape: clear the ledger entry, drop the new
+	// unique index, and reattach the old table-level UNIQUE. The constraint
+	// name deliberately differs from the server-derived default so the test
+	// proves the migration drops whatever name the catalog reports rather
+	// than a hardcoded one.
+	_, err := st.db.Exec(st.Rebind(
+		`DELETE FROM applied_migrations WHERE name = ?`), migrationRecipientEnvelopeUnique)
+	require.NoError(err, "clear migration sentinel")
+	_, err = st.db.Exec(`DROP INDEX IF EXISTS idx_message_recipients_envelope`)
+	require.NoError(err, "drop envelope unique index")
+	_, err = st.db.Exec(`
+		ALTER TABLE message_recipients
+		ADD CONSTRAINT legacy_recipients_unique UNIQUE (message_id, participant_id, recipient_type)
+	`)
+	require.NoError(err, "reattach legacy unique constraint")
+
+	// Run the migration we are testing.
+	require.NoError(st.ensureRecipientEnvelopeUniqueIndex(context.Background()),
+		"ensureRecipientEnvelopeUniqueIndex")
+
+	var constraintCount int
+	require.NoError(st.db.QueryRow(`
+		SELECT COUNT(*) FROM pg_constraint
+		WHERE conrelid = 'message_recipients'::regclass AND contype = 'u'
+	`).Scan(&constraintCount), "count unique constraints")
+	assert.Equal(0, constraintCount, "legacy table-level UNIQUE must be dropped")
+	var indexCount int
+	require.NoError(st.db.QueryRow(`
+		SELECT COUNT(*) FROM pg_indexes
+		WHERE schemaname = current_schema()
+		  AND tablename = 'message_recipients'
+		  AND indexname = 'idx_message_recipients_envelope'
+	`).Scan(&indexCount), "count envelope index")
+	assert.Equal(1, indexCount, "envelope unique index must exist")
+
+	// Alias snapshots for one participant now coexist; a case variant of an
+	// existing snapshot is still rejected.
+	source, err := st.GetOrCreateSource("gmail", "owner@example.test")
+	require.NoError(err, "GetOrCreateSource")
+	convID, err := st.EnsureConversation(source.ID, "thread-envelope-pg", "")
+	require.NoError(err, "EnsureConversation")
+	msgID, err := st.UpsertMessage(&Message{
+		ConversationID:  convID,
+		SourceID:        source.ID,
+		SourceMessageID: "msg-envelope-pg",
+		MessageType:     "email",
+		SizeEstimate:    100,
+	})
+	require.NoError(err, "UpsertMessage")
+	participantID, err := st.EnsureParticipant("primary@example.test", "Primary", "example.test")
+	require.NoError(err, "EnsureParticipant")
+
+	insertRecipient := func(email string) error {
+		_, err := st.db.Exec(st.Rebind(`
+			INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name, email_address)
+			VALUES (?, ?, 'to', 'Primary', ?)
+		`), msgID, participantID, email)
+		return err
+	}
+	require.NoError(insertRecipient("primary@example.test"), "insert primary snapshot")
+	require.NoError(insertRecipient("alias@example.test"), "alias envelope row must insert after the migration")
+	require.Error(insertRecipient("ALIAS@example.test"),
+		"case variant of an existing snapshot must still be rejected")
+
+	applied, err := st.IsMigrationApplied(migrationRecipientEnvelopeUnique)
+	require.NoError(err, "read migration ledger")
+	assert.True(applied, "migration must be marked applied")
+}

--- a/internal/store/pg_identity_discovery_index_test.go
+++ b/internal/store/pg_identity_discovery_index_test.go
@@ -1,0 +1,96 @@
+package store_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// concurrentlyBuiltIndexes are the indexes Store.buildLargeIndexesConcurrently
+// owns on PostgreSQL; none of them appear in schema_pg.sql, so these tests are
+// the only guard that the concurrent path actually creates them.
+var concurrentlyBuiltIndexes = []struct{ index, table string }{
+	{"idx_messages_source_id", "messages"},
+	{"idx_participants_email_lower", "participants"},
+	{"idx_participant_identifiers_value_lower", "participant_identifiers"},
+}
+
+// Both probes below check pg_index.indisvalid rather than just counting rows
+// in pg_indexes: pg_indexes lists an INVALID leftover (from a CREATE INDEX
+// CONCURRENTLY that failed or was cancelled partway through) the same as a
+// healthy index, so a plain row count cannot distinguish "built and usable"
+// from "present but unusable" — the failure this package's concurrent-build
+// recovery path exists to catch.
+
+func probeValidIndex(t *testing.T, st *store.Store, index, table string) bool {
+	t.Helper()
+	var valid bool
+	require.NoError(t, st.DB().QueryRow(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_class c
+			JOIN pg_index i ON i.indexrelid = c.oid
+			JOIN pg_class t ON t.oid = i.indrelid
+			WHERE c.relname = $1
+			  AND t.relname = $2
+			  AND c.relnamespace = current_schema()::regnamespace
+			  AND i.indisvalid = true
+		)
+	`, index, table).Scan(&valid))
+	return valid
+}
+
+func TestInitSchema_PGCreatesIdentityDiscoveryIndexForFreshAndUpgradedStores(t *testing.T) {
+	require := require.New(t)
+	testDB := os.Getenv("MSGVAULT_TEST_DB")
+	if !strings.HasPrefix(testDB, "postgres://") && !strings.HasPrefix(testDB, "postgresql://") {
+		t.Skip("PG-only: identity discovery index maintenance build requires PostgreSQL")
+	}
+
+	st := testutil.NewTestStore(t)
+	for _, target := range concurrentlyBuiltIndexes {
+		require.True(probeValidIndex(t, st, target.index, target.table),
+			"fresh schema must concurrently build %s", target.index)
+		_, err := st.DB().Exec(`DROP INDEX ` + target.index)
+		require.NoError(err, "simulate a store created before %s existed", target.index)
+		require.False(probeValidIndex(t, st, target.index, target.table))
+	}
+
+	require.NoError(st.InitSchema(), "concurrent index build must restore the dropped indexes")
+	for _, target := range concurrentlyBuiltIndexes {
+		require.True(probeValidIndex(t, st, target.index, target.table),
+			"upgraded schema must restore a valid %s", target.index)
+	}
+}
+
+// TestInitSchema_PGConcurrentIndexBuildIsIdempotent exercises repeated calls
+// against already-valid indexes. buildLargeIndexesConcurrently is
+// unexported, so this drives it indirectly through InitSchema, matching how
+// production calls it on every store open.
+//
+// The drop-retry branch (recovering from a leftover INVALID index left by a
+// CREATE INDEX CONCURRENTLY that failed or was cancelled partway through) is
+// not covered here: forcing that state requires cancelling a concurrent
+// build from a second connection mid-build, which is racy and
+// environment-dependent in CI. That branch is reviewed by inspection in
+// Store.buildLargeIndexesConcurrently / dropInvalidIndexConcurrently.
+func TestInitSchema_PGConcurrentIndexBuildIsIdempotent(t *testing.T) {
+	require := require.New(t)
+	testDB := os.Getenv("MSGVAULT_TEST_DB")
+	if !strings.HasPrefix(testDB, "postgres://") && !strings.HasPrefix(testDB, "postgresql://") {
+		t.Skip("PG-only: identity discovery index maintenance build requires PostgreSQL")
+	}
+
+	st := testutil.NewTestStore(t)
+	for range 3 {
+		for _, target := range concurrentlyBuiltIndexes {
+			require.True(probeValidIndex(t, st, target.index, target.table),
+				"repeated concurrent build must keep %s valid and idempotent", target.index)
+		}
+		require.NoError(st.InitSchema(), "repeated call must be a no-op, not an error")
+	}
+}

--- a/internal/store/provider_refresh_state.go
+++ b/internal/store/provider_refresh_state.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// providerIdentityRefreshKeyPrefix namespaces the per-source provider refresh
+// state rows in archive_metadata. Like the identity discovery backlog, the row
+// is only ever read and written on its own, so it stays outside the
+// identity-revision lock ordering documented in participant_links.go.
+const providerIdentityRefreshKeyPrefix = "provider_identity_refresh:"
+
+// ProviderIdentityRefreshState records the outcome of the most recent
+// automatic provider identity refresh for a source. Provider inventory can
+// change while a mailbox is idle, so no-op syncs use this state to decide
+// whether the provider must be consulted again: a missing or failed state is
+// always due, and even a successful one goes stale.
+type ProviderIdentityRefreshState struct {
+	LastSuccessAt time.Time
+	LastError     string
+	FailedAt      time.Time
+}
+
+// Fresh reports whether the last refresh succeeded recently enough that a
+// no-op sync may skip the provider round trip.
+func (s ProviderIdentityRefreshState) Fresh(now time.Time, maxAge time.Duration) bool {
+	if s.LastError != "" || s.LastSuccessAt.IsZero() {
+		return false
+	}
+	return now.Sub(s.LastSuccessAt) < maxAge
+}
+
+// providerIdentityRefreshMarker is the stored JSON shape of
+// ProviderIdentityRefreshState. Timestamps travel as RFC 3339 strings to match
+// the identity discovery backlog marker.
+type providerIdentityRefreshMarker struct {
+	LastSuccessAt string `json:"last_success_at,omitempty"`
+	LastError     string `json:"last_error,omitempty"`
+	FailedAt      string `json:"failed_at,omitempty"`
+}
+
+func providerIdentityRefreshKey(sourceID int64) string {
+	return providerIdentityRefreshKeyPrefix + strconv.FormatInt(sourceID, 10)
+}
+
+var errProviderRefreshSourceID = errors.New("source ID must be positive")
+
+// RecordProviderIdentityRefreshOutcomeContext stores the result of one
+// automatic provider identity refresh attempt. A nil refreshErr records a
+// success and clears any previous failure; a non-nil refreshErr records the
+// failure while preserving the last success time, so staleness keeps being
+// measured from the last refresh that actually worked.
+func (s *Store) RecordProviderIdentityRefreshOutcomeContext(
+	ctx context.Context,
+	sourceID int64,
+	refreshErr error,
+) error {
+	if sourceID <= 0 {
+		return fmt.Errorf("record provider identity refresh outcome: %w", errProviderRefreshSourceID)
+	}
+	key := providerIdentityRefreshKey(sourceID)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		if _, err := tx.ExecContext(ctx, s.dialect.InsertOrIgnore(
+			`INSERT OR IGNORE INTO archive_metadata (key, value) VALUES (?, '')`), key,
+		); err != nil {
+			return fmt.Errorf("seed provider identity refresh state: %w", err)
+		}
+		// Read the previous value back through an UPDATE so the row is locked
+		// before the new state is derived from it: a failure must not clobber
+		// the last success time a concurrent writer just recorded.
+		var previous string
+		if err := tx.QueryRowContext(ctx,
+			`UPDATE archive_metadata SET value = value WHERE key = ? RETURNING value`, key,
+		).Scan(&previous); err != nil {
+			return fmt.Errorf("lock provider identity refresh state: %w", err)
+		}
+
+		marker := providerIdentityRefreshMarker{LastSuccessAt: now}
+		if refreshErr != nil {
+			// An unreadable previous value drops the remembered success time
+			// instead of failing the caller: the state is a scheduling hint,
+			// not a ledger, and losing it only causes one extra refresh.
+			var prior providerIdentityRefreshMarker
+			_ = json.Unmarshal([]byte(previous), &prior)
+			marker = providerIdentityRefreshMarker{
+				LastSuccessAt: prior.LastSuccessAt,
+				LastError:     refreshErr.Error(),
+				FailedAt:      now,
+			}
+		}
+		encoded, err := json.Marshal(marker)
+		if err != nil {
+			return fmt.Errorf("encode provider identity refresh state: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE archive_metadata SET value = ? WHERE key = ?`, string(encoded), key,
+		); err != nil {
+			return fmt.Errorf("update provider identity refresh state: %w", err)
+		}
+		return nil
+	})
+}
+
+// ProviderIdentityRefreshStateContext returns the recorded refresh state for
+// sourceID. A source with no record reports found=false, which callers treat
+// as due. An undecodable payload reports found=true with a zero state — also
+// due — so a corrupted row heals itself on the next successful refresh.
+func (s *Store) ProviderIdentityRefreshStateContext(
+	ctx context.Context,
+	sourceID int64,
+) (state ProviderIdentityRefreshState, found bool, err error) {
+	if sourceID <= 0 {
+		return ProviderIdentityRefreshState{}, false,
+			fmt.Errorf("read provider identity refresh state: %w", errProviderRefreshSourceID)
+	}
+	var value string
+	err = s.db.QueryRowContext(ctx,
+		`SELECT value FROM archive_metadata WHERE key = ?`, providerIdentityRefreshKey(sourceID),
+	).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ProviderIdentityRefreshState{}, false, nil
+	}
+	if err != nil {
+		return ProviderIdentityRefreshState{}, false,
+			fmt.Errorf("read provider identity refresh state: %w", err)
+	}
+
+	var marker providerIdentityRefreshMarker
+	decodable := json.Unmarshal([]byte(value), &marker) == nil
+	if !decodable {
+		return ProviderIdentityRefreshState{}, true, nil
+	}
+	state = ProviderIdentityRefreshState{LastError: marker.LastError}
+	if t, parseErr := time.Parse(time.RFC3339, marker.LastSuccessAt); parseErr == nil {
+		state.LastSuccessAt = t
+	}
+	if t, parseErr := time.Parse(time.RFC3339, marker.FailedAt); parseErr == nil {
+		state.FailedAt = t
+	}
+	return state, true, nil
+}

--- a/internal/store/provider_refresh_state_test.go
+++ b/internal/store/provider_refresh_state_test.go
@@ -1,0 +1,132 @@
+package store_test
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestProviderIdentityRefreshStateRoundTrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "user@example.test")
+	require.NoError(err)
+
+	_, found, err := st.ProviderIdentityRefreshStateContext(t.Context(), source.ID)
+	require.NoError(err)
+	assert.False(found, "a source that never refreshed has no state")
+
+	require.NoError(st.RecordProviderIdentityRefreshOutcomeContext(t.Context(), source.ID, nil))
+	state, found, err := st.ProviderIdentityRefreshStateContext(t.Context(), source.ID)
+	require.NoError(err)
+	require.True(found)
+	assert.Empty(state.LastError)
+	assert.WithinDuration(time.Now(), state.LastSuccessAt, time.Minute)
+	assert.True(state.Fresh(time.Now(), time.Hour))
+}
+
+func TestProviderIdentityRefreshFailurePreservesLastSuccess(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "user@example.test")
+	require.NoError(err)
+
+	require.NoError(st.RecordProviderIdentityRefreshOutcomeContext(t.Context(), source.ID, nil))
+	require.NoError(st.RecordProviderIdentityRefreshOutcomeContext(
+		t.Context(), source.ID, errors.New("provider unavailable"),
+	))
+
+	state, found, err := st.ProviderIdentityRefreshStateContext(t.Context(), source.ID)
+	require.NoError(err)
+	require.True(found)
+	assert.Equal("provider unavailable", state.LastError)
+	assert.WithinDuration(time.Now(), state.FailedAt, time.Minute)
+	assert.False(state.LastSuccessAt.IsZero(),
+		"a failure keeps measuring staleness from the last refresh that worked")
+	assert.False(state.Fresh(time.Now(), time.Hour), "a failed refresh is always due")
+
+	require.NoError(st.RecordProviderIdentityRefreshOutcomeContext(t.Context(), source.ID, nil))
+	state, found, err = st.ProviderIdentityRefreshStateContext(t.Context(), source.ID)
+	require.NoError(err)
+	require.True(found)
+	assert.Empty(state.LastError, "a success clears the previous failure")
+	assert.True(state.Fresh(time.Now(), time.Hour))
+}
+
+func TestProviderIdentityRefreshStateFreshness(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name  string
+		state store.ProviderIdentityRefreshState
+		want  bool
+	}{
+		{name: "never succeeded", state: store.ProviderIdentityRefreshState{}, want: false},
+		{
+			name:  "recent success",
+			state: store.ProviderIdentityRefreshState{LastSuccessAt: now.Add(-time.Minute)},
+			want:  true,
+		},
+		{
+			name:  "stale success",
+			state: store.ProviderIdentityRefreshState{LastSuccessAt: now.Add(-2 * time.Hour)},
+			want:  false,
+		},
+		{
+			name: "recent success then failure",
+			state: store.ProviderIdentityRefreshState{
+				LastSuccessAt: now.Add(-time.Minute),
+				LastError:     "provider unavailable",
+				FailedAt:      now,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.state.Fresh(now, time.Hour))
+		})
+	}
+}
+
+func TestProviderIdentityRefreshStateUndecodablePayloadIsDue(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "user@example.test")
+	require.NoError(err)
+
+	_, err = st.DB().Exec(
+		st.Rebind(`INSERT INTO archive_metadata (key, value) VALUES (?, ?)`),
+		"provider_identity_refresh:"+strconv.FormatInt(source.ID, 10), "not json",
+	)
+	require.NoError(err)
+
+	state, found, err := st.ProviderIdentityRefreshStateContext(t.Context(), source.ID)
+	require.NoError(err)
+	assert.True(found)
+	assert.False(state.Fresh(time.Now(), time.Hour),
+		"a corrupted row must trigger a refresh, which heals it")
+
+	require.NoError(st.RecordProviderIdentityRefreshOutcomeContext(t.Context(), source.ID, nil))
+	state, found, err = st.ProviderIdentityRefreshStateContext(t.Context(), source.ID)
+	require.NoError(err)
+	require.True(found)
+	assert.True(state.Fresh(time.Now(), time.Hour))
+}
+
+func TestProviderIdentityRefreshStateRejectsNonPositiveSourceID(t *testing.T) {
+	st := testutil.NewTestStore(t)
+
+	_, _, err := st.ProviderIdentityRefreshStateContext(t.Context(), 0)
+	require.ErrorContains(t, err, "source ID must be positive")
+	err = st.RecordProviderIdentityRefreshOutcomeContext(t.Context(), -1, nil)
+	require.ErrorContains(t, err, "source ID must be positive")
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -261,8 +261,22 @@ CREATE TABLE IF NOT EXISTS message_recipients (
 
     recipient_type TEXT NOT NULL,  -- 'to', 'cc', 'bcc', 'mention'
     display_name TEXT,             -- as it appeared in the message
+    -- Envelope address as it appeared in the message. Immutable under
+    -- participant merges, unlike the participant row's email_address;
+    -- identity discovery reads it so merges cannot rewrite evidence.
+    -- NULL on rows from writers without envelope addresses (non-email
+    -- importers, legacy rows).
+    email_address TEXT
 
-    UNIQUE(message_id, participant_id, recipient_type)
+    -- Uniqueness spans the normalized envelope address so one participant
+    -- can carry several alias snapshots on the same message (two aliases of
+    -- an already-merged participant in one To: header, or rows preserved by
+    -- a later participant merge). Enforced by idx_message_recipients_envelope,
+    -- created in Go by Store.ensureRecipientEnvelopeUniqueIndex rather than
+    -- here: on upgraded DBs email_address is a late ADD COLUMN that does not
+    -- exist yet when this file runs, and legacy DBs additionally need their
+    -- old table-level UNIQUE(message_id, participant_id, recipient_type)
+    -- rebuilt away first.
 );
 
 -- ============================================================================
@@ -337,6 +351,7 @@ CREATE TABLE IF NOT EXISTS labels (
     source_label_id TEXT,           -- Gmail label ID
     name TEXT NOT NULL,
     label_type TEXT,                -- 'system', 'user', 'auto'
+    system_role TEXT,               -- trusted canonical role (for example, 'sent')
     color TEXT,
 
     UNIQUE(source_id, name)
@@ -514,10 +529,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_participants_email ON participants(email_a
 -- end up with a UNIQUE partial index.
 CREATE INDEX IF NOT EXISTS idx_participants_canonical ON participants(canonical_id)
     WHERE canonical_id IS NOT NULL;
+-- Serves case-insensitive address lookups (e.g. identity confirmation's
+-- participant resolution) without a full table scan.
+CREATE INDEX IF NOT EXISTS idx_participants_email_lower ON participants(LOWER(email_address));
 
 -- Participant identifiers
 CREATE INDEX IF NOT EXISTS idx_participant_identifiers_value ON participant_identifiers(identifier_value);
 CREATE INDEX IF NOT EXISTS idx_participant_identifiers_participant ON participant_identifiers(participant_id);
+-- Serves case-insensitive identifier lookups (e.g. identity confirmation's
+-- participant resolution) without a full table scan.
+CREATE INDEX IF NOT EXISTS idx_participant_identifiers_value_lower ON participant_identifiers(LOWER(identifier_value));
 
 -- Conversations
 CREATE INDEX IF NOT EXISTS idx_conversations_source ON conversations(source_id);
@@ -526,6 +547,9 @@ CREATE INDEX IF NOT EXISTS idx_conversations_type ON conversations(conversation_
 
 -- Messages
 CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, sent_at DESC);
+-- idx_messages_source_id (source_id, id) was removed: id is the rowid alias,
+-- and idx_messages_source below already orders ties by rowid, so the
+-- composite added no coverage beyond the single-column index.
 CREATE INDEX IF NOT EXISTS idx_messages_source ON messages(source_id);
 CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_id);
 CREATE INDEX IF NOT EXISTS idx_messages_sent_at ON messages(sent_at DESC);

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -200,8 +200,22 @@ CREATE TABLE IF NOT EXISTS message_recipients (
 
     recipient_type TEXT NOT NULL,
     display_name TEXT,
+    -- Envelope address as it appeared in the message. Immutable under
+    -- participant merges, unlike the participant row's email_address;
+    -- identity discovery reads it so merges cannot rewrite evidence.
+    -- NULL on rows from writers without envelope addresses (non-email
+    -- importers, legacy rows).
+    email_address TEXT
 
-    UNIQUE(message_id, participant_id, recipient_type)
+    -- Uniqueness spans the normalized envelope address so one participant
+    -- can carry several alias snapshots on the same message (two aliases of
+    -- an already-merged participant in one To: header, or rows preserved by
+    -- a later participant merge). Enforced by idx_message_recipients_envelope,
+    -- created in Go by Store.ensureRecipientEnvelopeUniqueIndex rather than
+    -- here: on upgraded DBs email_address is a late ADD COLUMN that does not
+    -- exist yet when this file runs, and legacy DBs additionally need their
+    -- old table-level UNIQUE(message_id, participant_id, recipient_type)
+    -- constraint dropped first.
 );
 
 -- ============================================================================
@@ -264,6 +278,7 @@ CREATE TABLE IF NOT EXISTS labels (
     source_label_id TEXT,
     name TEXT NOT NULL,
     label_type TEXT,
+    system_role TEXT,
     color TEXT,
 
     UNIQUE(source_id, name)
@@ -591,9 +606,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_participants_email ON participants(email_a
 -- end up with a UNIQUE partial index.
 CREATE INDEX IF NOT EXISTS idx_participants_canonical ON participants(canonical_id)
     WHERE canonical_id IS NOT NULL;
-
+-- idx_participants_email_lower is built by Store.buildLargeIndexesConcurrently:
+-- participants can be large on an existing archive, and an inline build here
+-- would run under the pool-wide statement_timeout.
 CREATE INDEX IF NOT EXISTS idx_participant_identifiers_value ON participant_identifiers(identifier_value);
 CREATE INDEX IF NOT EXISTS idx_participant_identifiers_participant ON participant_identifiers(participant_id);
+-- idx_participant_identifiers_value_lower is likewise built by
+-- Store.buildLargeIndexesConcurrently.
 
 CREATE INDEX IF NOT EXISTS idx_conversations_source ON conversations(source_id);
 CREATE INDEX IF NOT EXISTS idx_conversations_last_message ON conversations(last_message_at DESC);
@@ -601,6 +620,12 @@ CREATE INDEX IF NOT EXISTS idx_conversations_type ON conversations(conversation_
 
 CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, sent_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_source ON messages(source_id);
+-- idx_messages_source_id is built by Store.buildLargeIndexesConcurrently via
+-- CREATE INDEX CONCURRENTLY on a dedicated autocommit connection, outside any
+-- transaction; building it over an existing archive can take a long time,
+-- and CONCURRENTLY cannot run inside a transaction (or the pool-wide
+-- statement_timeout escape hatch, which only disables the timeout for one
+-- transaction).
 CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_id);
 CREATE INDEX IF NOT EXISTS idx_messages_sent_at ON messages(sent_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_type ON messages(message_type);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -619,6 +619,124 @@ func (s *Store) runMaintenance(ctx context.Context, fn func(ctx context.Context,
 	return nil
 }
 
+// buildLargeIndexesConcurrently creates big-table indexes without blocking
+// writers. CREATE INDEX CONCURRENTLY cannot run inside a transaction (unlike
+// the runMaintenance escape hatch, which only disables the pool-wide
+// statement_timeout for one transaction), so this runs on a dedicated
+// autocommit connection acquired directly from the pool.
+//
+// PostgreSQL's IF NOT EXISTS matches by name only: it treats an INVALID
+// leftover (from a process killed mid-build) as "already exists" and
+// returns success with a NOTICE instead of rebuilding. So a bad index from
+// an earlier crashed run would otherwise persist forever — degrading writes
+// on every subsequent start — because a name-matched no-op never reaches the
+// error path. This checks pg_index.indisvalid for a leftover BEFORE the
+// first attempt, and keeps the on-error check too for a build that goes
+// INVALID during this run.
+//
+// Both an initial failure and a failed retry are logged and swallowed: a
+// future InitSchema call (the next process start) retries the same
+// idempotent build. SQLite has no CONCURRENTLY equivalent and does not need
+// one — its index build over a working-set-sized archive is fast enough to
+// run inline in schema.sql — so this is a no-op there.
+func (s *Store) buildLargeIndexesConcurrently(ctx context.Context) {
+	if !s.IsPostgreSQL() {
+		return
+	}
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		slog.Warn("acquire connection for concurrent index build failed", "error", err.Error())
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "SET statement_timeout = 0"); err != nil {
+		slog.Warn("disable statement timeout for concurrent index build failed", "error", err.Error())
+		return
+	}
+	// The conn returned by s.db.Conn goes back to the pool on Close, not to
+	// the OS: pgx's stdlib driver does not run DISCARD ALL on release, so a
+	// session-level SET here would otherwise leak the disabled timeout onto
+	// whichever pooled connection this physical one becomes for its
+	// lifetime. RESET restores the role/database startup value. Deferred
+	// before any fallible step below so it always runs, and on a bounded
+	// context detached from ctx's cancellation so a caller-cancelled ctx
+	// cannot skip it — but, unlike context.Background(), also cannot hang
+	// the shutdown path indefinitely on an unresponsive server.
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		if _, err := conn.ExecContext(cleanupCtx, "RESET statement_timeout"); err != nil {
+			slog.Warn("reset statement timeout after concurrent index build failed", "error", err.Error())
+		}
+	}()
+
+	// Every index on a table that can already be large in an existing archive
+	// belongs here rather than inline in schema_pg.sql, where it would build
+	// under the pool-wide statement_timeout and could fail InitSchema outright.
+	concurrentIndexes := []struct{ name, definition string }{
+		{"idx_messages_source_id", "ON messages(source_id, id)"},
+		{"idx_participants_email_lower", "ON participants(LOWER(email_address))"},
+		{"idx_participant_identifiers_value_lower", "ON participant_identifiers(LOWER(identifier_value))"},
+	}
+	for _, index := range concurrentIndexes {
+		if dropErr := dropInvalidIndexConcurrently(ctx, conn, index.name); dropErr != nil {
+			slog.Warn("drop invalid leftover index failed", "index", index.name, "error", dropErr.Error())
+		}
+
+		build := func() error {
+			_, err := conn.ExecContext(ctx,
+				`CREATE INDEX CONCURRENTLY IF NOT EXISTS `+index.name+` `+index.definition)
+			return err
+		}
+
+		if err := build(); err != nil {
+			slog.Warn("concurrent index build failed, checking for an invalid leftover to retry",
+				"index", index.name, "error", err.Error())
+			if dropErr := dropInvalidIndexConcurrently(ctx, conn, index.name); dropErr != nil {
+				slog.Warn("drop invalid leftover index failed", "index", index.name, "error", dropErr.Error())
+			}
+			if err := build(); err != nil {
+				slog.Warn("concurrent index build failed after retry; will retry on next start",
+					"index", index.name, "error", err.Error())
+			}
+		}
+	}
+}
+
+// dropInvalidIndexConcurrently drops indexName only if PostgreSQL left it in
+// the INVALID state (a CREATE INDEX CONCURRENTLY that failed or was
+// cancelled partway through). A valid index that failed to build for some
+// other transient reason (e.g. a concurrent CREATE already in flight) is
+// left alone rather than dropped. The namespace check keeps this from
+// matching an INVALID index of the same name in a different schema — the
+// unqualified build/drop below both resolve the bare name via search_path,
+// so this must resolve against that same current_schema() to stay
+// consistent with what they will actually touch.
+func dropInvalidIndexConcurrently(ctx context.Context, conn *sql.Conn, indexName string) error {
+	var invalid bool
+	if err := conn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_class c
+			JOIN pg_index i ON i.indexrelid = c.oid
+			WHERE c.relname = $1
+			  AND c.relnamespace = current_schema()::regnamespace
+			  AND i.indisvalid = false
+		)
+	`, indexName).Scan(&invalid); err != nil {
+		return fmt.Errorf("check invalid index: %w", err)
+	}
+	if !invalid {
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx, `DROP INDEX CONCURRENTLY IF EXISTS `+indexName); err != nil {
+		return fmt.Errorf("drop invalid index: %w", err)
+	}
+	return nil
+}
+
 // queryInChunks executes a parameterized IN-query in chunks to stay within
 // SQLite's parameter limit. queryTemplate must contain a single %s placeholder
 // for the comma-separated "?" list. The prefix args are prepended before each
@@ -1034,6 +1152,28 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 	); err != nil {
 		return err
 	}
+
+	// Relax message_recipients uniqueness to include the normalized envelope
+	// address, so alias snapshots of one participant can coexist per message.
+	// Must run after the legacy ADD COLUMN loop above (the unique index
+	// expression reads email_address) and before any participant merge under
+	// the new email-aware collision rules can run.
+	if err := s.ensureRecipientEnvelopeUniqueIndex(ctx); err != nil {
+		return fmt.Errorf("ensure idx_message_recipients_envelope unique: %w", err)
+	}
+
+	// Identity discovery scans one source in message-ID order. On SQLite the
+	// plain idx_messages_source index already orders ties by rowid, so no
+	// separate composite index is needed there (see schema.sql). PostgreSQL
+	// still needs the explicit composite index, built via CREATE INDEX
+	// CONCURRENTLY on a dedicated connection so a one-time build over an
+	// existing archive never blocks writers or needs the pool-wide
+	// statement_timeout escape hatch (CONCURRENTLY cannot run inside a
+	// transaction at all, so runMaintenance does not apply here). Carries
+	// ctx like every other statement in this method: a cancelled build
+	// leaves at worst an INVALID leftover, which the next start drops and
+	// rebuilds.
+	s.buildLargeIndexesConcurrently(ctx)
 
 	// Partial expression indexes for live-message listing and date filtering.
 	// The first is a covering index for the ListMessages page

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -549,6 +550,103 @@ func TestStore_EnsureLabelsBatch_CrossRename(t *testing.T) {
 	f.AssertMessageHasLabel(msg1, l1ID)
 	f.AssertLabelCount(msg2, 1)
 	f.AssertMessageHasLabel(msg2, l2ID)
+}
+
+func TestStore_EnsureLabelsBatch_PersistsClearsAndCrossRenamesSystemRole(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+
+	initial := map[string]store.LabelInfo{
+		"L1": {Name: "Envoyes", Type: "system", SystemRole: store.LabelSystemRoleSent},
+		"L2": {Name: "Archive", Type: "system"},
+	}
+	ids, err := f.Store.EnsureLabelsBatch(f.Source.ID, initial)
+	require.NoError(err, "initial label refresh")
+
+	var role string
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind("SELECT system_role FROM labels WHERE id = ?"), ids["L1"],
+	).Scan(&role), "read persisted role")
+	assert.Equal(store.LabelSystemRoleSent, role, "L1 role")
+
+	// The roles must follow canonical label IDs through a cross-rename, not names.
+	swapped := map[string]store.LabelInfo{
+		"L1": {Name: "Archive", Type: "system"},
+		"L2": {Name: "Envoyes", Type: "system", SystemRole: store.LabelSystemRoleSent},
+	}
+	_, err = f.Store.EnsureLabelsBatch(f.Source.ID, swapped)
+	require.NoError(err, "cross-rename label refresh")
+
+	var l1Role, l2Role sql.NullString
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind("SELECT system_role FROM labels WHERE id = ?"), ids["L1"],
+	).Scan(&l1Role), "read cleared role")
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind("SELECT system_role FROM labels WHERE id = ?"), ids["L2"],
+	).Scan(&l2Role), "read moved role")
+	assert.False(l1Role.Valid, "L1 role must clear when canonical metadata no longer marks it sent")
+	assert.Equal(store.LabelSystemRoleSent, l2Role.String, "L2 role")
+
+	_, err = f.Store.EnsureLabelsBatch(f.Source.ID, map[string]store.LabelInfo{
+		"L2": {Name: "Envoyes", Type: "system"},
+	})
+	require.NoError(err, "repeated refresh clears stale role")
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind("SELECT system_role FROM labels WHERE id = ?"), ids["L2"],
+	).Scan(&l2Role), "read repeatedly cleared role")
+	assert.False(l2Role.Valid, "repeated refresh must clear stale role")
+}
+
+func TestStore_InitSchemaAddsLabelRoleWithoutRewritingLegacyRows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbPath := filepath.Join(t.TempDir(), "legacy-labels.db")
+	st, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	t.Cleanup(func() { _ = st.Close() })
+
+	_, err = st.DB().Exec(`
+		CREATE TABLE labels (
+			id INTEGER PRIMARY KEY,
+			source_id INTEGER,
+			source_label_id TEXT,
+			name TEXT NOT NULL,
+			label_type TEXT,
+			color TEXT,
+			UNIQUE(source_id, name)
+		)
+	`)
+	require.NoError(err, "create legacy labels")
+	_, err = st.DB().Exec(`
+		INSERT INTO labels (source_id, source_label_id, name, label_type)
+		VALUES (1, 'SENT', 'Envoyes', 'system')
+	`)
+	require.NoError(err, "insert legacy label")
+
+	require.NoError(st.InitSchema(), "migrate legacy labels")
+
+	var role sql.NullString
+	require.NoError(st.DB().QueryRow(
+		"SELECT system_role FROM labels WHERE source_label_id = 'SENT'",
+	).Scan(&role), "read migrated legacy label")
+	assert.False(role.Valid, "migration must not classify or rewrite existing labels")
+
+	indexCount := func(name string) int {
+		var count int
+		require.NoError(st.DB().QueryRow(
+			"SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?", name,
+		).Scan(&count), "read index: "+name)
+		return count
+	}
+	assert.Equal(0, indexCount("idx_labels_source_system_role"),
+		"unreachable index must not be created: labels is only ever queried via its PK join")
+	assert.Equal(0, indexCount("idx_messages_source_id"),
+		"SQLite-redundant composite index must not be created: id is the rowid alias")
+	assert.Equal(1, indexCount("idx_participants_email_lower"),
+		"participant email lower expression index")
+	assert.Equal(1, indexCount("idx_participant_identifiers_value_lower"),
+		"participant identifier value lower expression index")
 }
 
 func TestStore_MessageLabels(t *testing.T) {

--- a/internal/store/subset.go
+++ b/internal/store/subset.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -315,9 +314,7 @@ func copyData(tx *sql.Tx, rowCount int, options CopySubsetOptions) (*CopyResult,
 		return nil, fmt.Errorf("count selected messages: %w", err)
 	}
 
-	res, err = tx.Exec(`
-		INSERT INTO conversations SELECT * FROM src.conversations
-		WHERE id IN (
+	res, err = copyByName(tx, "conversations", `id IN (
 			SELECT DISTINCT conversation_id FROM src.messages
 			WHERE id IN (SELECT id FROM selected_messages)
 		)`)
@@ -328,9 +325,7 @@ func copyData(tx *sql.Tx, rowCount int, options CopySubsetOptions) (*CopyResult,
 		return nil, fmt.Errorf("conversations rows affected: %w", err)
 	}
 
-	res, err = tx.Exec(`
-		INSERT INTO participants SELECT * FROM src.participants
-		WHERE id IN (
+	res, err = copyByName(tx, "participants", `id IN (
 			SELECT sender_id FROM src.messages
 			WHERE id IN (SELECT id FROM selected_messages)
 			UNION
@@ -353,9 +348,7 @@ func copyData(tx *sql.Tx, rowCount int, options CopySubsetOptions) (*CopyResult,
 	// every included identity cluster and person profile is complete —
 	// components can pass through participants with no copied messages.
 	if options.IncludeIdentity {
-		res, err = tx.Exec(`
-			INSERT INTO participants SELECT * FROM src.participants
-			WHERE id IN (
+		res, err = copyByName(tx, "participants", `id IN (
 				WITH RECURSIVE symmetric_edge(a, b) AS (
 					SELECT participant_a, participant_b FROM src.participant_links
 					UNION ALL
@@ -614,10 +607,8 @@ func copyData(tx *sql.Tx, rowCount int, options CopySubsetOptions) (*CopyResult,
 		return nil, fmt.Errorf("copy message_raw: %w", err)
 	}
 
-	if _, err := tx.Exec(`
-		INSERT INTO message_recipients
-		SELECT * FROM src.message_recipients
-		WHERE message_id IN (SELECT id FROM selected_messages)`); err != nil {
+	if _, err := copyByName(tx, "message_recipients",
+		`message_id IN (SELECT id FROM selected_messages)`); err != nil {
 		return nil, fmt.Errorf("copy message_recipients: %w", err)
 	}
 
@@ -633,9 +624,7 @@ func copyData(tx *sql.Tx, rowCount int, options CopySubsetOptions) (*CopyResult,
 		return nil, fmt.Errorf("copy attachments: %w", err)
 	}
 
-	res, err = tx.Exec(`
-		INSERT INTO labels SELECT * FROM src.labels
-		WHERE source_id IN (SELECT id FROM sources)
+	res, err = copyByName(tx, "labels", `source_id IN (SELECT id FROM sources)
 		   OR id IN (
 			SELECT label_id FROM src.message_labels
 			WHERE message_id IN (SELECT id FROM selected_messages)
@@ -663,32 +652,46 @@ func copyData(tx *sql.Tx, rowCount int, options CopySubsetOptions) (*CopyResult,
 	return result, nil
 }
 
-// errNoCommonMessageColumns reports that the source and destination messages
-// tables have no column name in common, so there is nothing to copy.
-var errNoCommonMessageColumns = errors.New(
-	"source and destination share no messages columns")
-
 // copyMessages copies the selected messages, naming the columns the source and
 // destination have in common, read from the two schemas at copy time.
-//
-// A column the source lacks is left out of the INSERT, so the destination's own
-// DEFAULT, where it has one, supplies it. Columns the source has and the
-// destination does not are dropped.
 func copyMessages(tx *sql.Tx) error {
-	cols, err := commonColumns(tx, "messages")
-	if err != nil {
-		return fmt.Errorf("copy messages: %w", err)
-	}
-	if len(cols) == 0 {
-		return fmt.Errorf("copy messages: %w", errNoCommonMessageColumns)
-	}
-	list := strings.Join(cols, ", ")
-	if _, err := tx.Exec(fmt.Sprintf(`
-		INSERT INTO messages (%s) SELECT %s FROM src.messages
-		WHERE id IN (SELECT id FROM selected_messages)`, list, list)); err != nil {
+	if _, err := copyByName(tx, "messages",
+		`id IN (SELECT id FROM selected_messages)`); err != nil {
 		return fmt.Errorf("copy messages: %w", err)
 	}
 	return nil
+}
+
+// copyByName copies the rows of src.<table> satisfying the where clause into
+// the destination table, naming the columns the source and destination have in
+// common, read from the two schemas at copy time (see commonColumns).
+//
+// Naming the columns keeps the copy independent of declaration order: on a
+// database upgraded by the legacy ALTER TABLE ADD COLUMN migrations a
+// late-added column (labels.system_role, participants.phone_number,
+// conversations.title, ...) sits at the end of the table, while a fresh
+// schema.sql database declares it mid-table, so a positional SELECT * copy
+// from one into the other lands values in the wrong columns. A column the
+// source lacks is left out of the INSERT, so the destination's own DEFAULT,
+// where it has one, supplies it. Columns the source has and the destination
+// does not are dropped.
+func copyByName(tx *sql.Tx, table, where string, args ...any) (sql.Result, error) {
+	cols, err := commonColumns(tx, table)
+	if err != nil {
+		return nil, err
+	}
+	if len(cols) == 0 {
+		return nil, fmt.Errorf(
+			"source and destination share no %s columns", table)
+	}
+	list := strings.Join(cols, ", ")
+	res, err := tx.Exec(fmt.Sprintf(`
+		INSERT INTO %s (%s) SELECT %s FROM src.%s
+		WHERE %s`, table, list, list, table, where), args...)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // commonColumns returns the quoted names of the columns `table` has in both the

--- a/internal/store/subset_test.go
+++ b/internal/store/subset_test.go
@@ -1906,3 +1906,148 @@ func TestCopySubset_BodyTriggersRestampWatermarks(t *testing.T) {
 		"count unwatermarked messages")
 	assert.Zero(missing, "every copied message must carry a watermark")
 }
+
+// TestCopySubset_UpgradedAuxiliaryColumnOrder covers copying from a source
+// archive whose labels, participants, and conversations tables carry the
+// upgraded column order: the legacy ALTER TABLE ADD COLUMN migrations append
+// system_role, phone_number/canonical_id, and title/conversation_type at the
+// end of their tables, while a fresh schema.sql database declares them
+// mid-table. A positional SELECT * copy from such a source into a fresh
+// subset lands values in the wrong columns — labels.system_role and
+// labels.color swap, which loses the 'sent' role that sent-folder identity
+// discovery depends on. The copy names its columns, so every value must land
+// in its own column.
+func TestCopySubset_UpgradedAuxiliaryColumnOrder(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "dst")
+	srcDB := createTestSourceDB(t, srcDir, 2)
+
+	db, err := sql.Open("sqlite3", srcDB+"?_foreign_keys=OFF")
+	require.NoError(err, "open source db")
+
+	// Rebuild each table into the shape the legacy ADD COLUMN migrations
+	// produce: the late-added columns re-appended at the end, in migration
+	// order. Indexes on the dropped columns go first — SQLite refuses to
+	// drop an indexed column.
+	for _, stmt := range []string{
+		`ALTER TABLE labels DROP COLUMN system_role`,
+		`ALTER TABLE labels ADD COLUMN system_role TEXT`,
+
+		`DROP INDEX IF EXISTS idx_participants_phone`,
+		`DROP INDEX IF EXISTS idx_participants_canonical`,
+		`ALTER TABLE participants DROP COLUMN phone_number`,
+		`ALTER TABLE participants DROP COLUMN canonical_id`,
+		`ALTER TABLE participants ADD COLUMN phone_number TEXT`,
+		`ALTER TABLE participants ADD COLUMN canonical_id TEXT`,
+
+		`DROP INDEX IF EXISTS idx_conversations_type`,
+		`ALTER TABLE conversations DROP COLUMN conversation_type`,
+		`ALTER TABLE conversations DROP COLUMN title`,
+		`ALTER TABLE conversations ADD COLUMN title TEXT`,
+		`ALTER TABLE conversations ADD COLUMN conversation_type TEXT NOT NULL DEFAULT 'email_thread'`,
+	} {
+		_, err = db.Exec(stmt)
+		require.NoError(err, "rebuild upgraded order: %s", stmt)
+	}
+
+	_, err = db.Exec(`UPDATE labels
+		SET system_role = 'sent', color = '#16a765' WHERE id = 2`)
+	require.NoError(err, "seed upgraded label columns")
+	_, err = db.Exec(`UPDATE participants
+		SET phone_number = '+15550100', canonical_id = 'alice@example.com'
+		WHERE id = 1`)
+	require.NoError(err, "seed upgraded participant columns")
+	_, err = db.Exec(`UPDATE conversations
+		SET title = 'Thread 1', conversation_type = 'email_thread'`)
+	require.NoError(err, "seed upgraded conversation columns")
+	require.NoError(db.Close(), "close source db")
+
+	_, err = CopySubset(srcDB, dstDir, 100, false)
+	require.NoError(err, "CopySubset from upgraded column order")
+
+	dstDB, err := sql.Open("sqlite3", filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err, "open destination db")
+	defer func() { _ = dstDB.Close() }()
+
+	var systemRole, color sql.NullString
+	require.NoError(dstDB.QueryRow(
+		`SELECT system_role, color FROM labels WHERE id = 2`,
+	).Scan(&systemRole, &color), "read copied label")
+	assert.Equal("sent", systemRole.String, "labels.system_role")
+	assert.Equal("#16a765", color.String, "labels.color")
+
+	var phone, canonical, displayName, domain sql.NullString
+	require.NoError(dstDB.QueryRow(
+		`SELECT phone_number, canonical_id, display_name, domain
+		 FROM participants WHERE id = 1`,
+	).Scan(&phone, &canonical, &displayName, &domain),
+		"read copied participant")
+	assert.Equal("+15550100", phone.String, "participants.phone_number")
+	assert.Equal("alice@example.com", canonical.String,
+		"participants.canonical_id")
+	assert.Equal("Alice", displayName.String, "participants.display_name")
+	assert.Equal("example.com", domain.String, "participants.domain")
+
+	var title, convType string
+	require.NoError(dstDB.QueryRow(
+		`SELECT title, conversation_type FROM conversations WHERE id = 1`,
+	).Scan(&title, &convType), "read copied conversation")
+	assert.Equal("Thread 1", title, "conversations.title")
+	assert.Equal("email_thread", convType, "conversations.conversation_type")
+}
+
+// TestCopySubset_LegacyMessageRecipientsWithoutEnvelopeAddress covers a
+// source archive from before message_recipients.email_address was added. The
+// destination has the new column, so the copy must match columns by name and
+// let the destination default the missing envelope snapshot to NULL.
+func TestCopySubset_LegacyMessageRecipientsWithoutEnvelopeAddress(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srcDB := createTestSourceDB(t, t.TempDir(), 2)
+	dstDir := filepath.Join(t.TempDir(), "dst")
+
+	db, err := sql.Open("sqlite3", srcDB+"?_foreign_keys=OFF")
+	require.NoError(err, "open source db")
+	for _, stmt := range []string{
+		`DROP INDEX IF EXISTS idx_message_recipients_envelope`,
+		`DROP INDEX IF EXISTS idx_message_recipients_message`,
+		`DROP INDEX IF EXISTS idx_message_recipients_participant`,
+		`CREATE TABLE message_recipients_legacy (
+			id INTEGER PRIMARY KEY,
+			message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+			participant_id INTEGER NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+			recipient_type TEXT NOT NULL,
+			display_name TEXT,
+			UNIQUE(message_id, participant_id, recipient_type)
+		)`,
+		`INSERT INTO message_recipients_legacy
+			(id, message_id, participant_id, recipient_type, display_name)
+		 SELECT id, message_id, participant_id, recipient_type, display_name
+		 FROM message_recipients`,
+		`DROP TABLE message_recipients`,
+		`ALTER TABLE message_recipients_legacy RENAME TO message_recipients`,
+		`CREATE INDEX idx_message_recipients_message
+			ON message_recipients(message_id)`,
+		`CREATE INDEX idx_message_recipients_participant
+			ON message_recipients(participant_id, recipient_type)`,
+	} {
+		_, err = db.Exec(stmt)
+		require.NoError(err, "rebuild legacy message_recipients: %s", stmt)
+	}
+	require.NoError(db.Close(), "close source db")
+
+	_, err = CopySubset(srcDB, dstDir, 100, false)
+	require.NoError(err, "CopySubset from source without email_address")
+
+	dstDB, err := sql.Open("sqlite3", filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err, "open destination db")
+	defer func() { _ = dstDB.Close() }()
+
+	var count int64
+	require.NoError(dstDB.QueryRow(
+		`SELECT COUNT(*) FROM message_recipients WHERE email_address IS NULL`,
+	).Scan(&count), "count legacy recipients without envelope snapshots")
+	assert.Equal(int64(4), count)
+}

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"time"
 
@@ -64,10 +65,22 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 
 	s.logger.Info("incremental sync", "email", source.Identifier, "start_history", startHistoryID, "current_history", profile.HistoryID)
 
-	// If history IDs match, nothing to do
+	// Settle any discovery debt a previous run parked, before the up-to-date
+	// check can return. A wound-down archive syncs to a no-op indefinitely, so a
+	// drain behind that return would never run again for the account that needs
+	// it most. Unlike the post-completion hook below, this re-derives evidence
+	// from local messages and costs one key lookup when there is no debt.
+	s.drainIdentityDiscoveryBacklog(ctx, source.ID)
+
+	// If history IDs match, nothing to do locally — but provider inventory can
+	// change while a mailbox is idle, so the post-completion hook still runs,
+	// flagged as a no-op so it only reaches for the provider when a refresh is
+	// owed (never succeeded, previously failed, or stale).
 	if startHistoryID >= profile.HistoryID {
 		s.logger.Info("already up to date")
-		_ = s.store.CompleteSync(syncID, strconv.FormatUint(profile.HistoryID, 10))
+		if s.completeSyncWithoutHook(syncID, strconv.FormatUint(profile.HistoryID, 10)) {
+			s.runSuccessfulSyncHook(ctx, source, false)
+		}
 		summary.EndTime = time.Now()
 		summary.Duration = summary.EndTime.Sub(summary.StartTime)
 		summary.FinalHistoryID = profile.HistoryID
@@ -84,6 +97,7 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 	// Process history
 	checkpoint := &store.Checkpoint{}
 	pageToken := ""
+	var discoveryHealth pageDiscoveryHealth
 
 	for {
 		historyResp, err := s.client.ListHistory(ctx, startHistoryID, pageToken)
@@ -127,11 +141,14 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 		newMsgThreads := make(map[string]string) // deduplicates by ID
 		deletedSet := make(map[string]bool)
 		updatedExisting := make(map[string]struct{})
+		identityDiscoverySet := make(map[string]struct{})
 
 		for _, record := range historyResp.History {
 			for _, msg := range record.MessagesAdded {
 				if _, exists := existingMap[msg.Message.ID]; !exists {
 					newMsgThreads[msg.Message.ID] = msg.Message.ThreadID
+				} else {
+					identityDiscoverySet[msg.Message.ID] = struct{}{}
 				}
 			}
 			for _, msg := range record.MessagesDeleted {
@@ -139,7 +156,7 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 			}
 		}
 		for _, record := range historyResp.History {
-			s.processLabelChanges(ctx, syncID, source.ID, record, labelMap, existingMap, newMsgThreads, updatedExisting, checkpoint, summary)
+			s.processLabelChanges(ctx, syncID, source.ID, record, labelMap, existingMap, newMsgThreads, updatedExisting, identityDiscoverySet, checkpoint, summary)
 		}
 		checkpoint.MessagesUpdated += int64(len(updatedExisting))
 		checkpoint.MessagesProcessed += int64(len(newMsgThreads) + len(deletedSet) + len(updatedExisting))
@@ -187,6 +204,7 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 					}
 					checkpoint.MessagesAdded++
 					summary.BytesDownloaded += int64(len(raw.Raw))
+					identityDiscoverySet[newMsgIDs[i]] = struct{}{}
 				}
 
 				// Newly-persisted messages get embed_gen = NULL by column
@@ -206,6 +224,18 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 			}
 		}
 
+		identityDiscoveryIDs := make([]string, 0, len(identityDiscoverySet))
+		for id := range identityDiscoverySet {
+			identityDiscoveryIDs = append(identityDiscoveryIDs, id)
+		}
+		sort.Strings(identityDiscoveryIDs)
+		discoveryHealth.observe(s.runPageIdentityDiscovery(ctx, source.ID, identityDiscoveryIDs))
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err := fmt.Errorf("sync canceled during identity discovery: %w", ctxErr)
+			s.failSyncUnlessCanceled(syncID, err)
+			return nil, err
+		}
+
 		// Report progress
 		s.progress.OnProgress(checkpoint.MessagesProcessed, checkpoint.MessagesAdded, 0)
 
@@ -222,6 +252,12 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 		}
 	}
 
+	// Debt parked by an earlier page of this run is settled now, provided the
+	// run showed discovery recovering.
+	if discoveryHealth.shouldDrainAtCompletion() {
+		s.drainIdentityDiscoveryBacklog(ctx, source.ID)
+	}
+
 	// Always advance the cursor so a single permanently-failing
 	// message doesn't block all future incremental syncs.
 	// Failed messages can be recovered via full sync.
@@ -235,10 +271,8 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 		s.logger.Warn("failed to update sync cursor", "error", err)
 	}
 
-	// Mark sync complete
-	if err := s.store.CompleteSync(syncID, historyIDStr); err != nil {
-		s.logger.Warn("failed to complete sync", "error", err)
-	}
+	// Mark sync complete before running best-effort provider maintenance.
+	s.completeSyncAndRunHook(ctx, syncID, historyIDStr, source)
 
 	// Build summary
 	summary.EndTime = time.Now()
@@ -255,27 +289,33 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 
 // processLabelChanges handles label additions and removals for messages.
 // existingMap maps source_message_id -> internal message_id for known messages.
-func (s *Syncer) processLabelChanges(ctx context.Context, syncID, sourceID int64, record gmail.HistoryRecord, labelMap map[string]int64, existingMap map[string]int64, newMsgThreads map[string]string, updatedExisting map[string]struct{}, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) {
+func (s *Syncer) processLabelChanges(ctx context.Context, syncID, sourceID int64, record gmail.HistoryRecord, labelMap map[string]int64, existingMap map[string]int64, newMsgThreads map[string]string, updatedExisting, identityDiscoverySet map[string]struct{}, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) {
 	for _, item := range record.LabelsAdded {
 		if _, exists := existingMap[item.Message.ID]; !exists {
 			if _, pending := newMsgThreads[item.Message.ID]; pending {
 				continue
 			}
 		}
-		updated, err := s.handleLabelChange(ctx, syncID, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, true, existingMap, checkpoint, summary)
+		updated, discoverable, err := s.handleLabelChange(ctx, syncID, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, true, existingMap, checkpoint, summary)
 		if err != nil {
 			s.logLabelChangeError("add", item.Message.ID, err)
 			continue
+		}
+		if discoverable {
+			identityDiscoverySet[item.Message.ID] = struct{}{}
 		}
 		if updated {
 			updatedExisting[item.Message.ID] = struct{}{}
 		}
 	}
 	for _, item := range record.LabelsRemoved {
-		updated, err := s.handleLabelChange(ctx, syncID, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, false, existingMap, checkpoint, summary)
+		updated, discoverable, err := s.handleLabelChange(ctx, syncID, sourceID, item.Message.ID, item.Message.ThreadID, item.LabelIDs, labelMap, false, existingMap, checkpoint, summary)
 		if err != nil {
 			s.logLabelChangeError("remove", item.Message.ID, err)
 			continue
+		}
+		if discoverable {
+			identityDiscoverySet[item.Message.ID] = struct{}{}
 		}
 		if updated {
 			updatedExisting[item.Message.ID] = struct{}{}
@@ -286,7 +326,7 @@ func (s *Syncer) processLabelChanges(ctx context.Context, syncID, sourceID int64
 // handleLabelChange processes a label addition or removal.
 // For existing messages, applies the label diff directly without any API calls.
 // For unknown messages with labels being added, fetches and ingests the message.
-func (s *Syncer) handleLabelChange(ctx context.Context, syncID, sourceID int64, messageID, threadID string, gmailLabelIDs []string, labelMap map[string]int64, isAdd bool, existingMap map[string]int64, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) (bool, error) {
+func (s *Syncer) handleLabelChange(ctx context.Context, syncID, sourceID int64, messageID, threadID string, gmailLabelIDs []string, labelMap map[string]int64, isAdd bool, existingMap map[string]int64, checkpoint *store.Checkpoint, summary *gmail.SyncSummary) (bool, bool, error) {
 	internalID, exists := existingMap[messageID]
 
 	if !exists {
@@ -297,18 +337,18 @@ func (s *Syncer) handleLabelChange(ctx context.Context, syncID, sourceID int64, 
 			if err != nil {
 				if isGmailNotFound(err) {
 					s.recordSyncItem(syncID, messageID, syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, err)
-					return false, err
+					return false, false, err
 				}
 				s.recordSyncItem(syncID, messageID, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, err)
 				checkpoint.ErrorsCount++
-				return false, err
+				return false, false, err
 			}
 			if _, err := s.ingestMessage(
 				ctx, sourceID, raw, threadID, labelMap,
 			); err != nil {
 				s.recordSyncItem(syncID, messageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
 				checkpoint.ErrorsCount++
-				return false, err
+				return false, false, err
 			}
 			// The new message gets embed_gen = NULL by column default, so
 			// the scan-and-fill embed worker picks it up automatically — no
@@ -317,10 +357,10 @@ func (s *Syncer) handleLabelChange(ctx context.Context, syncID, sourceID int64, 
 			if raw != nil {
 				summary.BytesDownloaded += int64(len(raw.Raw))
 			}
-			return false, nil
+			return false, true, nil
 		}
 		// Removing labels from non-existent message is a no-op
-		return false, nil
+		return false, false, nil
 	}
 
 	// Convert Gmail label IDs to internal label IDs
@@ -333,9 +373,15 @@ func (s *Syncer) handleLabelChange(ctx context.Context, syncID, sourceID int64, 
 
 	// Apply label diff directly — no API call needed
 	if isAdd {
-		return true, s.store.AddMessageLabels(internalID, labelIDs)
+		if err := s.store.AddMessageLabels(internalID, labelIDs); err != nil {
+			return false, false, err
+		}
+		return true, true, nil
 	}
-	return true, s.store.RemoveMessageLabels(internalID, labelIDs)
+	if err := s.store.RemoveMessageLabels(internalID, labelIDs); err != nil {
+		return false, false, err
+	}
+	return true, true, nil
 }
 
 // logLabelChangeError logs label change errors, downgrading "not found"

--- a/internal/sync/recipient_set_test.go
+++ b/internal/sync/recipient_set_test.go
@@ -1,0 +1,47 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.kenn.io/msgvault/internal/mime"
+)
+
+// TestBuildRecipientSetKeepsAliasEnvelopeSnapshots covers the dedup key of
+// buildRecipientSet: one row per (participant, normalized envelope address),
+// not one row per participant. Two aliases resolving to the same merged
+// participant must each keep their own envelope snapshot, a case variant of
+// an already-seen address must collapse, and the display-name upgrade (an
+// empty first-seen name picks up a later non-empty one) must apply to every
+// row of that participant.
+func TestBuildRecipientSetKeepsAliasEnvelopeSnapshots(t *testing.T) {
+	assert := assert.New(t)
+
+	// primary@ and alias@ resolve to the same participant (7), as an
+	// already-merged alias pair would; other@ is an unrelated participant.
+	participantMap := map[string]int64{
+		"primary@example.test": 7,
+		"alias@example.test":   7,
+		"PRIMARY@example.test": 7,
+		"other@example.test":   9,
+	}
+	addresses := []mime.Address{
+		{Email: "primary@example.test"},
+		{Email: "alias@example.test", Name: "Prim"},
+		{Email: "PRIMARY@example.test", Name: "Prim Upper"},
+		{Email: "other@example.test", Name: "Other"},
+		{Email: "unknown@example.test", Name: "Skipped"},
+	}
+
+	rs := buildRecipientSet("to", addresses, participantMap)
+
+	assert.Equal("to", rs.Type)
+	assert.Equal([]int64{7, 7, 9}, rs.ParticipantIDs,
+		"aliases of one participant must produce one row each; case variants and unknown addresses must not")
+	assert.Equal(
+		[]string{"primary@example.test", "alias@example.test", "other@example.test"},
+		rs.EmailAddresses,
+		"each row must pin the envelope address that produced it")
+	assert.Equal([]string{"Prim", "Prim", "Other"}, rs.DisplayNames,
+		"a later non-empty display name must upgrade every row of the participant")
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -15,6 +15,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/identityops"
 	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/textutil"
@@ -64,12 +65,21 @@ func DefaultOptions() *Options {
 
 // Syncer performs Gmail synchronization.
 type Syncer struct {
-	client   gmail.API
-	store    *store.Store
-	logger   *slog.Logger
-	progress gmail.SyncProgress
-	opts     *Options
+	client             gmail.API
+	store              *store.Store
+	logger             *slog.Logger
+	progress           gmail.SyncProgress
+	opts               *Options
+	successfulHookName string
+	successfulHook     SuccessfulSyncHook
 }
+
+// SuccessfulSyncHook runs after the durable sync run is marked complete.
+// mailboxChanged reports whether the run observed provider-side change; a
+// no-op incremental run passes false so the hook can skip provider-facing
+// work it has performed recently.
+// Its failure is warning-only and never replaces the successful sync result.
+type SuccessfulSyncHook func(ctx context.Context, source *store.Source, mailboxChanged bool) error
 
 type messageAcknowledger interface {
 	AcknowledgeMessages(ctx context.Context, messageIDs []string)
@@ -138,6 +148,156 @@ func (s *Syncer) labelsSnapshotComplete() bool {
 	return !ok || completeness.LabelsSnapshotComplete()
 }
 
+// WithSuccessfulSyncHook installs one best-effort post-completion hook.
+func (s *Syncer) WithSuccessfulSyncHook(name string, hook SuccessfulSyncHook) *Syncer {
+	s.successfulHookName = strings.TrimSpace(name)
+	s.successfulHook = hook
+	return s
+}
+
+func (s *Syncer) runSuccessfulSyncHook(ctx context.Context, source *store.Source, mailboxChanged bool) {
+	if s.successfulHook == nil {
+		return
+	}
+	if err := s.successfulHook(ctx, source, mailboxChanged); err != nil {
+		s.logger.Warn(
+			"successful sync hook failed",
+			"hook", s.successfulHookName,
+			"source_id", source.ID,
+			"error", err,
+		)
+	}
+}
+
+// completeSyncWithoutHook marks the run complete and reports whether that
+// durable write succeeded.
+func (s *Syncer) completeSyncWithoutHook(syncID int64, historyID string) bool {
+	if err := s.store.CompleteSync(syncID, historyID); err != nil {
+		s.logger.Warn("failed to complete sync", "error", err)
+		return false
+	}
+	return true
+}
+
+func (s *Syncer) completeSyncAndRunHook(
+	ctx context.Context,
+	syncID int64,
+	historyID string,
+	source *store.Source,
+) {
+	if !s.completeSyncWithoutHook(syncID, historyID) {
+		return
+	}
+	s.runSuccessfulSyncHook(ctx, source, true)
+}
+
+// identityDiscoveryRetryBackoff is the delay before the second per-page
+// identity discovery attempt; each further attempt doubles it. It is a variable
+// so tests can run the retry loop without real backoff.
+var identityDiscoveryRetryBackoff = time.Second
+
+const (
+	identityDiscoveryAttempts          = 3
+	identityDiscoveryRetryLogMessage   = "identity discovery failed for sync page; retrying"
+	identityDiscoveryBacklogLogMessage = "identity discovery failed for sync page; recorded backlog"
+	identityDiscoveryDrainLogMessage   = "draining identity discovery backlog"
+)
+
+// runPageIdentityDiscovery merges one page's identity evidence into the
+// source's confirmed identities, retrying a bounded number of times.
+//
+// It deliberately returns no error. The page's messages are already durably
+// archived by the time it runs, and the evidence it derives is recomputable
+// from them, so failing the run here would discard real archived work over a
+// debt that RefreshConfirmedForSource can settle later. Persistent failure is
+// logged and parked in a durable per-source backlog marker instead. Callers
+// must still check ctx after it returns: a cancelled sync is an interruption,
+// not a discovery failure, and has to stay resumable.
+//
+// It reports whether the page ended up parking a backlog marker, which is the
+// signal callers use to decide whether an immediate drain is worth attempting.
+func (s *Syncer) runPageIdentityDiscovery(
+	ctx context.Context,
+	sourceID int64,
+	sourceMessageIDs []string,
+) (parkedBacklog bool) {
+	backoff := identityDiscoveryRetryBackoff
+	var err error
+	for attempt := range identityDiscoveryAttempts {
+		if _, err = identityops.DiscoverStrongForSourceMessageIDs(
+			ctx, s.store, sourceID, sourceMessageIDs,
+		); err == nil {
+			return false
+		}
+		if ctx.Err() != nil || attempt == identityDiscoveryAttempts-1 {
+			break
+		}
+		s.logger.Warn(identityDiscoveryRetryLogMessage,
+			"source_id", sourceID, "attempt", attempt+1, "error", err)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return false
+		}
+		backoff *= 2
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+	err = fmt.Errorf("discover identities for sync page: %w", err)
+	s.logger.Warn(identityDiscoveryBacklogLogMessage, "source_id", sourceID, "error", err)
+	if setErr := s.store.SetIdentityDiscoveryBacklogContext(ctx, sourceID, err); setErr != nil {
+		s.logger.Warn("record identity discovery backlog", "source_id", sourceID, "error", setErr)
+	}
+	return true
+}
+
+// pageDiscoveryHealth tracks whether the most recent page's identity discovery
+// worked, so a run only spends an end-of-run whole-archive refresh when there
+// is reason to believe it can succeed.
+type pageDiscoveryHealth struct {
+	ran    bool
+	parked bool
+}
+
+func (h *pageDiscoveryHealth) observe(parkedBacklog bool) {
+	h.ran = true
+	h.parked = parkedBacklog
+}
+
+// shouldDrainAtCompletion reports whether a run that just finished its pages
+// should try to settle debt it parked itself. Retrying right after discovery
+// failed every attempt on the last page costs a full archive scan to learn
+// nothing; debt parked by an earlier page of a run that recovered is worth
+// settling now rather than making the archive wait for the next sync.
+func (h *pageDiscoveryHealth) shouldDrainAtCompletion() bool {
+	return h.ran && !h.parked
+}
+
+// drainIdentityDiscoveryBacklog settles a parked discovery debt by re-deriving
+// the source's confirmed identities from the whole archive. A refresh that
+// fails leaves the marker in place for the next attempt; it never fails the
+// sync that happens to be carrying it.
+func (s *Syncer) drainIdentityDiscoveryBacklog(ctx context.Context, sourceID int64) {
+	found, lastError, err := s.store.IdentityDiscoveryBacklogContext(ctx, sourceID)
+	if err != nil {
+		s.logger.Warn("read identity discovery backlog", "source_id", sourceID, "error", err)
+		return
+	}
+	if !found {
+		return
+	}
+	s.logger.Info(identityDiscoveryDrainLogMessage,
+		"source_id", sourceID, "last_error", lastError)
+	if err := identityops.RefreshConfirmedForSource(ctx, s.store, sourceID); err != nil {
+		s.logger.Warn("drain identity discovery backlog", "source_id", sourceID, "error", err)
+		return
+	}
+	if err := s.store.ClearIdentityDiscoveryBacklogContext(ctx, sourceID); err != nil {
+		s.logger.Warn("clear identity discovery backlog", "source_id", sourceID, "error", err)
+	}
+}
+
 // syncState holds the state for a sync operation.
 type syncState struct {
 	syncID     int64
@@ -198,12 +358,13 @@ func (s *Syncer) initSyncState(sourceID int64) (*syncState, error) {
 
 // batchResult holds the result of processing a batch.
 type batchResult struct {
-	processed    int64
-	added        int64
-	updated      int64
-	skipped      int64
-	oldestDate   time.Time
-	acknowledged []string
+	processed        int64
+	added            int64
+	updated          int64
+	skipped          int64
+	oldestDate       time.Time
+	acknowledged     []string
+	sourceMessageIDs []string
 }
 
 type inconclusiveLabelRefresh struct {
@@ -227,6 +388,7 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 		messageIDs[i] = m.ID
 		threadIDs[m.ID] = m.ThreadID
 	}
+	result.sourceMessageIDs = messageIDs
 
 	// Check which messages already exist
 	existingMap, err := s.store.MessageMetadataWithRawBatch(
@@ -645,8 +807,12 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 		return nil, fmt.Errorf("sync labels: %w", err)
 	}
 
+	// Settle any discovery debt a previous run parked before this run adds to it.
+	s.drainIdentityDiscoveryBacklog(ctx, source.ID)
+
 	// List and sync messages
 	var totalEstimate int64
+	var discoveryHealth pageDiscoveryHealth
 	firstPage := true
 	pageToken := state.pageToken
 
@@ -689,12 +855,19 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 			return nil, err
 		}
 
-		state.checkpoint.MessagesProcessed += result.processed
-		state.checkpoint.MessagesAdded += result.added
-		state.checkpoint.MessagesUpdated += result.updated
+		discoveryHealth.observe(s.runPageIdentityDiscovery(ctx, source.ID, result.sourceMessageIDs))
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err := fmt.Errorf("sync canceled during identity discovery: %w", ctxErr)
+			s.failSyncUnlessCanceled(state.syncID, err)
+			return nil, err
+		}
 		if ack, ok := s.client.(messageAcknowledger); ok && len(result.acknowledged) > 0 {
 			ack.AcknowledgeMessages(ctx, result.acknowledged)
 		}
+
+		state.checkpoint.MessagesProcessed += result.processed
+		state.checkpoint.MessagesAdded += result.added
+		state.checkpoint.MessagesUpdated += result.updated
 
 		// Report current position date before progress (so UI shows consistent state)
 		if !result.oldestDate.IsZero() {
@@ -724,6 +897,12 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 		}
 	}
 
+	// Debt parked by an earlier page of this run is settled now, provided the
+	// run showed discovery recovering.
+	if discoveryHealth.shouldDrainAtCompletion() {
+		s.drainIdentityDiscoveryBacklog(ctx, source.ID)
+	}
+
 	// Update source with final history ID.
 	// Full sync always advances the cursor (it records the starting point
 	// for future incremental syncs), but warn when errors occurred.
@@ -737,10 +916,8 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 		s.logger.Warn("failed to update sync cursor", "error", err)
 	}
 
-	// Mark sync complete
-	if err := s.store.CompleteSync(state.syncID, historyIDStr); err != nil {
-		s.logger.Warn("failed to complete sync", "error", err)
-	}
+	// Mark sync complete before running best-effort provider maintenance.
+	s.completeSyncAndRunHook(ctx, state.syncID, historyIDStr, source)
 
 	// Checkpoint WAL after sync to fold it back into the main database.
 	// This prevents WAL accumulation across long sync sessions and ensures
@@ -779,7 +956,11 @@ func (s *Syncer) syncLabels(ctx context.Context, sourceID int64) (map[string]int
 				labelType = labelTypeSystem
 			}
 		}
-		labelInfos[l.ID] = store.LabelInfo{Name: l.Name, Type: labelType}
+		labelInfos[l.ID] = store.LabelInfo{
+			Name:       l.Name,
+			Type:       labelType,
+			SystemRole: l.SystemRole,
+		}
 	}
 
 	return s.store.EnsureLabelsBatch(sourceID, labelInfos)
@@ -1263,26 +1444,43 @@ func buildRecipientSet(recipientType string, addresses []mime.Address, participa
 		return rs
 	}
 
-	// Track participant ID -> display name, preferring non-empty names.
-	// Handles duplicates where the first occurrence might have an empty
-	// name but a later occurrence has a better display name.
+	// One row per (participant, normalized envelope address): two aliases
+	// that resolve to the same already-merged participant each keep their
+	// own envelope snapshot instead of collapsing onto the first-seen
+	// address, so identity discovery still observes both. Display names
+	// stay per participant, preferring non-empty names — a duplicate whose
+	// first occurrence has an empty name picks up a later, better one, and
+	// every row of that participant carries the same name.
+	type rowKey struct {
+		participantID int64
+		email         string
+	}
 	idToName := make(map[int64]string)
+	seen := make(map[rowKey]struct{})
 	var orderedIDs []int64
+	var orderedEmails []string
 
 	for _, addr := range addresses {
-		if id, ok := participantMap[addr.Email]; ok {
-			name := textutil.EnsureUTF8(addr.Name)
-			if _, seen := idToName[id]; !seen {
-				orderedIDs = append(orderedIDs, id)
-				idToName[id] = name
-			} else if idToName[id] == "" && name != "" {
-				idToName[id] = name
-			}
+		id, ok := participantMap[addr.Email]
+		if !ok {
+			continue
 		}
+		name := textutil.EnsureUTF8(addr.Name)
+		if existing, tracked := idToName[id]; !tracked || (existing == "" && name != "") {
+			idToName[id] = name
+		}
+		key := rowKey{participantID: id, email: strings.ToLower(addr.Email)}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		orderedIDs = append(orderedIDs, id)
+		orderedEmails = append(orderedEmails, addr.Email)
 	}
 
 	rs.ParticipantIDs = orderedIDs
 	rs.DisplayNames = make([]string, len(orderedIDs))
+	rs.EmailAddresses = orderedEmails
 	for i, id := range orderedIDs {
 		rs.DisplayNames[i] = idToName[id]
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,12 +1,14 @@
 package sync
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	imapv2 "github.com/emersion/go-imap/v2"
@@ -57,6 +60,85 @@ type acknowledgingAPI struct {
 
 func (a *acknowledgingAPI) AcknowledgeMessages(_ context.Context, messageIDs []string) {
 	a.acknowledged = append(a.acknowledged, messageIDs...)
+}
+
+// syncLogCapture records everything a Syncer logs and, optionally, reacts to
+// each record inline on the syncing goroutine. Reacting to a real log event is
+// how the retry tests hit an exact point in the retry loop without sleeping.
+// Attrs and groups are dropped: the sync code logs flat records only.
+type syncLogCapture struct {
+	inner    slog.Handler
+	buf      *bytes.Buffer
+	onRecord func(slog.Record)
+}
+
+func newSyncLogCapture(onRecord func(slog.Record)) *syncLogCapture {
+	buf := &bytes.Buffer{}
+	return &syncLogCapture{
+		inner:    slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		buf:      buf,
+		onRecord: onRecord,
+	}
+}
+
+func (c *syncLogCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+func (c *syncLogCapture) Handle(ctx context.Context, record slog.Record) error {
+	err := c.inner.Handle(ctx, record)
+	if c.onRecord != nil {
+		c.onRecord(record)
+	}
+	if err != nil {
+		return fmt.Errorf("capture sync log record: %w", err)
+	}
+	return nil
+}
+
+func (c *syncLogCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+
+func (c *syncLogCapture) WithGroup(string) slog.Handler { return c }
+
+func (c *syncLogCapture) String() string { return c.buf.String() }
+
+func (c *syncLogCapture) logger() *slog.Logger { return slog.New(c) }
+
+// shortenIdentityDiscoveryRetry keeps the bounded discovery retry from adding
+// seconds of real backoff to a test run.
+func shortenIdentityDiscoveryRetry(t *testing.T, backoff time.Duration) {
+	t.Helper()
+	previous := identityDiscoveryRetryBackoff
+	identityDiscoveryRetryBackoff = backoff
+	t.Cleanup(func() { identityDiscoveryRetryBackoff = previous })
+}
+
+const forcedDiscoveryFailure = "forced identity discovery failure"
+
+// installFailingIdentityDiscovery aborts every account_identities write.
+// Sync-time discovery only merges signals into already-confirmed identities,
+// so the failure seam has to intercept that update rather than an insert.
+func installFailingIdentityDiscovery(t *testing.T, env *TestEnv, trigger string) {
+	t.Helper()
+	_, err := env.Store.DB().Exec(`
+		CREATE TRIGGER ` + trigger + `
+		BEFORE UPDATE ON account_identities
+		BEGIN
+			SELECT RAISE(ABORT, '` + forcedDiscoveryFailure + `');
+		END
+	`)
+	require.NoError(t, err, "install identity discovery failure seam")
+	t.Cleanup(func() {
+		_, _ = env.Store.DB().Exec("DROP TRIGGER IF EXISTS " + trigger)
+	})
+}
+
+type staticLabelsAPI struct {
+	*gmail.MockAPI
+
+	labels []*gmail.Label
+}
+
+func (a *staticLabelsAPI) ListLabels(_ context.Context) ([]*gmail.Label, error) {
+	return a.labels, nil
 }
 
 func TestFullSync_PanicReturnsError(t *testing.T) {
@@ -136,6 +218,318 @@ func TestFullSync(t *testing.T) {
 
 	assertMockCalls(t, env, 1, 1, 3)
 	assertMessageCount(t, env.Store, 3)
+}
+
+func TestFullSyncProviderHookFailureWarnsOnceAfterSuccessfulCompletion(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	env := newTestEnv(t)
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	const hookFailure = "provider inventory unavailable"
+	hookCalls := 0
+	env.Syncer = env.Syncer.WithLogger(logger).WithSuccessfulSyncHook(
+		"provider identity refresh",
+		func(_ context.Context, source *store.Source, _ bool) error {
+			hookCalls++
+			assertions.Positive(source.ID)
+			return errors.New(hookFailure)
+		},
+	)
+
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+
+	requirements.NoError(err)
+	requirements.NotNil(summary)
+	assertions.Equal(1, hookCalls)
+	assertions.Equal(1, strings.Count(logs.String(), "successful sync hook failed"))
+	assertions.Contains(logs.String(), "provider identity refresh")
+	assertions.Contains(logs.String(), hookFailure,
+		"a warning without the cause leaves the operator nothing to act on")
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	requirements.NoError(err)
+	run, err := env.Store.GetLatestSync(source.ID)
+	requirements.NoError(err)
+	assertions.Equal(store.SyncStatusCompleted, run.Status)
+}
+
+func TestFullSyncProviderHookDoesNotRunAfterFailedSync(t *testing.T) {
+	env := newTestEnv(t)
+	seedMessages(env, 1, 12345, "msg1")
+	hookCalls := 0
+	env.Syncer = New(&batchErrorAPI{MockAPI: env.Mock}, env.Store, nil).WithSuccessfulSyncHook(
+		"provider identity refresh",
+		func(context.Context, *store.Source, bool) error {
+			hookCalls++
+			return nil
+		},
+	)
+
+	_, err := env.Syncer.Full(env.Context, testEmail)
+
+	require.Error(t, err)
+	assert.Zero(t, hookCalls)
+}
+
+// TestIncrementalSyncProviderHookRunsAfterSuccessfulCompletion also pins the
+// no-op flag: an unchanged mailbox still runs the hook — provider inventory
+// can change while a mailbox is idle — but flagged as unchanged so the
+// installer can skip provider round trips it has made recently.
+func TestIncrementalSyncProviderHookRunsAfterSuccessfulCompletion(t *testing.T) {
+	tests := []struct {
+		name               string
+		profileHistoryID   uint64
+		wantMailboxChanged bool
+	}{
+		{name: "already up to date", profileHistoryID: 1000, wantMailboxChanged: false},
+		{name: "history advanced", profileHistoryID: 1001, wantMailboxChanged: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			env := newTestEnv(t)
+			source := env.CreateSourceWithHistory(t, "1000")
+			env.Mock.Profile.HistoryID = tt.profileHistoryID
+			env.Mock.HistoryID = tt.profileHistoryID
+			var hookChangedFlags []bool
+			env.Syncer = env.Syncer.WithSuccessfulSyncHook(
+				"provider identity refresh",
+				func(_ context.Context, completedSource *store.Source, mailboxChanged bool) error {
+					hookChangedFlags = append(hookChangedFlags, mailboxChanged)
+					assertions.Equal(source.ID, completedSource.ID)
+					return nil
+				},
+			)
+
+			summary, err := env.Syncer.Incremental(env.Context, source)
+
+			requirements.NoError(err)
+			requirements.NotNil(summary)
+			assertions.Equal([]bool{tt.wantMailboxChanged}, hookChangedFlags)
+
+			run, err := env.Store.GetLatestSync(source.ID)
+			requirements.NoError(err)
+			assertions.Equal(store.SyncStatusCompleted, run.Status,
+				"running the hook must not run before completing the run")
+		})
+	}
+}
+
+func TestSyncLabelsPersistsRoleFromCanonicalGmailIDNotName(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	env.Mock.Labels = []*gmail.Label{
+		{ID: "SENT", Name: "Envoyes", Type: "system"},
+		{ID: "Label_1", Name: "Sent", Type: "user"},
+	}
+
+	_, err := env.Syncer.syncLabels(env.Context, source.ID)
+	require.NoError(err, "sync labels")
+
+	roles := make(map[string]sql.NullString)
+	rows, err := env.Store.DB().Query(
+		"SELECT name, system_role FROM labels WHERE source_id = ?", source.ID,
+	)
+	require.NoError(err, "query label roles")
+	defer func() { require.NoError(rows.Close(), "close label roles") }()
+	for rows.Next() {
+		var name string
+		var role sql.NullString
+		require.NoError(rows.Scan(&name, &role), "scan label role")
+		roles[name] = role
+	}
+	require.NoError(rows.Err(), "iterate label roles")
+
+	assert.Equal(store.LabelSystemRoleSent, roles["Envoyes"].String)
+	assert.False(roles["Sent"].Valid, "display names are not trusted as canonical roles")
+}
+
+// TestSyncPageRefreshesOnlyUnambiguousSentAliasesOnce pins which addresses a
+// sync page may contribute Sent evidence to. Every address here is confirmed up
+// front because sync-time discovery is refresh-only: it merges signals into
+// identities the source already owns and never confirms a new one.
+func TestSyncPageRefreshesOnlyUnambiguousSentAliasesOnce(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source, err := env.Store.GetOrCreateSource("imap", testEmail)
+	require.NoError(err, "GetOrCreateSource")
+	for _, address := range []string{
+		"masked-one@example.test",
+		"masked-two@example.test",
+		"recipient-only@example.test",
+	} {
+		require.NoError(env.Store.AddAccountIdentity(source.ID, address, "manual"), "seed confirmed identity")
+	}
+
+	labelMap, err := env.Store.EnsureLabelsBatch(source.ID, map[string]store.LabelInfo{
+		"Envoyes": {
+			Name:       "Envoyes",
+			Type:       "system",
+			SystemRole: store.LabelSystemRoleSent,
+		},
+	})
+	require.NoError(err, "persist localized IMAP \\Sent role")
+
+	env.Mock.AddMessage("m-existing", testemail.NewMessage().
+		From("Masked-One@Example.test").
+		To("recipient-only@example.test").
+		Header("Message-ID", "<existing@example.test>").
+		Bytes(), []string{"Envoyes"})
+	env.Mock.AddMessage("m-new", testemail.NewMessage().
+		From("masked-two@example.test, delegate@example.test").
+		To("another-recipient@example.test").
+		Header("Message-ID", "<new@example.test>").
+		Bytes(), []string{"Envoyes"})
+	_, err = env.Syncer.ingestMessage(
+		t.Context(),
+		source.ID,
+		env.Mock.Messages["m-existing"],
+		"thread-existing",
+		labelMap,
+	)
+	require.NoError(err, "pre-persist existing page row")
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.MessagePages = [][]string{{"m-existing", "m-new"}}
+	env.Syncer = New(&staticLabelsAPI{
+		MockAPI: env.Mock,
+		labels: []*gmail.Label{{
+			ID: "Envoyes", Name: "Envoyes", Type: "system", SystemRole: store.LabelSystemRoleSent,
+		}},
+	}, env.Store, &Options{SourceType: "imap"})
+
+	beforeRevision, err := env.Store.AccountIdentityRevision()
+	require.NoError(err, "AccountIdentityRevision before page")
+	store.ConfigureSQLLogging(store.SQLLogOptions{FullTrace: true, MaxStmtChars: 10_000})
+	t.Cleanup(func() { store.ConfigureSQLLogging(store.SQLLogOptions{}) })
+	var sqlTrace bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&sqlTrace, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "full sync")
+	assert.Equal(int64(1), summary.MessagesAdded, "new rows added")
+	assert.Equal(int64(1), summary.MessagesSkipped, "existing rows skipped")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	require.Len(identities, 3, "a sync page must not confirm a first-time identity")
+	byAddress := make(map[string]store.AccountIdentity, len(identities))
+	for _, identity := range identities {
+		byAddress[store.NormalizeIdentifierForCompare(identity.Address)] = identity
+	}
+	assert.Equal("masked-one@example.test", byAddress["masked-one@example.test"].Address)
+	assert.Equal("manual,sent-folder", byAddress["masked-one@example.test"].SourceSignal,
+		"the unambiguous From address gains the page's Sent evidence")
+	assert.Equal("manual", byAddress["masked-two@example.test"].SourceSignal, "multiple From authors remain weak")
+	assert.Equal("manual", byAddress["recipient-only@example.test"].SourceSignal,
+		"recipient-only evidence must stay weak")
+	assert.NotContains(byAddress, "delegate@example.test", "multiple From authors remain weak")
+	assert.NotContains(byAddress, "another-recipient@example.test", "recipient-only evidence must stay weak")
+
+	afterRevision, err := env.Store.AccountIdentityRevision()
+	require.NoError(err, "AccountIdentityRevision after page")
+	assert.Equal(beforeRevision, afterRevision, "a signal-only refresh must not bump ownership revision")
+	assert.Equal(1, strings.Count(strings.ToLower(sqlTrace.String()), "coalesce(m.source_is_from_me, false)"),
+		"one store observation query per sync page")
+}
+
+func TestSyncPageDoesNotTrustNameOnlySentMailbox(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.Mock.AddMessage("m-name-only", testemail.NewMessage().
+		From("untrusted-alias@example.test").
+		To("recipient-only@example.test").
+		Bytes(), []string{"Sent"})
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.MessagePages = [][]string{{"m-name-only"}}
+	env.Syncer = New(&staticLabelsAPI{
+		MockAPI: env.Mock,
+		labels:  []*gmail.Label{{ID: "Sent", Name: "Sent", Type: "system"}},
+	}, env.Store, &Options{SourceType: "imap"})
+
+	_, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "full sync")
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	assert.Empty(identities, "a mailbox display name is not trusted sent evidence")
+}
+
+func TestSyncPageRetryAfterCheckpointFailureIsCaseFoldedAndIdempotent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	require.NoError(env.Store.AddAccountIdentity(
+		source.ID,
+		"retry-alias@example.test",
+		"manual",
+	), "seed lower-case identity")
+
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.MessagePages = [][]string{{"m-retry"}, {"m-next"}}
+	env.Mock.AddMessage("m-retry", testemail.NewMessage().
+		From("Retry-Alias@Example.test").
+		To("recipient-only@example.test").
+		Bytes(), []string{"SENT"})
+	env.Mock.AddMessage("m-next", testemail.NewMessage().
+		From("other-sender@example.test").
+		Bytes(), []string{"INBOX"})
+
+	_, err := env.Store.DB().Exec(`
+		CREATE TRIGGER fail_sync_checkpoint
+		BEFORE UPDATE ON sync_runs
+		BEGIN
+			SELECT RAISE(ABORT, 'checkpoint unavailable');
+		END
+	`)
+	require.NoError(err, "install checkpoint failure seam")
+	t.Cleanup(func() {
+		_, _ = env.Store.DB().Exec("DROP TRIGGER IF EXISTS fail_sync_checkpoint")
+	})
+
+	env.Syncer = New(&cancelOnSecondListAPI{MockAPI: env.Mock}, env.Store, nil)
+	_, err = env.Syncer.Full(env.Context, testEmail)
+	require.ErrorIs(err, context.Canceled, "interrupt after first persisted page")
+	assertMessageCount(t, env.Store, 1)
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err, "GetLatestSync")
+	assert.Equal(store.SyncStatusRunning, run.Status, "cancelled run remains resumable")
+	assert.Equal(int64(0), run.MessagesProcessed, "failed checkpoint does not advance the page")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities after interrupted page")
+	require.Len(identities, 1, "case variants merge into the existing row")
+	assert.Equal("retry-alias@example.test", identities[0].Address, "first-confirmed spelling")
+	assert.Equal("manual,sent-folder,sent-label", identities[0].SourceSignal,
+		"sorted provider-native evidence; the identity's own derived attribution is not evidence for itself")
+	revisionAfterFirstPage, err := env.Store.AccountIdentityRevision()
+	require.NoError(err, "AccountIdentityRevision after first page")
+
+	_, err = env.Store.DB().Exec("DROP TRIGGER fail_sync_checkpoint")
+	require.NoError(err, "restore checkpoint updates")
+	env.Syncer = New(env.Mock, env.Store, nil)
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "resume sync")
+	assert.True(summary.WasResumed, "retry resumes the uncheckpointed run")
+
+	identities, err = env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities after retry")
+	require.Len(identities, 1, "retry must not create a case variant")
+	assert.Equal("retry-alias@example.test", identities[0].Address, "first-confirmed spelling after retry")
+	assert.Equal("manual,sent-folder,sent-label", identities[0].SourceSignal, "signals after retry")
+	revisionAfterRetry, err := env.Store.AccountIdentityRevision()
+	require.NoError(err, "AccountIdentityRevision after retry")
+	assert.Equal(revisionAfterFirstPage, revisionAfterRetry, "idempotent retry does not bump ownership revision")
 }
 
 func TestFullSyncResume(t *testing.T) {
@@ -226,6 +620,337 @@ func TestFullSyncAcknowledgesOnlySafelyHandledMessages(t *testing.T) {
 
 	assert.Equal(int64(1), summary.Errors, "errors")
 	assert.Equal([]string{"msg-ok"}, ackClient.acknowledged)
+}
+
+// seedConfirmedSentIdentity archives nothing but sets up the common shape of
+// the discovery tests: one Sent message whose From address the source has
+// already confirmed, so a sync page has real signals to merge.
+func seedConfirmedSentIdentity(t *testing.T, env *TestEnv) *store.Source {
+	t.Helper()
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.MessagePages = [][]string{{"msg-sent"}}
+	env.Mock.AddMessage("msg-sent", testemail.NewMessage().
+		From("sent-alias@example.test").
+		Bytes(), []string{"SENT"})
+	source := env.CreateSource(t)
+	require.NoError(t, env.Store.AddAccountIdentity(source.ID, "sent-alias@example.test", "manual"),
+		"seed the confirmed identity whose signals the sync page refreshes")
+	return source
+}
+
+// TestFullSyncCompletesAndSetsBacklogWhenDiscoveryFails pins the durability
+// trade-off behind the non-fatal discovery path. Identity evidence is
+// recomputable from the archived messages, so a page whose discovery keeps
+// failing parks a durable backlog marker rather than unwinding a run whose
+// messages are already safely stored.
+func TestFullSyncCompletesAndSetsBacklogWhenDiscoveryFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	shortenIdentityDiscoveryRetry(t, time.Millisecond)
+	logs := newSyncLogCapture(nil)
+	ackClient := &acknowledgingAPI{MockAPI: env.Mock}
+	env.Syncer = New(ackClient, env.Store, DefaultOptions()).WithLogger(logs.logger())
+	seedConfirmedSentIdentity(t, env)
+	installFailingIdentityDiscovery(t, env, "fail_identity_discovery")
+
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "persistent discovery failure must not fail the sync run")
+	require.NotNil(summary)
+	assert.Equal(int64(1), summary.MessagesAdded, "the page is archived despite discovery failing")
+	assertMessageCount(t, env.Store, 1)
+	assert.Equal([]string{"msg-sent"}, ackClient.acknowledged,
+		"a durably archived message is acknowledged once its discovery debt is recorded")
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err, "GetLatestSync")
+	assert.Equal(store.SyncStatusCompleted, run.Status, "the run completes")
+	assert.Equal(int64(1), run.MessagesProcessed, "the page checkpoint advanced")
+	require.True(source.SyncCursor.Valid, "the source cursor advanced")
+	assert.Equal("12345", source.SyncCursor.String, "SyncCursor")
+
+	found, lastError, err := env.Store.IdentityDiscoveryBacklogContext(env.Context, source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.True(found, "the failed page records a durable backlog marker")
+	assert.Contains(lastError, forcedDiscoveryFailure, "the marker keeps the underlying cause")
+	assert.Contains(logs.String(), forcedDiscoveryFailure,
+		"the operator sees the discovery error in the log")
+
+	assert.NotContains(logs.String(), identityDiscoveryDrainLogMessage,
+		"a whole-archive refresh right after three failed attempts costs a full scan to learn nothing")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities after discovery failure")
+	require.Len(identities, 1)
+	assert.Equal("manual", identities[0].SourceSignal, "failed discovery writes no partial evidence")
+}
+
+// TestFullSyncSettlesBacklogItParkedOnceDiscoveryRecovers covers the other side
+// of that gate: a long run whose later pages show discovery working again pays
+// the refresh immediately instead of leaving the archive inconsistent until
+// whenever the next sync happens to run.
+func TestFullSyncSettlesBacklogItParkedOnceDiscoveryRecovers(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	shortenIdentityDiscoveryRetry(t, time.Millisecond)
+
+	recovered := false
+	logs := newSyncLogCapture(func(record slog.Record) {
+		// Let the first page exhaust its attempts and park the debt, then let
+		// discovery work again for the second page.
+		if record.Message != identityDiscoveryBacklogLogMessage {
+			return
+		}
+		recovered = true
+		_, err := env.Store.DB().Exec("DROP TRIGGER IF EXISTS fail_identity_discovery")
+		require.NoError(err, "let discovery recover for the next page")
+	})
+	env.Syncer = New(env.Mock, env.Store, DefaultOptions()).WithLogger(logs.logger())
+
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.MessagePages = [][]string{{"msg-sent"}, {"msg-inbox"}}
+	env.Mock.AddMessage("msg-sent", testemail.NewMessage().
+		From("sent-alias@example.test").
+		Bytes(), []string{"SENT"})
+	env.Mock.AddMessage("msg-inbox", testemail.NewMessage().
+		From("stranger@example.test").
+		Bytes(), []string{"INBOX"})
+	source := env.CreateSource(t)
+	require.NoError(env.Store.AddAccountIdentity(source.ID, "sent-alias@example.test", "manual"),
+		"seed the confirmed identity whose signals the failed page never merged")
+	installFailingIdentityDiscovery(t, env, "fail_identity_discovery")
+
+	_, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "full sync")
+	require.True(recovered, "the first page parked a backlog marker")
+	assertMessageCount(t, env.Store, 2)
+
+	found, _, err := env.Store.IdentityDiscoveryBacklogContext(env.Context, source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.False(found, "the recovered run settles the debt it parked")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	require.Len(identities, 1)
+	assert.Equal("manual,sent-folder,sent-label", identities[0].SourceSignal,
+		"the completion drain re-derives what the failed page never wrote")
+}
+
+// TestFullSyncDiscoveryRetriesTransientFailureWithoutBacklog clears the failure
+// seam from the retry log record itself, so the retry happens at an exact point
+// in the loop rather than after a sleep the test hopes is long enough.
+func TestFullSyncDiscoveryRetriesTransientFailureWithoutBacklog(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	shortenIdentityDiscoveryRetry(t, time.Millisecond)
+
+	retries := 0
+	logs := newSyncLogCapture(func(record slog.Record) {
+		if record.Message != identityDiscoveryRetryLogMessage {
+			return
+		}
+		retries++
+		_, err := env.Store.DB().Exec("DROP TRIGGER IF EXISTS fail_identity_discovery")
+		require.NoError(err, "clear the transient discovery failure")
+	})
+	env.Syncer = New(env.Mock, env.Store, DefaultOptions()).WithLogger(logs.logger())
+	seedConfirmedSentIdentity(t, env)
+	installFailingIdentityDiscovery(t, env, "fail_identity_discovery")
+
+	_, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "full sync")
+	assert.Equal(1, retries, "one failed attempt is retried")
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+	found, _, err := env.Store.IdentityDiscoveryBacklogContext(env.Context, source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.False(found, "a retry that succeeds leaves no backlog behind")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	require.Len(identities, 1)
+	assert.Equal("manual,sent-folder,sent-label", identities[0].SourceSignal,
+		"the retried attempt merges the page's Sent evidence")
+}
+
+// TestSyncCancellationDuringDiscoveryStaysResumable separates "discovery is
+// broken" from "the operator stopped the sync". Only the former is a debt worth
+// recording; cancellation must leave the run exactly as resumable as any other
+// interruption.
+func TestSyncCancellationDuringDiscoveryStaysResumable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	shortenIdentityDiscoveryRetry(t, time.Minute)
+	ctx, cancel := context.WithCancel(env.Context)
+	t.Cleanup(cancel)
+	env.Context = ctx
+
+	logs := newSyncLogCapture(func(record slog.Record) {
+		if record.Message == identityDiscoveryRetryLogMessage {
+			cancel()
+		}
+	})
+	env.Syncer = New(env.Mock, env.Store, DefaultOptions()).WithLogger(logs.logger())
+	source := seedConfirmedSentIdentity(t, env)
+	installFailingIdentityDiscovery(t, env, "fail_identity_discovery")
+
+	_, err := env.Syncer.Full(ctx, testEmail)
+	require.ErrorIs(err, context.Canceled, "cancellation surfaces as cancellation")
+	assertMessageCount(t, env.Store, 1)
+
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err, "GetLatestSync")
+	assert.Equal(store.SyncStatusRunning, run.Status, "a cancelled run stays resumable")
+
+	found, _, err := env.Store.IdentityDiscoveryBacklogContext(context.Background(), source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.False(found, "cancellation is not a discovery failure")
+
+	_, err = env.Store.DB().Exec("DROP TRIGGER fail_identity_discovery")
+	require.NoError(err, "restore identity discovery")
+	env.Syncer = New(env.Mock, env.Store, DefaultOptions())
+	_, err = env.Syncer.Full(context.Background(), testEmail)
+	require.NoError(err, "resumed sync")
+
+	run, err = env.Store.GetLatestSync(source.ID)
+	require.NoError(err, "GetLatestSync after resume")
+	assert.Equal(store.SyncStatusCompleted, run.Status, "the resumed run completes")
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities after resume")
+	require.Len(identities, 1)
+	assert.Equal("manual,sent-folder,sent-label", identities[0].SourceSignal,
+		"the resumed run applies the discovery the cancellation interrupted")
+}
+
+// TestNextSyncDrainsIdentityDiscoveryBacklog proves the backlog is a real
+// repair path, not just a breadcrumb: the next sync re-derives the owed
+// evidence from the whole archive, which is why the page that fails can be
+// allowed to complete. The second sync lists only an unrelated message, so
+// merging the Sent evidence can come from nowhere but the drain.
+func TestNextSyncDrainsIdentityDiscoveryBacklog(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := seedConfirmedSentIdentity(t, env)
+	installFailingIdentityDiscovery(t, env, "fail_identity_discovery")
+	shortenIdentityDiscoveryRetry(t, time.Millisecond)
+	env.Syncer = New(env.Mock, env.Store, DefaultOptions()).WithLogger(newSyncLogCapture(nil).logger())
+
+	_, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "first full sync")
+	found, _, err := env.Store.IdentityDiscoveryBacklogContext(env.Context, source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	require.True(found, "the first sync parks the discovery debt")
+
+	_, err = env.Store.DB().Exec("DROP TRIGGER fail_identity_discovery")
+	require.NoError(err, "restore identity discovery")
+	env.Mock.Profile.HistoryID = 12346
+	env.Mock.MessagePages = [][]string{{"msg-inbox"}}
+	env.Mock.AddMessage("msg-inbox", testemail.NewMessage().
+		From("stranger@example.test").
+		Bytes(), []string{"INBOX"})
+
+	_, err = env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "second full sync")
+
+	found, _, err = env.Store.IdentityDiscoveryBacklogContext(env.Context, source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext after drain")
+	assert.False(found, "a successful refresh clears the backlog marker")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities after drain")
+	require.Len(identities, 1, "the drain must not confirm a first-time identity")
+	assert.Equal("manual,sent-folder,sent-label", identities[0].SourceSignal,
+		"the drain re-derives the evidence the failed page never wrote")
+}
+
+// TestNoOpIncrementalSyncDrainsIdentityDiscoveryBacklog covers the account
+// shape msgvault is built for: an archive that has been wound down and whose
+// scheduled incremental syncs are all no-ops. If the drain sat behind the
+// up-to-date early return, debt parked by the last page that ever ran would
+// never be settled, because no later sync would reach the drain.
+func TestNoOpIncrementalSyncDrainsIdentityDiscoveryBacklog(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.MessagePages = [][]string{{"msg-sent"}}
+	env.Mock.AddMessage("msg-sent", testemail.NewMessage().
+		From("sent-alias@example.test").
+		Bytes(), []string{"SENT"})
+	runFullSync(t, env)
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+	require.NoError(env.Store.AddAccountIdentity(source.ID, "sent-alias@example.test", "manual"),
+		"confirm the identity after the archive already holds its Sent evidence")
+	require.NoError(
+		env.Store.SetIdentityDiscoveryBacklogContext(env.Context, source.ID, errors.New("earlier page failed")),
+		"park discovery debt")
+
+	// The mailbox is now idle: the cursor already equals the current history.
+	env.Mock.HistoryID = 12345
+	var hookChangedFlags []bool
+	env.Syncer = New(env.Mock, env.Store, DefaultOptions()).WithSuccessfulSyncHook(
+		"provider identity refresh",
+		func(_ context.Context, _ *store.Source, mailboxChanged bool) error {
+			hookChangedFlags = append(hookChangedFlags, mailboxChanged)
+			return nil
+		},
+	)
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "GetSourceByID")
+	require.True(source.SyncCursor.Valid, "the full sync left a cursor")
+
+	summary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "no-op incremental sync")
+	require.NotNil(summary)
+
+	assert.Equal([]bool{false}, hookChangedFlags,
+		"a no-op run flags the hook as unchanged so the installer can avoid a provider call")
+	found, _, err := env.Store.IdentityDiscoveryBacklogContext(env.Context, source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.False(found, "an idle mailbox must not strand discovery debt forever")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	require.Len(identities, 1)
+	assert.Equal("manual,sent-folder,sent-label", identities[0].SourceSignal,
+		"the drain re-derives evidence from the archive even with nothing new to sync")
+}
+
+// TestFullSyncDoesNotConfirmFirstTimeIdentity pins the refresh-only contract at
+// the sync boundary: a Sent-placed message from an unknown address is archived,
+// but never claims that address as one of the account's identities.
+func TestFullSyncDoesNotConfirmFirstTimeIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.MessagePages = [][]string{{"msg-sent"}}
+	env.Mock.AddMessage("msg-sent", testemail.NewMessage().
+		From("stranger@example.test").
+		Bytes(), []string{"SENT"})
+
+	_, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "full sync")
+	assertMessageCount(t, env.Store, 1)
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	assert.Empty(identities, "one Sent-placed message must not confirm a brand-new identity")
 }
 
 func TestFullSyncWithErrors(t *testing.T) {
@@ -521,6 +1246,115 @@ func TestIncrementalSyncWithChanges(t *testing.T) {
 
 	summary := runIncrementalSync(t, env)
 	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
+}
+
+func TestIncrementalSyncDiscoversOnlySuccessfulChangesBeforeAdvancingCursor(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12340
+	env.Mock.AddMessage("existing-message", testemail.NewMessage().
+		From("existing-alias@example.test").
+		To("recipient-only@example.test").
+		Bytes(), []string{"INBOX"})
+	runFullSync(t, env)
+
+	env.Mock.AddMessage("new-success", testemail.NewMessage().
+		From("new-alias@example.test").
+		To("recipient-only@example.test").
+		Bytes(), []string{"SENT"})
+	env.Mock.AddMessage("new-failed", testemail.NewMessage().
+		From("failed-alias@example.test").
+		Bytes(), []string{"SENT"})
+	env.Mock.GetMessageError["new-failed"] = errors.New("temporary fetch failure")
+	env.SetHistory(12350,
+		historyLabelAdded("existing-message", "SENT"),
+		historyAdded("new-success"),
+		historyAdded("new-failed"),
+	)
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier before incremental sync")
+	// Confirming all three addresses keeps the failed fetch observable: if its
+	// page reached discovery, failed-alias would gain Sent evidence too.
+	for _, address := range []string{
+		"existing-alias@example.test",
+		"new-alias@example.test",
+		"failed-alias@example.test",
+	} {
+		require.NoError(env.Store.AddAccountIdentity(source.ID, address, "manual"), "seed confirmed identity")
+	}
+
+	_, err = env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "incremental sync")
+
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "GetSourceByID after incremental sync")
+	require.True(source.SyncCursor.Valid, "source cursor remains valid")
+	assert.Equal("12350", source.SyncCursor.String, "a completed sync advances the history cursor")
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities")
+	require.Len(identities, 3, "incremental sync must not confirm a first-time identity")
+	signalsByAddress := make(map[string]string, len(identities))
+	for _, identity := range identities {
+		signalsByAddress[identity.Address] = identity.SourceSignal
+	}
+	assert.Equal("manual,sent-folder,sent-label", signalsByAddress["existing-alias@example.test"],
+		"a label update provides strong evidence")
+	assert.Equal("manual,sent-folder,sent-label", signalsByAddress["new-alias@example.test"],
+		"a successful addition provides strong evidence")
+	assert.Equal("manual", signalsByAddress["failed-alias@example.test"],
+		"failed additions are not discovered")
+}
+
+// TestIncrementalSyncCompletesAndSetsBacklogWhenDiscoveryFails is the
+// incremental analog of TestFullSyncCompletesAndSetsBacklogWhenDiscoveryFails:
+// the history cursor advances, because holding it back would replay the same
+// already-archived changes forever over a debt the backlog can settle.
+func TestIncrementalSyncCompletesAndSetsBacklogWhenDiscoveryFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	shortenIdentityDiscoveryRetry(t, time.Millisecond)
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12340
+	env.Mock.AddMessage("existing-message", testemail.NewMessage().
+		From("existing-alias@example.test").
+		Bytes(), []string{"INBOX"})
+	runFullSync(t, env)
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier before incremental sync")
+	require.NoError(env.Store.AddAccountIdentity(source.ID, "existing-alias@example.test", "manual"),
+		"seed confirmed identity")
+	env.SetHistory(12350, historyLabelAdded("existing-message", "SENT"))
+	logs := newSyncLogCapture(nil)
+	env.Syncer = New(env.Mock, env.Store, DefaultOptions()).WithLogger(logs.logger())
+	installFailingIdentityDiscovery(t, env, "fail_incremental_identity_discovery")
+
+	summary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "persistent discovery failure must not fail the incremental run")
+	require.NotNil(summary)
+
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err, "GetLatestSync")
+	assert.Equal(store.SyncStatusCompleted, run.Status, "the run completes")
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "GetSourceByID after discovery failure")
+	require.True(source.SyncCursor.Valid, "source cursor remains valid")
+	assert.Equal("12350", source.SyncCursor.String, "the history cursor advances")
+
+	found, lastError, err := env.Store.IdentityDiscoveryBacklogContext(env.Context, source.ID)
+	require.NoError(err, "IdentityDiscoveryBacklogContext")
+	assert.True(found, "the failed page records a durable backlog marker")
+	assert.Contains(lastError, forcedDiscoveryFailure, "the marker keeps the underlying cause")
+	assert.Contains(logs.String(), forcedDiscoveryFailure, "the operator sees the discovery error")
+
+	identities, err := env.Store.ListAccountIdentities(source.ID)
+	require.NoError(err, "ListAccountIdentities after discovery failure")
+	require.Len(identities, 1)
+	assert.Equal("manual", identities[0].SourceSignal, "failed discovery writes no partial evidence")
 }
 
 func TestIncrementalSyncWithDeletions(t *testing.T) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -46,6 +46,28 @@ func TestGeneratedPatchPersonCanClearDisplayName(t *testing.T) {
 	assert.JSONEq(t, `{"display_name":null}`, string(encoded))
 }
 
+func TestGeneratedSourceIdentitiesPreserveRequiredEmptyArrays(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	emptyCatalog := generated.SourceIdentitiesResponse{
+		SourceID: 7, Account: "account@example.test", Identities: []generated.SourceIdentityResponse{},
+	}
+	encoded, err := json.Marshal(emptyCatalog)
+	requirements.NoError(err)
+	assertions.JSONEq(`{"source_id":7,"account":"account@example.test","identities":[]}`, string(encoded))
+
+	identity := generated.SourceIdentityResponse{
+		Identifier: "Alias@Example.test", Signals: []string{},
+		ConfirmedAt: time.Date(2026, 8, 3, 7, 0, 0, 0, time.UTC),
+	}
+	encoded, err = json.Marshal(identity)
+	requirements.NoError(err)
+	assertions.JSONEq(
+		`{"identifier":"Alias@Example.test","signals":[],"confirmed_at":"2026-08-03T07:00:00Z"}`,
+		string(encoded),
+	)
+}
+
 func TestGeneratedEnumNamesPreserveSavedViewCompatibilityAndQualifyExploration(t *testing.T) {
 	assertions := assert.New(t)
 	assertions.Equal(generated.Asc, generated.SavedViewSortDirection("asc"))
@@ -56,6 +78,7 @@ func TestGeneratedEnumNamesPreserveSavedViewCompatibilityAndQualifyExploration(t
 	assertions.Equal(generated.Table, generated.SavedViewStateEnvelopePresentation("table"))
 	assertions.Equal(generated.Timeline, generated.SavedViewStateEnvelopePresentation("timeline"))
 	assertions.Equal(generated.ExploreFilterDimensionAfter, generated.ExploreFilterDimension("after"))
+	assertions.Equal(generated.ExploreFilterDimensionIdentity, generated.ExploreFilterDimension("identity"))
 	assertions.Equal(generated.ExploreGroupSortDirectionAsc, generated.ExploreGroupSortDirection("asc"))
 	assertions.Equal(generated.ExploreGroupDimensionSource, generated.ExploreGroupDimension("source"))
 	assertions.Equal(generated.ExploreGroupsHTTPRequestSearchModeFullText, generated.ExploreGroupsHTTPRequestSearchMode("full_text"))

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -187,6 +187,14 @@ type ClientInterface interface {
 	AddCLIIdentity(ctx context.Context, options *AddCLIIdentityRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddCLIIdentityResponse, error)
 	AddCLIIdentityWithResponse(ctx context.Context, options *AddCLIIdentityRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddCLIIdentityResp, error)
 
+	// DiscoverCLIIdentities Discover source-scoped account identities
+	DiscoverCLIIdentities(ctx context.Context, options *DiscoverCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DiscoverCLIIdentitiesResponse, error)
+	DiscoverCLIIdentitiesWithResponse(ctx context.Context, options *DiscoverCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DiscoverCLIIdentitiesResp, error)
+
+	// ImportCLIIdentities Preview or apply parsed source-scoped identities
+	ImportCLIIdentities(ctx context.Context, options *ImportCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ImportCLIIdentitiesResponse, error)
+	ImportCLIIdentitiesWithResponse(ctx context.Context, options *ImportCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ImportCLIIdentitiesResp, error)
+
 	// InitCLIArchive Initialize the archive for CLI use
 	InitCLIArchive(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*InitCLIArchiveResponse, error)
 	InitCLIArchiveWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*InitCLIArchiveResp, error)
@@ -498,6 +506,10 @@ type ClientInterface interface {
 	// ListSourceStatus List source sync status
 	ListSourceStatus(ctx context.Context, options *ListSourceStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListSourceStatusResponse, error)
 	ListSourceStatusWithResponse(ctx context.Context, options *ListSourceStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListSourceStatusResp, error)
+
+	// ListSourceIdentities List confirmed identities for one source
+	ListSourceIdentities(ctx context.Context, options *ListSourceIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListSourceIdentitiesResponse, error)
+	ListSourceIdentitiesWithResponse(ctx context.Context, options *ListSourceIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListSourceIdentitiesResp, error)
 
 	// GetStats Get archive statistics
 	GetStats(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetStatsResponse, error)
@@ -2831,6 +2843,7 @@ func (c *Client) ListCLIIdentities(ctx context.Context, options *ListCLIIdentiti
 		"account":      {Style: "form", Explode: &[]bool{false}[0]},
 		"collection":   {Style: "form", Explode: &[]bool{false}[0]},
 		"primary_only": {Style: "form", Explode: &[]bool{false}[0]},
+		"source_id":    {Style: "form", Explode: &[]bool{false}[0]},
 	}
 	reqParams := runtime.RequestOptionsParameters{
 		RequestURL:    c.apiClient.GetBaseURL() + "/api/v1/cli/identities",
@@ -2951,6 +2964,120 @@ func (c *Client) AddCLIIdentity(ctx context.Context, options *AddCLIIdentityRequ
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/identities")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// DiscoverCLIIdentities Discover source-scoped account identities
+func (c *Client) DiscoverCLIIdentities(ctx context.Context, options *DiscoverCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DiscoverCLIIdentitiesResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/cli/identities/discover",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*DiscoverCLIIdentitiesResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(DiscoverCLIIdentitiesErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "DiscoverCLIIdentitiesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		result := DiscoverCLIIdentitiesResponse(bodyBytes)
+		return &result, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/identities/discover")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ImportCLIIdentities Preview or apply parsed source-scoped identities
+func (c *Client) ImportCLIIdentities(ctx context.Context, options *ImportCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ImportCLIIdentitiesResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/cli/identities/import",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ImportCLIIdentitiesResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ImportCLIIdentitiesErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ImportCLIIdentitiesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ImportCLIIdentitiesResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ImportCLIIdentitiesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/identities/import")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}
@@ -7731,6 +7858,69 @@ func (c *Client) ListSourceStatus(ctx context.Context, options *ListSourceStatus
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/sources/status")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ListSourceIdentities List confirmed identities for one source
+func (c *Client) ListSourceIdentities(ctx context.Context, options *ListSourceIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListSourceIdentitiesResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/sources/{source_id}/identities",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListSourceIdentitiesResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListSourceIdentitiesErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListSourceIdentitiesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListSourceIdentitiesResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListSourceIdentitiesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/sources/{source_id}/identities")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -1424,6 +1424,94 @@ func (o *AddCLIIdentityRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// DiscoverCLIIdentitiesRequestOptions is the options needed to make a request to DiscoverCLIIdentities.
+type DiscoverCLIIdentitiesRequestOptions struct {
+	Body *DiscoverCLIIdentitiesBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *DiscoverCLIIdentitiesRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *DiscoverCLIIdentitiesRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *DiscoverCLIIdentitiesRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *DiscoverCLIIdentitiesRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *DiscoverCLIIdentitiesRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ImportCLIIdentitiesRequestOptions is the options needed to make a request to ImportCLIIdentities.
+type ImportCLIIdentitiesRequestOptions struct {
+	Body *ImportCLIIdentitiesBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ImportCLIIdentitiesRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ImportCLIIdentitiesRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *ImportCLIIdentitiesRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ImportCLIIdentitiesRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *ImportCLIIdentitiesRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // GetCLIMessageRequestOptions is the options needed to make a request to GetCLIMessage.
 type GetCLIMessageRequestOptions struct {
 	Query *GetCLIMessageQuery
@@ -4611,6 +4699,50 @@ func (o *ListSourceStatusRequestOptions) GetBody() any {
 
 // GetHeader returns the headers as a map.
 func (o *ListSourceStatusRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ListSourceIdentitiesRequestOptions is the options needed to make a request to ListSourceIdentities.
+type ListSourceIdentitiesRequestOptions struct {
+	PathParams *ListSourceIdentitiesPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ListSourceIdentitiesRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ListSourceIdentitiesRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ListSourceIdentitiesRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ListSourceIdentitiesRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *ListSourceIdentitiesRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -3081,6 +3081,154 @@ func (c *Client) AddCLIIdentityWithResponse(ctx context.Context, options *AddCLI
 	}
 }
 
+// DiscoverCLIIdentities Discover source-scoped account identities
+func (c *Client) DiscoverCLIIdentitiesWithResponse(ctx context.Context, options *DiscoverCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DiscoverCLIIdentitiesResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/cli/identities/discover",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/identities/discover")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &DiscoverCLIIdentitiesResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// ImportCLIIdentities Preview or apply parsed source-scoped identities
+func (c *Client) ImportCLIIdentitiesWithResponse(ctx context.Context, options *ImportCLIIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ImportCLIIdentitiesResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/cli/identities/import",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/identities/import")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ImportCLIIdentitiesResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ImportCLIIdentitiesResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ImportCLIIdentitiesResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(ImportCLIIdentitiesErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ImportCLIIdentitiesErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 422:
+		out.JSON422 = new(ImportCLIIdentitiesErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON422); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ImportCLIIdentitiesErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(ImportCLIIdentitiesErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ImportCLIIdentitiesErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(ImportCLIIdentitiesErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ImportCLIIdentitiesErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // InitCLIArchive Initialize the archive for CLI use
 func (c *Client) InitCLIArchiveWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*InitCLIArchiveResp, error) {
 	var err error
@@ -8779,6 +8927,55 @@ func (c *Client) ListSourceStatusWithResponse(ctx context.Context, options *List
 					ContentType:   resp.Headers.Get("Content-Type"),
 					ContentLength: len(bodyBytes),
 					TargetType:    "ListSourceStatusResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// ListSourceIdentities List confirmed identities for one source
+func (c *Client) ListSourceIdentitiesWithResponse(ctx context.Context, options *ListSourceIdentitiesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListSourceIdentitiesResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/sources/{source_id}/identities",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/sources/{source_id}/identities")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListSourceIdentitiesResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListSourceIdentitiesResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListSourceIdentitiesResponse",
 					Body:          bodyBytes,
 					Err:           err,
 				}

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -25,6 +25,24 @@ func (a AddResultCacheState) Validate() error {
 	}
 }
 
+type CandidateClassification string
+
+const (
+	Confirmed CandidateClassification = "confirmed"
+	Strong    CandidateClassification = "strong"
+	Weak      CandidateClassification = "weak"
+)
+
+// Validate checks if the CandidateClassification value is valid
+func (c CandidateClassification) Validate() error {
+	switch c {
+	case Confirmed, Strong, Weak:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid CandidateClassification value, got: %v", c))
+	}
+}
+
 type CreateAttributeDefinitionRequestCardinality string
 
 const (
@@ -59,6 +77,24 @@ func (c CreateAttributeDefinitionRequestObjectType) Validate() error {
 	}
 }
 
+type DiscoverEventType string
+
+const (
+	DiscoverEventTypeProgress DiscoverEventType = "progress"
+	Error                     DiscoverEventType = "error"
+	Result                    DiscoverEventType = "result"
+)
+
+// Validate checks if the DiscoverEventType value is valid
+func (d DiscoverEventType) Validate() error {
+	switch d {
+	case DiscoverEventTypeProgress, Error, Result:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid DiscoverEventType value, got: %v", d))
+	}
+}
+
 type ExploreCacheUnavailableResponseReadiness string
 
 const (
@@ -85,6 +121,7 @@ const (
 	ExploreFilterDimensionBefore      ExploreFilterDimension = "before"
 	ExploreFilterDimensionDeletion    ExploreFilterDimension = "deletion"
 	ExploreFilterDimensionDomain      ExploreFilterDimension = "domain"
+	ExploreFilterDimensionIdentity    ExploreFilterDimension = "identity"
 	ExploreFilterDimensionMessageType ExploreFilterDimension = "message_type"
 	ExploreFilterDimensionParticipant ExploreFilterDimension = "participant"
 	ExploreFilterDimensionSource      ExploreFilterDimension = "source"
@@ -93,7 +130,7 @@ const (
 // Validate checks if the ExploreFilterDimension value is valid
 func (e ExploreFilterDimension) Validate() error {
 	switch e {
-	case ExploreFilterDimensionAfter, ExploreFilterDimensionBefore, ExploreFilterDimensionDeletion, ExploreFilterDimensionDomain, ExploreFilterDimensionMessageType, ExploreFilterDimensionParticipant, ExploreFilterDimensionSource:
+	case ExploreFilterDimensionAfter, ExploreFilterDimensionBefore, ExploreFilterDimensionDeletion, ExploreFilterDimensionDomain, ExploreFilterDimensionIdentity, ExploreFilterDimensionMessageType, ExploreFilterDimensionParticipant, ExploreFilterDimensionSource:
 		return nil
 	default:
 		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ExploreFilterDimension value, got: %v", e))

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -256,6 +256,11 @@ type PatchSavedViewPath struct {
 	ID int64 `json:"id"`
 }
 
+type ListSourceIdentitiesPath struct {
+	// SourceID Source ID
+	SourceID int64 `json:"source_id"`
+}
+
 type TriggerSyncPath struct {
 	// Account Account email or configured source identifier
 	Account string `json:"account" validate:"required"`

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -40,6 +40,10 @@ type RemoveCLIIdentityBody = RemoveRequest
 
 type AddCLIIdentityBody = AddRequest
 
+type DiscoverCLIIdentitiesBody = DiscoverRequest
+
+type ImportCLIIdentitiesBody = ImportRequest
+
 type RunCLIBody = CLIRunRequest
 
 type GetRemoteImageBody = RemoteImageRequest

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -151,6 +151,9 @@ type ListCLIIdentitiesQuery struct {
 	// Collection Restrict to all member accounts of one collection
 	Collection *string `json:"collection,omitempty"`
 
+	// SourceID Restrict to one source by numeric ID
+	SourceID *int64 `json:"source_id,omitempty"`
+
 	// PrimaryOnly For account scope, return only the primary source instead of related sources
 	PrimaryOnly *bool `json:"primary_only,omitempty"`
 }

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -281,6 +281,20 @@ type AddCLIIdentityErrorResponseJSON500 = APIHTTPError
 
 type AddCLIIdentityErrorResponseJSON503 = APIHTTPError
 
+type DiscoverCLIIdentitiesResponse = []byte
+
+type DiscoverCLIIdentitiesErrorResponse = ErrorResponse
+
+type ImportCLIIdentitiesResponse = ImportResult
+
+type ImportCLIIdentitiesErrorResponse = APIHTTPError
+
+type ImportCLIIdentitiesErrorResponseJSON = APIHTTPError
+
+type ImportCLIIdentitiesErrorResponseJSON500 = APIHTTPError
+
+type ImportCLIIdentitiesErrorResponseJSON503 = APIHTTPError
+
 type InitCLIArchiveResponse = CliInitDBResponse
 
 type InitCLIArchiveErrorResponse = ErrorResponse
@@ -1425,6 +1439,10 @@ type ListSourceStatusResponse = SourceStatusResponse
 
 type ListSourceStatusErrorResponse = ErrorResponse
 
+type ListSourceIdentitiesResponse = SourceIdentitiesResponse
+
+type ListSourceIdentitiesErrorResponse = ErrorResponse
+
 type GetStatsResponse = StatsResponse
 
 type GetStatsErrorResponse = ErrorResponse
@@ -1820,6 +1838,23 @@ type AddCLIIdentityResp struct {
 	JSON422      *AddCLIIdentityErrorResponseJSON
 	JSON500      *AddCLIIdentityErrorResponseJSON500
 	JSON503      *AddCLIIdentityErrorResponseJSON503
+}
+
+type DiscoverCLIIdentitiesResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+}
+
+type ImportCLIIdentitiesResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ImportCLIIdentitiesResponse
+	JSON400      *ImportCLIIdentitiesErrorResponse
+	JSON422      *ImportCLIIdentitiesErrorResponseJSON
+	JSON500      *ImportCLIIdentitiesErrorResponseJSON500
+	JSON503      *ImportCLIIdentitiesErrorResponseJSON503
 }
 
 type InitCLIArchiveResp struct {
@@ -2529,6 +2564,13 @@ type ListSourceStatusResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *ListSourceStatusResponse
+}
+
+type ListSourceIdentitiesResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListSourceIdentitiesResponse
 }
 
 type GetStatsResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -68,9 +68,10 @@ func (a AddAccountRequest) Validate() error {
 }
 
 type AddRequest struct {
-	Account    string `json:"account" validate:"required"`
-	Identifier string `json:"identifier" validate:"required"`
-	Signal     string `json:"signal" validate:"required"`
+	Account    *string `json:"account,omitempty"`
+	Identifier string  `json:"identifier" validate:"required"`
+	Signal     string  `json:"signal" validate:"required"`
+	SourceID   *int64  `json:"source_id,omitempty"`
 }
 
 func (a AddRequest) Validate() error {
@@ -648,6 +649,50 @@ type CancelDeletionResponse struct {
 
 func (c CancelDeletionResponse) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type Candidate struct {
+	AlreadyConfirmed     bool                    `json:"already_confirmed"`
+	Classification       CandidateClassification `json:"classification" validate:"required"`
+	FirstSeenAt          time.Time               `json:"first_seen_at" validate:"required"`
+	Identifier           string                  `json:"identifier" validate:"required"`
+	LastSeenAt           time.Time               `json:"last_seen_at" validate:"required"`
+	NormalizedIdentifier string                  `json:"normalized_identifier" validate:"required"`
+	ProviderStates       []string                `json:"provider_states" validate:"required"`
+	ReceivedMessageCount int64                   `json:"received_message_count"`
+	SentMessageCount     int64                   `json:"sent_message_count"`
+	Signals              []string                `json:"signals,omitempty" validate:"required"`
+}
+
+func (c Candidate) Validate() error {
+	var errors runtime.ValidationErrors
+	if v, ok := any(c.Classification).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Classification", err)
+		}
+	}
+	if err := typesValidator.Var(c.FirstSeenAt, "required"); err != nil {
+		errors = errors.Append("FirstSeenAt", err)
+	}
+	if err := typesValidator.Var(c.Identifier, "required"); err != nil {
+		errors = errors.Append("Identifier", err)
+	}
+	if err := typesValidator.Var(c.LastSeenAt, "required"); err != nil {
+		errors = errors.Append("LastSeenAt", err)
+	}
+	if err := typesValidator.Var(c.NormalizedIdentifier, "required"); err != nil {
+		errors = errors.Append("NormalizedIdentifier", err)
+	}
+	if err := typesValidator.Var(c.ProviderStates, "required"); err != nil {
+		errors = errors.Append("ProviderStates", err)
+	}
+	if err := typesValidator.Var(c.Signals, "required"); err != nil {
+		errors = errors.Append("Signals", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type ChangedMessageJSON struct {
@@ -1333,6 +1378,116 @@ func (d DeletionManifestSummary) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(d))
 }
 
+type DiscoverError struct {
+	Code    string `json:"code" validate:"required"`
+	Message string `json:"message" validate:"required"`
+}
+
+func (d DiscoverError) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(d))
+}
+
+type DiscoverEvent struct {
+	ErrorData *DiscoverError    `json:"error,omitempty"`
+	Progress  *DiscoverProgress `json:"progress,omitempty"`
+	Result    *DiscoverResult   `json:"result,omitempty"`
+	Type      DiscoverEventType `json:"type" validate:"required"`
+}
+
+func (d DiscoverEvent) Validate() error {
+	var errors runtime.ValidationErrors
+	if d.ErrorData != nil {
+		if v, ok := any(d.ErrorData).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("ErrorData", err)
+			}
+		}
+	}
+	if d.Progress != nil {
+		if v, ok := any(d.Progress).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Progress", err)
+			}
+		}
+	}
+	if d.Result != nil {
+		if v, ok := any(d.Result).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Result", err)
+			}
+		}
+	}
+	if v, ok := any(d.Type).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Type", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type DiscoverProgress struct {
+	Candidates int64 `json:"candidates"`
+	Done       int64 `json:"done"`
+	Total      int64 `json:"total"`
+}
+
+type DiscoverRequest struct {
+	Account  *string  `json:"account,omitempty"`
+	Apply    *bool    `json:"apply,omitempty"`
+	Confirm  []string `json:"confirm,omitempty"`
+	PageSize *int64   `json:"page_size,omitempty"`
+	Provider *bool    `json:"provider,omitempty"`
+	SourceID *int64   `json:"source_id,omitempty"`
+}
+
+type DiscoverResult struct {
+	Account         string                        `json:"account" validate:"required"`
+	Applied         []IdentityConfirmationOutcome `json:"applied,omitempty" validate:"required"`
+	Candidates      []Candidate                   `json:"candidates,omitempty" validate:"required"`
+	Rejected        []RejectedCandidate           `json:"rejected,omitempty" validate:"required"`
+	ScannedMessages int64                         `json:"scanned_messages"`
+	SourceID        int64                         `json:"source_id"`
+	SourceType      string                        `json:"source_type" validate:"required"`
+}
+
+func (d DiscoverResult) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(d.Account, "required"); err != nil {
+		errors = errors.Append("Account", err)
+	}
+	for i, item := range d.Applied {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Applied[%d]", i), err)
+			}
+		}
+	}
+	for i, item := range d.Candidates {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Candidates[%d]", i), err)
+			}
+		}
+	}
+	for i, item := range d.Rejected {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Rejected[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(d.SourceType, "required"); err != nil {
+		errors = errors.Append("SourceType", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type DomainContextSummaryHTTPResponse struct {
 	CacheRevision       string           `json:"cache_revision" validate:"required"`
 	CandidateSnapshotID *string          `json:"candidate_snapshot_id,omitempty"`
@@ -1432,27 +1587,29 @@ func (d DomainSummary) Validate() error {
 }
 
 type EntryRow struct {
-	AnchorMessageID          *int64       `json:"anchor_message_id,omitempty"`
-	AttachmentCount          int64        `json:"attachment_count"`
-	AttachmentSize           int64        `json:"attachment_size"`
-	ConversationID           *int64       `json:"conversation_id,omitempty"`
-	ConversationType         string       `json:"conversation_type" validate:"required"`
-	CounterpartParticipantID *int64       `json:"counterpart_participant_id,omitempty"`
-	DeletedFromSource        bool         `json:"deleted_from_source"`
-	HasAttachments           bool         `json:"has_attachments"`
-	Key                      string       `json:"key" validate:"required"`
-	Kind                     string       `json:"kind" validate:"required"`
-	Match                    MatchSummary `json:"match"`
-	MessageCount             int64        `json:"message_count"`
-	MessageType              string       `json:"message_type" validate:"required"`
-	OccurredAt               time.Time    `json:"occurred_at" validate:"required"`
-	ParticipantIds           []int64      `json:"participant_ids,omitempty"`
-	ParticipantLabels        []string     `json:"participant_labels,omitempty"`
-	Preview                  string       `json:"preview" validate:"required"`
-	SourceID                 int64        `json:"source_id"`
-	SourceIdentifier         string       `json:"source_identifier" validate:"required"`
-	SourceType               string       `json:"source_type" validate:"required"`
-	Title                    string       `json:"title" validate:"required"`
+	AnchorMessageID            *int64       `json:"anchor_message_id,omitempty"`
+	AttachmentCount            int64        `json:"attachment_count"`
+	AttachmentSize             int64        `json:"attachment_size"`
+	ConversationID             *int64       `json:"conversation_id,omitempty"`
+	ConversationType           string       `json:"conversation_type" validate:"required"`
+	CounterpartParticipantID   *int64       `json:"counterpart_participant_id,omitempty"`
+	DeletedFromSource          bool         `json:"deleted_from_source"`
+	HasAttachments             bool         `json:"has_attachments"`
+	Key                        string       `json:"key" validate:"required"`
+	Kind                       string       `json:"kind" validate:"required"`
+	Match                      MatchSummary `json:"match"`
+	MatchedRecipientIdentities []string     `json:"matched_recipient_identities" validate:"required"`
+	MatchedSenderIdentities    []string     `json:"matched_sender_identities" validate:"required"`
+	MessageCount               int64        `json:"message_count"`
+	MessageType                string       `json:"message_type" validate:"required"`
+	OccurredAt                 time.Time    `json:"occurred_at" validate:"required"`
+	ParticipantIds             []int64      `json:"participant_ids,omitempty"`
+	ParticipantLabels          []string     `json:"participant_labels,omitempty"`
+	Preview                    string       `json:"preview" validate:"required"`
+	SourceID                   int64        `json:"source_id"`
+	SourceIdentifier           string       `json:"source_identifier" validate:"required"`
+	SourceType                 string       `json:"source_type" validate:"required"`
+	Title                      string       `json:"title" validate:"required"`
 }
 
 func (e EntryRow) Validate() error {
@@ -1470,6 +1627,12 @@ func (e EntryRow) Validate() error {
 		if err := v.Validate(); err != nil {
 			errors = errors.Append("Match", err)
 		}
+	}
+	if err := typesValidator.Var(e.MatchedRecipientIdentities, "required"); err != nil {
+		errors = errors.Append("MatchedRecipientIdentities", err)
+	}
+	if err := typesValidator.Var(e.MatchedSenderIdentities, "required"); err != nil {
+		errors = errors.Append("MatchedSenderIdentities", err)
 	}
 	if err := typesValidator.Var(e.MessageType, "required"); err != nil {
 		errors = errors.Append("MessageType", err)
@@ -2538,6 +2701,16 @@ func (h HybridSearchResponse) Validate() error {
 	return errors
 }
 
+type IdentityConfirmationOutcome struct {
+	Added      bool     `json:"added"`
+	Identifier string   `json:"identifier" validate:"required"`
+	Signals    []string `json:"signals,omitempty" validate:"required"`
+}
+
+func (i IdentityConfirmationOutcome) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(i))
+}
+
 type IdentityLinkRequest struct {
 	ParticipantA int64 `json:"participant_a"`
 	ParticipantB int64 `json:"participant_b"`
@@ -2608,6 +2781,74 @@ func (i IdentitySearchSort) Validate() error {
 		if err := v.Validate(); err != nil {
 			errors = errors.Append("Field", err)
 		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ImportEntry struct {
+	Identifier string  `json:"identifier" validate:"required"`
+	State      *string `json:"state,omitempty"`
+}
+
+func (i ImportEntry) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(i))
+}
+
+type ImportRequest struct {
+	Account  *string       `json:"account,omitempty"`
+	Apply    *bool         `json:"apply,omitempty"`
+	Entries  []ImportEntry `json:"entries" validate:"required"`
+	Signal   *string       `json:"signal,omitempty"`
+	SourceID *int64        `json:"source_id,omitempty"`
+}
+
+func (i ImportRequest) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range i.Entries {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Entries[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ImportResult struct {
+	Account    string                        `json:"account" validate:"required"`
+	Applied    []IdentityConfirmationOutcome `json:"applied" validate:"required"`
+	Candidates []Candidate                   `json:"candidates" validate:"required"`
+	Signal     string                        `json:"signal" validate:"required"`
+	SourceID   int64                         `json:"source_id"`
+}
+
+func (i ImportResult) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(i.Account, "required"); err != nil {
+		errors = errors.Append("Account", err)
+	}
+	for i, item := range i.Applied {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Applied[%d]", i), err)
+			}
+		}
+	}
+	for i, item := range i.Candidates {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Candidates[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(i.Signal, "required"); err != nil {
+		errors = errors.Append("Signal", err)
 	}
 	if len(errors) == 0 {
 		return nil
@@ -3328,6 +3569,15 @@ func (q QueryResult) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(q))
 }
 
+type RejectedCandidate struct {
+	Identifier string `json:"identifier" validate:"required"`
+	Reason     string `json:"reason" validate:"required"`
+}
+
+func (r RejectedCandidate) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
 type RelationshipRow struct {
 	CanonicalID  int64               `json:"canonical_id"`
 	DisplayLabel string              `json:"display_label" validate:"required"`
@@ -3490,8 +3740,9 @@ func (r RemoteImageRequest) Validate() error {
 }
 
 type RemoveRequest struct {
-	Account    string `json:"account" validate:"required"`
-	Identifier string `json:"identifier" validate:"required"`
+	Account    *string `json:"account,omitempty"`
+	Identifier string  `json:"identifier" validate:"required"`
+	SourceID   *int64  `json:"source_id,omitempty"`
 }
 
 func (r RemoveRequest) Validate() error {
@@ -4102,6 +4353,40 @@ type SourceCount struct {
 }
 
 func (s SourceCount) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(s))
+}
+
+type SourceIdentitiesResponse struct {
+	Account    string                   `json:"account" validate:"required"`
+	Identities []SourceIdentityResponse `json:"identities" validate:"required"`
+	SourceID   int64                    `json:"source_id"`
+}
+
+func (s SourceIdentitiesResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(s.Account, "required"); err != nil {
+		errors = errors.Append("Account", err)
+	}
+	for i, item := range s.Identities {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Identities[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type SourceIdentityResponse struct {
+	ConfirmedAt time.Time `json:"confirmed_at" validate:"required"`
+	Identifier  string    `json:"identifier" validate:"required"`
+	Signals     []string  `json:"signals" validate:"required"`
+}
+
+func (s SourceIdentityResponse) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(s))
 }
 

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -77,8 +77,10 @@ components:
           type: string
         signal:
           type: string
+        source_id:
+          format: int64
+          type: integer
       required:
-        - account
         - identifier
         - signal
       type: object
@@ -768,6 +770,53 @@ components:
       required:
         - id
         - status
+      type: object
+    Candidate:
+      properties:
+        already_confirmed:
+          type: boolean
+        classification:
+          enum:
+            - confirmed
+            - strong
+            - weak
+          type: string
+        first_seen_at:
+          format: date-time
+          type: string
+        identifier:
+          type: string
+        last_seen_at:
+          format: date-time
+          type: string
+        normalized_identifier:
+          type: string
+        provider_states:
+          items:
+            type: string
+          type: array
+        received_message_count:
+          format: int64
+          type: integer
+        sent_message_count:
+          format: int64
+          type: integer
+        signals:
+          items:
+            type: string
+          nullable: true
+          type: array
+      required:
+        - identifier
+        - normalized_identifier
+        - classification
+        - already_confirmed
+        - signals
+        - provider_states
+        - sent_message_count
+        - received_message_count
+        - first_seen_at
+        - last_seen_at
       type: object
     ChangedMessageJSON:
       properties:
@@ -1465,6 +1514,106 @@ components:
         - description
         - message_count
       type: object
+    DiscoverError:
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+      type: object
+    DiscoverEvent:
+      properties:
+        error:
+          $ref: "#/components/schemas/DiscoverError"
+        progress:
+          $ref: "#/components/schemas/DiscoverProgress"
+        result:
+          $ref: "#/components/schemas/DiscoverResult"
+        type:
+          enum:
+            - progress
+            - result
+            - error
+          type: string
+      required:
+        - type
+      type: object
+    DiscoverProgress:
+      properties:
+        candidates:
+          format: int64
+          type: integer
+        done:
+          format: int64
+          type: integer
+        total:
+          format: int64
+          type: integer
+      required:
+        - done
+        - total
+        - candidates
+      type: object
+    DiscoverRequest:
+      additionalProperties: false
+      properties:
+        account:
+          type: string
+        apply:
+          type: boolean
+        confirm:
+          items:
+            type: string
+          nullable: true
+          type: array
+        page_size:
+          format: int64
+          type: integer
+        provider:
+          type: boolean
+        source_id:
+          format: int64
+          type: integer
+      type: object
+    DiscoverResult:
+      properties:
+        account:
+          type: string
+        applied:
+          items:
+            $ref: "#/components/schemas/IdentityConfirmationOutcome"
+          nullable: true
+          type: array
+        candidates:
+          items:
+            $ref: "#/components/schemas/Candidate"
+          nullable: true
+          type: array
+        rejected:
+          items:
+            $ref: "#/components/schemas/RejectedCandidate"
+          nullable: true
+          type: array
+        scanned_messages:
+          format: int64
+          type: integer
+        source_id:
+          format: int64
+          type: integer
+        source_type:
+          type: string
+      required:
+        - account
+        - source_id
+        - source_type
+        - scanned_messages
+        - candidates
+        - rejected
+        - applied
+      type: object
     DomainContextSummaryHTTPResponse:
       properties:
         cache_revision:
@@ -1569,6 +1718,14 @@ components:
           type: string
         match:
           $ref: "#/components/schemas/MatchSummary"
+        matched_recipient_identities:
+          items:
+            type: string
+          type: array
+        matched_sender_identities:
+          items:
+            type: string
+          type: array
         message_count:
           format: int64
           type: integer
@@ -1611,6 +1768,8 @@ components:
         - conversation_type
         - title
         - preview
+        - matched_sender_identities
+        - matched_recipient_identities
         - message_count
         - has_attachments
         - attachment_count
@@ -1794,6 +1953,7 @@ components:
             - after
             - before
             - deletion
+            - identity
           type: string
           x-enum-names:
             - ExploreFilterDimensionSource
@@ -1803,6 +1963,7 @@ components:
             - ExploreFilterDimensionAfter
             - ExploreFilterDimensionBefore
             - ExploreFilterDimensionDeletion
+            - ExploreFilterDimensionIdentity
         values:
           items:
             type: string
@@ -2689,6 +2850,22 @@ components:
         - took_ms
         - results
       type: object
+    IdentityConfirmationOutcome:
+      properties:
+        added:
+          type: boolean
+        identifier:
+          type: string
+        signals:
+          items:
+            type: string
+          nullable: true
+          type: array
+      required:
+        - identifier
+        - added
+        - signals
+      type: object
     IdentityLinkRequest:
       additionalProperties: false
       properties:
@@ -2760,6 +2937,59 @@ components:
       required:
         - field
         - direction
+      type: object
+    ImportEntry:
+      additionalProperties: false
+      properties:
+        identifier:
+          type: string
+        state:
+          type: string
+      required:
+        - identifier
+      type: object
+    ImportRequest:
+      additionalProperties: false
+      properties:
+        account:
+          type: string
+        apply:
+          type: boolean
+        entries:
+          items:
+            $ref: "#/components/schemas/ImportEntry"
+          type: array
+        signal:
+          type: string
+        source_id:
+          format: int64
+          type: integer
+      required:
+        - entries
+      type: object
+    ImportResult:
+      properties:
+        account:
+          type: string
+        applied:
+          items:
+            $ref: "#/components/schemas/IdentityConfirmationOutcome"
+          type: array
+        candidates:
+          items:
+            $ref: "#/components/schemas/Candidate"
+          type: array
+        signal:
+          type: string
+        source_id:
+          format: int64
+          type: integer
+      required:
+        - account
+        - source_id
+        - signal
+        - candidates
+        - applied
       type: object
     ListDeletionsResponse:
       properties:
@@ -3492,6 +3722,16 @@ components:
         - rows
         - row_count
       type: object
+    RejectedCandidate:
+      properties:
+        identifier:
+          type: string
+        reason:
+          type: string
+      required:
+        - identifier
+        - reason
+      type: object
     RelationshipRow:
       properties:
         canonical_id:
@@ -3655,8 +3895,10 @@ components:
           type: string
         identifier:
           type: string
+        source_id:
+          format: int64
+          type: integer
       required:
-        - account
         - identifier
       type: object
     RemoveResult:
@@ -4190,6 +4432,38 @@ components:
       required:
         - source_type
         - count
+      type: object
+    SourceIdentitiesResponse:
+      properties:
+        account:
+          type: string
+        identities:
+          items:
+            $ref: "#/components/schemas/SourceIdentityResponse"
+          type: array
+        source_id:
+          format: int64
+          type: integer
+      required:
+        - source_id
+        - account
+        - identities
+      type: object
+    SourceIdentityResponse:
+      properties:
+        confirmed_at:
+          format: date-time
+          type: string
+        identifier:
+          type: string
+        signals:
+          items:
+            type: string
+          type: array
+      required:
+        - identifier
+        - signals
+        - confirmed_at
       type: object
     SourceStatus:
       properties:
@@ -4895,7 +5169,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.35.0
+  version: 1.36.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -6449,6 +6723,14 @@ paths:
           schema:
             description: Restrict to all member accounts of one collection
             type: string
+        - description: Restrict to one source by numeric ID
+          explode: false
+          in: query
+          name: source_id
+          schema:
+            description: Restrict to one source by numeric ID
+            format: int64
+            type: integer
         - description: For account scope, return only the primary source instead of related sources
           explode: false
           in: query
@@ -6534,6 +6816,78 @@ paths:
       security:
         - apiKey: []
       summary: Add a confirmed identifier to an account identity
+      tags:
+        - CLI
+  /api/v1/cli/identities/discover:
+    post:
+      operationId: discoverCLIIdentities
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DiscoverRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/DiscoverEvent"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Discover source-scoped account identities
+      tags:
+        - API
+  /api/v1/cli/identities/import:
+    post:
+      operationId: importCLIIdentities
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportResult"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Bad Request
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Internal Server Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiHTTPError"
+          description: Service Unavailable
+      security:
+        - apiKey: []
+      summary: Preview or apply parsed source-scoped identities
       tags:
         - CLI
   /api/v1/cli/init-db:
@@ -10327,6 +10681,35 @@ paths:
       security:
         - apiKey: []
       summary: List source sync status
+      tags:
+        - API
+  /api/v1/sources/{source_id}/identities:
+    get:
+      operationId: listSourceIdentities
+      parameters:
+        - description: Source ID
+          in: path
+          name: source_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceIdentitiesResponse"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List confirmed identities for one source
       tags:
         - API
   /api/v1/stats:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -523,6 +523,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/cli/identities/discover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Discover source-scoped account identities */
+        post: operations["discoverCLIIdentities"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/cli/identities/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Preview or apply parsed source-scoped identities */
+        post: operations["importCLIIdentities"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/cli/init-db": {
         parameters: {
             query?: never;
@@ -1682,6 +1716,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sources/{source_id}/identities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List confirmed identities for one source */
+        get: operations["listSourceIdentities"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/stats": {
         parameters: {
             query?: never;
@@ -1875,9 +1926,11 @@ export interface components {
             schedule: string;
         };
         AddRequest: {
-            account: string;
+            account?: string;
             identifier: string;
             signal: string;
+            /** Format: int64 */
+            source_id?: number;
         };
         AddResult: {
             account: string;
@@ -2230,6 +2283,25 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        Candidate: {
+            already_confirmed: boolean;
+            /** @enum {string} */
+            classification: "confirmed" | "strong" | "weak";
+            /** Format: date-time */
+            first_seen_at: string;
+            identifier: string;
+            /** Format: date-time */
+            last_seen_at: string;
+            normalized_identifier: string;
+            provider_states: string[];
+            /** Format: int64 */
+            received_message_count: number;
+            /** Format: int64 */
+            sent_message_count: number;
+            signals: string[] | null;
+        } & {
+            [key: string]: unknown;
+        };
         ChangedMessageJSON: {
             /** Format: int64 */
             attachment_count: number;
@@ -2563,6 +2635,54 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        DiscoverError: {
+            code: string;
+            message: string;
+        } & {
+            [key: string]: unknown;
+        };
+        DiscoverEvent: {
+            error?: components["schemas"]["DiscoverError"];
+            progress?: components["schemas"]["DiscoverProgress"];
+            result?: components["schemas"]["DiscoverResult"];
+            /** @enum {string} */
+            type: "progress" | "result" | "error";
+        } & {
+            [key: string]: unknown;
+        };
+        DiscoverProgress: {
+            /** Format: int64 */
+            candidates: number;
+            /** Format: int64 */
+            done: number;
+            /** Format: int64 */
+            total: number;
+        } & {
+            [key: string]: unknown;
+        };
+        DiscoverRequest: {
+            account?: string;
+            apply?: boolean;
+            confirm?: string[] | null;
+            /** Format: int64 */
+            page_size?: number;
+            provider?: boolean;
+            /** Format: int64 */
+            source_id?: number;
+        };
+        DiscoverResult: {
+            account: string;
+            applied: components["schemas"]["IdentityConfirmationOutcome"][] | null;
+            candidates: components["schemas"]["Candidate"][] | null;
+            rejected: components["schemas"]["RejectedCandidate"][] | null;
+            /** Format: int64 */
+            scanned_messages: number;
+            /** Format: int64 */
+            source_id: number;
+            source_type: string;
+        } & {
+            [key: string]: unknown;
+        };
         DomainContextSummaryHTTPResponse: {
             cache_revision: string;
             candidate_snapshot_id?: string;
@@ -2616,6 +2736,8 @@ export interface components {
             key: string;
             kind: string;
             match: components["schemas"]["MatchSummary"];
+            matched_recipient_identities: string[];
+            matched_sender_identities: string[];
             /** Format: int64 */
             message_count: number;
             message_type: string;
@@ -2710,7 +2832,7 @@ export interface components {
         };
         ExploreFilter: {
             /** @enum {string} */
-            dimension: "source" | "participant" | "domain" | "message_type" | "after" | "before" | "deletion";
+            dimension: "source" | "participant" | "domain" | "message_type" | "after" | "before" | "deletion" | "identity";
             values: string[];
         };
         /** @enum {string} */
@@ -3058,6 +3180,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        IdentityConfirmationOutcome: {
+            added: boolean;
+            identifier: string;
+            signals: string[] | null;
+        } & {
+            [key: string]: unknown;
+        };
         IdentityLinkRequest: {
             /** Format: int64 */
             participant_a: number;
@@ -3085,6 +3214,28 @@ export interface components {
             direction: "asc" | "desc";
             /** @enum {string} */
             field: "activity_count" | "latest_at" | "display_label";
+        };
+        ImportEntry: {
+            identifier: string;
+            state?: string;
+        };
+        ImportRequest: {
+            account?: string;
+            apply?: boolean;
+            entries: components["schemas"]["ImportEntry"][];
+            signal?: string;
+            /** Format: int64 */
+            source_id?: number;
+        };
+        ImportResult: {
+            account: string;
+            applied: components["schemas"]["IdentityConfirmationOutcome"][];
+            candidates: components["schemas"]["Candidate"][];
+            signal: string;
+            /** Format: int64 */
+            source_id: number;
+        } & {
+            [key: string]: unknown;
         };
         ListDeletionsResponse: {
             manifests: components["schemas"]["DeletionManifestSummary"][] | null;
@@ -3434,6 +3585,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        RejectedCandidate: {
+            identifier: string;
+            reason: string;
+        } & {
+            [key: string]: unknown;
+        };
         RelationshipRow: {
             /** Format: int64 */
             canonical_id: number;
@@ -3508,8 +3665,10 @@ export interface components {
             url: string;
         };
         RemoveRequest: {
-            account: string;
+            account?: string;
             identifier: string;
+            /** Format: int64 */
+            source_id?: number;
         };
         RemoveResult: {
             account: string;
@@ -3738,6 +3897,22 @@ export interface components {
             /** Format: int64 */
             count: number;
             source_type: string;
+        } & {
+            [key: string]: unknown;
+        };
+        SourceIdentitiesResponse: {
+            account: string;
+            identities: components["schemas"]["SourceIdentityResponse"][];
+            /** Format: int64 */
+            source_id: number;
+        } & {
+            [key: string]: unknown;
+        };
+        SourceIdentityResponse: {
+            /** Format: date-time */
+            confirmed_at: string;
+            identifier: string;
+            signals: string[];
         } & {
             [key: string]: unknown;
         };
@@ -5837,6 +6012,8 @@ export interface operations {
                 account?: string;
                 /** @description Restrict to all member accounts of one collection */
                 collection?: string;
+                /** @description Restrict to one source by numeric ID */
+                source_id?: number;
                 /** @description For account scope, return only the primary source instead of related sources */
                 primary_only?: boolean;
             };
@@ -5973,6 +6150,99 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RemoveResult"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiHTTPError"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiHTTPError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiHTTPError"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiHTTPError"];
+                };
+            };
+        };
+    };
+    discoverCLIIdentities: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DiscoverRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/x-ndjson": components["schemas"]["DiscoverEvent"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    importCLIIdentities: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImportRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportResult"];
                 };
             };
             /** @description Bad Request */
@@ -10010,6 +10280,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SourceStatusResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listSourceIdentities: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Source ID */
+                source_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SourceIdentitiesResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/lib/components/explore/ContextBar.svelte
+++ b/web/src/lib/components/explore/ContextBar.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { Button, SelectDropdown } from '@kenn-io/kit-ui';
 
+  import type { APIClient } from '../../api/client';
   import type { ExploreFilter, ExploreGroupDimension, ExploreSearchMode, ExploreURLState } from '../../explore/models';
   import {
     groupingDimensionLabel,
     groupingOptions,
     isGroupingDimension
   } from '../../grouping/catalog';
+  import IdentityFilter from './IdentityFilter.svelte';
 
   let {
+    client,
     query,
     searchMode,
     filters,
@@ -18,9 +21,11 @@
     onAddGroup,
     onRemoveGroup,
     onClearFilters,
+    onFiltersChange,
     onSort = undefined,
     onPresentationChange = undefined
   }: {
+    client: APIClient;
     query: string;
     searchMode: ExploreSearchMode;
     filters: ExploreFilter[];
@@ -30,6 +35,7 @@
     onAddGroup: (dimension: ExploreGroupDimension) => void;
     onRemoveGroup: (index: number) => void;
     onClearFilters: () => void;
+    onFiltersChange: (filters: ExploreFilter[]) => void;
     onSort?: () => void;
     onPresentationChange?: (presentation: ExploreURLState['presentation']) => void;
   } = $props();
@@ -107,12 +113,15 @@
 
   {#if filtersOpen}
     <div class="filter-panel">
-      {#if filters.length === 0}
-        <span>No active filters. Filtering controls will expand with additional canonical dimensions.</span>
-      {:else}
-        <span>{filters.length} active {filters.length === 1 ? 'filter' : 'filters'}</span>
-        <Button size="sm" surface="outline" label="Clear filters" onclick={onClearFilters} />
-      {/if}
+      <div class="filter-summary">
+        {#if filters.length === 0}
+          <span>No active filters. Filtering controls will expand with additional canonical dimensions.</span>
+        {:else}
+          <span>{filters.length} active {filters.length === 1 ? 'filter' : 'filters'}</span>
+          <Button size="sm" surface="outline" label="Clear filters" onclick={onClearFilters} />
+        {/if}
+      </div>
+      <IdentityFilter {client} {filters} onChange={onFiltersChange} />
     </div>
   {/if}
 </section>
@@ -210,13 +219,20 @@
     left: 0;
     display: flex;
     min-width: 320px;
-    align-items: center;
-    justify-content: space-between;
+    align-items: stretch;
+    flex-direction: column;
     gap: var(--space-4);
     padding: var(--space-4);
     border: 1px solid var(--border-default);
     border-radius: var(--radius-md);
     background: var(--bg-surface);
     box-shadow: var(--shadow-md);
+  }
+
+  .filter-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
   }
 </style>

--- a/web/src/lib/components/explore/ContextBar.test.ts
+++ b/web/src/lib/components/explore/ContextBar.test.ts
@@ -1,15 +1,18 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 
+import { createAPIClient } from '../../api/client';
 import ContextBar from './ContextBar.svelte';
 
 describe('ContextBar presentation control', () => {
   it('exposes Table, Timeline, and Files as one keyboard-operable Show-as control', async () => {
     const onPresentationChange = vi.fn();
     render(ContextBar, {
+      client: createAPIClient(vi.fn<typeof fetch>()),
       query: 'pasta', searchMode: 'hybrid', filters: [], groupingChain: [],
       presentation: 'table', onPresentationChange,
-      onAddGroup: vi.fn(), onRemoveGroup: vi.fn(), onClearFilters: vi.fn()
+      onAddGroup: vi.fn(), onRemoveGroup: vi.fn(), onClearFilters: vi.fn(),
+      onFiltersChange: vi.fn()
     });
 
     const control = screen.getByRole('combobox', { name: 'Show as' });

--- a/web/src/lib/components/explore/EverythingTable.svelte
+++ b/web/src/lib/components/explore/EverythingTable.svelte
@@ -8,10 +8,11 @@
     ExploreColumn,
     ExploreScrollAnchor
   } from '../../explore/models';
-  import { DEFAULT_EXPLORE_COLUMNS } from '../../explore/models';
+  import { DEFAULT_EXPLORE_COLUMNS, isEmailMessageType } from '../../explore/models';
   import type { ExploreSelectionState } from '../../explore/state.svelte';
   import { rebaseVirtualScroll, RowGeometry, tableViewportHeight } from '../../theme/preferences.svelte';
   import EmptyState from '../common/EmptyState.svelte';
+  import IdentityBadge from './IdentityBadge.svelte';
   import RowKind from './RowKind.svelte';
 
   interface Props {
@@ -545,6 +546,12 @@
                       <RowKind kind={row.kind} messageType={row.message_type} />
                     {:else if column === 'people'}
                       {people(row)}
+                      {#if isEmailMessageType(row.message_type)}
+                        <IdentityBadge
+                          senderIdentities={row.matched_sender_identities}
+                          recipientIdentities={row.matched_recipient_identities}
+                        />
+                      {/if}
                     {:else if column === 'title'}
                       <strong>{row.title || '(untitled)'}</strong>
                     {:else if column === 'excerpt'}

--- a/web/src/lib/components/explore/EverythingTable.test.ts
+++ b/web/src/lib/components/explore/EverythingTable.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ExploreSelectionState } from '../../explore/state.svelte';
@@ -24,6 +24,8 @@ function row(index: number, overrides: Partial<EntryRow> = {}): EntryRow {
     has_attachments: false,
     deleted_from_source: false,
     message_count: 1,
+    matched_sender_identities: [],
+    matched_recipient_identities: [],
     match: {},
     ...overrides
   };
@@ -98,6 +100,36 @@ describe('EverythingTable', () => {
     expect(screen.getByRole('columnheader', { name: 'People / source' })).toBeDefined();
     expect(screen.getByRole('columnheader', { name: 'Attachments' }).textContent).toBe('⌕');
     expect(screen.getByLabelText('Email item')).toBeDefined();
+  });
+
+  it('shows identity intersections on email rows without replacing participant labels', () => {
+    render(EverythingTable, {
+      rows: [
+        row(1, {
+          participant_labels: ['Original From Header <sender@example.test>'],
+          matched_sender_identities: ['send-as@example.test'],
+          matched_recipient_identities: ['masked@example.test']
+        }),
+        row(2, {
+          message_type: 'sms',
+          matched_sender_identities: ['hidden-non-email@example.test'],
+          matched_recipient_identities: []
+        }),
+        row(3, {
+          message_type: '',
+          matched_sender_identities: ['legacy-email@example.test'],
+          matched_recipient_identities: []
+        })
+      ],
+      selection: new ExploreSelectionState()
+    });
+
+    const emailRow = screen.getByRole('row', { name: /Synthetic subject 1/ });
+    expect(within(emailRow).getByText('Original From Header <sender@example.test>')).toBeDefined();
+    expect(within(emailRow).getByText('Sent via: send-as@example.test')).toBeDefined();
+    expect(within(emailRow).getByText('Via: masked@example.test')).toBeDefined();
+    expect(screen.getByText('Sent via: legacy-email@example.test')).toBeDefined();
+    expect(screen.queryByText('Sent via: hidden-non-email@example.test')).toBeNull();
   });
 
   it('exposes size through the column picker without showing it initially', async () => {

--- a/web/src/lib/components/explore/IdentityBadge.svelte
+++ b/web/src/lib/components/explore/IdentityBadge.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  let {
+    senderIdentities = [],
+    recipientIdentities = []
+  }: {
+    senderIdentities?: string[];
+    recipientIdentities?: string[];
+  } = $props();
+
+  const senders = $derived(uniqueSorted(senderIdentities));
+  const recipients = $derived(uniqueSorted(recipientIdentities));
+
+  function uniqueSorted(values: string[]): string[] {
+    return [...new Set(values.filter(Boolean))].sort((left, right) => {
+      if (left < right) return -1;
+      if (left > right) return 1;
+      return 0;
+    });
+  }
+</script>
+
+{#each senders as identity (identity)}
+  <span class="identity-badge identity-badge--sender" data-testid="identity-badge">Sent via: {identity}</span>
+{/each}
+{#each recipients as identity (identity)}
+  <span class="identity-badge identity-badge--recipient" data-testid="identity-badge">Via: {identity}</span>
+{/each}
+
+<style>
+  .identity-badge {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    padding: 1px var(--space-1);
+    border-radius: var(--radius-sm);
+    background: var(--bg-inset);
+    color: var(--text-secondary);
+    font-size: var(--font-size-2xs);
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  .identity-badge--sender {
+    border-left: 2px solid var(--accent-teal);
+  }
+
+  .identity-badge--recipient {
+    border-left: 2px solid var(--accent-blue);
+  }
+</style>

--- a/web/src/lib/components/explore/IdentityBadge.svelte.test.ts
+++ b/web/src/lib/components/explore/IdentityBadge.svelte.test.ts
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import IdentityBadge from './IdentityBadge.svelte';
+
+describe('IdentityBadge', () => {
+  it('sorts and deduplicates sender and recipient matches with direction-specific labels', () => {
+    render(IdentityBadge, {
+      senderIdentities: ['z-send@example.test', 'a-send@example.test', 'z-send@example.test'],
+      recipientIdentities: ['b-mask@example.test', 'a-mask@example.test', 'b-mask@example.test']
+    });
+
+    expect(screen.getAllByTestId('identity-badge').map((badge) => badge.textContent)).toEqual([
+      'Sent via: a-send@example.test',
+      'Sent via: z-send@example.test',
+      'Via: a-mask@example.test',
+      'Via: b-mask@example.test'
+    ]);
+  });
+
+  it('renders no badge for empty matches', () => {
+    const rendered = render(IdentityBadge, {
+      senderIdentities: [],
+      recipientIdentities: []
+    });
+
+    expect(rendered.container.textContent?.trim()).toBe('');
+    expect(screen.queryByTestId('identity-badge')).toBeNull();
+  });
+});

--- a/web/src/lib/components/explore/IdentityFilter.svelte
+++ b/web/src/lib/components/explore/IdentityFilter.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  import type { APIClient } from '../../api/client';
+  import type {
+    ExploreFilter,
+    IdentityDirection,
+    SourceIdentityResponse
+  } from '../../explore/models';
+  import { isValidSourceID } from '../../explore/models';
+
+  let {
+    client,
+    filters,
+    onChange
+  }: {
+    client: APIClient;
+    filters: ExploreFilter[];
+    onChange: (filters: ExploreFilter[]) => void;
+  } = $props();
+
+  let identities = $state<SourceIdentityResponse[]>([]);
+  let loading = $state(false);
+  let error = $state('');
+  let requestGeneration = 0;
+  let requestController: AbortController | undefined;
+
+  const sourceID = $derived(singleSourceID(filters));
+  const selectedIdentity = $derived(validIdentityFilter(filters, sourceID));
+  const identifier = $derived(selectedIdentity?.values[1] ?? '');
+  const direction = $derived(identityDirection(selectedIdentity?.values[2]));
+
+  $effect(() => {
+    const currentFilters = filters;
+    const currentSourceID = singleSourceID(currentFilters);
+    const identity = currentFilters.find((filter) => filter.dimension === 'identity');
+    if (identity && (currentSourceID === undefined || identity.values[0] !== currentSourceID)) {
+      onChange(withoutIdentity(currentFilters));
+    }
+  });
+
+  $effect(() => {
+    const requestedSourceID = sourceID;
+    requestGeneration += 1;
+    requestController?.abort();
+    requestController = undefined;
+    identities = [];
+    error = '';
+    if (requestedSourceID === undefined) {
+      loading = false;
+      return;
+    }
+
+    const numericSourceID = Number(requestedSourceID);
+    const generation = requestGeneration;
+    const controller = new AbortController();
+    requestController = controller;
+    loading = true;
+    void client.GET('/api/v1/sources/{source_id}/identities', {
+      params: { path: { source_id: numericSourceID } },
+      signal: controller.signal
+    }).then(({ data }) => {
+      if (generation !== requestGeneration || controller.signal.aborted) return;
+      if (!data) {
+        error = 'Unable to load confirmed identities.';
+        return;
+      }
+      identities = data.identities;
+    }).catch((cause: unknown) => {
+      if (generation !== requestGeneration || controller.signal.aborted) return;
+      error = cause instanceof Error && cause.message
+        ? cause.message
+        : 'Unable to load confirmed identities.';
+    }).finally(() => {
+      if (generation === requestGeneration) loading = false;
+    });
+  });
+
+  onDestroy(() => {
+    requestGeneration += 1;
+    requestController?.abort();
+  });
+
+  function singleSourceID(currentFilters: ExploreFilter[]): string | undefined {
+    const source = currentFilters.find((filter) => filter.dimension === 'source');
+    const value = source?.values.length === 1 ? source.values[0] : undefined;
+    return isValidSourceID(value) ? value : undefined;
+  }
+
+  function validIdentityFilter(
+    currentFilters: ExploreFilter[],
+    currentSourceID: string | undefined
+  ): ExploreFilter | undefined {
+    const identity = currentFilters.find((filter) => filter.dimension === 'identity');
+    return identity?.values.length === 3 && identity.values[0] === currentSourceID
+      ? identity
+      : undefined;
+  }
+
+  function identityDirection(value: string | undefined): IdentityDirection {
+    return value === 'sender' || value === 'recipient' ? value : 'any';
+  }
+
+  function withoutIdentity(currentFilters: ExploreFilter[]): ExploreFilter[] {
+    return currentFilters.filter((filter) => filter.dimension !== 'identity');
+  }
+
+  function replaceIdentity(nextIdentifier: string, nextDirection: IdentityDirection): void {
+    const next = withoutIdentity(filters);
+    if (sourceID !== undefined && nextIdentifier) {
+      next.push({ dimension: 'identity', values: [sourceID, nextIdentifier, nextDirection] });
+    }
+    onChange(next);
+  }
+</script>
+
+{#if sourceID !== undefined}
+  <div class="identity-filter">
+    <label>
+      <span>Identity</span>
+      <select
+        aria-label="Identity"
+        value={identifier}
+        disabled={loading || (Boolean(error) && !identifier)}
+        onchange={(event) => replaceIdentity(
+          event.currentTarget.value,
+          identifier ? direction : 'any'
+        )}
+      >
+        <option value="">Any confirmed identity</option>
+        {#if identifier && !loading && !identities.some((identity) => identity.identifier === identifier)}
+          <option value={identifier}>{identifier} (unavailable)</option>
+        {/if}
+        {#each identities as identity (identity.identifier)}
+          <option value={identity.identifier}>{identity.identifier}</option>
+        {/each}
+      </select>
+    </label>
+    <label>
+      <span>Direction</span>
+      <select
+        aria-label="Identity direction"
+        value={direction}
+        disabled={!identifier}
+        onchange={(event) => replaceIdentity(
+          identifier,
+          event.currentTarget.value as IdentityDirection
+        )}
+      >
+        <option value="any">Any</option>
+        <option value="sender">Sent via</option>
+        <option value="recipient">Received via</option>
+      </select>
+    </label>
+    {#if loading}
+      <span role="status">Loading identities…</span>
+    {:else if error}
+      <span role="alert">{error}</span>
+    {:else if identities.length === 0}
+      <span role="status">No confirmed identities for this source.</span>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .identity-filter,
+  .identity-filter label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .identity-filter {
+    flex-wrap: wrap;
+  }
+
+  .identity-filter label > span,
+  .identity-filter > span {
+    color: var(--text-muted);
+  }
+
+  .identity-filter select {
+    min-height: var(--control-height);
+    border: 1px solid var(--control-border);
+    border-radius: var(--radius-sm);
+    background: var(--control-bg);
+    color: var(--text-primary);
+  }
+</style>

--- a/web/src/lib/components/explore/IdentityFilter.svelte.test.ts
+++ b/web/src/lib/components/explore/IdentityFilter.svelte.test.ts
@@ -1,0 +1,275 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAPIClient } from '../../api/client';
+import type { ExploreFilter } from '../../explore/models';
+import IdentityFilter from './IdentityFilter.svelte';
+
+function catalog(identities: string[] = ['primary@example.test', 'shop@example.test']) {
+  return {
+    source_id: 14,
+    account: 'Fastmail — primary@example.test',
+    identities: identities.map((identifier) => ({
+      identifier,
+      signals: ['provider'],
+      confirmed_at: '2026-08-03T00:00:00Z'
+    }))
+  };
+}
+
+describe('IdentityFilter', () => {
+  it('appears only for exactly one source and does not create source or account options', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () => Response.json(catalog()));
+    const rendered = render(IdentityFilter, {
+      client: createAPIClient(fetchFn),
+      filters: [],
+      onChange: vi.fn()
+    });
+
+    expect(screen.queryByRole('combobox')).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    await rendered.rerender({
+      client: createAPIClient(fetchFn),
+      filters: [{ dimension: 'source', values: ['14', '15'] }],
+      onChange: vi.fn()
+    });
+    expect(screen.queryByRole('combobox')).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    await rendered.rerender({
+      client: createAPIClient(fetchFn),
+      filters: [{ dimension: 'source', values: ['14'] }],
+      onChange: vi.fn()
+    });
+
+    const identity = await screen.findByRole('combobox', { name: 'Identity' });
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(new URL((fetchFn.mock.calls[0]![0] as Request).url).pathname)
+      .toBe('/api/v1/sources/14/identities');
+    await waitFor(() => expect(within(identity).getAllByRole('option')).toHaveLength(3));
+    expect(within(identity).queryByRole('option', { name: 'Fastmail — primary@example.test' })).toBeNull();
+    expect(within(identity).getAllByRole('option').map((option) => option.textContent)).toEqual([
+      'Any confirmed identity',
+      'primary@example.test',
+      'shop@example.test'
+    ]);
+    expect(screen.getAllByRole('combobox')).toHaveLength(2);
+  });
+
+  it('emits a complete replacement list while preserving its parent source and unrelated filters', async () => {
+    const onChange = vi.fn<(filters: ExploreFilter[]) => void>();
+    const filters: ExploreFilter[] = [
+      { dimension: 'source', values: ['14'] },
+      { dimension: 'message_type', values: ['email'] }
+    ];
+    render(IdentityFilter, {
+      client: createAPIClient(vi.fn<typeof fetch>(async () => Response.json(catalog()))),
+      filters,
+      onChange
+    });
+
+    const identity = await screen.findByRole('combobox', { name: 'Identity' });
+    await waitFor(() => expect(within(identity).getAllByRole('option')).toHaveLength(3));
+    await fireEvent.change(identity, {
+      target: { value: 'shop@example.test' }
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      { dimension: 'source', values: ['14'] },
+      { dimension: 'message_type', values: ['email'] },
+      { dimension: 'identity', values: ['14', 'shop@example.test', 'any'] }
+    ]);
+  });
+
+  it('restores the direction and exposes the required keyboard-operable labels', async () => {
+    const onChange = vi.fn<(filters: ExploreFilter[]) => void>();
+    const filters: ExploreFilter[] = [
+      { dimension: 'source', values: ['14'] },
+      { dimension: 'identity', values: ['14', 'shop@example.test', 'recipient'] }
+    ];
+    render(IdentityFilter, {
+      client: createAPIClient(vi.fn<typeof fetch>(async () => Response.json(catalog()))),
+      filters,
+      onChange
+    });
+
+    const identity = await screen.findByRole('combobox', { name: 'Identity' });
+    await waitFor(() => expect(within(identity).getAllByRole('option')).toHaveLength(3));
+    expect((identity as HTMLSelectElement).value).toBe('shop@example.test');
+    const direction = screen.getByRole('combobox', { name: 'Identity direction' });
+    expect(within(direction).getAllByRole('option').map((option) => option.textContent))
+      .toEqual(['Any', 'Sent via', 'Received via']);
+    expect((direction as HTMLSelectElement).value).toBe('recipient');
+
+    await fireEvent.change(direction, { target: { value: 'sender' } });
+    expect(onChange).toHaveBeenLastCalledWith([
+      { dimension: 'source', values: ['14'] },
+      { dimension: 'identity', values: ['14', 'shop@example.test', 'sender'] }
+    ]);
+  });
+
+  it('clears identity when its parent source changes or is removed', async () => {
+    const onChange = vi.fn<(filters: ExploreFilter[]) => void>();
+    const client = createAPIClient(vi.fn<typeof fetch>(async () => Response.json(catalog())));
+    const rendered = render(IdentityFilter, {
+      client,
+      filters: [
+        { dimension: 'source', values: ['14'] },
+        { dimension: 'identity', values: ['14', 'shop@example.test', 'recipient'] }
+      ],
+      onChange
+    });
+    await screen.findByRole('combobox', { name: 'Identity' });
+
+    await rendered.rerender({
+      client,
+      filters: [
+        { dimension: 'source', values: ['15'] },
+        { dimension: 'identity', values: ['14', 'shop@example.test', 'recipient'] }
+      ],
+      onChange
+    });
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([
+      { dimension: 'source', values: ['15'] }
+    ]));
+
+    onChange.mockClear();
+    await rendered.rerender({
+      client,
+      filters: [
+        { dimension: 'source', values: ['15'] },
+        { dimension: 'identity', values: ['15', 'shop@example.test', 'any'] }
+      ],
+      onChange
+    });
+    await rendered.rerender({
+      client,
+      filters: [{ dimension: 'identity', values: ['15', 'shop@example.test', 'any'] }],
+      onChange
+    });
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([]));
+  });
+
+  it('names loading, empty, and error catalog states', async () => {
+    let resolveCatalog!: (response: Response) => void;
+    const loadingFetch = vi.fn<typeof fetch>(() => new Promise((resolve) => { resolveCatalog = resolve; }));
+    const loading = render(IdentityFilter, {
+      client: createAPIClient(loadingFetch),
+      filters: [{ dimension: 'source', values: ['14'] }],
+      onChange: vi.fn()
+    });
+    expect((await screen.findByRole('status')).textContent).toContain('Loading identities…');
+    resolveCatalog(Response.json(catalog([])));
+    await waitFor(() => expect(screen.getByRole('status').textContent)
+      .toContain('No confirmed identities for this source.'));
+    loading.unmount();
+
+    render(IdentityFilter, {
+      client: createAPIClient(vi.fn<typeof fetch>(async () => Response.json(
+        { error: 'catalog_unavailable', message: 'Synthetic catalog failure.' },
+        { status: 500 }
+      ))),
+      filters: [{ dimension: 'source', values: ['14'] }],
+      onChange: vi.fn()
+    });
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to load confirmed identities.');
+  });
+
+  it('ignores a stale catalog response after the parent source changes', async () => {
+    let resolveFirst!: (response: Response) => void;
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      if (new URL(request.url).pathname.endsWith('/14/identities')) {
+        return await new Promise<Response>((resolve) => { resolveFirst = resolve; });
+      }
+      return Response.json({
+        ...catalog(['new-source@example.test']),
+        source_id: 15
+      });
+    });
+    const client = createAPIClient(fetchFn);
+    const rendered = render(IdentityFilter, {
+      client,
+      filters: [{ dimension: 'source', values: ['14'] }],
+      onChange: vi.fn()
+    });
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledOnce());
+
+    await rendered.rerender({
+      client,
+      filters: [{ dimension: 'source', values: ['15'] }],
+      onChange: vi.fn()
+    });
+    expect(await screen.findByRole('option', { name: 'new-source@example.test' })).toBeDefined();
+
+    resolveFirst(Response.json(catalog(['stale-source@example.test'])));
+    await Promise.resolve();
+    expect(screen.queryByRole('option', { name: 'stale-source@example.test' })).toBeNull();
+    expect(screen.getByRole('option', { name: 'new-source@example.test' })).toBeDefined();
+  });
+
+  it('keeps an active identity filter removable when the catalog request fails', async () => {
+    const onChange = vi.fn<(filters: ExploreFilter[]) => void>();
+    const filters: ExploreFilter[] = [
+      { dimension: 'source', values: ['14'] },
+      { dimension: 'identity', values: ['14', 'shop@example.test', 'recipient'] }
+    ];
+    render(IdentityFilter, {
+      client: createAPIClient(vi.fn<typeof fetch>(async () => {
+        throw new Error('Synthetic network failure.');
+      })),
+      filters,
+      onChange
+    });
+
+    const identity = await screen.findByRole('combobox', { name: 'Identity' });
+    await screen.findByRole('alert');
+    expect((identity as HTMLSelectElement).disabled).toBe(false);
+
+    await fireEvent.change(identity, { target: { value: '' } });
+    expect(onChange).toHaveBeenLastCalledWith([
+      { dimension: 'source', values: ['14'] }
+    ]);
+  });
+
+  it('renders a restored identity missing from the catalog as an unavailable option', async () => {
+    const onChange = vi.fn<(filters: ExploreFilter[]) => void>();
+    const filters: ExploreFilter[] = [
+      { dimension: 'source', values: ['14'] },
+      { dimension: 'identity', values: ['14', 'gone@example.test', 'any'] }
+    ];
+    render(IdentityFilter, {
+      client: createAPIClient(vi.fn<typeof fetch>(async () => Response.json(catalog()))),
+      filters,
+      onChange
+    });
+
+    const identity = await screen.findByRole('combobox', { name: 'Identity' });
+    await waitFor(() => expect(within(identity).getAllByRole('option')).toHaveLength(4));
+    const unavailable = within(identity).getByRole('option', { name: 'gone@example.test (unavailable)' });
+    expect((unavailable as HTMLOptionElement).value).toBe('gone@example.test');
+    expect((identity as HTMLSelectElement).value).toBe('gone@example.test');
+
+    await fireEvent.change(identity, { target: { value: '' } });
+    expect(onChange).toHaveBeenLastCalledWith([
+      { dimension: 'source', values: ['14'] }
+    ]);
+  });
+
+  it('does not flash a synthetic option while the catalog is loading', async () => {
+    const filters: ExploreFilter[] = [
+      { dimension: 'source', values: ['14'] },
+      { dimension: 'identity', values: ['14', 'gone@example.test', 'any'] }
+    ];
+    render(IdentityFilter, {
+      client: createAPIClient(vi.fn<typeof fetch>(() => new Promise(() => {}))),
+      filters,
+      onChange: vi.fn()
+    });
+
+    const identity = await screen.findByRole('combobox', { name: 'Identity' });
+    await screen.findByRole('status');
+    expect(within(identity).queryByRole('option', { name: 'gone@example.test (unavailable)' })).toBeNull();
+  });
+});

--- a/web/src/lib/components/reader/ReadingPane.svelte
+++ b/web/src/lib/components/reader/ReadingPane.svelte
@@ -19,12 +19,6 @@
 
   export type ReadingPaneStatus = 'ready' | 'loading' | 'missing' | 'error' | 'unavailable';
 
-  /** Rows archived before message types existed carry a blank message_type
-   * and count as email, matching the server's task-link gate
-   * (store.IsEmailMessageType). */
-  function isEmailMessageType(messageType: string): boolean {
-    return messageType === '' || messageType === 'email';
-  }
 </script>
 
 <script lang="ts">
@@ -35,7 +29,9 @@
   import { createExploreAPI } from '../../explore/api';
   import { filtersForGroup } from '../../explore/group-context';
   import type { ExploreCacheUnavailable, ExploreFileFact, ExploreFilter } from '../../explore/models';
+  import { isEmailMessageType } from '../../explore/models';
   import EmptyState from '../common/EmptyState.svelte';
+  import IdentityBadge from '../explore/IdentityBadge.svelte';
   import TaskLinks from '../tasks/TaskLinks.svelte';
   import AttachmentRail from './AttachmentRail.svelte';
   import ConversationView from './ConversationView.svelte';
@@ -217,6 +213,12 @@
     <div class="pane-heading">
       <strong class="pane-title">{title}</strong>
       {#if metaStrip}<span class="pane-meta" data-mono>{metaStrip}</span>{/if}
+      {#if selection?.kind === 'entry' && isEmailMessageType(selection.row.message_type)}
+        <IdentityBadge
+          senderIdentities={selection.row.matched_sender_identities}
+          recipientIdentities={selection.row.matched_recipient_identities}
+        />
+      {/if}
     </div>
     <div class="pane-actions">
       {#if showTasks}

--- a/web/src/lib/components/reader/ReadingPane.test.ts
+++ b/web/src/lib/components/reader/ReadingPane.test.ts
@@ -22,6 +22,8 @@ function entryRow(overrides: Partial<EntryRow> = {}): EntryRow {
     attachment_size: 0,
     has_attachments: false,
     deleted_from_source: false,
+    matched_sender_identities: [],
+    matched_recipient_identities: [],
     match: {},
     anchor_message_id: 42,
     ...overrides
@@ -57,6 +59,40 @@ describe('ReadingPane task gating', () => {
   it('hides Tasks when the entry has no anchor message', () => {
     renderPane(entryRow({ anchor_message_id: undefined }));
     expect(screen.queryByLabelText('Tasks for this message')).toBeNull();
+  });
+});
+
+describe('ReadingPane identity matches', () => {
+  it('shows via badges for email entries without replacing existing message metadata', () => {
+    renderPane(entryRow({
+      source_identifier: 'Original account header@example.test',
+      matched_sender_identities: ['send-as@example.test'],
+      matched_recipient_identities: ['masked@example.test']
+    }));
+
+    expect(screen.getByText(/Original account header@example\.test/)).toBeDefined();
+    expect(screen.getByText('Sent via: send-as@example.test')).toBeDefined();
+    expect(screen.getByText('Via: masked@example.test')).toBeDefined();
+  });
+
+  it('does not show via badges for non-email entries', () => {
+    renderPane(entryRow({
+      message_type: 'imessage',
+      matched_sender_identities: ['hidden-non-email@example.test'],
+      matched_recipient_identities: []
+    }));
+
+    expect(screen.queryByText('Sent via: hidden-non-email@example.test')).toBeNull();
+  });
+
+  it('shows via badges for legacy email entries with a blank message type', () => {
+    renderPane(entryRow({
+      message_type: '',
+      matched_sender_identities: ['legacy-email@example.test'],
+      matched_recipient_identities: []
+    }));
+
+    expect(screen.getByText('Sent via: legacy-email@example.test')).toBeDefined();
   });
 });
 

--- a/web/src/lib/components/relationships/timeline-support.test.ts
+++ b/web/src/lib/components/relationships/timeline-support.test.ts
@@ -76,7 +76,9 @@ describe('timelineRowToSelection', () => {
       source_id: 4,
       source_identifier: '4',
       attachment_count: 0,
-      has_attachments: false
+      has_attachments: false,
+      matched_sender_identities: [],
+      matched_recipient_identities: []
     });
   });
 

--- a/web/src/lib/components/relationships/timeline-support.ts
+++ b/web/src/lib/components/relationships/timeline-support.ts
@@ -45,6 +45,8 @@ export function timelineRowToSelection(row: RelationshipTimelineRow): ReadingPan
       attachment_size: 0,
       has_attachments: row.has_attachments,
       deleted_from_source: false,
+      matched_sender_identities: [],
+      matched_recipient_identities: [],
       match: {}
     }
   };

--- a/web/src/lib/components/shell/AppShell.svelte
+++ b/web/src/lib/components/shell/AppShell.svelte
@@ -907,6 +907,7 @@
   {:else if exploreState.current.workspace === 'files'}
     <div class="files-shell">
       <ContextBar
+        {client}
         query={exploreState.current.query}
         searchMode={exploreState.current.searchMode}
         filters={exploreState.current.filters}
@@ -927,6 +928,9 @@
           scrollAnchor: null
         })}
         onClearFilters={() => commitNavigation({ filters: [], activeRow: null, scrollAnchor: null })}
+        onFiltersChange={(filters) => commitNavigation({
+          filters, activeRow: null, selectedRow: null, scrollAnchor: null
+        })}
       />
       <span class="kit-sr-only" role="status" aria-label="Sort status" aria-live="polite">{sortNotice}</span>
       {#if exploreState.current.groupingChain.length > 0}

--- a/web/src/lib/components/shell/EverythingWorkspace.svelte
+++ b/web/src/lib/components/shell/EverythingWorkspace.svelte
@@ -524,6 +524,7 @@
   {/if}
 
   <ContextBar
+    {client}
     query={exploreState.current.query}
     searchMode={exploreState.current.searchMode}
     filters={exploreState.current.filters}
@@ -540,6 +541,9 @@
       scrollAnchor: null
     })}
     onClearFilters={() => commitNavigation({ filters: [], activeRow: null, scrollAnchor: null })}
+    onFiltersChange={(filters) => commitNavigation({
+      filters, activeRow: null, selectedRow: null, scrollAnchor: null
+    })}
     onSort={fixedSortNotice}
   />
   <span class="kit-sr-only" role="status" aria-label="Sort status" aria-live="polite">{sortNotice}</span>

--- a/web/src/lib/explore/models.ts
+++ b/web/src/lib/explore/models.ts
@@ -39,6 +39,9 @@ export type ExploreResponse = components['schemas']['ExploreHTTPResponse'];
 export type ExploreSearchMode = NonNullable<ExplorePredicate['search_mode']>;
 export type ExploreSort = components['schemas']['ExploreSort'];
 export type SearchProvenance = components['schemas']['SearchProvenance'];
+export type SourceIdentitiesResponse = components['schemas']['SourceIdentitiesResponse'];
+export type SourceIdentityResponse = components['schemas']['SourceIdentityResponse'];
+export type IdentityDirection = 'any' | 'sender' | 'recipient';
 export type PersonSummary = components['schemas']['PersonSummary'];
 export type PersonIdentifier = components['schemas']['PersonIdentifier'];
 export type PersonCluster = components['schemas']['PersonCluster'];
@@ -131,6 +134,17 @@ export interface AllMatchingExploreSelection {
 }
 
 export type ExploreSelection = ExplicitExploreSelection | AllMatchingExploreSelection;
+
+/** Rows archived before typed message kinds existed are email records. */
+export function isEmailMessageType(messageType: string): boolean {
+  return messageType === '' || messageType === 'email';
+}
+
+export function isValidSourceID(value: string | undefined): value is string {
+  if (value === undefined || !/^\d+$/.test(value)) return false;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0;
+}
 
 export interface ExploreResult {
   rows: EntryRow[];

--- a/web/src/lib/explore/state.svelte.ts
+++ b/web/src/lib/explore/state.svelte.ts
@@ -16,7 +16,7 @@ import type {
   ExploreWorkspace,
   RelationshipFacet
 } from './models';
-import { DEFAULT_EXPLORE_COLUMNS } from './models';
+import { DEFAULT_EXPLORE_COLUMNS, isValidSourceID } from './models';
 import { isGroupingDimension, validateGroupingChain } from '../grouping/catalog';
 import { hasValidSearchAuthority, predicateFingerprint } from './selection';
 import { parseAttachmentSelection } from './attachment-authority';
@@ -31,6 +31,7 @@ import {
 const STATE_PARAMETER = 'explore';
 const FILTER_DIMENSIONS = new Set([
   'source',
+  'identity',
   'participant',
   'domain',
   'message_type',
@@ -134,9 +135,22 @@ function isFilter(value: unknown): value is ExploreFilter {
 }
 
 function filters(value: unknown): ExploreFilter[] {
-  return Array.isArray(value) && value.every(isFilter)
-    ? value.map((filter) => ({ ...filter, values: [...filter.values] }))
-    : [];
+  if (!Array.isArray(value) || !value.every(isFilter)) return [];
+  const copied = value.map((filter) => ({ ...filter, values: [...filter.values] }));
+  const sourceFilters = copied.filter((filter) => filter.dimension === 'source');
+  const sourceValue = sourceFilters.length === 1 && sourceFilters[0]?.values.length === 1
+    ? sourceFilters[0].values[0]
+    : undefined;
+  const sourceID = isValidSourceID(sourceValue) ? sourceValue : undefined;
+  const identityFilters = copied.filter((filter) => filter.dimension === 'identity');
+  const identity = identityFilters.length === 1 ? identityFilters[0] : undefined;
+  const validIdentity = identity !== undefined &&
+    sourceID !== undefined &&
+    identity.values.length === 3 &&
+    identity.values[0] === sourceID &&
+    identity.values[1] !== '' &&
+    (identity.values[2] === 'any' || identity.values[2] === 'sender' || identity.values[2] === 'recipient');
+  return copied.filter((filter) => filter.dimension !== 'identity' || validIdentity);
 }
 
 function groups(value: unknown): ExploreGroupDimension[] {

--- a/web/src/lib/explore/state.test.ts
+++ b/web/src/lib/explore/state.test.ts
@@ -64,6 +64,75 @@ describe('Explore URL state', () => {
     expect(parseExploreURLState(serializeExploreURLState(state))).toEqual(state);
   });
 
+  it('restores an identity facet tuple from the URL', () => {
+    const state: ExploreURLState = {
+      ...defaultExploreURLState,
+      workspace: 'everything',
+      filters: [
+        { dimension: 'source', values: ['42'] },
+        { dimension: 'identity', values: ['42', 'archive@example.com', 'sender'] }
+      ]
+    };
+
+    expect(parseExploreURLState(serializeExploreURLState(state)).filters).toEqual(state.filters);
+  });
+
+  it('drops identity when its single parent source changes or is removed', () => {
+    const withChangedSource = parseExploreURLState(serializeExploreURLState({
+      ...defaultExploreURLState,
+      filters: [
+        { dimension: 'source', values: ['15'] },
+        { dimension: 'identity', values: ['14', 'archive@example.com', 'sender'] }
+      ]
+    }));
+    const withoutSource = parseExploreURLState(serializeExploreURLState({
+      ...defaultExploreURLState,
+      filters: [{ dimension: 'identity', values: ['14', 'archive@example.com', 'recipient'] }]
+    }));
+
+    expect(withChangedSource.filters).toEqual([{ dimension: 'source', values: ['15'] }]);
+    expect(withoutSource.filters).toEqual([]);
+  });
+
+  it.each([
+    [
+      'a nonnumeric parent source',
+      [
+        { dimension: 'source', values: ['abc'] },
+        { dimension: 'identity', values: ['abc', 'archive@example.com', 'sender'] }
+      ]
+    ],
+    [
+      'an empty identifier',
+      [
+        { dimension: 'source', values: ['14'] },
+        { dimension: 'identity', values: ['14', '', 'recipient'] }
+      ]
+    ],
+    [
+      'an invalid direction',
+      [
+        { dimension: 'source', values: ['14'] },
+        { dimension: 'identity', values: ['14', 'archive@example.com', 'sideways'] }
+      ]
+    ],
+    [
+      'duplicate identity filters',
+      [
+        { dimension: 'source', values: ['14'] },
+        { dimension: 'identity', values: ['14', 'first@example.com', 'any'] },
+        { dimension: 'identity', values: ['14', 'second@example.com', 'sender'] }
+      ]
+    ]
+  ])('drops identity URL state with %s', (_description, malformedFilters) => {
+    const restored = parseExploreURLState(serializeExploreURLState({
+      ...defaultExploreURLState,
+      filters: malformedFilters
+    } as ExploreURLState));
+
+    expect(restored.filters.some((filter) => filter.dimension === 'identity')).toBe(false);
+  });
+
   it('normalizes legacy unpinned inspector states to pinned', () => {
     const parsed = parseExploreURLState(serializeExploreURLState({
       ...defaultExploreURLState,


### PR DESCRIPTION
## What changed

- add source-scoped `identity discover` preview/apply and bulk `identity import`, with unambiguous `--source-id` selection across identity commands
- discover strong sender identities from trusted Sent metadata during full and incremental sync while keeping recipient-only evidence review-only
- optionally inventory Fastmail masked and send-as addresses from a source-scoped API token, retaining disabled and deleted addresses for historical mail
- expose matched sender/recipient identities and source-scoped identity filtering through the API and web UI

## Why

A mailbox can receive and send through many masked, delegated, or historical addresses without those addresses being separate ingestion sources. Confirming them under the existing account identity set makes sent-copy classification and dedup planning accurate while preserving the original message headers and mailbox provenance.

## Usage

Preview archived evidence, then apply strong candidates:

```console
msgvault identity discover --source-id 14
msgvault identity discover --source-id 14 --apply
```

For Fastmail inventory, configure a source-specific token and opt in on the command:

```toml
[[fastmail]]
source_id = 14
api_token = "replace-with-a-Fastmail-API-token"
```

```console
msgvault identity discover --source-id 14 --provider
msgvault identity discover --source-id 14 --provider --apply
```

Addresses can also be previewed or confirmed from a provider export with `msgvault identity import --source-id 14 --file aliases.json [--apply]`.

Addresses the identity-discovery portion of #397.

Closes #498.
