### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ oauth_client*.json
 # Local development state
 .beads/
 .mcp.json
+.worktrees/
 
 # Python
 __pycache__/


### PR DESCRIPTION
Feature work uses project-local linked worktrees for isolation. Ignoring the workspace directory keeps implementation checkouts from appearing as repository content or being accidentally included in future changes.