### PR TITLE
fix(beeper): discover accounts missing from the accounts API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export formats.
 - **Microsoft Teams sync**: archive delegated Graph chats, channels, replies, and inline media with `message_type = teams`
 - **Discord sync**: archive guild channels, threads, forum posts, and attachments through a read-only bot with `message_type = discord`
 - **Meeting notes**: sync Granola and Circleback notes and transcripts, then browse them in the TUI
-- **Beeper Desktop sync**: archive chats and media from every network bridged through Beeper's local API
+- **Beeper Desktop sync**: archive chats and media from every network connected to Beeper, including iMessage, through its local API
 - **IMAP sync**: archive mail from any standard IMAP server
 - **Incremental backup snapshots**: verifiable `msgvault backup` repositories for the SQLite archive and attachments
 - **MBOX / Apple Mail / PST import**: import email from local export formats

--- a/cmd/msgvault/cmd/add_beeper.go
+++ b/cmd/msgvault/cmd/add_beeper.go
@@ -29,6 +29,10 @@ Instagram, LinkedIn, X, Facebook, ...) into one local app with a read-only
 API on localhost. Each connected network account becomes its own msgvault
 source, so networks stay separately filterable and searchable.
 
+Accounts Beeper serves natively rather than through a bridge (iMessage) are
+missing from its accounts API, so they are found from chat data instead. Re-run
+this command after connecting a network in Beeper to register it.
+
 Requires Beeper Desktop to be running on this machine. Mint an access token
 in Beeper Desktop (Settings > Developer) and provide it via --token-file,
 the MSGVAULT_BEEPER_TOKEN environment variable, or the interactive prompt.
@@ -55,6 +59,9 @@ Examples:
 				if IsRemoteMode() {
 					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Remote daemon configured: it must run beside its own Beeper Desktop, which will validate the token.")
 				} else {
+					// A token check, not discovery: the daemon subprocess below
+					// does the real enumeration, so this stays the single
+					// cheapest authenticated request.
 					accounts, err := beeperClient(token).ListAccounts(cmd.Context())
 					if err != nil {
 						return err
@@ -70,7 +77,7 @@ Examples:
 			if token == "" {
 				return errors.New("missing Beeper token in daemon subprocess (set MSGVAULT_BEEPER_TOKEN)")
 			}
-			accounts, err := beeperClient(token).ListAccounts(cmd.Context())
+			accounts, err := beeperClient(token).DiscoverAccounts(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -101,7 +108,8 @@ Examples:
 					confirmDefaultIdentity(cmd.OutOrStdout(), s, source.ID,
 						acct.AccountID, beeperSelfIdentity(acct), "account-identifier")
 				}
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Added %s (%s)\n", acct.AccountID, beeperSourceDisplayName(acct))
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Added %s (%s)%s\n",
+					acct.AccountID, beeperSourceDisplayName(acct), beeperAccountOrigin(acct))
 				added++
 			}
 			if err := runPostSourceCreateMigrations(s); err != nil {
@@ -135,6 +143,15 @@ func beeperSourceDisplayName(acct beeper.Account) string {
 		return "Beeper " + acct.Network
 	}
 	return "Beeper " + acct.AccountID
+}
+
+// beeperAccountOrigin annotates accounts that only chat data revealed, so it
+// is obvious why a source exists that Beeper's own account list never named.
+func beeperAccountOrigin(acct beeper.Account) string {
+	if acct.Discovered {
+		return " [found via chats; not listed by Beeper's accounts API]"
+	}
+	return ""
 }
 
 // beeperSelfIdentity picks the best own-identity value for a Beeper account:

