### PR TITLE
fix(store): derive the subset message copy's column list from the schemas

### DIFF
--- a/internal/store/subset.go
+++ b/internal/store/subset.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,18 +22,6 @@ type CopyResult struct {
 	DBSize        int64
 	Elapsed       time.Duration
 }
-
-const messageCopyColumns = `
-	id, conversation_id, source_id, source_message_id,
-	rfc822_message_id, message_type,
-	sent_at, received_at, read_at, delivered_at, internal_date,
-	sender_id, is_from_me, source_is_from_me, identity_is_from_me,
-	subject, snippet, reply_to_message_id, thread_position,
-	is_read, is_delivered, is_sent, is_edited, is_forwarded,
-	size_estimate, has_attachments, attachment_count,
-	deleted_at, deleted_from_source_at, delete_batch_id,
-	archived_at, indexing_version, last_modified, metadata, embed_gen
-`
 
 // CopySubset copies rowCount most recent messages (and all referenced
 // data) from srcDBPath into a new database in dstDir. The destination
@@ -428,12 +417,8 @@ func copyData(tx *sql.Tx, rowCount int, includeIdentity bool) (*CopyResult, erro
 		return nil, fmt.Errorf("copy conversation_participants: %w", err)
 	}
 
-	if _, err := tx.Exec(`
-		INSERT INTO messages (` + messageCopyColumns + `)
-		SELECT ` + messageCopyColumns + `
-		FROM src.messages
-		WHERE id IN (SELECT id FROM selected_messages)`); err != nil {
-		return nil, fmt.Errorf("copy messages: %w", err)
+	if err := copyMessages(tx); err != nil {
+		return nil, err
 	}
 
 	// Null out reply_to_message_id when the parent message wasn't
@@ -506,6 +491,116 @@ func copyData(tx *sql.Tx, rowCount int, includeIdentity bool) (*CopyResult, erro
 	}
 
 	return result, nil
+}
+
+// errNoCommonMessageColumns reports that the source and destination messages
+// tables have no column name in common, so there is nothing to copy.
+var errNoCommonMessageColumns = errors.New(
+	"source and destination share no messages columns")
+
+// copyMessages copies the selected messages, naming the columns the source and
+// destination have in common, read from the two schemas at copy time.
+//
+// A column the source lacks is left out of the INSERT, so the destination's own
+// DEFAULT, where it has one, supplies it. Columns the source has and the
+// destination does not are dropped.
+func copyMessages(tx *sql.Tx) error {
+	cols, err := commonColumns(tx, "messages")
+	if err != nil {
+		return fmt.Errorf("copy messages: %w", err)
+	}
+	if len(cols) == 0 {
+		return fmt.Errorf("copy messages: %w", errNoCommonMessageColumns)
+	}
+	list := strings.Join(cols, ", ")
+	if _, err := tx.Exec(fmt.Sprintf(`
+		INSERT INTO messages (%s) SELECT %s FROM src.messages
+		WHERE id IN (SELECT id FROM selected_messages)`, list, list)); err != nil {
+		return fmt.Errorf("copy messages: %w", err)
+	}
+	return nil
+}
+
+// commonColumns returns the quoted names of the columns `table` has in both the
+// destination (main) and the attached source, in destination declaration order.
+// Names are matched the way SQLite matches identifiers — case-insensitively
+// over ASCII only, see foldIdentifier — and the destination's spelling is
+// emitted for both sides of the copy.
+//
+// A returned name is interpolated into the copy's SQL, so one containing a
+// double quote is rejected rather than quoted. Names outside the intersection
+// are not interpolated and so are not checked.
+func commonColumns(tx *sql.Tx, table string) ([]string, error) {
+	dst, err := schemaColumns(tx, "main", table)
+	if err != nil {
+		return nil, err
+	}
+	src, err := schemaColumns(tx, "src", table)
+	if err != nil {
+		return nil, err
+	}
+	inSrc := make(map[string]struct{}, len(src))
+	for _, name := range src {
+		inSrc[foldIdentifier(name)] = struct{}{}
+	}
+	common := make([]string, 0, len(dst))
+	for _, name := range dst {
+		if _, ok := inSrc[foldIdentifier(name)]; !ok {
+			continue
+		}
+		if strings.Contains(name, `"`) {
+			return nil, fmt.Errorf(
+				"%s column name contains a double quote: %q", table, name)
+		}
+		common = append(common, `"`+name+`"`)
+	}
+	return common, nil
+}
+
+// foldIdentifier folds an unquoted-identifier name to the form SQLite compares
+// on: A-Z map to a-z and every other byte is left alone.
+//
+// Do not "simplify" this to strings.ToLower. That applies Unicode case
+// conversion, which is strictly broader than SQLite's, whose built-in collating
+// sequences fold only ASCII (see sqlite3_stricmp). Go lowers, for example,
+// "İdentity_is_from_me" (U+0130, capital I with dot above) to
+// "identity_is_from_me", which SQLite treats as a different identifier. A
+// source-only column so named would then be misclassified as common to both
+// schemas, and the copy would name a column src.messages does not have. With
+// SQLite's default double-quoted-string misfeature the quoted name degrades to
+// a string literal and the copy silently stores that text in the destination
+// column instead of its DEFAULT; with SQLITE_DQS=0 the copy fails outright.
+func foldIdentifier(name string) string {
+	folded := []byte(name)
+	for i, c := range folded {
+		if c >= 'A' && c <= 'Z' {
+			folded[i] = c + ('a' - 'A')
+		}
+	}
+	return string(folded)
+}
+
+// schemaColumns lists a table's column names in declaration order.
+func schemaColumns(tx *sql.Tx, schema, table string) ([]string, error) {
+	rows, err := tx.Query(
+		`SELECT name FROM pragma_table_info(?, ?) ORDER BY cid`, table, schema)
+	if err != nil {
+		return nil, fmt.Errorf("list %s.%s columns: %w", schema, table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan %s.%s column: %w", schema, table, err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate %s.%s columns: %w", schema, table, err)
+	}
+	return names, nil
 }
 
 // updateConversationCounts updates the denormalized counts on

