### PR TITLE
docs: describe msgvault as an email, chat, and meeting archive

### DIFF
--- a/cmd/msgvault/cmd/initdb.go
+++ b/cmd/msgvault/cmd/initdb.go
@@ -13,7 +13,7 @@ var initDBCmd = &cobra.Command{
 	Short: "Initialize the database schema",
 	Long: `Initialize the msgvault database with the required schema.
 
-This command creates all necessary tables for storing emails, attachments,
+This command creates all necessary tables for storing messages, attachments,
 labels, and sync state. It is safe to run multiple times - tables are only
 created if they don't already exist.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/msgvault/cmd/list_accounts.go
+++ b/cmd/msgvault/cmd/list_accounts.go
@@ -16,13 +16,14 @@ var listAccountsJSON bool
 
 var listAccountsCmd = &cobra.Command{
 	Use:   "list-accounts",
-	Short: "List synced email accounts",
-	Long: `List all email accounts that have been added to msgvault.
+	Short: "List synced accounts",
+	Long: `List all accounts that have been added to msgvault, across email,
+chat, and meeting sources.
 
 Uses configured remote server or the local daemon by default.
 Use --local to use the local daemon even when a remote is configured.
 
-Shows account email, message count, and last sync time.
+Shows the account identifier, source type, message count, and last sync time.
 
 Examples:
 	msgvault list-accounts

--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -25,7 +25,7 @@ var mcpCmd = &cobra.Command{
 	Short: "Run MCP server for Claude Desktop integration",
 	Long: `Start an MCP (Model Context Protocol) server over stdio.
 
-This allows Claude Desktop (or any MCP client) to query your email archive
+This allows Claude Desktop (or any MCP client) to query your archive
 using tools like search_metadata, search_message_bodies, semantic_search_messages, get_message, list_messages, get_stats,
 aggregate, and stage_deletion.
 

--- a/cmd/msgvault/cmd/quickstart.md
+++ b/cmd/msgvault/cmd/quickstart.md
@@ -1,9 +1,9 @@
 # msgvault Agent Quickstart
 
-You have access to `msgvault`, an offline Gmail archive tool. The user's email
-archive is stored locally in a SQLite database with Parquet-based analytics.
-Use the commands below to help the user set up, sync, explore, search, and
-manage their email archive.
+You have access to `msgvault`, an offline email, chat, and meeting archive
+tool. The user's archive is stored locally in a SQLite database with
+Parquet-based analytics. Use the commands below to help the user set up, sync,
+explore, search, and manage their archive.
 
 All data is stored in `~/.msgvault/` by default (override with `MSGVAULT_HOME`).
 

--- a/cmd/msgvault/cmd/root.go
+++ b/cmd/msgvault/cmd/root.go
@@ -43,9 +43,9 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "msgvault",
-	Short: "Offline email archive tool",
-	Long: `msgvault is an offline email archive tool that exports and stores
-email data locally with full-text search capabilities.
+	Short: "Offline email, chat, and meeting archive tool",
+	Long: `msgvault is an offline archive tool that exports and stores email,
+chat, and meeting data locally with full-text search capabilities.
 
 This is the Go implementation providing sync, search, and TUI functionality
 in a single binary.`,

--- a/cmd/msgvault/cmd/root_test.go
+++ b/cmd/msgvault/cmd/root_test.go
@@ -94,7 +94,7 @@ func TestWrapOAuthError_NestedNotExist(t *testing.T) {
 func newTestRootCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "msgvault",
-		Short: "Offline email archive tool",
+		Short: "Offline email, chat, and meeting archive tool",
 	}
 }
 

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -28,7 +28,8 @@ var (
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search messages using Gmail-like query syntax",
-	Long: `Search your email archive using Gmail-like query syntax.
+	Long: `Search your archive using Gmail-like query syntax. Email, chat, and
+meeting records are all searchable; use message_type: to narrow to one of them.
 
 Uses the configured remote server when [remote].url is set; otherwise uses
 the local daemon for FTS search. Use --local to use the local daemon even

--- a/cmd/msgvault/cmd/stats.go
+++ b/cmd/msgvault/cmd/stats.go
@@ -16,7 +16,7 @@ var (
 var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Show database statistics",
-	Long: `Show statistics about the email archive.
+	Long: `Show statistics about the archive.
 
 Uses configured remote server or the local daemon by default.
 Use --local to use the local daemon even when a remote is configured.`,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -151,7 +151,7 @@ func newMCPServer(opts ServeOptions) *server.MCPServer {
 	return s
 }
 
-// Serve creates an MCP server with email archive tools and serves over stdio.
+// Serve creates an MCP server with archive tools and serves over stdio.
 // It blocks until stdin is closed or the context is cancelled.
 // dataDir is the base data directory (e.g., ~/.msgvault) used for deletions.
 //
@@ -571,7 +571,7 @@ func aggregateTool() mcp.Tool {
 
 func searchByDomainsTool() mcp.Tool {
 	return mcp.NewTool(ToolSearchByDomains,
-		mcp.WithDescription("Find emails where any participant (from, to, or cc) belongs to one of the given domains. Useful for finding all communication with a company regardless of direction."),
+		mcp.WithDescription("Find messages where any participant (from, to, or cc) belongs to one of the given domains. Useful for finding all communication with a company regardless of direction."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("domains",
 			mcp.Required(),

--- a/skills/claude-code/SKILL.md
+++ b/skills/claude-code/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: msgvault-query
-description: "Query msgvault email archive analytics via SQL views. Use when: querying email history, analyzing senders/domains/labels, thread analysis, attachment stats, messages per month, sender graphs, domain breakdowns, email analytics. Triggers on: msgvault, email archive, email search, email analytics, sender analysis, domain analysis."
+description: "Query msgvault archive analytics via SQL views. Use when: querying email, chat, or meeting history, analyzing senders/domains/labels, thread analysis, attachment stats, messages per month, sender graphs, domain breakdowns, message analytics. Triggers on: msgvault, message archive, email archive, chat archive, message search, email search, message analytics, sender analysis, domain analysis."
 triggers:
   - msgvault
+  - message archive
   - email archive
+  - chat archive
+  - message search
   - email search
-  - email analytics
+  - message analytics
   - sender analysis
   - domain analysis
 ---
 
 # msgvault-query
 
-Run SQL against the msgvault email archive via `msgvault query`. The analytics cache is DuckDB over Parquet — queries run in milliseconds. No DuckDB binary or Parquet path knowledge required.
+Run SQL against the msgvault archive via `msgvault query`. The analytics cache is DuckDB over Parquet — queries run in milliseconds. No DuckDB binary or Parquet path knowledge required.
 
 The analytics cache is built automatically when stale or missing.
 


### PR DESCRIPTION
## What changed

- reword the root command's short and long help to describe an email, chat, and meeting archive rather than an email archive
- drop the email qualifier from `search`, `stats`, `mcp`, and `init-db` help, and note in `search` that `message_type:` narrows to one kind of record
- correct `list-accounts`, which enumerates every registered source but announced itself as listing email accounts and described its output as showing "account email"
- reword the MCP `search_by_domains` tool description and the `Serve` doc comment, which told MCP clients the tool finds emails
- update the embedded agent quickstart and the bundled Claude Code skill, and add message/chat trigger phrases alongside the existing email ones

## Why

msgvault archives Gmail, IMAP, Google Calendar, Microsoft Teams, Discord, Slack, Beeper, Granola, and Circleback, plus offline imports from PST, MBOX, Apple Mail, and several chat and text export formats. The shipped copy still described it as an email-only tool. The docs site already says "email, chat, and meeting archive"; this brings `--help`, the MCP tool descriptions, and the agent-facing copy in line with it.

`list-accounts` was the one worth calling out. It lists all sources, so a user who ran it after `add-beeper` was told they were reading a list of email accounts.

The MCP and skill changes matter beyond presentation: an agent choosing tools reads those descriptions, and a tool that says it finds emails is one an agent will skip when asked about a chat.

## Scope

This changes CLI, MCP, and agent-facing copy only. The `docs/` tree carries the same email-only phrasing in a couple of places and is deliberately left for a separate change.

Several commands that mention email are correct as written and are untouched: `serve`'s "syncs email accounts on schedule" reflects the `[[accounts]]` cron schedule genuinely not covering chat sources; `repair-dates` filters on `message_type = 'email'`; `setup`'s "Sync your emails" sits inside a Gmail walkthrough; and `list-labels` is about Gmail labels.

No behavior, flags, output data, or API responses change. Text only.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)