--- a/cmd/msgvault/cmd/sync_beeper.go
+++ b/cmd/msgvault/cmd/sync_beeper.go
@@ -25,7 +25,7 @@ var (
 func newSyncBeeperCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync-beeper",
-		Short: "Sync chats from Beeper Desktop (all bridged networks)",
+		Short: "Sync chats from Beeper Desktop (all connected networks)",
 		Long: `Sync chats from Beeper Desktop for every registered Beeper account.
 
 The first run backfills each chat's full locally-available history; later

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,11 @@ All notable changes to msgvault, grouped by release.
 
 **Bug fixes**
 
+- `add-beeper` now registers networks Beeper Desktop serves natively rather
+  than through a bridge, such as iMessage. Beeper omits those accounts from its
+  accounts API, so they are found from chat data instead and then sync, resume,
+  and filter like any other Beeper source. Re-run `add-beeper` on an existing
+  install to pick them up.
 - Daemon-backed CLI, TUI, MCP, statistics, and backup operations now wait for
   completion or caller cancellation instead of failing at fixed HTTP or server
   deadlines on slow storage. Local daemon authentication uses the lightweight

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -455,7 +455,7 @@ the source message has since been deleted. See
 
 ## add-beeper
 
-Register the chat accounts bridged through a locally running
+Register the chat accounts connected to a locally running
 [Beeper Desktop](/usage/beeper/) as `beeper` sources, one per network.
 
 ```bash
@@ -469,6 +469,10 @@ minted in Beeper Desktop (Settings → Developer). The token is stored at
 `tokens/beeper.json`. Accounts filtered out by `[beeper].accounts` /
 `exclude_accounts` in `config.toml` are skipped.
 
+Networks Beeper serves natively instead of bridging — iMessage — are absent
+from its accounts API, so they are found from chat data and reported as *found
+via chats*. Re-run the command after connecting a network in Beeper Desktop.
+
 | Flag | Default | Description |
 |---|---|---|
 | `--token-file` | | Read the access token from a file instead of prompting |
@@ -481,7 +485,7 @@ After adding, sync with `msgvault sync-beeper`.
 ## sync-beeper
 
 Sync chats from Beeper Desktop for every registered Beeper account (all
-bridged networks). The first run backfills full locally-available history and
+connected networks). The first run backfills full locally-available history and
 is resumable; later runs are incremental. Per-account failures do not stop the
 run: remaining accounts still sync, the analytics cache is rebuilt for the
 successful ones, and the command exits non-zero listing the failures. Without

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ it lives in an archive on disk that you own and control.
   </section>
   <section>
     <h3>Meetings &amp; Beeper</h3>
-    <p>Sync Granola and Circleback notes and transcripts, and archive chats and media from networks bridged through Beeper Desktop. Explore each source in the Web UI or its dedicated TUI mode.</p>
+    <p>Sync Granola and Circleback notes and transcripts, and archive chats and media from networks connected to Beeper Desktop. Explore each source in the Web UI or its dedicated TUI mode.</p>
   </section>
   <section>
     <h3>Backup Snapshots</h3>

--- a/docs/usage/beeper.md
+++ b/docs/usage/beeper.md
@@ -1,14 +1,14 @@
 ---
 title: Beeper
-description: Archive every chat network bridged through Beeper Desktop via its local API.
+description: Archive every chat network connected to Beeper Desktop via its local API.
 ---
 
 [Beeper Desktop](https://www.beeper.com) bridges many chat networks — WhatsApp,
-Signal, Telegram, Instagram, LinkedIn, X, Facebook Messenger, and more — into
-one app. msgvault can archive all of them at once through Beeper Desktop's
-local API. Each connected network account becomes its own msgvault source, so
-a Signal thread and a Telegram thread stay separately filterable, while all
-Beeper-archived messages share `message_type = beeper` for search.
+Signal, Telegram, Instagram, LinkedIn, X, Facebook Messenger, iMessage, and
+more — into one app. msgvault can archive all of them at once through Beeper
+Desktop's local API. Each connected network account becomes its own msgvault
+source, so a Signal thread and a Telegram thread stay separately filterable,
+while all Beeper-archived messages share `message_type = beeper` for search.
 
 Beeper sync is strictly read-only: msgvault only calls read endpoints of the
 local API and never sends, edits, archives, or marks anything in Beeper.
@@ -28,7 +28,16 @@ msgvault add-beeper
 
 The command validates the token against the running Beeper Desktop, stores it
 at `tokens/beeper.json` (0600), and registers one `beeper` source per
-connected network account (e.g. `signal`, `telegram`, `whatsapp`).
+connected network account (e.g. `signal`, `telegram`, `whatsapp`,
+`imessage_…`).
+
+Beeper's accounts API omits some networks it serves natively rather than
+bridging — currently iMessage — so those are found from chat data instead.
+They are printed as *found via chats* and behave like any other `beeper`
+source afterwards.
+
+`add-beeper` is safe to re-run and does not disturb existing sources, so run it
+again after connecting a new network in Beeper Desktop to register it.
 
 Provide the token via the interactive prompt, `--token-file <path>`, or the
 `MSGVAULT_BEEPER_TOKEN` environment variable:
@@ -139,3 +148,10 @@ resolving to the same person).
   with an error; remove and re-add the Beeper sources in that case.
 - **Remote daemons**: the Beeper API is loopback-only, so the msgvault daemon
   must run on the same machine as Beeper Desktop.
