### PR TITLE
fix: accept Fastmail pod-scoped JMAP API URLs

### DIFF
--- a/internal/fastmail/client.go
+++ b/internal/fastmail/client.go
@@ -247,16 +247,20 @@ func resolveAPIURL(sessionURL *url.URL, rawAPIURL string) (*url.URL, error) {
 	if _, err := parseEndpoint(endpoint.String()); err != nil {
 		return nil, fmt.Errorf("invalid JMAP API endpoint from %s", sessionURL.Host)
 	}
-	if !sameOrigin(sessionURL, endpoint) {
+	if !sameOriginOrSubdomain(sessionURL, endpoint) {
 		return nil, fmt.Errorf("cross-origin JMAP API endpoint rejected for %s", sessionURL.Host)
 	}
 	return endpoint, nil
 }
 
-func sameOrigin(left, right *url.URL) bool {
-	return strings.EqualFold(left.Scheme, right.Scheme) &&
-		strings.EqualFold(left.Hostname(), right.Hostname()) &&
-		effectivePort(left) == effectivePort(right)
+func sameOriginOrSubdomain(parent, candidate *url.URL) bool {
+	if !strings.EqualFold(parent.Scheme, candidate.Scheme) ||
+		effectivePort(parent) != effectivePort(candidate) {
+		return false
+	}
+	parentHost := strings.ToLower(parent.Hostname())
+	candidateHost := strings.ToLower(candidate.Hostname())
+	return candidateHost == parentHost || strings.HasSuffix(candidateHost, "."+parentHost)
 }
 
 func effectivePort(endpoint *url.URL) string {

--- a/internal/fastmail/client_test.go
+++ b/internal/fastmail/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -274,6 +275,45 @@ func TestListIdentityRecordsRejectsAmbiguousCapabilityAccount(t *testing.T) {
 	require.ErrorContains(t, err, "ambiguous")
 	assert.NotContains(t, err.Error(), testToken)
 	assert.Equal(t, int32(0), methodRequests.Load())
+}
+
+func TestResolveAPIURLAllowsSessionHostSubdomainsOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		sessionURL string
+		apiURL     string
+		wantURL    string
+		wantError  string
+	}{
+		{name: "same origin", sessionURL: "https://api.example.test/jmap/session", apiURL: "https://api.example.test/jmap/api/", wantURL: "https://api.example.test/jmap/api/"},
+		{name: "pod child", sessionURL: "https://api.example.test/jmap/session", apiURL: "https://pod.api.example.test/jmap/api/", wantURL: "https://pod.api.example.test/jmap/api/"},
+		{name: "case insensitive pod child", sessionURL: "https://API.EXAMPLE.TEST/jmap/session", apiURL: "https://Pod.Api.Example.Test/jmap/api/", wantURL: "https://Pod.Api.Example.Test/jmap/api/"},
+		{name: "parent", sessionURL: "https://pod.api.example.test/jmap/session", apiURL: "https://api.example.test/jmap/api/", wantError: "cross-origin"},
+		{name: "sibling", sessionURL: "https://api.example.test/jmap/session", apiURL: "https://mail.example.test/jmap/api/", wantError: "cross-origin"},
+		{name: "label lookalike", sessionURL: "https://api.example.test/jmap/session", apiURL: "https://evilapi.example.test/jmap/api/", wantError: "cross-origin"},
+		{name: "suffix lookalike", sessionURL: "https://api.example.test/jmap/session", apiURL: "https://api.example.test.evil.test/jmap/api/", wantError: "cross-origin"},
+		{name: "different scheme", sessionURL: "https://api.example.test/jmap/session", apiURL: "http://pod.api.example.test/jmap/api/", wantError: "cross-origin"},
+		{name: "different port", sessionURL: "https://api.example.test/jmap/session", apiURL: "https://pod.api.example.test:8443/jmap/api/", wantError: "cross-origin"},
+		{name: "userinfo", sessionURL: "https://api.example.test/jmap/session", apiURL: "https://token@pod.api.example.test/jmap/api/", wantError: "invalid JMAP API endpoint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			sessionURL, err := url.Parse(tt.sessionURL)
+			require.NoError(err)
+
+			got, err := resolveAPIURL(sessionURL, tt.apiURL)
+			if tt.wantError != "" {
+				require.ErrorContains(err, tt.wantError)
+				assert.Nil(got)
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tt.wantURL, got.String())
+		})
+	}
 }
 
 func TestListIdentityRecordsRejectsCrossOriginAPIURLBeforeSendingToken(t *testing.T) {


### PR DESCRIPTION
Fastmail can route JMAP sessions to pod-specific subdomains. Accept the session host or a strict child hostname while preserving the existing scheme and effective-port boundary, so unrelated origins still cannot receive the bearer token.

Fixes #561