--- a/internal/store/subset_test.go
+++ b/internal/store/subset_test.go
@@ -1161,3 +1161,244 @@ func TestCopySubset_ControlCharInPath(t *testing.T) {
 		assert.Error(t, err, "CopySubset(%q) should reject control chars", p)
 	}
 }
+
+// TestCopySubset_LegacySourceMissingAttributionColumns covers a source archive
+// whose messages table lacks a column the destination schema has.
+//
+// source_is_from_me and identity_is_from_me are both added to older archives
+// by SQLiteDialect.LegacyColumnMigrations(), so an archive written before
+// those migrations legitimately lacks them. The copy intersects the source and
+// destination messages columns at run time, so such an archive copies the
+// columns the two schemas share and leaves the absent ones at the
+// destination's own default.
+//
+// TestCopySubset_LegacySourceWithoutOAuthApp rebuilds its table via CREATE
+// TABLE ... AS SELECT to avoid ALTER TABLE ... DROP COLUMN, which SQLite only
+// added in 3.35; this test does use DROP COLUMN and so needs SQLite 3.35 or
+// newer. The messages table cannot be rebuilt the other way: the triggers
+// trg_message_bodies_last_modified_upd and trg_message_bodies_last_modified_ins
+// update messages, which resolves to main.messages, so the rename back — ALTER
+// TABLE ... RENAME TO messages — fails its schema reparse with "error in
+// trigger trg_message_bodies_last_modified_upd: no such table: main.messages".
+// Neither attribution column is indexed or named by any trigger or view, so
+// ALTER TABLE ... DROP COLUMN works directly.
+func TestCopySubset_LegacySourceMissingAttributionColumns(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "dst")
+
+	srcDB := createTestSourceDB(t, srcDir, 3)
+
+	db, err := sql.Open("sqlite3", srcDB+"?_foreign_keys=OFF")
+	require.NoError(err, "open source db")
+
+	for _, col := range []string{"source_is_from_me", "identity_is_from_me"} {
+		_, err = db.Exec(
+			`ALTER TABLE messages DROP COLUMN ` + col,
+		)
+		require.NoError(err, "drop messages.%s", col)
+	}
+
+	var srcCount int
+	require.NoError(db.QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&srcCount),
+		"count source messages")
+	require.Equal(3, srcCount, "source messages")
+	require.NoError(db.Close(), "close source db")
+
+	result, err := CopySubset(srcDB, dstDir, 100, false)
+	require.NoError(err, "CopySubset from a source missing attribution columns")
+	assert.Equal(int64(srcCount), result.Messages, "Messages")
+
+	dstDB, err := sql.Open("sqlite3", filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err, "open destination db")
+	defer func() { _ = dstDB.Close() }()
+
+	var dstCount int
+	require.NoError(
+		dstDB.QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&dstCount),
+		"count destination messages")
+	assert.Equal(srcCount, dstCount, "destination message count")
+
+	// The absent columns take the destination schema's defaults:
+	// source_is_from_me has none (NULL), identity_is_from_me defaults to FALSE.
+	var sourceDefaults int
+	require.NoError(dstDB.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE source_is_from_me IS NULL`,
+	).Scan(&sourceDefaults), "count source_is_from_me defaults")
+	assert.Equal(dstCount, sourceDefaults,
+		"source_is_from_me should hold its schema default (NULL)")
+
+	var identityDefaults int
+	require.NoError(dstDB.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE identity_is_from_me = 0`,
+	).Scan(&identityDefaults), "count identity_is_from_me defaults")
+	assert.Equal(dstCount, identityDefaults,
+		"identity_is_from_me should hold its schema default (FALSE)")
+}
+
+// TestCopySubset_SourceOnlyColumnWithQuoteInName covers a source archive whose
+// messages table carries a column the destination schema does not have, and
+// whose name contains a double quote. The column falls outside the two
+// schemas' intersection, so it is never interpolated into the copy's SQL and
+// the copy proceeds without it.
+func TestCopySubset_SourceOnlyColumnWithQuoteInName(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "dst")
+
+	srcDB := createTestSourceDB(t, srcDir, 3)
+
+	db, err := sql.Open("sqlite3", srcDB+"?_foreign_keys=OFF")
+	require.NoError(err, "open source db")
+	_, err = db.Exec(`ALTER TABLE messages ADD COLUMN "we""ird" TEXT`)
+	require.NoError(err, `add messages."we""ird"`)
+	require.NoError(db.Close(), "close source db")
+
+	result, err := CopySubset(srcDB, dstDir, 100, false)
+	require.NoError(err, "CopySubset from a source with a quoted column name")
+	assert.Equal(int64(3), result.Messages, "Messages")
+
+	dstDB, err := sql.Open("sqlite3", filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err, "open destination db")
+	defer func() { _ = dstDB.Close() }()
+
+	var dstCount int
+	require.NoError(
+		dstDB.QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&dstCount),
+		"count destination messages")
+	assert.Equal(3, dstCount, "destination message count")
+}
+
+// TestCopySubset_CommonColumnWithQuoteRejected covers a column present in both
+// schemas whose name contains a double quote. That name would be interpolated
+// into the copy's SQL, so commonColumns refuses it instead of quoting it.
+func TestCopySubset_CommonColumnWithQuoteRejected(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.db")
+	dstPath := filepath.Join(dir, "dst.db")
+
+	for _, path := range []string{srcPath, dstPath} {
+		db, err := sql.Open("sqlite3", path)
+		require.NoError(err, "open %s", path)
+		_, err = db.Exec(`CREATE TABLE t (id INTEGER, "we""ird" TEXT)`)
+		require.NoError(err, "create t in %s", path)
+		require.NoError(db.Close(), "close %s", path)
+	}
+
+	db, err := sql.Open("sqlite3", dstPath)
+	require.NoError(err, "open destination db")
+	defer func() { _ = db.Close() }()
+	_, err = db.Exec(fmt.Sprintf("ATTACH DATABASE '%s' AS src", srcPath))
+	require.NoError(err, "attach source db")
+
+	tx, err := db.Begin()
+	require.NoError(err, "begin transaction")
+	defer func() { _ = tx.Rollback() }()
+
+	cols, err := commonColumns(tx, "t")
+	require.Error(err, "commonColumns should reject a quoted column name")
+	require.Nil(cols, "columns")
+	require.Contains(err.Error(), "double quote", "error message")
+}
+
+// TestCopySubset_SourceColumnCaseDiffers covers a source archive that declares
+// a messages column in a different case than the destination schema. SQLite
+// compares identifiers case-insensitively, so the two are the same column and
+// its values must be copied rather than left at the destination's default.
+func TestCopySubset_SourceColumnCaseDiffers(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "dst")
+
+	srcDB := createTestSourceDB(t, srcDir, 3)
+
+	db, err := sql.Open("sqlite3", srcDB+"?_foreign_keys=OFF")
+	require.NoError(err, "open source db")
+	_, err = db.Exec(`ALTER TABLE messages DROP COLUMN identity_is_from_me`)
+	require.NoError(err, "drop messages.identity_is_from_me")
+	_, err = db.Exec(`ALTER TABLE messages ADD COLUMN Identity_Is_From_Me BOOLEAN`)
+	require.NoError(err, "add messages.Identity_Is_From_Me")
+	_, err = db.Exec(`UPDATE messages SET Identity_Is_From_Me = TRUE`)
+	require.NoError(err, "set messages.Identity_Is_From_Me")
+	require.NoError(db.Close(), "close source db")
+
+	result, err := CopySubset(srcDB, dstDir, 100, false)
+	require.NoError(err, "CopySubset from a source whose column case differs")
+	assert.Equal(int64(3), result.Messages, "Messages")
+
+	dstDB, err := sql.Open("sqlite3", filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err, "open destination db")
+	defer func() { _ = dstDB.Close() }()
+
+	var copied int
+	require.NoError(dstDB.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE identity_is_from_me = 1`,
+	).Scan(&copied), "count copied identity_is_from_me")
+	assert.Equal(3, copied,
+		"identity_is_from_me should carry the source's values, not the default")
+}
+
+// TestCopySubset_SourceOnlyColumnUnicodeLookalike covers a source archive whose
+// messages table carries a source-only column whose name differs from a
+// destination column's only under Unicode case conversion: "İ" (U+0130, capital
+// I with dot above) where the destination has ASCII "i".
+//
+// SQLite folds identifiers over ASCII only, so İdentity_is_from_me and
+// identity_is_from_me are two different columns and the source simply lacks the
+// destination's. Go's strings.ToLower folds them together, which would put
+// identity_is_from_me in the copy's column list and make the copy select a
+// column src.messages does not have; SQLite's double-quoted-string misfeature
+// would then read that name as a string literal and store the text
+// "identity_is_from_me" in every destination row. The destination's own default
+// (FALSE) must win instead.
+//
+// This is the non-ASCII counterpart to
+// TestCopySubset_SourceColumnCaseDiffers, which covers the ordinary ASCII case
+// where the two spellings are the same column.
+func TestCopySubset_SourceOnlyColumnUnicodeLookalike(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "dst")
+
+	srcDB := createTestSourceDB(t, srcDir, 3)
+
+	db, err := sql.Open("sqlite3", srcDB+"?_foreign_keys=OFF")
+	require.NoError(err, "open source db")
+	_, err = db.Exec(`ALTER TABLE messages DROP COLUMN identity_is_from_me`)
+	require.NoError(err, "drop messages.identity_is_from_me")
+	_, err = db.Exec(`ALTER TABLE messages ADD COLUMN "İdentity_is_from_me" TEXT`)
+	require.NoError(err, "add messages.İdentity_is_from_me")
+	_, err = db.Exec(`UPDATE messages SET "İdentity_is_from_me" = 'source value'`)
+	require.NoError(err, "set messages.İdentity_is_from_me")
+	require.NoError(db.Close(), "close source db")
+
+	result, err := CopySubset(srcDB, dstDir, 100, false)
+	require.NoError(err, "CopySubset from a source with a Unicode-lookalike column")
+	assert.Equal(int64(3), result.Messages, "Messages")
+
+	dstDB, err := sql.Open("sqlite3", filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err, "open destination db")
+	defer func() { _ = dstDB.Close() }()
+
+	var defaulted int
+	require.NoError(dstDB.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE identity_is_from_me = 0`,
+	).Scan(&defaulted), "count identity_is_from_me defaults")
+	assert.Equal(3, defaulted,
+		"identity_is_from_me should hold the destination default (FALSE), "+
+			"the source not having that column")
+
+	// Name the failure the Unicode fold produces: the quoted column name
+	// degrading to a string literal writes its own text into every row.
+	var literals int
+	require.NoError(dstDB.QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE identity_is_from_me = 'identity_is_from_me'`,
+	).Scan(&literals), "count identity_is_from_me string literals")
+	assert.Equal(0, literals,
+		"identity_is_from_me must not hold its own name as a string")
+}


### PR DESCRIPTION
`CopySubset` names the `messages` columns it copies from a hand-maintained constant, `messageCopyColumns`. Every `ALTER TABLE messages ADD COLUMN` has to remember to update it, and an author who forgets gets no error — the column is silently absent from every subset that archive produces afterwards.

This derives the list from the columns present in both the source and destination `messages` tables, read at copy time.

**To be clear about what this is:** a maintenance hazard and a robustness improvement, not a fix for a bug anyone has reported. `messageCopyColumns` is currently correct — it lists exactly the 35 columns `schema.sql` declares, in the same order — so for a current-schema archive the derived list is byte-for-byte what the constant produced, and copy behavior is unchanged. What changes is that the list can no longer drift.

It also lets a source archive written against an older schema be copied rather than failing with `no such column`. A column the source lacks is left out of the `INSERT` instead of being selected from a table that does not have it, so the destination's own `DEFAULT`, where it has one, supplies the value. Names are matched case-insensitively, as SQLite matches identifiers. Interpolated names come from the live schema, and one containing a double quote is rejected rather than quoted, so the column list cannot carry an injection.

### Why only `messages`

`messages` is the table that grows columns over time. `sources` still hand-lists its columns in `copyData` and the remaining tables still copy positionally; those are left alone deliberately rather than widened into this change. Happy to do the rest separately if you want it.

### This is the base of a two-PR stack

The follow-up PR adds a content-change feed (`GET /api/v1/messages/changes`) and depends on this one, because it adds exactly the kind of column that the hand-maintained list would have silently dropped.

Two things that PR does which are worth knowing before you agree to this one, since this PR exists to enable it. **Neither happens in this PR** — this change adds no column, no trigger, and no endpoint:

1. **It modifies existing archives on open.** It adds a column, runs a full-table backfill, builds an index, and drops and recreates `trg_messages_last_modified`. So opening an existing archive with that build writes to it.
2. **Its SQLite commit-bound probe takes the database write lock from a read endpoint.** Measured: eight clients polling the feed in a tight loop cut writer throughput to **15%** of unloaded, against **49%** for an equivalent plain `SELECT`.

If either is a problem, it is better to know now than after this one lands.
