### PR TITLE
fix(store): repair dangling recipients during upgrade

### DIFF
--- a/internal/store/migrate_recipient_envelope.go
+++ b/internal/store/migrate_recipient_envelope.go
@@ -3,9 +3,19 @@ package store
 import (
 	"context"
 	"fmt"
+	"log/slog"
 )
 
 const migrationRecipientEnvelopeUnique = "message_recipients_envelope_unique_index"
+
+type recipientOrphanCleanup struct {
+	missingMessageRows     int64
+	missingParticipantRows int64
+}
+
+func (c recipientOrphanCleanup) total() int64 {
+	return c.missingMessageRows + c.missingParticipantRows
+}
 
 // ensureRecipientEnvelopeUniqueIndex relaxes message_recipients uniqueness
 // from (message_id, participant_id, recipient_type) to that triple plus the
@@ -39,13 +49,18 @@ func (s *Store) ensureRecipientEnvelopeUniqueIndex(ctx context.Context) error {
 	return s.runOnceMigration(
 		ctx, migrationRecipientEnvelopeUnique, false,
 		func(ctx context.Context) error {
-			return s.runMaintenance(ctx, func(ctx context.Context, tx *loggedTx) error {
+			var cleanup recipientOrphanCleanup
+			if err := s.runMaintenance(ctx, func(ctx context.Context, tx *loggedTx) error {
 				if s.IsPostgreSQL() {
 					if err := dropRecipientTableUniqueConstraintsPG(ctx, tx); err != nil {
 						return err
 					}
-				} else if err := rebuildRecipientTableWithoutUniqueSQLite(ctx, tx); err != nil {
-					return err
+				} else {
+					var err error
+					cleanup, err = rebuildRecipientTableWithoutUniqueSQLite(ctx, tx)
+					if err != nil {
+						return err
+					}
 				}
 				if _, err := tx.ExecContext(ctx, `
 					CREATE UNIQUE INDEX IF NOT EXISTS idx_message_recipients_envelope
@@ -55,7 +70,17 @@ func (s *Store) ensureRecipientEnvelopeUniqueIndex(ctx context.Context) error {
 					return fmt.Errorf("create idx_message_recipients_envelope: %w", err)
 				}
 				return nil
-			})
+			}); err != nil {
+				return err
+			}
+			if cleanup.total() > 0 {
+				slog.Warn("removed dangling message recipients during schema migration",
+					"table", "message_recipients",
+					"missing_message_rows", cleanup.missingMessageRows,
+					"missing_participant_rows", cleanup.missingParticipantRows,
+				)
+			}
+			return nil
 		},
 	)
 }
@@ -111,9 +136,15 @@ func dropRecipientTableUniqueConstraintsPG(ctx context.Context, tx *loggedTx) er
 // at it, so DROP TABLE plus RENAME inside the transaction is a complete
 // swap; only the two plain indexes the DROP took along need recreating (the
 // unique index is built by the caller for the rebuilt and fresh paths
-// alike). The whole-table copy writes the table once through the WAL — a
-// one-time upgrade cost on the order of the table's size.
-func rebuildRecipientTableWithoutUniqueSQLite(ctx context.Context, tx *loggedTx) error {
+// alike). Before the FK-checked copy, dangling legacy rows are removed. Rows
+// missing messages go first so a row missing both parents is counted once,
+// under the missing-message category. The whole-table copy writes the table
+// once through the WAL — a one-time upgrade cost on the order of the table's
+// size.
+func rebuildRecipientTableWithoutUniqueSQLite(
+	ctx context.Context,
+	tx *loggedTx,
+) (recipientOrphanCleanup, error) {
 	var hasTableUnique bool
 	if err := tx.QueryRowContext(ctx, `
 		SELECT EXISTS (
@@ -123,10 +154,43 @@ func rebuildRecipientTableWithoutUniqueSQLite(ctx context.Context, tx *loggedTx)
 			  AND name LIKE 'sqlite_autoindex%'
 		)
 	`).Scan(&hasTableUnique); err != nil {
-		return fmt.Errorf("check message_recipients table-level unique: %w", err)
+		return recipientOrphanCleanup{}, fmt.Errorf(
+			"check message_recipients table-level unique: %w", err,
+		)
 	}
 	if !hasTableUnique {
-		return nil
+		return recipientOrphanCleanup{}, nil
+	}
+
+	cleanup := recipientOrphanCleanup{}
+	result, err := tx.ExecContext(ctx, `
+		DELETE FROM message_recipients
+		WHERE NOT EXISTS (
+			SELECT 1 FROM messages
+			WHERE messages.id = message_recipients.message_id
+		)
+	`)
+	if err != nil {
+		return cleanup, fmt.Errorf("remove recipients missing messages: %w", err)
+	}
+	cleanup.missingMessageRows, err = result.RowsAffected()
+	if err != nil {
+		return cleanup, fmt.Errorf("count recipients missing messages: %w", err)
+	}
+
+	result, err = tx.ExecContext(ctx, `
+		DELETE FROM message_recipients
+		WHERE NOT EXISTS (
+			SELECT 1 FROM participants
+			WHERE participants.id = message_recipients.participant_id
+		)
+	`)
+	if err != nil {
+		return cleanup, fmt.Errorf("remove recipients missing participants: %w", err)
+	}
+	cleanup.missingParticipantRows, err = result.RowsAffected()
+	if err != nil {
+		return cleanup, fmt.Errorf("count recipients missing participants: %w", err)
 	}
 
 	for _, stmt := range []string{
@@ -151,8 +215,10 @@ func rebuildRecipientTableWithoutUniqueSQLite(ctx context.Context, tx *loggedTx)
 			ON message_recipients(participant_id, recipient_type)`,
 	} {
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("rebuild message_recipients without table-level unique: %w", err)
+			return cleanup, fmt.Errorf(
+				"rebuild message_recipients without table-level unique: %w", err,
+			)
 		}
 	}
-	return nil
+	return cleanup, nil
 }

--- a/internal/store/migrate_recipient_envelope_test.go
+++ b/internal/store/migrate_recipient_envelope_test.go
@@ -2,11 +2,14 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/sqliteutil"
 )
 
 // TestEnsureRecipientEnvelopeUniqueIndex_LegacyTableRebuild simulates an
@@ -147,6 +150,157 @@ func TestEnsureRecipientEnvelopeUniqueIndex_LegacyTableRebuild(t *testing.T) {
 		`SELECT COUNT(*) FROM message_recipients WHERE message_id = ?`, msgID,
 	).Scan(&rowCount), "count recipient rows")
 	assert.Equal(2, rowCount, "no-op rerun must not change row count")
+}
+
+func TestInitSchema_RepairsDanglingLegacyRecipients(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbPath := filepath.Join(t.TempDir(), "dangling_recipients.db")
+
+	seed, err := Open(dbPath)
+	require.NoError(err, "open seed archive")
+	require.NoError(seed.InitSchema(), "initialize seed archive")
+	source, err := seed.GetOrCreateSource("gmail", "owner@example.test")
+	require.NoError(err, "create source")
+	conversationID, err := seed.EnsureConversation(source.ID, "thread-dangling-recipients", "")
+	require.NoError(err, "create conversation")
+	messageID, err := seed.UpsertMessage(&Message{
+		ConversationID:  conversationID,
+		SourceID:        source.ID,
+		SourceMessageID: "msg-dangling-recipients",
+		MessageType:     "email",
+		SizeEstimate:    100,
+	})
+	require.NoError(err, "create message")
+	participantID, err := seed.EnsureParticipant(
+		"primary@example.test", "Primary", "example.test",
+	)
+	require.NoError(err, "create participant")
+
+	var validRecipientID int64
+	require.NoError(seed.db.QueryRow(`
+		INSERT INTO message_recipients
+			(message_id, participant_id, recipient_type, display_name, email_address)
+		VALUES (?, ?, 'to', 'Primary', 'primary@example.test')
+		RETURNING id
+	`, messageID, participantID).Scan(&validRecipientID), "create valid recipient")
+	require.NoError(seed.Close(), "close seed archive")
+
+	legacy, err := sql.Open(
+		sqliteutil.DriverName(), dbPath+"?_foreign_keys=OFF",
+	)
+	require.NoError(err, "open legacy archive with FK enforcement disabled")
+	for _, stmt := range []string{
+		`DELETE FROM applied_migrations
+		 WHERE name = 'message_recipients_envelope_unique_index'`,
+		`DROP INDEX IF EXISTS idx_message_recipients_envelope`,
+		`ALTER TABLE message_recipients RENAME TO message_recipients_current`,
+		`CREATE TABLE message_recipients (
+			id INTEGER PRIMARY KEY,
+			message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+			participant_id INTEGER NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+			recipient_type TEXT NOT NULL,
+			display_name TEXT,
+			email_address TEXT,
+			UNIQUE(message_id, participant_id, recipient_type)
+		)`,
+		`INSERT INTO message_recipients
+			(id, message_id, participant_id, recipient_type, display_name, email_address)
+		 SELECT id, message_id, participant_id, recipient_type, display_name, email_address
+		 FROM message_recipients_current`,
+		`DROP TABLE message_recipients_current`,
+	} {
+		_, err = legacy.Exec(stmt)
+		require.NoError(err, "restore legacy recipient schema: %q", stmt)
+	}
+
+	missingMessageID := messageID + 1000
+	missingParticipantID := participantID + 1000
+	for _, recipient := range []struct {
+		id            int64
+		messageID     int64
+		participantID int64
+	}{
+		{id: 9101, messageID: missingMessageID, participantID: participantID},
+		{id: 9102, messageID: messageID, participantID: missingParticipantID},
+		{id: 9103, messageID: missingMessageID + 1, participantID: missingParticipantID + 1},
+	} {
+		_, err = legacy.Exec(`
+			INSERT INTO message_recipients
+				(id, message_id, participant_id, recipient_type, display_name, email_address)
+			VALUES (?, ?, ?, 'to', 'Dangling', NULL)
+		`, recipient.id, recipient.messageID, recipient.participantID)
+		require.NoError(err, "create dangling recipient %d", recipient.id)
+	}
+	require.NoError(legacy.Close(), "close legacy archive")
+
+	logs := captureSlog(t)
+	upgraded, err := Open(dbPath)
+	require.NoError(err, "open legacy archive for upgrade")
+	t.Cleanup(func() { _ = upgraded.Close() })
+	require.NoError(upgraded.InitSchema(), "upgrade archive with dangling recipients")
+
+	var (
+		gotMessageID     int64
+		gotParticipantID int64
+		gotDisplayName   string
+		gotEmailAddress  string
+	)
+	require.NoError(upgraded.db.QueryRow(`
+		SELECT message_id, participant_id, display_name, email_address
+		FROM message_recipients
+		WHERE id = ?
+	`, validRecipientID).Scan(
+		&gotMessageID, &gotParticipantID, &gotDisplayName, &gotEmailAddress,
+	), "read preserved recipient")
+	assert.Equal(messageID, gotMessageID)
+	assert.Equal(participantID, gotParticipantID)
+	assert.Equal("Primary", gotDisplayName)
+	assert.Equal("primary@example.test", gotEmailAddress)
+
+	var danglingCount int
+	require.NoError(upgraded.db.QueryRow(`
+		SELECT COUNT(*) FROM message_recipients WHERE id IN (9101, 9102, 9103)
+	`).Scan(&danglingCount), "count dangling recipients")
+	assert.Zero(danglingCount)
+
+	var autoindexCount int
+	require.NoError(upgraded.db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'index'
+		  AND tbl_name = 'message_recipients'
+		  AND name LIKE 'sqlite_autoindex%'
+	`).Scan(&autoindexCount), "count legacy autoindexes")
+	assert.Zero(autoindexCount)
+	for _, index := range []string{
+		"idx_message_recipients_message",
+		"idx_message_recipients_participant",
+		"idx_message_recipients_envelope",
+	} {
+		var indexCount int
+		require.NoError(upgraded.db.QueryRow(`
+			SELECT COUNT(*) FROM sqlite_master
+			WHERE type = 'index' AND tbl_name = 'message_recipients' AND name = ?
+		`, index).Scan(&indexCount), "count index %s", index)
+		assert.Equal(1, indexCount, "index %s", index)
+	}
+
+	fkRows, err := upgraded.db.Query(`PRAGMA foreign_key_check`)
+	require.NoError(err, "check foreign keys")
+	require.False(fkRows.Next(), "upgraded archive must have no FK violations")
+	require.NoError(fkRows.Err(), "iterate FK violations")
+	require.NoError(fkRows.Close(), "close FK check")
+
+	logOutput := logs.String()
+	assert.Contains(logOutput, `"msg":"removed dangling message recipients during schema migration"`)
+	assert.Contains(logOutput, `"table":"message_recipients"`)
+	assert.Contains(logOutput, `"missing_message_rows":2`)
+	assert.Contains(logOutput, `"missing_participant_rows":1`)
+
+	require.NoError(upgraded.InitSchema(), "repeat schema initialization")
+	assert.Equal(1, strings.Count(
+		logs.String(), "removed dangling message recipients during schema migration",
+	), "cleanup warning must be emitted only for the repairing run")
 }
 
 // TestEnsureRecipientEnvelopeUniqueIndex_PGLegacyConstraintDrop simulates an


### PR DESCRIPTION
## Why

SQLite archives can contain historical `message_recipients` rows whose message or participant parent no longer exists. The 0.19 envelope migration copies every legacy recipient into a replacement table under foreign-key enforcement, so one latent violation prevents schema initialization and blocks the daemon and every archive-opening command.

## Behavior

On the legacy SQLite rebuild path, remove only recipient relationships with missing parents inside the existing atomic maintenance transaction. Valid rows retain their IDs and values, both foreign keys remain enforced, and the migration reports separate missing-message and missing-participant counts without exposing archived identifiers.

Fresh and already-migrated SQLite archives remain no-ops, and PostgreSQL behavior is unchanged.

Fixes #581.