### PR TITLE
fix(release): preserve updater checksum compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,7 +589,10 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum -- ./*.tar.gz ./*.zip > SHA256SUMS
+          for archive in *.tar.gz *.zip; do
+            [ -f "$archive" ] || continue
+            sha256sum -- "$archive"
+          done > SHA256SUMS
           cat SHA256SUMS
 
       - name: Get tag message


### PR DESCRIPTION
## Why

The v0.19.1 release generated `SHA256SUMS` entries with `./`-prefixed archive names. The shipped updater compares the manifest filename literally, so update checks failed on every platform before downloading the new archive.

## Consequence

Generate checksum entries from bare archive names while retaining option-safe `sha256sum` handling. Releases built from this workflow will remain consumable by v0.18.0 and current binaries, including the planned v0.19.2 release.