### PR TITLE
fix(embed): treat scheduler yields as benign

### DIFF
--- a/cmd/msgvault/cmd/setup.go
+++ b/cmd/msgvault/cmd/setup.go
@@ -136,7 +136,7 @@ func setupOAuthSecrets(reader *bufio.Reader) (string, error) {
 	}
 
 	// Verify file exists
-	if _, err := os.Stat(path); os.IsNotExist(err) { //nolint:gosec // the user explicitly selected this local OAuth credential path
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return "", fmt.Errorf("file not found: %s", path)
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1952,8 +1952,10 @@ type TextMessagesResponse struct {
 // aggregateViewTypes are the accepted view_type values, surfaced in 400 messages.
 var aggregateViewTypes = []string{
 	"senders", "sender_names", "recipients", "recipient_names",
-	"domains", "labels", "time",
+	"domains", aggregateViewLabels, "time",
 }
+
+const aggregateViewLabels = "labels"
 
 // parseViewType parses a view type string into query.ViewType.
 func parseViewType(s string) (query.ViewType, bool) {
@@ -1968,7 +1970,7 @@ func parseViewType(s string) (query.ViewType, bool) {
 		return query.ViewRecipientNames, true
 	case "domains":
 		return query.ViewDomains, true
-	case "labels":
+	case aggregateViewLabels:
 		return query.ViewLabels, true
 	case "time":
 		return query.ViewTime, true
@@ -1991,7 +1993,7 @@ func viewTypeString(v query.ViewType) string {
 	case query.ViewDomains:
 		return "domains"
 	case query.ViewLabels:
-		return "labels"
+		return aggregateViewLabels
 	case query.ViewTime:
 		return "time"
 	default:
@@ -2060,7 +2062,7 @@ func parseTextViewType(s string) (query.TextViewType, bool) {
 		return query.TextViewContactNames, true
 	case "sources":
 		return query.TextViewSources, true
-	case "labels":
+	case aggregateViewLabels:
 		return query.TextViewLabels, true
 	case "time":
 		return query.TextViewTime, true
@@ -2080,7 +2082,7 @@ func textViewTypeString(v query.TextViewType) string {
 	case query.TextViewSources:
 		return "sources"
 	case query.TextViewLabels:
-		return "labels"
+		return aggregateViewLabels
 	case query.TextViewTime:
 		return "time"
 	default:
@@ -3142,7 +3144,7 @@ func openLooseAttachmentContent(attachmentsDir, contentHash, storagePath string)
 	if err != nil {
 		return nil, 0, err
 	}
-	f, err := os.Open(path) //nolint:gosec // path is constrained by the content hash or validated recorded attachment path
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/api/session_routes.go
+++ b/internal/api/session_routes.go
@@ -105,7 +105,7 @@ func (s *Server) handleSessionLogin(w http.ResponseWriter, r *http.Request) {
 	// Secure follows the verified connection scheme; plain HTTP support is an
 	// explicit deployment mode surfaced by PlainHTTPWarning.
 
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, &http.Cookie{ //nolint:gosec // Secure follows the verified request scheme; plain HTTP is an explicit supported mode.
 		Name:     sessionCookieName,
 		Value:    id,
 		Path:     "/",
@@ -132,7 +132,7 @@ func (s *Server) handleSessionLogout(w http.ResponseWriter, r *http.Request) {
 		s.sessions.delete(cookie.Value)
 	}
 
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, &http.Cookie{ //nolint:gosec // Secure follows the verified request scheme; plain HTTP is an explicit supported mode.
 		Name:     sessionCookieName,
 		Value:    "",
 		Path:     "/",

--- a/internal/beeper/client.go
+++ b/internal/beeper/client.go
@@ -147,7 +147,7 @@ func retryAfter(header string, attempt int) time.Duration {
 			return time.Duration(secs) * time.Second
 		}
 	}
-	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second) //nolint:gosec // retry attempts are bounded by the caller
+	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
 }
 
 // getJSON fetches path and unmarshals the JSON body into out.

--- a/internal/circleback/oauth_test.go
+++ b/internal/circleback/oauth_test.go
@@ -74,7 +74,7 @@ func newFakeAS(t *testing.T) *fakeAS {
 		f.lastAuthorize = r.URL.Query()
 		redirect := r.URL.Query().Get("redirect_uri") +
 			"?code=authcode-1&state=" + url.QueryEscape(r.URL.Query().Get("state"))
-		http.Redirect(w, r, redirect, http.StatusFound)
+		http.Redirect(w, r, redirect, http.StatusFound) //nolint:gosec // the test fixture must follow the client-supplied OAuth callback.
 	})
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)

--- a/internal/config/edit_candidate_unix.go
+++ b/internal/config/edit_candidate_unix.go
@@ -33,7 +33,7 @@ func createConfigCandidate(dir string) (configCandidate, error) {
 			_ = unix.Close(dirfd)
 			return configCandidate{}, fmt.Errorf("create candidate relative to pinned directory: %w", openErr)
 		}
-		file := os.NewFile(uintptr(fd), filepath.Join(dir, name)) //nolint:gosec // successful Unix open returns a non-negative descriptor
+		file := os.NewFile(uintptr(fd), filepath.Join(dir, name))
 		info, statErr := file.Stat()
 		if statErr != nil {
 			_ = file.Close()
@@ -53,7 +53,7 @@ func createConfigCandidate(dir string) (configCandidate, error) {
 			return configCandidate{}, fmt.Errorf("retain config candidate identity: %w", duplicateErr)
 		}
 		unix.CloseOnExec(retainedFD)
-		retained := os.NewFile(uintptr(retainedFD), file.Name()) //nolint:gosec // successful Unix dup returns a non-negative descriptor
+		retained := os.NewFile(uintptr(retainedFD), file.Name())
 		return configCandidate{
 			file:     file,
 			retained: retained,

--- a/internal/config/edit_cleanup_unix.go
+++ b/internal/config/edit_cleanup_unix.go
@@ -95,7 +95,7 @@ func openConfigEntryAt(dirfd int, name, displayPath string) (*os.File, os.FileIn
 	if err != nil {
 		return nil, nil, fmt.Errorf("open config cleanup entry: %w", err)
 	}
-	file := os.NewFile(uintptr(fd), displayPath) //nolint:gosec // successful Unix open returns a non-negative descriptor
+	file := os.NewFile(uintptr(fd), displayPath)
 	info, err := file.Stat()
 	if err != nil {
 		_ = file.Close()
@@ -109,7 +109,7 @@ func retainConfigEntryAt(dirfd int, name, displayPath, expectedIdentity string) 
 	if err != nil {
 		return nil, fmt.Errorf("open retained config retirement entry: %w", err)
 	}
-	file := os.NewFile(uintptr(fd), displayPath) //nolint:gosec // successful Unix open returns a non-negative descriptor
+	file := os.NewFile(uintptr(fd), displayPath)
 	info, err := file.Stat()
 	if err != nil {
 		_ = file.Close()

--- a/internal/config/edit_exchange_unix.go
+++ b/internal/config/edit_exchange_unix.go
@@ -64,7 +64,7 @@ func readPhysicalConfigSnapshotAt(dir int, name, displayPath string) (ConfigFile
 	if err != nil {
 		return ConfigFile{}, fmt.Errorf("open pinned config entry: %w", err)
 	}
-	file := os.NewFile(uintptr(fd), displayPath) //nolint:gosec // successful Unix open returns a non-negative descriptor
+	file := os.NewFile(uintptr(fd), displayPath)
 	content, mode, identity, readErr := readVerifiedOpenedConfig(file)
 	closeErr := file.Close()
 	if readErr != nil || closeErr != nil {

--- a/internal/config/edit_open_unix.go
+++ b/internal/config/edit_open_unix.go
@@ -15,7 +15,7 @@ func openConfigNoFollow(path string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open config without following final symlink: %w", err)
 	}
-	return os.NewFile(uintptr(fd), path), nil //nolint:gosec // successful Unix open returns a non-negative descriptor
+	return os.NewFile(uintptr(fd), path), nil
 }
 
 func openedFileIdentity(file *os.File, info fs.FileInfo) (string, bool) {

--- a/internal/config/edit_publish_unix.go
+++ b/internal/config/edit_publish_unix.go
@@ -16,7 +16,7 @@ func publishNewConfig(candidatePath string, _ *os.File, before ConfigFile) (conf
 	if err != nil {
 		return configPublication{}, fmt.Errorf("pin publication directory: %w", err)
 	}
-	dir := os.NewFile(uintptr(dirfd), filepath.Dir(before.Path)) //nolint:gosec // successful Unix open returns a non-negative descriptor
+	dir := os.NewFile(uintptr(dirfd), filepath.Dir(before.Path))
 	dirInfo, err := dir.Stat()
 	if err != nil {
 		_ = dir.Close()

--- a/internal/config/edit_resolve_unix.go
+++ b/internal/config/edit_resolve_unix.go
@@ -164,12 +164,12 @@ func readConfigFileSnapshotUnix(path string, retain bool) (ConfigFile, error) {
 			}
 			snapshot = ConfigFile{Path: displayPath, Content: content, ETag: configETag(content), Mode: mode, Exists: true, identity: identity}
 			if retain {
-				fd, duplicateErr := unix.Dup(int(file.Fd())) //nolint:gosec // Unix file descriptors fit the int API used by x/sys/unix
+				fd, duplicateErr := unix.Dup(int(file.Fd()))
 				if duplicateErr != nil {
 					return fmt.Errorf("retain config snapshot identity: %w", duplicateErr)
 				}
 				unix.CloseOnExec(fd)
-				snapshot.retained = os.NewFile(uintptr(fd), displayPath) //nolint:gosec // successful Unix dup returns a non-negative descriptor
+				snapshot.retained = os.NewFile(uintptr(fd), displayPath)
 			}
 			return nil
 		}, func(displayPath string, parent *os.File) error {

--- a/internal/gcal/client.go
+++ b/internal/gcal/client.go
@@ -197,7 +197,7 @@ func (c *Client) request(ctx context.Context, op gmail.Operation, method, path s
 
 // calculateBackoff returns full-jitter exponential backoff for a retry attempt.
 func (c *Client) calculateBackoff(attempt int) time.Duration {
-	base := float64(uint(1) << uint(attempt)) //nolint:gosec // retry attempts are bounded before backoff calculation
+	base := float64(uint(1) << uint(attempt))
 	if base > maxBackoff {
 		base = maxBackoff
 	}

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -191,7 +191,7 @@ func (c *Client) request(ctx context.Context, op Operation, method, path string,
 // Uses exponential backoff with full jitter.
 func (c *Client) calculateBackoff(attempt int) time.Duration {
 	// Exponential: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 600, 600...
-	base := float64(uint(1) << uint(attempt)) //nolint:gosec // retry attempts are bounded before backoff calculation
+	base := float64(uint(1) << uint(attempt))
 	if base > maxBackoff {
 		base = maxBackoff
 	}

--- a/internal/granola/client.go
+++ b/internal/granola/client.go
@@ -99,7 +99,7 @@ func retryAfter(header string, attempt int) time.Duration {
 			return time.Duration(secs) * time.Second
 		}
 	}
-	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second) //nolint:gosec // retry attempts are bounded by the caller
+	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
 }
 
 // ListNotesParams filters GET /v1/notes. Zero-value fields are omitted.

--- a/internal/jobctx/yield.go
+++ b/internal/jobctx/yield.go
@@ -1,0 +1,16 @@
+package jobctx
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrYieldedToWaiter is the cancellation cause used when a resumable job
+// steps aside so a waiting operation can acquire the work gate.
+var ErrYieldedToWaiter = errors.New("yielded to a waiting operation")
+
+// YieldedToWaiter reports whether ctx was cancelled because a job yielded to
+// a waiting operation.
+func YieldedToWaiter(ctx context.Context) bool {
+	return errors.Is(context.Cause(ctx), ErrYieldedToWaiter)
+}

--- a/internal/scheduler/embed_job.go
+++ b/internal/scheduler/embed_job.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/msgvault/internal/jobctx"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/embed"
 )
@@ -135,6 +136,9 @@ func (j *EmbedJob) Run(ctx context.Context) {
 	defer j.running.Unlock()
 
 	if _, err := j.Worker.ReclaimStale(ctx); err != nil {
+		if jobctx.YieldedToWaiter(ctx) {
+			return
+		}
 		log.Warn("embed reclaim failed", "error", err)
 	}
 
@@ -144,6 +148,12 @@ func (j *EmbedJob) Run(ctx context.Context) {
 	}
 
 	res, err := j.Worker.RunOnce(ctx, target)
+	// The scheduler yield cause takes precedence over an operation error:
+	// drivers can return unwrapped errors after cancellation, so the cause at
+	// this operation boundary is authoritative.
+	if jobctx.YieldedToWaiter(ctx) {
+		return
+	}
 	if err != nil {
 		log.Warn("embed run failed", "gen", target, "error", err)
 		return
@@ -167,6 +177,9 @@ func (j *EmbedJob) Run(ctx context.Context) {
 	// non-locking batches, and is idempotent (already-covered rows are
 	// skipped) so it never re-embeds stamped messages.
 	j.maybeRunBackstop(ctx, target, log)
+	if jobctx.YieldedToWaiter(ctx) {
+		return
+	}
 
 	if !isBuilding {
 		return
@@ -191,6 +204,9 @@ func (j *EmbedJob) Run(ctx context.Context) {
 		return
 	}
 	missing, err := j.missingCount(ctx, target)
+	if jobctx.YieldedToWaiter(ctx) {
+		return
+	}
 	if err != nil {
 		log.Warn("embed: coverage count after run failed", "gen", target, "error", err)
 		return
@@ -202,8 +218,17 @@ func (j *EmbedJob) Run(ctx context.Context) {
 	}
 	// force=false: the missing==0 check above is the scheduler's gate,
 	// and the backend re-asserts it inside ActivateGeneration.
+	if jobctx.YieldedToWaiter(ctx) {
+		return
+	}
 	if err := j.Backend.ActivateGeneration(ctx, target, false); err != nil {
+		if jobctx.YieldedToWaiter(ctx) {
+			return
+		}
 		log.Warn("embed: activation failed", "gen", target, "error", err)
+		return
+	}
+	if jobctx.YieldedToWaiter(ctx) {
 		return
 	}
 	log.Info("embed: building generation activated", "gen", target)
@@ -246,6 +271,9 @@ func (j *EmbedJob) maybeRunBackstop(ctx context.Context, gen vector.GenerationID
 		return
 	}
 	res, err := j.Worker.RunBackstop(ctx, gen)
+	if jobctx.YieldedToWaiter(ctx) {
+		return
+	}
 	if err != nil {
 		log.Warn("embed backstop failed", "gen", gen, "error", err)
 		// Do not advance lastBackstop on failure so the next tick retries.
@@ -285,6 +313,9 @@ func (j *EmbedJob) maybeRunBackstop(ctx context.Context, gen vector.GenerationID
 // occurred (already logged); the caller should return.
 func (j *EmbedJob) pickTarget(ctx context.Context, log *slog.Logger) (vector.GenerationID, bool, bool) {
 	bg, bgErr := j.Backend.BuildingGeneration(ctx)
+	if jobctx.YieldedToWaiter(ctx) {
+		return 0, false, false
+	}
 	if bgErr != nil {
 		log.Warn("embed: building generation lookup failed", "error", bgErr)
 		return 0, false, false
@@ -311,6 +342,9 @@ func (j *EmbedJob) pickTarget(ctx context.Context, log *slog.Logger) (vector.Gen
 	}
 
 	active, err := j.Backend.ActiveGeneration(ctx)
+	if jobctx.YieldedToWaiter(ctx) {
+		return 0, false, false
+	}
 	switch {
 	case err == nil:
 		if j.Fingerprint != "" && active.Fingerprint != j.Fingerprint {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/robfig/cron/v3"
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/jobctx"
 	"go.kenn.io/msgvault/internal/syncerr"
 )
 
@@ -34,7 +35,7 @@ type YieldChecker interface {
 
 // ErrYieldedToWaiter is the cancellation cause set when a scheduled job is
 // interrupted to let a waiting operation acquire the work gate.
-var ErrYieldedToWaiter = errors.New("yielded to a waiting operation")
+var ErrYieldedToWaiter = jobctx.ErrYieldedToWaiter
 
 // yieldPollInterval is how often a running scheduled job checks for waiters.
 // Variable only so tests can shorten it.
@@ -102,7 +103,7 @@ type Scheduler struct {
 
 // New creates a new Scheduler with the given sync callback.
 func New(syncFunc SyncFunc) *Scheduler {
-	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // the scheduler stores cancel and invokes it in Stop
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Scheduler{
 		cron: cron.New(cron.WithParser(cron.NewParser(
 			cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow,
@@ -586,7 +587,7 @@ func (s *Scheduler) jobContext() (context.Context, func()) {
 }
 
 func yieldedToWaiter(ctx context.Context) bool {
-	return errors.Is(context.Cause(ctx), ErrYieldedToWaiter)
+	return jobctx.YieldedToWaiter(ctx)
 }
 
 // Status returns the current status of all scheduled accounts.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,8 +1,10 @@
 package scheduler
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/jobctx"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/embed"
 )
@@ -604,13 +607,16 @@ func (t *fakeWorkTracker) active() int {
 // BuildingGeneration, and ActivateGeneration are meaningfully populated;
 // the rest panic to catch accidental usage.
 type fakeBackend struct {
-	active    vector.Generation
-	activeErr error
-	building  *vector.Generation
-	buildErr  error
+	active        vector.Generation
+	activeErr     error
+	building      *vector.Generation
+	buildErr      error
+	yieldActive   context.CancelCauseFunc
+	yieldBuilding context.CancelCauseFunc
 	// activateErr is what ActivateGeneration returns. activateCalls
 	// records the gen IDs the EmbedJob asked to activate.
 	activateErr     error
+	yieldActivate   context.CancelCauseFunc
 	mu              sync.Mutex
 	activateCallIDs []vector.GenerationID
 
@@ -620,11 +626,17 @@ type fakeBackend struct {
 
 func (f *fakeBackend) ActiveGeneration(ctx context.Context) (vector.Generation, error) {
 	f.activeCalls.Add(1)
+	if f.yieldActive != nil {
+		f.yieldActive(jobctx.ErrYieldedToWaiter)
+	}
 	return f.active, f.activeErr
 }
 
 func (f *fakeBackend) BuildingGeneration(ctx context.Context) (*vector.Generation, error) {
 	f.buildingCalls.Add(1)
+	if f.yieldBuilding != nil {
+		f.yieldBuilding(jobctx.ErrYieldedToWaiter)
+	}
 	return f.building, f.buildErr
 }
 
@@ -635,6 +647,9 @@ func (f *fakeBackend) ActivateGeneration(ctx context.Context, gen vector.Generat
 	f.mu.Lock()
 	f.activateCallIDs = append(f.activateCallIDs, gen)
 	f.mu.Unlock()
+	if f.yieldActivate != nil {
+		f.yieldActivate(jobctx.ErrYieldedToWaiter)
+	}
 	return f.activateErr
 }
 func (f *fakeBackend) activations() []vector.GenerationID {
@@ -683,6 +698,9 @@ type fakeRunner struct {
 	backstopResult embed.RunResult
 	runDoneOnce    sync.Once
 	runDone        chan struct{} // optional: closed after first RunOnce
+	yieldCancel    context.CancelCauseFunc
+	yieldBackstop  context.CancelCauseFunc
+	yieldReclaim   context.CancelCauseFunc
 	// onBackstop, if set, is invoked from RunBackstop (after recording the
 	// call) to let tests model a side effect of the backstop pass, e.g. a
 	// straggler becoming covered. Called while r.mu is held.
@@ -691,9 +709,14 @@ type fakeRunner struct {
 
 func (r *fakeRunner) ReclaimStale(ctx context.Context) (int, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.reclaimCalls++
-	return 0, r.reclaimErr
+	reclaimErr := r.reclaimErr
+	yieldCancel := r.yieldReclaim
+	r.mu.Unlock()
+	if yieldCancel != nil {
+		yieldCancel(jobctx.ErrYieldedToWaiter)
+	}
+	return 0, reclaimErr
 }
 
 func (r *fakeRunner) RunOnce(ctx context.Context, gen vector.GenerationID) (embed.RunResult, error) {
@@ -704,6 +727,9 @@ func (r *fakeRunner) RunOnce(ctx context.Context, gen vector.GenerationID) (embe
 	res := r.runOnceResult
 	err := r.runErr
 	r.mu.Unlock()
+	if r.yieldCancel != nil {
+		r.yieldCancel(jobctx.ErrYieldedToWaiter)
+	}
 	if ch != nil {
 		r.runDoneOnce.Do(func() { close(ch) })
 	}
@@ -712,13 +738,19 @@ func (r *fakeRunner) RunOnce(ctx context.Context, gen vector.GenerationID) (embe
 
 func (r *fakeRunner) RunBackstop(ctx context.Context, gen vector.GenerationID) (embed.RunResult, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.backstopCalls++
 	r.lastBackstop = gen
 	if r.onBackstop != nil && r.backstopErr == nil {
 		r.onBackstop()
 	}
-	return r.backstopResult, r.backstopErr
+	backstopErr := r.backstopErr
+	backstopResult := r.backstopResult
+	yieldCancel := r.yieldBackstop
+	r.mu.Unlock()
+	if yieldCancel != nil {
+		yieldCancel(jobctx.ErrYieldedToWaiter)
+	}
+	return backstopResult, backstopErr
 }
 
 func (r *fakeRunner) calls() (reclaim, run int, lastGen vector.GenerationID) {
@@ -734,6 +766,268 @@ func (r *fakeRunner) backstops() (n int, lastGen vector.GenerationID) {
 }
 
 // ---------- EmbedJob tests ----------
+
+func TestEmbedJob_Run_YieldedCleanRunStopsBeforeCompletionWork(t *testing.T) {
+	assert := assert.New(t)
+	building := &vector.Generation{ID: 77, State: vector.GenerationBuilding, Fingerprint: "m:768"}
+	backend := &fakeBackend{activeErr: vector.ErrNoActiveGeneration, building: building}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	runner := &fakeRunner{yieldCancel: cancel}
+	coverage := &fakeCoverage{}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:      runner,
+		Backend:     backend,
+		Store:       coverage,
+		Fingerprint: "m:768",
+		Log:         slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(ctx)
+
+	_, run, _ := runner.calls()
+	assert.Equal(1, run, "RunOnce calls")
+	n, _ := runner.backstops()
+	assert.Equal(0, n, "RunBackstop calls")
+	assert.Equal(0, coverage.calls, "coverage queries")
+	assert.Empty(backend.activations(), "activation calls")
+	assert.NotContains(logs.String(), "embed run complete", "yield must not log completion")
+}
+
+func TestEmbedJob_Run_YieldedReclaimStopsWithoutWarning(t *testing.T) {
+	assert := assert.New(t)
+	backend := &fakeBackend{active: vector.Generation{ID: 5, State: vector.GenerationActive}}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	runner := &fakeRunner{
+		reclaimErr:   errors.New("reclaim operation failed"),
+		yieldReclaim: cancel,
+	}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:  runner,
+		Backend: backend,
+		Log:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(ctx)
+
+	_, run, _ := runner.calls()
+	assert.Equal(0, run, "RunOnce calls after yielded reclaim")
+	assert.NotContains(logs.String(), "embed reclaim failed", "yield must not log a reclaim warning")
+}
+
+func TestEmbedJob_Run_YieldedBuildingLookupStopsWithoutWarning(t *testing.T) {
+	assert := assert.New(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	runner := &fakeRunner{}
+	backend := &fakeBackend{
+		buildErr:      errors.New("building lookup failed"),
+		yieldBuilding: cancel,
+	}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:  runner,
+		Backend: backend,
+		Log:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(ctx)
+
+	_, run, _ := runner.calls()
+	assert.Equal(0, run, "RunOnce calls after yielded building lookup")
+	assert.NotContains(logs.String(), "building generation lookup failed", "yield must not log a lookup warning")
+}
+
+func TestEmbedJob_Run_YieldedActiveLookupStopsWithoutWarning(t *testing.T) {
+	assert := assert.New(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	runner := &fakeRunner{}
+	backend := &fakeBackend{
+		activeErr:   errors.New("active lookup failed"),
+		yieldActive: cancel,
+	}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:  runner,
+		Backend: backend,
+		Log:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(ctx)
+
+	_, run, _ := runner.calls()
+	assert.Equal(0, run, "RunOnce calls after yielded active lookup")
+	assert.NotContains(logs.String(), "active generation lookup failed", "yield must not log a lookup warning")
+}
+
+func TestEmbedJob_Run_YieldedBackstopStopsBeforeActivationWork(t *testing.T) {
+	assert := assert.New(t)
+	building := &vector.Generation{ID: 77, State: vector.GenerationBuilding, Fingerprint: "m:768"}
+	backend := &fakeBackend{activeErr: vector.ErrNoActiveGeneration, building: building}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	runner := &fakeRunner{yieldBackstop: cancel}
+	coverage := &fakeCoverage{}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:      runner,
+		Backend:     backend,
+		Store:       coverage,
+		Fingerprint: "m:768",
+		Log:         slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(ctx)
+
+	_, run, _ := runner.calls()
+	assert.Equal(1, run, "RunOnce calls")
+	n, _ := runner.backstops()
+	assert.Equal(1, n, "RunBackstop calls")
+	assert.Equal(0, coverage.calls, "coverage queries after yielded backstop")
+	assert.Empty(backend.activations(), "activation calls after yielded backstop")
+	assert.Contains(logs.String(), "embed run complete", "RunOnce completion is logged before backstop")
+	assert.NotContains(logs.String(), "embed backstop failed", "yield is not a backstop failure")
+	assert.NotContains(logs.String(), "building generation activated", "yield must stop activation")
+}
+
+func TestEmbedJob_Run_YieldedCoverageStopsBeforeActivation(t *testing.T) {
+	assert := assert.New(t)
+	building := &vector.Generation{ID: 77, State: vector.GenerationBuilding, Fingerprint: "m:768"}
+	backend := &fakeBackend{activeErr: vector.ErrNoActiveGeneration, building: building}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	coverage := &fakeCoverage{missing: 0, yieldCancel: cancel}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:      &fakeRunner{},
+		Backend:     backend,
+		Store:       coverage,
+		Fingerprint: "m:768",
+		Log:         slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(ctx)
+
+	assert.Equal(1, coverage.calls, "coverage queries")
+	assert.Empty(backend.activations(), "activation calls after yielded coverage")
+	assert.NotContains(logs.String(), "embed: building generation activated", "yield must stop activation logging")
+}
+
+func TestEmbedJob_Run_YieldedActivationStopsWithoutWarningOrCompletion(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		activateErr error
+	}{
+		{name: "error", activateErr: errors.New("activation operation failed")},
+		{name: "success"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			building := &vector.Generation{ID: 77, State: vector.GenerationBuilding, Fingerprint: "m:768"}
+			ctx, cancel := context.WithCancelCause(context.Background())
+			t.Cleanup(func() { cancel(nil) })
+			backend := &fakeBackend{
+				activeErr:     vector.ErrNoActiveGeneration,
+				building:      building,
+				activateErr:   test.activateErr,
+				yieldActivate: cancel,
+			}
+			coverage := &fakeCoverage{missing: 0}
+			var logs bytes.Buffer
+			job := &EmbedJob{
+				Worker:      &fakeRunner{},
+				Backend:     backend,
+				Store:       coverage,
+				Fingerprint: "m:768",
+				Log:         slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+
+			job.Run(ctx)
+
+			assert.Equal([]vector.GenerationID{77}, backend.activations(), "activation calls")
+			assert.NotContains(logs.String(), "embed: activation failed", "yield must not log activation failure")
+			assert.NotContains(logs.String(), "embed: building generation activated", "yield must not log activation completion")
+		})
+	}
+}
+
+func TestEmbedJob_Run_YieldedRunErrorStopsWithoutFailureWork(t *testing.T) {
+	assert := assert.New(t)
+	building := &vector.Generation{ID: 77, State: vector.GenerationBuilding, Fingerprint: "m:768"}
+	backend := &fakeBackend{activeErr: vector.ErrNoActiveGeneration, building: building}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	runner := &fakeRunner{
+		runErr:      errors.New("operation failed"),
+		yieldCancel: cancel,
+	}
+	coverage := &fakeCoverage{}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:      runner,
+		Backend:     backend,
+		Store:       coverage,
+		Fingerprint: "m:768",
+		Log:         slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(ctx)
+
+	_, run, _ := runner.calls()
+	assert.Equal(1, run, "RunOnce calls")
+	n, _ := runner.backstops()
+	assert.Equal(0, n, "RunBackstop calls")
+	assert.Equal(0, coverage.calls, "coverage queries")
+	assert.Empty(backend.activations(), "activation calls")
+	assert.NotContains(logs.String(), "embed run failed", "yield must not log a failure")
+	assert.NotContains(logs.String(), "embed run complete", "yield must not log completion")
+}
+
+func TestEmbedJob_Run_ErrorWithoutYieldLogsFailure(t *testing.T) {
+	assert := assert.New(t)
+	backend := &fakeBackend{active: vector.Generation{ID: 5, State: vector.GenerationActive}}
+	runner := &fakeRunner{runErr: errors.New("operation failed")}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker:  runner,
+		Backend: backend,
+		Log:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(context.Background())
+
+	assert.Contains(logs.String(), "embed run failed", "ordinary errors must log a failure")
+	assert.NotContains(logs.String(), "embed run complete", "failed runs must not log completion")
+}
+
+func TestEmbedJob_MaybeRunBackstop_YieldedCleanRunDoesNotRecordCompletion(t *testing.T) {
+	assert := assert.New(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	runner := &fakeRunner{yieldBackstop: cancel}
+	now := time.Now()
+	job := &EmbedJob{
+		Worker:           runner,
+		BackstopInterval: time.Hour,
+		Now:              func() time.Time { return now },
+	}
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	const gen = vector.GenerationID(5)
+
+	job.maybeRunBackstop(ctx, gen, logger)
+	job.maybeRunBackstop(ctx, gen, logger)
+
+	assert.NotContains(logs.String(), "embed backstop complete", "yield must not log completion")
+	n, _ := runner.backstops()
+	assert.Equal(2, n, "yield must not throttle a retry")
+	_, recorded := job.lastBackstop[gen]
+	assert.False(recorded, "yield must not record lastBackstop")
+}
 
 func TestEmbedJob_Run_ActiveGeneration(t *testing.T) {
 	assert := assert.New(t)
@@ -1152,10 +1446,16 @@ func (c *recoverOnBackstopCoverage) MissingCount(context.Context, int64) (int64,
 // fakeCoverage satisfies EmbedCoverage for the activation-gate tests:
 // it reports a fixed number of live messages still needing embedding.
 type fakeCoverage struct {
-	missing int64
+	missing     int64
+	calls       int
+	yieldCancel context.CancelCauseFunc
 }
 
 func (c *fakeCoverage) MissingCount(_ context.Context, _ int64) (int64, error) {
+	c.calls++
+	if c.yieldCancel != nil {
+		c.yieldCancel(jobctx.ErrYieldedToWaiter)
+	}
 	return c.missing, nil
 }
 

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -226,7 +226,7 @@ func retryAfter(header string, attempt int) time.Duration {
 			return time.Duration(secs) * time.Second
 		}
 	}
-	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second) //nolint:gosec // retry attempts are bounded by the caller
+	return min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
 }
 
 func truncate(b []byte, n int) string {

--- a/internal/taskclient/discovery_posix.go
+++ b/internal/taskclient/discovery_posix.go
@@ -41,7 +41,7 @@ func openSecureRegularFile(path string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open secure file without following links: %w", err)
 	}
-	return os.NewFile(uintptr(fd), filepath.Base(path)), nil //nolint:gosec // successful Unix open returns a non-negative descriptor
+	return os.NewFile(uintptr(fd), filepath.Base(path)), nil
 }
 
 func validateSecureSocket(path string, expectedOwner uint32) error {

--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -122,7 +122,7 @@ func retryAfter(header string, attempt int) time.Duration {
 			return time.Duration(secs) * time.Second
 		}
 	}
-	d := min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second) //nolint:gosec // retry attempts are bounded by the caller
+	d := min(time.Duration(1<<uint(attempt))*time.Second, 60*time.Second)
 	return d
 }
 

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"go.kenn.io/msgvault/internal/jobctx"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 )
@@ -201,6 +202,14 @@ type inputChunk struct {
 // and the next scan re-finds them. Always returns (0, nil).
 func (w *Worker) ReclaimStale(ctx context.Context) (int, error) { return 0, nil }
 
+func (w *Worker) stopIfYielded(ctx context.Context, gen vector.GenerationID) bool {
+	if !jobctx.YieldedToWaiter(ctx) {
+		return false
+	}
+	w.deps.Log.Info("embed run yielded to a waiting operation; stopping", "gen", gen)
+	return true
+}
+
 // startEmbedRun inserts an embed_runs row and returns the new row's id.
 // A failure is non-fatal — run tracking is observability, not correctness.
 func (w *Worker) startEmbedRun(ctx context.Context, gen vector.GenerationID, now int64) int64 {
@@ -212,6 +221,9 @@ func (w *Worker) startEmbedRun(ctx context.Context, gen vector.GenerationID, now
 		w.rebind(`INSERT INTO embed_runs (generation_id, started_at) VALUES (?, ?) RETURNING id`),
 		int64(gen), now).Scan(&id)
 	if err != nil {
+		if jobctx.YieldedToWaiter(ctx) {
+			return 0
+		}
 		w.deps.Log.Warn("embed_runs: start insert failed", "error", err)
 		return 0
 	}
@@ -294,6 +306,9 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 	if !backstop {
 		wm, err := w.wm.GetWatermark(ctx, gen)
 		if err != nil {
+			if w.stopIfYielded(ctx, gen) {
+				return res, nil
+			}
 			// Non-fatal: a missing/unreadable watermark just restarts the
 			// scan from 0 (the scan predicate + idempotent upsert make this
 			// harmless). Log and continue.
@@ -306,11 +321,17 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 
 	for {
 		if err := ctx.Err(); err != nil {
+			if w.stopIfYielded(ctx, gen) {
+				return res, nil
+			}
 			return res, fmt.Errorf("RunOnce: %w", err)
 		}
 		batchStart := time.Now()
 		ids, err := w.scanForEmbedding(ctx, int64(gen), afterID)
 		if err != nil {
+			if w.stopIfYielded(ctx, gen) {
+				return res, nil
+			}
 			return res, fmt.Errorf("scan for embedding: %w", err)
 		}
 		if len(ids) == 0 {
@@ -324,9 +345,11 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 
 		eb, err := w.embedBatch(ctx, ids)
 		if err != nil {
+			if w.stopIfYielded(ctx, gen) {
+				return res, nil
+			}
 			consecutiveFailures++
 			lastErr = err
-			w.deps.Log.Warn("embed batch failed", "gen", gen, "ids", len(ids), "error", err)
 
 			if errors.Is(err, ErrPermanent4xx) {
 				// Walk the scanned ids one at a time. Drain decides per-ID
@@ -336,6 +359,10 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 				w.deps.Log.Info("embed: downshifting to BatchSize=1 to drain failing batch",
 					"gen", gen, "batch_size", len(ids))
 				embedded, embeddedOK, stamped, safeAdvanceID, drainErr := w.downshiftDrain(ctx, gen, ids, &res, &completedRows)
+				if w.stopIfYielded(ctx, gen) {
+					return res, nil
+				}
+				w.deps.Log.Warn("embed batch failed", "gen", gen, "ids", len(ids), "error", err)
 				res.Succeeded += embedded
 				if drainErr != nil {
 					w.deps.Log.Info("embed: downshift drain returned error",
@@ -402,6 +429,7 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 			// Non-4xx error: leave the batch unstamped (next scan re-finds
 			// it) and do not advance the cursor, so the failure cap can
 			// short-circuit the loop on a persistent fault.
+			w.deps.Log.Warn("embed batch failed", "gen", gen, "ids", len(ids), "error", err)
 			res.Failed += len(ids)
 			if consecutiveFailures >= w.deps.MaxConsecutiveFailures {
 				return res, fmt.Errorf("embed worker aborting after %d consecutive failures: %w",
@@ -428,6 +456,9 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 				}
 				missed, serr := w.stampSkipped(ctx, gen, skipIDs, eb.lastModified)
 				if serr != nil {
+					if w.stopIfYielded(ctx, gen) {
+						return res, nil
+					}
 					res.Failed += len(skipIDs)
 					w.deps.Log.Error("stamp skip set failed", "error", serr, "gen", gen, "ids", len(skipIDs))
 					consecutiveFailures++
@@ -461,6 +492,9 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 				w.deps.Log.Info("embed: generation retired mid-run; stopping", "gen", gen)
 				return res, nil
 			}
+			if w.stopIfYielded(ctx, gen) {
+				return res, nil
+			}
 			res.Failed += len(eb.embeddedIDs)
 			w.deps.Log.Error("upsert failed", "gen", gen, "ids", len(eb.embeddedIDs), "error", err)
 			consecutiveFailures++
@@ -482,6 +516,9 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 			var err error
 			skipMissed, err = w.stampSkipped(ctx, gen, skipIDs, eb.lastModified)
 			if err != nil {
+				if w.stopIfYielded(ctx, gen) {
+					return res, nil
+				}
 				res.Failed += len(skipIDs)
 				w.deps.Log.Error("stamp skip set failed", "gen", gen, "ids", len(skipIDs), "error", err)
 				consecutiveFailures++
@@ -498,6 +535,9 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 		// before this stamp just re-does the embedded rows next scan.
 		missed, serr := w.stampCovered(ctx, gen, eb.embeddedIDs, eb.lastModified)
 		if serr != nil {
+			if w.stopIfYielded(ctx, gen) {
+				return res, nil
+			}
 			res.Failed += len(eb.embeddedIDs)
 			w.deps.Log.Error("stamp embed_gen failed", "gen", gen, "ids", len(eb.embeddedIDs), "error", serr)
 			consecutiveFailures++
@@ -576,6 +616,9 @@ func (w *Worker) advanceWatermark(ctx context.Context, gen vector.GenerationID, 
 		return
 	}
 	if err := w.wm.SetWatermark(ctx, gen, id); err != nil {
+		if jobctx.YieldedToWaiter(ctx) {
+			return
+		}
 		w.deps.Log.Warn("embed: advance watermark failed (non-critical)",
 			"gen", gen, "id", id, "error", err)
 	}
@@ -884,6 +927,9 @@ func (w *Worker) downshiftDrain(
 		batchStart := time.Now()
 		eb, e := w.embedBatch(ctx, []int64{id})
 		if e != nil {
+			if jobctx.YieldedToWaiter(ctx) {
+				return embedded, embeddedOK, stamped, contiguousStampedID, e
+			}
 			if errors.Is(e, ErrPermanent4xx) {
 				maps.Copy(lm, eb.lastModified)
 				// Defer the drop decision. See function-level comment. A
@@ -913,6 +959,9 @@ func (w *Worker) downshiftDrain(
 			if len(skip) > 0 {
 				missed, serr := w.stampSkipped(ctx, gen, skip, eb.lastModified)
 				if serr != nil {
+					if jobctx.YieldedToWaiter(ctx) {
+						return embedded, embeddedOK, stamped, contiguousStampedID, serr
+					}
 					res.Failed += len(skip)
 					return embedded, embeddedOK, stamped, contiguousStampedID, fmt.Errorf("stamp skip: %w", serr)
 				}
@@ -961,6 +1010,9 @@ func (w *Worker) downshiftDrain(
 		embeddedOK++
 		missed, serr := w.stampCovered(ctx, gen, eb.embeddedIDs, eb.lastModified)
 		if serr != nil {
+			if jobctx.YieldedToWaiter(ctx) {
+				return embedded, embeddedOK, stamped, contiguousStampedID, serr
+			}
 			return embedded, embeddedOK, stamped, contiguousStampedID, fmt.Errorf("stamp embed_gen: %w", serr)
 		}
 		w.logCASMisses(gen, missed)
@@ -1008,6 +1060,9 @@ func (w *Worker) downshiftDrain(
 		// CAS-missed its stamp still proves the endpoint is healthy, and must
 		// not let a genuine 4xx sibling be misclassified as an all-drop.
 		// Stamp the deferred 4xxs so they drop out of future scans.
+		if jobctx.YieldedToWaiter(ctx) {
+			return embedded, embeddedOK, stamped, contiguousStampedID, nil
+		}
 		for _, id := range deferredDrops {
 			w.deps.Log.Warn("stamping (dropping) message after singleton 4xx",
 				"gen", gen, "id", id, "error", lastDeferredErr)
@@ -1018,6 +1073,9 @@ func (w *Worker) downshiftDrain(
 		// deletes stale vectors only for rows whose drop stamp actually landed.
 		missed, serr := w.stampSkipped(ctx, gen, deferredDrops, lm)
 		if serr != nil {
+			if jobctx.YieldedToWaiter(ctx) {
+				return embedded, embeddedOK, stamped, contiguousStampedID, serr
+			}
 			res.Failed += len(deferredDrops)
 			// Some deferred drops are now unstamped; do not advance past the
 			// contiguous-stamped prefix.

--- a/internal/vector/embed/worker_test.go
+++ b/internal/vector/embed/worker_test.go
@@ -4,8 +4,10 @@ package embed
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -13,8 +15,58 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/msgvault/internal/jobctx"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 )
+
+type yieldingBackend struct {
+	vector.Backend
+
+	cancel context.CancelCauseFunc
+}
+
+func (b *yieldingBackend) Upsert(context.Context, vector.GenerationID, []vector.Chunk) error {
+	b.cancel(jobctx.ErrYieldedToWaiter)
+	return errors.New("SQL logic error")
+}
+
+type yieldingEmbedClient struct {
+	EmbeddingClient
+
+	cancel context.CancelCauseFunc
+}
+
+func (c *yieldingEmbedClient) Embed(context.Context, []string) ([][]float32, error) {
+	c.cancel(jobctx.ErrYieldedToWaiter)
+	return nil, errors.New("embedding operation failed")
+}
+
+type yieldingStampStore struct {
+	WorkStore
+
+	cancel context.CancelCauseFunc
+}
+
+func (s *yieldingStampStore) SetEmbedGenIfUnchanged(context.Context, []store.EmbedGenStamp, int64) ([]int64, error) {
+	s.cancel(jobctx.ErrYieldedToWaiter)
+	return nil, errors.New("stamp operation failed")
+}
+
+type captureLogHandler struct {
+	records []slog.Record
+}
+
+func (h *captureLogHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureLogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *captureLogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *captureLogHandler) WithGroup(string) slog.Handler { return h }
 
 // newTestWorker builds a Worker over the fixture with the given batch
 // size and any extra deps overrides applied via the mutate callback.
@@ -99,6 +151,116 @@ func TestWorker_AbortsAfterConsecutiveFailures(t *testing.T) {
 	assert.Equal(0, res.Succeeded, "nothing should succeed")
 	assert. // All messages left unstamped (next scan re-finds them).
 		Equal(10, countMissing(t, f.MainDB, int64(f.BuildingGen)), "still missing")
+}
+
+func TestWorker_YieldCancellationDuringUpsertStopsCleanly(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newWorkerFixture(t, 1)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	logs := &captureLogHandler{}
+	w := NewWorker(WorkerDeps{
+		Backend:                &yieldingBackend{Backend: f.Backend, cancel: cancel},
+		VectorsDB:              f.VectorsDB,
+		MainDB:                 f.MainDB,
+		Store:                  f.Store,
+		Client:                 f.FakeClient,
+		BatchSize:              1,
+		MaxConsecutiveFailures: 1,
+		Log:                    slog.New(logs),
+	})
+
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	require.NoError(err, "yield cancellation must stop cleanly")
+	assert.Equal(1, res.Claimed, "Claimed")
+	assert.Equal(0, res.Succeeded, "Succeeded")
+	assert.Equal(0, res.Failed, "Failed")
+	assert.Equal(1, countMissing(t, f.MainDB, int64(f.BuildingGen)), "row remains unstamped")
+	var embedGen sql.NullInt64
+	require.NoError(f.MainDB.QueryRow(`SELECT embed_gen FROM messages WHERE id = 1`).Scan(&embedGen))
+	assert.False(embedGen.Valid, "row remains unstamped")
+	assert.Equal(int64(0), readWatermark(t, f.VectorsDB, int64(f.BuildingGen)), "watermark does not advance")
+	for _, record := range logs.records {
+		assert.NotEqual(slog.LevelWarn, record.Level, "yield must not log a warning: %q", record.Message)
+		assert.NotEqual(slog.LevelError, record.Level, "yield must not log an error: %q", record.Message)
+	}
+
+	healthy := newTestWorker(f, 1)
+	res, err = healthy.RunOnce(context.Background(), f.BuildingGen)
+	require.NoError(err, "healthy worker retry")
+	assert.Equal(1, res.Succeeded, "healthy worker succeeds")
+	assert.Equal(0, countMissing(t, f.MainDB, int64(f.BuildingGen)), "row stamped after retry")
+}
+
+func TestWorker_YieldCancellationDuringEmbedStopsCleanly(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newWorkerFixture(t, 1)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	logs := &captureLogHandler{}
+	w := NewWorker(WorkerDeps{
+		Backend:                f.Backend,
+		VectorsDB:              f.VectorsDB,
+		MainDB:                 f.MainDB,
+		Store:                  f.Store,
+		Client:                 &yieldingEmbedClient{EmbeddingClient: f.FakeClient, cancel: cancel},
+		BatchSize:              1,
+		MaxConsecutiveFailures: 1,
+		Log:                    slog.New(logs),
+	})
+
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	require.NoError(err, "yield cancellation during embed must stop cleanly")
+	assert.Equal(1, res.Claimed, "Claimed")
+	assert.Equal(0, res.Succeeded, "Succeeded")
+	assert.Equal(0, res.Failed, "Failed")
+	assert.Equal(1, countMissing(t, f.MainDB, int64(f.BuildingGen)), "row remains unstamped")
+	for _, record := range logs.records {
+		assert.NotEqual(slog.LevelWarn, record.Level, "yield must not log a warning: %q", record.Message)
+		assert.NotEqual(slog.LevelError, record.Level, "yield must not log an error: %q", record.Message)
+	}
+}
+
+func TestWorker_YieldCancellationDuringDownshiftStampLogsOnce(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newWorkerFixture(t, 2)
+	f.FakeClient.OnEmbed = func(inputs []string) ([][]float32, error) {
+		if len(inputs) > 1 {
+			return nil, fmt.Errorf("batch rejected: %w", ErrPermanent4xx)
+		}
+		return [][]float32{make([]float32, f.FakeClient.dim)}, nil
+	}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	logs := &captureLogHandler{}
+	w := NewWorker(WorkerDeps{
+		Backend:                f.Backend,
+		VectorsDB:              f.VectorsDB,
+		MainDB:                 f.MainDB,
+		Store:                  &yieldingStampStore{WorkStore: f.Store, cancel: cancel},
+		Client:                 f.FakeClient,
+		BatchSize:              2,
+		MaxConsecutiveFailures: 1,
+		Log:                    slog.New(logs),
+	})
+
+	res, err := w.RunOnce(ctx, f.BuildingGen)
+	require.NoError(err, "yield cancellation during downshift stamp must stop cleanly")
+	assert.Equal(0, res.Failed, "Failed")
+	yieldInfo := 0
+	for _, record := range logs.records {
+		assert.NotEqual(slog.LevelWarn, record.Level, "yield must not log a warning: %q", record.Message)
+		assert.NotEqual(slog.LevelError, record.Level, "yield must not log an error: %q", record.Message)
+	}
+	for _, record := range logs.records {
+		if record.Level == slog.LevelInfo && record.Message == "embed run yielded to a waiting operation; stopping" {
+			yieldInfo++
+		}
+	}
+	assert.Equal(1, yieldInfo, "yield stop is logged once")
 }
 
 // TestWorker_FailureLeavesUnstampedThenRecovers: a transient failure on


### PR DESCRIPTION
## What changed

- Treat scheduler yield cancellation as benign embed-worker control flow before failure accounting, error logging, stamping, or watermark advancement.
- Share the yield sentinel through a neutral job-context package so the scheduler and embed worker keep one cancellation identity without an import cycle.
- Stop yielded scheduled embed jobs at each operation boundary before completion logging, backstop throttling, coverage checks, or generation activation.
- Restore the pinned linter baseline by removing stale suppressions and keeping the remaining security suppressions narrow and explicit.

## Why

When the scheduler yielded an embed job during a vector upsert, the SQLite driver could return a generic SQL error instead of `context.Canceled`. The worker then counted expected cooperative preemption as a failed batch and could abort an otherwise healthy run under sustained gate pressure.

The current `main` branch also failed its pinned lint gate on stale suppressions and three intentional HTTP patterns. That blocked the required CI rerun for this fix, so this branch includes the minimum behavior-preserving lint cleanup.

## Usage

No usage change.

Closes #578
