### PR TITLE
sync: rename --folders to --folder and --skip-folders to --skip-folder

### DIFF
--- a/cmd/msgvault/cmd/listfolders.go
+++ b/cmd/msgvault/cmd/listfolders.go
@@ -19,8 +19,8 @@ func newListFoldersCmd() *cobra.Command {
 		Short: "List IMAP folders (mailboxes) available for an account",
 		Long: `List all IMAP folders (mailboxes) available for one or all
 IMAP accounts, along with message count. This helps you
-choose which folders to include or exclude via --folders or
---skip-folders on the sync command.`,
+	choose which folders to include or exclude via --folder or
+	--skip-folder on the sync command.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !isDaemonCLISubprocess() {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1060,8 +1060,9 @@ func (a *storeAPIAdapter) runCLISyncWithRunner(
 	}, emitWarning)
 }
 
-// emitFolderArgs appends a --folders/<--skip-folders> flag for each
-// element in values, e.g. "--folders Inbox --folders Archive".
+// emitFolderArgs appends a --folder/--skip-folder flag for each
+// element in values, e.g. "--folder Inbox --folder Archive".
+
 func emitFolderArgs(args []string, flag string, values []string) []string {
 	for _, v := range values {
 		args = append(args, flag, v)
@@ -1087,16 +1088,16 @@ func cliSyncSubprocessArgs(req api.CLISyncRequest) []string {
 		if req.Limit > 0 {
 			args = append(args, "--limit", strconv.Itoa(req.Limit))
 		}
-		args = emitFolderArgs(args, "--folders", req.Folders)
-		args = emitFolderArgs(args, "--skip-folders", req.SkipFolders)
+		args = emitFolderArgs(args, "--folder", req.Folders)
+		args = emitFolderArgs(args, "--skip-folder", req.SkipFolders)
 		if req.Email != "" {
 			args = append(args, req.Email)
 		}
 		return args
 	}
 	args := []string{syncIncrementalCmd.Name()}
-	args = emitFolderArgs(args, "--folders", req.Folders)
-	args = emitFolderArgs(args, "--skip-folders", req.SkipFolders)
+	args = emitFolderArgs(args, "--folder", req.Folders)
+	args = emitFolderArgs(args, "--skip-folder", req.SkipFolders)
 	if req.Email != "" {
 		args = append(args, req.Email)
 	}

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -643,7 +643,7 @@ func TestStoreAPIAdapterRunCLISyncPacksOnlyAfterSubprocessSuccess(t *testing.T) 
 
 func TestCLISyncSubprocessArgsIncrementalIncludesFolderFilters(t *testing.T) {
 	assert.Equal(t,
-		[]string{"sync", "--folders", "INBOX", "--folders", "Archive", "--skip-folders", "Trash", "alice@example.com"},
+		[]string{"sync", "--folder", "INBOX", "--folder", "Archive", "--skip-folder", "Trash", "alice@example.com"},
 		cliSyncSubprocessArgs(api.CLISyncRequest{
 			Email:       "alice@example.com",
 			Folders:     []string{"INBOX", "Archive"},
@@ -651,14 +651,14 @@ func TestCLISyncSubprocessArgsIncrementalIncludesFolderFilters(t *testing.T) {
 		}),
 	)
 	assert.Equal(t,
-		[]string{"sync", "--folders", "Folder,With,Comma", "alice@example.com"},
+		[]string{"sync", "--folder", "Folder,With,Comma", "alice@example.com"},
 		cliSyncSubprocessArgs(api.CLISyncRequest{
 			Email:   "alice@example.com",
 			Folders: []string{"Folder,With,Comma"},
 		}),
 	)
 	assert.Equal(t,
-		[]string{"sync", "--folders", "Path\\To\\File", "--skip-folders", "Fold,er", "alice@example.com"},
+		[]string{"sync", "--folder", "Path\\To\\File", "--skip-folder", "Fold,er", "alice@example.com"},
 		cliSyncSubprocessArgs(api.CLISyncRequest{
 			Email:       "alice@example.com",
 			Folders:     []string{"Path\\To\\File"},

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -305,7 +305,7 @@ func runIncrementalSync(ctx context.Context, s *store.Store, getOAuthMgr func(st
 }
 
 func init() {
-	syncIncrementalCmd.Flags().StringArrayVar(&syncFolders, "folders", []string{}, "Folder names to include (repeatable)")
-	syncIncrementalCmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folders", []string{}, "Folder names to exclude (repeatable)")
+	syncIncrementalCmd.Flags().StringArrayVar(&syncFolders, "folder", []string{}, "IMAP folder to scan (repeatable)")
+	syncIncrementalCmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folder", []string{}, "IMAP folder to skip (repeatable)")
 	rootCmd.AddCommand(syncIncrementalCmd)
 }

--- a/cmd/msgvault/cmd/sync_http_test.go
+++ b/cmd/msgvault/cmd/sync_http_test.go
@@ -43,13 +43,13 @@ func TestSyncUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: syncIncrementalCmd.Use, Args: syncIncrementalCmd.Args, RunE: syncIncrementalCmd.RunE}
-	cmd.Flags().StringArrayVar(&syncFolders, "folders", []string{}, "IMAP folders to include")
-	cmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folders", []string{}, "IMAP folders to exclude")
+	cmd.Flags().StringArrayVar(&syncFolders, "folder", []string{}, "IMAP folders to include")
+	cmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folder", []string{}, "IMAP folders to exclude")
 	cmd.SetArgs([]string{
 		"alice@example.com",
-		"--folders", "INBOX",
-		"--folders", "Archive",
-		"--skip-folders", "Trash",
+		"--folder", "INBOX",
+		"--folder", "Archive",
+		"--skip-folder", "Trash",
 	})
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)

--- a/cmd/msgvault/cmd/sync_test.go
+++ b/cmd/msgvault/cmd/sync_test.go
@@ -674,15 +674,15 @@ func TestTrimFolderFilter(t *testing.T) {
 }
 
 func TestSyncCommandRegistersFolderFlags(t *testing.T) {
-	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("folders"))
-	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("skip-folders"))
+	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("folder"))
+	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("skip-folder"))
 }
 
 // Full e2e integration with an in-memory IMAP server is tested in
 // internal/imap/client_folderstate_test.go via WithFolderFilter().
 
 func TestTrimFolderFilter_DoesNotBlockOnErrorInSyncFull(t *testing.T) {
-	// Verify the CLI accepts --folders and --skip-folders through
+	// Verify the CLI accepts --folder and --skip-folder through
 	// parseFolderFilter without error, even when the value is
 	// malformed or whitespace-only.
 	require := require.New(t)

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -28,8 +28,8 @@ var (
 	syncBefore      string
 	syncAfter       string
 	syncLimit       int
-	syncFolders     []string // folder names to include (from --folders flag)
-	syncSkipFolders []string // folder names to exclude (from --skip-folders flag)
+	syncFolders     []string // folder names to include (from --folder flag)
+	syncSkipFolders []string // folder names to exclude (from --skip-folder flag)
 )
 
 var syncFullCmd = &cobra.Command{
@@ -428,12 +428,12 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	imapOpts := imapFolderStateOptions(s, src, syncNoResume)
 
 	// Pass CLI folder filter strings to the IMAP client. The IMAP
-	// client selects the effective include list (CLI --folders when
-	// set, otherwise config Folders) and applies CLI --skip-folders
+	// client selects the effective include list (CLI --folder when
+	// set, otherwise config Folders) and applies CLI --skip-folder
 	// as an exclusion on top. Both CLI filters are applied in a
-	// single call to filterMailboxes so --folders can fully
-	// override configuration and --skip-folders works together with
-	// --folders.
+	// single call to filterMailboxes so --folder can fully
+	// override configuration and --skip-folder works together with
+	// --folder.
 	imapOpts = append(imapOpts,
 		imaplib.WithFolderFilter(
 			parseFolderFilter(syncFolders),
@@ -829,7 +829,7 @@ func init() {
 	syncFullCmd.Flags().StringVar(&syncBefore, "before", "", "Only messages before this date (YYYY-MM-DD)")
 	syncFullCmd.Flags().StringVar(&syncAfter, "after", "", "Only messages after this date (YYYY-MM-DD)")
 	syncFullCmd.Flags().IntVar(&syncLimit, "limit", 0, "Limit number of messages (for testing)")
-	syncFullCmd.Flags().StringArrayVar(&syncFolders, "folders", []string{}, "Folder names to include (repeatable)")
-	syncFullCmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folders", []string{}, "Folder names to exclude (repeatable)")
+	syncFullCmd.Flags().StringArrayVar(&syncFolders, "folder", []string{}, "IMAP folder to scan (repeatable)")
+	syncFullCmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folder", []string{}, "IMAP folder to skip (repeatable)")
 	rootCmd.AddCommand(syncFullCmd)
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -110,7 +110,7 @@ an approximate message count for each folder.
 msgvault list-folders [account]
 ```
 
-Use the folder names in repeated `--folders` or `--skip-folders` flags on
+Use the folder names in repeated `--folder` or `--skip-folder` flags on
 `sync-full` and `sync`. When the account argument is omitted, the command lists
 folders for every configured IMAP account. See
 [IMAP Folder Sync](/usage/imap/) for examples and matching rules.
@@ -206,8 +206,8 @@ msgvault sync-full [email] [flags]
 | `--before YYYY-MM-DD` | Only messages before this date |
 | `--query` | Gmail search query filter |
 | `--noresume` | Ignore checkpoints, start fresh |
-| `--folders NAME` | Scan this IMAP folder (repeatable) |
-| `--skip-folders NAME` | Skip this IMAP folder (repeatable) |
+| `--folder NAME` | Scan this IMAP folder (repeatable) |
+| `--skip-folder NAME` | Skip this IMAP folder (repeatable) |
 | `--verbose` | Detailed progress output |
 
 The CLI sends the sync request to the configured remote server or local daemon
@@ -227,8 +227,8 @@ msgvault sync [email] [flags]
 
 | Flag | Description |
 |---|---|
-| `--folders NAME` | Scan this IMAP folder (repeatable) |
-| `--skip-folders NAME` | Skip this IMAP folder (repeatable) |
+| `--folder NAME` | Scan this IMAP folder (repeatable) |
+| `--skip-folder NAME` | Skip this IMAP folder (repeatable) |
 
 The CLI sends the incremental sync request to the configured remote server or
 local daemon and streams the daemon's stdout/stderr back to the terminal. The

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -175,7 +175,7 @@ msgvault sync-full you@fastmail.com
 IMAP accounts are stored in the same database as Gmail accounts. All tools
 (Web UI, TUI, search, MCP, and REST API) work with IMAP messages the same way.
 To start with only part of a large account, see
-[IMAP Folder Sync](/usage/imap/) for `--folders` and `--skip-folders` examples.
+[IMAP Folder Sync](/usage/imap/) for `--folder` and `--skip-folder` examples.
 
 !!! tip "Microsoft 365 / Outlook.com"
     For Outlook, Hotmail, Live.com, and Microsoft 365 accounts, `add-o365` provides OAuth-based access without app passwords. It auto-detects the correct IMAP host and configures XOAUTH2 authentication. See the [OAuth Setup guide](/guides/oauth-setup/#microsoft-365-outlook-hotmail) for details.

--- a/docs/usage/imap.md
+++ b/docs/usage/imap.md
@@ -45,20 +45,20 @@ msgvault shows `??`, but you can still use the folder name in a filter.
 
 ## Sync Only Selected Folders
 
-Repeat `--folders` once for each folder you want to include:
+Repeat `--folder` once for each folder you want to include:
 
 ```bash
 msgvault sync-full you@example.com \
-  --folders INBOX \
-  --folders Archive
+  --folder INBOX \
+  --folder Archive
 ```
 
 To scan the same folders during a later sync:
 
 ```bash
 msgvault sync you@example.com \
-  --folders INBOX \
-  --folders Archive
+  --folder INBOX \
+  --folder Archive
 ```
 
 Each flag takes one complete folder name. Repeat the flag instead of joining
@@ -66,7 +66,7 @@ names with commas. This also means a folder whose name contains a comma works
 without special handling:
 
 ```bash
-msgvault sync-full you@example.com --folders "Receipts, 2025"
+msgvault sync-full you@example.com --folder "Receipts, 2025"
 ```
 
 ## Skip Selected Folders

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -47,7 +47,7 @@ func WithListProgress(fn func(done, total int, mailbox string, found, unchanged 
 }
 
 // WithFolderFilter sets folder include/exclude lists for a single sync run.
-// --folders/--skip-folders replaces or filters the config's folder list.
+// --folder/--skip-folder replaces or filters the config's folder list.
 func WithFolderFilter(include, exclude []string) Option {
 	return func(c *Client) {
 		c.folderFilterInclude = include
@@ -569,7 +569,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 
 	// Apply folder selection once against the full LIST result so CLI
 	// includes can override configuration, and CLI exclusions apply
-	// regardless of whether --folders was provided.
+	// regardless of whether --folder was provided.
 	allMailboxes = filterMailboxes(
 		allMailboxes,
 		c.effectiveFolderIncludeLocked(),
@@ -782,7 +782,7 @@ func (c *Client) mailboxIncludedLocked(mailbox string) bool {
 // effectiveFolderIncludeLocked returns the active folder allow list. Caller
 // must hold mu.
 func (c *Client) effectiveFolderIncludeLocked() []string {
-	// CLI --folders replaces config folders when set; otherwise use
+	// CLI --folder replaces config folders when set; otherwise use
 	// config.Folders.
 	if len(c.folderFilterInclude) > 0 {
 		return c.folderFilterInclude

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -347,7 +347,7 @@ func TestWithFolderFilter_ConfigFoldersRespectsIncludeList(t *testing.T) {
 	assert.NotContains(states, "Drafts")
 }
 
-// TestWithFolderFilter_CLIReplacingConfig verifies that a CLI --folders
+// TestWithFolderFilter_CLIReplacingConfig verifies that a CLI --folder
 // include filter fully replaces the config's include list when set.
 // CLI exclusions apply on top of the effective include regardless.
 func TestWithFolderFilter_CLIReplacingConfig(t *testing.T) {
@@ -355,7 +355,7 @@ func TestWithFolderFilter_CLIReplacingConfig(t *testing.T) {
 	assert := assert.New(t)
 
 	// Case 1: CLI include replaces config include — config says
-	// Archive, --folders says INBOX, expect only INBOX.
+	// Archive, --folder says INBOX, expect only INBOX.
 	t.Run("CLI include replaces config include", func(t *testing.T) {
 		addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
 
@@ -383,8 +383,8 @@ func TestWithFolderFilter_CLIReplacingConfig(t *testing.T) {
 	})
 
 	// Case 2: CLI include + CLI exclude applied together — config
-	// includes nothing, --folders=["Inbox,Archive"],
-	// --skip-folders=["Inbox"]. Expect only Archive.
+	// includes nothing, --folder=["Inbox,Archive"],
+	// --skip-folder=["Inbox"]. Expect only Archive.
 	t.Run("CLI include and CLI exclude combine", func(t *testing.T) {
 		addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3, "Trash": 1})
 
@@ -412,8 +412,8 @@ func TestWithFolderFilter_CLIReplacingConfig(t *testing.T) {
 }
 
 // TestWithFolderFilter_CLIExcludeWithConfigIncludes verifies that when
-// only --skip-folders is set (CLI exclude), it excludes from the config's
-// include list. With no config Folders set, --skip-folders excludes from
+// only --skip-folder is set (CLI exclude), it excludes from the config's
+// include list. With no config Folders set, --skip-folder excludes from
 // all mailboxes.
 func TestWithFolderFilter_CLIExcludeConfigIncludes(t *testing.T) {
 	require := require.New(t)

--- a/internal/imap/config.go
+++ b/internal/imap/config.go
@@ -31,7 +31,7 @@ type Config struct {
 
 	// Folders is a case-insensitive allow list. When non-empty,
 	// only these mailboxes are synced. An empty list means "all
-	// mailboxes". CLI --folders/--skip-folders override this config:
+	// mailboxes". CLI --folder/--skip-folder override this config:
 	// they are applied after config folders in
 	// buildMessageListCache, so CLI values always take precedence.
 	Folders []string `json:"folders,omitempty"`


### PR DESCRIPTION
Each --folders flag value represents a single folder name, never a comma-separated list. This is a holdover from the original plan where the intent was --folders X,Y,Z to select multiple folders via commas. Since we switched to StringArrayVar (repeatable flag) to safely handle folder names containing commas, the plural flag name is misleading.

Changes:
- CLI flag names: --folders -> --folder, --skip-folders -> --skip-folder
- Help text updated throughout
- Subprocess arg generation in serve.go updated
- Test assertions on flag names and subprocess args updated
- Doc comments in imap/client.go, imap/config.go updated
- Documentation updated: imap.md, cli-reference.md, setup.md, imap-folder-sync.md