### PR TITLE
docs: document the 0.19.2 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,21 @@ All notable changes to msgvault, grouped by release.
 
 ---
 
+## 0.19.2
+<small>2026-08-08</small>
+
+**Improvements**
+
+- Shows cache-building progress during daemon startup.
+- Bounds relationship index builds to improve resource usage and reliability.
+
+**Bug fixes**
+
+- Preserves checksum compatibility for automatic updates.
+- Accepts Fastmail pod-scoped JMAP API URLs.
+
+---
+
 ## 0.19.1
 <small>2026-08-07</small>
 


### PR DESCRIPTION
The tagged 0.19.2 bugfix release improves cache-build visibility and resource bounds while restoring compatibility for automatic updates and Fastmail JMAP discovery. Without a matching changelog entry, users cannot identify those operational changes from the documentation.

This adds a dated 0.19.2 release entry that separates the two improvements from the two compatibility fixes.