### PR TITLE
fix(cache): make daemon startup builds transparent

### DIFF
--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/csv"
@@ -1947,10 +1948,23 @@ func buildCacheSubprocessMode(ctx context.Context, mode buildCacheMode) error {
 	if err != nil {
 		return err
 	}
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("build-cache subprocess: %w; output: %s",
-			err, strings.TrimSpace(string(out)))
+	return runBuildCacheSubprocessCommand(cmd, os.Stderr)
+}
+
+func runBuildCacheSubprocessCommand(cmd *exec.Cmd, stderrWriter io.Writer) error {
+	if stderrWriter == nil {
+		stderrWriter = io.Discard
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.MultiWriter(stderrWriter, &stderr)
+	if err := cmd.Run(); err != nil {
+		output := strings.TrimSpace(strings.Join([]string{stdout.String(), stderr.String()}, "\n"))
+		if output != "" {
+			return fmt.Errorf("build-cache subprocess: %w; output: %s", err, output)
+		}
+		return fmt.Errorf("build-cache subprocess: %w", err)
 	}
 	return nil
 }

--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -308,11 +308,33 @@ func requestedBuildCacheMode(full, auto, derived bool) (buildCacheMode, error) {
 }
 
 func runBuildCacheHTTP(cmd *cobra.Command, fullRebuild bool) error {
-	st, _, err := OpenHTTPStore(cmd.Context())
+	intent := startupCacheBuildIntentDefault
+	if fullRebuild {
+		intent = startupCacheBuildIntentFull
+	}
+	st, info, err := openHTTPStoreWithStartupCacheIntent(cmd.Context(), intent)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = st.Close() }()
+	if info.StartedLocalDaemon {
+		switch info.StartupCacheBuildOutcome {
+		case startupCacheBuildOutcomeFulfilled:
+			_, writeErr := fmt.Fprintln(cmd.OutOrStdout(),
+				"Cache build complete. The daemon is running and using the analytics cache.")
+			if writeErr != nil {
+				return fmt.Errorf("write build-cache completion: %w", writeErr)
+			}
+			return nil
+		case startupCacheBuildOutcomeFailed:
+			return fmt.Errorf(
+				"analytics cache build failed during daemon startup; "+
+					"the daemon is running with live SQL\nLogs: %s",
+				info.DaemonLogPath,
+			)
+		case startupCacheBuildOutcomeNone, startupCacheBuildOutcomeUnconsumed:
+		}
+	}
 
 	return st.BuildCLICache(cmd.Context(), fullRebuild, func(stream, data string) error {
 		switch stream {

--- a/cmd/msgvault/cmd/build_cache_http_test.go
+++ b/cmd/msgvault/cmd/build_cache_http_test.go
@@ -44,6 +44,8 @@ func TestBuildCacheAutostartFulfilledSkipsRedundantHTTPRequest(t *testing.T) {
 }
 
 func TestBuildCacheAutostartFailedReturnsErrorWithoutRetry(t *testing.T) {
+	require := require.New(t)
+
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		requests.Add(1)
@@ -59,10 +61,10 @@ func TestBuildCacheAutostartFailedReturnsErrorWithoutRetry(t *testing.T) {
 		err = runBuildCacheHTTP(cmd, false)
 	})
 
-	require.Error(t, err)
-	require.ErrorContains(t, err, "analytics cache build failed during daemon startup")
-	require.ErrorContains(t, err, "daemon is running with live SQL")
-	require.ErrorContains(t, err, logPath)
+	require.Error(err)
+	require.ErrorContains(err, "analytics cache build failed during daemon startup")
+	require.ErrorContains(err, "daemon is running with live SQL")
+	require.ErrorContains(err, logPath)
 	assert.Zero(t, requests.Load())
 }
 
@@ -159,6 +161,9 @@ func TestBuildCacheUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 }
 
 func TestBuildCacheRunningLocalDaemonUsesSingleHTTPRequest(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
 	var requests atomic.Int32
 	mux := http.NewServeMux()
 	mux.Handle("/api/ping", daemon.NewPingHandler(daemon.PingHandlerOptions{
@@ -182,21 +187,21 @@ func TestBuildCacheRunningLocalDaemonUsesSingleHTTPRequest(t *testing.T) {
 	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
 	rt := daemonRuntimeForHTTPServer(t, server, daemonAPIKeyFingerprint(""))
 	_, err := daemonRuntimeStore(dataDir).Write(rt.Record)
-	require.NoError(t, err, "write running daemon record")
+	require.NoError(err, "write running daemon record")
 	stubStartServeBackgroundProcess(t, func(
 		*config.Config,
 		backgroundServeStartOptions,
 	) (*backgroundServeProcess, error) {
-		require.FailNow(t, "a running local daemon must not be restarted with cache intent")
+		require.FailNow("a running local daemon must not be restarted with cache intent")
 		return nil, errors.New("unreachable daemon restart")
 	})
 
 	cmd, stdout := buildCacheHTTPTestCommand()
 	err = runBuildCacheHTTP(cmd, false)
 
-	require.NoError(t, err)
-	assert.Equal(t, int32(1), requests.Load())
-	assert.Equal(t, "Built through running daemon.\n", stdout.String())
+	require.NoError(err)
+	assert.Equal(int32(1), requests.Load())
+	assert.Equal("Built through running daemon.\n", stdout.String())
 }
 
 func buildCacheHTTPTestCommand() (*cobra.Command, *bytes.Buffer) {

--- a/cmd/msgvault/cmd/build_cache_http_test.go
+++ b/cmd/msgvault/cmd/build_cache_http_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
 	"go.kenn.io/msgvault/internal/config"
 )
 
@@ -154,6 +156,47 @@ func TestBuildCacheUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 	assert.Equal(int32(1), requests.Load(), "HTTP requests")
 	assert.Equal("Building cache...\nExported 42 messages to /tmp/msgvault-analytics\n", stdout.String())
 	assert.Equal("Warning: using CSV fallback\n", stderr.String())
+}
+
+func TestBuildCacheRunningLocalDaemonUsesSingleHTTPRequest(t *testing.T) {
+	var requests atomic.Int32
+	mux := http.NewServeMux()
+	mux.Handle("/api/ping", daemon.NewPingHandler(daemon.PingHandlerOptions{
+		Service: daemonService,
+		Version: Version,
+	}))
+	mux.HandleFunc("/api/v1/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	mux.HandleFunc("/api/v1/cli/build-cache", func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"stdout","data":"Built through running daemon.\n"}` + "\n"))
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	rt := daemonRuntimeForHTTPServer(t, server, daemonAPIKeyFingerprint(""))
+	_, err := daemonRuntimeStore(dataDir).Write(rt.Record)
+	require.NoError(t, err, "write running daemon record")
+	stubStartServeBackgroundProcess(t, func(
+		*config.Config,
+		backgroundServeStartOptions,
+	) (*backgroundServeProcess, error) {
+		require.FailNow(t, "a running local daemon must not be restarted with cache intent")
+		return nil, errors.New("unreachable daemon restart")
+	})
+
+	cmd, stdout := buildCacheHTTPTestCommand()
+	err = runBuildCacheHTTP(cmd, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), requests.Load())
+	assert.Equal(t, "Built through running daemon.\n", stdout.String())
 }
 
 func buildCacheHTTPTestCommand() (*cobra.Command, *bytes.Buffer) {

--- a/cmd/msgvault/cmd/build_cache_http_test.go
+++ b/cmd/msgvault/cmd/build_cache_http_test.go
@@ -2,18 +2,109 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
 )
+
+func TestBuildCacheAutostartFulfilledSkipsRedundantHTTPRequest(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	stubBuildCacheDaemonAutostart(t, server, startupCacheBuildOutcomeFulfilled, nil)
+
+	cmd, stdout := buildCacheHTTPTestCommand()
+	var err error
+	captureStderrDuring(t, func() {
+		err = runBuildCacheHTTP(cmd, false)
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, requests.Load())
+	assert.Equal(t,
+		"Cache build complete. The daemon is running and using the analytics cache.\n",
+		stdout.String(),
+	)
+}
+
+func TestBuildCacheAutostartFailedReturnsErrorWithoutRetry(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	logPath := filepath.Join(t.TempDir(), "serve.log")
+	stubBuildCacheDaemonAutostart(t, server, startupCacheBuildOutcomeFailed, &logPath)
+
+	cmd, _ := buildCacheHTTPTestCommand()
+	var err error
+	captureStderrDuring(t, func() {
+		err = runBuildCacheHTTP(cmd, false)
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "analytics cache build failed during daemon startup")
+	require.ErrorContains(t, err, "daemon is running with live SQL")
+	require.ErrorContains(t, err, logPath)
+	assert.Zero(t, requests.Load())
+}
+
+func TestBuildCacheAutostartUnconsumedUsesHTTPRequest(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		assert.Equal(t, "/api/v1/cli/build-cache", r.URL.Path)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"stdout","data":"Built through HTTP.\n"}` + "\n"))
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	}))
+	t.Cleanup(server.Close)
+	stubBuildCacheDaemonAutostart(t, server, startupCacheBuildOutcomeUnconsumed, nil)
+
+	cmd, stdout := buildCacheHTTPTestCommand()
+	var err error
+	captureStderrDuring(t, func() {
+		err = runBuildCacheHTTP(cmd, false)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), requests.Load())
+	assert.Equal(t, "Built through HTTP.\n", stdout.String())
+}
+
+func TestBuildCacheFullRebuildPassesFullStartupIntent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	var gotIntent startupCacheBuildIntent
+	stubBuildCacheDaemonAutostart(t, server, startupCacheBuildOutcomeFulfilled, nil,
+		func(intent startupCacheBuildIntent) { gotIntent = intent })
+
+	cmd, _ := buildCacheHTTPTestCommand()
+	var err error
+	captureStderrDuring(t, func() {
+		err = runBuildCacheHTTP(cmd, true)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, startupCacheBuildIntentFull, gotIntent)
+}
 
 func TestBuildCacheUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 	assert := assert.New(t)
@@ -63,4 +154,50 @@ func TestBuildCacheUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 	assert.Equal(int32(1), requests.Load(), "HTTP requests")
 	assert.Equal("Building cache...\nExported 42 messages to /tmp/msgvault-analytics\n", stdout.String())
 	assert.Equal("Warning: using CSV fallback\n", stderr.String())
+}
+
+func buildCacheHTTPTestCommand() (*cobra.Command, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	cmd := &cobra.Command{Use: "build-cache"}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	return cmd, stdout
+}
+
+func stubBuildCacheDaemonAutostart(
+	t *testing.T,
+	server *httptest.Server,
+	outcome startupCacheBuildOutcome,
+	logPathOverride *string,
+	observeIntent ...func(startupCacheBuildIntent),
+) {
+	t.Helper()
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	waitCh := make(chan error)
+	logPath := filepath.Join(dataDir, "serve.log")
+	if logPathOverride != nil {
+		logPath = *logPathOverride
+	}
+	stubStartServeBackgroundProcess(t, func(
+		_ *config.Config,
+		opts backgroundServeStartOptions,
+	) (*backgroundServeProcess, error) {
+		for _, observe := range observeIntent {
+			observe(opts.CacheBuildIntent)
+		}
+		return &backgroundServeProcess{PID: 4242, LogPath: logPath, Wait: waitCh}, nil
+	})
+	stubWaitForBackgroundServeReady(t, func(
+		context.Context,
+		string,
+		<-chan error,
+		time.Duration,
+	) (*DaemonRuntime, bool, error) {
+		rt := daemonRuntimeForHTTPServer(t, server, daemonAPIKeyFingerprint(""))
+		rt.Record.PID = 4242
+		rt.Record.Metadata[runtimeStartupCacheBuildOutcome] = string(outcome)
+		return rt, true, nil
+	})
 }

--- a/cmd/msgvault/cmd/build_cache_test.go
+++ b/cmd/msgvault/cmd/build_cache_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -28,6 +29,16 @@ func TestDaemonBuildCacheChildUsesQuietConsolePolicy(t *testing.T) {
 	t.Setenv(daemonCLISubprocessEnv, "")
 	t.Setenv(buildCacheDaemonSubprocessEnv, strconv.Itoa(os.Getppid()))
 	assert.True(t, isDaemonConsoleSubprocess())
+}
+
+func TestRunBuildCacheSubprocessCommandStreamsStderrOnSuccess(t *testing.T) {
+	cmd := helperProcessCommand(context.Background(), "stdout-stderr-ok")
+	var stderr bytes.Buffer
+
+	err := runBuildCacheSubprocessCommand(cmd, &stderr)
+
+	require.NoError(t, err)
+	assert.Equal(t, "cache build warning\n", stderr.String())
 }
 
 // setupTestSQLite creates a test SQLite database with realistic email data.

--- a/cmd/msgvault/cmd/build_cache_test.go
+++ b/cmd/msgvault/cmd/build_cache_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,12 @@ import (
 	"go.kenn.io/msgvault/internal/identityindex"
 	"go.kenn.io/msgvault/internal/query"
 )
+
+func TestDaemonBuildCacheChildUsesQuietConsolePolicy(t *testing.T) {
+	t.Setenv(daemonCLISubprocessEnv, "")
+	t.Setenv(buildCacheDaemonSubprocessEnv, strconv.Itoa(os.Getppid()))
+	assert.True(t, isDaemonConsoleSubprocess())
+}
 
 // setupTestSQLite creates a test SQLite database with realistic email data.
 func setupTestSQLite(t *testing.T) string {

--- a/cmd/msgvault/cmd/cache_startup.go
+++ b/cmd/msgvault/cmd/cache_startup.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const daemonStartupCacheBuildEnv = "MSGVAULT_DAEMON_STARTUP_CACHE_BUILD"
+
+type startupCacheBuildIntent string
+
+const (
+	startupCacheBuildIntentNone    startupCacheBuildIntent = ""
+	startupCacheBuildIntentDefault startupCacheBuildIntent = "default"
+	startupCacheBuildIntentFull    startupCacheBuildIntent = "full"
+)
+
+type startupCacheBuildOutcome string
+
+const (
+	startupCacheBuildOutcomeNone       startupCacheBuildOutcome = ""
+	startupCacheBuildOutcomeFulfilled  startupCacheBuildOutcome = "fulfilled"
+	startupCacheBuildOutcomeFailed     startupCacheBuildOutcome = "failed"
+	startupCacheBuildOutcomeUnconsumed startupCacheBuildOutcome = "unconsumed"
+)
+
+func startupCacheBuildIntentFromEnv() (startupCacheBuildIntent, error) {
+	intent := startupCacheBuildIntent(os.Getenv(daemonStartupCacheBuildEnv))
+	switch intent {
+	case startupCacheBuildIntentNone,
+		startupCacheBuildIntentDefault,
+		startupCacheBuildIntentFull:
+		return intent, nil
+	default:
+		return startupCacheBuildIntentNone,
+			fmt.Errorf("invalid daemon startup cache build intent %q", intent)
+	}
+}
+
+func withStartupCacheBuildIntent(base []string, intent startupCacheBuildIntent) []string {
+	prefix := daemonStartupCacheBuildEnv + "="
+	out := make([]string, 0, len(base)+1)
+	for _, entry := range base {
+		if !strings.HasPrefix(entry, prefix) {
+			out = append(out, entry)
+		}
+	}
+	if intent != startupCacheBuildIntentNone {
+		out = append(out, prefix+string(intent))
+	}
+	return out
+}
+
+func startupCacheBuildOutcomeFromRuntime(rt *DaemonRuntime) startupCacheBuildOutcome {
+	if rt == nil || rt.Record.Metadata == nil {
+		return startupCacheBuildOutcomeNone
+	}
+	return startupCacheBuildOutcome(rt.Record.Metadata[runtimeStartupCacheBuildOutcome])
+}

--- a/cmd/msgvault/cmd/cache_startup.go
+++ b/cmd/msgvault/cmd/cache_startup.go
@@ -41,12 +41,18 @@ func startupCacheBuildIntentFromEnv() (startupCacheBuildIntent, error) {
 func withStartupCacheBuildIntent(base []string, intent startupCacheBuildIntent) []string {
 	prefix := daemonStartupCacheBuildEnv + "="
 	out := make([]string, 0, len(base)+1)
+	replaced := false
 	for _, entry := range base {
-		if !strings.HasPrefix(entry, prefix) {
-			out = append(out, entry)
+		if strings.HasPrefix(entry, prefix) {
+			if !replaced && intent != startupCacheBuildIntentNone {
+				out = append(out, prefix+string(intent))
+				replaced = true
+			}
+			continue
 		}
+		out = append(out, entry)
 	}
-	if intent != startupCacheBuildIntentNone {
+	if !replaced && intent != startupCacheBuildIntentNone {
 		out = append(out, prefix+string(intent))
 	}
 	return out

--- a/cmd/msgvault/cmd/cache_startup_test.go
+++ b/cmd/msgvault/cmd/cache_startup_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
+)
+
+func TestStartupCacheBuildIntentFromEnv(t *testing.T) {
+	t.Setenv(daemonStartupCacheBuildEnv, string(startupCacheBuildIntentFull))
+
+	intent, err := startupCacheBuildIntentFromEnv()
+
+	require.NoError(t, err)
+	assert.Equal(t, startupCacheBuildIntentFull, intent)
+}
+
+func TestStartupCacheBuildIntentFromEnvRejectsUnknownValue(t *testing.T) {
+	t.Setenv(daemonStartupCacheBuildEnv, "surprise")
+
+	_, err := startupCacheBuildIntentFromEnv()
+
+	require.ErrorContains(t, err, "invalid daemon startup cache build intent")
+}
+
+func TestWithStartupCacheBuildIntentReplacesStaleValue(t *testing.T) {
+	base := []string{"KEEP=1", daemonStartupCacheBuildEnv + "=default", "TAIL=2"}
+
+	got := withStartupCacheBuildIntent(base, startupCacheBuildIntentFull)
+
+	assert.Equal(t, []string{
+		"KEEP=1",
+		daemonStartupCacheBuildEnv + "=full",
+		"TAIL=2",
+	}, got)
+}
+
+func TestStartupCacheBuildOutcomeFromRuntime(t *testing.T) {
+	rt := &DaemonRuntime{Record: daemon.RuntimeRecord{Metadata: map[string]string{
+		runtimeStartupCacheBuildOutcome: string(startupCacheBuildOutcomeFailed),
+	}}}
+
+	assert.Equal(t, startupCacheBuildOutcomeFailed, startupCacheBuildOutcomeFromRuntime(rt))
+	assert.Equal(t, startupCacheBuildOutcomeNone, startupCacheBuildOutcomeFromRuntime(nil))
+}

--- a/cmd/msgvault/cmd/daemon_cli_subprocess.go
+++ b/cmd/msgvault/cmd/daemon_cli_subprocess.go
@@ -20,6 +20,10 @@ func isDaemonCLISubprocess() bool {
 	return os.Getenv(daemonCLISubprocessEnv) == strconv.Itoa(os.Getppid())
 }
 
+func isDaemonConsoleSubprocess() bool {
+	return isDaemonCLISubprocess() || isDaemonBuildCacheChild()
+}
+
 func runDaemonCLISubprocessStream(
 	ctx context.Context,
 	args []string,

--- a/cmd/msgvault/cmd/daemon_cli_subprocess_test.go
+++ b/cmd/msgvault/cmd/daemon_cli_subprocess_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -23,6 +24,10 @@ func TestHelperProcess(t *testing.T) {
 	switch os.Getenv("GO_HELPER_MODE") {
 	case "exit3":
 		os.Exit(3)
+	case "stdout-stderr-ok":
+		_, _ = fmt.Fprintln(os.Stdout, "cache build detail")
+		_, _ = fmt.Fprintln(os.Stderr, "cache build warning")
+		os.Exit(0)
 	case "block":
 		select {}
 	default:

--- a/cmd/msgvault/cmd/daemon_cli_subprocess_test.go
+++ b/cmd/msgvault/cmd/daemon_cli_subprocess_test.go
@@ -30,6 +30,18 @@ func TestHelperProcess(t *testing.T) {
 		os.Exit(0)
 	case "block":
 		select {}
+	case "spawn-blocking-child":
+		child := helperProcessCommand(context.Background(), "block")
+		if err := child.Start(); err != nil {
+			os.Exit(10)
+		}
+		pidPath := os.Getenv("GO_HELPER_CHILD_PID_PATH")
+		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			_ = child.Process.Kill()
+			os.Exit(11)
+		}
+		_ = child.Wait()
+		os.Exit(0)
 	default:
 		os.Exit(0)
 	}

--- a/cmd/msgvault/cmd/daemon_logline_test.go
+++ b/cmd/msgvault/cmd/daemon_logline_test.go
@@ -120,6 +120,19 @@ func TestDaemonStartupProgressStateRepeatsActiveCacheBuild(t *testing.T) {
 	assert.Equal(t, "still waiting", state.Next(completeLine))
 }
 
+func TestDaemonStartupProgressStateClearsFailedCacheBuild(t *testing.T) {
+	state := daemonStartupProgressState{}
+	buildLine := `time=2026-07-01T12:00:00Z level=INFO msg="daemon startup step" step=build_analytics_cache reason="analytics cache schema is stale" full_rebuild=true`
+	assert.Equal(t,
+		"building the analytics cache (full rebuild: analytics cache schema is stale)",
+		state.Next(buildLine),
+	)
+
+	failedLine := `time=2026-07-01T12:00:10Z level=WARN msg="daemon startup step failed" step=build_analytics_cache error="simulated build failure"`
+	assert.Equal(t, "building the analytics cache (failed) : simulated build failure", state.Next(failedLine))
+	assert.Equal(t, "still waiting", state.Next(failedLine))
+}
+
 // TestHumanizeDaemonLogLineTruncatesLongRawFallback locks in the length cap:
 // a record with unknown keys falls back to the raw line, which can embed
 // arbitrarily large values, and the terminal echo must stay bounded.

--- a/cmd/msgvault/cmd/daemon_logline_test.go
+++ b/cmd/msgvault/cmd/daemon_logline_test.go
@@ -25,6 +25,11 @@ func TestHumanizeDaemonLogLine(t *testing.T) {
 			want: "build cache",
 		},
 		{
+			name: "cache build step explains a full rebuild",
+			line: `time=2026-07-01T12:00:00Z level=INFO msg="daemon startup step" step=build_analytics_cache reason="analytics cache schema is stale" full_rebuild=true`,
+			want: "building the analytics cache (full rebuild: analytics cache schema is stale)",
+		},
+		{
 			name: "startup step completion renders label (done)",
 			line: `time=2026-07-01T12:00:00Z level=INFO msg="daemon startup step complete" step=init_archive_schema`,
 			want: "checking the database schema (done)",
@@ -95,6 +100,24 @@ func TestHumanizeDaemonLogLine(t *testing.T) {
 			assert.Equal(t, tt.want, humanizeDaemonLogLine(tt.line))
 		})
 	}
+}
+
+func TestDaemonStartupProgressStateRepeatsActiveCacheBuild(t *testing.T) {
+	state := daemonStartupProgressState{}
+	buildLine := `time=2026-07-01T12:00:00Z level=INFO msg="daemon startup step" step=build_analytics_cache reason="analytics cache schema is stale" full_rebuild=true`
+	assert.Equal(t,
+		"building the analytics cache (full rebuild: analytics cache schema is stale)",
+		state.Next(buildLine),
+	)
+	assert.Equal(t, "still building the analytics cache", state.Next(buildLine))
+
+	warningLine := `time=2026-07-01T12:00:10Z level=WARN msg="builder memory pressure"`
+	assert.Equal(t, "builder memory pressure", state.Next(warningLine))
+	assert.Equal(t, "still building the analytics cache", state.Next(warningLine))
+
+	completeLine := `time=2026-07-01T12:01:00Z level=INFO msg="daemon startup step complete" step=build_analytics_cache full_rebuild=true`
+	assert.Equal(t, "building the analytics cache (done)", state.Next(completeLine))
+	assert.Equal(t, "still waiting", state.Next(completeLine))
 }
 
 // TestHumanizeDaemonLogLineTruncatesLongRawFallback locks in the length cap:

--- a/cmd/msgvault/cmd/daemon_logline_test.go
+++ b/cmd/msgvault/cmd/daemon_logline_test.go
@@ -36,7 +36,7 @@ func TestHumanizeDaemonLogLine(t *testing.T) {
 		},
 		{
 			name: "open_archive_database step drops its database attr",
-			line: `time=2026-07-01T12:00:00Z level=INFO msg="daemon startup step" run_id=abc123 step=open_archive_database database=/home/user/.msgvault/msgvault.db`,
+			line: `time=2026-07-01T12:00:00Z level=INFO msg="daemon startup step" run_id=abc123 step=open_archive_database database=example.db`,
 			want: "opening the archive database",
 		},
 		{

--- a/cmd/msgvault/cmd/daemon_logline_test.go
+++ b/cmd/msgvault/cmd/daemon_logline_test.go
@@ -103,21 +103,23 @@ func TestHumanizeDaemonLogLine(t *testing.T) {
 }
 
 func TestDaemonStartupProgressStateRepeatsActiveCacheBuild(t *testing.T) {
+	assert := assert.New(t)
+
 	state := daemonStartupProgressState{}
 	buildLine := `time=2026-07-01T12:00:00Z level=INFO msg="daemon startup step" step=build_analytics_cache reason="analytics cache schema is stale" full_rebuild=true`
-	assert.Equal(t,
+	assert.Equal(
 		"building the analytics cache (full rebuild: analytics cache schema is stale)",
 		state.Next(buildLine),
 	)
-	assert.Equal(t, "still building the analytics cache", state.Next(buildLine))
+	assert.Equal("still building the analytics cache", state.Next(buildLine))
 
 	warningLine := `time=2026-07-01T12:00:10Z level=WARN msg="builder memory pressure"`
-	assert.Equal(t, "builder memory pressure", state.Next(warningLine))
-	assert.Equal(t, "still building the analytics cache", state.Next(warningLine))
+	assert.Equal("builder memory pressure", state.Next(warningLine))
+	assert.Equal("still building the analytics cache", state.Next(warningLine))
 
 	completeLine := `time=2026-07-01T12:01:00Z level=INFO msg="daemon startup step complete" step=build_analytics_cache full_rebuild=true`
-	assert.Equal(t, "building the analytics cache (done)", state.Next(completeLine))
-	assert.Equal(t, "still waiting", state.Next(completeLine))
+	assert.Equal("building the analytics cache (done)", state.Next(completeLine))
+	assert.Equal("still waiting", state.Next(completeLine))
 }
 
 func TestDaemonStartupProgressStateClearsFailedCacheBuild(t *testing.T) {

--- a/cmd/msgvault/cmd/daemon_runtime.go
+++ b/cmd/msgvault/cmd/daemon_runtime.go
@@ -22,18 +22,19 @@ import (
 )
 
 const (
-	daemonService           = "msgvault"
-	daemonAPIVersion        = 1
-	defaultDaemonBindAddr   = "127.0.0.1"
-	runtimeHost             = "host"
-	runtimePort             = "port"
-	runtimeAPIVersion       = "api_version"
-	runtimeAPISchemaVersion = "api_schema_version"
-	runtimeAuthFingerprint  = "auth_fingerprint"
-	runtimeCreateTime       = "create_time"
-	runtimeShutdownToken    = "shutdown_token"
-	runtimeStartupPhase     = "startup_phase"
-	daemonProbeTick         = 250 * time.Millisecond
+	daemonService                   = "msgvault"
+	daemonAPIVersion                = 1
+	defaultDaemonBindAddr           = "127.0.0.1"
+	runtimeHost                     = "host"
+	runtimePort                     = "port"
+	runtimeAPIVersion               = "api_version"
+	runtimeAPISchemaVersion         = "api_schema_version"
+	runtimeAuthFingerprint          = "auth_fingerprint"
+	runtimeCreateTime               = "create_time"
+	runtimeShutdownToken            = "shutdown_token"
+	runtimeStartupPhase             = "startup_phase"
+	runtimeStartupCacheBuildOutcome = "startup_cache_build_outcome"
+	daemonProbeTick                 = 250 * time.Millisecond
 )
 
 // daemonStartupPhaseInitial is published in the runtime record the moment the

--- a/cmd/msgvault/cmd/root.go
+++ b/cmd/msgvault/cmd/root.go
@@ -127,7 +127,7 @@ in a single binary.`,
 			stderrIsTerminal := isatty.IsTerminal(os.Stderr.Fd()) ||
 				isatty.IsCygwinTerminal(os.Stderr.Fd())
 			if consoleLevel := logging.ResolveConsoleLevel(
-				levelString, verbose, fileDisabled, stderrIsTerminal, isDaemonCLISubprocess(),
+				levelString, verbose, fileDisabled, stderrIsTerminal, isDaemonConsoleSubprocess(),
 			); consoleLevel != nil {
 				levelOverride = consoleLevel
 				humanConsole = true

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -75,6 +75,17 @@ var buildCacheSubprocessForRun = func(ctx context.Context, fullRebuild bool) err
 	return buildCacheSubprocess(ctx, fullRebuild, true)
 }
 
+var buildStartupCacheSubprocessForRun = func(
+	ctx context.Context,
+	intent startupCacheBuildIntent,
+) error {
+	mode := buildCacheModeAuto
+	if intent == startupCacheBuildIntentFull {
+		mode = buildCacheModeFull
+	}
+	return buildCacheSubprocessMode(ctx, mode)
+}
+
 var executeBuildCacheSubprocessMode = buildCacheSubprocessMode
 
 var runDerivedCacheSubprocess = func(ctx context.Context, analyticsDir string) error {
@@ -251,9 +262,23 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	setStartupPhase("building analytics cache")
 	logger.Info("daemon startup step", "step", "init_analytics_engine")
-	engine, analyticsMode, err := openDaemonAnalyticsEngine(cmd.Context(), cfg, s)
+	startupCacheIntent, err := startupCacheBuildIntentFromEnv()
 	if err != nil {
 		return err
+	}
+	engine, analyticsMode, cacheOutcome, engineErr := openDaemonAnalyticsEngine(
+		cmd.Context(), cfg, s, startupCacheIntent,
+	)
+	if startupCacheIntent != startupCacheBuildIntentNone {
+		if outcomeErr := ownership.SetStartupCacheBuildOutcome(cacheOutcome); outcomeErr != nil {
+			if engine != nil {
+				_ = engine.Close()
+			}
+			return outcomeErr
+		}
+	}
+	if engineErr != nil {
+		return engineErr
 	}
 	defer func() { _ = engine.Close() }()
 	logger.Info("daemon startup step complete", "step", "init_analytics_engine")
@@ -720,12 +745,18 @@ func openDaemonAnalyticsEngine(
 	ctx context.Context,
 	c *config.Config,
 	s *store.Store,
-) (query.Engine, string, error) {
+	intent startupCacheBuildIntent,
+) (query.Engine, string, startupCacheBuildOutcome, error) {
 	if c == nil || s == nil {
-		return nil, "", errors.New("daemon analytics engine unavailable")
+		return nil, "", startupCacheBuildOutcomeNone,
+			errors.New("daemon analytics engine unavailable")
 	}
 	if s.IsPostgreSQL() {
-		return query.NewEngine(s.DB(), true), api.AnalyticsModePostgres, nil
+		outcome := startupCacheBuildOutcomeNone
+		if intent != startupCacheBuildIntentNone {
+			outcome = startupCacheBuildOutcomeUnconsumed
+		}
+		return query.NewEngine(s.DB(), true), api.AnalyticsModePostgres, outcome, nil
 	}
 
 	engineMode := c.Analytics.Engine
@@ -735,28 +766,59 @@ func openDaemonAnalyticsEngine(
 	if engineMode == config.AnalyticsEngineSQL {
 		logger.Info("using live SQL analytics engine",
 			"engine", engineMode)
-		return query.NewEngine(s.DB(), false), api.AnalyticsModeSQL, nil
+		outcome := startupCacheBuildOutcomeNone
+		if intent != startupCacheBuildIntentNone {
+			outcome = startupCacheBuildOutcomeUnconsumed
+		}
+		return query.NewEngine(s.DB(), false), api.AnalyticsModeSQL, outcome, nil
 	}
 
 	dbPath := c.DatabaseDSN()
 	analyticsDir := c.AnalyticsDir()
 	staleness := cacheNeedsBuild(dbPath, analyticsDir)
-	if staleness.NeedsBuild && c.Analytics.AutoBuildCache {
+	outcome := startupCacheBuildOutcomeNone
+	shouldBuild := intent != startupCacheBuildIntentNone ||
+		(staleness.NeedsBuild && c.Analytics.AutoBuildCache)
+	if shouldBuild {
 		// Build the cache before serving rather than starting on live-SQL
 		// fallback: incremental rebuilds take seconds, and startup progress
 		// already streams to the CLI that auto-started the daemon. A failed
 		// build is fatal for engine="duckdb" (documented to never fall back)
 		// and falls back to live SQL for engine="auto".
-		if err := buildCacheSubprocessForRun(ctx, staleness.FullRebuild); err != nil {
+		fullBuild := staleness.FullRebuild
+		reason := staleness.Reason
+		if intent == startupCacheBuildIntentFull {
+			fullBuild = true
+			reason = "explicit full rebuild requested"
+		}
+		logger.Info("daemon startup step",
+			"step", "build_analytics_cache",
+			"reason", reason,
+			"full_rebuild", fullBuild)
+
+		var buildErr error
+		if intent != startupCacheBuildIntentNone {
+			buildErr = buildStartupCacheSubprocessForRun(ctx, intent)
+		} else {
+			buildErr = buildCacheSubprocessForRun(ctx, staleness.FullRebuild)
+		}
+		if buildErr != nil {
+			if intent != startupCacheBuildIntentNone {
+				outcome = startupCacheBuildOutcomeFailed
+			}
 			if engineMode == config.AnalyticsEngineDuckDB {
-				return nil, "", fmt.Errorf("build analytics cache: %w", err)
+				return nil, "", outcome, fmt.Errorf("build analytics cache: %w", buildErr)
 			}
 			logger.Warn("analytics cache build failed; using live SQL engine",
-				"error", err)
+				"error", buildErr)
 		} else {
-			logger.Info("rebuilt analytics cache",
-				"reason", staleness.Reason,
-				"full_rebuild", staleness.FullRebuild)
+			logger.Info("daemon startup step complete",
+				"step", "build_analytics_cache",
+				"reason", reason,
+				"full_rebuild", fullBuild)
+			if intent != startupCacheBuildIntentNone {
+				outcome = startupCacheBuildOutcomeFulfilled
+			}
 		}
 		staleness = cacheNeedsBuild(dbPath, analyticsDir)
 	}
@@ -765,13 +827,13 @@ func openDaemonAnalyticsEngine(
 		duckEngine, err := openDaemonDuckDBEngine(c, s)
 		if err != nil {
 			if engineMode == config.AnalyticsEngineDuckDB {
-				return nil, "", err
+				return nil, "", outcome, err
 			}
 			logger.Warn("DuckDB engine failed, falling back to live SQL",
 				"error", err)
-			return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, nil
+			return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, outcome, nil
 		}
-		return duckEngine, api.AnalyticsModeDuckDB, nil
+		return duckEngine, api.AnalyticsModeDuckDB, outcome, nil
 	}
 
 	if engineMode == config.AnalyticsEngineDuckDB {
@@ -779,7 +841,8 @@ func openDaemonAnalyticsEngine(
 		if reason == "" {
 			reason = "analytics cache is missing or incomplete"
 		}
-		return nil, "", fmt.Errorf("analytics engine=duckdb requires a usable cache: %s", reason)
+		return nil, "", outcome,
+			fmt.Errorf("analytics engine=duckdb requires a usable cache: %s", reason)
 	}
 	if staleness.Reason != "" {
 		logger.Info("analytics cache not usable, using live SQL engine",
@@ -789,7 +852,7 @@ func openDaemonAnalyticsEngine(
 		logger.Info("analytics cache not built - using live SQL engine (run 'msgvault build-cache' for faster aggregates)",
 			"auto_build_cache", c.Analytics.AutoBuildCache)
 	}
-	return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, nil
+	return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, outcome, nil
 }
 
 func openDaemonDuckDBEngine(c *config.Config, s *store.Store) (*query.DuckDBEngine, error) {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -811,21 +811,24 @@ func openDaemonAnalyticsEngine(
 			}
 			logger.Warn("analytics cache build failed; using live SQL engine",
 				"error", buildErr)
+			if intent != startupCacheBuildIntentNone {
+				return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, outcome, nil
+			}
 		} else {
 			logger.Info("daemon startup step complete",
 				"step", "build_analytics_cache",
 				"reason", reason,
 				"full_rebuild", fullBuild)
-			if intent != startupCacheBuildIntentNone {
-				outcome = startupCacheBuildOutcomeFulfilled
-			}
 		}
 		staleness = cacheNeedsBuild(dbPath, analyticsDir)
 	}
 
 	if !staleness.NeedsBuild {
-		duckEngine, err := openDaemonDuckDBEngine(c, s)
+		duckEngine, err := openDaemonDuckDBEngineForRun(c, s)
 		if err != nil {
+			if intent != startupCacheBuildIntentNone {
+				outcome = startupCacheBuildOutcomeFailed
+			}
 			if engineMode == config.AnalyticsEngineDuckDB {
 				return nil, "", outcome, err
 			}
@@ -833,9 +836,15 @@ func openDaemonAnalyticsEngine(
 				"error", err)
 			return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, outcome, nil
 		}
+		if intent != startupCacheBuildIntentNone {
+			outcome = startupCacheBuildOutcomeFulfilled
+		}
 		return duckEngine, api.AnalyticsModeDuckDB, outcome, nil
 	}
 
+	if intent != startupCacheBuildIntentNone {
+		outcome = startupCacheBuildOutcomeFailed
+	}
 	if engineMode == config.AnalyticsEngineDuckDB {
 		reason := staleness.Reason
 		if reason == "" {
@@ -854,6 +863,8 @@ func openDaemonAnalyticsEngine(
 	}
 	return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, outcome, nil
 }
+
+var openDaemonDuckDBEngineForRun = openDaemonDuckDBEngine
 
 func openDaemonDuckDBEngine(c *config.Config, s *store.Store) (*query.DuckDBEngine, error) {
 	if c == nil || s == nil {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -806,11 +806,14 @@ func openDaemonAnalyticsEngine(
 			if intent != startupCacheBuildIntentNone {
 				outcome = startupCacheBuildOutcomeFailed
 			}
+			logger.Warn("daemon startup step failed",
+				"step", "build_analytics_cache",
+				"reason", reason,
+				"full_rebuild", fullBuild,
+				"error", buildErr)
 			if engineMode == config.AnalyticsEngineDuckDB {
 				return nil, "", outcome, fmt.Errorf("build analytics cache: %w", buildErr)
 			}
-			logger.Warn("analytics cache build failed; using live SQL engine",
-				"error", buildErr)
 			if intent != startupCacheBuildIntentNone {
 				return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback, outcome, nil
 			}

--- a/cmd/msgvault/cmd/serve_lifecycle.go
+++ b/cmd/msgvault/cmd/serve_lifecycle.go
@@ -239,7 +239,8 @@ type backgroundDaemonStartPreparation struct {
 }
 
 type backgroundServeStartOptions struct {
-	ExecutablePath string
+	ExecutablePath   string
+	CacheBuildIntent startupCacheBuildIntent
 }
 
 func prepareBackgroundDaemonStart(
@@ -819,7 +820,10 @@ func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOpti
 
 	//nolint:gosec // exe is this binary and args are reconstructed from fixed global flags.
 	child := exec.Command(exe, serveBackgroundChildArgs()...)
-	child.Env = append(os.Environ(), "MSGVAULT_HOME="+c.HomeDir, serveBackgroundChildEnv+"=1")
+	child.Env = withStartupCacheBuildIntent(
+		append(os.Environ(), "MSGVAULT_HOME="+c.HomeDir, serveBackgroundChildEnv+"=1"),
+		opts.CacheBuildIntent,
+	)
 	child.Stdin = devNull
 	child.Stdout = logFile
 	child.Stderr = logFile

--- a/cmd/msgvault/cmd/serve_lifecycle.go
+++ b/cmd/msgvault/cmd/serve_lifecycle.go
@@ -341,6 +341,7 @@ func runServeStartWithOptions(cmd *cobra.Command, c *config.Config, opts backgro
 	if err != nil {
 		return fmt.Errorf("start background daemon: %w", err)
 	}
+	defer func() { _ = proc.releaseProcessTree() }()
 	rt, ready, err := waitForBackgroundServeReadyForRun(
 		cmd.Context(), c.Data.DataDir, proc.Wait, backgroundServeReadyTimeout,
 	)
@@ -780,10 +781,30 @@ func reportBackgroundLaunchInProgress(cmd *cobra.Command, dataDir string) {
 }
 
 type backgroundServeProcess struct {
-	PID     int
-	Process *os.Process
-	LogPath string
-	Wait    <-chan error
+	PID         int
+	Process     *os.Process
+	ProcessTree backgroundServeProcessTree
+	LogPath     string
+	Wait        <-chan error
+}
+
+type backgroundServeProcessTree interface {
+	Attach(process *os.Process) error
+	Terminate() error
+	Close() error
+}
+
+type backgroundServeCommandConfig struct {
+	ProcessTree backgroundServeProcessTree
+}
+
+func (p *backgroundServeProcess) releaseProcessTree() error {
+	if p == nil || p.ProcessTree == nil {
+		return nil
+	}
+	tree := p.ProcessTree
+	p.ProcessTree = nil
+	return tree.Close()
 }
 
 const backgroundServeStartupCancelGrace = 5 * time.Second
@@ -834,9 +855,26 @@ func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOpti
 	child.Stdin = devNull
 	child.Stdout = logFile
 	child.Stderr = logFile
-	configureServeBackgroundCommand(child)
+	commandConfig, err := configureServeBackgroundCommand(child)
+	if err != nil {
+		return nil, fmt.Errorf("configure background process tree: %w", err)
+	}
+	processTree := commandConfig.ProcessTree
+	closeProcessTree := true
+	defer func() {
+		if closeProcessTree && processTree != nil {
+			_ = processTree.Close()
+		}
+	}()
 	if err := child.Start(); err != nil {
 		return nil, fmt.Errorf("start server: %w", err)
+	}
+	if processTree != nil {
+		if err := processTree.Attach(child.Process); err != nil {
+			_ = child.Process.Kill()
+			_, _ = child.Process.Wait()
+			return nil, fmt.Errorf("attach server process tree: %w", err)
+		}
 	}
 	closeLog = false
 	_ = logFile.Close()
@@ -846,10 +884,11 @@ func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOpti
 		waitCh <- child.Wait()
 	}()
 	return &backgroundServeProcess{
-		PID:     child.Process.Pid,
-		Process: child.Process,
-		LogPath: logPath,
-		Wait:    waitCh,
+		PID:         child.Process.Pid,
+		Process:     child.Process,
+		ProcessTree: processTree,
+		LogPath:     logPath,
+		Wait:        waitCh,
 	}, nil
 }
 
@@ -857,6 +896,7 @@ func stopBackgroundServeStartup(proc *backgroundServeProcess, grace time.Duratio
 	if proc == nil {
 		return nil
 	}
+	defer func() { _ = proc.releaseProcessTree() }()
 	process := proc.Process
 	if process == nil {
 		var err error
@@ -865,11 +905,17 @@ func stopBackgroundServeStartup(proc *backgroundServeProcess, grace time.Duratio
 			return fmt.Errorf("find background daemon process: %w", err)
 		}
 	}
-	if err := signalDaemonProcess(process); err != nil {
-		if errors.Is(err, os.ErrProcessDone) {
+	var signalErr error
+	if proc.ProcessTree != nil {
+		signalErr = proc.ProcessTree.Terminate()
+	} else {
+		signalErr = signalDaemonProcess(process)
+	}
+	if signalErr != nil {
+		if errors.Is(signalErr, os.ErrProcessDone) {
 			return nil
 		}
-		return fmt.Errorf("signal canceled background daemon startup: %w", err)
+		return fmt.Errorf("signal canceled background daemon startup: %w", signalErr)
 	}
 	if grace <= 0 {
 		grace = backgroundServeStartupCancelGrace

--- a/cmd/msgvault/cmd/serve_lifecycle.go
+++ b/cmd/msgvault/cmd/serve_lifecycle.go
@@ -781,8 +781,15 @@ func reportBackgroundLaunchInProgress(cmd *cobra.Command, dataDir string) {
 
 type backgroundServeProcess struct {
 	PID     int
+	Process *os.Process
 	LogPath string
 	Wait    <-chan error
+}
+
+const backgroundServeStartupCancelGrace = 5 * time.Second
+
+var stopBackgroundServeStartupForRun = func(proc *backgroundServeProcess) error {
+	return stopBackgroundServeStartup(proc, backgroundServeStartupCancelGrace)
 }
 
 func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOptions) (*backgroundServeProcess, error) {
@@ -840,9 +847,50 @@ func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOpti
 	}()
 	return &backgroundServeProcess{
 		PID:     child.Process.Pid,
+		Process: child.Process,
 		LogPath: logPath,
 		Wait:    waitCh,
 	}, nil
+}
+
+func stopBackgroundServeStartup(proc *backgroundServeProcess, grace time.Duration) error {
+	if proc == nil {
+		return nil
+	}
+	process := proc.Process
+	if process == nil {
+		var err error
+		process, err = os.FindProcess(proc.PID)
+		if err != nil {
+			return fmt.Errorf("find background daemon process: %w", err)
+		}
+	}
+	if err := signalDaemonProcess(process); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return fmt.Errorf("signal canceled background daemon startup: %w", err)
+	}
+	if grace <= 0 {
+		grace = backgroundServeStartupCancelGrace
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-proc.Wait:
+		return nil
+	case <-timer.C:
+	}
+	if err := killDaemonProcess(process); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("kill canceled background daemon startup: %w", err)
+	}
+	timer.Reset(grace)
+	select {
+	case <-proc.Wait:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("background daemon pid %d did not exit after cancellation", proc.PID)
+	}
 }
 
 func serveBackgroundChildArgs() []string {

--- a/cmd/msgvault/cmd/serve_lifecycle.go
+++ b/cmd/msgvault/cmd/serve_lifecycle.go
@@ -41,10 +41,12 @@ var (
 )
 
 var (
-	startServeBackgroundProcessForRun = startServeBackgroundProcess
-	waitForBackgroundServeReadyForRun = waitForBackgroundServeReady
-	stopDaemonRuntimeForUpgrade       = stopDaemonRuntimeForUpgradeImpl
-	requestDaemonShutdownForRun       = requestDaemonShutdown
+	startServeBackgroundProcessForRun     = startServeBackgroundProcess
+	waitForBackgroundServeReadyForRun     = waitForBackgroundServeReady
+	stopDaemonRuntimeForUpgrade           = stopDaemonRuntimeForUpgradeImpl
+	requestDaemonShutdownForRun           = requestDaemonShutdown
+	newServeBackgroundCommandForRun       = exec.Command
+	configureServeBackgroundCommandForRun = configureServeBackgroundCommand
 )
 
 var errDaemonIdentityUnconfirmed = errors.New("daemon identity is unconfirmed")
@@ -846,8 +848,7 @@ func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOpti
 	}
 	defer func() { _ = devNull.Close() }()
 
-	//nolint:gosec // exe is this binary and args are reconstructed from fixed global flags.
-	child := exec.Command(exe, serveBackgroundChildArgs()...)
+	child := newServeBackgroundCommandForRun(exe, serveBackgroundChildArgs()...)
 	child.Env = withStartupCacheBuildIntent(
 		append(os.Environ(), "MSGVAULT_HOME="+c.HomeDir, serveBackgroundChildEnv+"=1"),
 		opts.CacheBuildIntent,
@@ -855,7 +856,7 @@ func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOpti
 	child.Stdin = devNull
 	child.Stdout = logFile
 	child.Stderr = logFile
-	commandConfig, err := configureServeBackgroundCommand(child)
+	commandConfig, err := configureServeBackgroundCommandForRun(child)
 	if err != nil {
 		return nil, fmt.Errorf("configure background process tree: %w", err)
 	}
@@ -876,6 +877,7 @@ func startServeBackgroundProcess(c *config.Config, opts backgroundServeStartOpti
 			return nil, fmt.Errorf("attach server process tree: %w", err)
 		}
 	}
+	closeProcessTree = false
 	closeLog = false
 	_ = logFile.Close()
 

--- a/cmd/msgvault/cmd/serve_lifecycle_test.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_test.go
@@ -1185,6 +1185,23 @@ func TestRunServeStartNotReadyPointsAtStatusForAutoPort(t *testing.T) {
 	assert.Empty(t, stderr.String())
 }
 
+func TestStopBackgroundServeStartupTerminatesProcess(t *testing.T) {
+	cmd := helperProcessCommand(context.Background(), "block")
+	require.NoError(t, cmd.Start(), "start blocking helper")
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	proc := &backgroundServeProcess{
+		PID:     cmd.Process.Pid,
+		Process: cmd.Process,
+		Wait:    waitCh,
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	err := stopBackgroundServeStartup(proc, 2*time.Second)
+
+	require.NoError(t, err)
+}
+
 func TestServeStopGraceTimeoutCoversDaemonShutdownBudget(t *testing.T) {
 	assert.GreaterOrEqual(t,
 		serveStopGraceTimeout,

--- a/cmd/msgvault/cmd/serve_lifecycle_test.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1220,6 +1221,45 @@ func (t *recordingBackgroundProcessTree) Terminate() error {
 func (t *recordingBackgroundProcessTree) Close() error {
 	t.closeCalls.Add(1)
 	return nil
+}
+
+func TestStartServeBackgroundProcessTransfersProcessTreeOwnership(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("GO_HELPER_MODE", "block")
+	tree := &recordingBackgroundProcessTree{terminate: func() error { return nil }}
+	oldCommand := newServeBackgroundCommandForRun
+	oldConfigure := configureServeBackgroundCommandForRun
+	newServeBackgroundCommandForRun = func(string, ...string) *exec.Cmd {
+		return helperProcessCommand(context.Background(), "block")
+	}
+	configureServeBackgroundCommandForRun = func(*exec.Cmd) (backgroundServeCommandConfig, error) {
+		return backgroundServeCommandConfig{ProcessTree: tree}, nil
+	}
+	t.Cleanup(func() {
+		newServeBackgroundCommandForRun = oldCommand
+		configureServeBackgroundCommandForRun = oldConfigure
+	})
+
+	proc, err := startServeBackgroundProcess(
+		lifecycleTestConfig(t.TempDir()),
+		backgroundServeStartOptions{ExecutablePath: os.Args[0]},
+	)
+	require.NoError(err)
+	t.Cleanup(func() {
+		_ = proc.Process.Kill()
+		select {
+		case <-proc.Wait:
+		case <-time.After(2 * time.Second):
+		}
+		_ = proc.releaseProcessTree()
+	})
+
+	assert.Zero(tree.closeCalls.Load(), "successful startup must transfer process-tree ownership")
+	require.NoError(proc.releaseProcessTree())
+	assert.Equal(int32(1), tree.closeCalls.Load(), "owner releases process-tree handle")
 }
 
 func TestStopBackgroundServeStartupTerminatesProcessTree(t *testing.T) {

--- a/cmd/msgvault/cmd/serve_lifecycle_test.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_test.go
@@ -1202,6 +1202,48 @@ func TestStopBackgroundServeStartupTerminatesProcess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+type recordingBackgroundProcessTree struct {
+	terminateCalls atomic.Int32
+	closeCalls     atomic.Int32
+	terminate      func() error
+}
+
+func (t *recordingBackgroundProcessTree) Attach(*os.Process) error {
+	return nil
+}
+
+func (t *recordingBackgroundProcessTree) Terminate() error {
+	t.terminateCalls.Add(1)
+	return t.terminate()
+}
+
+func (t *recordingBackgroundProcessTree) Close() error {
+	t.closeCalls.Add(1)
+	return nil
+}
+
+func TestStopBackgroundServeStartupTerminatesProcessTree(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cmd := helperProcessCommand(context.Background(), "block")
+	require.NoError(cmd.Start(), "start blocking helper")
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	tree := &recordingBackgroundProcessTree{terminate: cmd.Process.Kill}
+	proc := &backgroundServeProcess{
+		PID:         cmd.Process.Pid,
+		Process:     cmd.Process,
+		ProcessTree: tree,
+		Wait:        waitCh,
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	require.NoError(stopBackgroundServeStartup(proc, 2*time.Second))
+	assert.Equal(int32(1), tree.terminateCalls.Load(), "terminate process tree")
+	assert.Equal(int32(1), tree.closeCalls.Load(), "close process tree handle")
+}
+
 func TestServeStopGraceTimeoutCoversDaemonShutdownBudget(t *testing.T) {
 	assert.GreaterOrEqual(t,
 		serveStopGraceTimeout,

--- a/cmd/msgvault/cmd/serve_lifecycle_unix.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_unix.go
@@ -8,11 +8,12 @@ import (
 	"syscall"
 )
 
-func configureServeBackgroundCommand(cmd *exec.Cmd) {
+func configureServeBackgroundCommand(cmd *exec.Cmd) (backgroundServeCommandConfig, error) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.Setsid = true
+	return backgroundServeCommandConfig{}, nil
 }
 
 func signalDaemonProcess(process *os.Process) error {

--- a/cmd/msgvault/cmd/serve_lifecycle_windows.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_windows.go
@@ -55,7 +55,9 @@ func configureServeBackgroundCommand(cmd *exec.Cmd) (backgroundServeCommandConfi
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
-	cmd.SysProcAttr.CreationFlags |= syscall.CREATE_NEW_PROCESS_GROUP | windowsDetachedProcess
+	cmd.SysProcAttr.CreationFlags |= syscall.CREATE_NEW_PROCESS_GROUP |
+		windows.CREATE_SUSPENDED |
+		windowsDetachedProcess
 	// Keep one Job handle in the detached daemon. The launching CLI releases
 	// its copy after readiness, while the daemon's inherited copy keeps the Job
 	// alive until daemon exit; KILL_ON_JOB_CLOSE then removes any straggling
@@ -78,7 +80,46 @@ func (t *windowsBackgroundProcessTree) Attach(process *os.Process) error {
 	if assignErr != nil {
 		return fmt.Errorf("assign process to Job Object: %w", assignErr)
 	}
+	if err := resumeSuspendedProcess(uint32(process.Pid)); err != nil {
+		return fmt.Errorf("resume background process: %w", err)
+	}
 	return nil
+}
+
+func resumeSuspendedProcess(processID uint32) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("snapshot process threads: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return fmt.Errorf("enumerate process threads: %w", err)
+	}
+	// CREATE_SUSPENDED prevents user code from creating more threads, so the
+	// process-owned thread in this snapshot is the primary thread to resume.
+	for {
+		if entry.OwnerProcessID == processID {
+			thread, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+			if err != nil {
+				return fmt.Errorf("open primary thread: %w", err)
+			}
+			defer func() { _ = windows.CloseHandle(thread) }()
+
+			previousSuspendCount, err := windows.ResumeThread(thread)
+			if err != nil {
+				return fmt.Errorf("resume primary thread: %w", err)
+			}
+			if previousSuspendCount != 1 {
+				return fmt.Errorf("resume primary thread: unexpected suspend count %d", previousSuspendCount)
+			}
+			return nil
+		}
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			return fmt.Errorf("find primary thread for process %d: %w", processID, err)
+		}
+	}
 }
 
 func (t *windowsBackgroundProcessTree) Terminate() error {

--- a/cmd/msgvault/cmd/serve_lifecycle_windows.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_windows.go
@@ -3,18 +3,96 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"sync"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 const windowsDetachedProcess = 0x00000008
 
-func configureServeBackgroundCommand(cmd *exec.Cmd) {
+type windowsBackgroundProcessTree struct {
+	handle    windows.Handle
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func configureServeBackgroundCommand(cmd *exec.Cmd) (backgroundServeCommandConfig, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return backgroundServeCommandConfig{}, fmt.Errorf("create Job Object: %w", err)
+	}
+	tree := &windowsBackgroundProcessTree{handle: job}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = tree.Close()
+		}
+	}()
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		return backgroundServeCommandConfig{}, fmt.Errorf("configure Job Object termination: %w", err)
+	}
+	if err := windows.SetHandleInformation(
+		job,
+		windows.HANDLE_FLAG_INHERIT,
+		windows.HANDLE_FLAG_INHERIT,
+	); err != nil {
+		return backgroundServeCommandConfig{}, fmt.Errorf("make Job Object handle inheritable: %w", err)
+	}
+
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.CreationFlags |= syscall.CREATE_NEW_PROCESS_GROUP | windowsDetachedProcess
+	// Keep one Job handle in the detached daemon. The launching CLI releases
+	// its copy after readiness, while the daemon's inherited copy keeps the Job
+	// alive until daemon exit; KILL_ON_JOB_CLOSE then removes any straggling
+	// cache-build descendants.
+	cmd.SysProcAttr.AdditionalInheritedHandles = append(
+		cmd.SysProcAttr.AdditionalInheritedHandles,
+		syscall.Handle(job),
+	)
+	closeOnError = false
+	return backgroundServeCommandConfig{ProcessTree: tree}, nil
+}
+
+func (t *windowsBackgroundProcessTree) Attach(process *os.Process) error {
+	var assignErr error
+	if err := process.WithHandle(func(handle uintptr) {
+		assignErr = windows.AssignProcessToJobObject(t.handle, windows.Handle(handle))
+	}); err != nil {
+		return fmt.Errorf("access background process handle: %w", err)
+	}
+	if assignErr != nil {
+		return fmt.Errorf("assign process to Job Object: %w", assignErr)
+	}
+	return nil
+}
+
+func (t *windowsBackgroundProcessTree) Terminate() error {
+	if err := windows.TerminateJobObject(t.handle, 1); err != nil {
+		return fmt.Errorf("terminate Job Object: %w", err)
+	}
+	return nil
+}
+
+func (t *windowsBackgroundProcessTree) Close() error {
+	t.closeOnce.Do(func() {
+		t.closeErr = windows.CloseHandle(t.handle)
+	})
+	return t.closeErr
 }
 
 func signalDaemonProcess(process *os.Process) error {

--- a/cmd/msgvault/cmd/serve_lifecycle_windows_test.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_windows_test.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -15,6 +16,38 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
+
+func TestWindowsBackgroundProcessDoesNotRunBeforeJobAttachment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	cmd := helperProcessCommand(context.Background(), "spawn-blocking-child")
+	cmd.Env = append(cmd.Env, "GO_HELPER_CHILD_PID_PATH="+pidPath)
+	commandConfig, err := configureServeBackgroundCommand(cmd)
+	require.NoError(err, "configure process tree")
+	tree := commandConfig.ProcessTree
+	require.NotNil(tree, "Windows background daemon must own a process tree")
+	require.NoError(cmd.Start(), "start suspended parent helper")
+	t.Cleanup(func() {
+		_ = tree.Terminate()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = tree.Close()
+	})
+
+	assert.Never(func() bool {
+		_, statErr := os.Stat(pidPath)
+		return statErr == nil || !errors.Is(statErr, os.ErrNotExist)
+	}, 500*time.Millisecond, 10*time.Millisecond,
+		"daemon work must not begin before Job Object attachment")
+
+	require.NoError(tree.Attach(cmd.Process), "attach and resume parent helper")
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(pidPath)
+		return statErr == nil
+	}, 10*time.Second, 25*time.Millisecond, "blocking child PID")
+}
 
 func TestStopBackgroundServeStartupTerminatesWindowsProcessTree(t *testing.T) {
 	assert := assert.New(t)

--- a/cmd/msgvault/cmd/serve_lifecycle_windows_test.go
+++ b/cmd/msgvault/cmd/serve_lifecycle_windows_test.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestStopBackgroundServeStartupTerminatesWindowsProcessTree(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	cmd := helperProcessCommand(context.Background(), "spawn-blocking-child")
+	cmd.Env = append(cmd.Env, "GO_HELPER_CHILD_PID_PATH="+pidPath)
+	commandConfig, err := configureServeBackgroundCommand(cmd)
+	require.NoError(err, "configure process tree")
+	tree := commandConfig.ProcessTree
+	require.NotNil(tree, "Windows background daemon must own a process tree")
+	require.NoError(cmd.Start(), "start parent helper")
+	t.Cleanup(func() {
+		_ = tree.Terminate()
+		_ = tree.Close()
+		_ = cmd.Process.Kill()
+	})
+	require.NoError(tree.Attach(cmd.Process), "attach parent helper to job")
+
+	var childPID int
+	require.Eventually(func() bool {
+		contents, readErr := os.ReadFile(pidPath)
+		if readErr != nil {
+			return false
+		}
+		childPID, readErr = strconv.Atoi(strings.TrimSpace(string(contents)))
+		return readErr == nil && childPID > 0
+	}, 10*time.Second, 25*time.Millisecond, "blocking child PID")
+	child, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(childPID))
+	require.NoError(err, "open blocking child")
+	t.Cleanup(func() { _ = windows.CloseHandle(child) })
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	proc := &backgroundServeProcess{
+		PID:         cmd.Process.Pid,
+		Process:     cmd.Process,
+		ProcessTree: tree,
+		Wait:        waitCh,
+	}
+
+	require.NoError(stopBackgroundServeStartup(proc, 5*time.Second))
+	waitResult, err := windows.WaitForSingleObject(child, 5_000)
+	require.NoError(err, "wait for blocking child")
+	assert.Equal(uint32(windows.WAIT_OBJECT_0), waitResult,
+		"terminating daemon startup must terminate its blocking child")
+}
+
+func TestReleaseWindowsProcessTreeLeavesDetachedDaemonRunning(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cmd := helperProcessCommand(context.Background(), "block")
+	commandConfig, err := configureServeBackgroundCommand(cmd)
+	require.NoError(err, "configure process tree")
+	tree := commandConfig.ProcessTree
+	require.NotNil(tree, "Windows background daemon must own a process tree")
+	require.NoError(cmd.Start(), "start daemon helper")
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = tree.Close()
+	})
+	require.NoError(tree.Attach(cmd.Process), "attach daemon helper to job")
+	require.NoError(tree.Close(), "release launcher Job handle")
+
+	var waitResult uint32
+	var waitErr error
+	require.NoError(cmd.Process.WithHandle(func(handle uintptr) {
+		waitResult, waitErr = windows.WaitForSingleObject(windows.Handle(handle), 250)
+	}), "access daemon helper handle")
+	require.NoError(waitErr, "probe daemon helper")
+	assert.Equal(uint32(windows.WAIT_TIMEOUT), waitResult,
+		"the daemon's inherited Job handle must keep it running after launcher release")
+}

--- a/cmd/msgvault/cmd/serve_ownership.go
+++ b/cmd/msgvault/cmd/serve_ownership.go
@@ -70,6 +70,14 @@ func claimServeOwnership(
 // the HTTP server is not answering pings yet (for example during a long
 // analytics cache rebuild). An empty phase marks startup as finished.
 func (o *serveOwnership) SetStartupPhase(phase string) error {
+	return o.setRuntimeMetadata(runtimeStartupPhase, phase)
+}
+
+func (o *serveOwnership) SetStartupCacheBuildOutcome(outcome startupCacheBuildOutcome) error {
+	return o.setRuntimeMetadata(runtimeStartupCacheBuildOutcome, string(outcome))
+}
+
+func (o *serveOwnership) setRuntimeMetadata(key, value string) error {
 	if o == nil {
 		return nil
 	}
@@ -83,14 +91,14 @@ func (o *serveOwnership) SetStartupPhase(phase string) error {
 	if metadata == nil {
 		metadata = map[string]string{}
 	}
-	if phase == "" {
-		delete(metadata, runtimeStartupPhase)
+	if value == "" {
+		delete(metadata, key)
 	} else {
-		metadata[runtimeStartupPhase] = phase
+		metadata[key] = value
 	}
 	rec.Metadata = metadata
 	if _, err := daemonRuntimeStore(o.dataDir).Write(rec); err != nil {
-		return fmt.Errorf("update daemon startup phase: %w", err)
+		return fmt.Errorf("update daemon runtime metadata %q: %w", key, err)
 	}
 	o.record = rec
 	return nil

--- a/cmd/msgvault/cmd/serve_ownership_test.go
+++ b/cmd/msgvault/cmd/serve_ownership_test.go
@@ -240,6 +240,35 @@ func TestServeOwnershipStartupPhaseUpdatesRuntimeRecord(t *testing.T) {
 	assert.NotContains(cleared.Metadata, runtimeStartupPhase, "phase cleared")
 }
 
+func TestServeOwnershipStartupCacheBuildOutcomeUpdatesRuntimeRecord(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	dataDir := t.TempDir()
+	cfg := &config.Config{Data: config.DataConfig{DataDir: dataDir}}
+	owner, err := claimServeOwnership(context.Background(), cfg, "127.0.0.1", 8123, "v-test")
+	require.NoError(err, "claimServeOwnership")
+	t.Cleanup(func() { require.NoError(owner.Close(), "close ownership") })
+
+	readRecord := func() daemon.RuntimeRecord {
+		records, err := daemonRuntimeStore(dataDir).List()
+		require.NoError(err, "list runtime records")
+		require.Len(records, 1, "runtime records")
+		return records[0]
+	}
+
+	initial := readRecord()
+	require.NoError(
+		owner.SetStartupCacheBuildOutcome(startupCacheBuildOutcomeFailed),
+		"set startup cache build outcome",
+	)
+	updated := readRecord()
+
+	assert.Equal("failed", updated.Metadata[runtimeStartupCacheBuildOutcome], "cache build outcome")
+	assert.Equal(initial.Metadata[runtimeShutdownToken], updated.Metadata[runtimeShutdownToken], "shutdown token preserved")
+	assert.Equal(initial.Metadata[runtimeStartupPhase], updated.Metadata[runtimeStartupPhase], "startup phase preserved")
+}
+
 func TestClaimServeOwnershipRejectsSecondOwner(t *testing.T) {
 	dataDir := t.TempDir()
 	cfg := &config.Config{Data: config.DataConfig{DataDir: dataDir}}

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -490,6 +490,10 @@ func TestOpenDaemonAnalyticsEngineAutoFallsBackWhenStartupBuildFails(t *testing.
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineAuto
 	c.Analytics.AutoBuildCache = true
+	var logs bytes.Buffer
+	oldLogger := logger
+	logger = slog.New(slog.NewTextHandler(&logs, nil))
+	t.Cleanup(func() { logger = oldLogger })
 	stubBuildCacheSubprocess(t, func(context.Context, bool) error {
 		return errors.New("simulated build failure")
 	})
@@ -504,6 +508,8 @@ func TestOpenDaemonAnalyticsEngineAutoFallsBackWhenStartupBuildFails(t *testing.
 	assert.Equal(api.AnalyticsModeSQLFallback, mode,
 		"a failed build falls back to live SQL for engine=auto")
 	assert.Equal(startupCacheBuildOutcomeNone, outcome, "automatic failures have no explicit outcome")
+	assert.Contains(logs.String(), `msg="daemon startup step failed"`)
+	assert.Contains(logs.String(), "step=build_analytics_cache")
 }
 
 func TestOpenDaemonAnalyticsEngineDuckDBRequiresCacheBuild(t *testing.T) {

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -592,6 +592,72 @@ func TestOpenDaemonAnalyticsEngineExplicitFailureKeepsAutoFallback(t *testing.T)
 	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome)
 }
 
+func TestOpenDaemonAnalyticsEngineExplicitSuccessWithoutUsableCacheIsFailed(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
+		return nil
+	})
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentDefault,
+	)
+	require.NoError(t, err)
+	defer func() { _ = engine.Close() }()
+
+	assert.IsType(t, &query.SQLiteEngine{}, engine)
+	assert.Equal(t, api.AnalyticsModeSQLFallback, mode)
+	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome,
+		"a successful child exit does not fulfill intent without a usable cache")
+}
+
+func TestOpenDaemonAnalyticsEngineExplicitFullFailureDoesNotReuseOldCache(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
+	require.NoError(t, err)
+	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
+		return errors.New("simulated full rebuild failure")
+	})
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentFull,
+	)
+	require.NoError(t, err)
+	defer func() { _ = engine.Close() }()
+
+	assert.IsType(t, &query.SQLiteEngine{}, engine)
+	assert.Equal(t, api.AnalyticsModeSQLFallback, mode,
+		"explicit auto-mode failure must preserve the documented live-SQL fallback")
+	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome)
+}
+
+func TestOpenDaemonAnalyticsEngineExplicitDuckDBOpenFailureMarksIntentFailed(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
+		_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
+		return err
+	})
+	sentinel := errors.New("simulated DuckDB open failure")
+	oldOpen := openDaemonDuckDBEngineForRun
+	openDaemonDuckDBEngineForRun = func(*config.Config, *store.Store) (*query.DuckDBEngine, error) {
+		return nil, sentinel
+	}
+	t.Cleanup(func() { openDaemonDuckDBEngineForRun = oldOpen })
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentDefault,
+	)
+	require.NoError(t, err, "auto mode must preserve live-SQL fallback")
+	defer func() { _ = engine.Close() }()
+
+	assert.IsType(t, &query.SQLiteEngine{}, engine)
+	assert.Equal(t, api.AnalyticsModeSQLFallback, mode)
+	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome,
+		"the CLI must not claim the daemon is using a cache it could not open")
+}
+
 func TestOpenDaemonAnalyticsEngineSQLLeavesExplicitIntentUnconsumed(t *testing.T) {
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineSQL

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -535,13 +535,15 @@ func TestOpenDaemonAnalyticsEngineDuckDBRequiresCacheBuild(t *testing.T) {
 }
 
 func TestOpenDaemonAnalyticsEngineExplicitIntentOverridesDisabledAutoBuild(t *testing.T) {
+	assert := assert.New(t)
+
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineAuto
 	c.Analytics.AutoBuildCache = false
 	builds := 0
 	stubStartupCacheBuild(t, func(_ context.Context, intent startupCacheBuildIntent) error {
 		builds++
-		assert.Equal(t, startupCacheBuildIntentDefault, intent)
+		assert.Equal(startupCacheBuildIntentDefault, intent)
 		_, err := buildCacheAuto(c.DatabaseDSN(), c.AnalyticsDir())
 		return err
 	})
@@ -552,19 +554,22 @@ func TestOpenDaemonAnalyticsEngineExplicitIntentOverridesDisabledAutoBuild(t *te
 	require.NoError(t, err)
 	defer func() { _ = engine.Close() }()
 
-	assert.Equal(t, 1, builds)
-	assert.Equal(t, api.AnalyticsModeDuckDB, mode)
-	assert.Equal(t, startupCacheBuildOutcomeFulfilled, outcome)
+	assert.Equal(1, builds)
+	assert.Equal(api.AnalyticsModeDuckDB, mode)
+	assert.Equal(startupCacheBuildOutcomeFulfilled, outcome)
 }
 
 func TestOpenDaemonAnalyticsEngineExplicitFullBuildRunsWhenCacheIsFresh(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
 	c, s := openTestDaemonAnalyticsStore(t)
 	_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
-	require.NoError(t, err)
+	require.NoError(err)
 	builds := 0
 	stubStartupCacheBuild(t, func(_ context.Context, intent startupCacheBuildIntent) error {
 		builds++
-		assert.Equal(t, startupCacheBuildIntentFull, intent)
+		assert.Equal(startupCacheBuildIntentFull, intent)
 		_, buildErr := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
 		return buildErr
 	})
@@ -572,15 +577,17 @@ func TestOpenDaemonAnalyticsEngineExplicitFullBuildRunsWhenCacheIsFresh(t *testi
 	engine, mode, outcome, err := openDaemonAnalyticsEngine(
 		context.Background(), c, s, startupCacheBuildIntentFull,
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 	defer func() { _ = engine.Close() }()
 
-	assert.Equal(t, 1, builds)
-	assert.Equal(t, api.AnalyticsModeDuckDB, mode)
-	assert.Equal(t, startupCacheBuildOutcomeFulfilled, outcome)
+	assert.Equal(1, builds)
+	assert.Equal(api.AnalyticsModeDuckDB, mode)
+	assert.Equal(startupCacheBuildOutcomeFulfilled, outcome)
 }
 
 func TestOpenDaemonAnalyticsEngineExplicitFailureKeepsAutoFallback(t *testing.T) {
+	assert := assert.New(t)
+
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineAuto
 	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
@@ -593,12 +600,14 @@ func TestOpenDaemonAnalyticsEngineExplicitFailureKeepsAutoFallback(t *testing.T)
 	require.NoError(t, err)
 	defer func() { _ = engine.Close() }()
 
-	assert.IsType(t, &query.SQLiteEngine{}, engine)
-	assert.Equal(t, api.AnalyticsModeSQLFallback, mode)
-	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome)
+	assert.IsType(&query.SQLiteEngine{}, engine)
+	assert.Equal(api.AnalyticsModeSQLFallback, mode)
+	assert.Equal(startupCacheBuildOutcomeFailed, outcome)
 }
 
 func TestOpenDaemonAnalyticsEngineExplicitSuccessWithoutUsableCacheIsFailed(t *testing.T) {
+	assert := assert.New(t)
+
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineAuto
 	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
@@ -611,17 +620,20 @@ func TestOpenDaemonAnalyticsEngineExplicitSuccessWithoutUsableCacheIsFailed(t *t
 	require.NoError(t, err)
 	defer func() { _ = engine.Close() }()
 
-	assert.IsType(t, &query.SQLiteEngine{}, engine)
-	assert.Equal(t, api.AnalyticsModeSQLFallback, mode)
-	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome,
+	assert.IsType(&query.SQLiteEngine{}, engine)
+	assert.Equal(api.AnalyticsModeSQLFallback, mode)
+	assert.Equal(startupCacheBuildOutcomeFailed, outcome,
 		"a successful child exit does not fulfill intent without a usable cache")
 }
 
 func TestOpenDaemonAnalyticsEngineExplicitFullFailureDoesNotReuseOldCache(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineAuto
 	_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
-	require.NoError(t, err)
+	require.NoError(err)
 	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
 		return errors.New("simulated full rebuild failure")
 	})
@@ -629,16 +641,18 @@ func TestOpenDaemonAnalyticsEngineExplicitFullFailureDoesNotReuseOldCache(t *tes
 	engine, mode, outcome, err := openDaemonAnalyticsEngine(
 		context.Background(), c, s, startupCacheBuildIntentFull,
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 	defer func() { _ = engine.Close() }()
 
-	assert.IsType(t, &query.SQLiteEngine{}, engine)
-	assert.Equal(t, api.AnalyticsModeSQLFallback, mode,
+	assert.IsType(&query.SQLiteEngine{}, engine)
+	assert.Equal(api.AnalyticsModeSQLFallback, mode,
 		"explicit auto-mode failure must preserve the documented live-SQL fallback")
-	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome)
+	assert.Equal(startupCacheBuildOutcomeFailed, outcome)
 }
 
 func TestOpenDaemonAnalyticsEngineExplicitDuckDBOpenFailureMarksIntentFailed(t *testing.T) {
+	assert := assert.New(t)
+
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineAuto
 	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
@@ -658,9 +672,9 @@ func TestOpenDaemonAnalyticsEngineExplicitDuckDBOpenFailureMarksIntentFailed(t *
 	require.NoError(t, err, "auto mode must preserve live-SQL fallback")
 	defer func() { _ = engine.Close() }()
 
-	assert.IsType(t, &query.SQLiteEngine{}, engine)
-	assert.Equal(t, api.AnalyticsModeSQLFallback, mode)
-	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome,
+	assert.IsType(&query.SQLiteEngine{}, engine)
+	assert.Equal(api.AnalyticsModeSQLFallback, mode)
+	assert.Equal(startupCacheBuildOutcomeFailed, outcome,
 		"the CLI must not claim the daemon is using a cache it could not open")
 }
 

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -388,12 +388,15 @@ func TestOpenDaemonAnalyticsEngineForceSQLSkipsCacheBuild(t *testing.T) {
 		return nil
 	})
 
-	engine, mode, err := openDaemonAnalyticsEngine(context.Background(), c, s)
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
 	require.NoError(err, "openDaemonAnalyticsEngine")
 	defer func() { _ = engine.Close() }()
 
 	assert.IsType(&query.SQLiteEngine{}, engine)
 	assert.Equal(api.AnalyticsModeSQL, mode, "engine=sql is a deliberate live-SQL choice")
+	assert.Equal(startupCacheBuildOutcomeNone, outcome, "no explicit intent has no outcome")
 }
 
 func TestOpenDaemonAnalyticsEngineSkipsCacheBuildWhenDisabled(t *testing.T) {
@@ -407,12 +410,15 @@ func TestOpenDaemonAnalyticsEngineSkipsCacheBuildWhenDisabled(t *testing.T) {
 		return nil
 	})
 
-	engine, mode, err := openDaemonAnalyticsEngine(context.Background(), c, s)
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
 	require.NoError(err, "openDaemonAnalyticsEngine")
 	defer func() { _ = engine.Close() }()
 
 	assert.IsType(&query.SQLiteEngine{}, engine)
 	assert.Equal(api.AnalyticsModeSQLFallback, mode, "auto mode without a cache is a fallback")
+	assert.Equal(startupCacheBuildOutcomeNone, outcome, "no explicit intent has no outcome")
 }
 
 func TestOpenDaemonAnalyticsEngineAutoBuildsCacheAtStartup(t *testing.T) {
@@ -437,13 +443,16 @@ func TestOpenDaemonAnalyticsEngineAutoBuildsCacheAtStartup(t *testing.T) {
 		return err
 	})
 
-	engine, mode, err := openDaemonAnalyticsEngine(context.Background(), c, s)
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
 	require.NoError(err, "openDaemonAnalyticsEngine")
 	defer func() { _ = engine.Close() }()
 
 	assert.Equal(1, builds, "a stale cache must be built synchronously at startup")
 	assert.Equal(api.AnalyticsModeDuckDB, mode,
 		"the daemon must serve DuckDB over the fresh cache, not live-SQL fallback")
+	assert.Equal(startupCacheBuildOutcomeNone, outcome, "automatic builds have no explicit outcome")
 }
 
 func TestDaemonDuckDBEnginesUseIsolatedSpillDirectories(t *testing.T) {
@@ -485,13 +494,16 @@ func TestOpenDaemonAnalyticsEngineAutoFallsBackWhenStartupBuildFails(t *testing.
 		return errors.New("simulated build failure")
 	})
 
-	engine, mode, err := openDaemonAnalyticsEngine(context.Background(), c, s)
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
 	require.NoError(err, "a failed auto-mode build must not fail daemon startup")
 	defer func() { _ = engine.Close() }()
 
 	assert.IsType(&query.SQLiteEngine{}, engine)
 	assert.Equal(api.AnalyticsModeSQLFallback, mode,
 		"a failed build falls back to live SQL for engine=auto")
+	assert.Equal(startupCacheBuildOutcomeNone, outcome, "automatic failures have no explicit outcome")
 }
 
 func TestOpenDaemonAnalyticsEngineDuckDBRequiresCacheBuild(t *testing.T) {
@@ -504,13 +516,117 @@ func TestOpenDaemonAnalyticsEngineDuckDBRequiresCacheBuild(t *testing.T) {
 		return sentinel
 	})
 
-	engine, _, err := openDaemonAnalyticsEngine(context.Background(), c, s)
+	engine, _, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
 	if engine != nil {
 		_ = engine.Close()
 	}
 
 	require.Error(err, "duckdb mode should fail when the required cache build fails")
 	require.ErrorIs(err, sentinel, "error")
+	require.Equal(startupCacheBuildOutcomeNone, outcome, "automatic failure has no explicit outcome")
+}
+
+func TestOpenDaemonAnalyticsEngineExplicitIntentOverridesDisabledAutoBuild(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	c.Analytics.AutoBuildCache = false
+	builds := 0
+	stubStartupCacheBuild(t, func(_ context.Context, intent startupCacheBuildIntent) error {
+		builds++
+		assert.Equal(t, startupCacheBuildIntentDefault, intent)
+		_, err := buildCacheAuto(c.DatabaseDSN(), c.AnalyticsDir())
+		return err
+	})
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentDefault,
+	)
+	require.NoError(t, err)
+	defer func() { _ = engine.Close() }()
+
+	assert.Equal(t, 1, builds)
+	assert.Equal(t, api.AnalyticsModeDuckDB, mode)
+	assert.Equal(t, startupCacheBuildOutcomeFulfilled, outcome)
+}
+
+func TestOpenDaemonAnalyticsEngineExplicitFullBuildRunsWhenCacheIsFresh(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
+	require.NoError(t, err)
+	builds := 0
+	stubStartupCacheBuild(t, func(_ context.Context, intent startupCacheBuildIntent) error {
+		builds++
+		assert.Equal(t, startupCacheBuildIntentFull, intent)
+		_, buildErr := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
+		return buildErr
+	})
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentFull,
+	)
+	require.NoError(t, err)
+	defer func() { _ = engine.Close() }()
+
+	assert.Equal(t, 1, builds)
+	assert.Equal(t, api.AnalyticsModeDuckDB, mode)
+	assert.Equal(t, startupCacheBuildOutcomeFulfilled, outcome)
+}
+
+func TestOpenDaemonAnalyticsEngineExplicitFailureKeepsAutoFallback(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
+		return errors.New("simulated explicit build failure")
+	})
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentDefault,
+	)
+	require.NoError(t, err)
+	defer func() { _ = engine.Close() }()
+
+	assert.IsType(t, &query.SQLiteEngine{}, engine)
+	assert.Equal(t, api.AnalyticsModeSQLFallback, mode)
+	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome)
+}
+
+func TestOpenDaemonAnalyticsEngineSQLLeavesExplicitIntentUnconsumed(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineSQL
+	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
+		require.FailNow(t, "SQL engine must leave cache intent for the HTTP path")
+		return nil
+	})
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentDefault,
+	)
+	require.NoError(t, err)
+	defer func() { _ = engine.Close() }()
+
+	assert.Equal(t, api.AnalyticsModeSQL, mode)
+	assert.Equal(t, startupCacheBuildOutcomeUnconsumed, outcome)
+}
+
+func TestOpenDaemonAnalyticsEngineExplicitDuckDBFailureIsFatal(t *testing.T) {
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineDuckDB
+	sentinel := errors.New("explicit build failed")
+	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
+		return sentinel
+	})
+
+	engine, _, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentDefault,
+	)
+	if engine != nil {
+		_ = engine.Close()
+	}
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome)
 }
 
 func openTestDaemonAnalyticsStore(t *testing.T) (*config.Config, *store.Store) {
@@ -531,6 +647,16 @@ func stubBuildCacheSubprocess(
 	old := buildCacheSubprocessForRun
 	buildCacheSubprocessForRun = fn
 	t.Cleanup(func() { buildCacheSubprocessForRun = old })
+}
+
+func stubStartupCacheBuild(
+	t *testing.T,
+	fn func(context.Context, startupCacheBuildIntent) error,
+) {
+	t.Helper()
+	old := buildStartupCacheSubprocessForRun
+	buildStartupCacheSubprocessForRun = fn
+	t.Cleanup(func() { buildStartupCacheSubprocessForRun = old })
 }
 
 func TestStoreAPIAdapterServesSourceStatus(t *testing.T) {

--- a/cmd/msgvault/cmd/store_resolver.go
+++ b/cmd/msgvault/cmd/store_resolver.go
@@ -297,7 +297,15 @@ func ensureLocalDaemonRuntimeWithStartupCacheIntent(
 		ctx, c.Data.DataDir, proc.Wait, localDaemonAutoStartReadyTimeout,
 	)
 	if err != nil {
-		return nil, localDaemonStartupInfo{}, backgroundServeStartupError(err, proc)
+		startupErr := backgroundServeStartupError(err, proc)
+		if intent != startupCacheBuildIntentNone && ctx.Err() != nil {
+			stopErr := stopBackgroundServeStartupForRun(proc)
+			if stopErr != nil {
+				startupErr = errors.Join(startupErr,
+					fmt.Errorf("stop canceled daemon startup: %w", stopErr))
+			}
+		}
+		return nil, localDaemonStartupInfo{}, startupErr
 	}
 	if !ready {
 		return nil, localDaemonStartupInfo{}, fmt.Errorf(
@@ -464,7 +472,7 @@ func (s *daemonStartupProgressState) Next(line string) string {
 		switch fields["msg"] {
 		case "daemon startup step":
 			s.activeStep = daemonStartupStepLabel(fields["step"])
-		case "daemon startup step complete":
+		case "daemon startup step complete", "daemon startup step failed":
 			s.activeStep = ""
 		}
 	}
@@ -542,6 +550,9 @@ func summarizeDaemonLogLine(line string) string {
 	case msg == "daemon startup step complete" && step != "":
 		sb.WriteString(daemonStartupStepLabel(step))
 		sb.WriteString(" (done)")
+	case msg == "daemon startup step failed" && step != "":
+		sb.WriteString(daemonStartupStepLabel(step))
+		sb.WriteString(" (failed)")
 	// SQL logger records carry the full statement in stmt — schema
 	// migrations dump multiple kilobytes of SQL into a single line.
 	// Summarize to the duration; the statement stays in serve.log.

--- a/cmd/msgvault/cmd/store_resolver.go
+++ b/cmd/msgvault/cmd/store_resolver.go
@@ -355,7 +355,7 @@ func reportLocalDaemonStartup(ctx context.Context, proc *backgroundServeProcess)
 		timer := time.NewTimer(localDaemonStartupProgressDelay)
 		defer timer.Stop()
 		started := time.Now()
-		lastLine := ""
+		state := daemonStartupProgressState{}
 		announced := false
 		for {
 			select {
@@ -376,19 +376,14 @@ func reportLocalDaemonStartup(ctx context.Context, proc *backgroundServeProcess)
 			}
 
 			elapsed := time.Since(started).Round(time.Second)
-			line := latestDaemonLogLine(proc.LogPath)
-			switch {
-			case line != "" && line != lastLine:
-				_, _ = fmt.Fprintf(os.Stderr, "Daemon startup (%s): %s\n", elapsed, humanizeDaemonLogLine(line))
-				lastLine = line
-			case proc.LogPath != "":
+			message := state.Next(latestDaemonLogLine(proc.LogPath))
+			if message == "still waiting" && proc.LogPath != "" {
 				_, _ = fmt.Fprintf(os.Stderr,
 					"Daemon startup (%s): still waiting. Logs: %s\n",
 					elapsed, proc.LogPath)
-			default:
+			} else {
 				_, _ = fmt.Fprintf(os.Stderr,
-					"Daemon startup (%s): still waiting.\n",
-					elapsed)
+					"Daemon startup (%s): %s\n", elapsed, message)
 			}
 			timer.Reset(localDaemonStartupProgressInterval)
 		}
@@ -419,10 +414,36 @@ func compactDuration(d time.Duration) string {
 var daemonStartupStepLabels = map[string]string{
 	"open_archive_database": "opening the archive database",
 	"init_archive_schema":   "checking the database schema",
+	"build_analytics_cache": "building the analytics cache",
 	"init_analytics_engine": "starting the analytics engine",
 	"init_vector_backend":   "initializing vector search",
 	"skip_vector_backend":   "vector search disabled",
 	"start_api_server":      "starting the API server",
+}
+
+type daemonStartupProgressState struct {
+	lastLine   string
+	activeStep string
+}
+
+func (s *daemonStartupProgressState) Next(line string) string {
+	if line == s.lastLine {
+		if s.activeStep != "" {
+			return "still " + s.activeStep
+		}
+		return "still waiting"
+	}
+	s.lastLine = line
+	fields, ok := parseLogfmt(strings.TrimSpace(line))
+	if ok && fields["step"] != "" {
+		switch fields["msg"] {
+		case "daemon startup step":
+			s.activeStep = daemonStartupStepLabel(fields["step"])
+		case "daemon startup step complete":
+			s.activeStep = ""
+		}
+	}
+	return humanizeDaemonLogLine(line)
 }
 
 func daemonStartupStepLabel(step string) string {
@@ -483,7 +504,16 @@ func summarizeDaemonLogLine(line string) string {
 	// bind, enabled), which are detail — never a reason to fall back
 	// to the raw line, so they skip the unknown-key guard below.
 	case msg == "daemon startup step" && step != "":
-		sb.WriteString(daemonStartupStepLabel(step))
+		label := daemonStartupStepLabel(step)
+		sb.WriteString(label)
+		if step == "build_analytics_cache" && fields["reason"] != "" {
+			sb.WriteString(" (")
+			if fields["full_rebuild"] == "true" {
+				sb.WriteString("full rebuild: ")
+			}
+			sb.WriteString(fields["reason"])
+			sb.WriteString(")")
+		}
 	case msg == "daemon startup step complete" && step != "":
 		sb.WriteString(daemonStartupStepLabel(step))
 		sb.WriteString(" (done)")

--- a/cmd/msgvault/cmd/store_resolver.go
+++ b/cmd/msgvault/cmd/store_resolver.go
@@ -104,8 +104,11 @@ const (
 // HTTPStoreInfo carries the selected daemon endpoint alongside the client.
 // Commands use it for user-facing endpoint labels and local-daemon cwd policy.
 type HTTPStoreInfo struct {
-	Kind HTTPStoreKind
-	URL  string
+	Kind                     HTTPStoreKind
+	URL                      string
+	StartedLocalDaemon       bool
+	DaemonLogPath            string
+	StartupCacheBuildOutcome startupCacheBuildOutcome
 }
 
 // IsRemoteMode returns true when CLI requests should target the configured
@@ -126,6 +129,13 @@ func IsRemoteMode() bool {
 // daemon is discovered or started so SQLite remains owned by one long-lived
 // process.
 func OpenHTTPStore(ctx context.Context) (*daemonclient.Client, HTTPStoreInfo, error) {
+	return openHTTPStoreWithStartupCacheIntent(ctx, startupCacheBuildIntentNone)
+}
+
+func openHTTPStoreWithStartupCacheIntent(
+	ctx context.Context,
+	intent startupCacheBuildIntent,
+) (*daemonclient.Client, HTTPStoreInfo, error) {
 	if cfg == nil {
 		return nil, HTTPStoreInfo{}, errors.New("nil config")
 	}
@@ -140,7 +150,7 @@ func OpenHTTPStore(ctx context.Context) (*daemonclient.Client, HTTPStoreInfo, er
 		}, nil
 	}
 
-	rt, err := ensureLocalDaemonRuntime(ctx, cfg)
+	rt, startup, err := ensureLocalDaemonRuntimeWithStartupCacheIntent(ctx, cfg, intent)
 	if err != nil {
 		return nil, HTTPStoreInfo{}, err
 	}
@@ -155,8 +165,11 @@ func OpenHTTPStore(ctx context.Context) (*daemonclient.Client, HTTPStoreInfo, er
 	}
 	st.SetBusyNotifier(reportDaemonBusyWait)
 	return st, HTTPStoreInfo{
-		Kind: HTTPStoreLocalDaemon,
-		URL:  url,
+		Kind:                     HTTPStoreLocalDaemon,
+		URL:                      url,
+		StartedLocalDaemon:       startup.Started,
+		DaemonLogPath:            startup.LogPath,
+		StartupCacheBuildOutcome: startup.Outcome,
 	}, nil
 }
 
@@ -185,26 +198,36 @@ func openRemoteStore(ctx context.Context) (*daemonclient.Client, error) {
 	return st, nil
 }
 
-func ensureLocalDaemonRuntime(ctx context.Context, c *config.Config) (*DaemonRuntime, error) {
+type localDaemonStartupInfo struct {
+	Started bool
+	LogPath string
+	Outcome startupCacheBuildOutcome
+}
+
+func ensureLocalDaemonRuntimeWithStartupCacheIntent(
+	ctx context.Context,
+	c *config.Config,
+	intent startupCacheBuildIntent,
+) (*DaemonRuntime, localDaemonStartupInfo, error) {
 	if c == nil {
-		return nil, errors.New("nil config")
+		return nil, localDaemonStartupInfo{}, errors.New("nil config")
 	}
 	if err := os.MkdirAll(c.Data.DataDir, 0o700); err != nil {
-		return nil, fmt.Errorf("create data directory: %w", err)
+		return nil, localDaemonStartupInfo{}, fmt.Errorf("create data directory: %w", err)
 	}
 	if rt := findDaemonRuntime(c.Data.DataDir); rt != nil &&
 		!shouldUpgradeDaemonRuntimeWithPolicy(rt, Version, c.Server.DaemonAutoRestart) {
 		if err := probeLocalDaemonAuth(ctx, rt, c); err != nil {
-			return nil, err
+			return nil, localDaemonStartupInfo{}, err
 		}
-		return rt, nil
+		return rt, localDaemonStartupInfo{}, nil
 	}
 
 	// No usable daemon was found. If a direct CLI writer owns the archive,
 	// fail fast with a clear message instead of spawning a daemon that cannot
 	// claim the held write-owner lock.
 	if err := daemonAutostartPreflight(c); err != nil {
-		return nil, err
+		return nil, localDaemonStartupInfo{}, err
 	}
 
 	launchLock, ok := acquireBackgroundLaunchLock(c.Data.DataDir)
@@ -218,7 +241,7 @@ func ensureLocalDaemonRuntime(ctx context.Context, c *config.Config) (*DaemonRun
 		inProgress, err := daemonStartInProgress(ctx, c.Data.DataDir)
 		if err != nil {
 			_ = launchLock.Unlock()
-			return nil, err
+			return nil, localDaemonStartupInfo{}, err
 		}
 		if inProgress {
 			_ = launchLock.Unlock()
@@ -233,52 +256,66 @@ func ensureLocalDaemonRuntime(ctx context.Context, c *config.Config) (*DaemonRun
 			ctx, c.Data.DataDir, c.Server.DaemonAutoRestart, localDaemonAutoStartReadyTimeout,
 		)
 		if err != nil {
-			return nil, err
+			return nil, localDaemonStartupInfo{}, err
 		}
 		if rt != nil {
 			if err := probeLocalDaemonAuth(ctx, rt, c); err != nil {
-				return nil, err
+				return nil, localDaemonStartupInfo{}, err
 			}
-			return rt, nil
+			return rt, localDaemonStartupInfo{}, nil
 		}
 		if acquiredLock != nil {
 			launchLock = acquiredLock
 		} else {
-			return nil, errors.New("msgvault daemon start is already in progress")
+			return nil, localDaemonStartupInfo{},
+				errors.New("msgvault daemon start is already in progress")
 		}
 	}
 	defer func() { _ = launchLock.Unlock() }()
 
 	prep, err := prepareBackgroundDaemonStart(c, "run `msgvault daemon stop` or retry with --local")
 	if err != nil {
-		return nil, err
+		return nil, localDaemonStartupInfo{}, err
 	}
 	if rt := prep.Reusable; rt != nil {
 		if err := probeLocalDaemonAuth(ctx, rt, c); err != nil {
-			return nil, err
+			return nil, localDaemonStartupInfo{}, err
 		}
-		return rt, nil
+		return rt, localDaemonStartupInfo{}, nil
 	}
 
-	proc, err := startServeBackgroundProcessForRun(c, backgroundServeStartOptions{})
+	startedAt := time.Now()
+	proc, err := startServeBackgroundProcessForRun(c, backgroundServeStartOptions{
+		CacheBuildIntent: intent,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("start background daemon: %w", err)
+		return nil, localDaemonStartupInfo{}, fmt.Errorf("start background daemon: %w", err)
 	}
 	stopProgress := reportLocalDaemonStartup(ctx, proc)
-	defer stopProgress()
+	defer func() { stopProgress() }()
 	rt, ready, err := waitForBackgroundServeReadyForRun(
 		ctx, c.Data.DataDir, proc.Wait, localDaemonAutoStartReadyTimeout,
 	)
 	if err != nil {
-		return nil, backgroundServeStartupError(err, proc)
+		return nil, localDaemonStartupInfo{}, backgroundServeStartupError(err, proc)
 	}
 	if !ready {
-		return nil, fmt.Errorf(
+		return nil, localDaemonStartupInfo{}, fmt.Errorf(
 			"msgvault daemon did not become ready within %s (pid %d)\nLogs: %s",
 			localDaemonAutoStartReadyTimeout, proc.PID, proc.LogPath,
 		)
 	}
-	return rt, nil
+	stopProgress()
+	stopProgress = func() {}
+	if intent != startupCacheBuildIntentNone {
+		_, _ = fmt.Fprintf(os.Stderr, "Daemon ready after %s.\n",
+			time.Since(startedAt).Round(time.Second))
+	}
+	return rt, localDaemonStartupInfo{
+		Started: true,
+		LogPath: proc.LogPath,
+		Outcome: startupCacheBuildOutcomeFromRuntime(rt),
+	}, nil
 }
 
 func backgroundServeStartupError(err error, proc *backgroundServeProcess) error {

--- a/cmd/msgvault/cmd/store_resolver.go
+++ b/cmd/msgvault/cmd/store_resolver.go
@@ -305,6 +305,9 @@ func ensureLocalDaemonRuntimeWithStartupCacheIntent(
 			localDaemonAutoStartReadyTimeout, proc.PID, proc.LogPath,
 		)
 	}
+	if intent != startupCacheBuildIntentNone {
+		rt = refreshDaemonRuntimeRecord(c.Data.DataDir, rt)
+	}
 	stopProgress()
 	stopProgress = func() {}
 	if intent != startupCacheBuildIntentNone {
@@ -316,6 +319,28 @@ func ensureLocalDaemonRuntimeWithStartupCacheIntent(
 		LogPath: proc.LogPath,
 		Outcome: startupCacheBuildOutcomeFromRuntime(rt),
 	}, nil
+}
+
+// refreshDaemonRuntimeRecord reloads the exact process record after readiness.
+// A readiness probe can read the record before startup metadata is published,
+// then block on the reserved listener until the API server starts. In that
+// race, the endpoint is ready but the probe's record snapshot is stale.
+func refreshDaemonRuntimeRecord(dataDir string, rt *DaemonRuntime) *DaemonRuntime {
+	if rt == nil {
+		return nil
+	}
+	records, err := daemonRuntimeStore(dataDir).List()
+	if err != nil {
+		return rt
+	}
+	for _, rec := range records {
+		if rec.PID == rt.Record.PID {
+			fresh := *rt
+			fresh.Record = rec
+			return &fresh
+		}
+	}
+	return rt
 }
 
 func backgroundServeStartupError(err error, proc *backgroundServeProcess) error {

--- a/cmd/msgvault/cmd/store_resolver.go
+++ b/cmd/msgvault/cmd/store_resolver.go
@@ -291,6 +291,7 @@ func ensureLocalDaemonRuntimeWithStartupCacheIntent(
 	if err != nil {
 		return nil, localDaemonStartupInfo{}, fmt.Errorf("start background daemon: %w", err)
 	}
+	defer func() { _ = proc.releaseProcessTree() }()
 	stopProgress := reportLocalDaemonStartup(ctx, proc)
 	defer func() { stopProgress() }()
 	rt, ready, err := waitForBackgroundServeReadyForRun(

--- a/cmd/msgvault/cmd/store_resolver_test.go
+++ b/cmd/msgvault/cmd/store_resolver_test.go
@@ -174,6 +174,55 @@ func TestOpenHTTPStoreStartsLocalDaemonWhenNoRemoteConfigured(t *testing.T) {
 	assert.Equal("http://127.0.0.1:9911", info.URL)
 }
 
+func TestOpenHTTPStoreReportsFulfilledStartupCacheBuild(t *testing.T) {
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	waitCh := make(chan error)
+	var gotIntent startupCacheBuildIntent
+	stubStartServeBackgroundProcess(t, func(
+		_ *config.Config,
+		opts backgroundServeStartOptions,
+	) (*backgroundServeProcess, error) {
+		gotIntent = opts.CacheBuildIntent
+		return &backgroundServeProcess{
+			PID:     4242,
+			LogPath: filepath.Join(dataDir, "serve.log"),
+			Wait:    waitCh,
+		}, nil
+	})
+	stubWaitForBackgroundServeReady(t, func(
+		context.Context,
+		string,
+		<-chan error,
+		time.Duration,
+	) (*DaemonRuntime, bool, error) {
+		return &DaemonRuntime{
+			Record: daemon.RuntimeRecord{PID: 4242, Metadata: map[string]string{
+				runtimeStartupCacheBuildOutcome: string(startupCacheBuildOutcomeFulfilled),
+			}},
+			Host: "127.0.0.1",
+			Port: 9911,
+			API:  daemonAPIVersion,
+		}, true, nil
+	})
+
+	var st *daemonclient.Client
+	var info HTTPStoreInfo
+	var err error
+	captureStderrDuring(t, func() {
+		st, info, err = openHTTPStoreWithStartupCacheIntent(
+			context.Background(), startupCacheBuildIntentDefault,
+		)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	assert.Equal(t, startupCacheBuildIntentDefault, gotIntent)
+	assert.True(t, info.StartedLocalDaemon)
+	assert.Equal(t, startupCacheBuildOutcomeFulfilled, info.StartupCacheBuildOutcome)
+	assert.Equal(t, filepath.Join(dataDir, "serve.log"), info.DaemonLogPath)
+}
+
 func TestOpenHTTPStoreReportsLocalDaemonStartupToStderr(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cmd/msgvault/cmd/store_resolver_test.go
+++ b/cmd/msgvault/cmd/store_resolver_test.go
@@ -196,13 +196,24 @@ func TestOpenHTTPStoreReportsFulfilledStartupCacheBuild(t *testing.T) {
 		<-chan error,
 		time.Duration,
 	) (*DaemonRuntime, bool, error) {
-		return &DaemonRuntime{
-			Record: daemon.RuntimeRecord{PID: 4242, Metadata: map[string]string{
+		_, err := daemonRuntimeStore(dataDir).Write(daemon.RuntimeRecord{
+			PID:     4242,
+			Network: daemon.NetworkTCP,
+			Address: "127.0.0.1:9911",
+			Service: daemonService,
+			Version: Version,
+			Metadata: map[string]string{
 				runtimeStartupCacheBuildOutcome: string(startupCacheBuildOutcomeFulfilled),
-			}},
-			Host: "127.0.0.1",
-			Port: 9911,
-			API:  daemonAPIVersion,
+			},
+		})
+		require.NoError(t, err, "write fresh startup outcome")
+		return &DaemonRuntime{
+			// Readiness may have loaded this record before the daemon wrote
+			// the outcome, then blocked on the reserved listener until ready.
+			Record: daemon.RuntimeRecord{PID: 4242},
+			Host:   "127.0.0.1",
+			Port:   9911,
+			API:    daemonAPIVersion,
 		}, true, nil
 	})
 

--- a/cmd/msgvault/cmd/store_resolver_test.go
+++ b/cmd/msgvault/cmd/store_resolver_test.go
@@ -175,6 +175,8 @@ func TestOpenHTTPStoreStartsLocalDaemonWhenNoRemoteConfigured(t *testing.T) {
 }
 
 func TestOpenHTTPStoreReportsFulfilledStartupCacheBuild(t *testing.T) {
+	assert := assert.New(t)
+
 	dataDir := t.TempDir()
 	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
 	waitCh := make(chan error)
@@ -228,10 +230,10 @@ func TestOpenHTTPStoreReportsFulfilledStartupCacheBuild(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = st.Close() })
 
-	assert.Equal(t, startupCacheBuildIntentDefault, gotIntent)
-	assert.True(t, info.StartedLocalDaemon)
-	assert.Equal(t, startupCacheBuildOutcomeFulfilled, info.StartupCacheBuildOutcome)
-	assert.Equal(t, filepath.Join(dataDir, "serve.log"), info.DaemonLogPath)
+	assert.Equal(startupCacheBuildIntentDefault, gotIntent)
+	assert.True(info.StartedLocalDaemon)
+	assert.Equal(startupCacheBuildOutcomeFulfilled, info.StartupCacheBuildOutcome)
+	assert.Equal(filepath.Join(dataDir, "serve.log"), info.DaemonLogPath)
 }
 
 func TestOpenHTTPStoreReportsLocalDaemonStartupToStderr(t *testing.T) {

--- a/cmd/msgvault/cmd/store_resolver_test.go
+++ b/cmd/msgvault/cmd/store_resolver_test.go
@@ -312,6 +312,82 @@ func TestOpenHTTPStoreIncludesLastDaemonLogWhenStartupExits(t *testing.T) {
 	assert.Contains(err.Error(), "Logs: "+logPath)
 }
 
+func TestCommandAwareDaemonAutostartCancellationStopsStartedDaemon(t *testing.T) {
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	waitCh := make(chan error)
+	proc := &backgroundServeProcess{
+		PID:     4242,
+		LogPath: filepath.Join(dataDir, "serve.log"),
+		Wait:    waitCh,
+	}
+	stubStartServeBackgroundProcess(t, func(*config.Config, backgroundServeStartOptions) (*backgroundServeProcess, error) {
+		return proc, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	stubWaitForBackgroundServeReady(t, func(
+		context.Context,
+		string,
+		<-chan error,
+		time.Duration,
+	) (*DaemonRuntime, bool, error) {
+		cancel()
+		return nil, false, context.Canceled
+	})
+	stopped := false
+	oldStop := stopBackgroundServeStartupForRun
+	stopBackgroundServeStartupForRun = func(got *backgroundServeProcess) error {
+		stopped = true
+		assert.Same(t, proc, got)
+		return nil
+	}
+	t.Cleanup(func() { stopBackgroundServeStartupForRun = oldStop })
+
+	st, _, err := openHTTPStoreWithStartupCacheIntent(ctx, startupCacheBuildIntentDefault)
+	if st != nil {
+		t.Cleanup(func() { _ = st.Close() })
+	}
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.True(t, stopped, "canceling command-aware startup must stop the daemon it launched")
+}
+
+func TestOrdinaryDaemonAutostartCancellationLeavesDetachedDaemonRunning(t *testing.T) {
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	waitCh := make(chan error)
+	stubStartServeBackgroundProcess(t, func(*config.Config, backgroundServeStartOptions) (*backgroundServeProcess, error) {
+		return &backgroundServeProcess{
+			PID:     4242,
+			LogPath: filepath.Join(dataDir, "serve.log"),
+			Wait:    waitCh,
+		}, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	stubWaitForBackgroundServeReady(t, func(
+		context.Context,
+		string,
+		<-chan error,
+		time.Duration,
+	) (*DaemonRuntime, bool, error) {
+		cancel()
+		return nil, false, context.Canceled
+	})
+	oldStop := stopBackgroundServeStartupForRun
+	stopBackgroundServeStartupForRun = func(*backgroundServeProcess) error {
+		require.FailNow(t, "ordinary autostart must retain detached-daemon cancellation semantics")
+		return errors.New("unreachable startup stop")
+	}
+	t.Cleanup(func() { stopBackgroundServeStartupForRun = oldStop })
+
+	st, _, err := OpenHTTPStore(ctx)
+	if st != nil {
+		t.Cleanup(func() { _ = st.Close() })
+	}
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestOpenHTTPStoreTakesOverWhenConcurrentDaemonStartExits(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -343,10 +343,10 @@ func BuildHandler(opts Options) (*Result, error) {
 // terminal) and whose startup lines are parsed by the autostart
 // progress reporter.
 //
-// daemonCLISubprocess quiets the same routine INFO noise for the
-// non-TTY CLI subprocess the daemon spawns to serve proxied CLI
-// commands: its stderr is a pipe streamed verbatim to the user's
-// console, so its structured startup/exit lines are noise even though
+// daemonCLISubprocess quiets the same routine INFO noise for non-TTY
+// CLI subprocesses the daemon spawns for proxied commands and analytics
+// cache builds: their stderr is streamed verbatim to the user's console
+// or daemon log, so structured startup/exit lines are noise even though
 // stderrIsTerminal is false.
 func ResolveConsoleLevel(
 	explicitLevel string, verbose, fileDisabled, stderrIsTerminal, daemonCLISubprocess bool,


### PR DESCRIPTION
## Why

When `msgvault build-cache` had to start the local daemon, daemon startup could perform the requested cache rebuild before readiness and the CLI would then submit the same build again. Users waited through real work while seeing generic readiness messages and structured lifecycle noise, only to receive a misleading no-op result afterward.

## Behavior

A newly launched daemon now receives a one-shot default or full-build intent, publishes its outcome separately from readiness, and remains running with DuckDB only after the cache is usable. The initiating CLI skips the redundant HTTP request only for fulfilled startup work; running, remote, SQL-oriented, and concurrently adopted daemons retain the existing streamed request path.

Long startup waits name the active cache-build phase and keep repeating it without exposing routine logfmt. Warnings and failures remain visible, failed phases stop claiming work is ongoing, and canceling the initiating cache command terminates only the daemon it launched while startup is pending.

## Review boundaries

The cache format and build algorithm are unchanged. Explicit requests override automatic-build policy, while automatic engine fallback and existing daemon ownership rules remain intact.