### PR TITLE
fix(circleback): unblock sync on keyed-object insights and provider rate limits

### DIFF
--- a/internal/circleback/client.go
+++ b/internal/circleback/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -17,6 +18,11 @@ import (
 type Session struct {
 	cs      *mcp.ClientSession
 	limiter *rate.Limiter
+
+	// rateLimitDelay is the first backoff pause after a provider rate-limit
+	// rejection; each further attempt doubles it. Zero disables waiting so
+	// tests exercise the retry loop without sleeping.
+	rateLimitDelay time.Duration
 }
 
 // ToolInfo is the MCP tool metadata printed by sync-circleback --probe.
@@ -29,6 +35,27 @@ type ToolInfo struct {
 // ErrContract identifies a Circleback result that cannot be interpreted
 // without risking silent data loss.
 var ErrContract = errors.New("circleback MCP contract error")
+
+// errRateLimited marks a provider rate-limit rejection. It is the only
+// tool-result error worth retrying: unlike a contract or missing-result
+// failure it is transient and clears on its own, and without a retry it
+// fails the whole sync run. A first backfill issues one detail call per
+// five meetings, so a large history reliably trips the provider's limit.
+var errRateLimited = errors.New("circleback rate limited")
+
+const (
+	// rateLimitAttempts bounds total tries (one initial + retries) so a
+	// sustained limit still surfaces instead of hanging the run. Meetings
+	// written before the failure persist, and the next run resumes from
+	// them, so giving up is recoverable.
+	rateLimitAttempts = 5
+	// rateLimitBaseDelay is the first pause; it doubles per attempt, so the
+	// default budget is roughly 2+4+8+16 = 30s of waiting.
+	rateLimitBaseDelay = 2 * time.Second
+	// rateLimitMaxDelay caps a single pause so the doubling cannot stall a
+	// run for minutes.
+	rateLimitMaxDelay = 30 * time.Second
+)
 
 const archiveIntent = "Archiving Circleback meetings in msgvault."
 
@@ -49,7 +76,7 @@ func Connect(ctx context.Context, endpoint string, handler auth.OAuthHandler) (*
 	if err != nil {
 		return nil, fmt.Errorf("connect to circleback MCP at %s: %w", endpoint, err)
 	}
-	return &Session{cs: cs, limiter: rate.NewLimiter(2, 4)}, nil
+	return &Session{cs: cs, limiter: rate.NewLimiter(2, 4), rateLimitDelay: rateLimitBaseDelay}, nil
 }
 
 // NewSessionForTesting wraps an already-connected mcp.ClientSession (e.g.
@@ -100,7 +127,34 @@ func (s *Session) ToolInventory(ctx context.Context) ([]ToolInfo, error) {
 // CallToolJSON calls an MCP tool and returns its result payload as raw JSON:
 // StructuredContent when the server provides it, otherwise the concatenated
 // text content (which Circleback uses to carry JSON).
+// A provider rate-limit rejection is retried with exponential backoff; every
+// other error returns immediately.
 func (s *Session) CallToolJSON(ctx context.Context, name string, args map[string]any) (json.RawMessage, error) {
+	delay := s.rateLimitDelay
+	var lastErr error
+	for attempt := 1; attempt <= rateLimitAttempts; attempt++ {
+		payload, err := s.callToolOnce(ctx, name, args)
+		if err == nil {
+			return payload, nil
+		}
+		if !errors.Is(err, errRateLimited) {
+			return nil, err
+		}
+		lastErr = err
+		if attempt == rateLimitAttempts {
+			break
+		}
+		if err := sleepContext(ctx, delay); err != nil {
+			return nil, fmt.Errorf("circleback tool %s: %w", name, err)
+		}
+		delay = min(delay*2, rateLimitMaxDelay)
+	}
+	// lastErr already names the tool, so this does not repeat it.
+	return nil, fmt.Errorf("still rate limited after %d attempts: %w", rateLimitAttempts, lastErr)
+}
+
+// callToolOnce performs one paced tool call.
+func (s *Session) callToolOnce(ctx context.Context, name string, args map[string]any) (json.RawMessage, error) {
 	if err := s.limiter.Wait(ctx); err != nil {
 		return nil, fmt.Errorf("wait for circleback rate limit: %w", err)
 	}
@@ -110,9 +164,42 @@ func (s *Session) CallToolJSON(ctx context.Context, name string, args map[string
 	}
 	payload, err := toolResultJSON(res)
 	if err != nil {
+		// %w keeps errRateLimited reachable through errors.Is so the
+		// retry loop in CallToolJSON can still recognize it.
 		return nil, fmt.Errorf("circleback tool %s: %w", name, err)
 	}
 	return payload, nil
+}
+
+// sleepContext waits for d, returning early if ctx is cancelled. A
+// non-positive duration returns immediately.
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// isRateLimitMessage reports whether a tool-result error text is a provider
+// rate-limit rejection. Circleback reports these in band as a plain message
+// ("Rate limit exceeded. Please try again later.") with no status code or
+// machine-readable field, so matching on the text is the only signal
+// available; the extra variants cover equivalent phrasings.
+func isRateLimitMessage(message string) bool {
+	message = strings.ToLower(message)
+	for _, marker := range []string{"rate limit", "rate-limit", "too many requests", "429"} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // toolResultJSON extracts the JSON payload from a tool result.
@@ -124,7 +211,11 @@ func toolResultJSON(res *mcp.CallToolResult) (json.RawMessage, error) {
 		}
 	}
 	if res.IsError {
-		return nil, fmt.Errorf("server returned an error: %s", strings.TrimSpace(text.String()))
+		message := strings.TrimSpace(text.String())
+		if isRateLimitMessage(message) {
+			return nil, fmt.Errorf("%w: %s", errRateLimited, message)
+		}
+		return nil, fmt.Errorf("server returned an error: %s", message)
 	}
 	if res.StructuredContent != nil {
 		b, err := json.Marshal(res.StructuredContent)

--- a/internal/circleback/client_test.go
+++ b/internal/circleback/client_test.go
@@ -385,6 +385,21 @@ func TestInsightListTolerantShapes(t *testing.T) {
 			want:  []Insight{{Title: "Schedule risk", Content: "Tight"}},
 		},
 		{
+			// json.Unmarshal succeeds here while ignoring "text", so an
+			// error check alone would drop the value and report success.
+			name:  "keyed object with only unknown fields keeps verbatim JSON",
+			input: `{"Risk":{"text":"Timeline is tight"}}`,
+			want:  []Insight{{Name: "Risk", Content: `{"text":"Timeline is tight"}`}},
+		},
+		{
+			name:  "recognized title with unknown value key keeps verbatim JSON",
+			input: `{"Risk":{"title":"Schedule risk","body":"Tight"}}`,
+			want: []Insight{{
+				Title:   "Schedule risk",
+				Content: `{"title":"Schedule risk","body":"Tight"}`,
+			}},
+		},
+		{
 			name:  "scalar value degrades to verbatim JSON",
 			input: `{"Score":7}`,
 			want:  []Insight{{Name: "Score", Content: "7"}},

--- a/internal/circleback/client_test.go
+++ b/internal/circleback/client_test.go
@@ -211,6 +211,93 @@ func TestBuildBodyIncludesSearchableMeetingMetadata(t *testing.T) {
 	assert.Contains(t, body, "Tags: forecast, customer-health")
 }
 
+// Circleback returns "insights" as a label-keyed object, not the array the
+// decoder originally required. Every meeting in a workspace carries the same
+// shape, so an array-only decoder rejects all of them and fails the entire
+// sync run — no meetings reach the archive at all.
+func TestReadMeetings_KeyedInsightsObjectDoesNotRejectMeeting(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var calls []contractToolCall
+	s := newContractMCPSession(t, map[string]string{
+		toolReadMeetings: `{"meetings":[{
+			"id":"meeting-9",
+			"name":"Planning",
+			"notes":"Agreed on scope.",
+			"insights":{},
+			"actionItems":[{"title":"Send recap","status":"open"}],
+			"tags":["planning"]
+		}]}`,
+	}, &calls)
+
+	meetings, err := s.ReadMeetings(context.Background(), []string{"meeting-9"})
+	require.NoError(err)
+	require.Len(meetings, 1)
+	assert.Equal("Planning", meetings[0].DisplayName())
+	assert.Empty(meetings[0].Insights)
+
+	// An empty insight set must not emit an empty "Insights:" heading.
+	body := buildBody(&meetings[0], nil)
+	assert.Contains(body, "- Send recap")
+	assert.NotContains(body, "Insights:")
+}
+
+func TestInsightListTolerantShapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []Insight
+	}{
+		{name: "null", input: `null`},
+		{name: "empty array", input: `[]`},
+		{name: "empty object (production shape)", input: `{}`},
+		{
+			name:  "array of objects preserved",
+			input: `[{"title":"Risk","content":"Timeline is tight"}]`,
+			want:  []Insight{{Title: "Risk", Content: "Timeline is tight"}},
+		},
+		{
+			// Labels are sorted so a Go map's random iteration order cannot
+			// churn the composed body between otherwise identical syncs.
+			name:  "keyed strings sort by label",
+			input: `{"Zeta":"last","Alpha":"first"}`,
+			want: []Insight{
+				{Name: "Alpha", Content: "first"},
+				{Name: "Zeta", Content: "last"},
+			},
+		},
+		{
+			name:  "keyed object borrows its label when untitled",
+			input: `{"Risk":{"content":"Timeline is tight"}}`,
+			want:  []Insight{{Name: "Risk", Content: "Timeline is tight"}},
+		},
+		{
+			name:  "keyed object keeps its own title",
+			input: `{"Risk":{"title":"Schedule risk","content":"Tight"}}`,
+			want:  []Insight{{Title: "Schedule risk", Content: "Tight"}},
+		},
+		{
+			name:  "scalar value degrades to verbatim JSON",
+			input: `{"Score":7}`,
+			want:  []Insight{{Name: "Score", Content: "7"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got InsightList
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &got))
+			if tt.want == nil {
+				// Empty is the contract; nil vs. empty slice is not, since
+				// json.Unmarshal yields a non-nil empty slice for "[]".
+				assert.Empty(t, got)
+				return
+			}
+			assert.Equal(t, InsightList(tt.want), got)
+		})
+	}
+}
+
 func TestGetTranscripts_OfficialArgumentsAndSchemas(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/circleback/client_test.go
+++ b/internal/circleback/client_test.go
@@ -242,6 +242,114 @@ func TestReadMeetings_KeyedInsightsObjectDoesNotRejectMeeting(t *testing.T) {
 	assert.NotContains(body, "Insights:")
 }
 
+// scriptedResponse is one canned tool result. The last entry repeats once the
+// script is exhausted, so an "always fails" case needs a single entry.
+type scriptedResponse struct {
+	isError bool
+	text    string
+}
+
+// newScriptedMCPSession serves responses in order for one tool and counts
+// calls, so retry behaviour can be observed. The returned Session has a zero
+// backoff delay (see NewSessionForTesting), so the retry loop runs without
+// real sleeping.
+func newScriptedMCPSession(t *testing.T, tool string, responses []scriptedResponse, calls *int) *Session {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "fake-circleback", Version: "0.2.2"}, nil)
+	mcp.AddTool[map[string]any, any](server, &mcp.Tool{
+		Name:        tool,
+		Description: "scripted rate-limit fixture",
+		InputSchema: officialCirclebackInputSchemas[tool],
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
+		response := responses[min(*calls, len(responses)-1)]
+		*calls++
+		return &mcp.CallToolResult{
+			IsError: response.isError,
+			Content: []mcp.Content{&mcp.TextContent{Text: response.text}},
+		}, nil, nil
+	})
+
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(context.Background(), st, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ss.Wait() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "msgvault-test", Version: "0"}, nil)
+	cs, err := client.Connect(context.Background(), ct, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cs.Close() })
+	return NewSessionForTesting(cs)
+}
+
+const rateLimitText = "Rate limit exceeded. Please try again later."
+
+// A first backfill reliably trips Circleback's limit. Without a retry the
+// rejection fails the whole sync run, so a transient limit reads as a hard
+// sync failure.
+func TestCallToolJSON_RetriesProviderRateLimit(t *testing.T) {
+	require := require.New(t)
+	calls := 0
+	s := newScriptedMCPSession(t, toolReadMeetings, []scriptedResponse{
+		{isError: true, text: rateLimitText},
+		{isError: true, text: rateLimitText},
+		{text: `{"meetings":[{"id":"meeting-1","name":"Planning"}]}`},
+	}, &calls)
+
+	meetings, err := s.ReadMeetings(context.Background(), []string{"meeting-1"})
+	require.NoError(err)
+	require.Len(meetings, 1)
+	require.Equal(3, calls, "should retry until the provider recovers")
+}
+
+func TestCallToolJSON_RateLimitGivesUpAfterBoundedAttempts(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	calls := 0
+	s := newScriptedMCPSession(t, toolReadMeetings, []scriptedResponse{
+		{isError: true, text: rateLimitText},
+	}, &calls)
+
+	_, err := s.ReadMeetings(context.Background(), []string{"meeting-1"})
+	require.Error(err)
+	assert.Equal(rateLimitAttempts, calls, "retries must be bounded, not infinite")
+	assert.Contains(err.Error(), "still rate limited")
+	// The provider's own wording survives so the cause stays diagnosable.
+	assert.Contains(err.Error(), "Rate limit exceeded")
+}
+
+// Only rate limits are transient. Retrying a contract or missing-result
+// failure would repeat a call that cannot succeed.
+func TestCallToolJSON_DoesNotRetryOtherServerErrors(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	calls := 0
+	s := newScriptedMCPSession(t, toolReadMeetings, []scriptedResponse{
+		{isError: true, text: "meeting not found"},
+	}, &calls)
+
+	_, err := s.ReadMeetings(context.Background(), []string{"meeting-1"})
+	require.Error(err)
+	assert.Equal(1, calls)
+	assert.Contains(err.Error(), "meeting not found")
+	assert.NotContains(err.Error(), "still rate limited")
+}
+
+func TestIsRateLimitMessage(t *testing.T) {
+	for _, tt := range []struct {
+		message string
+		want    bool
+	}{
+		{"Rate limit exceeded. Please try again later.", true},
+		{"rate-limit hit", true},
+		{"Too Many Requests", true},
+		{"HTTP 429", true},
+		{"meeting not found", false},
+		{"", false},
+	} {
+		assert.Equal(t, tt.want, isRateLimitMessage(tt.message), tt.message)
+	}
+}
+
 func TestInsightListTolerantShapes(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/circleback/types.go
+++ b/internal/circleback/types.go
@@ -260,6 +260,15 @@ func insightFromEntry(label string, value json.RawMessage) Insight {
 		if insight.Title == "" && insight.Name == "" {
 			insight.Name = label
 		}
+		if insight.DisplayContent() == "" {
+			// Decoding cannot fail on a well-formed object whose value sits
+			// under a key this struct does not declare — json.Unmarshal just
+			// ignores it — so an error check alone would drop the value while
+			// still reporting success. Since no populated object shape has
+			// been observed, an unrecognized key is the likely case rather
+			// than an edge case, so keep the verbatim JSON as the content.
+			insight.Content = string(value)
+		}
 		return insight
 	case value[0] == '"':
 		var text string

--- a/internal/circleback/types.go
+++ b/internal/circleback/types.go
@@ -3,6 +3,7 @@ package circleback
 import (
 	"bytes"
 	"encoding/json"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -178,7 +179,7 @@ type Meeting struct {
 	Summary string `json:"summary,omitempty"`
 
 	ActionItems []ActionItem `json:"actionItems,omitempty"`
-	Insights    []Insight    `json:"insights,omitempty"`
+	Insights    InsightList  `json:"insights,omitempty"`
 	Tags        []string     `json:"tags,omitempty"`
 
 	URL          string `json:"url,omitempty"`
@@ -187,6 +188,91 @@ type Meeting struct {
 
 	// Raw preserves this meeting's verbatim tool-result JSON.
 	Raw json.RawMessage `json:"-"`
+}
+
+// InsightList is a meeting's insight collection. Circleback returns it as a
+// JSON array in some payloads and as a label-keyed object in others — every
+// meeting observed in production carries the object form, empty (`{}`), which
+// is what a workspace with no insights configured returns. Decoding accepts
+// both so one shape does not reject the whole meeting; a rejected meeting
+// fails its entire sync run, which is how the array-only decoder blocked
+// ingestion outright.
+//
+// The keyed form maps an insight label to its value. Values are stored as
+// strings when scalar and as verbatim JSON otherwise, so an unanticipated
+// value shape degrades to raw text instead of failing the sync. No populated
+// object has been observed, so that mapping is a best-effort guess; the
+// verbatim payload is archived in message_raw either way.
+type InsightList []Insight
+
+// UnmarshalJSON implements tolerant insight-collection decoding.
+func (l *InsightList) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	*l = nil
+	if len(b) == 0 || bytes.Equal(b, []byte("null")) {
+		return nil
+	}
+	if b[0] == '[' {
+		type insightArray []Insight // avoids recursing back into this method
+		var array insightArray
+		if err := json.Unmarshal(b, &array); err != nil {
+			return err
+		}
+		*l = InsightList(array)
+		return nil
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(b, &object); err != nil {
+		return err
+	}
+	// Sort the labels: Go randomizes map iteration, and an unstable order
+	// would rewrite the composed body on every sync, making identical
+	// snapshots look edited and needlessly invalidating the search cache.
+	labels := make([]string, 0, len(object))
+	for label := range object {
+		labels = append(labels, label)
+	}
+	slices.Sort(labels)
+	for _, label := range labels {
+		*l = append(*l, insightFromEntry(label, object[label]))
+	}
+	return nil
+}
+
+// insightFromEntry builds one Insight from a keyed-object entry, falling back
+// to the label when the value carries no title of its own.
+func insightFromEntry(label string, value json.RawMessage) Insight {
+	value = bytes.TrimSpace(value)
+	insight := Insight{Name: label}
+	switch {
+	case len(value) == 0 || bytes.Equal(value, []byte("null")):
+		return insight
+	case value[0] == '{':
+		type insightObject Insight // avoids recursing if Insight gains a decoder
+		var nested insightObject
+		if err := json.Unmarshal(value, &nested); err != nil {
+			// Unknown object shape: keep the label and the verbatim JSON
+			// rather than failing the meeting.
+			insight.Content = string(value)
+			return insight
+		}
+		insight = Insight(nested)
+		if insight.Title == "" && insight.Name == "" {
+			insight.Name = label
+		}
+		return insight
+	case value[0] == '"':
+		var text string
+		if err := json.Unmarshal(value, &text); err != nil {
+			insight.Content = string(value)
+			return insight
+		}
+		insight.Content = text
+		return insight
+	default:
+		insight.Content = string(value)
+		return insight
+	}
 }
 
 // Insight is a custom workspace insight attached to a meeting. Shape is


### PR DESCRIPTION
Circleback sync currently imports nothing. Two provider behaviours each fail the whole run:

- **`insights` arrives as a keyed object**, not the array the decoder required. Every meeting failed to decode, and since a decode error fails the sync run, no meetings reached the archive at all.
- **Rate-limit rejections are fatal.** Circleback reports them in band as a tool error; a first backfill issues one detail call per five meetings, so any sizeable history trips the limit and the run dies on a condition that clears by itself.

## Changes

- `insights` decodes from either an array or a keyed object. Object labels map to insight names, scalar values become content, and unrecognised shapes degrade to verbatim JSON rather than failing the meeting. Labels are sorted so identical snapshots do not look edited between syncs.
- Provider rate limits retry with exponential backoff (2s doubling, capped at 30s per pause, 5 attempts). Other tool errors still fail immediately, since they are not transient.

## Upgrading

No configuration or schema change. Existing sources resume on the next `msgvault sync-circleback`; already-archived meetings are upserted in place rather than duplicated. A large first backfill may still need more than one run if the provider limit persists beyond the retry budget — each run makes forward progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)