### PR TITLE
docs: document the 0.19.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Archive a lifetime of email, messages, meetings. Analytics and search in millise
 
 Your messages are yours. Decades of correspondence, attachments, and history shouldn't be locked behind a web interface or an API. By default, msgvault downloads a complete local copy and then everything runs offline. Search, analytics, and the MCP server all work against your msgvault archive with no mailbox network access required. If you configure a remote deployment, the archive lives on your own server rather than a hosted msgvault service.
 
-Currently supports Gmail, Google Calendar, Microsoft Teams, Discord, Granola,
-Circleback, Beeper Desktop, and IMAP sync, plus offline imports from MBOX
+Currently supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack,
+Granola, Circleback, Beeper Desktop, and IMAP sync, plus offline imports from MBOX
 exports, Apple Mail (`.emlx`) directories, PST archives, and common chat/text
 export formats.
 
@@ -36,6 +36,7 @@ export formats.
 - **Google Calendar sync**: archive events, organizers, and attendees; searchable alongside email
 - **Microsoft Teams sync**: archive delegated Graph chats, channels, replies, and inline media with `message_type = teams`
 - **Discord sync**: archive guild channels, threads, forum posts, and attachments through a read-only bot with `message_type = discord`
+- **Slack sync**: archive joined channels, group DMs, direct messages, threads, reactions, and files with `message_type = slack`
 - **Meeting notes**: sync Granola and Circleback notes and transcripts, then browse them in the TUI
 - **Beeper Desktop sync**: archive chats and media from every network connected to Beeper, including iMessage, through its local API
 - **IMAP sync**: archive mail from any standard IMAP server
@@ -121,6 +122,7 @@ available with `msgvault tui`.
 | `add-teams EMAIL` | Authorize delegated Microsoft Graph access for Teams |
 | `sync-teams EMAIL` | Sync Microsoft Teams chats and channels |
 | `add-discord` / `sync-discord` | Register a read-only bot and sync Discord guild channels and threads |
+| `add-slack` / `sync-slack` | Register and archive a Slack workspace, including threads and media |
 | `export-messages` | Stream a bounded, provider-neutral archive window as versioned JSONL |
 | `export-discord` | Temporary compatibility export for bounded Discord history |
 | `backfill-discord-media` | Retry incomplete Discord attachment downloads |
@@ -136,7 +138,11 @@ available with `msgvault tui`.
 | `show-message ID` | View full message details (`--json` for machine output) |
 | `mcp` | Start the MCP server for AI assistant integration |
 | `skills install` | Install bundled agent skills for search, attachments, and analytics |
-| `serve` | Run the API/scheduler or manage the background daemon (`start`, `status`, `stop`, `restart`) |
+| `identity` | Manage and discover source-scoped identifiers that mean “me” |
+| `person` | Manage durable person profiles and typed attributes |
+| `attribute-definition` | Manage portable metadata-defined profile fields |
+| `daemon` | Manage the local background daemon (`start`, `status`, `stop`, `restart`) |
+| `serve` | Run the Web UI, API, and scheduler in the foreground |
 | `stats` | Show archive statistics |
 | `list-accounts` | List synced email accounts |
 | `verify EMAIL` | Verify archive integrity against Gmail |
@@ -150,7 +156,9 @@ available with `msgvault tui`.
 | `repair-dates` | Report or repair missing and implausible email sent dates |
 | `list-senders` / `list-domains` / `list-labels` | Explore metadata |
 
