### PR TITLE
fix(cache): bound relationship index builds

### DIFF
--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -342,6 +342,7 @@ func runBuildCacheLocal(fullRebuild, auto bool) error {
 func runBuildCacheLocalMode(mode buildCacheMode) error {
 	dbPath := cfg.DatabaseDSN()
 	analyticsDir := cfg.AnalyticsDir()
+	builderOverrides := analyticsBuilderOverrides(cfg.Analytics)
 
 	// The Parquet cache is a SQLite -> DuckDB ETL; feeding a postgres:// DSN to
 	// the SQLite driver inside buildCache fails immediately with a confusing
@@ -371,13 +372,13 @@ func runBuildCacheLocalMode(mode buildCacheMode) error {
 	var result *buildResult
 	switch mode {
 	case buildCacheModeAuto:
-		result, err = buildCacheAuto(dbPath, analyticsDir)
+		result, err = buildCacheAuto(dbPath, analyticsDir, builderOverrides)
 	case buildCacheModeDerived:
-		result, err = buildCacheDerivedOnly(dbPath, analyticsDir)
+		result, err = buildCacheDerivedOnly(dbPath, analyticsDir, builderOverrides)
 	case buildCacheModeFull:
-		result, err = buildCache(dbPath, analyticsDir, true)
+		result, err = buildCache(dbPath, analyticsDir, true, builderOverrides)
 	case buildCacheModeDefault:
-		result, err = buildCache(dbPath, analyticsDir, false)
+		result, err = buildCache(dbPath, analyticsDir, false, builderOverrides)
 	default:
 		return fmt.Errorf("unknown build-cache mode %d", mode)
 	}
@@ -399,7 +400,25 @@ func runBuildCacheLocalMode(mode buildCacheMode) error {
 	return nil
 }
 
-func buildCacheDerivedOnly(dbPath, analyticsDir string) (*buildResult, error) {
+func analyticsBuilderOverrides(analytics config.AnalyticsConfig) duckdbutil.BuilderOverrides {
+	return duckdbutil.BuilderOverrides{
+		MemoryLimit:          analytics.BuilderMemoryLimit,
+		Threads:              analytics.BuilderThreads,
+		MaxTempDirectorySize: analytics.BuilderTempLimit,
+	}
+}
+
+func firstBuilderOverrides(overrides []duckdbutil.BuilderOverrides) duckdbutil.BuilderOverrides {
+	if len(overrides) == 0 {
+		return duckdbutil.BuilderOverrides{}
+	}
+	return overrides[0]
+}
+
+func buildCacheDerivedOnly(
+	dbPath, analyticsDir string,
+	builderOverrides ...duckdbutil.BuilderOverrides,
+) (*buildResult, error) {
 	buildCacheMu.Lock()
 	defer buildCacheMu.Unlock()
 
@@ -408,7 +427,13 @@ func buildCacheDerivedOnly(dbPath, analyticsDir string) (*buildResult, error) {
 		return nil, err
 	}
 	defer func() { _ = buildLock.Unlock() }()
-	return refreshDerivedDatasetsOnly(context.Background(), dbPath, analyticsDir, acquirePublishLock)
+	return refreshDerivedDatasetsOnly(
+		context.Background(),
+		dbPath,
+		analyticsDir,
+		acquirePublishLock,
+		builderOverrides...,
+	)
 }
 
 func acquireBuildCacheWriteLock(cfg *config.Config) (func(), error) {
@@ -433,8 +458,12 @@ type buildResult struct {
 // buildCache honors an explicit full rebuild unconditionally. Default builds
 // recheck staleness under the inter-process lock so retries cannot skip cache
 // repairs for deletions or other mutations that leave the ID boundary intact.
-func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, error) {
-	return buildCacheImpl(dbPath, analyticsDir, fullRebuild, !fullRebuild)
+func buildCache(
+	dbPath, analyticsDir string,
+	fullRebuild bool,
+	builderOverrides ...duckdbutil.BuilderOverrides,
+) (*buildResult, error) {
+	return buildCacheImpl(dbPath, analyticsDir, fullRebuild, !fullRebuild, builderOverrides...)
 }
 
 // buildCacheAuto builds the cache for automatic (staleness-derived) callers.
@@ -442,11 +471,18 @@ func buildCache(dbPath, analyticsDir string, fullRebuild bool) (*buildResult, er
 // re-evaluated once the lock is held: a build another process finished while
 // we waited can make the work unnecessary or downgrade a full rebuild to an
 // incremental one, instead of erasing a cache that was just completed.
-func buildCacheAuto(dbPath, analyticsDir string) (*buildResult, error) {
-	return buildCacheImpl(dbPath, analyticsDir, false, true)
+func buildCacheAuto(
+	dbPath, analyticsDir string,
+	builderOverrides ...duckdbutil.BuilderOverrides,
+) (*buildResult, error) {
+	return buildCacheImpl(dbPath, analyticsDir, false, true, builderOverrides...)
 }
 
-func buildCacheImpl(dbPath, analyticsDir string, fullRebuild, recheckStaleness bool) (*buildResult, error) {
+func buildCacheImpl(
+	dbPath, analyticsDir string,
+	fullRebuild, recheckStaleness bool,
+	builderOverrides ...duckdbutil.BuilderOverrides,
+) (*buildResult, error) {
 	buildCacheMu.Lock()
 	defer buildCacheMu.Unlock()
 
@@ -455,7 +491,14 @@ func buildCacheImpl(dbPath, analyticsDir string, fullRebuild, recheckStaleness b
 		return nil, err
 	}
 	defer func() { _ = buildLock.Unlock() }()
-	return buildCacheLocked(dbPath, analyticsDir, fullRebuild, recheckStaleness, acquirePublishLock)
+	return buildCacheLocked(
+		dbPath,
+		analyticsDir,
+		fullRebuild,
+		recheckStaleness,
+		acquirePublishLock,
+		builderOverrides...,
+	)
 }
 
 // acquireCacheBuildLock takes the exclusive builder lock that serializes
@@ -537,8 +580,15 @@ func derivedDriftOnly(staleness cacheStaleness) bool {
 func refreshIdentityDatasetsOnly(
 	dbPath, analyticsDir string,
 	locking cachePublishLocking,
+	builderOverrides ...duckdbutil.BuilderOverrides,
 ) (*buildResult, error) {
-	return refreshDerivedDatasetsOnly(context.Background(), dbPath, analyticsDir, locking)
+	return refreshDerivedDatasetsOnly(
+		context.Background(),
+		dbPath,
+		analyticsDir,
+		locking,
+		builderOverrides...,
+	)
 }
 
 // buildCacheLocked exports and publishes a cache while the caller holds the
@@ -548,6 +598,7 @@ func buildCacheLocked(
 	dbPath, analyticsDir string,
 	fullRebuild, recheckStaleness bool,
 	locking cachePublishLocking,
+	builderOverrides ...duckdbutil.BuilderOverrides,
 ) (*buildResult, error) {
 	if err := cleanupStaleCacheStaging(analyticsDir); err != nil {
 		return nil, err
@@ -558,7 +609,7 @@ func buildCacheLocked(
 			return &buildResult{Skipped: true, OutputDir: analyticsDir}, nil
 		}
 		if derivedDriftOnly(staleness) {
-			return refreshIdentityDatasetsOnly(dbPath, analyticsDir, locking)
+			return refreshIdentityDatasetsOnly(dbPath, analyticsDir, locking, builderOverrides...)
 		}
 		fullRebuild = staleness.FullRebuild
 	}
@@ -643,7 +694,10 @@ func buildCacheLocked(
 
 	db, err := duckdbutil.Open(
 		context.Background(),
-		duckdbutil.BuilderPolicy(filepath.Join(staging.root, "duckdb-tmp")),
+		duckdbutil.BuilderPolicyWithOverrides(
+			filepath.Join(staging.root, "duckdb-tmp"),
+			firstBuilderOverrides(builderOverrides),
+		),
 	)
 	if err != nil {
 		return nil, err
@@ -1813,7 +1867,7 @@ func rebuildCacheAfterWrite(dbPath string) error {
 	if !staleness.NeedsBuild {
 		return nil
 	}
-	result, err := buildCacheAuto(dbPath, analyticsDir)
+	result, err := buildCacheAuto(dbPath, analyticsDir, analyticsBuilderOverrides(cfg.Analytics))
 	if err != nil {
 		return fmt.Errorf("refresh analytics cache: %w", err)
 	}

--- a/cmd/msgvault/cmd/cache_derived.go
+++ b/cmd/msgvault/cmd/cache_derived.go
@@ -27,6 +27,7 @@ func refreshDerivedDatasetsOnly(
 	ctx context.Context,
 	dbPath, analyticsDir string,
 	locking cachePublishLocking,
+	builderOverrides ...duckdbutil.BuilderOverrides,
 ) (*buildResult, error) {
 	readiness, err := query.InspectCacheReadiness(analyticsDir)
 	if err != nil {
@@ -93,7 +94,10 @@ func refreshDerivedDatasetsOnly(
 	}
 
 	spillDir := filepath.Join(staging.root, "duckdb-tmp")
-	duckDB, err := duckdbutil.Open(ctx, duckdbutil.BuilderPolicy(spillDir))
+	duckDB, err := duckdbutil.Open(ctx, duckdbutil.BuilderPolicyWithOverrides(
+		spillDir,
+		firstBuilderOverrides(builderOverrides),
+	))
 	if err != nil {
 		return nil, fmt.Errorf("open bounded DuckDB for derived refresh: %w", err)
 	}

--- a/cmd/msgvault/cmd/cache_refresh_test.go
+++ b/cmd/msgvault/cmd/cache_refresh_test.go
@@ -49,6 +49,42 @@ func TestDerivedOnlyRefusesStaleSchemaBeforeCreatingStaging(t *testing.T) {
 	assert.Empty(t, staging)
 }
 
+func TestProductionCacheBuilderOpenSitesUseConfiguredOverrides(t *testing.T) {
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+
+	configure := func(dataDir, dbPath string) {
+		cfg = config.NewDefaultConfig()
+		cfg.Data.DataDir = dataDir
+		cfg.Data.DatabaseURL = dbPath
+		cfg.Analytics.BuilderMemoryLimit = "1B"
+	}
+
+	t.Run("full build", func(t *testing.T) {
+		tmp := setupTestSQLite(t)
+		configure(tmp, filepath.Join(tmp, "test.db"))
+
+		err := runBuildCacheLocalMode(buildCacheModeFull)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "memory_limit")
+	})
+
+	t.Run("derived refresh", func(t *testing.T) {
+		tmp := setupTestSQLite(t)
+		dbPath := filepath.Join(tmp, "test.db")
+		analyticsDir := filepath.Join(tmp, "analytics")
+		_, err := buildCache(dbPath, analyticsDir, true)
+		require.NoError(t, err)
+		configure(tmp, dbPath)
+
+		err = runBuildCacheLocalMode(buildCacheModeDerived)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "memory_limit")
+	})
+}
+
 func TestDerivedOnlyRefreshCarriesStatsAndRefreshesMembershipRollups(t *testing.T) {
 	requirementsForTest := require.New(t)
 	assertionsForTest := assert.New(t)

--- a/cmd/msgvault/cmd/import_imessage.go
+++ b/cmd/msgvault/cmd/import_imessage.go
@@ -154,7 +154,12 @@ func finishImessageImport(s *store.Store) error {
 		// staleness check, so the standard rebuildCacheAfterWrite would skip.
 		// Force a full rebuild so conversations.parquet and
 		// participants.parquet are re-exported and the TUI sees the new names.
-		if _, err := buildCache(dbPath, cfg.AnalyticsDir(), true); err != nil {
+		if _, err := buildCache(
+			dbPath,
+			cfg.AnalyticsDir(),
+			true,
+			analyticsBuilderOverrides(cfg.Analytics),
+		); err != nil {
 			return fmt.Errorf("refresh analytics cache: %w", err)
 		}
 		return nil

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -233,7 +233,14 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 			removeAccountAfterCascadeHook()
 		}
 		fmt.Println("\nRebuilding analytics cache...")
-		_, cacheRefreshErr = buildCacheLocked(cfg.DatabaseDSN(), cfg.AnalyticsDir(), true, false, publishLockHeld)
+		_, cacheRefreshErr = buildCacheLocked(
+			cfg.DatabaseDSN(),
+			cfg.AnalyticsDir(),
+			true,
+			false,
+			publishLockHeld,
+			analyticsBuilderOverrides(cfg.Analytics),
+		)
 		cacheRefreshErr = errors.Join(
 			cacheRefreshErr,
 			wrapError(unlockCache(), "release analytics cache lock"),

--- a/cmd/msgvault/cmd/repair_dates.go
+++ b/cmd/msgvault/cmd/repair_dates.go
@@ -164,6 +164,7 @@ func runRepairDatesLocal(
 			true,
 			false,
 			publishLockHeld,
+			analyticsBuilderOverrides(cfg.Analytics),
 		); err != nil {
 			ledger.Status = "applied-cache-failed"
 			ledger.Error = err.Error()

--- a/cmd/msgvault/cmd/repair_encoding.go
+++ b/cmd/msgvault/cmd/repair_encoding.go
@@ -73,7 +73,12 @@ func runRepairEncodingLocal(cmd *cobra.Command) error {
 
 	dbPath := cfg.DatabaseDSN()
 	analyticsDir := cfg.AnalyticsDir()
-	if _, err := buildCache(dbPath, analyticsDir, true); err != nil {
+	if _, err := buildCache(
+		dbPath,
+		analyticsDir,
+		true,
+		analyticsBuilderOverrides(cfg.Analytics),
+	); err != nil {
 		return fmt.Errorf("encoding repair completed, but analytics cache refresh failed: %w", err)
 	}
 	fmt.Println("\nAnalytics cache rebuilt.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"go.kenn.io/msgvault/internal/duckdbutil"
 	"go.kenn.io/msgvault/internal/fileutil"
 	"go.kenn.io/msgvault/internal/identityops"
 	"go.kenn.io/msgvault/internal/store"
@@ -42,8 +43,11 @@ type ChatConfig struct {
 
 // AnalyticsConfig controls daemon-side analytics engine selection.
 type AnalyticsConfig struct {
-	Engine         string `toml:"engine"`           // auto, sql, or duckdb
-	AutoBuildCache bool   `toml:"auto_build_cache"` // Build stale/missing Parquet cache before using DuckDB
+	Engine             string `toml:"engine"`               // auto, sql, or duckdb
+	AutoBuildCache     bool   `toml:"auto_build_cache"`     // Build stale/missing Parquet cache before using DuckDB
+	BuilderMemoryLimit string `toml:"builder_memory_limit"` // Optional DuckDB cache-builder memory limit
+	BuilderThreads     int    `toml:"builder_threads"`      // Optional DuckDB cache-builder threads; zero uses the default
+	BuilderTempLimit   string `toml:"builder_temp_limit"`   // Optional DuckDB cache-builder temp-directory limit
 }
 
 const (
@@ -140,7 +144,6 @@ func (a *AnalyticsConfig) ApplyDefaults() {
 func (a *AnalyticsConfig) Validate() error {
 	switch a.Engine {
 	case AnalyticsEngineAuto, AnalyticsEngineSQL, AnalyticsEngineDuckDB:
-		return nil
 	default:
 		return fmt.Errorf("invalid [analytics] engine %q (want %q, %q, or %q)",
 			a.Engine,
@@ -148,6 +151,22 @@ func (a *AnalyticsConfig) Validate() error {
 			AnalyticsEngineSQL,
 			AnalyticsEngineDuckDB)
 	}
+	for _, size := range []struct {
+		key   string
+		value string
+	}{
+		{key: "builder_memory_limit", value: a.BuilderMemoryLimit},
+		{key: "builder_temp_limit", value: a.BuilderTempLimit},
+	} {
+		if size.value != "" && !duckdbutil.ValidSize(size.value) {
+			return fmt.Errorf("invalid [analytics] %s %q: want a positive integer followed by B, KB, MB, GB, TB, KiB, MiB, GiB, or TiB",
+				size.key, size.value)
+		}
+	}
+	if a.BuilderThreads < 0 {
+		return fmt.Errorf("invalid [analytics] builder_threads %d: must be zero or positive", a.BuilderThreads)
+	}
+	return nil
 }
 
 // ServerConfig holds HTTP API server configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,10 +27,63 @@ func TestServerConfigDefaults(t *testing.T) {
 }
 
 func TestAnalyticsConfigDefaults(t *testing.T) {
+	assertions := assert.New(t)
 	cfg := NewDefaultConfig()
 
-	assert.Equal(t, AnalyticsEngineAuto, cfg.Analytics.Engine)
-	assert.True(t, cfg.Analytics.AutoBuildCache)
+	assertions.Equal(AnalyticsEngineAuto, cfg.Analytics.Engine)
+	assertions.True(cfg.Analytics.AutoBuildCache)
+	assertions.Empty(cfg.Analytics.BuilderMemoryLimit)
+	assertions.Zero(cfg.Analytics.BuilderThreads)
+	assertions.Empty(cfg.Analytics.BuilderTempLimit)
+}
+
+func TestLoadWithAnalyticsBuilderResourceLimits(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+	requirements.NoError(os.WriteFile(configPath, []byte(`
+[analytics]
+builder_memory_limit = "1536mIb"
+builder_threads = 3
+builder_temp_limit = "12gB"
+`), 0o600))
+
+	cfg, err := Load(configPath, "")
+	requirements.NoError(err)
+	assertions.Equal("1536mIb", cfg.Analytics.BuilderMemoryLimit)
+	assertions.Equal(3, cfg.Analytics.BuilderThreads)
+	assertions.Equal("12gB", cfg.Analytics.BuilderTempLimit)
+}
+
+func TestLoadRejectsInvalidAnalyticsBuilderResourceLimits(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "zero memory", key: "builder_memory_limit", value: `"0GB"`},
+		{name: "fractional memory", key: "builder_memory_limit", value: `"1.5GB"`},
+		{name: "missing memory unit", key: "builder_memory_limit", value: `"2"`},
+		{name: "whitespace in memory", key: "builder_memory_limit", value: `" 2GB"`},
+		{name: "zero temp", key: "builder_temp_limit", value: `"0GiB"`},
+		{name: "negative temp", key: "builder_temp_limit", value: `"-8GB"`},
+		{name: "missing temp number", key: "builder_temp_limit", value: `"GB"`},
+		{name: "negative threads", key: "builder_threads", value: "-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.toml")
+			content := "[analytics]\n" + tt.key + " = " + tt.value + "\n"
+			require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+			_, err := Load(configPath, "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid [analytics] "+tt.key)
+		})
+	}
 }
 
 func TestDiscordConfigDefaults(t *testing.T) {

--- a/internal/duckdbutil/connection.go
+++ b/internal/duckdbutil/connection.go
@@ -25,6 +25,14 @@ type Policy struct {
 	MaxTempDirectorySize string
 }
 
+// BuilderOverrides contains optional cache-builder policy values. Empty size
+// values and zero threads retain BuilderPolicy defaults.
+type BuilderOverrides struct {
+	MemoryLimit          string
+	Threads              int
+	MaxTempDirectorySize string
+}
+
 // InteractivePolicy returns the bounded policy for daemon-side queries.
 func InteractivePolicy(tempDirectory string) Policy {
 	return Policy{
@@ -43,6 +51,21 @@ func BuilderPolicy(tempDirectory string) Policy {
 		TempDirectory:        tempDirectory,
 		MaxTempDirectorySize: "8GB",
 	}
+}
+
+// BuilderPolicyWithOverrides applies non-zero overrides to BuilderPolicy.
+func BuilderPolicyWithOverrides(tempDirectory string, overrides BuilderOverrides) Policy {
+	policy := BuilderPolicy(tempDirectory)
+	if overrides.MemoryLimit != "" {
+		policy.MemoryLimit = overrides.MemoryLimit
+	}
+	if overrides.Threads != 0 {
+		policy.Threads = overrides.Threads
+	}
+	if overrides.MaxTempDirectorySize != "" {
+		policy.MaxTempDirectorySize = overrides.MaxTempDirectorySize
+	}
+	return policy
 }
 
 // Open creates one in-memory DuckDB connection and applies policy before any
@@ -69,10 +92,10 @@ func Apply(ctx context.Context, db *sql.DB, policy Policy) error {
 	if policy.Threads <= 0 {
 		return errors.New("apply duckdb policy: threads must be positive")
 	}
-	if !validSize(policy.MemoryLimit) {
+	if !ValidSize(policy.MemoryLimit) {
 		return fmt.Errorf("apply duckdb policy: invalid memory limit %q", policy.MemoryLimit)
 	}
-	if !validSize(policy.MaxTempDirectorySize) {
+	if !ValidSize(policy.MaxTempDirectorySize) {
 		return fmt.Errorf("apply duckdb policy: invalid temp-directory limit %q", policy.MaxTempDirectorySize)
 	}
 	if policy.TempDirectory == "" || !filepath.IsAbs(policy.TempDirectory) {
@@ -101,6 +124,8 @@ func Apply(ctx context.Context, db *sql.DB, policy Policy) error {
 	return nil
 }
 
-func validSize(value string) bool {
+// ValidSize reports whether value is a positive integer followed by a
+// case-insensitive DuckDB byte-size unit.
+func ValidSize(value string) bool {
 	return duckDBSizePattern.MatchString(value)
 }

--- a/internal/duckdbutil/connection_test.go
+++ b/internal/duckdbutil/connection_test.go
@@ -3,11 +3,42 @@ package duckdbutil
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBuilderPolicyDefaults(t *testing.T) {
+	assertions := assert.New(t)
+	tempDir := filepath.Join(t.TempDir(), "spill")
+
+	policy := BuilderPolicy(tempDir)
+
+	assertions.Equal("2GB", policy.MemoryLimit)
+	assertions.Equal(min(runtime.GOMAXPROCS(0), 2), policy.Threads)
+	assertions.Equal(tempDir, policy.TempDirectory)
+	assertions.Equal("8GB", policy.MaxTempDirectorySize)
+}
+
+func TestBuilderPolicyWithOverrides(t *testing.T) {
+	assertions := assert.New(t)
+	tempDir := filepath.Join(t.TempDir(), "spill")
+	policy := BuilderPolicyWithOverrides(tempDir, BuilderOverrides{
+		MemoryLimit:          "1536mIb",
+		Threads:              3,
+		MaxTempDirectorySize: "12gB",
+	})
+
+	assertions.Equal("1536mIb", policy.MemoryLimit)
+	assertions.Equal(3, policy.Threads)
+	assertions.Equal(tempDir, policy.TempDirectory)
+	assertions.Equal("12gB", policy.MaxTempDirectorySize)
+
+	defaultThreads := BuilderPolicyWithOverrides(tempDir, BuilderOverrides{Threads: 0})
+	assertions.Equal(min(runtime.GOMAXPROCS(0), 2), defaultThreads.Threads)
+}
 
 func TestPolicyAppliesEffectiveSettings(t *testing.T) {
 	tempDir := filepath.Join(t.TempDir(), "spill")

--- a/internal/identityindex/build.go
+++ b/internal/identityindex/build.go
@@ -95,11 +95,7 @@ func Build(
 		}
 	}
 
-	if err := b.copyDataset(
-		ctx,
-		DatasetActivity,
-		buildRelationshipActivitySQL(b.base),
-	); err != nil {
+	if err := b.copyRelationshipActivity(ctx); err != nil {
 		return BuildResult{}, err
 	}
 	activity := b.activityRelation()
@@ -232,34 +228,88 @@ func (b builder) copyDataset(ctx context.Context, dataset, query string) error {
 	start := time.Now()
 	output := filepath.Join(b.opts.OutputRoot, dataset, "data.parquet")
 	options := "FORMAT PARQUET, COMPRESSION 'zstd'"
-	if dataset == DatasetActivity {
-		output = filepath.Join(b.opts.OutputRoot, dataset)
-		options += ", PARTITION_BY (occurred_year), WRITE_PARTITION_COLUMNS true, OVERWRITE_OR_IGNORE"
-	}
 	statement := "COPY (" + query + ") TO '" + quoteSQLString(output) +
 		"' (" + options + ")"
 	if _, err := b.db.ExecContext(ctx, statement); err != nil {
 		return fmt.Errorf("build %s: %w", dataset, err)
 	}
-	if dataset == DatasetActivity &&
-		!datasetContainsParquet(b.opts.OutputRoot, dataset) {
-		emptyOutput := filepath.Join(
-			b.opts.OutputRoot,
-			dataset,
-			"occurred_year=0",
-			"empty.parquet",
-		)
-		if err := os.MkdirAll(filepath.Dir(emptyOutput), 0o755); err != nil {
-			return fmt.Errorf("create empty %s partition: %w", dataset, err)
+	if b.opts.Progress != nil {
+		b.opts.Progress(dataset, time.Since(start))
+	}
+	return nil
+}
+
+func (b builder) copyRelationshipActivity(ctx context.Context) error {
+	start := time.Now()
+	years, err := b.relationshipActivityYears(ctx)
+	if err != nil {
+		return err
+	}
+
+	output := filepath.Join(b.opts.OutputRoot, DatasetActivity)
+	options := "FORMAT PARQUET, COMPRESSION 'zstd', PARTITION_BY (occurred_year), " +
+		"WRITE_PARTITION_COLUMNS true, OVERWRITE_OR_IGNORE"
+	for _, year := range years {
+		query := buildRelationshipActivitySQL(b.base, year)
+		statement := "COPY (" + query + ") TO '" + quoteSQLString(output) +
+			"' (" + options + ")"
+		if _, err := b.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("build %s for year %d: %w", DatasetActivity, year, err)
 		}
-		emptyStatement := "COPY (SELECT * FROM (" + query + ") WHERE false) TO '" +
-			quoteSQLString(emptyOutput) + "' (FORMAT PARQUET, COMPRESSION 'zstd')"
-		if _, err := b.db.ExecContext(ctx, emptyStatement); err != nil {
-			return fmt.Errorf("build empty %s: %w", dataset, err)
+	}
+
+	if !datasetContainsParquet(b.opts.OutputRoot, DatasetActivity) {
+		if err := b.copyEmptyRelationshipActivity(ctx); err != nil {
+			return err
 		}
 	}
 	if b.opts.Progress != nil {
-		b.opts.Progress(dataset, time.Since(start))
+		b.opts.Progress(DatasetActivity, time.Since(start))
+	}
+	return nil
+}
+
+func (b builder) relationshipActivityYears(ctx context.Context) ([]int64, error) {
+	query := `
+		SELECT DISTINCT year(sent_at)::BIGINT AS occurred_year
+		FROM read_parquet('` + quoteSQLString(b.base("messages")) + `',
+		                  hive_partitioning=true, union_by_name=true)
+		ORDER BY occurred_year`
+	rows, err := b.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list relationship activity years: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var years []int64
+	for rows.Next() {
+		var year int64
+		if err := rows.Scan(&year); err != nil {
+			return nil, fmt.Errorf("scan relationship activity year: %w", err)
+		}
+		years = append(years, year)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list relationship activity years: %w", err)
+	}
+	return years, nil
+}
+
+func (b builder) copyEmptyRelationshipActivity(ctx context.Context) error {
+	emptyOutput := filepath.Join(
+		b.opts.OutputRoot,
+		DatasetActivity,
+		"occurred_year=0",
+		"empty.parquet",
+	)
+	if err := os.MkdirAll(filepath.Dir(emptyOutput), 0o755); err != nil {
+		return fmt.Errorf("create empty %s partition: %w", DatasetActivity, err)
+	}
+	query := buildRelationshipActivitySQL(b.base, 0)
+	statement := "COPY (SELECT * FROM (" + query + ") WHERE false) TO '" +
+		quoteSQLString(emptyOutput) + "' (FORMAT PARQUET, COMPRESSION 'zstd')"
+	if _, err := b.db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("build empty %s: %w", DatasetActivity, err)
 	}
 	return nil
 }

--- a/internal/identityindex/build_test.go
+++ b/internal/identityindex/build_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"go.kenn.io/msgvault/internal/duckdbutil"
 
@@ -69,6 +70,60 @@ func TestBuildPublishesFourRelationshipDatasets(t *testing.T) {
 		"non-chat people fan-out excludes conversation-only members")
 	assertions.Equal(int64(3), relationshipParquetCount(t, db, root, DatasetDomains),
 		"non-chat domain fan-out includes conversation-only domains")
+}
+
+func TestBuildChunksRelationshipActivityByOccurrenceYear(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	root, db := writeRelationshipBaseFixture(t, false)
+	replaceRelationshipParquet(t, db, root, "messages", `
+		SELECT * FROM (VALUES
+			(100::BIGINT, 1::BIGINT, 'm-100'::VARCHAR, 10::BIGINT,
+			 'Earlier'::VARCHAR, ''::VARCHAR, TIMESTAMP '2025-12-31 10:30:00',
+			 50::BIGINT, true, 1::INTEGER, NULL::TIMESTAMP,
+			 1::BIGINT, 'email'::VARCHAR, false, 2025::INTEGER, 12::INTEGER),
+			(101::BIGINT, 1::BIGINT, 'm-101'::VARCHAR, 10::BIGINT,
+			 'Later'::VARCHAR, ''::VARCHAR, TIMESTAMP '2026-01-01 10:30:00',
+			 50::BIGINT, false, 0::INTEGER, NULL::TIMESTAMP,
+			 1::BIGINT, 'email'::VARCHAR, false, 2026::INTEGER, 1::INTEGER)
+		) AS t(id, source_id, source_message_id, conversation_id, subject,
+			snippet, sent_at, size_estimate, has_attachments, attachment_count,
+			deleted_from_source_at, sender_id, message_type, is_from_me, year, month)`)
+
+	recordingDB := &relationshipActivityCopyRecorder{sqlExecutor: db}
+	activityProgressCalls := 0
+	_, err := Build(context.Background(), recordingDB, BuildOptions{
+		Mode:           ModeFull,
+		StagedBaseRoot: root,
+		OutputRoot:     root,
+		Progress: func(dataset string, _ time.Duration) {
+			if dataset == DatasetActivity {
+				activityProgressCalls++
+			}
+		},
+	})
+	requirements.NoError(err)
+
+	assertions.Equal(2, recordingDB.activityCopies)
+	assertions.Equal(1, activityProgressCalls)
+	for _, year := range []int64{2025, 2026} {
+		shard := filepath.Join(
+			root,
+			DatasetActivity,
+			fmt.Sprintf("occurred_year=%d", year),
+			"data_0.parquet",
+		)
+		assertions.FileExists(shard)
+
+		var minYear, maxYear int64
+		requirements.NoError(db.QueryRow(`
+			SELECT min(occurred_year), max(occurred_year)
+			FROM read_parquet(?, hive_partitioning=false)
+		`, shard).Scan(&minYear, &maxYear))
+		assertions.Equal(year, minYear)
+		assertions.Equal(year, maxYear)
+	}
+	assertions.Equal(int64(5), relationshipParquetCount(t, db, root, DatasetActivity))
 }
 
 func TestBuildEmptyArchivePublishesSchemaCorrectActivityShard(t *testing.T) {
@@ -180,6 +235,12 @@ func TestBuildIncrementalWritesActivityDeltaAndRebuildsCompactPopulation(t *test
 	requirements.NoError(err)
 
 	assertions.Equal(int64(3), relationshipParquetCount(t, db, stagedRoot, DatasetActivity))
+	assertions.FileExists(filepath.Join(
+		stagedRoot,
+		DatasetActivity,
+		"occurred_year=2027",
+		"data_0.parquet",
+	))
 	assertions.Equal(int64(2), result.Stats.TotalMessages)
 	var activityCount int64
 	requirements.NoError(db.QueryRow(`
@@ -330,9 +391,9 @@ func rewriteRelationshipFixtureIDs(
 		SELECT * FROM (VALUES
 			(%d::BIGINT, 1::BIGINT, 'm-%d'::VARCHAR, %d::BIGINT,
 			 'Subject'::VARCHAR, 'Preview'::VARCHAR,
-			 TIMESTAMP '2026-07-21 10:30:00', 50::BIGINT, true,
+			 TIMESTAMP '2027-07-21 10:30:00', 50::BIGINT, true,
 			 1::INTEGER, NULL::TIMESTAMP, 1::BIGINT, 'email'::VARCHAR,
-			 false, 2026::INTEGER, 7::INTEGER)
+			 false, 2027::INTEGER, 7::INTEGER)
 		) AS t(id, source_id, source_message_id, conversation_id, subject,
 			snippet, sent_at, size_estimate, has_attachments, attachment_count,
 			deleted_from_source_at, sender_id, message_type, is_from_me, year, month)`,
@@ -359,6 +420,23 @@ func rewriteRelationshipFixtureIDs(
 			(2::BIGINT, %d::BIGINT, 12::BIGINT, 'file.txt'::VARCHAR, 'text/plain'::VARCHAR)
 		) AS t(attachment_id, message_id, size, filename, mime_type)`,
 		messageID))
+}
+
+type relationshipActivityCopyRecorder struct {
+	sqlExecutor
+
+	activityCopies int
+}
+
+func (r *relationshipActivityCopyRecorder) ExecContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) (sql.Result, error) {
+	if strings.Contains(query, "PARTITION_BY (occurred_year)") {
+		r.activityCopies++
+	}
+	return r.sqlExecutor.ExecContext(ctx, query, args...)
 }
 
 func replaceRelationshipParquet(

--- a/internal/identityindex/relationship_sql.go
+++ b/internal/identityindex/relationship_sql.go
@@ -15,38 +15,13 @@ func logicalActivitySQL(activityPath, filterSQL string) string {
 	}
 	activity := activityRelation(activityPath, true)
 	return fmt.Sprintf(`
-WITH relationship_activity AS (
-	SELECT * FROM %s
-), filtered_facts AS (
+WITH filtered_facts AS (
 	SELECT f.message_id, f.conversation_id, f.source_id, f.source_type,
 	       f.occurred_at, f.message_type, f.conversation_type, f.entry_kind,
 	       f.is_chat, f.is_from_me, f.attachment_count, f.deleted_from_source
-	FROM relationship_activity f
-	WHERE %s
+	FROM %[1]s f
+	WHERE %[2]s
 	GROUP BY ALL
-), filtered_activity AS (
-	SELECT a.*
-	FROM relationship_activity a
-	JOIN filtered_facts f USING (message_id)
-), canonical_message_domain_edges AS (
-	SELECT message_id, canonical_id, participant_domain,
-	       bool_or(is_direct) AS is_direct,
-	       bool_or(is_conversation_member) AS is_conversation_member,
-	       bool_or(is_sender) AS is_sender,
-	       bool_or(is_author) AS is_author,
-	       bool_or(is_owner) AS is_owner
-	FROM filtered_activity
-	WHERE canonical_id IS NOT NULL
-	GROUP BY message_id, canonical_id, participant_domain
-), canonical_message_edges AS (
-	SELECT message_id, canonical_id,
-	       bool_or(is_direct) AS is_direct,
-	       bool_or(is_conversation_member) AS is_conversation_member,
-	       bool_or(is_sender) AS is_sender,
-	       bool_or(is_author) AS is_author,
-	       bool_or(is_owner) AS is_owner
-	FROM canonical_message_domain_edges
-	GROUP BY message_id, canonical_id
 ), nonchat_units AS (
 	SELECT ('message:' || f.message_id)::VARCHAR AS entry_key,
 	       f.message_id::BIGINT AS anchor_message_id,
@@ -83,21 +58,35 @@ WITH relationship_activity AS (
 	UNION ALL
 	SELECT * FROM chat_units
 ), logical_people_candidates AS (
-	SELECT u.entry_key, d.canonical_id, d.is_author, d.is_owner
+	SELECT u.entry_key, f.canonical_id, f.is_author, f.is_owner
 	FROM nonchat_units u
-	JOIN canonical_message_edges d ON d.message_id = u.anchor_message_id
-	WHERE d.is_direct
+	JOIN %[1]s f ON f.message_id = u.anchor_message_id
+	WHERE f.canonical_id IS NOT NULL
+	  AND f.is_direct
 
 	UNION ALL
 
-	SELECT u.entry_key, d.canonical_id,
-	       (d.message_id = u.anchor_message_id AND d.is_author) AS is_author,
-	       d.is_owner
+	SELECT u.entry_key, f.canonical_id,
+	       (f.message_id = u.anchor_message_id AND f.is_author) AS is_author,
+	       f.is_owner
 	FROM chat_units u
-	JOIN filtered_facts f
-	  ON f.source_id = u.source_id AND f.conversation_id = u.conversation_id
-	 AND f.is_chat
-	JOIN canonical_message_edges d ON d.message_id = f.message_id
+	JOIN %[1]s f ON f.message_id = u.anchor_message_id
+	WHERE f.canonical_id IS NOT NULL
+
+	UNION ALL
+
+	SELECT u.entry_key, f.canonical_id,
+	       (f.message_id = u.anchor_message_id AND f.is_author) AS is_author,
+	       f.is_owner
+	FROM chat_units u
+	JOIN filtered_facts selected
+	  ON selected.source_id = u.source_id
+	 AND selected.conversation_id = u.conversation_id
+	 AND selected.is_chat
+	JOIN %[1]s f ON f.message_id = selected.message_id
+	WHERE f.canonical_id IS NOT NULL
+	  AND f.is_direct
+	  AND f.message_id <> u.anchor_message_id
 ), logical_people_grouped AS (
 	SELECT entry_key, canonical_id,
 	       bool_or(is_author) AS is_author,
@@ -115,35 +104,59 @@ WITH relationship_activity AS (
 	JOIN logical_units u USING (entry_key)
 	LEFT JOIN logical_owner_presence op USING (entry_key)
 ), logical_person_domain_candidates AS (
-	SELECT u.entry_key, d.canonical_id, d.participant_domain AS domain
+	SELECT u.entry_key, f.canonical_id, f.participant_domain AS domain
 	FROM nonchat_units u
-	JOIN canonical_message_domain_edges d ON d.message_id = u.anchor_message_id
-	WHERE d.is_direct
+	JOIN %[1]s f ON f.message_id = u.anchor_message_id
+	WHERE f.canonical_id IS NOT NULL
+	  AND f.is_direct
 
 	UNION ALL
 
-	SELECT u.entry_key, d.canonical_id, d.participant_domain AS domain
+	SELECT u.entry_key, f.canonical_id, f.participant_domain AS domain
 	FROM chat_units u
-	JOIN filtered_facts f
-	  ON f.source_id = u.source_id AND f.conversation_id = u.conversation_id
-	 AND f.is_chat
-	JOIN canonical_message_domain_edges d ON d.message_id = f.message_id
+	JOIN %[1]s f ON f.message_id = u.anchor_message_id
+	WHERE f.canonical_id IS NOT NULL
+
+	UNION ALL
+
+	SELECT u.entry_key, f.canonical_id, f.participant_domain AS domain
+	FROM chat_units u
+	JOIN filtered_facts selected
+	  ON selected.source_id = u.source_id
+	 AND selected.conversation_id = u.conversation_id
+	 AND selected.is_chat
+	JOIN %[1]s f ON f.message_id = selected.message_id
+	WHERE f.canonical_id IS NOT NULL
+	  AND f.is_direct
+	  AND f.message_id <> u.anchor_message_id
 ), logical_person_domains AS (
 	SELECT DISTINCT entry_key, canonical_id, domain
 	FROM logical_person_domain_candidates
 ), logical_domain_candidates AS (
-	SELECT u.entry_key, d.participant_domain AS domain
+	SELECT u.entry_key, f.participant_domain AS domain
 	FROM nonchat_units u
-	JOIN canonical_message_domain_edges d ON d.message_id = u.anchor_message_id
+	JOIN %[1]s f ON f.message_id = u.anchor_message_id
+	WHERE f.canonical_id IS NOT NULL
 
 	UNION ALL
 
-	SELECT u.entry_key, d.participant_domain AS domain
+	SELECT u.entry_key, f.participant_domain AS domain
 	FROM chat_units u
-	JOIN filtered_facts f
-	  ON f.source_id = u.source_id AND f.conversation_id = u.conversation_id
-	 AND f.is_chat
-	JOIN canonical_message_domain_edges d ON d.message_id = f.message_id
+	JOIN %[1]s f ON f.message_id = u.anchor_message_id
+	WHERE f.canonical_id IS NOT NULL
+
+	UNION ALL
+
+	SELECT u.entry_key, f.participant_domain AS domain
+	FROM chat_units u
+	JOIN filtered_facts selected
+	  ON selected.source_id = u.source_id
+	 AND selected.conversation_id = u.conversation_id
+	 AND selected.is_chat
+	JOIN %[1]s f ON f.message_id = selected.message_id
+	WHERE f.canonical_id IS NOT NULL
+	  AND f.is_direct
+	  AND f.message_id <> u.anchor_message_id
 ), logical_domain_keys AS (
 	SELECT DISTINCT entry_key, domain
 	FROM logical_domain_candidates
@@ -165,7 +178,7 @@ WITH relationship_activity AS (
 	)
 }
 
-func buildRelationshipActivitySQL(path func(string) string) string {
+func buildRelationshipActivitySQL(path func(string) string, occurredYear int64) string {
 	return fmt.Sprintf(`
 WITH message_facts AS (
 	SELECT m.id::BIGINT AS message_id,
@@ -186,6 +199,11 @@ WITH message_facts AS (
 	FROM read_parquet('%s', hive_partitioning=true, union_by_name=true) m
 	JOIN read_parquet('%s') s ON s.id = m.source_id
 	LEFT JOIN read_parquet('%s') c ON c.id = m.conversation_id
+	WHERE year(m.sent_at) = %d
+), scoped_conversations AS (
+	SELECT DISTINCT conversation_id
+	FROM message_facts
+	WHERE conversation_id IS NOT NULL
 ), canon AS (
 	SELECT p.id::BIGINT AS participant_id,
 	       coalesce(c.canonical_id, p.id)::BIGINT AS canonical_id,
@@ -196,59 +214,127 @@ WITH message_facts AS (
 	SELECT DISTINCT c.canonical_id
 	FROM read_parquet('%s') o
 	JOIN canon c ON c.participant_id = o.participant_id
-), raw_edges AS (
+), direct_edges AS (
 	SELECT mr.message_id::BIGINT AS message_id,
 	       mr.participant_id::BIGINT AS participant_id,
 	       true AS is_direct,
-	       false AS is_conversation_member,
 	       false AS is_sender,
 	       (mr.recipient_type = 'from') AS is_author
 	FROM read_parquet('%s') mr
+	JOIN message_facts m ON m.message_id = mr.message_id
 
 	UNION ALL
 
-	SELECT m.message_id, m.sender_id, true, false, true, true
+	SELECT m.message_id, m.sender_id, true, true, true
 	FROM message_facts m
 	WHERE m.sender_id IS NOT NULL
-
-	UNION ALL
-
-	SELECT m.message_id, cp.participant_id::BIGINT,
-	       false, true, false, false
-	FROM message_facts m
-	JOIN read_parquet('%s') cp
-	  ON cp.conversation_id = m.conversation_id
+), direct_canon AS (
+	SELECT e.message_id, e.is_direct, e.is_sender, e.is_author,
+	       c.canonical_id, c.participant_domain
+	FROM direct_edges e
+	LEFT JOIN canon c USING (participant_id)
+), direct_agg AS (
+	SELECT message_id, canonical_id, participant_domain,
+	       bool_or(is_direct) AS is_direct,
+	       bool_or(is_sender) AS is_sender,
+	       bool_or(is_author) AS is_author
+	FROM direct_canon
+	WHERE canonical_id IS NOT NULL
+	GROUP BY message_id, canonical_id, participant_domain
+), conv_members AS (
+	SELECT cp.conversation_id::BIGINT AS conversation_id,
+	       c.canonical_id, c.participant_domain
+	FROM read_parquet('%s') cp
+	JOIN scoped_conversations sc ON sc.conversation_id = cp.conversation_id
+	LEFT JOIN canon c ON c.participant_id = cp.participant_id
+), conv_members_canon AS (
+	SELECT DISTINCT conversation_id, canonical_id, participant_domain
+	FROM conv_members
+	WHERE canonical_id IS NOT NULL
 )
 SELECT m.message_id, m.conversation_id, m.source_id, m.source_type,
        m.occurred_at, m.message_type, m.conversation_type, m.entry_kind,
        m.is_chat, m.is_from_me, m.attachment_count, m.has_attachments,
        m.deleted_from_source,
-       c.canonical_id, c.participant_domain,
-       coalesce(bool_or(e.is_direct)
-           FILTER (WHERE c.canonical_id IS NOT NULL), false) AS is_direct,
-       coalesce(bool_or(e.is_conversation_member)
-           FILTER (WHERE c.canonical_id IS NOT NULL), false)
-           AS is_conversation_member,
-       coalesce(bool_or(e.is_sender)
-           FILTER (WHERE c.canonical_id IS NOT NULL), false) AS is_sender,
-       coalesce(bool_or(e.is_author)
-           FILTER (WHERE c.canonical_id IS NOT NULL), false) AS is_author,
+       cm.canonical_id, cm.participant_domain,
+       coalesce(d.is_direct, false) AS is_direct,
+       true AS is_conversation_member,
+       coalesce(d.is_sender, false) AS is_sender,
+       coalesce(d.is_author, false) AS is_author,
        (o.canonical_id IS NOT NULL) AS is_owner,
        m.occurred_year
 FROM message_facts m
-LEFT JOIN raw_edges e USING (message_id)
-LEFT JOIN canon c USING (participant_id)
-LEFT JOIN owner_canon o USING (canonical_id)
-GROUP BY m.message_id, m.conversation_id, m.source_id, m.source_type,
-         m.occurred_at, m.message_type, m.conversation_type, m.entry_kind,
-         m.is_chat, m.is_from_me, m.attachment_count, m.has_attachments,
-         m.deleted_from_source,
-         c.canonical_id, c.participant_domain, o.canonical_id, m.occurred_year`,
+	JOIN conv_members_canon cm USING (conversation_id)
+	LEFT JOIN direct_agg d
+	  ON d.message_id = m.message_id
+	 AND d.canonical_id = cm.canonical_id
+	 AND d.participant_domain = cm.participant_domain
+	LEFT JOIN owner_canon o ON o.canonical_id = cm.canonical_id
+
+UNION ALL
+
+SELECT m.message_id, m.conversation_id, m.source_id, m.source_type,
+       m.occurred_at, m.message_type, m.conversation_type, m.entry_kind,
+       m.is_chat, m.is_from_me, m.attachment_count, m.has_attachments,
+       m.deleted_from_source,
+       d.canonical_id, d.participant_domain,
+       d.is_direct,
+       false AS is_conversation_member,
+       d.is_sender,
+       d.is_author,
+       (o.canonical_id IS NOT NULL) AS is_owner,
+       m.occurred_year
+FROM message_facts m
+	JOIN direct_agg d USING (message_id)
+	LEFT JOIN conv_members_canon cm
+	  ON cm.conversation_id = m.conversation_id
+	 AND cm.canonical_id = d.canonical_id
+	 AND cm.participant_domain = d.participant_domain
+	LEFT JOIN owner_canon o ON o.canonical_id = d.canonical_id
+WHERE cm.canonical_id IS NULL
+
+UNION ALL
+
+SELECT m.message_id, m.conversation_id, m.source_id, m.source_type,
+       m.occurred_at, m.message_type, m.conversation_type, m.entry_kind,
+       m.is_chat, m.is_from_me, m.attachment_count, m.has_attachments,
+       m.deleted_from_source,
+       NULL::BIGINT AS canonical_id,
+       NULL::VARCHAR AS participant_domain,
+       false AS is_direct,
+       false AS is_conversation_member,
+       false AS is_sender,
+       false AS is_author,
+       false AS is_owner,
+       m.occurred_year
+FROM message_facts m
+WHERE EXISTS (
+	SELECT 1
+	FROM direct_canon d
+	WHERE d.message_id = m.message_id AND d.canonical_id IS NULL
+)
+OR EXISTS (
+	SELECT 1
+	FROM conv_members cm
+	WHERE cm.conversation_id = m.conversation_id
+	  AND cm.canonical_id IS NULL
+)
+OR (
+	NOT EXISTS (
+		SELECT 1 FROM direct_agg d WHERE d.message_id = m.message_id
+	)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM conv_members_canon cm
+		WHERE cm.conversation_id = m.conversation_id
+	)
+)`,
 		EntryKindSQL("m.message_type"),
 		IsChatSQL("m.message_type", "coalesce(c.conversation_type, '')"),
 		quoteSQLString(path("messages")),
 		quoteSQLString(path("sources")),
 		quoteSQLString(path("conversations")),
+		occurredYear,
 		quoteSQLString(path("participants")),
 		quoteSQLString(path("participant_clusters")),
 		quoteSQLString(path("owner_participants")),

--- a/internal/identityindex/relationship_sql_test.go
+++ b/internal/identityindex/relationship_sql_test.go
@@ -1,0 +1,819 @@
+package identityindex
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const stressRelationshipActivity100MEnv = "MSGVAULT_STRESS_RELATIONSHIP_ACTIVITY_100M"
+
+func TestRelationshipActivityMatchesLegacyRowSet(t *testing.T) {
+	root, db := writeRelationshipEquivalenceFixture(t)
+	path := func(dataset string) string {
+		return parquetDatasetGlob(root, dataset)
+	}
+
+	query := `
+		WITH legacy AS (` + buildLegacyRelationshipActivitySQL(path) + `),
+		production AS (` + buildRelationshipActivitySQL(path, 2026) + `)
+		SELECT
+			(SELECT count(*) FROM (SELECT * FROM legacy EXCEPT SELECT * FROM production)),
+			(SELECT count(*) FROM (SELECT * FROM production EXCEPT SELECT * FROM legacy))`
+	var legacyOnly, productionOnly int64
+	require.NoError(t, db.QueryRow(query).Scan(&legacyOnly, &productionOnly))
+	assert.Zero(t, legacyOnly)
+	assert.Zero(t, productionOnly)
+}
+
+func TestRelationshipActivityYearQueryExcludesOffYearEdgesUnderLowMemory(t *testing.T) {
+	type activityRow struct {
+		messageID            int64
+		conversationID       int64
+		occurredYear         int64
+		canonicalID          int64
+		participantDomain    string
+		isDirect             bool
+		isConversationMember bool
+		isSender             bool
+		isAuthor             bool
+		isOwner              bool
+	}
+
+	requirements := require.New(t)
+	root, db := writeRelationshipBaseFixture(t, true)
+	writeRelationshipYearScopeFixture(t, db, root)
+	requirements.NoError(setRelationshipTestMemoryLimit(db, "128MB"))
+
+	path := func(dataset string) string {
+		return parquetDatasetGlob(root, dataset)
+	}
+	output := filepath.Join(t.TempDir(), "relationship-activity-2025.parquet")
+	_, err := db.Exec(`COPY (` + buildRelationshipActivitySQL(path, 2025) + `) TO '` +
+		quoteSQLString(output) + `' (FORMAT PARQUET)`)
+	requirements.NoError(err)
+
+	rows, err := db.Query(`
+		SELECT message_id, conversation_id, occurred_year, canonical_id,
+		       participant_domain, is_direct, is_conversation_member,
+		       is_sender, is_author, is_owner
+		FROM read_parquet(?)
+		ORDER BY canonical_id`, output)
+	requirements.NoError(err)
+	t.Cleanup(func() {
+		requirements.NoError(rows.Close())
+	})
+
+	var got []activityRow
+	for rows.Next() {
+		var row activityRow
+		requirements.NoError(rows.Scan(
+			&row.messageID,
+			&row.conversationID,
+			&row.occurredYear,
+			&row.canonicalID,
+			&row.participantDomain,
+			&row.isDirect,
+			&row.isConversationMember,
+			&row.isSender,
+			&row.isAuthor,
+			&row.isOwner,
+		))
+		got = append(got, row)
+	}
+	requirements.NoError(rows.Err())
+	assert.Equal(t, []activityRow{
+		{
+			messageID:         1,
+			conversationID:    10,
+			occurredYear:      2025,
+			canonicalID:       1,
+			participantDomain: "example.test",
+			isDirect:          true,
+			isSender:          true,
+			isAuthor:          true,
+			isOwner:           true,
+		},
+		{
+			messageID:            1,
+			conversationID:       10,
+			occurredYear:         2025,
+			canonicalID:          2,
+			participantDomain:    "example.test",
+			isConversationMember: true,
+		},
+	}, got)
+}
+
+func TestBuildStreamsRelationshipActivityUnderLowMemory(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	root, db := writeRelationshipBaseFixture(t, true)
+	writeSyntheticRelationshipFanOut(t, db, root, syntheticRelationshipFanOutOptions{
+		firstMessageID:   1,
+		messageCount:     5_000,
+		memberCount:      200,
+		startDate:        "2026-01-01",
+		messageType:      "email",
+		conversationType: "email_thread",
+	})
+	requirements.NoError(setRelationshipTestMemoryLimit(db, "128MB"))
+
+	path := func(dataset string) string {
+		return parquetDatasetGlob(root, dataset)
+	}
+	legacyOutput := filepath.Join(t.TempDir(), "legacy.parquet")
+	_, err := db.Exec(`COPY (` + buildLegacyRelationshipActivitySQL(path) + `) TO '` +
+		quoteSQLString(legacyOutput) + `' (FORMAT PARQUET)`)
+	requirements.Error(err)
+	assertions.Contains(strings.ToLower(err.Error()), "out of memory")
+
+	result, err := Build(context.Background(), db, BuildOptions{
+		Mode:           ModeFull,
+		StagedBaseRoot: root,
+		OutputRoot:     root,
+	})
+	requirements.NoError(err)
+	assertions.Equal(int64(1_000_000), result.Activity.FinalRows)
+	assertions.Equal(int64(1_000_000), result.Activity.ConversationExpandedRows)
+}
+
+func TestBuildIncrementalAppendsIntervalOverFanOut(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	committedRoot, db := writeRelationshipBaseFixture(t, true)
+	writeSyntheticRelationshipFanOut(t, db, committedRoot, syntheticRelationshipFanOutOptions{
+		firstMessageID:   1,
+		messageCount:     4,
+		memberCount:      5,
+		startDate:        "2026-01-01",
+		messageType:      "email",
+		conversationType: "email_thread",
+	})
+	_, err := Build(context.Background(), db, BuildOptions{
+		Mode:           ModeFull,
+		StagedBaseRoot: committedRoot,
+		OutputRoot:     committedRoot,
+	})
+	requirements.NoError(err)
+
+	stagedRoot := t.TempDir()
+	writeSyntheticRelationshipFanOut(t, db, stagedRoot, syntheticRelationshipFanOutOptions{
+		firstMessageID:   101,
+		messageCount:     3,
+		memberCount:      5,
+		startDate:        "2026-02-01",
+		messageType:      "email",
+		conversationType: "email_thread",
+	})
+	result, err := Build(context.Background(), db, BuildOptions{
+		Mode:           ModeIncremental,
+		CommittedRoot:  committedRoot,
+		StagedBaseRoot: stagedRoot,
+		OutputRoot:     stagedRoot,
+	})
+	requirements.NoError(err)
+
+	assertions.Equal(int64(15), relationshipParquetCount(
+		t, db, stagedRoot, DatasetActivity,
+	))
+	assertions.Equal(int64(7), result.Activity.DirectRows)
+	assertions.Equal(int64(35), result.Activity.ConversationExpandedRows)
+	assertions.Equal(int64(35), result.Activity.FinalRows)
+	assertions.Equal(int64(7), result.Stats.TotalMessages)
+
+	var activityCount int64
+	requirements.NoError(db.QueryRow(`
+		SELECT activity_count
+		FROM read_parquet(?)
+		WHERE canonical_id = 1
+	`, relationshipParquetGlob(stagedRoot, DatasetPeople)).Scan(&activityCount))
+	assertions.Equal(int64(7), activityCount)
+}
+
+func TestLogicalChatReductionPreservesCanonicalAliasDomains(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	root, db := writeRelationshipBaseFixture(t, true)
+	replaceRelationshipParquet(t, db, root, "messages", `
+		SELECT * FROM (VALUES
+			(100::BIGINT, 1::BIGINT, 'message-100'::VARCHAR, 10::BIGINT,
+			 'Earlier message'::VARCHAR, ''::VARCHAR,
+			 TIMESTAMP '2026-01-01 12:00:00', 10::BIGINT, false,
+			 0::INTEGER, NULL::TIMESTAMP, 1::BIGINT, 'chat'::VARCHAR,
+			 false, 2026::INTEGER, 1::INTEGER),
+			(101::BIGINT, 1::BIGINT, 'message-101'::VARCHAR, 10::BIGINT,
+			 'Newest message'::VARCHAR, ''::VARCHAR,
+			 TIMESTAMP '2026-01-02 12:00:00', 10::BIGINT, false,
+			 0::INTEGER, NULL::TIMESTAMP, 2::BIGINT, 'chat'::VARCHAR,
+			 false, 2026::INTEGER, 1::INTEGER)
+		) AS t(id, source_id, source_message_id, conversation_id, subject,
+			snippet, sent_at, size_estimate, has_attachments, attachment_count,
+			deleted_from_source_at, sender_id, message_type, is_from_me, year, month)`)
+	replaceRelationshipParquet(t, db, root, "sources", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@alpha.test'::VARCHAR, 'gmail'::VARCHAR)
+		) AS t(id, account_email, source_type)`)
+	replaceRelationshipParquet(t, db, root, "conversations", `
+		SELECT * FROM (VALUES
+			(10::BIGINT, 'conversation-10'::VARCHAR,
+			 'Synthetic group chat'::VARCHAR, 'group_chat'::VARCHAR)
+		) AS t(id, source_conversation_id, title, conversation_type)`)
+	replaceRelationshipParquet(t, db, root, "participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@alpha.test'::VARCHAR, 'alpha.test'::VARCHAR,
+			 'Owner'::VARCHAR, ''::VARCHAR),
+			(2::BIGINT, 'alias@beta.test'::VARCHAR, 'beta.test'::VARCHAR,
+			 'Owner Alias'::VARCHAR, ''::VARCHAR)
+		) AS t(id, email_address, domain, display_name, phone_number)`)
+	replaceRelationshipParquet(t, db, root, "message_recipients", `
+		SELECT * FROM (VALUES
+			(100::BIGINT, 1::BIGINT, 'from'::VARCHAR, 'Owner'::VARCHAR),
+			(100::BIGINT, 2::BIGINT, 'to'::VARCHAR, 'Owner Alias'::VARCHAR),
+			(101::BIGINT, 2::BIGINT, 'from'::VARCHAR, 'Owner Alias'::VARCHAR),
+			(101::BIGINT, 1::BIGINT, 'to'::VARCHAR, 'Owner'::VARCHAR)
+		) AS t(message_id, participant_id, recipient_type, display_name)`)
+	replaceRelationshipParquet(t, db, root, "conversation_participants", `
+		SELECT * FROM (VALUES
+			(10::BIGINT, 1::BIGINT),
+			(10::BIGINT, 2::BIGINT)
+		) AS t(conversation_id, participant_id)`)
+	replaceRelationshipParquet(t, db, root, "owner_participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 1::BIGINT)
+		) AS t(source_id, participant_id)`)
+	replaceRelationshipParquet(t, db, root, "participant_clusters", `
+		SELECT * FROM (VALUES
+			(2::BIGINT, 1::BIGINT)
+		) AS t(participant_id, canonical_id)`)
+
+	_, err := Build(context.Background(), db, BuildOptions{
+		Mode:           ModeFull,
+		StagedBaseRoot: root,
+		OutputRoot:     root,
+	})
+	requirements.NoError(err)
+
+	query := logicalActivitySQL(
+		relationshipParquetGlob(root, DatasetActivity),
+		"f.source_id = ?",
+	) + `
+		SELECT
+			(SELECT count(*) FROM logical_people),
+			(SELECT canonical_id FROM logical_people),
+			(SELECT anchor_message_id FROM logical_people),
+			(SELECT is_author FROM logical_people),
+			(SELECT is_owner FROM logical_people),
+			(SELECT with_owner FROM logical_people),
+			(SELECT CAST(to_json(list(struct_pack(
+				canonical_id := canonical_id,
+				domain := domain
+			) ORDER BY canonical_id, domain)) AS VARCHAR)
+			 FROM logical_person_domains),
+			(SELECT CAST(to_json(list(domain ORDER BY domain)) AS VARCHAR)
+			 FROM logical_domain_keys)`
+	var peopleCount, canonicalID, anchorMessageID int64
+	var isAuthor, isOwner, withOwner bool
+	var personDomainsJSON, domainKeysJSON string
+	requirements.NoError(db.QueryRow(query, int64(1)).Scan(
+		&peopleCount,
+		&canonicalID,
+		&anchorMessageID,
+		&isAuthor,
+		&isOwner,
+		&withOwner,
+		&personDomainsJSON,
+		&domainKeysJSON,
+	))
+
+	assertions.Equal(int64(1), peopleCount)
+	assertions.Equal(int64(1), canonicalID)
+	assertions.Equal(int64(101), anchorMessageID)
+	assertions.True(isAuthor)
+	assertions.True(isOwner)
+	assertions.True(withOwner)
+	assertions.JSONEq(`[
+		{"canonical_id": 1, "domain": "alpha.test"},
+		{"canonical_id": 1, "domain": "beta.test"}
+	]`, personDomainsJSON)
+	assertions.JSONEq(`["alpha.test", "beta.test"]`, domainKeysJSON)
+}
+
+func TestLogicalChatReductionKeepsEarlierDirectOnlyIdentity(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	root, db := writeRelationshipBaseFixture(t, true)
+	replaceRelationshipParquet(t, db, root, "messages", `
+		SELECT * FROM (VALUES
+			(100::BIGINT, 1::BIGINT, 'message-100'::VARCHAR, 10::BIGINT,
+			 'Earlier direct message'::VARCHAR, ''::VARCHAR,
+			 TIMESTAMP '2026-01-01 12:00:00', 10::BIGINT, false,
+			 0::INTEGER, NULL::TIMESTAMP, 2::BIGINT, 'chat'::VARCHAR,
+			 false, 2026::INTEGER, 1::INTEGER),
+			(101::BIGINT, 1::BIGINT, 'message-101'::VARCHAR, 10::BIGINT,
+			 'Newest member message'::VARCHAR, ''::VARCHAR,
+			 TIMESTAMP '2026-01-02 12:00:00', 10::BIGINT, false,
+			 0::INTEGER, NULL::TIMESTAMP, 1::BIGINT, 'chat'::VARCHAR,
+			 false, 2026::INTEGER, 1::INTEGER)
+		) AS t(id, source_id, source_message_id, conversation_id, subject,
+			snippet, sent_at, size_estimate, has_attachments, attachment_count,
+			deleted_from_source_at, sender_id, message_type, is_from_me, year, month)`)
+	replaceRelationshipParquet(t, db, root, "sources", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@alpha.test'::VARCHAR, 'gmail'::VARCHAR)
+		) AS t(id, account_email, source_type)`)
+	replaceRelationshipParquet(t, db, root, "conversations", `
+		SELECT * FROM (VALUES
+			(10::BIGINT, 'conversation-10'::VARCHAR,
+			 'Synthetic group chat'::VARCHAR, 'group_chat'::VARCHAR)
+		) AS t(id, source_conversation_id, title, conversation_type)`)
+	replaceRelationshipParquet(t, db, root, "participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@alpha.test'::VARCHAR, 'alpha.test'::VARCHAR,
+			 'Owner'::VARCHAR, ''::VARCHAR),
+			(2::BIGINT, 'guest@gamma.test'::VARCHAR, 'gamma.test'::VARCHAR,
+			 'Earlier Guest'::VARCHAR, ''::VARCHAR)
+		) AS t(id, email_address, domain, display_name, phone_number)`)
+	replaceRelationshipParquet(t, db, root, "message_recipients", `
+		SELECT * FROM (VALUES
+			(100::BIGINT, 2::BIGINT, 'from'::VARCHAR, 'Earlier Guest'::VARCHAR),
+			(100::BIGINT, 1::BIGINT, 'to'::VARCHAR, 'Owner'::VARCHAR),
+			(101::BIGINT, 1::BIGINT, 'from'::VARCHAR, 'Owner'::VARCHAR)
+		) AS t(message_id, participant_id, recipient_type, display_name)`)
+	replaceRelationshipParquet(t, db, root, "conversation_participants", `
+		SELECT * FROM (VALUES
+			(10::BIGINT, 1::BIGINT)
+		) AS t(conversation_id, participant_id)`)
+	replaceRelationshipParquet(t, db, root, "owner_participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 1::BIGINT)
+		) AS t(source_id, participant_id)`)
+
+	_, err := Build(context.Background(), db, BuildOptions{
+		Mode:           ModeFull,
+		StagedBaseRoot: root,
+		OutputRoot:     root,
+	})
+	requirements.NoError(err)
+
+	query := logicalActivitySQL(
+		relationshipParquetGlob(root, DatasetActivity),
+		"true",
+	) + `
+		SELECT
+			(SELECT CAST(to_json(list(struct_pack(
+				canonical_id := canonical_id,
+				anchor_message_id := anchor_message_id,
+				is_author := is_author,
+				is_owner := is_owner,
+				with_owner := with_owner
+			) ORDER BY canonical_id)) AS VARCHAR)
+			 FROM logical_people),
+			(SELECT CAST(to_json(list(struct_pack(
+				canonical_id := canonical_id,
+				domain := domain
+			) ORDER BY canonical_id, domain)) AS VARCHAR)
+			 FROM logical_person_domains),
+			(SELECT CAST(to_json(list(domain ORDER BY domain)) AS VARCHAR)
+			 FROM logical_domain_keys)`
+	var peopleJSON, personDomainsJSON, domainKeysJSON string
+	requirements.NoError(db.QueryRow(query).Scan(
+		&peopleJSON,
+		&personDomainsJSON,
+		&domainKeysJSON,
+	))
+
+	assertions.JSONEq(`[
+		{
+			"canonical_id": 1,
+			"anchor_message_id": 101,
+			"is_author": true,
+			"is_owner": true,
+			"with_owner": true
+		},
+		{
+			"canonical_id": 2,
+			"anchor_message_id": 101,
+			"is_author": false,
+			"is_owner": false,
+			"with_owner": true
+		}
+	]`, peopleJSON)
+	assertions.JSONEq(`[
+		{"canonical_id": 1, "domain": "alpha.test"},
+		{"canonical_id": 2, "domain": "gamma.test"}
+	]`, personDomainsJSON)
+	assertions.JSONEq(`["alpha.test", "gamma.test"]`, domainKeysJSON)
+}
+
+func TestBuildRelationshipActivity100MillionEdgeAcceptance(t *testing.T) {
+	if os.Getenv(stressRelationshipActivity100MEnv) != "1" {
+		t.Skip("set " + stressRelationshipActivity100MEnv + "=1 to run")
+	}
+
+	root, db := writeRelationshipBaseFixture(t, true)
+	writeSyntheticRelationshipFanOut(t, db, root, syntheticRelationshipFanOutOptions{
+		firstMessageID:   1,
+		messageCount:     500_000,
+		memberCount:      200,
+		startDate:        "2026-01-01",
+		messageType:      "chat",
+		conversationType: "group_chat",
+	})
+	result, err := Build(context.Background(), db, BuildOptions{
+		Mode:           ModeFull,
+		StagedBaseRoot: root,
+		OutputRoot:     root,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(100_000_000), result.Activity.ConversationExpandedRows)
+	assert.Equal(t, int64(100_000_000), result.Activity.FinalRows)
+}
+
+func writeRelationshipEquivalenceFixture(t *testing.T) (string, *sql.DB) {
+	t.Helper()
+	root, db := writeRelationshipBaseFixture(t, true)
+	replaceRelationshipParquet(t, db, root, "messages", `
+		SELECT * FROM (VALUES
+			(100::BIGINT, 1::BIGINT, 'message-100'::VARCHAR, 10::BIGINT,
+			 'Synthetic subject'::VARCHAR, 'Synthetic preview'::VARCHAR,
+			 TIMESTAMP '2026-01-01 12:00:00', 50::BIGINT, true,
+			 1::INTEGER, NULL::TIMESTAMP, 1::BIGINT, 'email'::VARCHAR,
+			 false, 2026::INTEGER, 1::INTEGER),
+			(101::BIGINT, 1::BIGINT, 'message-101'::VARCHAR, 11::BIGINT,
+			 'No valid edge'::VARCHAR, ''::VARCHAR,
+			 TIMESTAMP '2026-01-02 12:00:00', 10::BIGINT, false,
+			 0::INTEGER, NULL::TIMESTAMP, NULL::BIGINT, 'email'::VARCHAR,
+			 false, 2026::INTEGER, 1::INTEGER),
+			(102::BIGINT, 1::BIGINT, 'message-102'::VARCHAR, 12::BIGINT,
+			 'Unresolved conversation member'::VARCHAR, ''::VARCHAR,
+			 TIMESTAMP '2026-01-03 12:00:00', 10::BIGINT, false,
+			 0::INTEGER, NULL::TIMESTAMP, 1::BIGINT, 'email'::VARCHAR,
+			 false, 2026::INTEGER, 1::INTEGER)
+		) AS t(id, source_id, source_message_id, conversation_id, subject,
+			snippet, sent_at, size_estimate, has_attachments, attachment_count,
+			deleted_from_source_at, sender_id, message_type, is_from_me, year, month)`)
+	replaceRelationshipParquet(t, db, root, "sources", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@example.test'::VARCHAR, 'gmail'::VARCHAR)
+		) AS t(id, account_email, source_type)`)
+	replaceRelationshipParquet(t, db, root, "conversations", `
+		SELECT * FROM (VALUES
+			(10::BIGINT, 'conversation-10'::VARCHAR, 'Synthetic thread'::VARCHAR,
+			 'email_thread'::VARCHAR),
+			(11::BIGINT, 'conversation-11'::VARCHAR, 'No valid edge'::VARCHAR,
+			 'email_thread'::VARCHAR),
+			(12::BIGINT, 'conversation-12'::VARCHAR, 'Unresolved member'::VARCHAR,
+			 'email_thread'::VARCHAR)
+		) AS t(id, source_conversation_id, title, conversation_type)`)
+	replaceRelationshipParquet(t, db, root, "participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@example.test'::VARCHAR, 'example.test'::VARCHAR,
+			 'Owner'::VARCHAR, ''::VARCHAR),
+			(2::BIGINT, 'owner-alias@example.test'::VARCHAR, 'example.test'::VARCHAR,
+			 'Owner Alias'::VARCHAR, ''::VARCHAR),
+			(3::BIGINT, 'direct@direct.test'::VARCHAR, 'direct.test'::VARCHAR,
+			 'Direct'::VARCHAR, ''::VARCHAR),
+			(4::BIGINT, 'member@member.test'::VARCHAR, 'member.test'::VARCHAR,
+			 'Member'::VARCHAR, ''::VARCHAR)
+		) AS t(id, email_address, domain, display_name, phone_number)`)
+	replaceRelationshipParquet(t, db, root, "participant_identifiers", `
+		SELECT NULL::BIGINT AS participant_id,
+		       NULL::VARCHAR AS identifier_type,
+		       NULL::VARCHAR AS identifier_value,
+		       NULL::VARCHAR AS display_value,
+		       NULL::BOOLEAN AS is_primary
+		WHERE false`)
+	replaceRelationshipParquet(t, db, root, "message_recipients", `
+		SELECT * FROM (VALUES
+			(100::BIGINT, 2::BIGINT, 'from'::VARCHAR, 'Owner Alias'::VARCHAR),
+			(100::BIGINT, 2::BIGINT, 'from'::VARCHAR, 'Owner Alias'::VARCHAR),
+			(100::BIGINT, 1::BIGINT, 'to'::VARCHAR, 'Owner'::VARCHAR),
+			(100::BIGINT, 3::BIGINT, 'to'::VARCHAR, 'Direct'::VARCHAR),
+			(100::BIGINT, 999::BIGINT, 'cc'::VARCHAR, 'Missing'::VARCHAR),
+			(101::BIGINT, 999::BIGINT, 'to'::VARCHAR, 'Missing'::VARCHAR)
+		) AS t(message_id, participant_id, recipient_type, display_name)`)
+	replaceRelationshipParquet(t, db, root, "conversation_participants", `
+		SELECT * FROM (VALUES
+			(10::BIGINT, 1::BIGINT),
+			(10::BIGINT, 2::BIGINT),
+			(10::BIGINT, 4::BIGINT),
+			(11::BIGINT, 999::BIGINT),
+			(12::BIGINT, 999::BIGINT)
+		) AS t(conversation_id, participant_id)`)
+	replaceRelationshipParquet(t, db, root, "owner_participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 2::BIGINT)
+		) AS t(source_id, participant_id)`)
+	replaceRelationshipParquet(t, db, root, "participant_clusters", `
+		SELECT * FROM (VALUES
+			(2::BIGINT, 1::BIGINT)
+		) AS t(participant_id, canonical_id)`)
+	replaceRelationshipParquet(t, db, root, "attachments", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 100::BIGINT, 12::BIGINT, 'synthetic.txt'::VARCHAR,
+			 'text/plain'::VARCHAR)
+		) AS t(attachment_id, message_id, size, filename, mime_type)`)
+	return root, db
+}
+
+type syntheticRelationshipFanOutOptions struct {
+	firstMessageID   int64
+	messageCount     int64
+	memberCount      int64
+	startDate        string
+	messageType      string
+	conversationType string
+}
+
+func writeSyntheticRelationshipFanOut(
+	t *testing.T,
+	db *sql.DB,
+	root string,
+	opts syntheticRelationshipFanOutOptions,
+) {
+	t.Helper()
+	lastMessageID := opts.firstMessageID + opts.messageCount
+	replaceRelationshipParquet(t, db, root, "messages", fmt.Sprintf(`
+		SELECT (i + %d)::BIGINT AS id,
+		       1::BIGINT AS source_id,
+		       ('message-' || (i + %d))::VARCHAR AS source_message_id,
+		       10::BIGINT AS conversation_id,
+		       'Synthetic subject'::VARCHAR AS subject,
+		       ''::VARCHAR AS snippet,
+		       (TIMESTAMP '%s' + i * INTERVAL '1 second')::TIMESTAMP AS sent_at,
+		       10::BIGINT AS size_estimate,
+		       false AS has_attachments,
+		       0::INTEGER AS attachment_count,
+		       NULL::TIMESTAMP AS deleted_from_source_at,
+		       1::BIGINT AS sender_id,
+		       '%s'::VARCHAR AS message_type,
+		       false AS is_from_me,
+		       year(TIMESTAMP '%s' + i * INTERVAL '1 second')::INTEGER AS year,
+		       month(TIMESTAMP '%s' + i * INTERVAL '1 second')::INTEGER AS month
+		FROM range(0, %d) AS t(i)`,
+		opts.firstMessageID, opts.firstMessageID, opts.startDate,
+		quoteSQLString(opts.messageType), opts.startDate, opts.startDate, opts.messageCount))
+	replaceRelationshipParquet(t, db, root, "sources", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@example.test'::VARCHAR, 'gmail'::VARCHAR)
+		) AS t(id, account_email, source_type)`)
+	replaceRelationshipParquet(t, db, root, "conversations", `
+		SELECT * FROM (VALUES
+			(10::BIGINT, 'conversation-10'::VARCHAR, 'Synthetic thread'::VARCHAR,
+			 '`+quoteSQLString(opts.conversationType)+`'::VARCHAR)
+		) AS t(id, source_conversation_id, title, conversation_type)`)
+	replaceRelationshipParquet(t, db, root, "participants", fmt.Sprintf(`
+		SELECT i::BIGINT AS id,
+		       ('person-' || i || '@example.test')::VARCHAR AS email_address,
+		       'example.test'::VARCHAR AS domain,
+		       ('Person ' || i)::VARCHAR AS display_name,
+		       ''::VARCHAR AS phone_number
+		FROM range(1, %d) AS t(i)`, opts.memberCount+1))
+	replaceRelationshipParquet(t, db, root, "participant_identifiers", `
+		SELECT NULL::BIGINT AS participant_id,
+		       NULL::VARCHAR AS identifier_type,
+		       NULL::VARCHAR AS identifier_value,
+		       NULL::VARCHAR AS display_value,
+		       NULL::BOOLEAN AS is_primary
+		WHERE false`)
+	replaceRelationshipParquet(t, db, root, "message_recipients", fmt.Sprintf(`
+		SELECT message_id::BIGINT AS message_id,
+		       participant_id::BIGINT AS participant_id,
+		       recipient_type::VARCHAR AS recipient_type,
+		       ''::VARCHAR AS display_name
+		FROM range(%d, %d) AS messages(message_id)
+		CROSS JOIN (VALUES (1, 'from'), (1, 'to')) AS edges(participant_id, recipient_type)`,
+		opts.firstMessageID, lastMessageID))
+	replaceRelationshipParquet(t, db, root, "conversation_participants", fmt.Sprintf(`
+		SELECT 10::BIGINT AS conversation_id, i::BIGINT AS participant_id
+		FROM range(1, %d) AS t(i)`, opts.memberCount+1))
+	replaceRelationshipParquet(t, db, root, "owner_participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 1::BIGINT)
+		) AS t(source_id, participant_id)`)
+	replaceRelationshipParquet(t, db, root, "participant_clusters", `
+		SELECT NULL::BIGINT AS participant_id, NULL::BIGINT AS canonical_id
+		WHERE false`)
+	replaceRelationshipParquet(t, db, root, "attachments", `
+		SELECT NULL::BIGINT AS attachment_id,
+		       NULL::BIGINT AS message_id,
+		       NULL::BIGINT AS size,
+		       NULL::VARCHAR AS filename,
+		       NULL::VARCHAR AS mime_type
+		WHERE false`)
+}
+
+func writeRelationshipYearScopeFixture(t *testing.T, db *sql.DB, root string) {
+	t.Helper()
+	const (
+		offYearMessages     = 200_000
+		offYearParticipants = 100
+	)
+
+	replaceRelationshipParquet(t, db, root, "messages", fmt.Sprintf(`
+		SELECT * FROM (VALUES
+			(1::BIGINT, 1::BIGINT, 'selected-message'::VARCHAR, 10::BIGINT,
+			 'Selected year'::VARCHAR, ''::VARCHAR,
+			 TIMESTAMP '2025-01-01 12:00:00', 10::BIGINT, false,
+			 0::INTEGER, NULL::TIMESTAMP, 1::BIGINT, 'email'::VARCHAR,
+			 false, 2025::INTEGER, 1::INTEGER)
+		) AS selected(id, source_id, source_message_id, conversation_id, subject,
+			snippet, sent_at, size_estimate, has_attachments, attachment_count,
+			deleted_from_source_at, sender_id, message_type, is_from_me, year, month)
+
+		UNION ALL
+
+		SELECT (1000 + i)::BIGINT AS id,
+		       1::BIGINT AS source_id,
+		       ('off-year-message-' || i)::VARCHAR AS source_message_id,
+		       (1000 + i)::BIGINT AS conversation_id,
+		       'Off year'::VARCHAR AS subject,
+		       ''::VARCHAR AS snippet,
+		       (TIMESTAMP '2024-01-01' + i * INTERVAL '1 second')::TIMESTAMP AS sent_at,
+		       10::BIGINT AS size_estimate,
+		       false AS has_attachments,
+		       0::INTEGER AS attachment_count,
+		       NULL::TIMESTAMP AS deleted_from_source_at,
+		       NULL::BIGINT AS sender_id,
+		       'email'::VARCHAR AS message_type,
+		       false AS is_from_me,
+		       2024::INTEGER AS year,
+		       1::INTEGER AS month
+		FROM range(0, %d) AS off_year(i)`, offYearMessages))
+	replaceRelationshipParquet(t, db, root, "sources", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 'owner@example.test'::VARCHAR, 'gmail'::VARCHAR)
+		) AS t(id, account_email, source_type)`)
+	replaceRelationshipParquet(t, db, root, "conversations", fmt.Sprintf(`
+		SELECT * FROM (VALUES
+			(10::BIGINT, 'selected-conversation'::VARCHAR,
+			 'Selected year'::VARCHAR, 'email_thread'::VARCHAR)
+		) AS selected(id, source_conversation_id, title, conversation_type)
+
+		UNION ALL
+
+		SELECT (1000 + i)::BIGINT AS id,
+		       ('off-year-conversation-' || i)::VARCHAR AS source_conversation_id,
+		       'Off year'::VARCHAR AS title,
+		       'email_thread'::VARCHAR AS conversation_type
+		FROM range(0, %d) AS off_year(i)`, offYearMessages))
+	replaceRelationshipParquet(t, db, root, "participants", fmt.Sprintf(`
+		SELECT i::BIGINT AS id,
+		       ('person-' || i || '@example.test')::VARCHAR AS email_address,
+		       'example.test'::VARCHAR AS domain,
+		       ('Person ' || i)::VARCHAR AS display_name,
+		       ''::VARCHAR AS phone_number
+		FROM range(1, %d) AS participants(i)`, offYearParticipants+1))
+	replaceRelationshipParquet(t, db, root, "participant_identifiers", `
+		SELECT NULL::BIGINT AS participant_id,
+		       NULL::VARCHAR AS identifier_type,
+		       NULL::VARCHAR AS identifier_value,
+		       NULL::VARCHAR AS display_value,
+		       NULL::BOOLEAN AS is_primary
+		WHERE false`)
+	replaceRelationshipParquet(t, db, root, "message_recipients", fmt.Sprintf(`
+		SELECT * FROM (VALUES
+			(1::BIGINT, 1::BIGINT, 'to'::VARCHAR, 'Person 1'::VARCHAR)
+		) AS selected(message_id, participant_id, recipient_type, display_name)
+
+		UNION ALL
+
+		SELECT (1000 + message_index)::BIGINT AS message_id,
+		       participant_id::BIGINT AS participant_id,
+		       'to'::VARCHAR AS recipient_type,
+		       ''::VARCHAR AS display_name
+		FROM range(0, %d) AS messages(message_index)
+		CROSS JOIN range(1, %d) AS participants(participant_id)`,
+		offYearMessages, offYearParticipants+1))
+	replaceRelationshipParquet(t, db, root, "conversation_participants", fmt.Sprintf(`
+		SELECT * FROM (VALUES
+			(10::BIGINT, 2::BIGINT)
+		) AS selected(conversation_id, participant_id)
+
+		UNION ALL
+
+		SELECT (1000 + conversation_index)::BIGINT AS conversation_id,
+		       participant_id::BIGINT AS participant_id
+		FROM range(0, %d) AS conversations(conversation_index)
+		CROSS JOIN range(1, %d) AS participants(participant_id)`,
+		offYearMessages, offYearParticipants+1))
+	replaceRelationshipParquet(t, db, root, "owner_participants", `
+		SELECT * FROM (VALUES
+			(1::BIGINT, 1::BIGINT)
+		) AS t(source_id, participant_id)`)
+	replaceRelationshipParquet(t, db, root, "participant_clusters", `
+		SELECT NULL::BIGINT AS participant_id, NULL::BIGINT AS canonical_id
+		WHERE false`)
+	replaceRelationshipParquet(t, db, root, "attachments", `
+		SELECT NULL::BIGINT AS attachment_id,
+		       NULL::BIGINT AS message_id,
+		       NULL::BIGINT AS size,
+		       NULL::VARCHAR AS filename,
+		       NULL::VARCHAR AS mime_type
+		WHERE false`)
+}
+
+func setRelationshipTestMemoryLimit(db *sql.DB, limit string) error {
+	_, err := db.Exec("SET memory_limit = '" + limit + "'")
+	return err
+}
+
+func buildLegacyRelationshipActivitySQL(path func(string) string) string {
+	return fmt.Sprintf(`
+WITH message_facts AS (
+	SELECT m.id::BIGINT AS message_id,
+	       m.conversation_id::BIGINT AS conversation_id,
+	       m.source_id::BIGINT AS source_id,
+	       s.source_type::VARCHAR AS source_type,
+	       m.sent_at::TIMESTAMP AS occurred_at,
+	       m.message_type::VARCHAR AS message_type,
+	       coalesce(c.conversation_type, '')::VARCHAR AS conversation_type,
+	       %s AS entry_kind,
+	       (%s) AS is_chat,
+	       m.is_from_me::BOOLEAN AS is_from_me,
+	       m.attachment_count::INTEGER AS attachment_count,
+	       coalesce(m.has_attachments::BOOLEAN, false) AS has_attachments,
+	       (m.deleted_from_source_at IS NOT NULL) AS deleted_from_source,
+	       year(m.sent_at)::SMALLINT AS occurred_year,
+	       m.sender_id::BIGINT AS sender_id
+	FROM read_parquet('%s', hive_partitioning=true, union_by_name=true) m
+	JOIN read_parquet('%s') s ON s.id = m.source_id
+	LEFT JOIN read_parquet('%s') c ON c.id = m.conversation_id
+), canon AS (
+	SELECT p.id::BIGINT AS participant_id,
+	       coalesce(c.canonical_id, p.id)::BIGINT AS canonical_id,
+	       lower(coalesce(p.domain, ''))::VARCHAR AS participant_domain
+	FROM read_parquet('%s') p
+	LEFT JOIN read_parquet('%s') c ON c.participant_id = p.id
+), owner_canon AS (
+	SELECT DISTINCT c.canonical_id
+	FROM read_parquet('%s') o
+	JOIN canon c ON c.participant_id = o.participant_id
+), raw_edges AS (
+	SELECT mr.message_id::BIGINT AS message_id,
+	       mr.participant_id::BIGINT AS participant_id,
+	       true AS is_direct,
+	       false AS is_conversation_member,
+	       false AS is_sender,
+	       (mr.recipient_type = 'from') AS is_author
+	FROM read_parquet('%s') mr
+
+	UNION ALL
+
+	SELECT m.message_id, m.sender_id, true, false, true, true
+	FROM message_facts m
+	WHERE m.sender_id IS NOT NULL
+
+	UNION ALL
+
+	SELECT m.message_id, cp.participant_id::BIGINT,
+	       false, true, false, false
+	FROM message_facts m
+	JOIN read_parquet('%s') cp
+	  ON cp.conversation_id = m.conversation_id
+)
+SELECT m.message_id, m.conversation_id, m.source_id, m.source_type,
+	   m.occurred_at, m.message_type, m.conversation_type, m.entry_kind,
+	   m.is_chat, m.is_from_me, m.attachment_count, m.has_attachments,
+	   m.deleted_from_source,
+	   c.canonical_id, c.participant_domain,
+	   coalesce(bool_or(e.is_direct)
+	       FILTER (WHERE c.canonical_id IS NOT NULL), false) AS is_direct,
+	   coalesce(bool_or(e.is_conversation_member)
+	       FILTER (WHERE c.canonical_id IS NOT NULL), false)
+	       AS is_conversation_member,
+	   coalesce(bool_or(e.is_sender)
+	       FILTER (WHERE c.canonical_id IS NOT NULL), false) AS is_sender,
+	   coalesce(bool_or(e.is_author)
+	       FILTER (WHERE c.canonical_id IS NOT NULL), false) AS is_author,
+	   (o.canonical_id IS NOT NULL) AS is_owner,
+	   m.occurred_year
+FROM message_facts m
+LEFT JOIN raw_edges e USING (message_id)
+LEFT JOIN canon c USING (participant_id)
+LEFT JOIN owner_canon o USING (canonical_id)
+GROUP BY m.message_id, m.conversation_id, m.source_id, m.source_type,
+	     m.occurred_at, m.message_type, m.conversation_type, m.entry_kind,
+	     m.is_chat, m.is_from_me, m.attachment_count, m.has_attachments,
+	     m.deleted_from_source,
+	     c.canonical_id, c.participant_domain, o.canonical_id, m.occurred_year`,
+		EntryKindSQL("m.message_type"),
+		IsChatSQL("m.message_type", "coalesce(c.conversation_type, '')"),
+		quoteSQLString(path("messages")),
+		quoteSQLString(path("sources")),
+		quoteSQLString(path("conversations")),
+		quoteSQLString(path("participants")),
+		quoteSQLString(path("participant_clusters")),
+		quoteSQLString(path("owner_participants")),
+		quoteSQLString(path("message_recipients")),
+		quoteSQLString(path("conversation_participants")),
+	)
+}


### PR DESCRIPTION
Fixes #560.

- Stream relationship-activity fan-out and logical chat reductions so large group conversations do not build fan-out-sized hash tables.
- Scope activity work by occurrence year, including direct recipients and conversation memberships.
- Add optional `analytics.builder_memory_limit`, `analytics.builder_threads`, and `analytics.builder_temp_limit` settings while keeping existing defaults.

Output schemas, readers, and incremental behavior remain unchanged.