### PR TITLE
Update nix flake for v0.19.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
   sqlite,
 }:
 let
-  version = "0.18.0";
+  version = "0.19.0";
 in
 buildGoModule {
   pname = "msgvault";


### PR DESCRIPTION
## Summary
- Updated `vendorHash` to `sha256-ewgr0NmadvzjVSKteutPbifmhbTbOVMwG0267DHzPLY=`
- Updated version to `0.19.0`

Automated update via `scripts/update-nix-flake.sh`.