### PR TITLE
perf(test): cut PostgreSQL test wall clock by pre-warming schemas and not running the suite twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,10 +526,14 @@ jobs:
       # This lane uses a stock postgres:16 image (no pgvector extension), so it
       # must NOT build the pgvector tag — those tests CREATE EXTENSION "vector"
       # and fail here. pgvector is covered by the dedicated test-pgvector job
-      # against a pgvector/pgvector image. (Run go test directly rather than
-      # `make test-pg`, whose PG_TEST_TAGS include pgvector.)
+      # against a pgvector/pgvector image. That is why this runs test-pg-shipped
+      # (BUILD_TAGS) and not test-pg (PG_TEST_TAGS, which include pgvector).
+      #
+      # The target carries -timeout 20m for the same reason `make test` does:
+      # the heavy DuckDB packages can exceed go test's 10m per-package default
+      # on a contended runner, and this lane is the slowest one there is.
       - name: Test (PostgreSQL)
-        run: go test -tags "fts5 sqlite_vec" ./...
+        run: make test-pg-shipped
 
       - name: Concurrency tests (-count=5)
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,20 @@ See `docs/internal/PG_STATUS.md` for the current implementation state and
 follow-up work.
 
 **Test env**: `MSGVAULT_TEST_DB=postgres://...` runs PostgreSQL-backed
-tests (`make test-pg`). pgvector tests require a PostgreSQL instance
-with the `vector` extension and the `pgvector` build tag.
+tests. pgvector tests require a PostgreSQL instance with the `vector`
+extension and the `pgvector` build tag.
+
+There are two PostgreSQL configurations to cover: the pgvector build
+(`make test-pg`) and the shipped build, which has no pgvector tag
+(`make test-pg-shipped`). Run `make test-pg-both` rather than both of those —
+the tag changes the test binary of only nine packages, so the second full
+run would reprove the first. Fixtures build their schemas in concurrent
+batches (`internal/testutil/pg_warm_pool.go`) rather than one at a time: a
+fixture that finds the buffer empty builds several and the next few claim
+theirs for free. All of that happens inside the claiming fixture's own setup —
+the pool runs no background work, so it can never issue a statement while a
+test body is running. Each schema is still private to its test, still built by
+the same `InitSchema()` path, and still dropped on cleanup.
 
 ## Parquet Analytics
 
@@ -284,7 +296,9 @@ automatically:
 ```bash
 make install-hooks             # Install pre-commit hook via prek
 make test                      # Run tests (SQLite default)
-make test-pg                   # Run PostgreSQL-backed tests with MSGVAULT_TEST_DB set
+make test-pg-both              # Both PostgreSQL configurations, needs MSGVAULT_TEST_DB
+make test-pg                   # PostgreSQL, pgvector build only
+make test-pg-shipped           # PostgreSQL, shipped build only
 make fmt                       # Format code (go fmt)
 make lint                      # Run linter (auto-fix)
 make lint-ci                   # Run linter (CI, no auto-fix)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,17 @@ BUILD_TAGS := fts5 sqlite_vec
 # Omitting sqlite_vec compiles those out and the target gives false confidence.
 PG_TEST_TAGS := fts5 sqlite_vec pgvector
 
+# The only packages that build a different test binary under BUILD_TAGS than
+# under PG_TEST_TAGS. That is not just the packages carrying pgvector-gated
+# files: a package whose own sources are identical still links different code
+# when something in its dependency closure changed, so this is the reverse
+# dependency closure of the tag-sensitive packages, not the tag-sensitive
+# packages themselves. Every package outside this set compiles byte-identically
+# in both configurations, so test-pg-both runs just these in the shipped-build
+# configuration. Verified by `make pg-shipped-only-check`, which re-derives the
+# closure from `go list`.
+PG_SHIPPED_ONLY_PKGS := ./cmd/msgvault ./cmd/msgvault/cmd ./internal/api ./internal/mcp ./internal/scheduler ./internal/vector/chunkmatch ./internal/vector/embed ./internal/vector/hybrid ./internal/vector/pgvector
+
 OPENAPI_ARTIFACTS := api/openapi.yaml pkg/client/openapi.yaml pkg/client/generated
 WEB_INSTALL_STAMP := web/node_modules/.msgvault-install-stamp
 
@@ -36,7 +47,7 @@ DEFAULT_GOLANGCI_LINT_CACHE := $(shell git rev-parse --path-format=absolute --gi
 GOLANGCI_LINT_CACHE ?= $(DEFAULT_GOLANGCI_LINT_CACHE)
 export GOLANGCI_LINT_CACHE
 
-.PHONY: build build-release install clean test test-v test-pg fmt lint lint-ci testify-helper-check tidy openapi api-generate openapi-check api-check web-install web-generate web-check web-test web-test-browser web-e2e web-build web-embed web-assets-check smoke-web-release shootout run-shootout install-hooks bench vcard-registry-check vcard-registry-update docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy help
+.PHONY: build build-release install clean test test-v test-pg test-pg-shipped test-pg-both pg-shipped-only-check require-test-db fmt lint lint-ci testify-helper-check tidy openapi api-generate openapi-check api-check web-install web-generate web-check web-test web-test-browser web-e2e web-build web-embed web-assets-check smoke-web-release shootout run-shootout install-hooks bench vcard-registry-check vcard-registry-update docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy help
 
 # Build the binary (debug)
 build: web-embed
@@ -79,17 +90,90 @@ test:
 test-v:
 	go test -timeout 20m -tags "$(BUILD_TAGS)" -v ./...
 
-# Run tests against PostgreSQL (set MSGVAULT_TEST_DB first).
+# Run tests against PostgreSQL with the pgvector tag (set MSGVAULT_TEST_DB
+# first). Needs a server with the vector extension available.
 # Example: MSGVAULT_TEST_DB=postgres://user:pass@localhost:5432/db make test-pg
 #
-# CI runs the same target under .github/workflows/ci.yml's test-postgres job.
+# CI does not run this target as-is: .github/workflows/ci.yml splits the same
+# ground into test-pgvector (pgvector image, pgvector-tagged packages) and
+# test-postgres (stock image, test-pg-shipped below).
 # See docs/internal/PG_STATUS.md for the supported feature surface.
-test-pg:
+test-pg: require-test-db
+	go test -timeout 20m -tags "$(PG_TEST_TAGS)" ./...
+
+# Run the SHIPPED build's tests against PostgreSQL (set MSGVAULT_TEST_DB first).
+# The released binary is built with BUILD_TAGS and no pgvector, so that build
+# has to be exercised against a PostgreSQL archive too. This is the lane
+# .github/workflows/ci.yml's test-postgres job runs.
+#
+# It is a named target rather than an inline `go test` so its flags match the
+# `test` target exactly. Go's test cache keys on the flags, so any package that
+# never reads MSGVAULT_TEST_DB — the SQLite-only ones — is served from `make
+# test`'s cache instead of being re-run here.
+test-pg-shipped: require-test-db
+	go test -timeout 20m -tags "$(BUILD_TAGS)" ./...
+
+# Both PostgreSQL lanes' coverage in one pass.
+#
+# test-pg and test-pg-shipped differ only in the pgvector build tag, and that
+# tag changes the test binary of just the packages in PG_SHIPPED_ONLY_PKGS. For
+# every other package the two lanes compile a byte-identical test binary and run
+# it against the same server with the same environment, so running both in full
+# repeats roughly 1000s of work per round. This target runs test-pg in full and
+# then only the packages the tag actually changes.
+#
+# Use this instead of running the two lanes back to back. Do NOT run
+# test-pg-shipped's narrow half on its own and call PostgreSQL covered — the
+# equivalence argument depends on the full pgvector lane having run on the same
+# tree. pg-shipped-only-check re-derives the package set and fails if it drifts.
+test-pg-both: require-test-db pg-shipped-only-check
+	go test -timeout 20m -tags "$(PG_TEST_TAGS)" ./...
+	go test -timeout 20m -tags "$(BUILD_TAGS)" $(PG_SHIPPED_ONLY_PKGS)
+
+# Fail if the set of packages whose test binary changes when the pgvector tag is
+# dropped no longer matches PG_SHIPPED_ONLY_PKGS. This is the assumption
+# test-pg-both rests on, so it is checked rather than trusted: a new
+# pgvector-gated file, or a new import of a package that has one, would
+# otherwise silently stop being covered in the shipped-build configuration.
+#
+# Two steps, because a package's own source list is not enough. The first finds
+# the packages the tag changes directly. The second walks the test dependency
+# graph and adds every package that links one of them, since its test binary
+# differs even though its own files do not.
+pg-shipped-only-check:
+	@set -e; \
+	module="$$(go list -m)"; \
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	fmt='{{.ImportPath}}|{{.GoFiles}}|{{.TestGoFiles}}|{{.XTestGoFiles}}|{{.CgoFiles}}'; \
+	go list -deps -test -tags "$(BUILD_TAGS)" -f "$$fmt" ./... | sort > "$$tmp/shipped"; \
+	go list -deps -test -tags "$(PG_TEST_TAGS)" -f "$$fmt" ./... | sort > "$$tmp/pgvector"; \
+	diff "$$tmp/shipped" "$$tmp/pgvector" \
+		| sed -n 's/^[<>] \([^|]*\)|.*/\1/p' \
+		| sed 's/ \[.*//; s/\.test$$//' \
+		| sort -u > "$$tmp/sensitive"; \
+	go list -test -tags "$(BUILD_TAGS)" -f '{{.ImportPath}}|{{join .Deps " "}}' ./... > "$$tmp/deps"; \
+	awk -v mod="$$module" -F'|' 'NR==FNR { sensitive[$$0]=1; next } { \
+		name = $$1; \
+		sub(/ \[.*/, "", name); sub(/\.test$$/, "", name); sub(/_test$$/, "", name); \
+		if (index(name, mod) != 1) next; \
+		hit = (name in sensitive); \
+		if (!hit) { n = split($$2, d, " "); for (i = 1; i <= n && !hit; i++) if (d[i] in sensitive) hit = 1 } \
+		if (hit) print name \
+	}' "$$tmp/sensitive" "$$tmp/deps" \
+		| sed "s|^$$module/|./|; s|^$$module$$|.|" \
+		| sort -u > "$$tmp/actual"; \
+	printf '%s\n' $(PG_SHIPPED_ONLY_PKGS) | sort -u > "$$tmp/expected"; \
+	if ! diff -u "$$tmp/expected" "$$tmp/actual"; then \
+		echo "PG_SHIPPED_ONLY_PKGS is stale ('-' expected, '+' actual). Update it in the Makefile; test-pg-both's coverage argument depends on it." >&2; \
+		exit 1; \
+	fi
+
+require-test-db:
 	@if [ -z "$$MSGVAULT_TEST_DB" ]; then \
 		echo "MSGVAULT_TEST_DB must be set, e.g., postgres://user:pass@localhost:5432/db" >&2; \
 		exit 1; \
 	fi
