### PR TITLE
fix: harden daemon jobs and meeting imports

### DIFF
--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -2150,6 +2150,11 @@ func globalConfigFlagArgs() []string {
 // to keep DuckDB's bundled SQLite library out of a long-lived daemon's
 // address space (issue #379).
 func rebuildCacheAfterScheduledSync(ctx context.Context, identifier string) error {
+	if !cfg.Analytics.AutoBuildCache {
+		// AutoBuildCache opts out of automatic daemon rebuilds, even when startup
+		// selected a usable DuckDB cache; engine = "sql" is the live-data choice.
+		return nil
+	}
 	dbPath := cfg.DatabaseDSN()
 	if store.IsPostgresURL(dbPath) {
 		return nil

--- a/cmd/msgvault/cmd/cache_refresh_test.go
+++ b/cmd/msgvault/cmd/cache_refresh_test.go
@@ -332,6 +332,34 @@ func TestRebuildCacheAfterWriteReturnsError(t *testing.T) {
 	require.ErrorContains(err, "refresh analytics cache")
 }
 
+func TestScheduledCacheRefreshSkipsWhenAutoBuildCacheDisabled(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmpDir := t.TempDir()
+
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+		Analytics: config.AnalyticsConfig{
+			AutoBuildCache: false,
+		},
+	}
+
+	builds := 0
+	oldRunBuild := runBuildCacheSubprocess
+	runBuildCacheSubprocess = func(context.Context, bool, bool) error {
+		builds++
+		return errors.New("unexpected scheduled cache build")
+	}
+	t.Cleanup(func() { runBuildCacheSubprocess = oldRunBuild })
+
+	err := rebuildCacheAfterScheduledSync(context.Background(), "disabled")
+	require.NoError(err)
+	assert.Zero(builds, "disabled auto_build_cache must not start a cache build")
+}
+
 func TestRepairEncodingReturnsCacheRefreshError(t *testing.T) {
 	require := require.New(t)
 	tmpDir := t.TempDir()
@@ -373,7 +401,13 @@ func TestScheduledCacheRefreshFailurePreservesCompletedSyncRun(t *testing.T) {
 
 	savedCfg := cfg
 	t.Cleanup(func() { cfg = savedCfg })
-	cfg = &config.Config{HomeDir: tmpDir, Data: config.DataConfig{DataDir: tmpDir}}
+	cfg = &config.Config{
+		HomeDir: tmpDir,
+		Data:    config.DataConfig{DataDir: tmpDir},
+		Analytics: config.AnalyticsConfig{
+			AutoBuildCache: true,
+		},
+	}
 
 	sentinel := errors.New("scheduled cache sentinel")
 	oldRunBuild := runBuildCacheSubprocess

--- a/cmd/msgvault/cmd/meeting_import_e2e_test.go
+++ b/cmd/msgvault/cmd/meeting_import_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -120,4 +121,50 @@ func TestMeetingImportAPIToStoreUpdatesCanonicalMessage(t *testing.T) {
 	assert.Contains(current.Body, "Replacement summary.")
 	assert.Contains(current.Body, "Speaker 2: replacement transcript")
 	assert.Empty(current.To)
+}
+
+func TestMeetingImportReturnsSuccessWhenCacheRefreshFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	cacheErr := errors.New("synthetic cache refresh failure")
+	adapter := &storeAPIAdapter{
+		store: st,
+		meetingImporter: meetingimport.NewImporter(st, meetingimport.Hooks{
+			AfterSourceSetup: func() error { return nil },
+			RefreshCache: func(context.Context, string) error {
+				return cacheErr
+			},
+		}),
+	}
+	srv := api.NewServer(
+		&config.Config{Server: config.ServerConfig{}},
+		adapter,
+		nil,
+		slog.New(slog.DiscardHandler),
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/import/meeting",
+		bytes.NewBufferString(meetingImportE2EBody),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+
+	require.Equal(http.StatusCreated, resp.Code, "body: %s", resp.Body.String())
+	var created api.MeetingImportResponse
+	require.NoError(json.NewDecoder(resp.Body).Decode(&created))
+	assert.Equal(meetingimport.StatusCreated, created.Status)
+	assert.NotZero(created.MessageID)
+
+	var persisted int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*)
+		FROM messages
+		WHERE id = ? AND source_message_id = ? AND message_type = ?
+	`), created.MessageID, "meeting:42", meetingimport.MessageType).Scan(&persisted))
+	assert.Equal(1, persisted)
 }

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -480,8 +480,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 		AfterSourceSetup: func() error {
 			return runPostSourceCreateMigrations(s)
 		},
-		RefreshCache: rebuildCacheAfterScheduledSync,
-	})
+		RefreshCache: func(_ context.Context, label string) error {
+			// The import is already durable. Keep the refresh independent of the
+			// client, but let daemon shutdown stop it before the store closes.
+			return daemonCacheRefreshError(ctx, rebuildCacheAfterScheduledSync(ctx, label))
+		},
+	}).WithLogger(logger)
 	storeAdapter := &storeAPIAdapter{
 		store:                 s,
 		attachmentMaintenance: attachmentMaint,
@@ -594,6 +598,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func daemonCacheRefreshError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func applyServerRuntimeConfig(options *api.ServerOptions, cfg *config.Config) {
@@ -841,6 +855,13 @@ func openDaemonAnalyticsEngine(
 		}
 		if intent != startupCacheBuildIntentNone {
 			outcome = startupCacheBuildOutcomeFulfilled
+		}
+		if !c.Analytics.AutoBuildCache {
+			logger.Warn(
+				`automatic analytics cache refresh disabled; DuckDB analytics can become stale; engine = "sql" selects live aggregate data`,
+				"auto_build_cache", false,
+				"engine", engineMode,
+			)
 		}
 		return duckEngine, api.AnalyticsModeDuckDB, outcome, nil
 	}

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -421,6 +421,50 @@ func TestOpenDaemonAnalyticsEngineSkipsCacheBuildWhenDisabled(t *testing.T) {
 	assert.Equal(startupCacheBuildOutcomeNone, outcome, "no explicit intent has no outcome")
 }
 
+func TestOpenDaemonAnalyticsEngineWarnsWhenDuckDBRefreshDisabled(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	c.Analytics.AutoBuildCache = false
+	_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), true)
+	require.NoError(err, "build ready analytics cache")
+	staleness := cacheNeedsBuild(c.DatabaseDSN(), c.AnalyticsDir())
+	require.False(staleness.NeedsBuild, "test cache must be ready: %+v", staleness)
+	var logs bytes.Buffer
+	oldLogger := logger
+	logger = slog.New(slog.NewTextHandler(&logs, nil))
+	t.Cleanup(func() { logger = oldLogger })
+
+	engine, mode, outcome, err := openDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
+	require.NoError(err, "openDaemonAnalyticsEngine")
+	defer func() { _ = engine.Close() }()
+
+	assert.IsType(&query.DuckDBEngine{}, engine,
+		"auto mode must keep using a usable cache")
+	assert.Equal(api.AnalyticsModeDuckDB, mode,
+		"usable cache selects DuckDB even when automatic refresh is disabled")
+	assert.Equal(startupCacheBuildOutcomeNone, outcome, "no explicit intent has no outcome")
+	assert.Contains(logs.String(),
+		"automatic analytics cache refresh disabled",
+		"startup warning explains the live-SQL opt-out")
+	assert.Contains(logs.String(),
+		"auto_build_cache=false",
+		"startup warning records the disabled setting")
+}
+
+func TestDaemonCacheRefreshErrorReportsDaemonCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	subprocessErr := errors.New("signal: killed")
+
+	require.ErrorIs(t, daemonCacheRefreshError(ctx, subprocessErr), context.Canceled)
+	assert.Same(t, subprocessErr, daemonCacheRefreshError(context.Background(), subprocessErr))
+	assert.NoError(t, daemonCacheRefreshError(ctx, nil))
+}
+
 func TestOpenDaemonAnalyticsEngineAutoBuildsCacheAtStartup(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1949,8 +1949,6 @@ type TextMessagesResponse struct {
 	Messages []query.MessageSummary `json:"messages"`
 }
 
-const labelsViewType = "labels"
-
 // aggregateViewTypes are the accepted view_type values, surfaced in 400 messages.
 var aggregateViewTypes = []string{
 	"senders", "sender_names", "recipients", "recipient_names",

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1949,6 +1949,8 @@ type TextMessagesResponse struct {
 	Messages []query.MessageSummary `json:"messages"`
 }
 
+const labelsViewType = "labels"
+
 // aggregateViewTypes are the accepted view_type values, surfaced in 400 messages.
 var aggregateViewTypes = []string{
 	"senders", "sender_names", "recipients", "recipient_names",

--- a/internal/api/operation_gate.go
+++ b/internal/api/operation_gate.go
@@ -53,6 +53,7 @@ type SerialOperationGate struct {
 	holderLabel    string
 	holderSince    time.Time
 	requestWaiters int
+	requestsDone   chan struct{}
 }
 
 func NewSerialOperationGate() *SerialOperationGate {
@@ -73,15 +74,21 @@ func (g *SerialOperationGate) BeginWorkContext(ctx context.Context) (func(), boo
 func (g *SerialOperationGate) BeginRequestWorkContext(ctx context.Context, label string) (func(), bool) {
 	if g != nil {
 		g.mu.Lock()
+		if g.requestWaiters == 0 {
+			g.requestsDone = make(chan struct{})
+		}
 		g.requestWaiters++
 		g.mu.Unlock()
 		defer func() {
 			g.mu.Lock()
 			g.requestWaiters--
+			if g.requestWaiters == 0 {
+				close(g.requestsDone)
+			}
 			g.mu.Unlock()
 		}()
 	}
-	return g.BeginLabeledWorkContext(ctx, label)
+	return g.beginLabeledWorkContext(ctx, label, true)
 }
 
 // HasRequestWaiters reports whether an API request is queued on the gate.
@@ -95,6 +102,15 @@ func (g *SerialOperationGate) HasRequestWaiters() bool {
 }
 
 func (g *SerialOperationGate) BeginLabeledWorkContext(ctx context.Context, label string) (func(), bool) {
+	return g.beginLabeledWorkContext(ctx, label, false)
+}
+
+// beginLabeledWorkContext keeps background work queued while API requests are
+// waiting. The background operation runs after the request queue drains; it is
+// never reported as cancelled only because a request arrived first. Requests
+// always take priority, so background work can remain queued until the request
+// queue drains, its context is cancelled, or the gate starts draining.
+func (g *SerialOperationGate) beginLabeledWorkContext(ctx context.Context, label string, requestWork bool) (func(), bool) {
 	if g == nil {
 		return func() {}, true
 	}
@@ -105,26 +121,56 @@ func (g *SerialOperationGate) BeginLabeledWorkContext(ctx context.Context, label
 		return func() {}, false
 	}
 	sem, drainCh := g.state()
-	select {
-	case sem <- struct{}{}:
-		if ctx.Err() != nil {
-			<-sem
+	for {
+		if !requestWork {
+			g.mu.Lock()
+			requestsDone := g.requestsDone
+			waiting := g.requestWaiters > 0
+			draining := g.draining
+			g.mu.Unlock()
+			if draining {
+				return func() {}, false
+			}
+			if waiting {
+				select {
+				case <-requestsDone:
+					continue
+				case <-ctx.Done():
+					return func() {}, false
+				case <-drainCh:
+					return func() {}, false
+				}
+			}
+		}
+
+		select {
+		case sem <- struct{}{}:
+			if ctx.Err() != nil {
+				<-sem
+				return func() {}, false
+			}
+		case <-ctx.Done():
+			return func() {}, false
+		case <-drainCh:
 			return func() {}, false
 		}
+
 		g.mu.Lock()
 		if g.draining {
 			g.mu.Unlock()
 			<-sem
 			return func() {}, false
 		}
+		if !requestWork && g.requestWaiters > 0 {
+			g.mu.Unlock()
+			<-sem
+			continue
+		}
 		g.active++
 		g.holderLabel = label
 		g.holderSince = time.Now()
 		g.mu.Unlock()
-	case <-ctx.Done():
-		return func() {}, false
-	case <-drainCh:
-		return func() {}, false
+		break
 	}
 	var once sync.Once
 	return func() {

--- a/internal/api/operation_gate_test.go
+++ b/internal/api/operation_gate_test.go
@@ -304,6 +304,172 @@ func TestOperationGateMiddlewareStopsWaitingWhenRequestContextCancels(t *testing
 	assert.Equal(http.StatusServiceUnavailable, resp.Code, "status")
 }
 
+type parkedContext struct {
+	context.Context
+
+	parked chan struct{}
+	once   sync.Once
+}
+
+func (c *parkedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.parked) })
+	return c.Context.Done()
+}
+
+func waitForParkedContext(t *testing.T, parked <-chan struct{}, work string) {
+	t.Helper()
+	select {
+	case <-parked:
+	case <-time.After(time.Second):
+		require.FailNowf(t, "operation gate wait timed out", "%s did not park on the operation gate", work)
+	}
+}
+
+func TestServerBackgroundOperationGateStopsWhenContextCancelsBehindRequest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	gate := NewSerialOperationGate()
+	srv := &Server{operationGate: gate}
+	activeRelease, ok := gate.BeginLabeledWorkContext(context.Background(), "active work")
+	require.True(ok, "hold gate")
+	requestCtx, requestCancel := context.WithCancel(context.Background())
+	requestParked := make(chan struct{})
+	requestResult := make(chan bool, 1)
+	go func() {
+		release, acquired := gate.BeginRequestWorkContext(&parkedContext{
+			Context: requestCtx,
+			parked:  requestParked,
+		}, "queued request")
+		if acquired {
+			release()
+		}
+		requestResult <- acquired
+	}()
+	waitForParkedContext(t, requestParked, "request")
+
+	backgroundCtx, backgroundCancel := context.WithCancel(context.Background())
+	backgroundParked := make(chan struct{})
+	backgroundResult := make(chan bool, 1)
+	go func() {
+		release, acquired := srv.beginBackgroundOperationGateWork(&parkedContext{
+			Context: backgroundCtx,
+			parked:  backgroundParked,
+		}, "background work")
+		if acquired {
+			release()
+		}
+		backgroundResult <- acquired
+	}()
+	waitForParkedContext(t, backgroundParked, "background work")
+
+	backgroundCancel()
+	select {
+	case acquired := <-backgroundResult:
+		assert.False(acquired, "parked background work must escape after context cancellation")
+	case <-time.After(time.Second):
+		require.FailNow("background acquisition did not return after context cancellation")
+	}
+
+	requestCancel()
+	select {
+	case acquired := <-requestResult:
+		assert.False(acquired, "request cleanup should release its waiter")
+	case <-time.After(time.Second):
+		require.FailNow("request waiter did not clean up")
+	}
+	activeRelease()
+	assert.False(gate.HasRequestWaiters(), "request waiter must be removed after cancellation")
+}
+
+func TestServerBackgroundOperationGateStopsWhenDrainStartsBehindRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		startDrain func(*SerialOperationGate) <-chan error
+	}{
+		{
+			name: "StartDrain",
+			startDrain: func(gate *SerialOperationGate) <-chan error {
+				gate.StartDrain()
+				return nil
+			},
+		},
+		{
+			name: "Drain",
+			startDrain: func(gate *SerialOperationGate) <-chan error {
+				done := make(chan error, 1)
+				go func() { done <- gate.Drain(context.Background()) }()
+				return done
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			gate := NewSerialOperationGate()
+			srv := &Server{operationGate: gate}
+			activeRelease, ok := gate.BeginLabeledWorkContext(context.Background(), "active work")
+			require.True(ok, "hold gate")
+			requestCtx, requestCancel := context.WithCancel(context.Background())
+			requestParked := make(chan struct{})
+			requestResult := make(chan bool, 1)
+			go func() {
+				release, acquired := gate.BeginRequestWorkContext(&parkedContext{
+					Context: requestCtx,
+					parked:  requestParked,
+				}, "queued request")
+				if acquired {
+					release()
+				}
+				requestResult <- acquired
+			}()
+			waitForParkedContext(t, requestParked, "request")
+
+			backgroundCtx := context.Background()
+			backgroundParked := make(chan struct{})
+			backgroundResult := make(chan bool, 1)
+			go func() {
+				release, acquired := srv.beginBackgroundOperationGateWork(&parkedContext{
+					Context: backgroundCtx,
+					parked:  backgroundParked,
+				}, "background work")
+				if acquired {
+					release()
+				}
+				backgroundResult <- acquired
+			}()
+			waitForParkedContext(t, backgroundParked, "background work")
+
+			drainDone := tt.startDrain(gate)
+			select {
+			case acquired := <-backgroundResult:
+				assert.False(acquired, "parked background work must escape when drain starts")
+			case <-time.After(time.Second):
+				require.FailNow("background acquisition did not return after drain started")
+			}
+			select {
+			case acquired := <-requestResult:
+				assert.False(acquired, "queued request must be rejected during drain")
+			case <-time.After(time.Second):
+				require.FailNow("request waiter did not return after drain started")
+			}
+
+			requestCancel()
+			activeRelease()
+			if drainDone != nil {
+				select {
+				case err := <-drainDone:
+					require.NoError(err, "drain")
+				case <-time.After(time.Second):
+					require.FailNow("drain did not finish after active work released")
+				}
+			}
+		})
+	}
+}
+
 func TestSerialOperationGateDrainRejectsQueuedWorkAndWaitsForActive(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -770,6 +936,69 @@ func TestSerialOperationGateCountsRequestWaiters(t *testing.T) {
 		require.FailNow("waiter did not acquire gate")
 	}
 	assert.False(gate.HasRequestWaiters(), "waiter count returns to zero")
+}
+
+func TestSerialOperationGatePrioritizesQueuedRequestOverBackgroundWork(t *testing.T) {
+	require := require.New(t)
+
+	gate := NewSerialOperationGate()
+	releaseActive, ok := gate.BeginLabeledWorkContext(context.Background(), "first scheduled sync")
+	require.True(ok, "occupy gate")
+	t.Cleanup(releaseActive)
+
+	type acquisition struct {
+		release func()
+		ok      bool
+	}
+	requestAcquired := make(chan acquisition, 1)
+	go func() {
+		release, acquired := gate.BeginRequestWorkContext(context.Background(), "meeting import")
+		requestAcquired <- acquisition{release: release, ok: acquired}
+	}()
+	require.Eventually(gate.HasRequestWaiters, time.Second, time.Millisecond,
+		"request must register before the next background admission")
+
+	backgroundAcquired := make(chan acquisition, 1)
+	go func() {
+		release, acquired := gate.BeginLabeledWorkContext(context.Background(), "manual sync")
+		backgroundAcquired <- acquisition{release: release, ok: acquired}
+	}()
+
+	select {
+	case result := <-backgroundAcquired:
+		if result.ok {
+			result.release()
+		}
+		require.FailNow("background work returned while the gate was held", "ok=%v", result.ok)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	releaseActive()
+	var request acquisition
+	select {
+	case request = <-requestAcquired:
+		require.True(request.ok, "queued request must acquire after active work releases")
+	case <-time.After(time.Second):
+		require.FailNow("queued request did not acquire after active work released")
+	}
+	select {
+	case result := <-backgroundAcquired:
+		if result.ok {
+			result.release()
+		}
+		require.FailNow("background work acquired before the request released", "ok=%v", result.ok)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	request.release()
+	select {
+	case background := <-backgroundAcquired:
+		require.True(background.ok, "background work waits and then acquires")
+		background.release()
+	case <-time.After(time.Second):
+		require.FailNow("background work did not acquire after the request released")
+	}
+	require.False(gate.HasRequestWaiters(), "request waiter drains")
 }
 
 func TestBeginLabeledOperationGateWorkCountsAsRequestWaiter(t *testing.T) {

--- a/internal/beeper/client.go
+++ b/internal/beeper/client.go
@@ -8,16 +8,17 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"go.kenn.io/msgvault/internal/httpretry"
 	"golang.org/x/time/rate"
 )
 
 const (
-	maxRetries = 8
+	maxRetries    = 8
+	maxRetryAfter = httpretry.DefaultMaxRetryAfter
 	// DefaultBaseURL is the Beeper Desktop API loopback address.
 	DefaultBaseURL = "http://localhost:23373"
 	// defaultQPS bounds request rate against the live Beeper Desktop app. The
@@ -40,10 +41,11 @@ type TokenFunc func(context.Context) (string, error)
 // Client is a read-only Beeper Desktop API client. It exposes only GET
 // endpoints by construction, so the archiver can never mutate Beeper state.
 type Client struct {
-	baseURL string
-	token   TokenFunc
-	http    *http.Client
-	limiter *rate.Limiter
+	baseURL       string
+	token         TokenFunc
+	http          *http.Client
+	limiter       *rate.Limiter
+	retryAfterMax time.Duration
 }
 
 // NewClient creates a Client. baseURL is injected so tests can point at
@@ -56,10 +58,11 @@ func NewClient(baseURL string, token TokenFunc, qps float64) *Client {
 		qps = defaultQPS
 	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		token:   token,
-		http:    &http.Client{Timeout: 60 * time.Second},
-		limiter: rate.NewLimiter(rate.Limit(qps), 1),
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		token:         token,
+		http:          &http.Client{Timeout: 60 * time.Second},
+		limiter:       rate.NewLimiter(rate.Limit(qps), 1),
+		retryAfterMax: maxRetryAfter,
 	}
 }
 
@@ -123,7 +126,7 @@ func (c *Client) fetch(ctx context.Context, path string, maxBytes int64) ([]byte
 		case resp.StatusCode == http.StatusNotFound:
 			return nil, fmt.Errorf("beeper GET %s: %w", reqURL, ErrNotFound)
 		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
-			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			wait := httpretry.RetryAfter(resp.Header.Get("Retry-After"), attempt, c.retryAfterMax)
 			timer := time.NewTimer(wait)
 			select {
 			case <-ctx.Done():
@@ -137,17 +140,6 @@ func (c *Client) fetch(ctx context.Context, path string, maxBytes int64) ([]byte
 		}
 	}
 	return nil, fmt.Errorf("beeper GET %s: exhausted %d retries", reqURL, maxRetries)
-}
-
-// retryAfter parses a Retry-After header value (seconds) or falls back to
-// exponential back-off capped at 60 s.
-func retryAfter(header string, attempt int) time.Duration {
-	if header != "" {
-		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
 }
 
 // getJSON fetches path and unmarshals the JSON body into out.

--- a/internal/beeper/client_test.go
+++ b/internal/beeper/client_test.go
@@ -35,6 +35,32 @@ func TestClientRetriesOn429(t *testing.T) {
 	assert.EqualValues(3, calls.Load())
 }
 
+func TestClientCapsOversizedRetryAfter(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "86400")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testToken, 1000)
+	c.retryAfterMax = 10 * time.Millisecond
+	start := time.Now()
+	accounts, err := c.ListAccounts(context.Background())
+	require.NoError(err)
+	assert.Empty(accounts)
+	assert.EqualValues(2, calls.Load())
+	assert.Less(time.Since(start), time.Second,
+		"provider Retry-After must not park a sync for the requested day")
+}
+
 func TestClientUnauthorizedMessage(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/granola/client.go
+++ b/internal/granola/client.go
@@ -12,10 +12,14 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/httpretry"
 	"golang.org/x/time/rate"
 )
 
-const maxRetries = 8
+const (
+	maxRetries    = 8
+	maxRetryAfter = httpretry.ProviderMaxRetryAfter
+)
 
 // maxPageSize is the API's page_size ceiling.
 const maxPageSize = 30
@@ -75,7 +79,7 @@ func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
 		case resp.StatusCode == http.StatusUnauthorized:
 			return nil, errors.New("granola API rejected the key (401): check [[granola]] api_key in config.toml (a grn_… key from the desktop app's settings; requires a Business plan)")
 		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
-			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			wait := httpretry.RetryAfter(resp.Header.Get("Retry-After"), attempt, maxRetryAfter)
 			timer := time.NewTimer(wait)
 			select {
 			case <-ctx.Done():
@@ -89,17 +93,6 @@ func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
 		}
 	}
 	return nil, fmt.Errorf("granola GET %s: exhausted %d retries", reqURL, maxRetries)
-}
-
-// retryAfter parses a Retry-After header value (seconds) or falls back to
-// exponential back-off capped at 60 s.
-func retryAfter(header string, attempt int) time.Duration {
-	if header != "" {
-		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
 }
 
 // ListNotesParams filters GET /v1/notes. Zero-value fields are omitted.

--- a/internal/httpretry/retry_after.go
+++ b/internal/httpretry/retry_after.go
@@ -1,0 +1,64 @@
+// Package httpretry contains small helpers shared by HTTP clients.
+package httpretry
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultMaxRetryAfter caps exponential retry delays and is the safe
+	// default for callers that do not provide a provider-specific cap.
+	DefaultMaxRetryAfter = 60 * time.Second
+	// ProviderMaxRetryAfter is the finite cap for providers that can return
+	// meaningful throttling windows longer than one minute.
+	ProviderMaxRetryAfter = 15 * time.Minute
+)
+
+const maxDuration = time.Duration(1<<63 - 1)
+
+// RetryAfter returns a Retry-After header delay capped by maximum. When the
+// header is absent or invalid, it returns an exponential fallback capped by
+// DefaultMaxRetryAfter and maximum. A zero or negative maximum uses
+// DefaultMaxRetryAfter. Invalid and overflowing header values use the fallback
+// instead of being treated as a very large provider delay.
+func RetryAfter(header string, attempt int, maximum time.Duration) time.Duration {
+	if maximum <= 0 {
+		maximum = DefaultMaxRetryAfter
+	}
+	if header != "" {
+		secs, err := strconv.ParseUint(strings.TrimSpace(header), 10, 64)
+		if err == nil {
+			if delay, ok := secondsToDuration(secs); ok {
+				return capDelay(delay, maximum)
+			}
+		}
+	}
+
+	return capDelay(exponentialBackoff(attempt), maximum)
+}
+
+func secondsToDuration(seconds uint64) (time.Duration, bool) {
+	if seconds > uint64(maxDuration/time.Second) {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
+func exponentialBackoff(attempt int) time.Duration {
+	if attempt <= 0 {
+		return time.Second
+	}
+	if attempt >= 6 {
+		return DefaultMaxRetryAfter
+	}
+	return time.Duration(1<<uint(attempt)) * time.Second
+}
+
+func capDelay(delay, maximum time.Duration) time.Duration {
+	if maximum > 0 && delay > maximum {
+		return maximum
+	}
+	return delay
+}

--- a/internal/httpretry/retry_after_test.go
+++ b/internal/httpretry/retry_after_test.go
@@ -1,0 +1,57 @@
+package httpretry
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryAfterBoundsProviderDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		attempt int
+		maximum time.Duration
+		want    time.Duration
+	}{
+		{name: "negative falls back", header: "-1", attempt: 2, maximum: ProviderMaxRetryAfter, want: 4 * time.Second},
+		{name: "valid long value within provider cap", header: "600", maximum: ProviderMaxRetryAfter, want: 10 * time.Minute},
+		{name: "valid value above provider cap", header: "3600", maximum: ProviderMaxRetryAfter, want: ProviderMaxRetryAfter},
+		{name: "beeper cap", header: "120", maximum: DefaultMaxRetryAfter, want: DefaultMaxRetryAfter},
+		{name: "duration overflow falls back", header: "9223372037", attempt: 5, maximum: ProviderMaxRetryAfter, want: 32 * time.Second},
+		{name: "uint64 overflow falls back", header: "18446744073709551616", attempt: 4, maximum: ProviderMaxRetryAfter, want: 16 * time.Second},
+		{name: "malformed falls back", header: "1s", attempt: 3, maximum: ProviderMaxRetryAfter, want: 8 * time.Second},
+		{name: "zero is immediate", header: "0", attempt: 4, maximum: ProviderMaxRetryAfter, want: 0},
+		{name: "positive value honors subsecond maximum", header: "1", maximum: 10 * time.Millisecond, want: 10 * time.Millisecond},
+		{name: "zero maximum uses safe default", header: "120", want: DefaultMaxRetryAfter},
+		{name: "negative maximum uses safe default", header: "120", maximum: -time.Second, want: DefaultMaxRetryAfter},
+		{name: "fallback caps", attempt: 6, want: DefaultMaxRetryAfter},
+		{name: "fallback honors maximum", attempt: 6, maximum: 10 * time.Millisecond, want: 10 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RetryAfter(tt.header, tt.attempt, tt.maximum))
+		})
+	}
+}
+
+func TestRetryAfterFallbackAttemptBounds(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{attempt: -1, want: time.Second},
+		{attempt: 0, want: time.Second},
+		{attempt: 1, want: 2 * time.Second},
+		{attempt: 5, want: 32 * time.Second},
+		{attempt: 6, want: DefaultMaxRetryAfter},
+		{attempt: 100, want: DefaultMaxRetryAfter},
+	}
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.attempt), func(t *testing.T) {
+			assert.Equal(t, tt.want, RetryAfter("", tt.attempt, ProviderMaxRetryAfter))
+		})
+	}
+}

--- a/internal/meetingimport/importer.go
+++ b/internal/meetingimport/importer.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"go.kenn.io/msgvault/internal/meetingidentity"
@@ -34,12 +35,21 @@ type Hooks struct {
 }
 
 type Importer struct {
-	store *store.Store
-	hooks Hooks
+	store  *store.Store
+	hooks  Hooks
+	logger *slog.Logger
 }
 
 func NewImporter(s *store.Store, hooks Hooks) *Importer {
-	return &Importer{store: s, hooks: hooks}
+	return &Importer{store: s, hooks: hooks, logger: slog.Default()}
+}
+
+// WithLogger sets the logger used for best-effort post-import work.
+func (i *Importer) WithLogger(logger *slog.Logger) *Importer {
+	if logger != nil {
+		i.logger = logger
+	}
+	return i
 }
 
 func (i *Importer) Import(ctx context.Context, req Request) (result Result, retErr error) {
@@ -143,12 +153,8 @@ func (i *Importer) Import(ctx context.Context, req Request) (result Result, retE
 				if err := i.store.CompleteSyncContext(ctx, syncID, ""); err != nil {
 					return result, fmt.Errorf("complete meeting import sync: %w", err)
 				}
-				if i.hooks.RefreshCache != nil {
-					cacheLabel := SourceType + ":" + snapshot.SourceIdentifier
-					if err := i.hooks.RefreshCache(ctx, cacheLabel); err != nil {
-						return result, fmt.Errorf("refresh meeting analytics cache: %w", err)
-					}
-				}
+				i.refreshCache(ctx, SourceType+":"+snapshot.SourceIdentifier,
+					source.ID, snapshot.SourceMessageID)
 				return result, nil
 			}
 		}
@@ -277,13 +283,31 @@ func (i *Importer) Import(ctx context.Context, req Request) (result Result, retE
 	if err := i.store.CompleteSyncContext(ctx, syncID, ""); err != nil {
 		return result, fmt.Errorf("complete meeting import sync: %w", err)
 	}
-	if i.hooks.RefreshCache != nil {
-		cacheLabel := SourceType + ":" + snapshot.SourceIdentifier
-		if err := i.hooks.RefreshCache(ctx, cacheLabel); err != nil {
-			return result, fmt.Errorf("refresh meeting analytics cache: %w", err)
-		}
-	}
+	i.refreshCache(ctx, SourceType+":"+snapshot.SourceIdentifier,
+		source.ID, snapshot.SourceMessageID)
 	return result, nil
+}
+
+func (i *Importer) refreshCache(ctx context.Context, label string, sourceID int64, sourceMessageID string) {
+	if i.hooks.RefreshCache == nil {
+		return
+	}
+	// The import has completed successfully before this best-effort hook runs.
+	if err := i.hooks.RefreshCache(ctx, label); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		logger := i.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Error("meeting analytics cache refresh failed",
+			"source", label,
+			"source_id", sourceID,
+			"source_message_id", sourceMessageID,
+			"error", err,
+		)
+	}
 }
 
 func emailDomain(email string) string {

--- a/internal/meetingimport/importer_test.go
+++ b/internal/meetingimport/importer_test.go
@@ -1,10 +1,12 @@
 package meetingimport
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -601,7 +603,7 @@ func TestImporterPreconfirmedAccountEmailKeepsEarlierMeetingAttributionCurrent(t
 	assert.True(earlierIsFromMe)
 }
 
-func TestImporterMarksCacheFailureAndSafelyRetries(t *testing.T) {
+func TestImporterCompletesSyncAndSafelyRetriesAfterCacheFailure(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -618,7 +620,7 @@ func TestImporterMarksCacheFailureAndSafelyRetries(t *testing.T) {
 	})
 
 	_, err := importer.Import(context.Background(), validImportRequest(t))
-	require.ErrorIs(err, cacheErr)
+	require.NoError(err)
 
 	var messageID, sourceID int64
 	require.NoError(st.DB().QueryRow(`
@@ -626,11 +628,11 @@ func TestImporterMarksCacheFailureAndSafelyRetries(t *testing.T) {
 	`).Scan(&messageID, &sourceID))
 	assert.NotZero(messageID, "message remains durable after cache failure")
 
-	failed, err := st.GetLatestSync(sourceID)
+	completed, err := st.GetLatestSync(sourceID)
 	require.NoError(err)
-	assert.Equal(store.SyncStatusFailed, failed.Status)
-	assert.Equal(int64(1), failed.MessagesProcessed)
-	assert.Equal(int64(1), failed.MessagesAdded)
+	assert.Equal(store.SyncStatusCompleted, completed.Status)
+	assert.Equal(int64(1), completed.MessagesProcessed)
+	assert.Equal(int64(1), completed.MessagesAdded)
 
 	failCache = false
 	result, err := importer.Import(context.Background(), validImportRequest(t))
@@ -638,10 +640,22 @@ func TestImporterMarksCacheFailureAndSafelyRetries(t *testing.T) {
 	assert.Equal(StatusUpdated, result.Status)
 	assert.Equal(messageID, result.MessageID)
 
-	completed, err := st.GetLatestSync(sourceID)
+	completed, err = st.GetLatestSync(sourceID)
 	require.NoError(err)
 	assert.Equal(store.SyncStatusCompleted, completed.Status)
 	assert.Equal(int64(0), completed.MessagesUpdated)
+}
+
+func TestImporterRefreshCacheDoesNotLogShutdownCancellation(t *testing.T) {
+	var logs bytes.Buffer
+	importer := NewImporter(nil, Hooks{
+		RefreshCache: func(context.Context, string) error {
+			return context.Canceled
+		},
+	}).WithLogger(slog.New(slog.NewTextHandler(&logs, nil)))
+
+	importer.refreshCache(context.Background(), "meeting_import:local-meetings", 1, "meeting:42")
+	assert.Empty(t, logs.String())
 }
 
 func TestImporterSourceHookFailureStopsBeforeSync(t *testing.T) {

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -12,11 +12,13 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/httpretry"
 	"golang.org/x/time/rate"
 )
 
 const (
-	maxRetries = 8
+	maxRetries    = 8
+	maxRetryAfter = httpretry.ProviderMaxRetryAfter
 	// DefaultBaseURL is the Slack Web API root. Injected so tests can point
 	// at httptest servers.
 	DefaultBaseURL = "https://slack.com/api"
@@ -168,7 +170,7 @@ func (c *Client) call(ctx context.Context, method string, params url.Values, out
 		}
 
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			wait := httpretry.RetryAfter(resp.Header.Get("Retry-After"), attempt, maxRetryAfter)
 			timer := time.NewTimer(wait)
 			select {
 			case <-ctx.Done():
@@ -216,17 +218,6 @@ func apiError(method string, envelope *apiResponse) error {
 	default:
 		return fmt.Errorf("slack %s: %s", method, envelope.Error)
 	}
-}
-
-// retryAfter parses a Retry-After header (seconds) or falls back to
-// exponential back-off capped at 60 s.
-func retryAfter(header string, attempt int) time.Duration {
-	if header != "" {
-		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
 }
 
 func truncate(b []byte, n int) string {

--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -7,14 +7,17 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/httpretry"
 	"golang.org/x/time/rate"
 )
 
-const maxRetries = 8
+const (
+	maxRetries    = 8
+	maxRetryAfter = httpretry.ProviderMaxRetryAfter
+)
 
 // TokenFunc returns a bearer token for a Graph API request.
 type TokenFunc func(context.Context) (string, error)
@@ -80,7 +83,7 @@ func (c *Client) get(ctx context.Context, rawURL string) ([]byte, error) {
 		case resp.StatusCode == http.StatusOK:
 			return body, nil
 		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
-			wait := retryAfter(resp.Header.Get("Retry-After"), attempt)
+			wait := httpretry.RetryAfter(resp.Header.Get("Retry-After"), attempt, maxRetryAfter)
 			timer := time.NewTimer(wait)
 			select {
 			case <-ctx.Done():
@@ -112,18 +115,6 @@ func (c *Client) resolveRequestURL(rawURL string) (string, error) {
 		return "", fmt.Errorf("graph GET %s: off-origin absolute URL", rawURL)
 	}
 	return u.String(), nil
-}
-
-// retryAfter parses a Retry-After header value (seconds) or falls back to
-// exponential back-off capped at 60 s.
-func retryAfter(header string, attempt int) time.Duration {
-	if header != "" {
-		if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	d := min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
-	return d
 }
 
 // GetRaw fetches url and returns the raw response bytes. url should be a


### PR DESCRIPTION
## What changed

- Serve queued API mutations before background operation-gate waiters without dropping or cancelling queued background work.
- Bound provider-directed retry delays for Beeper, Slack, Teams, and Granola, with safe fallback for malformed or overflowing `Retry-After` values.
- Honor `analytics.auto_build_cache = false` after scheduled syncs and meeting imports, and warn when a ready DuckDB cache will not refresh automatically.
- Keep persisted meeting imports successful when the derived cache refresh fails, and log that failure separately.

## Why

Busy schedulers could starve user-triggered writes, oversized retry delays could make a sync look hung, and disabled cache builds still ran after syncs. A cache refresh failure could also turn a successful meeting import into a false 500 and trap spooling clients in retries.

## Usage

No usage change.

Closes #574.
Closes #539.
Closes #576.
Closes #577.