### PR TITLE
Add loose-only attachment storage mode

### DIFF
--- a/cmd/msgvault/cmd/attachment_maintenance.go
+++ b/cmd/msgvault/cmd/attachment_maintenance.go
@@ -25,17 +25,19 @@ const (
 // callers already hold the daemon operation gate; these methods must not try
 // to acquire it again.
 type attachmentMaintenance struct {
-	store       *store.Store
-	maintainer  *packstore.Maintainer
-	coordinator *packstore.Coordinator
-	blob        *attachmentstore.Store
-	logger      *slog.Logger
+	store               *store.Store
+	maintainer          *packstore.Maintainer
+	coordinator         *packstore.Coordinator
+	blob                *attachmentstore.Store
+	logger              *slog.Logger
+	packCreationEnabled bool
 }
 
 func newAttachmentMaintenance(
 	s *store.Store,
 	attachmentsDir string,
 	logger *slog.Logger,
+	packCreationEnabled bool,
 ) (*attachmentMaintenance, error) {
 	layout, err := packstore.NewLayout(attachmentsDir, packstore.LayoutOptions{
 		Staging: packstore.StagingSameDirectory,
@@ -51,11 +53,12 @@ func newAttachmentMaintenance(
 		return nil, fmt.Errorf("create attachment maintainer: %w", err)
 	}
 	return &attachmentMaintenance{
-		store:       s,
-		maintainer:  maintainer,
-		coordinator: coordinator,
-		blob:        attachmentstore.Wrap(maintainer.Store()),
-		logger:      logger,
+		store:               s,
+		maintainer:          maintainer,
+		coordinator:         coordinator,
+		blob:                attachmentstore.Wrap(maintainer.Store()),
+		logger:              logger,
+		packCreationEnabled: packCreationEnabled,
 	}, nil
 }
 
@@ -71,6 +74,11 @@ func (m *attachmentMaintenance) close() error {
 
 // pack performs one packer pass with the requested soft raw-byte budget.
 func (m *attachmentMaintenance) pack(ctx context.Context, maxBytes int64) (packstore.PackStats, error) {
+	if !m.packCreationEnabled {
+		return packstore.PackStats{}, errors.New(
+			"attachment pack creation is disabled by [data].loose_attachments",
+		)
+	}
 	stats, err := m.maintainer.Pack(ctx, packstore.PackOptions{MaxBytes: maxBytes})
 	if err != nil {
 		return stats, fmt.Errorf("pack attachments: %w", err)
@@ -81,6 +89,11 @@ func (m *attachmentMaintenance) pack(ctx context.Context, maxBytes int64) (packs
 // repack performs one physical-GC pass through the daemon's shared blob-store
 // cache with the requested soft live-raw-byte budget.
 func (m *attachmentMaintenance) repack(ctx context.Context, maxBytes int64) (packstore.RepackStats, error) {
+	if !m.packCreationEnabled {
+		return packstore.RepackStats{}, errors.New(
+			"attachment pack creation is disabled by [data].loose_attachments",
+		)
+	}
 	stats, err := m.maintainer.Repack(ctx, packstore.RepackOptions{MaxBytes: maxBytes})
 	if err != nil {
 		return stats, fmt.Errorf("repack attachments: %w", err)
@@ -100,6 +113,10 @@ func (m *attachmentMaintenance) unpack(ctx context.Context) (packstore.UnpackSta
 // visible to schedulers, while callers following a successful ingest can log
 // or stream the warning and deliberately preserve the ingest result.
 func (m *attachmentMaintenance) runAutomaticPack(ctx context.Context, emitWarning func(string) error) error {
+	if !m.packCreationEnabled {
+		m.log().Debug("automatic attachment packing disabled")
+		return nil
+	}
 	stats, err := m.pack(ctx, automaticAttachmentBytes)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -148,6 +165,10 @@ func (m *attachmentMaintenance) logAutomaticPackSummary(message string, stats pa
 }
 
 func (m *attachmentMaintenance) runAutomaticRepack(ctx context.Context, emitWarning func(string) error) error {
+	if !m.packCreationEnabled {
+		m.log().Debug("automatic attachment repacking disabled")
+		return nil
+	}
 	stats, err := m.repack(ctx, automaticAttachmentBytes)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/cmd/msgvault/cmd/attachment_maintenance_bench_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_bench_test.go
@@ -42,7 +42,7 @@ func newAttachmentMaintenanceBenchmark(b *testing.B) *attachmentMaintenanceBench
 	})
 	require.NoError(b, err)
 	dir := filepath.Join(root, "attachments")
-	maintenance, err := newAttachmentMaintenance(s, dir, nil)
+	maintenance, err := newAttachmentMaintenance(s, dir, nil, true)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, maintenance.close())

--- a/cmd/msgvault/cmd/attachment_maintenance_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_test.go
@@ -194,22 +194,24 @@ func TestAutomaticAttachmentMaintenancePacksBoundedAndLogsCompleteStats(t *testi
 }
 
 func TestLooseAttachmentModeSkipsAutomaticPackingAndRejectsPackCreation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	f := newAttachmentMaintenanceFixture(t)
 	f.maintenance.packCreationEnabled = false
 	hash := f.addLoose([]byte("remain loose when attachment packing is disabled"))
 
 	err := f.maintenance.runAutomaticPack(context.Background(), nil)
-	require.NoError(t, err)
-	assert.Nil(t, f.packedEntry(hash))
-	assert.Contains(t, f.logs.String(), "automatic attachment packing disabled")
+	require.NoError(err)
+	assert.Nil(f.packedEntry(hash))
+	assert.Contains(f.logs.String(), "automatic attachment packing disabled")
 
 	_, err = f.maintenance.pack(context.Background(), 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "[data].loose_attachments")
+	require.Error(err)
+	assert.Contains(err.Error(), "[data].loose_attachments")
 
 	_, err = f.maintenance.repack(context.Background(), 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "[data].loose_attachments")
+	require.Error(err)
+	assert.Contains(err.Error(), "[data].loose_attachments")
 }
 
 func TestAutomaticAttachmentMaintenanceCancellationIsInformational(t *testing.T) {

--- a/cmd/msgvault/cmd/attachment_maintenance_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_test.go
@@ -43,7 +43,7 @@ func newAttachmentMaintenanceFixture(t *testing.T) *attachmentMaintenanceFixture
 	dir := t.TempDir()
 	logs := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	maintenance, err := newAttachmentMaintenance(storeFixture.Store, dir, logger)
+	maintenance, err := newAttachmentMaintenance(storeFixture.Store, dir, logger, true)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, maintenance.close(), "close attachment maintenance") })
 	return &attachmentMaintenanceFixture{
@@ -63,7 +63,7 @@ func newFailingAttachmentMaintenance(t *testing.T) (*attachmentMaintenance, *byt
 	attachmentsPath := filepath.Join(t.TempDir(), "attachments")
 	logs := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	maintenance, err := newAttachmentMaintenance(storeFixture.Store, attachmentsPath, logger)
+	maintenance, err := newAttachmentMaintenance(storeFixture.Store, attachmentsPath, logger, true)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, maintenance.close(), "close attachment maintenance") })
 	require.NoError(t, storeFixture.Store.Close(), "close catalog to inject maintenance failure")
@@ -191,6 +191,25 @@ func TestAutomaticAttachmentMaintenancePacksBoundedAndLogsCompleteStats(t *testi
 	} {
 		assert.Contains(logOutput, field, "complete stats field %q", field)
 	}
+}
+
+func TestLooseAttachmentModeSkipsAutomaticPackingAndRejectsPackCreation(t *testing.T) {
+	f := newAttachmentMaintenanceFixture(t)
+	f.maintenance.packCreationEnabled = false
+	hash := f.addLoose([]byte("remain loose when attachment packing is disabled"))
+
+	err := f.maintenance.runAutomaticPack(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, f.packedEntry(hash))
+	assert.Contains(t, f.logs.String(), "automatic attachment packing disabled")
+
+	_, err = f.maintenance.pack(context.Background(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "[data].loose_attachments")
+
+	_, err = f.maintenance.repack(context.Background(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "[data].loose_attachments")
 }
 
 func TestAutomaticAttachmentMaintenanceCancellationIsInformational(t *testing.T) {

--- a/cmd/msgvault/cmd/backup.go
+++ b/cmd/msgvault/cmd/backup.go
@@ -249,6 +249,7 @@ func runBackupRestore(cmd *cobra.Command, args []string) error {
 	}
 	renderer := newBackupProgressRenderer(cmd.OutOrStdout(), progressModeAuto)
 	defer renderer.finish()
+	looseAttachments := backupRestoreLooseAttachments || cfg.Data.LooseAttachments
 	res, err := backup.Restore(cmd.Context(), r, backupapp.New(Version), backup.RestoreOptions{
 		SnapshotID:         snapshotID,
 		TargetDir:          backupRestoreTarget,
@@ -257,13 +258,13 @@ func runBackupRestore(cmd *cobra.Command, args []string) error {
 		ForceUnlock:        backupRestoreForceUnlock,
 		SkipIntegrityCheck: !backupRestoreIntegrityCheck,
 		Progress:           renderer.handle,
-		PackedContent:      backupRestorePackedContentTarget(backupRestoreLooseAttachments),
+		PackedContent:      backupRestorePackedContentTarget(looseAttachments),
 		TargetCoordinator:  targetCoordinatorOption,
 	})
 	if err != nil {
 		return fmt.Errorf("restoring snapshot: %w", err)
 	}
-	return printBackupRestoreSummary(cmd.OutOrStdout(), backupRestoreTarget, res, backupRestoreLooseAttachments)
+	return printBackupRestoreSummary(cmd.OutOrStdout(), backupRestoreTarget, res, looseAttachments)
 }
 
 func backupRestorePackedContentTarget(loose bool) backup.PackedContentTarget {
@@ -522,7 +523,7 @@ func (l *daemonRestoreTargetLease) Release() error {
 	return errors.Join(writeErr, daemonErr)
 }
 
-func printBackupRestoreSummary(w io.Writer, target string, res *backup.RestoreResult, explicitLoose bool) error {
+func printBackupRestoreSummary(w io.Writer, target string, res *backup.RestoreResult, looseOnly bool) error {
 	if res == nil {
 		return errors.New("backup restore result is nil")
 	}
@@ -550,9 +551,9 @@ func printBackupRestoreSummary(w io.Writer, target string, res *backup.RestoreRe
 		lines = append(lines, "Pack fallbacks: "+strings.Join(parts, ", ")+"\n")
 	}
 	if res.LooseAttachmentBlobs > 0 {
-		if explicitLoose {
+		if looseOnly {
 			lines = append(lines,
-				"Pack metadata cleared: attachments were restored as loose files by request; 'msgvault pack-attachments' will pack eligible blobs\n")
+				"Pack metadata cleared: attachments were restored as loose files\n")
 		} else {
 			lines = append(lines, fmt.Sprintf(
 				"%d attachment blob(s) remain loose; 'msgvault pack-attachments' can pack eligible blobs later\n",

--- a/cmd/msgvault/cmd/backup_test.go
+++ b/cmd/msgvault/cmd/backup_test.go
@@ -544,8 +544,8 @@ func TestPrintBackupRestoreSummaryReportsPackedMixedAndLooseLayouts(t *testing.T
 			looseFlag: true,
 			result: backup.RestoreResult{SnapshotID: "snap", DBPath: "/target/msgvault.db",
 				AttachmentBlobs: 3, AttachmentBytes: 30, LooseAttachmentBlobs: 3},
-			contains: []string{"0 packed in 0 pack(s), 3 loose", "restored as loose files by request",
-				"msgvault pack-attachments"},
+			contains:    []string{"0 packed in 0 pack(s), 3 loose", "restored as loose files"},
+			notContains: []string{"msgvault pack-attachments"},
 		},
 		{
 			name: "whole pack fallback",

--- a/cmd/msgvault/cmd/pack_attachments.go
+++ b/cmd/msgvault/cmd/pack_attachments.go
@@ -39,7 +39,9 @@ func runPackAttachmentsLocal(cmd *cobra.Command) error {
 	}
 	defer cleanup()
 
-	maintenance, err := newAttachmentMaintenance(s, cfg.AttachmentsDir(), nil)
+	maintenance, err := newAttachmentMaintenance(
+		s, cfg.AttachmentsDir(), nil, !cfg.Data.LooseAttachments,
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -314,7 +314,7 @@ func TestRemoveAccountCmd_DeletesUniquePackedMappings(t *testing.T) {
 	require.NoError(err)
 	seedAttachmentFile(t, attachmentsDir, storagePath, string(content))
 	seedAttachmentFile(t, attachmentsDir, thumbnailPath, string(thumbnail))
-	maintenance, err := newAttachmentMaintenance(s, attachmentsDir, nil)
+	maintenance, err := newAttachmentMaintenance(s, attachmentsDir, nil, true)
 	require.NoError(err)
 	packed, err := maintenance.pack(context.Background(), 0)
 	require.NoError(err)

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -229,7 +229,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	operationGate := api.NewSerialOperationGate()
 	// Closed on shutdown so cached pack readers don't hold attachment pack
 	// files open past the daemon's lifetime (blocks deletion on Windows).
-	attachmentMaint, err := newAttachmentMaintenance(s, cfg.AttachmentsDir(), logger)
+	attachmentMaint, err := newAttachmentMaintenance(
+		s, cfg.AttachmentsDir(), logger, !cfg.Data.LooseAttachments,
+	)
 	if err != nil {
 		return fmt.Errorf("open attachment maintenance: %w", err)
 	}

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -768,6 +768,24 @@ func TestStoreAPIAdapterInterceptsExplicitRepackInDaemonParent(t *testing.T) {
 	assert.Contains(events[0].Data, "removed 1 old pack(s)")
 }
 
+func TestStoreAPIAdapterRejectsExplicitRepackInLooseAttachmentMode(t *testing.T) {
+	f := newAttachmentMaintenanceFixture(t)
+	f.maintenance.packCreationEnabled = false
+	adapter := &storeAPIAdapter{store: f.store, attachmentMaintenance: f.maintenance}
+
+	err := adapter.runCLICommandWithRunner(
+		context.Background(), api.CLIRunRequest{Args: []string{"repack-attachments"}},
+		nil,
+		func(context.Context, []string, map[string]string, string, func(string, string) error) error {
+			require.FailNow(t, "disabled repack must never spawn a child process")
+			return nil
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "[data].loose_attachments")
+}
+
 func TestStoreAPIAdapterExplicitRepackAcceptsLoggingPassthroughFlags(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cmd/msgvault/cmd/unpack_attachments.go
+++ b/cmd/msgvault/cmd/unpack_attachments.go
@@ -77,7 +77,7 @@ func runUnpackAttachmentsLocal(cmd *cobra.Command) (runErr error) {
 	}
 	defer cleanup()
 
-	maintenance, err := newAttachmentMaintenance(s, cfg.AttachmentsDir(), nil)
+	maintenance, err := newAttachmentMaintenance(s, cfg.AttachmentsDir(), nil, false)
 	if err != nil {
 		return err
 	}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -966,6 +966,9 @@ rerun as new loose content arrives. Bounded packing also runs after successful
 attachment-producing operations and during scheduled maintenance; this command
 processes the complete eligible backlog immediately.
 
+With `[data].loose_attachments = true`, automatic packing is disabled and this
+command refuses to run.
+
 ---
 
 ## repack-attachments
@@ -979,6 +982,8 @@ msgvault repack-attachments
 Repack always runs through the selected daemon so it can atomically replace
 live blob mappings, retire shared readers, and remove old pack files. It is
 safe to retry after interruption or a Windows file-sharing error.
+It refuses to run when `[data].loose_attachments = true` because repacking
+creates replacement pack files.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,8 +153,14 @@ client_secrets = 'C:\Users\you\Downloads\client_secret.json'
 |---|---|---|
 | `data_dir` | `~/.msgvault` | Base directory for all data |
 | `database_url` | `{data_dir}/msgvault.db` | SQLite database path or PostgreSQL DSN |
+| `loose_attachments` | `false` | Keep attachments as loose files and reject pack/repack commands instead of creating immutable packs |
 
 Attachments and OAuth tokens are stored in subdirectories of `data_dir` (`attachments/` and `tokens/` respectively). These paths are not independently configurable.
+
+Setting `loose_attachments = true` prevents new pack files but does not
+convert existing packs. Stop the daemon and run `msgvault unpack-attachments`
+once to materialize their contents as loose files. Backup restore also restores
+attachments loose while this setting is enabled.
 
 ### `[oauth]`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -375,8 +375,9 @@ type LogConfig struct {
 
 // DataConfig holds data storage configuration.
 type DataConfig struct {
-	DataDir     string `toml:"data_dir"`
-	DatabaseURL string `toml:"database_url"`
+	DataDir          string `toml:"data_dir"`
+	DatabaseURL      string `toml:"database_url"`
+	LooseAttachments bool   `toml:"loose_attachments"`
 }
 
 // OAuthApp holds configuration for a named OAuth application.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1051,16 +1051,17 @@ mcp_enabled = true
 }
 
 func TestNewDefaultConfig(t *testing.T) {
+	assert := assert.New(t)
 	// Use a temp directory as MSGVAULT_HOME
 	tmpDir := t.TempDir()
 	t.Setenv("MSGVAULT_HOME", tmpDir)
 
 	cfg := NewDefaultConfig()
 
-	assert.Equal(t, tmpDir, cfg.HomeDir)
-	assert.Equal(t, tmpDir, cfg.Data.DataDir)
-	assert.False(t, cfg.Data.LooseAttachments)
-	assert.Equal(t, 5, cfg.Sync.RateLimitQPS)
+	assert.Equal(tmpDir, cfg.HomeDir)
+	assert.Equal(tmpDir, cfg.Data.DataDir)
+	assert.False(cfg.Data.LooseAttachments)
+	assert.Equal(5, cfg.Sync.RateLimitQPS)
 }
 
 func TestDataLooseAttachmentsConfig(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1059,7 +1059,17 @@ func TestNewDefaultConfig(t *testing.T) {
 
 	assert.Equal(t, tmpDir, cfg.HomeDir)
 	assert.Equal(t, tmpDir, cfg.Data.DataDir)
+	assert.False(t, cfg.Data.LooseAttachments)
 	assert.Equal(t, 5, cfg.Sync.RateLimitQPS)
+}
+
+func TestDataLooseAttachmentsConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("[data]\nloose_attachments = true\n"), 0o600))
+
+	cfg, err := Load(path, "")
+	require.NoError(t, err)
+	assert.True(t, cfg.Data.LooseAttachments)
 }
 
 func TestSaveAndLoad_RoundTrip(t *testing.T) {


### PR DESCRIPTION
Add `[data].loose_attachments` for installations that need attachments to remain as individual files.

My use case is an attachment directory being backed up by file-based backup software. Packing and repacking creates filesystem churn that causes otherwise unchanged attachment data to be backed up again, increasing storage costs with the cloud backup provider. Since most attachments are already compressed, the resulting space savings do not justify that additional backup activity.

When enabled, msgvault skips automatic pack and repack maintenance, rejects explicit `pack-attachments` and `repack-attachments` commands, and restores backup attachments as loose files.

Existing packs are not converted automatically. Operators can stop the daemon and run `msgvault unpack-attachments` once to migrate existing packed content.