-	go test -tags "$(PG_TEST_TAGS)" ./...
 
 # Network-check or update the vendored IANA vCard Elements registry. These are
 # manual targets; CI validates handling coverage against the vendored snapshot.

--- a/docs/internal/PG_STATUS.md
+++ b/docs/internal/PG_STATUS.md
@@ -108,9 +108,22 @@ this repo's `docs/` directory unless they are explicitly codebase-internal.
 
 ```bash
 make test
-MSGVAULT_TEST_DB=postgres://user:pass@localhost:5432/msgvault_test make test-pg
+MSGVAULT_TEST_DB=postgres://user:pass@localhost:5432/msgvault_test make test-pg-both
 go test -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
 ```
 
-`make test-pg` requires a live PostgreSQL database. pgvector-tagged tests require
-a PostgreSQL instance with the `vector` extension installed.
+All the `test-pg*` targets require a live PostgreSQL database, and the
+pgvector-tagged ones require the `vector` extension installed.
+
+`test-pg-both` is the one to run. The shipped binary carries no `pgvector` tag,
+so that build has to be exercised against PostgreSQL as well as the pgvector
+build does — but the tag changes the test binary of only nine packages out of
+the full transitive test closure, so running both lanes in full reproves
+roughly a thousand seconds of identical work. `test-pg-both` runs the pgvector
+lane in full and then only the packages that differ, and its
+`pg-shipped-only-check` prerequisite fails if that set ever drifts. That set is
+the reverse dependency closure of the tag-sensitive packages, not just the
+packages carrying pgvector-gated files: a package linking one of those builds a
+different test binary even though its own sources are identical. The
+single-lane targets `test-pg` and `test-pg-shipped` remain for narrowing down a
+failure; neither covers PostgreSQL on its own.

--- a/internal/store/content_changed_at_test.go
+++ b/internal/store/content_changed_at_test.go
@@ -575,12 +575,12 @@ func TestContentChangedAt_InterruptedBackfillResumesWhereItStopped(t *testing.T)
 	// the backfill, and shrink the batch so six rows span several batches.
 	dropContentChangedAtColumn(t, st)
 	clearContentChangedBackfillLedger(t, st)
-	defer store.SetContentChangedBackfillBatchSizeForTest(2)()
+	defer st.SetContentChangedBackfillBatchSizeForTest(2)()
 
 	// Interrupt at the second batch boundary: the first batch has committed and
 	// nothing else has run.
 	batches := 0
