### PR TITLE
fix: restore clean lint on main

### DIFF
--- a/internal/taskclient/peer_darwin.go
+++ b/internal/taskclient/peer_darwin.go
@@ -24,7 +24,7 @@ func verifyPeerCredentials(conn net.Conn, expectedOwner uint32) error {
 		return fmt.Errorf("%w: Unix peer credential handle unavailable", ErrInsecureEndpoint)
 	}
 	err = raw.Control(func(fd uintptr) {
-		credential, socketErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED) //nolint:gosec // Darwin's socket API uses an int descriptor
+		credential, socketErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
 	})
 	if err != nil || socketErr != nil || credential == nil || credential.Uid != expectedOwner {
 		return fmt.Errorf("%w: Unix peer credential mismatch", ErrInsecureEndpoint)


### PR DESCRIPTION
The pinned golangci-lint v2.12.2 run on main is failing on stale security suppressions, session-cookie security checks, a test redirect false positive, and a repeated view-type value.

This PR removes the stale suppressions, documents the two intentional security exceptions, and names the shared labels view type so main passes lint again.