+- **iMessage**: Beeper only carries iMessage on macOS, so archiving it this way
+  needs a Mac running Beeper Desktop beside the msgvault daemon. Networks found
+  from chat data are looked for in a bounded scan of your most recently active
+  conversations, so one with no chats — or none recent enough to fall inside
+  that window — stays invisible until it sees activity; send or receive a
+  message, then re-run `add-beeper`. The scan logs a warning when it stops at
+  its bound.

--- a/internal/beeper/discover.go
+++ b/internal/beeper/discover.go
@@ -1,0 +1,188 @@
+package beeper
+
+import (
+	"context"
+	"log/slog"
+)
+
+const (
+	// discoverChatPages bounds the unfiltered chat sweep DiscoverAccounts uses
+	// to find accounts the accounts endpoint omits. Chats come back ordered by
+	// last activity, so a few pages of 200 cover every account that has been
+	// used recently. This is discovery, not enumeration: the sweep runs in
+	// add-beeper, never on the sync path.
+	discoverChatPages = 5
+	// discoverIdentityProbes bounds the chat-detail fetches used to work out
+	// who "me" is on a discovered account.
+	discoverIdentityProbes = 3
+)
+
+// candidateAccount is an account seen in the chat sweep but missing from the
+// accounts endpoint, along with the chats that can answer who "me" is on it.
+type candidateAccount struct {
+	accountID string
+	network   string
+	chatIDs   []string
+}
+
+// DiscoverAccounts returns the accounts Beeper Desktop serves, including any
+// that its accounts endpoint leaves out.
+//
+// Beeper carries some networks as native platform-sdk accounts rather than as
+// Matrix bridges. Those accounts are absent from GET /v1/accounts — and from
+// GET /v1/accounts/{id}, which answers 404 for them — while the chat and
+// message endpoints serve them like any other account. Enumerating accounts
+// from that endpoint alone therefore skips whole networks silently.
+//
+// Discovery unions the accounts endpoint with the distinct account IDs seen in
+// a bounded, unfiltered chat sweep, synthesising an Account for each ID the
+// endpoint did not report and marking it Discovered. Callers get one list and
+// need not care which half an account came from.
+//
+// The sweep is best-effort: if it stops early, discovery keeps whatever it had
+// already found and still returns everything the accounts endpoint reported.
+func (c *Client) DiscoverAccounts(ctx context.Context) ([]Account, error) {
+	listed, err := c.ListAccounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	known := make(map[string]bool, len(listed))
+	for _, acct := range listed {
+		known[acct.AccountID] = true
+	}
+
+	// A cancelled context means the caller gave up, not that Beeper failed a
+	// probe. Both steps below tolerate fetch failures by design, so each has to
+	// rule cancellation out explicitly; otherwise add-beeper would report
+	// success and register sources whose identity was never actually looked up.
+	candidates := c.sweepChatAccounts(ctx, known)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for _, cand := range candidates {
+		acct, err := c.resolveCandidate(ctx, cand)
+		if err != nil {
+			return nil, err
+		}
+		listed = append(listed, acct)
+	}
+	return listed, nil
+}
+
+// sweepChatAccounts pages the unfiltered chat search and returns the accounts
+// that own chats but are absent from known, in the order they were first seen.
+//
+// Discovery is additive, so a page that fails ends the sweep with whatever it
+// has rather than failing registration: a Beeper Desktop that cannot serve the
+// chat search still reports the accounts its accounts endpoint listed. Both
+// early exits are logged, because from the outside they are indistinguishable
+// from a network that genuinely has no chats.
+func (c *Client) sweepChatAccounts(ctx context.Context, known map[string]bool) []candidateAccount {
+	var (
+		out   []candidateAccount
+		index = make(map[string]int)
+		p     SearchChatsParams
+	)
+	for range discoverChatPages {
+		page, err := c.SearchChats(ctx, p)
+		if err != nil {
+			slog.Warn("beeper account discovery: chat sweep failed; an account missing from the accounts endpoint may go unregistered",
+				"error", err)
+			return out
+		}
+		for _, chat := range page.Items {
+			if chat.ID == "" || chat.AccountID == "" || known[chat.AccountID] {
+				continue
+			}
+			i, seen := index[chat.AccountID]
+			if !seen {
+				i = len(out)
+				index[chat.AccountID] = i
+				out = append(out, candidateAccount{accountID: chat.AccountID})
+			}
+			if out[i].network == "" {
+				out[i].network = chat.Network
+			}
+			if len(out[i].chatIDs) < discoverIdentityProbes {
+				out[i].chatIDs = append(out[i].chatIDs, chat.ID)
+			}
+		}
+		if !page.HasMore || page.OldestCursor == "" {
+			return out
+		}
+		p.Cursor = page.OldestCursor
+	}
+	slog.Warn("beeper account discovery: chat sweep reached its page bound; an account whose chats are all older than the scanned window may go unregistered",
+		"pages", discoverChatPages)
+	return out
+}
+
+// resolveCandidate turns a swept account ID into an Account, reading the
+// logged-in user's own identity from the isSelf member of up to
+// discoverIdentityProbes of its chats.
+//
+// Several chats are probed and their identity fields merged because Beeper
+// exposes different fields on different chats: one chat may carry the self
+// member's email and another the phone number. Getting this right decides
+// which archived messages are later attributed to the account owner.
+//
+// A chat that cannot be fetched, or that omits the self member, is skipped: an
+// account whose identity stays unknown is still worth registering. The one
+// failure that is not tolerated is a cancelled context, which would otherwise
+// look like a run of unreadable chats and yield an account with no identity at
+// all.
+func (c *Client) resolveCandidate(ctx context.Context, cand candidateAccount) (Account, error) {
+	acct := Account{AccountID: cand.accountID, Network: cand.network, Discovered: true}
+	for _, chatID := range cand.chatIDs {
+		chat, err := c.GetChat(ctx, chatID)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return Account{}, ctxErr
+			}
+			continue
+		}
+		if acct.Network == "" {
+			acct.Network = chat.Network
+		}
+		self, ok := selfParticipant(chat)
+		if !ok {
+			continue
+		}
+		mergeIdentity(&acct.User, self)
+		if acct.User.PhoneNumber != "" && acct.User.Email != "" {
+			break // nothing further to learn
+		}
+	}
+	return acct, nil
+}
+
+// selfParticipant returns the chat member Beeper marks as the logged-in user.
+func selfParticipant(chat *Chat) (User, bool) {
+	for _, p := range chat.Participants.Items {
+		if p.IsSelf {
+			return p.User, true
+		}
+	}
+	return User{}, false
+}
+
+// mergeIdentity fills empty identity fields on dst from src. Both describe the
+// same account owner, so a field only ever moves from unknown to known.
+func mergeIdentity(dst *User, src User) {
+	if dst.ID == "" {
+		dst.ID = src.ID
+	}
+	if dst.Username == "" {
+		dst.Username = src.Username
+	}
+	if dst.PhoneNumber == "" {
+		dst.PhoneNumber = src.PhoneNumber
+	}
+	if dst.Email == "" {
+		dst.Email = src.Email
+	}
+	if dst.FullName == "" {
+		dst.FullName = src.FullName
+	}
+	dst.IsSelf = true
+}