-	restoreHook := store.SetContentChangedBackfillBatchHookForTest(func(fromID, toID int64) error {
+	restoreHook := st.SetContentChangedBackfillBatchHookForTest(func(fromID, toID int64) error {
 		batches++
 		if batches == 2 {
 			return errors.New("simulated interruption mid-upgrade")
@@ -668,14 +668,14 @@ func TestContentChangedAt_BackfillStopsWhenTheContextIsCancelled(t *testing.T) {
 
 	dropContentChangedAtColumn(t, st)
 	clearContentChangedBackfillLedger(t, st)
-	defer store.SetContentChangedBackfillBatchSizeForTest(2)()
+	defer st.SetContentChangedBackfillBatchSizeForTest(2)()
 
 	// Cancel at the second batch boundary: one batch has committed and the rest
 	// of the table is still ahead, which is where an operator's Ctrl-C lands.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	batches := 0
-	restoreHook := store.SetContentChangedBackfillBatchHookForTest(func(fromID, toID int64) error {
+	restoreHook := st.SetContentChangedBackfillBatchHookForTest(func(fromID, toID int64) error {
 		batches++
 		if batches == 2 {
 			cancel()
@@ -765,10 +765,10 @@ func seedMessageAtID(t *testing.T, st *store.Store, n int, id int64) int64 {
 // asserted on the count would hang the whole suite instead of failing. The hook
 // aborts the run once the batch count passes what any correct walk could need,
 // turning that into a fast, readable failure.
-func countBackfillBatches(t *testing.T, maxBatches int) *int {
+func countBackfillBatches(t *testing.T, st *store.Store, maxBatches int) *int {
 	t.Helper()
 	batches := 0
-	restore := store.SetContentChangedBackfillBatchHookForTest(func(fromID, toID int64) error {
+	restore := st.SetContentChangedBackfillBatchHookForTest(func(fromID, toID int64) error {
 		batches++
 		if batches > maxBatches {
 			return fmt.Errorf(
@@ -837,7 +837,7 @@ func TestContentChangedAt_BackfillFinishesAtTheEdgesOfTheIDSpace(t *testing.T) {
 	clearContentChangedBackfillLedger(t, st)
 	// Both rows fit in one batch, so anything past a handful of batches is the
 	// walk crawling the id span.
-	batches := countBackfillBatches(t, 4)
+	batches := countBackfillBatches(t, st, 4)
 
 	require.NoError(st.InitSchema(),
 		"the upgrade must finish on an archive holding ids at the edges of the id space")
@@ -871,7 +871,7 @@ func TestContentChangedAt_BackfillSkipsIDRangesWithNoWork(t *testing.T) {
 
 	dropContentChangedAtColumn(t, st)
 	clearContentChangedBackfillLedger(t, st)
-	batches := countBackfillBatches(t, 8)
+	batches := countBackfillBatches(t, st, 8)
 
 	require.NoError(st.InitSchema())
 	assert.Contains(readContentChangedAt(t, st, first), "2020-01-02", "the first row")
@@ -968,7 +968,7 @@ func TestContentChangedAt_MessageInsertedDuringUpgradeIsStamped(t *testing.T) {
 	clearContentChangedBackfillLedger(t, st)
 
 	var concurrent int64
-	restore := store.SetInitSchemaWindowHookForTest(func() {
+	restore := st.SetInitSchemaWindowHookForTest(func() {
 		concurrent = seedMessage(t, st, 2)
 	})
 	defer restore()

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -46,9 +46,13 @@ func SetFTS5AvailableForTest(s *Store, v bool) {
 // Tests use it to deterministically trigger backfillFTSRowByRow's
 // skip-the-bad-row-and-continue fallback. Returns a restore func that clears
 // the hook, so callers can defer it.
-func SetBackfillFTSBatchErrHookForTest(fn func(fromID, toID int64) error) func() {
-	backfillFTSBatchErrHook = fn
-	return func() { backfillFTSBatchErrHook = nil }
+//
+// Scoped to this Store: other Stores migrating concurrently in the same test
+// binary — test fixtures build their schemas in the background — must not see
+// this test's injected failure.
+func (s *Store) SetBackfillFTSBatchErrHookForTest(fn func(fromID, toID int64) error) func() {
+	s.backfillFTSBatchErrHook = fn
+	return func() { s.backfillFTSBatchErrHook = nil }
 }
 
 // SetContentChangedBackfillBatchHookForTest installs (or, with nil, clears) the
@@ -58,19 +62,23 @@ func SetBackfillFTSBatchErrHookForTest(fn func(fromID, toID int64) error) func()
 // between two committed batches; counting the calls is how a test measures the
 // transactions an archive's shape costs. Returns a restore func that clears the
 // hook, so callers can defer it.
-func SetContentChangedBackfillBatchHookForTest(fn func(fromID, toID int64) error) func() {
-	contentChangedBackfillBatchHook = fn
-	return func() { contentChangedBackfillBatchHook = nil }
+//
+// Scoped to this Store; see SetBackfillFTSBatchErrHookForTest.
+func (s *Store) SetContentChangedBackfillBatchHookForTest(fn func(fromID, toID int64) error) func() {
+	s.contentChangedBackfillBatchHook = fn
+	return func() { s.contentChangedBackfillBatchHook = nil }
 }
 
 // SetContentChangedBackfillBatchSizeForTest shrinks how many rows one backfill
 // batch stamps, so a test can span several batches over a handful of rows.
 // Returns a restore func that puts the production value back, so callers can
 // defer it.
-func SetContentChangedBackfillBatchSizeForTest(n int64) func() {
-	prev := contentChangedBackfillBatchSize
-	contentChangedBackfillBatchSize = n
-	return func() { contentChangedBackfillBatchSize = prev }
+//
+// Scoped to this Store; see SetBackfillFTSBatchErrHookForTest.
+func (s *Store) SetContentChangedBackfillBatchSizeForTest(n int64) func() {
+	prev := s.contentChangedBackfillBatchSizeOverride
+	s.contentChangedBackfillBatchSizeOverride = n
+	return func() { s.contentChangedBackfillBatchSizeOverride = prev }
 }
 
 // SetInitSchemaWindowHookForTest installs (or, with nil, clears) the test-only
@@ -78,7 +86,12 @@ func SetContentChangedBackfillBatchSizeForTest(n int64) func() {
 // recorded itself and while the remaining index builds are still pending. Tests
 // use it to perform a real INSERT exactly where a concurrent writer used to lose
 // its watermark. Returns a restore func, so callers can defer it.
-func SetInitSchemaWindowHookForTest(fn func()) func() {
-	initSchemaWindowHook = fn
-	return func() { initSchemaWindowHook = nil }
+//
+// Scoped to this Store; see SetBackfillFTSBatchErrHookForTest. This one is the
+// reason the seams are per-Store at all: it calls back into the installing
+// test's own Store, so a concurrent fixture build firing it would write through
+// a Store the test had already closed.
+func (s *Store) SetInitSchemaWindowHookForTest(fn func()) func() {
+	s.initSchemaWindowHook = fn
+	return func() { s.initSchemaWindowHook = nil }
 }

--- a/internal/store/fts_rowbyrow_fallback_test.go
+++ b/internal/store/fts_rowbyrow_fallback_test.go
@@ -91,7 +91,7 @@ func TestPG_BackfillFTS_RowByRowFallbackSkipsBadRow(t *testing.T) {
 	// range [id, id+1), so only the [badID, badID+1) call errors and is skipped —
 	// every other row (including the ones after badID) indexes normally.
 	buf := captureWarnings(t)
-	restore := store.SetBackfillFTSBatchErrHookForTest(func(fromID, toID int64) error {
+	restore := f.Store.SetBackfillFTSBatchErrHookForTest(func(fromID, toID int64) error {
 		if fromID <= badID && badID < toID {
 			return &pgconn.PgError{
 				Code:    "54000",
@@ -189,7 +189,7 @@ func TestPG_BackfillFTS_NonSizeErrorAborts(t *testing.T) {
 	// Case 1: a plain (non-pg) error must abort.
 	t.Run("plain_error", func(t *testing.T) {
 		sentinel := errors.New("simulated dead connection")
-		restore := store.SetBackfillFTSBatchErrHookForTest(func(fromID, toID int64) error {
+		restore := f.Store.SetBackfillFTSBatchErrHookForTest(func(fromID, toID int64) error {
 			return sentinel
 		})
 		defer restore()
@@ -201,7 +201,7 @@ func TestPG_BackfillFTS_NonSizeErrorAborts(t *testing.T) {
 
 	// Case 2: a different (non-54000) SQLSTATE must also abort.
 	t.Run("other_sqlstate", func(t *testing.T) {
-		restore := store.SetBackfillFTSBatchErrHookForTest(func(fromID, toID int64) error {
+		restore := f.Store.SetBackfillFTSBatchErrHookForTest(func(fromID, toID int64) error {
 			return &pgconn.PgError{Code: "08006", Message: "connection failure (injected)"}
 		})
 		defer restore()

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2441,8 +2441,8 @@ func (s *Store) backfillFTSRowByRowContext(
 // fail for the given id range. It lets tests exercise backfillFTSRowByRow's
 // skip-and-continue fallback deterministically without depending on a body that
 // happens to overflow PostgreSQL's tsvector limit after the LEFT cap. Nil (and
-// thus a no-op) in production; only export_test.go ever sets it.
-var backfillFTSBatchErrHook func(fromID, toID int64) error
+// thus a no-op) in production; only export_test.go ever sets it, and it is
+// per-Store: see the field's declaration on Store.
 
 // backfillFTSBatch inserts FTS rows for messages with id in [fromID, toID).
 //
@@ -2455,8 +2455,8 @@ func (s *Store) backfillFTSBatchContext(
 	ctx context.Context,
 	fromID, toID int64,
 ) (int64, error) {
-	if backfillFTSBatchErrHook != nil {
-		if err := backfillFTSBatchErrHook(fromID, toID); err != nil {
+	if s.backfillFTSBatchErrHook != nil {
+		if err := s.backfillFTSBatchErrHook(fromID, toID); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/store/open_fts_probe_test.go
+++ b/internal/store/open_fts_probe_test.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenReportsFTSAvailableForInitializedSQLiteDB pins an invariant the
+// read-only open paths already hold: a Store knows whether full-text search is
+// available in the database it just opened. Until Open probes for it, a store
+// opened against an already-initialized database reports FTS as unavailable
+// until something calls InitSchema again, and every search it serves silently
+// falls back to the slow path.
+func TestOpenReportsFTSAvailableForInitializedSQLiteDB(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	first, err := Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(first.InitSchema(), "init schema")
+	require.True(first.FTS5Available(), "FTS is available once the schema is initialized")
+	require.NoError(first.Close(), "close store")
+
+	second, err := Open(dbPath)
+	require.NoError(err, "reopen store")
+	t.Cleanup(func() { _ = second.Close() })
+
+	assert.True(second.FTS5Available(), "reopening an initialized database reports FTS as available")
+}
+
+// TestOpenReportsFTSAvailableForInitializedPostgresSchema is the PostgreSQL
+// half of the same invariant: there the FTS column lives in the messages table,
+// so a second Store opened on an initialized schema must see it too.
+func TestOpenReportsFTSAvailableForInitializedPostgresSchema(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := skipUnlessPostgresInternal(t)
+
+	buf := make([]byte, 8)
+	_, err := rand.Read(buf)
+	require.NoError(err, "random schema name")
+	schemaName := "msgvault_test_" + hex.EncodeToString(buf)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	require.NoError(err, "open setup connection")
+	t.Cleanup(func() { _ = adminDB.Close() })
+	_, err = adminDB.Exec("CREATE SCHEMA " + schemaName)
+	require.NoErrorf(err, "create schema %s", schemaName)
+	t.Cleanup(func() { _, _ = adminDB.Exec("DROP SCHEMA IF EXISTS " + schemaName + " CASCADE") })
+
+	separator := "?"
+	if strings.Contains(dbURL, "?") {
+		separator = "&"
+	}
+	schemaURL := dbURL + separator + "search_path=" + schemaName
+
+	first, err := Open(schemaURL)
+	require.NoError(err, "open store")
+	require.NoError(first.InitSchema(), "init schema")
+	require.True(first.FTS5Available(), "FTS is available once the schema is initialized")
+	require.NoError(first.Close(), "close store")
+
+	second, err := Open(schemaURL)
+	require.NoError(err, "reopen store")
+	t.Cleanup(func() { _ = second.Close() })
+
+	assert.True(second.FTS5Available(), "reopening an initialized schema reports FTS as available")
+}

--- a/internal/store/seam_scope_test.go
+++ b/internal/store/seam_scope_test.go
@@ -1,0 +1,46 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// TestInitSchemaWindowHookFiresOnlyForItsOwnStore pins the invariant that makes
+// the test-only migration seams safe to use in a binary where more than one
+// Store migrates at a time.
+//
+// The fixtures in internal/testutil build PostgreSQL schemas on background
+// workers, so an InitSchema can be running on some other Store at any moment
+// while a test has a seam installed. When these seams were package-level
+// variables that was a live defect, not a theoretical one: the window hook
+// writes through the Store that installed it, so a background migration firing
+// it after the installing test returned failed with "sql: database is closed" —
+// and, worse, could have written into a live test's archive.
+func TestInitSchemaWindowHookFiresOnlyForItsOwnStore(t *testing.T) {
+	require := require.New(t)
+	owner := testutil.NewTestStore(t)
+	other := testutil.NewTestStore(t)
+
+	fired := 0
+	restore := owner.SetInitSchemaWindowHookForTest(func() { fired++ })
+	defer restore()
+
+	// Another Store's migration must not see this test's hook.
+	require.NoError(other.InitSchema())
+	require.Zero(fired,
+		"a hook installed on one Store fired during another Store's InitSchema: "+
+			"concurrent fixture builds can now reach into this test's archive")
+
+	// The hook must still fire for the Store that installed it, or the check
+	// above would pass just as well on a seam that never works at all.
+	require.NoError(owner.InitSchema())
+	require.Equal(1, fired,
+		"the hook did not fire on its own Store's InitSchema, so this test proves nothing")
+
+	// And clearing it is scoped the same way.
+	restore()
+	require.NoError(owner.InitSchema())
+	require.Equal(1, fired, "the restore func did not clear the hook")
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -49,6 +49,22 @@ type Store struct {
 	readOnly      bool // Opened via OpenReadOnly; skips WAL checkpoint on close
 	fts5Available bool // Whether FTS5 is available for full-text search
 	closeCleanup  func()
+
+	// Test-only seams into the migration and backfill paths, nil in
+	// production and settable only from export_test.go. They belong to the
+	// Store rather than the package because more than one Store can be
+	// migrating at once inside a single test binary — test fixtures build
+	// their schemas concurrently — and a hook installed by one test must
+	// never fire on another Store's migration. As package-level variables
+	// they were also a data race between a test that installs one and any
+	// concurrent migration that reads it.
+	initSchemaWindowHook            func()
+	contentChangedBackfillBatchHook func(fromID, toID int64) error
+	backfillFTSBatchErrHook         func(fromID, toID int64) error
+
+	// Zero means "use the production batch size"; see
+	// contentChangedBackfillBatch. Per-Store for the same reason.
+	contentChangedBackfillBatchSizeOverride int64
 }
 
 // synchronous=FULL + fullfsync=true protects WAL writes against OS/power crashes
@@ -943,8 +959,7 @@ func (s *Store) SchemaStale() (bool, string, error) {
 // large archive. A row that lands here has to be stamped by the INSERT trigger
 // or it never appears in the change feed at all, which is why the watermark
 // triggers are created before the backfill rather than after the indexes. Nil
-// in production.
-var initSchemaWindowHook func()
+// in production, and per-Store: see the field's declaration.
 
 // InitSchema initializes the database schema, uninterruptibly.
 //
@@ -1395,8 +1410,8 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 		return err
 	}
 
-	if initSchemaWindowHook != nil {
-		initSchemaWindowHook()
+	if s.initSchemaWindowHook != nil {
+		s.initSchemaWindowHook()
 	}
 
 	// Keyset index for the content-change feed, on both backends. Composite
@@ -1532,9 +1547,18 @@ func (s *Store) runOnceMigration(
 // (backfillFTSRangeContext): large enough that the per-transaction overhead
 // disappears against the row work, small enough that one batch's transaction is
 // short and its PostgreSQL dead tuples are reclaimable by autovacuum while the
-// next batches run. A var, not a const, only so a test can shrink it; nothing in
-// production writes it.
-var contentChangedBackfillBatchSize int64 = 5000
+// next batches run. Nothing overrides it in production; a test shrinks it for
+// one Store at a time through the per-Store override, never by writing here.
+const contentChangedBackfillBatchSize int64 = 5000
+
+// contentChangedBackfillBatch is the batch size this Store's backfill uses:
+// the production default unless a test has overridden it for this Store.
+func (s *Store) contentChangedBackfillBatch() int64 {
+	if s.contentChangedBackfillBatchSizeOverride > 0 {
+		return s.contentChangedBackfillBatchSizeOverride
+	}
+	return contentChangedBackfillBatchSize
+}
 
 // contentChangedBackfillBatchHook is a test-only seam: when non-nil it is
 // consulted before each batch with the batch's first and last id (inclusive),
@@ -1542,8 +1566,8 @@ var contentChangedBackfillBatchSize int64 = 5000
 // test interrupt an upgrade exactly between two committed batches — the case
 // that decides whether the backfill is resumable — without racing a real crash,
 // and it lets a test count the transactions an archive's shape costs. Nil (and
-// thus a no-op) in production; only export_test.go ever sets it.
-var contentChangedBackfillBatchHook func(fromID, toID int64) error
+// thus a no-op) in production; only export_test.go ever sets it, and it is
+// per-Store: see the field's declaration.
 
 // backfillContentChangedAt seeds content_changed_at on rows that predate the
 // column, walking the rows that still need it in committed batches.
@@ -1657,7 +1681,7 @@ func (s *Store) backfillContentChangedAt(ctx context.Context) error {
 	}
 	stampSQL = s.dialect.Rebind(stampSQL)
 
-	batchSize := contentChangedBackfillBatchSize
+	batchSize := s.contentChangedBackfillBatch()
 	started := time.Now()
 	lastLog := started
 	var stamped int64
@@ -1683,12 +1707,12 @@ func (s *Store) backfillContentChangedAt(ctx context.Context) error {
 			if count == 0 {
 				return nil
 			}
-			if contentChangedBackfillBatchHook != nil {
+			if s.contentChangedBackfillBatchHook != nil {
 				// Before the stamp, so a test that aborts here aborts a batch
 				// that has written nothing -- the transaction rolls back and
 				// the committed batches before it are what an interrupted
 				// upgrade leaves behind.
-				if err := contentChangedBackfillBatchHook(firstID, lastID); err != nil {
+				if err := s.contentChangedBackfillBatchHook(firstID, lastID); err != nil {
 					return err
 				}
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -155,11 +155,28 @@ func openSQLite(dbPath, params string) (*Store, error) {
 		return nil, fmt.Errorf("init connection: %w", err)
 	}
 
-	return &Store{
+	s := &Store{
 		db:      newLoggedDB(db, dialect.Rebind),
 		dbPath:  dbPath,
 		dialect: dialect,
-	}, nil
+	}
+
+	// Probe like the read-only opens do: a Store must know whether full-text
+	// search is available in the database it just opened. InitSchema re-probes
+	// after creating the FTS objects, so a caller that initializes a fresh
+	// database still gets the right answer; a caller that opens an already
+	// initialized one no longer has to run InitSchema to learn it.
+	//
+	// As in OpenReadOnly, this constructor takes no context, so the probe
+	// cannot be cancelled; its error is still checked rather than dropped.
+	available, err := dialect.FTSAvailable(context.Background(), db)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("probe FTS availability: %w", err)
+	}
+	s.fts5Available = available
+
+	return s, nil
 }
 
 // openPostgres opens a PostgreSQL database using the given connection URL.
@@ -187,12 +204,24 @@ func openPostgres(dbURL string) (*Store, error) {
 		return nil, fmt.Errorf("init PostgreSQL connection: %w", err)
 	}
 
-	return &Store{
+	s := &Store{
 		db:           newLoggedDB(db, dialect.Rebind),
 		dbPath:       dbURL,
 		dialect:      dialect,
 		closeCleanup: cleanup,
-	}, nil
+	}
+
+	// See openSQLite: availability is a property of the database, not of
+	// whether this caller happened to run InitSchema.
+	available, err := dialect.FTSAvailable(context.Background(), db)
+	if err != nil {
+		_ = db.Close()
+		cleanup()
+		return nil, fmt.Errorf("probe FTS availability: %w", err)
+	}
+	s.fts5Available = available
+
+	return s, nil
 }
 
 // OpenReadOnly opens an existing database in read-only mode. Suitable for

--- a/internal/testutil/pg_warm_pool.go
+++ b/internal/testutil/pg_warm_pool.go
@@ -1,0 +1,518 @@
+package testutil
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // Register pgx driver for test setup
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// The PostgreSQL fixture's cost is almost entirely CREATE SCHEMA plus the
+// InitSchema() DDL replay, and that work is round-trip bound rather than CPU
+// bound. This file makes fixtures pay for it in batches instead of one at a
+// time: a fixture that finds the buffer empty builds warmPoolBatch schemas
+// concurrently — barely more wall clock than the one it needed — and the
+// fixtures that follow claim theirs for free. Every fixture still gets a
+// private, never-used schema built by the same InitSchema() code path, and
+// still drops it in t.Cleanup — nothing is shared, reused, or truncated.
+const (
+	// warmSchemaPrefix marks a schema as pool-owned. A full name also carries
+	// the owner token (see warmOwnerToken) and the pid that created it. The
+	// prefix deliberately does not overlap the msgvault_test_ prefix used for
+	// directly created fixtures: the orphan sweep only ever acts on names
+	// carrying this prefix, so a fixture schema — including one belonging to an
+	// unrelated process sharing the server — can never be a candidate.
+	warmSchemaPrefix = "msgvault_warm_"
+
+	// warmOwnerTokenBytes is the width of the owner token in the schema name.
+	warmOwnerTokenBytes = 6
+
+	// warmPoolBatch is how many schemas one refill builds, and therefore how
+	// many connections that refill holds while it runs. It is a host-safety
+	// limit, not a tuning knob, and must never be derived from GOMAXPROCS or
+	// the -p flag. A shared test server offers ~97 usable connections; a refill
+	// holds one per schema it is building, and the shared admin handle adds two
+	// more, so a test binary peaks at roughly six.
+	//
+	// That bound is per test binary. `go test ./...` builds one binary per
+	// package and runs up to -p of them at once, so a wide fan-out against a
+	// small shared server can still exceed its limit in aggregate; there is no
+	// cross-process budget here. warmPoolBatchEnv lowers this side of that
+	// arithmetic, and -p lowers the other. The failure mode is not corruption:
+	// a refill that cannot connect gives up and fixtures create their own
+	// schemas exactly as they did before the pool existed.
+	warmPoolBatch = 4
+
+	// warmPoolDisableEnv set to "0" turns the pool off and sends every fixture
+	// down the direct-creation path. An escape hatch for diagnosing whether the
+	// pool is implicated in a failure.
+	warmPoolDisableEnv = "MSGVAULT_TEST_PG_WARM_POOL"
+
+	// warmPoolBatchEnv narrows the refill for a server with a tighter
+	// connection budget than the arithmetic above assumes. It can only lower
+	// warmPoolBatch: a knob able to raise a safety limit is not a safety limit.
+	warmPoolBatchEnv = "MSGVAULT_TEST_PG_WARM_POOL_BATCH"
+
+	// warmPoolMaxFailures stops refilling after this many consecutive empty
+	// refills, so a server outage does not make every remaining fixture pay for
+	// a failed batch first. Fixtures fall back to direct creation and fail with
+	// the error they would have reported without the pool.
+	warmPoolMaxFailures = 3
+
+	// warmSchemaSuffixBytes is the entropy in a schema's random suffix.
+	warmSchemaSuffixBytes = 8
+)
+
+// warmSchemaNamePattern is the sole gate on what the sweep may consider. It is
+// built from warmSchemaPrefix so the prefix has one definition.
+var warmSchemaNamePattern = regexp.MustCompile(
+	"^" + regexp.QuoteMeta(warmSchemaPrefix) +
+		"([0-9a-f]{" + strconv.Itoa(warmOwnerTokenBytes*2) + "})" +
+		"_p([0-9]{1,10})_([0-9a-f]{" + strconv.Itoa(warmSchemaSuffixBytes*2) + "})$")
+
+// warmOwnerToken names the PID namespace that this process's /proc describes,
+// and warmOwnerUsable reports whether the pool may run at all.
+//
+// A pid is only meaningful relative to a namespace. Two containers sharing one
+// PostgreSQL server each see their own /proc, so a sweeper in one of them can
+// look up a pid belonging to the other, find nothing, and conclude the owner
+// has exited — while that owner is mid-test. A warm schema keeps its name for
+// the whole life of the test that claims it, so the schema being deleted is a
+// live one, and the test loses its tables underneath it.
+//
+// Encoding the namespace in the name closes that off: the sweep skips every
+// candidate whose token is not its own, so it only ever judges liveness for
+// pids its own /proc can resolve. Foreign orphans are left for the namespace
+// that created them to reclaim, which is the trade this sweep should make —
+// a leaked schema costs a name until that binary runs again, and a wrong
+// verdict corrupts a running test.
+var warmOwnerToken, warmOwnerUsable = deriveWarmOwner()
+
+// deriveWarmOwner builds the owner token from the boot id and the pid namespace
+// — the two things that decide whether another process's pid is resolvable
+// through our /proc.
+//
+// It reports false unless both are readable, and that is the point rather than
+// a limitation. The sweep reclaims an orphan by asking /proc whether the process
+// that created it has exited, so a host that cannot answer that question can
+// never reclaim anything this pool leaves behind: every run would strand its
+// buffer permanently. Rather than leak on those hosts, the pool stays off there
+// and fixtures create their own schemas exactly as they always did.
+func deriveWarmOwner() (string, bool) {
+	var bootID []byte
+	if read, err := os.ReadFile("/proc/sys/kernel/random/boot_id"); err == nil {
+		bootID = read
+	}
+	var namespace []byte
+	if link, err := os.Readlink("/proc/self/ns/pid"); err == nil {
+		namespace = []byte(link)
+	}
+
+	return warmOwnerFrom(bootID, namespace)
+}
+
+// warmOwnerFrom hashes the two identifiers into the token that goes in a schema
+// name, reporting false when either is missing.
+//
+// Both are required, and neither is redundant. A boot id is shared by every
+// container on the machine, so on its own it would give two containers the same
+// token and put us straight back to sweeping each other's live schemas. A
+// namespace inode number is shared by every machine that happens to number its
+// namespaces alike — the initial namespace has the same well-known id
+// everywhere — so on its own it would do the same across hosts. Only the pair
+// identifies "a /proc that can resolve these pids".
+//
+// Split out from deriveWarmOwner so the rule is testable without a host that
+// lacks either.
+func warmOwnerFrom(bootID, namespace []byte) (string, bool) {
+	if len(bootID) == 0 || len(namespace) == 0 {
+		return "", false
+	}
+
+	digest := sha256.New()
+	_, _ = digest.Write(bootID)
+	_, _ = digest.Write(namespace)
+
+	return hex.EncodeToString(digest.Sum(nil)[:warmOwnerTokenBytes]), true
+}
+
+var (
+	adminDBMu  sync.Mutex
+	adminDBs   = map[string]*sql.DB{}
+	warmPoolMu sync.Mutex
+	warmPools  = map[string]*warmSchemaPool{}
+)
+
+// pgAdminDB returns the process-wide administrative handle for a database URL,
+// opening it on first use. Fixtures previously paid a TCP and authentication
+// handshake to create a schema and another to drop it; sql.DB is already a
+// pool, so one handle per URL serves every fixture in the binary. It is capped
+// small and intentionally never closed: it lives as long as the test binary.
+func pgAdminDB(dbURL string) (*sql.DB, error) {
+	adminDBMu.Lock()
+	defer adminDBMu.Unlock()
+
+	if db, ok := adminDBs[dbURL]; ok {
+		return db, nil
+	}
+
+	db, err := sql.Open("pgx", dbURL)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(2)
+	adminDBs[dbURL] = db
+
+	return db, nil
+}
+
+// warmSchemaPool hands out names of schemas that have already been created and
+// migrated. It serves names rather than open stores, so the buffer holds no
+// database connections at rest; the claiming test opens its own handle.
+//
+// The pool owns no background goroutine, and that is a correctness property
+// rather than a simplification. A refill runs synchronously inside the fixture
+// that emptied the buffer, so every statement the pool issues lands in the same
+// window where that fixture's own CREATE SCHEMA and InitSchema already landed —
+// never while a test body is running. Tests in this repository observe
+// process-global state: several capture slog.Default() and assert over the whole
+// buffer, and the migration paths carry seams. Warming in the background put a
+// second migration on the wire underneath those tests and broke them. Warming
+// inside fixture setup cannot, because it adds no overlap that fixture creation
+// did not already have.
+type warmSchemaPool struct {
+	dbURL string
+
+	mu       sync.Mutex
+	names    []string
+	failures int
+	swept    bool
+}
+
+// warmPoolFor returns the pool for a database URL, creating it on first use.
+// Nothing happens until a PostgreSQL fixture is requested, so SQLite runs and
+// packages that never touch PostgreSQL pay nothing.
+func warmPoolFor(dbURL string) *warmSchemaPool {
+	warmPoolMu.Lock()
+	defer warmPoolMu.Unlock()
+
+	if pool, ok := warmPools[dbURL]; ok {
+		return pool
+	}
+
+	pool := &warmSchemaPool{dbURL: dbURL}
+	warmPools[dbURL] = pool
+
+	return pool
+}
+
+// claim takes a ready schema name, refilling the buffer first when it is empty.
+// It reports false rather than an error: a fixture the pool cannot serve creates
+// its own schema and surfaces any real failure itself, so the pool can only make
+// a run faster, never fail one.
+func (p *warmSchemaPool) claim() (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.names) == 0 {
+		p.refillLocked()
+	}
+	if len(p.names) == 0 {
+		return "", false
+	}
+
+	name := p.names[len(p.names)-1]
+	p.names = p.names[:len(p.names)-1]
+
+	return name, true
+}
+
+// refillLocked builds a batch of schemas concurrently. Concurrency is where the
+// saving comes from: the work is round-trip bound rather than CPU bound, so a
+// batch costs little more than the one schema this fixture needed anyway and the
+// rest are free to the fixtures that follow. It stops refilling for good after
+// warmPoolMaxFailures empty batches so an unreachable server does not make every
+// remaining fixture pay for a doomed round trip first.
+func (p *warmSchemaPool) refillLocked() {
+	if p.failures >= warmPoolMaxFailures {
+		return
+	}
+	if !p.swept {
+		p.swept = true
+		if db, err := pgAdminDB(p.dbURL); err == nil {
+			_, _ = sweepWarmSchemas(db, warmOwnerToken, processAlive)
+		}
+	}
+
+	built := make([]string, warmPoolBatchWidth())
+	var building sync.WaitGroup
+	for i := range built {
+		building.Go(func() {
+			if name, err := p.warmOne(); err == nil {
+				built[i] = name
+			}
+		})
+	}
+	building.Wait()
+
+	for _, name := range built {
+		if name != "" {
+			p.names = append(p.names, name)
+		}
+	}
+
+	if len(p.names) == 0 {
+		p.failures++
+
+		return
+	}
+	p.failures = 0
+}
+
+// warmPoolBatchWidth is the refill width this binary uses: warmPoolBatch, or a
+// smaller value from warmPoolBatchEnv. Anything unparseable, below one, or above
+// the constant is ignored — the constant is a ceiling on the connection
+// footprint, so the environment may only lower it.
+func warmPoolBatchWidth() int {
+	width, err := strconv.Atoi(os.Getenv(warmPoolBatchEnv))
+	if err != nil || width < 1 || width > warmPoolBatch {
+		return warmPoolBatch
+	}
+
+	return width
+}
+
+// warmOne creates a schema, replays the production DDL into it, and closes the
+// connection it used, leaving a ready-to-claim schema and no open connection.
+func (p *warmSchemaPool) warmOne() (string, error) {
+	db, err := pgAdminDB(p.dbURL)
+	if err != nil {
+		return "", err
+	}
+
+	name, err := newWarmSchemaName()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := db.Exec("CREATE SCHEMA " + name); err != nil {
+		return "", err
+	}
+
+	st, err := store.Open(schemaURL(p.dbURL, name))
+	if err != nil {
+		dropOwnedSchema(db, name)
+
+		return "", err
+	}
+
+	if err := st.InitSchema(); err != nil {
+		_ = st.Close()
+		dropOwnedSchema(db, name)
+
+		return "", err
+	}
+
+	if err := st.Close(); err != nil {
+		dropOwnedSchema(db, name)
+
+		return "", err
+	}
+
+	return name, nil
+}
+
+// claimWarmSchema takes a ready schema, building a batch first when the buffer
+// is empty. It is off entirely when the escape hatch is set, and on a host whose
+// /proc cannot identify the pid namespace, because nothing the pool left behind
+// there could ever be reclaimed.
+func claimWarmSchema(dbURL string) (string, bool) {
+	if os.Getenv(warmPoolDisableEnv) == "0" || !warmOwnerUsable {
+		return "", false
+	}
+
+	return warmPoolFor(dbURL).claim()
+}
+
+// newWarmSchemaName returns a fresh warm schema name owned by this process.
+func newWarmSchemaName() (string, error) {
+	buf := make([]byte, warmSchemaSuffixBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("random schema name: %w", err)
+	}
+
+	return warmSchemaName(warmOwnerToken, os.Getpid(), hex.EncodeToString(buf)), nil
+}
+
+// warmSchemaName assembles a name from validated parts. Every name this package
+// creates, and every name its sweep drops, is built here.
+func warmSchemaName(owner string, pid int, suffix string) string {
+	return fmt.Sprintf("%s%s_p%d_%s", warmSchemaPrefix, owner, pid, suffix)
+}
+
+// parseWarmSchemaName splits a warm schema name into the owner token and pid
+// that created it, plus its random suffix. Anything that is not exactly a name
+// this package generates — including every msgvault_test_ fixture schema — is
+// rejected.
+func parseWarmSchemaName(name string) (owner string, pid int, suffix string, ok bool) {
+	match := warmSchemaNamePattern.FindStringSubmatch(name)
+	if match == nil {
+		return "", 0, "", false
+	}
+
+	pid, err := strconv.Atoi(match[2])
+	if err != nil || pid <= 0 {
+		return "", 0, "", false
+	}
+
+	return match[1], pid, match[3], true
+}
+
+// sweepWarmSchemas reclaims the warm schemas owned by owner whose creating
+// process has exited — the buffer a test binary leaves behind when it stops. It
+// returns the names it dropped, and does nothing at all for an empty owner,
+// which is how a host that cannot identify its own pid namespace sweeps.
+//
+// Ownership and liveness are parameters rather than globals so a test can pose
+// the question this function actually answers on any platform, without a
+// synthetic pid having to be absent from a /proc the host may not have.
+//
+// Three properties matter more than completeness. First, the statement it
+// executes is rebuilt from the parsed parts, so its target always begins with
+// warmSchemaPrefix; a msgvault_test_ schema cannot be named by this function no
+// matter what the server returns. Second, a candidate owned by another pid
+// namespace is skipped outright — its pid is not ours to resolve, so no
+// liveness answer about it could be trusted. Third, liveness fails safe toward
+// "alive": an unreadable /proc, an unsupported platform, or a name it cannot
+// parse leaves the schema alone. A missed orphan costs a schema until the
+// owning binary runs again; a wrong verdict would delete a running test's data.
+func sweepWarmSchemas(db *sql.DB, owner string, alive func(pid int) bool) ([]string, error) {
+	if owner == "" {
+		return nil, nil
+	}
+
+	candidates, err := listWarmSchemas(db)
+	if err != nil {
+		return nil, err
+	}
+
+	var dropped []string
+	self := os.Getpid()
+	for _, candidate := range candidates {
+		candidateOwner, pid, suffix, ok := parseWarmSchemaName(candidate)
+		if !ok || candidateOwner != owner || pid == self || alive(pid) {
+			continue
+		}
+
+		// Rebuilt from validated parts, never interpolated from the row.
+		target := warmSchemaName(candidateOwner, pid, suffix)
+		if target != candidate {
+			continue
+		}
+
+		if _, err := db.Exec("DROP SCHEMA " + target + " CASCADE"); err != nil {
+			continue
+		}
+		dropped = append(dropped, target)
+	}
+
+	return dropped, nil
+}
+
+// listWarmSchemas returns the schema names carrying the warm prefix. The LIKE
+// pattern is derived from the prefix constant with its underscores escaped, so
+// the server is never asked about any other family of schema.
+func listWarmSchemas(db *sql.DB) ([]string, error) {
+	pattern := strings.ReplaceAll(warmSchemaPrefix, "_", `\_`) + "%"
+	rows, err := db.Query("SELECT nspname FROM pg_namespace WHERE nspname LIKE $1", pattern)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return names, nil
+}
+
+// processAlive reports whether a pid is still running, answering "yes" whenever
+// it cannot tell. Only Linux is decidable here, via /proc.
+func processAlive(pid int) bool {
+	if pid <= 0 || runtime.GOOS != "linux" {
+		return true
+	}
+
+	if _, err := os.Stat("/proc/self"); err != nil {
+		return true
+	}
+
+	_, err := os.Stat("/proc/" + strconv.Itoa(pid))
+	if err == nil {
+		return true
+	}
+
+	return !errors.Is(err, fs.ErrNotExist)
+}
+
+// fixtureSchemaNamePattern matches the schemas createTestSchema builds, so a
+// drop can rebuild its target from validated parts the same way the sweep does.
+var fixtureSchemaNamePattern = regexp.MustCompile(
+	"^msgvault_test_([0-9a-f]{" + strconv.Itoa(warmSchemaSuffixBytes*2) + "})$")
+
+// dropOwnedSchema removes a schema this package created, and does nothing at
+// all for any other name. Failure is ignored: the sweep reclaims what is left
+// behind.
+//
+// The statement is assembled from the parts a pattern matched rather than from
+// the caller's string — the same discipline sweepWarmSchemas applies. A name
+// that did not come from this package cannot become SQL here, whatever a future
+// caller passes in.
+func dropOwnedSchema(db *sql.DB, name string) {
+	var target string
+	switch fixture := fixtureSchemaNamePattern.FindStringSubmatch(name); {
+	case fixture != nil:
+		target = "msgvault_test_" + fixture[1]
+	default:
+		owner, pid, suffix, ok := parseWarmSchemaName(name)
+		if !ok {
+			return
+		}
+		target = warmSchemaName(owner, pid, suffix)
+	}
+
+	//nolint:gosec // target is rebuilt from matched parts above, not the argument.
+	_, _ = db.Exec("DROP SCHEMA IF EXISTS " + target + " CASCADE")
+}
+
+// schemaURL returns dbURL with its search_path pointed at a schema.
+func schemaURL(dbURL, schemaName string) string {
+	separator := "?"
+	if strings.Contains(dbURL, "?") {
+		separator = "&"
+	}
+
+	return dbURL + separator + "search_path=" + schemaName
+}

--- a/internal/testutil/pg_warm_pool_test.go
+++ b/internal/testutil/pg_warm_pool_test.go
@@ -1,0 +1,524 @@
+package testutil
+
+import (
+	"bytes"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// requirePostgresTestURL returns the configured PostgreSQL test URL, skipping
+// the calling test when MSGVAULT_TEST_DB is unset or points at SQLite.
+func requirePostgresTestURL(t *testing.T) string {
+	t.Helper()
+
+	testDB := os.Getenv("MSGVAULT_TEST_DB")
+	if !strings.HasPrefix(testDB, "postgres://") && !strings.HasPrefix(testDB, "postgresql://") {
+		t.Skip("PostgreSQL-only: set MSGVAULT_TEST_DB to a postgres:// URL")
+	}
+
+	return testDB
+}
+
+// currentSchemaOf reports the schema a store's connections resolve unqualified
+// names against, which is the per-test schema the fixture handed it.
+func currentSchemaOf(t *testing.T, st *store.Store) string {
+	t.Helper()
+
+	var name string
+	require.NoError(t, st.DB().QueryRow("SELECT current_schema()").Scan(&name), "select current_schema")
+
+	return name
+}
+
+// schemaExists reports whether a schema of the given name is present.
+func schemaExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+
+	var count int
+	require.NoError(t,
+		db.QueryRow("SELECT count(*) FROM pg_namespace WHERE nspname = $1", name).Scan(&count),
+		"count pg_namespace rows")
+
+	return count > 0
+}
+
+// countSources reports how many rows the store's sources table holds. A fresh
+// fixture has none; a fixture that shares a schema with another test does not.
+func countSources(t *testing.T, st *store.Store) int {
+	t.Helper()
+
+	var count int
+	require.NoError(t, st.DB().QueryRow("SELECT count(*) FROM sources").Scan(&count), "count sources")
+
+	return count
+}
+
+// randomSchemaSuffix returns a suffix in the same shape the fixture uses.
+func randomSchemaSuffix(t *testing.T) string {
+	t.Helper()
+
+	buf := make([]byte, 8)
+	_, err := rand.Read(buf)
+	require.NoError(t, err, "random schema suffix")
+
+	return hex.EncodeToString(buf)
+}
+
+// syntheticOwner returns an owner token in the shape a name carries, unique to
+// the calling test. Posing the sweeper's question with one of these rather than
+// this process's real token keeps a test independent of whether the host can
+// identify its own pid namespace, and keeps it from competing with a sibling
+// run of this binary for the same schemas.
+func syntheticOwner(t *testing.T) string {
+	t.Helper()
+
+	buf := make([]byte, warmOwnerTokenBytes)
+	_, err := rand.Read(buf)
+	require.NoError(t, err, "random owner token")
+
+	return hex.EncodeToString(buf)
+}
+
+// createSchemaForTest creates a schema and registers its removal, so a test can
+// stage schemas for the sweeper to consider without leaking them on failure.
+func createSchemaForTest(t *testing.T, db *sql.DB, name string) {
+	t.Helper()
+
+	_, err := db.Exec("CREATE SCHEMA " + name)
+	require.NoErrorf(t, err, "create schema %s", name)
+	t.Cleanup(func() {
+		_, _ = db.Exec("DROP SCHEMA IF EXISTS " + name + " CASCADE")
+	})
+}
+
+// reapedPID returns the pid of a process that has run to completion and been
+// waited for, so the kernel no longer lists it under /proc.
+func reapedPID(t *testing.T) int {
+	t.Helper()
+
+	cmd := exec.Command("/bin/true")
+	require.NoError(t, cmd.Run(), "run short-lived helper process")
+	pid := cmd.Process.Pid
+
+	_, statErr := os.Stat("/proc/" + strconv.Itoa(pid))
+	require.True(t, os.IsNotExist(statErr), "reaped helper pid must be absent from /proc")
+
+	return pid
+}
+
+// TestPostgresFixturesGetPrivateEmptySchemas locks the fixture contract the
+// warm pool must not weaken: two fixtures in one binary get different schemas,
+// each starts empty, and writes through one are invisible to the other.
+func TestPostgresFixturesGetPrivateEmptySchemas(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	requirePostgresTestURL(t)
+
+	first := NewTestStore(t)
+	second := NewTestStore(t)
+
+	firstSchema := currentSchemaOf(t, first)
+	secondSchema := currentSchemaOf(t, second)
+	assert.NotEqual(firstSchema, secondSchema, "fixtures must not share a schema")
+
+	assert.Equal(0, countSources(t, first), "first fixture starts empty")
+	assert.Equal(0, countSources(t, second), "second fixture starts empty")
+
+	_, err := first.GetOrCreateSource("gmail", "isolation@example.com")
+	require.NoError(err, "write through the first fixture")
+
+	assert.Equal(1, countSources(t, first), "write lands in the first fixture")
+	assert.Equal(0, countSources(t, second), "write must not leak into the second fixture")
+}
+
+// TestPostgresFixtureSchemaDroppedAfterCleanup proves the claiming test still
+// owns removal of whatever schema it was handed.
+func TestPostgresFixtureSchemaDroppedAfterCleanup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := requirePostgresTestURL(t)
+
+	adminDB, err := pgAdminDB(dbURL)
+	require.NoError(err, "open admin connection")
+
+	var schema string
+	t.Run("owner", func(t *testing.T) {
+		schema = currentSchemaOf(t, NewTestStore(t))
+	})
+
+	require.NotEmpty(schema, "subtest recorded its schema")
+	assert.False(schemaExists(t, adminDB, schema), "claimed schema is gone after the owning test's cleanup")
+}
+
+// TestSweepWarmSchemasDropsOnlyDeadOwners covers the sweeper's liveness rule:
+// a warm schema whose creating process is gone is reclaimed, one whose owner is
+// still running is left alone.
+func TestSweepWarmSchemasDropsOnlyDeadOwners(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := requirePostgresTestURL(t)
+
+	adminDB, err := pgAdminDB(dbURL)
+	require.NoError(err, "open admin connection")
+
+	// This is the wired-up case: the real owner token and the real /proc
+	// liveness check. Where the host cannot identify its namespace there is no
+	// token, the pool is off, and the sweep must be a no-op — assert that
+	// rather than pass over the platform, because a sweep that still ran there
+	// would be judging pids it cannot resolve.
+	if !warmOwnerUsable {
+		dropped, err := sweepWarmSchemas(adminDB, warmOwnerToken, processAlive)
+		require.NoError(err, "sweep warm schemas")
+		assert.Empty(dropped, "a process with no owner token must sweep nothing")
+
+		return
+	}
+
+	dead := warmSchemaName(warmOwnerToken, reapedPID(t), randomSchemaSuffix(t))
+	self := warmSchemaName(warmOwnerToken, os.Getpid(), randomSchemaSuffix(t))
+	otherLive := warmSchemaName(warmOwnerToken, 1, randomSchemaSuffix(t))
+	createSchemaForTest(t, adminDB, dead)
+	createSchemaForTest(t, adminDB, self)
+	createSchemaForTest(t, adminDB, otherLive)
+
+	dropped, err := sweepWarmSchemas(adminDB, warmOwnerToken, processAlive)
+	require.NoError(err, "sweep warm schemas")
+
+	assert.Contains(dropped, dead, "sweep reports the reclaimed schema")
+	assert.False(schemaExists(t, adminDB, dead), "dead owner's warm schema is reclaimed")
+	assert.True(schemaExists(t, adminDB, self), "this process's own warm schema survives")
+	assert.True(schemaExists(t, adminDB, otherLive), "a live owner's warm schema survives")
+}
+
+// TestSweepWarmSchemasNeverDropsTestSchemas is the safety test: other agents'
+// in-flight fixtures use the msgvault_test_ prefix on this shared server, and no
+// liveness verdict may ever put one of those in the sweeper's sights.
+func TestSweepWarmSchemasNeverDropsTestSchemas(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := requirePostgresTestURL(t)
+
+	adminDB, err := pgAdminDB(dbURL)
+	require.NoError(err, "open admin connection")
+
+	// A fixture-shaped schema, plus one that mimics the warm naming inside the
+	// test prefix — neither may be touched.
+	owner := syntheticOwner(t)
+	testSchema := "msgvault_test_" + randomSchemaSuffix(t)
+	lookalike := fmt.Sprintf("msgvault_test_%s_p%d_%s", owner, 1, randomSchemaSuffix(t))
+	createSchemaForTest(t, adminDB, testSchema)
+	createSchemaForTest(t, adminDB, lookalike)
+
+	// Bait: a genuine warm schema owned by a pid this sweep will call dead, so
+	// the survival assertions below cannot pass vacuously.
+	const strangerPID = 424242
+	bait := warmSchemaName(owner, strangerPID, randomSchemaSuffix(t))
+	createSchemaForTest(t, adminDB, bait)
+
+	// Declare only the bait's owner dead: sibling test binaries sharing this
+	// server keep their warm schemas.
+	dropped, err := sweepWarmSchemas(adminDB, owner, func(pid int) bool { return pid != strangerPID })
+	require.NoError(err, "sweep warm schemas")
+
+	assert.Contains(dropped, bait, "sweep did drop something in this run")
+	for _, name := range dropped {
+		assert.Truef(strings.HasPrefix(name, warmSchemaPrefix),
+			"sweep may only ever drop names carrying the warm prefix, got %q", name)
+	}
+	assert.True(schemaExists(t, adminDB, testSchema), "a msgvault_test_ schema must survive the sweep")
+	assert.True(schemaExists(t, adminDB, lookalike), "a warm-looking msgvault_test_ schema must survive the sweep")
+}
+
+// TestParseWarmSchemaName pins which names the sweeper is even able to consider.
+func TestParseWarmSchemaName(t *testing.T) {
+	suffix := "0123456789abcdef"
+
+	// A synthetic token, so what this test means does not depend on whether the
+	// host running it can identify its own pid namespace.
+	owner := strings.Repeat("ab", warmOwnerTokenBytes)
+
+	t.Run("accepts every name warmSchemaName assembles", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+
+		name := warmSchemaName(owner, 4242, suffix)
+
+		parsedOwner, pid, parsedSuffix, ok := parseWarmSchemaName(name)
+		require.True(ok, "an assembled name must round-trip")
+		assert.Equal(owner, parsedOwner, "name carries the owner token")
+		assert.Equal(4242, pid, "name carries the creating pid")
+		assert.Equal(suffix, parsedSuffix, "name carries the suffix")
+	})
+
+	t.Run("accepts a name this package generated", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+
+		name, err := newWarmSchemaName()
+		require.NoError(err, "generate warm schema name")
+
+		parsedOwner, pid, parsedSuffix, ok := parseWarmSchemaName(name)
+
+		// Where /proc cannot identify the pid namespace there is no owner
+		// token, the pool does not run, and nothing it could name is
+		// sweepable. Assert that rather than passing over the platform: an
+		// ownerless name reaching the sweeper would be the bug.
+		if !warmOwnerUsable {
+			assert.False(ok, "a name built without an owner token must not be sweepable")
+
+			return
+		}
+
+		require.True(ok, "generated names must round-trip")
+		assert.Equal(os.Getpid(), pid, "name carries the creating pid")
+		assert.Equal(warmOwnerToken, parsedOwner, "name carries this namespace's owner token")
+		assert.Equal(name, warmSchemaName(parsedOwner, pid, parsedSuffix), "parts rebuild the name")
+	})
+
+	rejected := []string{
+		"msgvault_test_" + suffix,
+		"msgvault_test_" + owner + "_p1_" + suffix,
+		"msgvault_warm_" + suffix,
+		"msgvault_warm_" + owner + "_pfoo_" + suffix,
+		"msgvault_warm_" + owner + "_p_" + suffix,
+		"msgvault_warm_" + owner + "_p-1_" + suffix,
+		"msgvault_warm_" + owner + "_p1_" + suffix + "; DROP SCHEMA msgvault_test_x",
+		"msgvault_warm_" + owner + "_p1_" + strings.ToUpper(suffix),
+		// Owner token of the wrong width or alphabet is not a name we make.
+		"msgvault_warm_" + owner + "ab_p1_" + suffix,
+		"msgvault_warm_zzzzzzzzzzzz_p1_" + suffix,
+		"msgvault_warm_p1_" + suffix,
+		"public",
+		"",
+		" msgvault_warm_" + owner + "_p1_" + suffix,
+	}
+	for _, name := range rejected {
+		t.Run("rejects "+name, func(t *testing.T) {
+			_, _, _, ok := parseWarmSchemaName(name)
+			assert.False(t, ok, "name %q must not be sweepable", name)
+		})
+	}
+}
+
+// TestWarmPoolServesInitializedSchemas proves the pool's product is a real,
+// already-migrated schema, not just a name.
+func TestWarmPoolServesInitializedSchemas(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := requirePostgresTestURL(t)
+
+	adminDB, err := pgAdminDB(dbURL)
+	require.NoError(err, "open admin connection")
+
+	// Through claimWarmSchema, not the pool directly: the gate that keeps a
+	// host with no owner token from creating schemas nothing could reclaim
+	// lives there, and a test that reaches past it would create exactly those.
+	name, ok := claimWarmSchema(dbURL)
+	if !warmOwnerUsable {
+		assert.False(ok, "a host that cannot reclaim warm schemas must not create them")
+
+		return
+	}
+	require.True(ok, "warm pool produced a schema")
+	t.Cleanup(func() { dropOwnedSchema(adminDB, name) })
+
+	assert.Truef(strings.HasPrefix(name, warmSchemaPrefix), "warm schemas are self-owned, got %q", name)
+
+	var messagesTable sql.NullString
+	require.NoError(adminDB.QueryRow("SELECT to_regclass($1)", name+".messages").Scan(&messagesTable),
+		"look up the messages table in the warm schema")
+	assert.True(messagesTable.Valid, "warm schema already carries the initialized DDL")
+}
+
+// TestNewTestStoreFallsBackWhenWarmPoolDisabled covers the path a pool outage
+// takes: the fixture creates its own schema and behaves exactly as before.
+func TestNewTestStoreFallsBackWhenWarmPoolDisabled(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	requirePostgresTestURL(t)
+	t.Setenv(warmPoolDisableEnv, "0")
+
+	st := NewTestStore(t)
+
+	schema := currentSchemaOf(t, st)
+	assert.Truef(strings.HasPrefix(schema, "msgvault_test_"),
+		"the fallback path creates its own schema, got %q", schema)
+	assert.Equal(0, countSources(t, st), "fallback fixture starts empty")
+
+	_, err := st.GetOrCreateSource("gmail", "fallback@example.com")
+	require.NoError(err, "write through the fallback fixture")
+	assert.Equal(1, countSources(t, st), "fallback fixture is writable")
+}
+
+// TestSweepWarmSchemasNeverDropsForeignNamespaces is the cross-namespace safety
+// test. A pid only means something relative to a namespace, so when two
+// containers share one PostgreSQL server each sees a /proc the other's pids are
+// absent from. Without an owner token the sweeper reads that absence as "the
+// owner exited" and drops a schema whose test is still running — a warm schema
+// keeps its name for the whole life of the test that claims it, so the victim
+// is live, not spare.
+//
+// The foreign schema here is built to be maximally tempting: its pid is one
+// this process's /proc genuinely cannot find. Only the owner token stands
+// between it and deletion.
+func TestSweepWarmSchemasNeverDropsForeignNamespaces(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := requirePostgresTestURL(t)
+
+	adminDB, err := pgAdminDB(dbURL)
+	require.NoError(err, "open admin connection")
+
+	// Same shape, same dead pid; only the namespace differs. Both owners are
+	// synthetic and liveness is injected, so the question this poses does not
+	// depend on the host having a /proc to be absent from.
+	owner := syntheticOwner(t)
+	foreignOwner := syntheticOwner(t)
+	require.NotEqual(owner, foreignOwner, "the foreign token must not be ours")
+
+	const deadPID = 424243
+	foreign := warmSchemaName(foreignOwner, deadPID, randomSchemaSuffix(t))
+	ours := warmSchemaName(owner, deadPID, randomSchemaSuffix(t))
+	createSchemaForTest(t, adminDB, foreign)
+	createSchemaForTest(t, adminDB, ours)
+
+	dropped, err := sweepWarmSchemas(adminDB, owner, func(pid int) bool { return false })
+	require.NoError(err, "sweep warm schemas")
+
+	// Our own orphan proves the sweep ran and would have taken the foreign one
+	// had the token not stopped it.
+	assert.Contains(dropped, ours, "our own namespace's orphan is still reclaimed")
+	assert.NotContains(dropped, foreign, "a foreign namespace's schema must never be swept")
+	assert.True(schemaExists(t, adminDB, foreign),
+		"another container's warm schema survives: its pid is not ours to judge")
+}
+
+// drainWarmPool empties a pool's buffer and drops what it held, so the next
+// fixture is the one that pays for a refill.
+func drainWarmPool(t *testing.T, pool *warmSchemaPool) {
+	t.Helper()
+
+	adminDB, err := pgAdminDB(pool.dbURL)
+	require.NoError(t, err, "open admin connection")
+
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	for _, name := range pool.names {
+		dropOwnedSchema(adminDB, name)
+	}
+	pool.names = nil
+}
+
+// TestWarmPoolIssuesNoStatementsOnceATestBodyIsRunning is the invariant that
+// decides the pool's shape. Several tests in this repository capture
+// slog.Default() and assert over the whole captured buffer, and the migration
+// paths carry seams; all of that is safe only while exactly one migration is on
+// the wire at a time. A pool that warmed in the background broke it — an
+// upstream test asserting that a query never touches message_raw failed on a
+// pool worker's migration writing that table underneath it.
+//
+// Building inside the claiming fixture's own setup is what closes that off: the
+// pool's statements land where fixture statements already landed, so a test body
+// observes nothing it would not have observed without the pool. The buffer is
+// drained first so the fixture below genuinely triggers a refill, which is
+// exactly the moment the background design would have kept working.
+func TestWarmPoolIssuesNoStatementsOnceATestBodyIsRunning(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbURL := requirePostgresTestURL(t)
+
+	drainWarmPool(t, warmPoolFor(dbURL))
+	fixture := NewTestStore(t)
+
+	store.ConfigureSQLLogging(store.SQLLogOptions{FullTrace: true, MaxStmtChars: 10_000})
+	t.Cleanup(func() { store.ConfigureSQLLogging(store.SQLLogOptions{}) })
+	var logged bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	// Real work, and enough of it to give any stray warming the wall clock it
+	// would need to appear in the capture.
+	for i := range 20 {
+		_, err := fixture.GetOrCreateSource("gmail", fmt.Sprintf("warm-quiet-%d@example.test", i))
+		require.NoError(err, "write through the fixture")
+	}
+
+	trace := strings.ToLower(logged.String())
+	require.Contains(trace, "sources", "the capture observed this test's own queries")
+	assert.NotContains(trace, "create table",
+		"pool migrations must not run while a test body is capturing the process logger")
+	assert.NotContains(trace, "create index",
+		"pool migrations must not run while a test body is capturing the process logger")
+	assert.NotContains(trace, warmSchemaPrefix,
+		"no pool schema may be named in a statement issued during a test body")
+}
+
+// TestWarmOwnerRequiresBothNamespaceIdentifiers pins the rule that keeps the
+// pool from leaking on hosts it cannot clean up after, and from mistaking a
+// stranger for itself.
+//
+// The sweep reclaims an orphan by asking /proc whether its creator exited, so
+// where the namespace cannot be identified there is no token and the pool
+// declines to run. Neither identifier suffices alone: a boot id is common to
+// every container on a machine, and a namespace inode is common to every
+// machine that numbers its namespaces alike. Either on its own would let two
+// processes that cannot see each other's /proc agree on a token — the exact
+// condition under which one deletes the other's live schema.
+func TestWarmOwnerRequiresBothNamespaceIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+
+	bootID := []byte("boot-id")
+	namespace := []byte("pid:[4026531836]")
+
+	_, ok := warmOwnerFrom(nil, nil)
+	assert.False(ok, "a host that identifies neither must not run the pool")
+
+	_, ok = warmOwnerFrom(bootID, nil)
+	assert.False(ok, "a boot id alone is shared by every container on the host")
+
+	_, ok = warmOwnerFrom(nil, namespace)
+	assert.False(ok, "a namespace id alone is shared by every host that numbers alike")
+
+	token, ok := warmOwnerFrom(bootID, namespace)
+	assert.True(ok, "both identifiers yield a token")
+	assert.Len(token, warmOwnerTokenBytes*2, "the token is the width the name pattern expects")
+
+	sameHost, _ := warmOwnerFrom(bootID, []byte("pid:[4026532999]"))
+	assert.NotEqual(token, sameHost, "two namespaces on one host must not share a token")
+
+	sameNamespace, _ := warmOwnerFrom([]byte("another-boot-id"), namespace)
+	assert.NotEqual(token, sameNamespace, "two hosts numbering alike must not share a token")
+}
+
+// TestWarmPoolBatchWidthOnlyEverNarrows covers the connection-budget knob. The
+// constant is a ceiling on how many connections one refill holds, so an
+// environment able to raise it would not be a safety limit at all.
+func TestWarmPoolBatchWidthOnlyEverNarrows(t *testing.T) {
+	ignored := []string{"", "0", "-1", "abc", "1.5", strconv.Itoa(warmPoolBatch + 1), "999"}
+	for _, value := range ignored {
+		t.Run("ignores "+value, func(t *testing.T) {
+			t.Setenv(warmPoolBatchEnv, value)
+			assert.Equal(t, warmPoolBatch, warmPoolBatchWidth(),
+				"%q must not change the refill width", value)
+		})
+	}
+
+	t.Run("accepts a narrower width", func(t *testing.T) {
+		t.Setenv(warmPoolBatchEnv, "1")
+		assert.Equal(t, 1, warmPoolBatchWidth(), "the environment may lower the connection footprint")
+	})
+}

--- a/internal/testutil/store_helpers.go
+++ b/internal/testutil/store_helpers.go
@@ -2,15 +2,12 @@ package testutil
 
 import (
 	"crypto/rand"
-	"database/sql"
 	"encoding/hex"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	_ "github.com/jackc/pgx/v5/stdlib" // Register pgx driver for test setup
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/store"
 )
@@ -74,21 +71,19 @@ func SkipIfPostgres(t *testing.T, reason string) {
 
 // newPostgresTestStore creates a test-isolated PostgreSQL store using a random schema name.
 // The schema is dropped on test cleanup.
+//
+// The schema is taken from the warm pool when one is ready — already created
+// and already migrated, so the test pays only for opening its own connection.
+// Otherwise the test creates and migrates one itself, exactly as it always did.
+// Either way the schema is private to this test, never previously used, and
+// dropped on cleanup.
 func newPostgresTestStore(t *testing.T, dbURL string) *store.Store {
 	t.Helper()
 
-	// Generate a random schema name for test isolation
-	buf := make([]byte, 8)
-	_, err := rand.Read(buf)
-	require.NoError(t, err, "random schema name")
-	schemaName := "msgvault_test_" + hex.EncodeToString(buf)
-
-	// Create the schema using a separate connection
-	setupDB, err := sql.Open("pgx", dbURL)
-	require.NoError(t, err, "open setup connection")
-	_, schemaErr := setupDB.Exec("CREATE SCHEMA " + schemaName)
-	_ = setupDB.Close()
-	require.NoErrorf(t, schemaErr, "create schema %s", schemaName)
+	schemaName, warmed := claimWarmSchema(dbURL)
+	if !warmed {
+		schemaName = createTestSchema(t, dbURL)
+	}
 
 	// Register schema cleanup immediately so that any failure below this
 	// point (store.Open, InitSchema) doesn't leak the schema.
@@ -97,25 +92,38 @@ func newPostgresTestStore(t *testing.T, dbURL string) *store.Store {
 		if st != nil {
 			_ = st.Close()
 		}
-		cleanupDB, err := sql.Open("pgx", dbURL)
+		cleanupDB, err := pgAdminDB(dbURL)
 		if err != nil {
 			return
 		}
-		defer func() { _ = cleanupDB.Close() }()
-		_, _ = cleanupDB.Exec(fmt.Sprintf("DROP SCHEMA %s CASCADE", schemaName))
+		dropOwnedSchema(cleanupDB, schemaName)
 	})
 
-	// Build a URL that uses the test schema via search_path
-	testURL := dbURL
-	sep := "?"
-	if strings.Contains(dbURL, "?") {
-		sep = "&"
-	}
-	testURL += sep + "search_path=" + schemaName
-
-	st, err = store.Open(testURL)
+	st, err := store.Open(schemaURL(dbURL, schemaName))
 	require.NoError(t, err, "open store")
-	require.NoError(t, st.InitSchema(), "init schema")
+	if !warmed {
+		require.NoError(t, st.InitSchema(), "init schema")
+	}
 
 	return st
+}
+
+// createTestSchema creates an empty, unmigrated schema for one test. This is
+// the path a fixture takes when the warm pool has nothing ready or is
+// unavailable, so its failures must read exactly as they did before the pool
+// existed.
+func createTestSchema(t *testing.T, dbURL string) string {
+	t.Helper()
+
+	buf := make([]byte, 8)
+	_, err := rand.Read(buf)
+	require.NoError(t, err, "random schema name")
+	schemaName := "msgvault_test_" + hex.EncodeToString(buf)
+
+	setupDB, err := pgAdminDB(dbURL)
+	require.NoError(t, err, "open setup connection")
+	_, schemaErr := setupDB.Exec("CREATE SCHEMA " + schemaName)
+	require.NoErrorf(t, schemaErr, "create schema %s", schemaName)
+
+	return schemaName
 }


### PR DESCRIPTION
## Summary

- Pre-warms private PostgreSQL test schemas in small synchronous batches, reducing fixture setup time without sharing state or adding background database work.
- Scopes migration and backfill test hooks to each `Store`, preventing concurrent fixtures from triggering hooks installed by another test.
- Detects full-text search support when reopening read-write stores, avoiding an unnecessary fallback to slower search behavior.
- Updates `make test-pg-both` to run the full pgvector suite once, then run the shipped-build variant only for packages whose test binaries differ. A dependency check keeps that package list from drifting.
- Preserves test coverage: no tests are skipped, shortened, shared, or newly parallelized.
- Improves measured PostgreSQL test time: `internal/store` fell from 350s to 256s (27%), and the shipped-build lane fell from 881s to 305s on the development host.

## Configuration

- Set `MSGVAULT_TEST_PG_WARM_POOL_BATCH` to lower the default batch size of 4.
- Set `MSGVAULT_TEST_PG_WARM_POOL=0` to disable schema pre-warming and use the previous fixture behavior.