-See the [CLI Reference](https://msgvault.io/cli-reference/) for full details.
+See the [CLI Reference](https://msgvault.io/cli-reference/) for full details
+and [People, Profiles, and Source Identities](https://msgvault.io/usage/people/)
+for the identity and profile model.
 
 ## Vector Search
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,7 +4,7 @@ description: Package structure and data flow.
 ---
 
 msgvault syncs Gmail, Google Calendar, IMAP, Microsoft 365 mail, Microsoft
-Teams, Discord, Beeper Desktop, Granola, and Circleback into a local SQLite database by
+Teams, Discord, Slack, Beeper Desktop, Granola, and Circleback into a local SQLite database by
 default and can import local PST/MBOX archives, Apple Mail exports, and common
 chat/text formats. PostgreSQL is available as an opt-in backend for new
 archives. Keyword search, analytics, the Web UI, the TUI, and the MCP server run against

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -156,7 +156,27 @@ this on the default SQLite backend with denormalized Parquet files queried by
 an embedded DuckDB engine, delivering aggregate queries hundreds of times
 faster than SQLite.
 
-The Parquet cache is disposable and can be rebuilt at any time. Aggregate views never trigger a build mid-session: with `auto_build_cache = true` (the default) the daemon builds a stale or missing cache synchronously at startup — incremental builds take seconds — and then serves DuckDB over it, refreshing the cache after scheduled syncs and ingest commands. Cache builds hold an exclusive cross-process lock and queries hold it shared, so a rebuild never removes Parquet files out from under a running query. `msgvault build-cache` builds the cache on demand. PostgreSQL archives currently use live SQL for aggregate views rather than this Parquet acceleration layer.
+The Parquet cache is disposable and can be rebuilt at any time. Aggregate views
+never trigger a build mid-session: with `auto_build_cache = true` (the default)
+the daemon builds a stale or missing cache synchronously at startup, then serves
+DuckDB over it and refreshes after scheduled syncs and ingest commands.
+
+Each build writes and verifies a same-filesystem staging tree before publishing
+under the exclusive cache lock. `_last_sync.json` is the commit marker: it is
+invalidated before any live dataset changes and replaced last. A failure before
+publication leaves the previous committed cache usable; interruption during
+publication leaves the cache explicitly unavailable for repair, never marked
+ready with mixed old and new datasets. Queries hold the lock shared, so a build
+cannot replace Parquet files underneath an active reader. `msgvault
+build-cache` builds or repairs the cache on demand. PostgreSQL archives use live
+SQL for aggregate views rather than this Parquet acceleration layer.
+
+Version 0.19.0 adds `relationship_activity`, `relationship_people`,
+`relationship_domains`, and `relationship_daily` datasets. These compact edges
+and rollups avoid expanding every message's participant list during people,
+domain, relationship, timeline, and file-group queries. Existing SQLite caches
+need one full rebuild after upgrading; automatic cache building performs it at
+daemon startup, or run `msgvault build-cache --full-rebuild` explicitly.
 
 ```bash
 # Manual build
@@ -181,6 +201,10 @@ analytics/
 ├── sources/
 ├── conversations/
 ├── message_labels/
+├── relationship_activity/
+├── relationship_people/
+├── relationship_domains/
+├── relationship_daily/
 └── _last_sync.json
 ```
 
@@ -218,6 +242,12 @@ downgrading. The last command is local-only and requires the daemon to be
 stopped because it removes production pack files. See the [CLI
 reference](/cli-reference/#pack-attachments) and [Backup](/usage/backup/) guide
 for maintenance and restore behavior.
+
+Set `[data].loose_attachments = true` when file-oriented backup or storage
+software requires stable individual attachment files. It prevents new packs,
+rejects pack and repack commands, and restores backup content loose, but does
+not convert existing packs automatically. Stop the daemon and run
+`unpack-attachments` once if the existing archive must become fully loose.
 
 ## Token Storage
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,17 @@ All notable changes to msgvault, grouped by release.
 
 ---
 
+## 0.19.1
+<small>2026-08-07</small>
+
+**Bug fixes**
+
+- Advance Slack `--limit 1` sweeps beyond the certified overlap window.
+- Stop Windows daemons cleanly during releases.
+- Recover interrupted releases from existing tags.
+
+---
+
 ## 0.19.0
 <small>2026-08-07</small>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,12 +7,94 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
+---
+
+## 0.19.0
+<small>2026-08-07</small>
+
 **New features**
 
+- A new relationships-focused Web UI explores a mixed archive as messages,
+  conversations, files, people, and domains. It adds explicit full-text,
+  semantic, and hybrid search states; Saved Views; source status; safe deletion
+  staging; settings; keyboard navigation; and authenticated remote sessions.
+- Slack workspace archiving imports the channels a user belongs to, group DMs,
+  direct messages, threads, reactions, mentions, and files through a read-only
+  user token. Incremental sync discovers late replies to threads of any age,
+  and `backfill-slack-media` retries deferred downloads.
+- Discord guild archiving imports bot-visible channels, threads, forum posts,
+  edits, deletion state, reaction summaries, and attachments with resumable
+  per-container checkpoints. `sync-discord`, bounded compatibility and generic
+  exports, scheduled sync, and `backfill-discord-media` cover ongoing archive
+  maintenance; personal DMs and user-token automation are intentionally out of
+  scope.
+- `POST /api/v1/import/meeting` accepts one provider-neutral meeting at a time,
+  stores it as a searchable meeting transcript, and updates repeated deliveries
+  in place by source identifier and external meeting ID.
+- `list-folders` shows selectable IMAP folders and approximate counts.
+  Repeatable `--folder` and `--skip-folder` flags on `sync-full` and `sync`
+  safely restrict a scan without removing messages or labels learned earlier.
+- `export-messages` streams required, bounded time windows as deterministic,
+  provider-neutral `msgvault-message-export/1` JSON Lines. A completion trailer
+  lets consumers reject interrupted output, and exact source and message-type
+  filters keep large mixed archives bounded.
+- `GET /api/v1/messages/changes` provides current message snapshots ordered by
+  a content-change watermark, with opaque archive-bound cursors and a safe
+  completion bound. It is an invalidation feed, not an audit log: multiple
+  edits may collapse into one row, and related-table-only changes are outside
+  its contract.
+- Email sync now confirms strong source-scoped identity evidence from trusted
+  Sent metadata. `identity discover` previews archived and optional Fastmail
+  alias evidence, while `identity import` previews or applies text and JSON
+  lists with unambiguous numeric source selection.
+- Durable person profiles provide stable IDs, vCard UIDs, explicit participant
+  bindings, display-name overrides, and optimistic concurrency. Typed,
+  historized person attributes and portable metadata-defined fields are
+  available through the CLI, HTTP API, and generated clients. Together with
+  the meeting, change-feed, and source-identity additions, these changes
+  advance the OpenAPI schema to 1.36.0.
 - MCP Streamable HTTP can reuse `[server].api_key` for bearer authentication.
   Authenticated listeners may bind beyond loopback without the insecure
   override, while keyless non-loopback listeners still require an explicit
   `--http-allow-insecure` opt-in.
+- The vCard codec now parses, validates, and deterministically renders vCard
+  2.1, 3.0, and 4.0 while preserving ordered properties, groups, parameters,
+  unknown extensions, legacy encodings, and source spelling. Its IANA registry
+  snapshot and coverage declarations are vendored and checkable.
+- `[data].loose_attachments = true` keeps newly stored attachments as individual
+  files, disables automatic and explicit pack/repack creation, and makes backup
+  restore materialize loose files. Existing packs remain readable until the
+  operator stops the daemon and runs `unpack-attachments` once.
+
+**Improvements**
+
+- Relationship activity, people, domains, and daily signals now use compact
+  Parquet indexes. The Relationships workspace and person/domain/file grouping
+  stay within the daemon's interactive memory budget on multi-million-message
+  archives; upgrading an existing SQLite cache triggers one full rebuild.
+- Email ingestion rejects missing, malformed, and implausible canonical dates
+  outside 1990 through 30 days in the future, then falls back through the oldest
+  plausible `Received` timestamp and source metadata. `repair-dates` previews
+  the same rules and `--apply` records an audit ledger before refreshing the
+  analytics cache.
+- The official Docker image now includes the SQLite vector extension, so
+  SQLite-backed semantic and hybrid search can be enabled without rebuilding
+  the container.
+- `[microsoft].redirect_uri` can override the Microsoft 365 and Teams OAuth
+  callback when the application registration requires a custom URI.
+- The repeatable IMAP sync flags are now singular: `--folder` and
+  `--skip-folder`.
+- Background lifecycle management is standardized under `msgvault daemon`
+  with `start`, `status`, `stop`, and `restart`; `msgvault serve` is the
+  foreground Web UI/API and scheduler. The old `serve` lifecycle forms remain
+  hidden compatibility aliases.
+- Analytics cache builds stage and verify every dataset before publishing it
+  under one lock, with `_last_sync.json` written last as the commit marker.
+  Failed exports retain the previous committed cache, while interrupted
+  publication is rejected and repaired instead of exposing mixed Parquet data.
+- Newly generated NAS Compose bundles use `pull_policy: always` for the moving
+  GHCR `latest` tag. A restart still reuses the installed image; reconcile with
+  `docker compose up -d` or explicitly pull before restarting older bundles.
 
 **Bug fixes**
 
@@ -26,9 +108,58 @@ All notable changes to msgvault, grouped by release.
   deadlines on slow storage. Local daemon authentication uses the lightweight
   authenticated health endpoint, while connection setup, browser traffic, and
   ordinary API clients retain protective timeouts.
-- Newly generated NAS Compose bundles explicitly pull the GHCR `latest` image
-  when reconciling the service, and deployment guidance now distinguishes
-  restarting the installed container from updating it.
+- Daemon runtime-record cleanup now requires a probe-confirmed identity
+  mismatch before deletion, tolerates small creation-time clock skew, and lets
+  a live daemon republish a missing record. This prevents false local-writer
+  conflicts during later operations such as backup.
+- Full message detail, including MCP `get_message`, restores chat senders from
+  `messages.sender_id` when a direct message has no explicit `from` recipient
+  row. Explicit email sender rows remain authoritative.
+- MBOX imports recover dates whose header value gained a trailing continuation
+  artifact and accept weekday plus US month-day ordering.
+- `deduplicate --content-hash` batches RFC822 duplicate-group reads and uses a
+  supporting index instead of issuing one unindexed query per group, avoiding
+  planning timeouts on large archives.
+- Generic and Discord compatibility exports use stable keyset reads, the same
+  sender precedence as message APIs, and outer source constraints when scanning
+  conversations, avoiding rescans, skipped rows, and unrelated archive work.
+- Repeated source-deletion observations preserve the original tombstone time
+  and no longer bump a message's content-change watermark until its state
+  actually changes.
+- Canceled maintenance transactions preserve the caller's cancellation error
+  when `database/sql` has already rolled the transaction back, without masking
+  substantive commit failures.
+- Granola accepts exact date-only values for note, calendar, and transcript
+  timestamps and normalizes them to midnight UTC instead of dropping the note.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for the Web UI, bounded
+  message export, transactional analytics cache, daemon lifecycle and slow-I/O
+  work, Docker deployment freshness, and release documentation infrastructure.
+- Thanks to [Rusty Shackleford](https://github.com/salmonumbrella) for source
+  identity discovery, durable person profiles and typed attributes, generic
+  meeting ingestion, MCP bearer authentication, the vCard codec, Beeper account
+  discovery, and direct-message sender hydration.
+- Thanks to [Matt Richmond](https://github.com/m-j-r) for Slack workspace
+  archiving, reply discovery, media handling, and Granola test portability.
+- Thanks to [Matthew Farrellee](https://github.com/mattf) for IMAP folder
+  discovery and filtering, the singular sync flags, configurable Microsoft
+  OAuth redirects, and error-handling cleanup.
+- Thanks to [Jesse Robbins](https://github.com/jesserobbins) for date recovery
+  and repair, scalable duplicate planning, and the relationship-query fan-out
+  work incorporated into the memory-bounded index.
+- Thanks to [danshapiro](https://github.com/danshapiro) for the message change
+  feed, idempotent source-deletion tombstones, daemon runtime-record safety,
+  schema-copy robustness, and faster PostgreSQL tests.
+- Thanks to [Nicholas Wang](https://github.com/nicwn) for enabling SQLite vector
+  search in the Docker image.
+- Thanks to [Martin Schürrer](https://github.com/MSch) for the loose-files-only
+  attachment storage mode.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for accepting
+  date-only Granola timestamps.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for keeping PostgreSQL
+  CI coverage on reliable hosted runners.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,10 +54,11 @@ All notable changes to msgvault, grouped by release.
   completion bound. It is an invalidation feed, not an audit log: multiple
   edits may collapse into one row, and related-table-only changes are outside
   its contract.
-- Email sync now confirms strong source-scoped identity evidence from trusted
-  Sent metadata. `identity discover` previews archived and optional Fastmail
-  alias evidence, while `identity import` previews or applies text and JSON
-  lists with unambiguous numeric source selection.
+- Email sync now enriches already-confirmed source-scoped identities with
+  strong evidence from trusted Sent metadata; first-time aliases require
+  `identity discover --apply`. `identity discover` previews archived and
+  optional Fastmail alias evidence, while `identity import` previews or applies
+  text and JSON lists with unambiguous numeric source selection.
 - Durable person profiles provide stable IDs, vCard UIDs, explicit participant
   bindings, display-name overrides, and optimistic concurrency. Typed,
   historized person attributes and portable metadata-defined fields are

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1225,10 +1225,12 @@ msgvault identity import [<account>] [--source-id <id>] (--file <path> | --stdin
 | `--signal` | `import` | Evidence signal recorded for imported identities (default `manual`) |
 | `--apply` | `import` | Confirm every validated imported identity; without it the command only previews |
 
-Email sync automatically confirms strong sender evidence from trusted Sent
-metadata. Recipient-only evidence stays review-only. See [People, Profiles,
-and Source Identities](/usage/people/) for classifications, Fastmail inventory,
-and import formats.
+Email sync enriches identities already confirmed for the source with strong
+sender evidence from trusted Sent metadata; it does not confirm first-time
+aliases. Review candidates with `msgvault identity discover` and apply strong
+candidates with `msgvault identity discover --apply`. Recipient-only evidence
+stays review-only. See [People, Profiles, and Source Identities](/usage/people/)
+for classifications, Fastmail inventory, and import formats.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1194,10 +1194,12 @@ Manage the confirmed "me" identifiers for each account.
 The identity subcommands use the configured remote server or local daemon by default. `--local` uses the local daemon even when a remote is configured.
 
 ```bash
-msgvault identity list [flags]
-msgvault identity show <account> [flags]
-msgvault identity add <account> <identifier> [flags]
-msgvault identity remove <account> <identifier>
+msgvault identity list [--account <account> | --collection <name> | --source-id <id>]
+msgvault identity show [<account>] [--source-id <id>]
+msgvault identity add [<account>] <identifier> [--source-id <id>]
+msgvault identity remove [<account>] <identifier> [--source-id <id>]
+msgvault identity discover [<account>] [--source-id <id>] [--apply]
+msgvault identity import [<account>] [--source-id <id>] (--file <path> | --stdin)
 ```
 
 | Command | Description |
@@ -1206,13 +1208,92 @@ msgvault identity remove <account> <identifier>
 | `identity show <account>` | Show one account's identity in detail |
 | `identity add <account> <identifier>` | Add a confirmed identifier |
 | `identity remove <account> <identifier>` | Remove a confirmed identifier |
+| `identity discover <account>` | Preview archived source evidence; `--apply` confirms strong candidates |
+| `identity import <account>` | Preview or apply source-scoped identifiers from text or JSON |
 
 | Flag | Applies to | Description |
 |---|---|---|
 | `--account` | `list` | Restrict to a single account |
 | `--collection` | `list` | Restrict to all member accounts of a collection |
-| `--json` | `list`, `show` | Output as JSON |
+| `--source-id` | all subcommands | Select one source unambiguously by numeric ID; mutually exclusive with an account argument or `list` scope |
+| `--json` | `list`, `show`, `discover`, `import` | Output structured JSON; discovery also suppresses progress |
 | `--signal` | `add` | Evidence signal name (default `manual`) |
+| `--apply` | `discover` | After the complete preview scan, confirm strong evidence |
+| `--provider` | `discover` | Include the source's configured `[[fastmail]]` alias inventory |
+| `--confirm <address>` | `discover` | Explicitly confirm one weak candidate; repeatable and requires `--apply` |
+| `--file <path>` / `--stdin` | `import` | Read a text or JSON identity list from exactly one input |
+| `--signal` | `import` | Evidence signal recorded for imported identities (default `manual`) |
+| `--apply` | `import` | Confirm every validated imported identity; without it the command only previews |
+
+Email sync automatically confirms strong sender evidence from trusted Sent
+metadata. Recipient-only evidence stays review-only. See [People, Profiles,
+and Source Identities](/usage/people/) for classifications, Fastmail inventory,
+and import formats.
+
+---
+
+## person
+
+Manage durable person profiles and their typed, historized attributes. A
+profile is created only by explicit promotion of an observed participant's
+identity cluster.
+
+```bash
+msgvault person promote <participant-id>
+msgvault person list [--json]
+msgvault person get <person-id> [--json]
+msgvault person set-display-name <person-id> <display-name> [--json]
+msgvault person set-display-name <person-id> --clear [--json]
+msgvault person delete <person-id>
+
+msgvault person attributes list <person-id> [--slug <slug>] [--history] [--json]
+msgvault person attributes set <person-id> <slug> (--value <scalar> | --value-json <json|@path|->) [flags]
+msgvault person attributes clear <person-id> <slug> [flags]
+```
+
+`promote` is idempotent. `set-display-name` preserves the profile's stable ID
+and vCard UID. `delete` permanently retires that UID and removes the profile's
+participant bindings.
+
+| Attribute flag | Applies to | Description |
+|---|---|---|
+| `--slug <slug>` | `list` | Restrict output to one definition |
+| `--history` | `list` | Include superseded values instead of current values only |
+| `--value <scalar>` | `set` | Coerce text, integer, real, boolean, date, or timestamp input to the definition's type |
+| `--value-json <json\|@path\|->` | `set` | Supply a structured typed-value envelope |
+| `--ordinal <n>` | `set`, `clear` | Address one slot of a multi-valued definition |
+| `--source <name>` | `set` | Provenance: `user`, `carddav_import`, `vcard_import`, `archive_observation`, `extraction`, `enrichment`, or `system` |
+| `--source-ref <value>` | `set` | Resource or message reference that produced the value |
+| `--confidence <0..1>` | `set` | Confidence for a derived or suggested value |
+| `--actor <value>` | `set` | Actor recorded with the value |
+| `--expected-value-id <id>` | `set`, `clear` | Compare-and-swap guard for the current value |
+| `--dry-run` | `set`, `clear` | Validate and preview without writing |
+| `--json` | `list`, `set`, `clear` | Output structured JSON |
+
+Setting or clearing a value closes the current history row rather than deleting
+it. See [People, Profiles, and Source Identities](/usage/people/) for the
+shipped definitions and complete workflow.
+
+---
+
+## attribute-definition
+
+Manage portable field metadata. Definitions add no runtime database columns;
+their universal IDs and slugs remain stable while labels and descriptions may
+change.
+
+```bash
+msgvault attribute-definition list [--object-type person|organization] [--include-hidden] [--json]
+msgvault attribute-definition get <definition-id> [--json]
+msgvault attribute-definition create --definition <json|@path|-> [--dry-run] [--json]
+msgvault attribute-definition rename <definition-id> [--label <text>] [--description <text> | --clear-description] [--json]
+msgvault attribute-definition delete <definition-id>
+```
+
+`create --dry-run` performs local structural validation but cannot detect a
+conflict with definitions already stored by the daemon. `rename` does not
+change the immutable slug or universal ID. Deletion is limited to user-created,
+deletable definitions that have no stored values.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,9 @@ data_dir = "/path/to/msgvault/data"
 # Database URL (default: {data_dir}/msgvault.db; PostgreSQL DSN supported)
 database_url = "/path/to/msgvault.db"
 
+# Keep attachment content as individual files instead of creating packs.
+# loose_attachments = true
+
 [oauth]
 # Path to Google OAuth client secrets JSON for browser OAuth
 client_secrets = "/path/to/client_secret.json"
@@ -39,6 +42,12 @@ client_secrets = "/path/to/acme_workspace_secret.json"
 client_id = "your-azure-app-client-id"
 # redirect_uri = "http://localhost:8089/callback/microsoft"  # default
 # tenant_id = "your-tenant-id"   # optional, default "common"
+
+# Optional source-scoped Fastmail alias inventory.
+[[fastmail]]
+source_id = 14
+api_token = "replace-with-a-Fastmail-API-token"
+auto_confirm_identities = false
 
 [discord]
 # Per-attachment download cap (default: 50 MiB)
@@ -201,6 +210,25 @@ sync. Required only if you use `add-o365`, `add-teams`, or `sync-teams`.
 | `tenant_id` | `common` | Azure AD tenant ID; `common` allows both personal and org accounts |
 
 See [OAuth Setup: Microsoft 365](/guides/oauth-setup/#microsoft-365-outlook-hotmail) for app registration steps. Teams uses the same `client_id` but requests Microsoft Graph scopes and stores tokens under `tokens/teams_<email>.json`; Outlook/Hotmail IMAP OAuth uses `tokens/microsoft_<email>.json`.
+
+### `[[fastmail]]`
+
+Optional source-scoped Fastmail JMAP identity inventory. This does not replace
+IMAP ingestion credentials: add and sync the mailbox normally, then use the API
+token only to discover masked and send-as addresses that belong to that source.
+
+| Key | Default | Description |
+|---|---|---|
+| `source_id` | — | Positive numeric archive source ID; mutually exclusive with `account` |
+| `account` | — | Unambiguous source identifier or display name; mutually exclusive with `source_id` |
+| `api_token` | (required) | Fastmail API token used for the JMAP identity inventory |
+| `auto_confirm_identities` | `false` | Refresh and apply strong provider identity evidence after successful mailbox syncs |
+
+Exactly one source selector is required. Prefer `source_id` when two sources
+share an identifier or display name. With automatic confirmation disabled,
+`msgvault identity discover --source-id <id> --provider` fetches the inventory
+for an explicit preview; add `--apply` only after reviewing it. See [People,
+Profiles, and Source Identities](/usage/people/#fastmail-alias-inventory).
 
 ### `[discord]`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -80,6 +80,25 @@ make lint
 go vet ./...
 ```
 
+## vCard registry maintenance
+
+The lossless vCard 2.1/3.0/4.0 codec vendors the IANA vCard Elements registry
+under `internal/vcard/registry/data`. Registry checks are deliberate networked
+maintenance commands, not ordinary CI steps:
+
+```bash
+# Report whether the upstream registry differs from the vendored snapshot.
+make vcard-registry-check
+
+# Fetch, validate, and atomically update the snapshot for review.
+make vcard-registry-update
+```
+
+The codec preserves ordered properties, source spelling, parameter quoting,
+unknown extensions, and raw values. Keep new registry elements covered by an
+explicit handling declaration so an upstream addition cannot be silently
+ignored.
+
 ## Code Conventions
 
 - **Web UI**: Svelte with TypeScript, generated OpenAPI types, and components

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,13 +30,13 @@ By default, everything stays on your local machine. msgvault stores messages in 
 <p class="faq-question">Can I use msgvault with non-Gmail accounts?</p>
 
 Yes. You can sync any standard IMAP server, Microsoft 365 mail and Teams,
-Discord guilds, Beeper Desktop chats, Google Calendar, and supported meeting
+Discord guilds, Slack workspaces, Beeper Desktop chats, Google Calendar, and supported meeting
 note services. You can also import email from PST, MBOX, or Apple Mail and
 chats/texts from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS
 Backup & Restore. All messages use the same Web UI, search, TUI, MCP, REST API,
 and export surfaces. See [Setup Guide](/setup/#add-an-imap-account),
 [Importing Local Email](/usage/importing/), [Text Messages](/usage/text-messages/),
-and [Discord](/usage/discord/).
+and [Discord](/usage/discord/) or [Slack](/usage/slack/).
 
 <p class="faq-question">Can msgvault archive Discord direct messages?</p>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,8 @@ Restore, and can sync Teams conversations, Discord guilds, Slack workspaces,
 Beeper chats, plus Granola and Circleback meeting notes.
 Keyword search, analytics, the Web UI, the TUI, and the MCP server query your archive.
 **Source services are contacted only by authorization/registration, sync,
-media-backfill, and deletion workflows that you run or schedule explicitly.**
+media-backfill, provider-backed identity discovery, and deletion workflows that
+you run or schedule explicitly.**
 Optional vector search calls only the embedding endpoint you configure; use a
 local or self-hosted endpoint if message text must never leave your machine or
 network.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: msgvault
-description: Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, a keyboard-driven TUI, and sync for Gmail, IMAP, Teams, Discord, Beeper, Granola, and Circleback.
+description: Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, a keyboard-driven TUI, and sync for Gmail, IMAP, Teams, Discord, Slack, Beeper, Granola, and Circleback.
 ---
 
 # msgvault
@@ -18,7 +18,7 @@ search, and local AI workflows.
   <img src="/assets/generated/tui-senders.svg" alt="msgvault TUI showing the Senders view" loading="eager">
 </figure>
 
-Supports Gmail, Google Calendar, Microsoft Teams, Discord, Granola, Circleback, Beeper
+Supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack, Granola, Circleback, Beeper
 Desktop, IMAP, and Microsoft 365 mail sync; verifiable backup snapshots; PST,
 MBOX, and Apple Mail import; and chat/text import from WhatsApp, iMessage,
 Google Voice, Facebook Messenger, and SMS Backup & Restore.
@@ -41,19 +41,19 @@ powershell -ExecutionPolicy ByPass -c "irm https://msgvault.io/install.ps1 | iex
 Then [set up OAuth credentials](/guides/oauth-setup/) and [start
 syncing](/setup/). You can also [build from source](/setup/#build-from-source).
 
-!!! note "New in 0.18.0"
-    Archive Beeper Desktop chats and Granola or Circleback meeting notes;
-    browse meetings in the TUI; install bundled agent skills; retrieve
-    attachments by hash through the HTTP API; and use native Windows ARM64
-    releases. See the [Changelog](/changelog/) for the full release notes.
+!!! note "New in 0.19.0"
+    Explore relationships in the new Web UI; archive Slack workspaces and
+    Discord guilds; ingest meetings through the API; export bounded message
+    windows; discover source identities; and manage durable person profiles.
+    See the [Changelog](/changelog/) for the full release notes.
 
 ## Why msgvault?
 
 Your email and message data is yours. msgvault downloads a complete local copy
 of your email (from Gmail, IMAP, or local archives) and imports chats and texts
 from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup &
-Restore, and can sync Teams conversations, Discord guilds, Beeper chats, plus
-Granola and Circleback meeting notes.
+Restore, and can sync Teams conversations, Discord guilds, Slack workspaces,
+Beeper chats, plus Granola and Circleback meeting notes.
 Keyword search, analytics, the Web UI, the TUI, and the MCP server query your archive.
 **Source services are contacted only by authorization/registration, sync,
 media-backfill, and deletion workflows that you run or schedule explicitly.**
@@ -86,8 +86,8 @@ it lives in an archive on disk that you own and control.
     <p>Archive guild channels, threads, forum posts, and attachments through a dedicated read-only bot. Resumable per-container checkpoints and bounded repair preserve history safely under <code>message_type = discord</code>.</p>
   </section>
   <section>
-    <h3>Meetings &amp; Beeper</h3>
-    <p>Sync Granola and Circleback notes and transcripts, and archive chats and media from networks connected to Beeper Desktop. Explore each source in the Web UI or its dedicated TUI mode.</p>
+    <h3>Slack, Meetings &amp; Beeper</h3>
+    <p>Archive Slack workspaces, sync Granola and Circleback notes and transcripts, and archive chats and media from networks connected to Beeper Desktop. Explore each source in the Web UI or its dedicated TUI mode.</p>
   </section>
   <section>
     <h3>Backup Snapshots</h3>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,8 +24,9 @@ This means:
   over the years.
 
 I started with Gmail but I want all my life's messages in this system,
-including Google Calendar, Microsoft Teams, Discord guilds, Beeper Desktop chats, Granola and
-Circleback meeting notes, WhatsApp, iMessage, Google Voice, Facebook Messenger,
+including Google Calendar, Microsoft Teams, Discord guilds, Slack workspaces,
+Beeper Desktop chats, Granola and Circleback meeting notes, WhatsApp, iMessage,
+Google Voice, Facebook Messenger,
 SMS Backup & Restore archives, and old local email
 archives.
 

--- a/docs/screenshots/Dockerfile
+++ b/docs/screenshots/Dockerfile
@@ -2,13 +2,17 @@
 # Stage 1: Build msgvault binary
 FROM golang:1.26-bookworm AS builder
 
+ARG MSGVAULT_VERSION=dev
+
 RUN apt-get update && apt-get install -y --no-install-recommends git make gcc g++ libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 
 COPY . /src
 WORKDIR /src
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    make build
+    CGO_ENABLED=1 go build -buildvcs=false -tags "fts5 sqlite_vec" \
+      -ldflags="-X go.kenn.io/msgvault/cmd/msgvault/cmd.Version=${MSGVAULT_VERSION}" \
+      -o msgvault ./cmd/msgvault
 
 # Stage 2: Screenshot runtime with freeze + tmux
 FROM debian:bookworm-slim

--- a/docs/screenshots/generate-all.sh
+++ b/docs/screenshots/generate-all.sh
@@ -41,6 +41,7 @@ REPO_RESOLVED="$(cd "$REPO" 2>/dev/null && pwd)" || {
 }
 REPO="$REPO_RESOLVED"
 export MSGVAULT_REPO="$REPO"
+SCREENSHOT_VERSION="${MSGVAULT_DOCS_SCREENSHOT_VERSION:-$(git -C "$REPO" describe --tags --abbrev=0 2>/dev/null || printf 'dev')}"
 
 # --- Step 1: Generate demo data ---
 if [[ "$SKIP_DATA" == false ]]; then
@@ -52,7 +53,9 @@ fi
 # --- Step 2: Build Docker image ---
 if [[ "$SKIP_BUILD" == false ]]; then
     echo "==> Building Docker image: $IMAGE_NAME"
-    DOCKER_BUILDKIT=1 docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/Dockerfile" "$REPO"
+    DOCKER_BUILDKIT=1 docker build \
+        --build-arg "MSGVAULT_VERSION=$SCREENSHOT_VERSION" \
+        -t "$IMAGE_NAME" -f "$SCRIPT_DIR/Dockerfile" "$REPO"
     echo ""
 fi
 
@@ -61,9 +64,9 @@ echo "==> Building analytics cache..."
 docker run --rm \
     -v "$DEMO_DATA_DIR:/data" \
     -e "MSGVAULT_HOME=/data" \
-    --entrypoint msgvault \
+    --entrypoint bash \
     "$IMAGE_NAME" \
-    build-cache --full-rebuild
+    -c 'MSGVAULT_DAEMON_BUILD_CACHE_PARENT_PID=$$ msgvault --local build-cache --full-rebuild; status=$?; exit "$status"'
 echo ""
 
 # --- Step 4: Generate screenshots ---

--- a/docs/screenshots/generate-screenshots.sh
+++ b/docs/screenshots/generate-screenshots.sh
@@ -6,6 +6,7 @@ OUTPUT_DIR="${1:-/output}"
 FREEZE_CFG="/tapes/freeze.json"
 SESSION="mv"
 SVG_FONT_FAMILY="Liberation Mono, Menlo, Monaco, Consolas, Courier New, monospace"
+DARK_BACKGROUND_RESPONSE=$'\033]11;rgb:1a1a/1b1b/2626\033\\'
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -53,6 +54,11 @@ echo "==> TUI screenshots"
 
 send "MSGVAULT_HOME=/data msgvault tui" Enter
 wait_until "Sender"
+# The detached tmux session has no terminal emulator to answer Bubble Tea's
+# OSC 11 background-color query. Supply the dark canvas color used by freeze so
+# adaptive TUI styles select their dark palette before any capture.
+send -l "$DARK_BACKGROUND_RESPONSE"
+wait_until "alex.chen@gmail.com"
 
 # 1. Senders view (default)
 sleep 0.5

--- a/docs/usage/imap.md
+++ b/docs/usage/imap.md
@@ -71,23 +71,23 @@ msgvault sync-full you@example.com --folder "Receipts, 2025"
 
 ## Skip Selected Folders
 
-Use `--skip-folders` to scan every folder except the ones you name:
+Use `--skip-folder` to scan every folder except the ones you name:
 
 ```bash
 msgvault sync-full you@example.com \
-  --skip-folders Trash \
-  --skip-folders Spam
+  --skip-folder Trash \
+  --skip-folder Spam
 ```
 
 You can combine include and exclude filters. msgvault first keeps the folders
-named by `--folders`, then removes any named by `--skip-folders`:
+named by `--folder`, then removes any named by `--skip-folder`:
 
 ```bash
 msgvault sync-full you@example.com \
-  --folders INBOX \
-  --folders Archive \
-  --folders "Archive/Newsletters" \
-  --skip-folders "Archive/Newsletters"
+  --folder INBOX \
+  --folder Archive \
+  --folder "Archive/Newsletters" \
+  --skip-folder "Archive/Newsletters"
 ```
 
 That example scans `INBOX` and `Archive`.

--- a/docs/usage/multi-account.md
+++ b/docs/usage/multi-account.md
@@ -85,6 +85,11 @@ If a token expires during sync, msgvault prints the re-authorization URL with th
 
 Each account has a confirmed "me" identity: the email addresses, phone numbers, chat handles, or synthetic identifiers that mean you inside that source. Deduplication uses this set for sent-copy detection, so for "sent" versus "received" to mean anything in older imports, msgvault needs to know which identifiers are you in each account.
 
+Source identities are different from the observed people and durable profiles
+used by relationship exploration. See [People, Profiles, and Source
+Identities](/usage/people/) for evidence discovery, bulk import, optional
+Fastmail alias inventory, person promotion, and typed attributes.
+
 New Gmail, IMAP, Microsoft 365, MBOX, EMLX, WhatsApp, and Google Voice sources auto-confirm the source identifier by default. Use `--no-default-identity` on supported add/import commands when that is not correct. (iMessage imports are exempt, because iMessage contacts are not self-identifying.)
 
 ```bash

--- a/docs/usage/people.md
+++ b/docs/usage/people.md
@@ -20,9 +20,12 @@ profile data through the selected local or remote daemon.
 
 ## Discover source identities
 
-Full and incremental email sync automatically confirm strong sender evidence
-from trusted Sent metadata. Recipient-only evidence remains a review candidate:
-receiving mail at an address does not by itself prove that the address is you.
+Full and incremental email sync enrich identities already confirmed for the
+source with strong sender evidence from trusted Sent metadata. Sync does not
+confirm first-time aliases; review them with `msgvault identity discover` and
+apply strong candidates with `msgvault identity discover --apply`.
+Recipient-only evidence remains a review candidate: receiving mail at an
+address does not by itself prove that the address is you.
 
 Preview all evidence for one source without changing the archive:
 

--- a/docs/usage/people.md
+++ b/docs/usage/people.md
@@ -1,0 +1,185 @@
+---
+title: People, Profiles, and Source Identities
+description: Discover the addresses that mean you inside each source, curate stable person profiles, and store typed profile attributes.
+---
+
+Msgvault keeps three related concepts separate so archive evidence is not
+mistaken for user-curated data:
+
+- A **source identity** is an address or handle that means you inside one
+  ingestion source. It drives sent-message classification and deduplication.
+- An **observed person** is an identity cluster assembled from explicit archive
+  links. Equal display names alone never merge people.
+- A **durable person profile** is an observed cluster you explicitly promote.
+  It has a stable numeric ID and vCard UID, so curated data survives later
+  identity-link changes.
+
+The Web UI's People and Relationships workspaces use observed identity
+evidence. The commands on this page add explicit source identities and durable
+profile data through the selected local or remote daemon.
+
+## Discover source identities
+
+Full and incremental email sync automatically confirm strong sender evidence
+from trusted Sent metadata. Recipient-only evidence remains a review candidate:
+receiving mail at an address does not by itself prove that the address is you.
+
+Preview all evidence for one source without changing the archive:
+
+```bash
+msgvault list-accounts
+msgvault identity discover --source-id 14
+```
+
+Use the numeric source ID when account identifiers or display names are not
+unique. After reviewing the classifications, apply strong evidence:
+
+```bash
+msgvault identity discover --source-id 14 --apply
+```
+
+Weak evidence is never applied implicitly. Confirm an exact weak candidate
+deliberately with a repeatable flag:
+
+```bash
+msgvault identity discover --source-id 14 --apply \
+  --confirm you+archive@example.com
+```
+
+`--json` suppresses progress and returns the final structured result. Discovery
+does not modify source messages or provider state.
+
+## Import an owned identity list
+
+`identity import` accepts either a text file with one identifier per line or a
+JSON array/envelope. It validates and previews by default:
+
+```bash
+msgvault identity import --source-id 14 --file aliases.txt
+msgvault identity import --source-id 14 --file aliases.json --apply
+printf '%s\n' you@example.com you+news@example.com | \
+  msgvault identity import --source-id 14 --stdin --apply
+```
+
+Exactly one of `--file` and `--stdin` is required. `--signal` changes the
+recorded evidence name from its `manual` default. Imported provider state is
+reporting metadata only; imports never remove a previously confirmed identity.
+
+## Fastmail alias inventory
+
+An optional Fastmail JMAP token can add masked and send-as addresses to the same
+review. Select exactly one archive source by `source_id`, or by an unambiguous
+account identifier or display name:
+
+```toml
+[[fastmail]]
+source_id = 14
+api_token = "replace-with-a-Fastmail-API-token"
+auto_confirm_identities = false
+```
+
+Fetch the inventory only when requested:
+
+```bash
+msgvault identity discover --source-id 14 --provider
+msgvault identity discover --source-id 14 --provider --apply
+```
+
+Enabled, disabled, and deleted aliases are strong historical evidence; pending
+aliases remain review-only, and wildcard identities are rejected. Set
+`auto_confirm_identities = true` to refresh and apply strong Fastmail evidence
+after successful mailbox syncs. A changed mailbox refreshes immediately; a
+no-change sync rechecks only when the last successful provider refresh is more
+than 24 hours old or the prior attempt failed.
+
+The API token is stored in `config.toml`; protect that file like the rest of the
+msgvault data directory.
+
+## Promote a durable person
+
+People returned by the Web UI or API include participant IDs. Promote any
+participant in one identity cluster to reserve a stable profile:
+
+```bash
+msgvault person promote 42
+msgvault person list
+msgvault person get 7
+msgvault person set-display-name 7 "Alex Example"
+```
+
+Promotion is explicit and idempotent; observed people are not promoted
+automatically. Linking another cluster into a promoted one expands that
+profile's participant bindings. Linking two clusters that already belong to
+different profiles reports a conflict instead of silently merging curated
+data. Unlinking evidence does not move or delete profile bindings.
+
+Clear only the display-name override with `--clear`:
+
+```bash
+msgvault person set-display-name 7 --clear
+```
+
+`person delete` is permanent. It removes the profile bindings and retires the
+vCard UID forever; promoting the same observed cluster later creates a new
+person and UID.
+
+## Store typed attributes
+
+Every archive starts with four person-field definitions:
+
+| Slug | Type | Cardinality | Behavior |
+|---|---|---|---|
+| `primary_channel` | text choice | single | Writable: email, phone, SMS, chat, or in person |
+| `contact_frequency` | integer days | single | Writable |
+| `ask_me_about` | text | multiple | Writable and searchable |
+| `last_contacted` | timestamp | single | Read-only derived field; it remains empty until its producer supplies a value |
+
+List fields and values, set scalar values, and retain superseded history:
+
+```bash
+msgvault attribute-definition list --object-type person
+msgvault person attributes list 7
+msgvault person attributes set 7 primary_channel --value email
+msgvault person attributes set 7 ask_me_about --ordinal 0 --value "release engineering"
+msgvault person attributes set 7 ask_me_about --ordinal 1 --value databases
+msgvault person attributes list 7 --history
+```
+
+Setting a value supersedes the current value at the same slug and ordinal; it
+does not overwrite history. `person attributes clear` closes the current value
+and also retains it in history. Use `--dry-run` to validate a set or clear, and
+`--expected-value-id` for compare-and-swap protection when automating updates.
+
+Scalar `--value` input handles text, integer, real, boolean, date, and timestamp
+definitions. Structured record and JSON values use `--value-json` with inline
+JSON, `@path`, or `-` for standard input.
+
+## Create a portable field definition
+
+Custom fields are metadata rows, not runtime database migrations. Their
+universal IDs and slugs are stable; labels and descriptions can change.
+Validate a definition locally before creating it:
+
+```bash
+msgvault attribute-definition create --dry-run --definition '{
+  "object_type": "person",
+  "slug": "favorite_project",
+  "label": "Favorite project",
+  "value_type": "text",
+  "field_type": "text",
+  "cardinality": "single",
+  "is_searchable": true,
+  "is_audited": true
+}'
+
+msgvault attribute-definition create --definition @favorite-project.json
+```
+
+`attribute-definition rename` changes presentation metadata without changing
+stored references. Deletion is limited to user-created definitions that still
+have no stored values; shipped and non-deletable definitions are protected.
+
+For automation, run `msgvault openapi` or read `/openapi.json` from the daemon.
+The contract includes source identities, person profiles, attribute
+definitions, and historized person-attribute routes, and the generated Go
+client exposes the same operations.

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -52,8 +52,10 @@ on your own machine or network.
    target already passes `-tags "fts5 sqlite_vec"`. If you see errors
    mentioning "binary was built without -tags sqlite_vec", rebuild
    via `make build` (or `go build -tags "fts5 sqlite_vec"` if you are
-   invoking `go build` directly). PostgreSQL vector search additionally
-   requires the `pgvector` build tag, for example
+   invoking `go build` directly). The official Docker image also includes
+   `sqlite_vec`, so SQLite-backed container deployments do not need a custom
+   image for vector search. PostgreSQL vector search additionally requires the
+   `pgvector` build tag, for example
    `go build -tags "fts5 sqlite_vec pgvector" ./cmd/msgvault`.
 
 !!! tip "Fastest path to using embeddings on Mac"
@@ -286,7 +288,7 @@ trigger).
 | Manual `sync-calendar` / `sync-teams` / `sync-discord` | No. Run `msgvault embeddings build` afterward |
 | Manual `sync-beeper` / `sync-granola` / `sync-circleback` | No. Run `msgvault embeddings build` afterward |
 | Scheduled account syncs in `msgvault serve` (Gmail, IMAP, Teams, Discord) | Yes, when `[vector.embed.schedule].run_after_sync = true` |
-| Scheduled calendar, Beeper, Granola, and Circleback syncs in `msgvault serve` | No immediate post-sync run. Picked up by the embed worker's `[vector.embed.schedule].cron` schedule |
+| Scheduled calendar, Slack, Beeper, Granola, and Circleback syncs in `msgvault serve` | No immediate post-sync run. Picked up by the embed worker's `[vector.embed.schedule].cron` schedule |
 | `import-pst`, `import-emlx`, `import-mbox` | No. Re-run `--full-rebuild` after large imports |
 | Chat/text imports (iMessage, WhatsApp, Google Voice, Messenger, SyncTech SMS) | No. Run a full rebuild after importing if you want chats included |
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -145,6 +145,11 @@ person to inspect contextual activity across email, chat, calendar events, and
 meeting notes, plus the files associated with that person. The active search
 and filters continue to scope both the timeline and file table.
 
+People in this workspace are observed identity clusters. Source identities
+that mean “me,” explicit durable profile promotion, display-name overrides, and
+typed profile attributes are separate curated operations; see [People,
+Profiles, and Source Identities](/usage/people/).
+
 Domains provides the same activity-and-files analysis for an exact domain
 fact. A domain is not treated as an inferred organization identity. Selecting
 a grouped person or domain in Everything opens its inspector in the current

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_name = "msgvault"
 site_url = "https://msgvault.io"
-site_description = "Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, and sync for Gmail, IMAP, Teams, Discord, Beeper, Granola, and Circleback."
+site_description = "Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, and sync for Gmail, IMAP, Teams, Discord, Slack, Beeper, Granola, and Circleback."
 site_author = "Kenn Software LLC"
 copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>. MIT License.'
 docs_dir = "docs"
@@ -37,6 +37,7 @@ nav = [
     {"Analytics & Stats" = "usage/analytics.md"},
     {"SQL Queries" = "usage/querying.md"},
     {"Deleting Email" = "usage/deletion.md"},
+    {"People, Profiles & Identities" = "usage/people.md"},
     {"Accounts & Collections" = "usage/multi-account.md"},
     {"Deduplication" = "usage/deduplication.md"},
     {"Backup" = "usage/backup.md"},


### PR DESCRIPTION
## Why

msgvault 0.19.0 adds several major archive sources, API surfaces, identity and profile workflows, and storage changes. The public documentation did not yet collect those changes into a complete release record, and a few existing pages still described obsolete IMAP flags, daemon commands, and provider coverage.

A source-backed release pass keeps operators and integrators from missing new workflows or following stale instructions.

## What changed

- Publishes comprehensive 0.19.0 release notes with contributor acknowledgements.
- Adds the missing guide for source identities, durable person profiles, Fastmail alias discovery, and typed attributes.
- Aligns the README and public guides with the shipped CLI, configuration, API schema, analytics cache, Docker vector support, vCard maintenance, and provider coverage.

## How to use it

Start with the 0.19.0 changelog for the release overview. For identity and profile workflows, follow the new People, Profiles, and Source Identities guide. This PR changes documentation only; it does not alter runtime behavior.