--- a/internal/beeper/discover_test.go
+++ b/internal/beeper/discover_test.go
@@ -1,0 +1,263 @@
+package beeper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// selfParticipantJSON builds an isSelf chat member for the fake server.
+func selfParticipantJSON(id, phone, email string) map[string]any {
+	return map[string]any{
+		"id": id, "phoneNumber": phone, "email": email,
+		"fullName": "Test User", "isSelf": true,
+	}
+}
+
+// otherParticipantJSON builds a non-self chat member for the fake server.
+func otherParticipantJSON(id, name string) map[string]any {
+	return map[string]any{"id": id, "fullName": name, "isSelf": false}
+}
+
+// searchRequests counts chat-search calls in the fake server's request log.
+func searchRequests(reqs []string) int {
+	n := 0
+	for _, r := range reqs {
+		if strings.HasPrefix(r, "/v1/chats/search") {
+			n++
+		}
+	}
+	return n
+}
+
+// An account Beeper serves chats for but leaves out of /v1/accounts (how it
+// treats its native platform-sdk networks) must still be discovered, with the
+// network name and the account owner's identity taken from chat data.
+func TestDiscoverAccountsFindsAccountMissingFromAccountsEndpoint(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.addAccount(map[string]any{
+		"accountID": "signal",
+		"network":   "Signal",
+		"user":      map[string]any{"id": "@signal_me:beeper.local", "phoneNumber": "+15550000001"},
+	})
+	f.addChat(&fakeChat{ID: "!s:x", AccountID: "signal", Network: "Signal", Title: "S", Type: "single",
+		LastActivity: time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)})
+	f.addChat(&fakeChat{ID: "!i:x", AccountID: "imessage_abc", Network: "iMessage", Title: "Bob", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Participants: []map[string]any{
+			otherParticipantJSON("bob@example.com", "Bob"),
+			selfParticipantJSON("alice@example.com", "+15550000002", "alice@example.com"),
+		}})
+	srv := f.server()
+	defer srv.Close()
+
+	accounts, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(context.Background())
+	require.NoError(err)
+	require.Len(accounts, 2)
+
+	assert.Equal("signal", accounts[0].AccountID)
+	assert.False(accounts[0].Discovered, "accounts the endpoint reported are not discovered")
+
+	found := accounts[1]
+	assert.Equal("imessage_abc", found.AccountID)
+	assert.True(found.Discovered)
+	assert.Equal("iMessage", found.Network, "network name comes from the chat")
+	assert.Equal("+15550000002", found.User.PhoneNumber, "identity comes from the isSelf member")
+	assert.Equal("alice@example.com", found.User.Email)
+}
+
+// An account reported by /v1/accounts must not be re-added just because it
+// also owns chats, and its endpoint-provided identity must survive.
+func TestDiscoverAccountsDoesNotDuplicateListedAccounts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.addAccount(map[string]any{
+		"accountID": "signal",
+		"network":   "Signal",
+		"user":      map[string]any{"id": "@signal_me:beeper.local", "phoneNumber": "+15550000001"},
+	})
+	for i := range 3 {
+		f.addChat(&fakeChat{ID: "!s" + strconv.Itoa(i) + ":x", AccountID: "signal", Network: "Signal",
+			Type: "single", LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			Participants: []map[string]any{selfParticipantJSON("@other:x", "+15559999999", "")}})
+	}
+	srv := f.server()
+	defer srv.Close()
+
+	accounts, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(context.Background())
+	require.NoError(err)
+	require.Len(accounts, 1)
+	assert.Equal("signal", accounts[0].AccountID)
+	assert.False(accounts[0].Discovered)
+	assert.Equal("+15550000001", accounts[0].User.PhoneNumber, "chat data must not overwrite the account's own identity")
+	for _, req := range f.requests() {
+		assert.NotContains(req, "/v1/chats/!s0:x", "no chat detail fetch for an already known account")
+	}
+}
+
+// Discovery is additive: when the chat sweep fails, registration must still
+// proceed with whatever /v1/accounts returned.
+func TestDiscoverAccountsDegradesWhenChatSweepFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.addAccount(map[string]any{"accountID": "signal", "network": "Signal"})
+	f.addChat(&fakeChat{ID: "!i:x", AccountID: "imessage_abc", Network: "iMessage", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)})
+	f.setChatSearchFailure(true)
+	srv := f.server()
+	defer srv.Close()
+
+	accounts, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(context.Background())
+	require.NoError(err, "a failed sweep must not fail discovery")
+	require.Len(accounts, 1)
+	assert.Equal("signal", accounts[0].AccountID)
+}
+
+// A rejected accounts endpoint is fatal: the token is bad, which the chat
+// sweep cannot paper over and must not mask.
+func TestDiscoverAccountsFailsWhenAccountsEndpointFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.setAccountsFailure(true)
+	f.addChat(&fakeChat{ID: "!i:x", AccountID: "imessage_abc", Network: "iMessage", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)})
+	srv := f.server()
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(context.Background())
+	require.Error(err)
+	assert.Contains(err.Error(), "unauthorized")
+	assert.Equal(0, searchRequests(f.requests()), "a rejected token must not trigger a chat sweep")
+}
+
+// Interrupting add-beeper must abort registration rather than half-finish it.
+// Both fetch loops tolerate failures by design, so cancellation has to be
+// caught at each: during the sweep, and during the identity probe that follows
+// it. Neither may be reported as success.
+func TestDiscoverAccountsPropagatesCancellation(t *testing.T) {
+	// cancelOn names the request path at which the caller gives up.
+	for _, tc := range []struct {
+		name     string
+		cancelOn string
+	}{
+		{name: "during the chat sweep", cancelOn: "/v1/chats/search"},
+		{name: "during the identity probe", cancelOn: "/v1/chats/!i:x"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == tc.cancelOn {
+					cancel()
+					http.Error(w, `{"error":"aborted"}`, http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/v1/accounts":
+					_, _ = w.Write([]byte(`[]`))
+				case "/v1/chats/search":
+					_, _ = w.Write([]byte(`{"items":[{"id":"!i:x","accountID":"imessage_abc",` +
+						`"network":"iMessage","type":"single"}],"hasMore":false}`))
+				default:
+					http.Error(w, `{"error":"unexpected"}`, http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			_, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(ctx)
+			require.ErrorIs(err, context.Canceled)
+		})
+	}
+}
+
+// The sweep must stay bounded on a busy install rather than walking every
+// chat the user has ever had.
+func TestDiscoverAccountsBoundsTheChatSweep(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.chatPageSize = 2
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	for i := range 4 * discoverChatPages {
+		f.addChat(&fakeChat{ID: "!c" + strconv.Itoa(i) + ":x", AccountID: "imessage_abc", Network: "iMessage",
+			Type: "single", LastActivity: base.Add(-time.Duration(i) * time.Hour)})
+	}
+	srv := f.server()
+	defer srv.Close()
+
+	accounts, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(context.Background())
+	require.NoError(err)
+	require.Len(accounts, 1)
+	assert.Equal("imessage_abc", accounts[0].AccountID)
+	assert.Equal(discoverChatPages, searchRequests(f.requests()), "sweep must stop at its page bound")
+}
+
+// Beeper exposes different identity fields on different chats, so the identity
+// probe merges what it finds instead of trusting the first chat it sees.
+func TestDiscoverAccountsMergesSelfIdentityAcrossChats(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.chatPageSize = 10
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	// Newest chat first: no self member at all, then email only, then phone.
+	f.addChat(&fakeChat{ID: "!a:x", AccountID: "imessage_abc", Network: "iMessage", Type: "group",
+		LastActivity: base,
+		Participants: []map[string]any{otherParticipantJSON("bob@example.com", "Bob")}})
+	f.addChat(&fakeChat{ID: "!b:x", AccountID: "imessage_abc", Network: "iMessage", Type: "single",
+		LastActivity: base.Add(-time.Hour),
+		Participants: []map[string]any{selfParticipantJSON("alice@example.com", "", "alice@example.com")}})
+	f.addChat(&fakeChat{ID: "!c:x", AccountID: "imessage_abc", Network: "iMessage", Type: "single",
+		LastActivity: base.Add(-2 * time.Hour),
+		Participants: []map[string]any{selfParticipantJSON("+15550000002", "+15550000002", "")}})
+	// Beyond the probe bound: never fetched.
+	f.addChat(&fakeChat{ID: "!d:x", AccountID: "imessage_abc", Network: "iMessage", Type: "single",
+		LastActivity: base.Add(-3 * time.Hour),
+		Participants: []map[string]any{selfParticipantJSON("+15559999999", "+15559999999", "")}})
+	srv := f.server()
+	defer srv.Close()
+
+	accounts, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(context.Background())
+	require.NoError(err)
+	require.Len(accounts, 1)
+	assert.Equal("alice@example.com", accounts[0].User.Email, "email survives from the chat that had it")
+	assert.Equal("+15550000002", accounts[0].User.PhoneNumber, "phone comes from a later chat")
+	for _, req := range f.requests() {
+		assert.NotEqual("/v1/chats/!d:x?maxParticipantCount=-1", req, "identity probing must stay bounded")
+	}
+}
+
+// An account whose chats cannot be read is still worth registering: the sync
+// path only needs the account ID.
+func TestDiscoverAccountsRegistersAccountWithUnreadableChat(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.addChat(&fakeChat{ID: "!gone:x", AccountID: "imessage_abc", Network: "iMessage", Type: "single",
+		LastActivity: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)})
+	srv := f.server()
+	defer srv.Close()
+
+	f.setChatGetFailure("!gone:x", true)
+
+	accounts, err := NewClient(srv.URL, testToken, 1000).DiscoverAccounts(context.Background())
+	require.NoError(err)
+	require.Len(accounts, 1)
+	assert.Equal("imessage_abc", accounts[0].AccountID)
+	assert.True(accounts[0].Discovered)
+	assert.Empty(accounts[0].User.PhoneNumber)
+}

--- a/internal/beeper/fake_server_test.go
+++ b/internal/beeper/fake_server_test.go
@@ -64,10 +64,25 @@ type fakeChat struct {
 type fakeBeeper struct {
 	t        *testing.T
 	pageSize int
+	// chatPageSize paginates GET /v1/chats/search (0 = one page with
+	// everything, which is what most tests want). When set, chats are served
+	// newest-activity-first like the live API.
+	chatPageSize int
 
-	mu     sync.Mutex
-	chats  []*fakeChat
-	assets map[string][]byte // asset URL (mxc://...) -> bytes served by /v1/assets/serve
+	mu sync.Mutex
+	// accounts is what GET /v1/accounts reports. Beeper omits its native
+	// platform-sdk accounts here even though their chats are served normally,
+	// so tests can register a chat without registering its account.
+	accounts []map[string]any
+	// failAccounts makes GET /v1/accounts answer 401, the way a stale token
+	// is rejected.
+	failAccounts bool
+	// failChatSearch makes GET /v1/chats/search answer 400.
+	failChatSearch bool
+	// failChatGets makes GET /v1/chats/{id} answer 400 for the listed chats.
+	failChatGets map[string]bool
+	chats        []*fakeChat
+	assets       map[string][]byte // asset URL (mxc://...) -> bytes served by /v1/assets/serve
 	// failMessageGets makes GET /v1/chats/{id}/messages/{mid} answer 400
 	// (a non-retryable transient error) for the listed message IDs.
 	failMessageGets map[string]bool
@@ -84,7 +99,8 @@ type fakeBeeper struct {
 
 func newFakeBeeper(t *testing.T) *fakeBeeper {
 	t.Helper()
-	return &fakeBeeper{t: t, pageSize: 20, assets: map[string][]byte{}, failMessageGets: map[string]bool{}, failMessageLists: map[string]bool{}}
+	return &fakeBeeper{t: t, pageSize: 20, assets: map[string][]byte{}, failMessageGets: map[string]bool{},
+		failMessageLists: map[string]bool{}, failChatGets: map[string]bool{}}
 }
 
 // setMessageListFailure toggles a 400 response for message-list fetches of a chat.
@@ -106,6 +122,34 @@ func (f *fakeBeeper) setAsset(url string, data []byte) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.assets[url] = data
+}
+
+// addAccount makes an account visible to GET /v1/accounts.
+func (f *fakeBeeper) addAccount(acct map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.accounts = append(f.accounts, acct)
+}
+
+// setAccountsFailure toggles a 401 response for the accounts endpoint.
+func (f *fakeBeeper) setAccountsFailure(fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failAccounts = fail
+}
+
+// setChatSearchFailure toggles a 400 response for chat searches.
+func (f *fakeBeeper) setChatSearchFailure(fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failChatSearch = fail
+}
+
+// setChatGetFailure toggles a 400 response for chat-detail fetches of a chat.
+func (f *fakeBeeper) setChatGetFailure(chatID string, fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failChatGets[chatID] = fail
 }
 
 func (f *fakeBeeper) addChat(ch *fakeChat) {
@@ -167,6 +211,8 @@ func (f *fakeBeeper) server() *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		path := r.URL.Path
 		switch {
+		case path == "/v1/accounts":
+			f.writeAccounts(w)
 		case path == "/v1/assets/serve":
 			f.writeAsset(w, r)
 		case path == "/v1/chats/search":
@@ -201,9 +247,27 @@ func (f *fakeBeeper) writeAsset(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(data)
 }
 
+func (f *fakeBeeper) writeAccounts(w http.ResponseWriter) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failAccounts {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+	accounts := f.accounts
+	if accounts == nil {
+		accounts = []map[string]any{}
+	}
+	writeJSON(f.t, w, accounts)
+}
+
 func (f *fakeBeeper) writeChatSearch(w http.ResponseWriter, r *http.Request) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.failChatSearch {
+		http.Error(w, `{"error":"transient"}`, http.StatusBadRequest)
+		return
+	}
 	q := r.URL.Query()
 	accountID := q.Get("accountIDs")
 	var after time.Time
@@ -215,7 +279,7 @@ func (f *fakeBeeper) writeChatSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		after = t
 	}
-	items := []map[string]any{}
+	var matched []*fakeChat
 	for _, ch := range f.chats {
 		if accountID != "" && ch.AccountID != accountID {
 			continue
@@ -223,16 +287,42 @@ func (f *fakeBeeper) writeChatSearch(w http.ResponseWriter, r *http.Request) {
 		if !after.IsZero() && !ch.LastActivity.After(after) {
 			continue
 		}
+		matched = append(matched, ch)
+	}
+
+	// Unpaginated by default: one page with everything, as most tests expect.
+	// With chatPageSize set, mirror the live API's newest-activity-first order
+	// and hand out an opaque cursor (here: the offset of the next page).
+	window, oldestCursor, hasMore := matched, any(nil), false
+	if f.chatPageSize > 0 {
+		sort.SliceStable(matched, func(i, j int) bool {
+			return matched[i].LastActivity.After(matched[j].LastActivity)
+		})
+		start, _ := strconv.Atoi(q.Get("cursor"))
+		start = min(max(start, 0), len(matched))
+		end := min(start+f.chatPageSize, len(matched))
+		window = matched[start:end]
+		if end < len(matched) {
+			oldestCursor, hasMore = strconv.Itoa(end), true
+		}
+	}
+
+	items := []map[string]any{}
+	for _, ch := range window {
 		items = append(items, f.chatJSON(ch, true))
 	}
 	writeJSON(f.t, w, map[string]any{
-		"items": items, "hasMore": false, "oldestCursor": nil, "newestCursor": nil,
+		"items": items, "hasMore": hasMore, "oldestCursor": oldestCursor, "newestCursor": nil,
 	})
 }
 
 func (f *fakeBeeper) writeChat(w http.ResponseWriter, chatID string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.failChatGets[chatID] {
+		http.Error(w, `{"error":"transient"}`, http.StatusBadRequest)
+		return
+	}
 	for _, ch := range f.chats {
 		if ch.ID == chatID {
 			writeJSON(f.t, w, f.chatJSON(ch, false))

--- a/internal/beeper/types.go
+++ b/internal/beeper/types.go
@@ -12,6 +12,10 @@ type Account struct {
 	AccountID string `json:"accountID"`
 	Network   string `json:"network"` // human-friendly name; may be empty
 	User      User   `json:"user"`
+	// Discovered marks an account assembled from chat data because the
+	// accounts endpoint did not report it (see DiscoverAccounts). It is never
+	// decoded from the API.
+	Discovered bool `json:"-"`
 }
 
 // User identifies a person on a network. Only fields the importer consumes


### PR DESCRIPTION
## What changed

- discover Beeper accounts by unioning `GET /v1/accounts` with the distinct account IDs seen in a bounded, unfiltered chat search, synthesising an account for each ID the endpoint did not report
- resolve a synthesised account's network name and own identity from chat data, merging the `isSelf` member's identity fields across a few of its chats
- point `add-beeper` at the new discovery and mark such sources as *found via chats* in its output
- correct help text and docs that described Beeper as bridging every network

## Root cause

Beeper Desktop serves some networks natively rather than through a Matrix bridge and leaves those accounts out of its accounts endpoint — `GET /v1/accounts/{id}` answers 404 for them too — while `/v1/chats/search`, `/v1/chats/{id}`, `/v1/chats/{id}/messages` and `/v1/messages/search` all serve them normally. `add-beeper` enumerated only that endpoint, so no source was ever created for such a network and nothing downstream ran for it. iMessage is the case that matters today. Details and endpoint-by-endpoint evidence in #543.

Nothing keys off a network name or an ID prefix: the defect is "absent from `/v1/accounts`", so any account Beeper adds under the same mechanism is picked up too, and if a later release starts listing these accounts they are found in the endpoint's own result and the sweep skips them.

## Impact

Re-running `msgvault add-beeper` on an existing install registers the missing networks and leaves existing sources untouched; `sync-beeper` then backfills and syncs them incrementally with the same cursors, anchors, resume behaviour and `[beeper]` include/exclude filtering as every other Beeper source, keeping `message_type = beeper` with the network carried by the source. No configuration or schema changes are required.

The sweep is bounded at five pages and runs only where sources are created, never on the sync path or in the token pre-flight. It is additive: a failed chat search still registers whatever the accounts endpoint returned, and both early exits are logged so a stopped sweep is distinguishable from a network that genuinely has no chats. Beeper carries iMessage on macOS only, so the daemon still has to run beside a Mac running Beeper Desktop.

Two things I left alone deliberately: only one identifier is persisted for a discovered account, matching what `add-account` and `add-imap` do — collecting several and writing them all is a worthwhile follow-up but is not specific to this change; and attachment handling is shared code with no network-conditional branches, so media should behave identically here, though I have not verified an iMessage attachment end to end.

Closes #543
