### PR TITLE
fix(serve): start API before analytics cache build

### DIFF
--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -333,6 +333,12 @@ func runBuildCacheHTTP(cmd *cobra.Command, fullRebuild bool) error {
 					"the daemon is running with live SQL\nLogs: %s",
 				info.DaemonLogPath,
 			)
+		case startupCacheBuildOutcomeFatal:
+			return fmt.Errorf(
+				"analytics cache build failed during required DuckDB initialization; "+
+					"the daemon is shutting down\nLogs: %s",
+				info.DaemonLogPath,
+			)
 		case startupCacheBuildOutcomeNone, startupCacheBuildOutcomeUnconsumed:
 		}
 	}

--- a/cmd/msgvault/cmd/build_cache_http_test.go
+++ b/cmd/msgvault/cmd/build_cache_http_test.go
@@ -68,6 +68,32 @@ func TestBuildCacheAutostartFailedReturnsErrorWithoutRetry(t *testing.T) {
 	assert.Zero(t, requests.Load())
 }
 
+func TestBuildCacheAutostartFatalDuckDBFailureDoesNotReportSQLFallback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	logPath := filepath.Join(t.TempDir(), "serve.log")
+	stubBuildCacheDaemonAutostart(t, server, startupCacheBuildOutcomeFatal, &logPath)
+
+	cmd, _ := buildCacheHTTPTestCommand()
+	var err error
+	captureStderrDuring(t, func() {
+		err = runBuildCacheHTTP(cmd, false)
+	})
+
+	require.Error(err)
+	assert.Contains(err.Error(), "required DuckDB initialization")
+	assert.Contains(err.Error(), "daemon is shutting down")
+	assert.NotContains(err.Error(), "live SQL")
+	assert.Contains(err.Error(), logPath)
+	assert.Zero(requests.Load())
+}
+
 func TestBuildCacheAutostartUnconsumedUsesHTTPRequest(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/msgvault/cmd/cache_startup.go
+++ b/cmd/msgvault/cmd/cache_startup.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"go.kenn.io/kit/daemon"
 )
 
 const daemonStartupCacheBuildEnv = "MSGVAULT_DAEMON_STARTUP_CACHE_BUILD"
@@ -22,6 +26,7 @@ const (
 	startupCacheBuildOutcomeNone       startupCacheBuildOutcome = ""
 	startupCacheBuildOutcomeFulfilled  startupCacheBuildOutcome = "fulfilled"
 	startupCacheBuildOutcomeFailed     startupCacheBuildOutcome = "failed"
+	startupCacheBuildOutcomeFatal      startupCacheBuildOutcome = "fatal"
 	startupCacheBuildOutcomeUnconsumed startupCacheBuildOutcome = "unconsumed"
 )
 
@@ -63,4 +68,78 @@ func startupCacheBuildOutcomeFromRuntime(rt *DaemonRuntime) startupCacheBuildOut
 		return startupCacheBuildOutcomeNone
 	}
 	return startupCacheBuildOutcome(rt.Record.Metadata[runtimeStartupCacheBuildOutcome])
+}
+
+// durableStartupCacheBuildOutcomePath identifies the one-shot result for an
+// exact daemon process. A fatal required-DuckDB failure shuts the daemon down,
+// so its normal runtime record can disappear before the parent polls again.
+func durableStartupCacheBuildOutcomePath(dataDir string, rec daemon.RuntimeRecord) string {
+	return filepath.Join(dataDir, fmt.Sprintf(
+		".daemon.%d.%d.startup-cache-outcome",
+		rec.PID, rec.StartedAt.UnixNano(),
+	))
+}
+
+func writeDurableStartupCacheBuildOutcome(
+	dataDir string,
+	rec daemon.RuntimeRecord,
+	outcome startupCacheBuildOutcome,
+) error {
+	path := durableStartupCacheBuildOutcomePath(dataDir, rec)
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".startup-cache-outcome-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create startup cache outcome: %w", err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure startup cache outcome: %w", err)
+	}
+	if _, err := tmp.WriteString(string(outcome) + "\n"); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write startup cache outcome: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync startup cache outcome: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close startup cache outcome: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("publish startup cache outcome: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func consumeDurableStartupCacheBuildOutcome(
+	dataDir string,
+	rec daemon.RuntimeRecord,
+) (startupCacheBuildOutcome, bool, error) {
+	path := durableStartupCacheBuildOutcomePath(dataDir, rec)
+	body, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return startupCacheBuildOutcomeNone, false, nil
+	}
+	if err != nil {
+		return startupCacheBuildOutcomeNone, false,
+			fmt.Errorf("read startup cache outcome: %w", err)
+	}
+	outcome := startupCacheBuildOutcome(strings.TrimSpace(string(body)))
+	if outcome != startupCacheBuildOutcomeFatal {
+		return startupCacheBuildOutcomeNone, false,
+			fmt.Errorf("invalid durable startup cache outcome %q", outcome)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return startupCacheBuildOutcomeNone, false,
+			fmt.Errorf("consume startup cache outcome: %w", err)
+	}
+	return outcome, true, nil
 }

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -111,6 +111,9 @@ var runDerivedCacheSubprocess = func(ctx context.Context, analyticsDir string) e
 var (
 	importDiscordSourceForScheduledRun  = importDiscordSource
 	rebuildCacheAfterScheduledSourceRun = rebuildCacheAfterScheduledSync
+	startServeAPIServer                 = func(server *api.Server, listener net.Listener) error {
+		return server.StartOnListener(listener)
+	}
 )
 
 type serveRuntimeAPIServer interface {
@@ -208,7 +211,18 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
-	defer func() { _ = s.Close() }()
+	var analyticsInit *daemonAnalyticsInitHandle
+	var vectorInit *vectorInitHandle
+	resourceCleanupSafe := true
+	defer func() {
+		if !resourceCleanupSafe {
+			logger.Warn("archive database cleanup skipped", "error", "HTTP shutdown did not complete")
+			return
+		}
+		if err := closeDaemonStoreAfterInitializers(s, analyticsInit, vectorInit); err != nil {
+			logger.Warn("archive database cleanup skipped", "error", err)
+		}
+	}()
 	logger.Info("daemon startup step complete", "step", "open_archive_database")
 
 	setStartupPhase("migrating archive schema")
@@ -246,7 +260,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("open attachment maintenance: %w", err)
 	}
-	defer func() { _ = attachmentMaint.close() }()
+	defer func() {
+		if resourceCleanupSafe {
+			_ = attachmentMaint.close()
+		}
+	}()
 	blobStore := attachmentMaint.blob
 
 	// Vector misconfiguration still fails startup fast; the expensive
@@ -266,10 +284,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	engine, analyticsMode, cacheOutcome, engineErr := openDaemonAnalyticsEngine(
-		cmd.Context(), cfg, s, startupCacheIntent,
+	engine, analyticsMode, cacheOutcome, analyticsAsync, engineErr := prepareDaemonAnalyticsEngine(
+		ctx, cfg, s, startupCacheIntent,
 	)
-	if startupCacheIntent != startupCacheBuildIntentNone {
+	if startupCacheIntent != startupCacheBuildIntentNone && !analyticsAsync {
 		if outcomeErr := ownership.SetStartupCacheBuildOutcome(cacheOutcome); outcomeErr != nil {
 			if engine != nil {
 				_ = engine.Close()
@@ -278,10 +296,21 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if engineErr != nil {
+		if engine != nil {
+			_ = engine.Close()
+		}
 		return engineErr
 	}
-	defer func() { _ = engine.Close() }()
-	logger.Info("daemon startup step complete", "step", "init_analytics_engine")
+	initialAnalyticsEngine := engine
+	analyticsServerStarted := false
+	defer func() {
+		if resourceCleanupSafe && !analyticsServerStarted && initialAnalyticsEngine != nil {
+			_ = initialAnalyticsEngine.Close()
+		}
+	}()
+	if !analyticsAsync {
+		logger.Info("daemon startup step complete", "step", "init_analytics_engine")
+	}
 
 	getOAuthMgr := oauthManagerCache()
 
@@ -495,13 +524,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	schedAdapter := &schedulerAdapter{scheduler: sched}
 
 	// Create and start API server
+	var apiServer *api.Server
 	apiOpts := api.ServerOptions{
 		Config:         cfg,
 		Store:          storeAdapter,
 		SavedViewStore: s,
 		Engine:         engine,
 		SQLQueryRunner: func(ctx context.Context, sql string) (*query.QueryResult, error) {
-			return runDaemonSQLQuery(ctx, cfg, s, engine, sql)
+			if apiServer == nil {
+				return nil, errors.New("daemon API server unavailable")
+			}
+			return runDaemonSQLQuery(ctx, cfg, s, apiServer.QueryEngineForRequest(ctx), sql)
 		},
 		ShutdownToken: ownership.shutdownToken,
 		ShutdownFunc:  cancel,
@@ -517,57 +550,98 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if cfg.Vector.Enabled {
 		apiOpts.VectorStatus = api.VectorStatusInitializing
 	}
-	apiServer := api.NewServerWithOptions(apiOpts)
+	apiServer = api.NewServerWithOptions(apiOpts)
 
 	// Start API server in goroutine
 	apiAddr := apiListener.Addr().String()
 	setStartupPhase("")
 	logger.Info("daemon startup step", "step", "start_api_server", "bind", apiAddr)
 	serverErr := make(chan error, 1)
-	listenerReserved = false
 	go func() {
-		if err := apiServer.StartOnListener(apiListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := startServeAPIServer(apiServer, apiListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErr <- err
 		}
 	}()
-	if idleTracker != nil {
-		idleTracker.Touch()
-		go idleTracker.Run(ctx)
-		logger.Info("background daemon idle shutdown enabled", "timeout", cfg.Server.DaemonIdleTimeout)
-	}
-
-	vectorInit := startVectorInit(
-		ctx, s, dbPath,
-		combineWorkTrackers(idleTracker, labelWorkTracker(operationGate, "background embedding work")),
-		apiServer, sched,
-	)
-
-	fmt.Printf("msgvault daemon started\n")
-	fmt.Printf("  API server: http://%s\n", apiAddr)
-	fmt.Printf("  Scheduled accounts: %d\n", count)
-	fmt.Printf("  Data directory: %s\n", cfg.Data.DataDir)
-	fmt.Println()
-	fmt.Println("Press Ctrl+C to stop.")
-	fmt.Println()
-
-	// Print schedule info
-	for _, status := range sched.Status() {
-		fmt.Printf("  %s: next sync at %s\n", status.Email, status.NextRun.Local().Format("2006-01-02 15:04:05"))
-	}
-	fmt.Println()
-
-	// Wait for shutdown signal or server error
 	var serverStartupErr error
-	select {
-	case sig := <-sigChan:
-		logger.Info("received shutdown signal", "signal", sig)
-		fmt.Printf("\nReceived %s, shutting down...\n", sig)
-	case err := <-serverErr:
-		logger.Error("API server error", "error", err)
-		fmt.Printf("\nAPI server error: %v\n", err)
-		serverStartupErr = err
-	case <-ctx.Done():
-		logger.Info("context cancelled")
+	startErr := apiServer.WaitStarted(ctx)
+	if startErr != nil {
+		if ctx.Err() == nil {
+			serverStartupErr = startErr
+		}
+		// A cancelled context may win the readiness wait before the listener
+		// goroutine gets scheduled. Wait for its startup barrier to settle before
+		// shutdown or deferred cleanup can release resources used by startup.
+		if barrierErr := apiServer.WaitStarted(context.Background()); barrierErr != nil && serverStartupErr == nil {
+			serverStartupErr = barrierErr
+		} else if barrierErr == nil {
+			listenerReserved = false
+			resourceCleanupSafe = false
+		}
+		cancel()
+	} else {
+		listenerReserved = false
+		analyticsServerStarted = true
+		resourceCleanupSafe = false
+		if analyticsAsync {
+			analyticsInit = startDaemonAnalyticsInitializer(
+				ctx, cfg, s, startupCacheIntent, apiServer, ownership,
+				combineWorkTrackers(
+					idleTracker,
+					labelWorkTracker(operationGate, "analytics cache initialization"),
+				),
+			)
+		} else {
+			analyticsInit = completedDaemonAnalyticsInitHandle()
+		}
+		// Analytics must acquire the serial mutation gate before vector
+		// initialization can compete for it. This keeps an explicit cache
+		// request from waiting behind a long vector migration or backfill.
+		_ = analyticsInit.WaitStarted(ctx)
+		if idleTracker != nil {
+			idleTracker.Touch()
+			go idleTracker.Run(ctx)
+			logger.Info("background daemon idle shutdown enabled", "timeout", cfg.Server.DaemonIdleTimeout)
+		}
+
+		vectorInit = startVectorInit(
+			ctx, s, dbPath,
+			combineWorkTrackers(idleTracker, labelWorkTracker(operationGate, "background embedding work")),
+			apiServer, sched,
+		)
+
+		fmt.Printf("msgvault daemon started\n")
+		fmt.Printf("  API server: http://%s\n", apiAddr)
+		fmt.Printf("  Scheduled accounts: %d\n", count)
+		fmt.Printf("  Data directory: %s\n", cfg.Data.DataDir)
+		fmt.Println()
+		fmt.Println("Press Ctrl+C to stop.")
+		fmt.Println()
+
+		// Print schedule info
+		for _, status := range sched.Status() {
+			fmt.Printf("  %s: next sync at %s\n", status.Email, status.NextRun.Local().Format("2006-01-02 15:04:05"))
+		}
+		fmt.Println()
+
+		// Wait for shutdown signal or server error
+		select {
+		case sig := <-sigChan:
+			logger.Info("received shutdown signal", "signal", sig)
+			fmt.Printf("\nReceived %s, shutting down...\n", sig)
+		case err := <-serverErr:
+			logger.Error("API server error", "error", err)
+			fmt.Printf("\nAPI server error: %v\n", err)
+			serverStartupErr = err
+		case err := <-analyticsInit.Fatal():
+			if ctx.Err() == nil {
+				logger.Error("analytics initialization error", "error", err)
+				fmt.Printf("\nAnalytics initialization error: %v\n", err)
+				serverStartupErr = err
+				cancel()
+			}
+		case <-ctx.Done():
+			logger.Info("context cancelled")
+		}
 	}
 
 	// Stop background work first: vector init honors ctx, so cancelling
@@ -577,6 +651,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), serveOperationDrainTimeout)
 	defer shutdownCancel()
 	shutdownErr := shutdownServeRuntime(shutdownCtx, cmd.OutOrStdout(), apiServer, sched, operationGate)
+	if shutdownErr == nil {
+		resourceCleanupSafe = true
+	}
 	// Wait for the background vector init regardless of the shutdown
 	// outcome: the deferred s.Close() must not run under a still-running
 	// init goroutine, and vectors.db needs closing whenever init finished.
@@ -584,10 +661,24 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// fresh full drain window — shutdownServeRuntime already consumed part
 	// of it, and `daemon stop` budgets only one drain window before it kills
 	// the daemon (serveStopGraceTimeout).
-	if vectorInit.WaitContext(shutdownCtx) {
-		vectorInit.CloseFeatures()
-	} else {
-		logger.Warn("vector init did not stop within the shutdown drain timeout; skipping vectors.db close")
+	if vectorInit != nil {
+		if vectorInit.WaitContext(shutdownCtx) {
+			if resourceCleanupSafe {
+				vectorInit.CloseFeatures()
+			}
+		} else {
+			logger.Warn("vector init did not stop within the shutdown drain timeout; skipping vectors.db close")
+		}
+	}
+	if analyticsInit != nil {
+		analyticsReady := analyticsInit.WaitContext(shutdownCtx)
+		if analyticsReady && resourceCleanupSafe {
+			if err := closeDaemonAnalyticsEngines(apiServer, initialAnalyticsEngine, analyticsInit); err != nil {
+				shutdownErr = errors.Join(shutdownErr, err)
+			}
+		} else if !analyticsReady {
+			logger.Warn("analytics initialization did not stop within the shutdown drain timeout; skipping analytics engine close")
+		}
 	}
 	if shutdownErr != nil {
 		logger.Error("daemon shutdown error", "error", shutdownErr)
@@ -717,6 +808,9 @@ func runDaemonSQLQuery(
 	if c == nil || s == nil {
 		return nil, errors.New("daemon query unavailable")
 	}
+	if engine == nil {
+		return nil, api.ErrSQLQueryEngineUnavailable
+	}
 	if s.IsPostgreSQL() {
 		if querier, ok := engine.(query.SQLQuerier); ok {
 			return querier.QuerySQL(ctx, sqlStr)
@@ -826,6 +920,9 @@ func openDaemonAnalyticsEngine(
 				"full_rebuild", fullBuild,
 				"error", buildErr)
 			if engineMode == config.AnalyticsEngineDuckDB {
+				if intent != startupCacheBuildIntentNone {
+					outcome = startupCacheBuildOutcomeFatal
+				}
 				return nil, "", outcome, fmt.Errorf("build analytics cache: %w", buildErr)
 			}
 			if intent != startupCacheBuildIntentNone {
@@ -847,6 +944,9 @@ func openDaemonAnalyticsEngine(
 				outcome = startupCacheBuildOutcomeFailed
 			}
 			if engineMode == config.AnalyticsEngineDuckDB {
+				if intent != startupCacheBuildIntentNone {
+					outcome = startupCacheBuildOutcomeFatal
+				}
 				return nil, "", outcome, err
 			}
 			logger.Warn("DuckDB engine failed, falling back to live SQL",
@@ -870,6 +970,9 @@ func openDaemonAnalyticsEngine(
 		outcome = startupCacheBuildOutcomeFailed
 	}
 	if engineMode == config.AnalyticsEngineDuckDB {
+		if intent != startupCacheBuildIntentNone {
+			outcome = startupCacheBuildOutcomeFatal
+		}
 		reason := staleness.Reason
 		if reason == "" {
 			reason = "analytics cache is missing or incomplete"

--- a/cmd/msgvault/cmd/serve_analytics.go
+++ b/cmd/msgvault/cmd/serve_analytics.go
@@ -1,0 +1,320 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/scheduler"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// daemonAnalyticsInitHandle tracks the background cache maintenance started
+// after the HTTP listener is accepting requests. Its fatal channel is only
+// used for required DuckDB initialization failures; automatic mode keeps its
+// initial SQL engine when maintenance fails.
+type daemonAnalyticsInitHandle struct {
+	started chan struct{}
+	done    chan struct{}
+	fatal   chan error
+
+	mu      sync.Mutex
+	err     error
+	swapped bool
+}
+
+func newDaemonAnalyticsInitHandle() *daemonAnalyticsInitHandle {
+	return &daemonAnalyticsInitHandle{
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+		fatal:   make(chan error, 1),
+	}
+}
+
+func completedDaemonAnalyticsInitHandle() *daemonAnalyticsInitHandle {
+	h := newDaemonAnalyticsInitHandle()
+	close(h.started)
+	close(h.done)
+	return h
+}
+
+func (h *daemonAnalyticsInitHandle) WaitStarted(ctx context.Context) bool {
+	if h == nil {
+		return true
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-h.started:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// WaitContext reports whether the initializer completed before ctx ended.
+// The final done check makes a simultaneous completion and timeout deterministic
+// in favor of completion, so the daemon never closes an engine while the
+// initializer is still able to install it.
+func (h *daemonAnalyticsInitHandle) WaitContext(ctx context.Context) bool {
+	if h == nil {
+		return true
+	}
+	select {
+	case <-h.done:
+		return true
+	default:
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-h.done:
+		return true
+	case <-ctx.Done():
+		select {
+		case <-h.done:
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+func (h *daemonAnalyticsInitHandle) Fatal() <-chan error {
+	if h == nil {
+		return nil
+	}
+	return h.fatal
+}
+
+func (h *daemonAnalyticsInitHandle) setError(err error) {
+	if h == nil || err == nil {
+		return
+	}
+	h.mu.Lock()
+	h.err = err
+	h.mu.Unlock()
+	select {
+	case h.fatal <- err:
+	default:
+	}
+}
+
+func (h *daemonAnalyticsInitHandle) setSwapped() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.swapped = true
+	h.mu.Unlock()
+}
+
+func (h *daemonAnalyticsInitHandle) Err() error {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.err
+}
+
+func (h *daemonAnalyticsInitHandle) Swapped() bool {
+	if h == nil {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.swapped
+}
+
+// prepareDaemonAnalyticsEngine creates the state that can be installed before
+// the scheduler and HTTP server start. SQL and PostgreSQL need no cache
+// maintenance and retain the old synchronous selection. Auto and DuckDB defer
+// cache inspection/build/open until the listener is already serving.
+func prepareDaemonAnalyticsEngine(
+	ctx context.Context,
+	c *config.Config,
+	s *store.Store,
+	intent startupCacheBuildIntent,
+) (query.Engine, string, startupCacheBuildOutcome, bool, error) {
+	if c == nil || s == nil {
+		return nil, "", startupCacheBuildOutcomeNone, false,
+			errors.New("daemon analytics engine unavailable")
+	}
+
+	engineMode := c.Analytics.Engine
+	if engineMode == "" {
+		engineMode = config.AnalyticsEngineAuto
+	}
+	if s.IsPostgreSQL() || engineMode == config.AnalyticsEngineSQL {
+		engine, mode, outcome, err := openDaemonAnalyticsEngine(ctx, c, s, intent)
+		return engine, mode, outcome, false, err
+	}
+
+	switch engineMode {
+	case config.AnalyticsEngineAuto:
+		logger.Info("using live SQL analytics engine while cache initializes",
+			"engine", engineMode)
+		return query.NewEngine(s.DB(), false), api.AnalyticsModeSQLFallback,
+			startupCacheBuildOutcomeNone, true, nil
+	case config.AnalyticsEngineDuckDB:
+		logger.Info("DuckDB analytics unavailable while required cache initializes",
+			"engine", engineMode)
+		// Keep SQLite-backed detail, search, attachment, and text routes live.
+		// The API mode gates DuckDB-dependent analytics until the initializer
+		// atomically replaces this engine.
+		return query.NewEngine(s.DB(), false), api.AnalyticsModeInitializing,
+			startupCacheBuildOutcomeNone, true, nil
+	default:
+		// Config validation normally rejects this before runServe. Keep the old
+		// final-selection behavior as a defensive fallback for embedded callers.
+		engine, mode, outcome, err := openDaemonAnalyticsEngine(ctx, c, s, intent)
+		return engine, mode, outcome, false, err
+	}
+}
+
+// startDaemonAnalyticsInitializer performs final cache selection after the
+// HTTP listener starts. The operation tracker prevents scheduled/API writes
+// from racing cache export and keeps an idle-shutdown daemon alive until the
+// worker exits.
+func startDaemonAnalyticsInitializer(
+	ctx context.Context,
+	c *config.Config,
+	s *store.Store,
+	intent startupCacheBuildIntent,
+	apiServer *api.Server,
+	ownership *serveOwnership,
+	tracker scheduler.WorkTracker,
+) *daemonAnalyticsInitHandle {
+	h := newDaemonAnalyticsInitHandle()
+	go func() {
+		defer close(h.done)
+		if tracker != nil {
+			release, ok := tracker.BeginWorkContext(ctx)
+			close(h.started)
+			if !ok {
+				logger.Info("analytics cache initialization aborted", "reason", "daemon shutting down")
+				return
+			}
+			defer release()
+		} else {
+			close(h.started)
+		}
+
+		logger.Info("daemon startup step", "step", "init_analytics_engine")
+		engine, mode, outcome, err := openDaemonAnalyticsEngine(ctx, c, s, intent)
+		if ctx.Err() != nil {
+			if engine != nil {
+				_ = engine.Close()
+			}
+			return
+		}
+
+		if err != nil {
+			if engine != nil {
+				_ = engine.Close()
+			}
+			if intent != startupCacheBuildIntentNone {
+				if outcomeErr := ownership.SetStartupCacheBuildOutcome(outcome); outcomeErr != nil {
+					h.setError(outcomeErr)
+					return
+				}
+			}
+			logger.Error("daemon startup analytics initialization failed", "error", err)
+			h.setError(err)
+			return
+		}
+
+		if mode == api.AnalyticsModeDuckDB {
+			if engine == nil {
+				err := errors.New("DuckDB analytics initialization returned no engine")
+				if intent != startupCacheBuildIntentNone {
+					_ = ownership.SetStartupCacheBuildOutcome(startupCacheBuildOutcomeFatal)
+				}
+				h.setError(err)
+				return
+			}
+			apiServer.SetAnalyticsEngine(engine, mode)
+			h.setSwapped()
+		} else if engine != nil {
+			// Auto mode returns a newly-created SQL fallback when maintenance
+			// fails or is disabled. Keep the original live engine installed so
+			// requests do not observe a needless engine replacement.
+			_ = engine.Close()
+		}
+
+		if intent != startupCacheBuildIntentNone {
+			if outcomeErr := ownership.SetStartupCacheBuildOutcome(outcome); outcomeErr != nil {
+				h.setError(outcomeErr)
+				return
+			}
+		}
+		logger.Info("daemon startup step complete", "step", "init_analytics_engine")
+	}()
+	return h
+}
+
+// closeDaemonAnalyticsEngines closes the current API engine only after HTTP
+// shutdown and then closes the original fallback when a DuckDB swap occurred.
+// SetAnalyticsEngine intentionally leaves the previous engine open, so both
+// daemon-owned engines must be closed here.
+func closeDaemonAnalyticsEngines(
+	apiServer *api.Server,
+	initialEngine query.Engine,
+	initializer *daemonAnalyticsInitHandle,
+) error {
+	if initializer != nil {
+		select {
+		case <-initializer.done:
+		default:
+			return errors.New("analytics initialization is still running")
+		}
+	}
+	var errs []error
+	if apiServer != nil {
+		if err := apiServer.CloseAnalyticsEngine(); err != nil {
+			errs = append(errs, fmt.Errorf("close analytics engine: %w", err))
+		}
+	}
+	if initializer != nil && initializer.Swapped() && initialEngine != nil {
+		if err := initialEngine.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close initial analytics engine: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// closeDaemonStoreAfterInitializers avoids closing the archive database while
+// either background initializer can still be using it. A shutdown timeout
+// skips deferred cleanup; the process is exiting, and keeping the handle open
+// is safer than racing a worker that has not joined.
+func closeDaemonStoreAfterInitializers(
+	s *store.Store,
+	analyticsInitializer *daemonAnalyticsInitHandle,
+	vectorInitializer *vectorInitHandle,
+) error {
+	if s == nil {
+		return nil
+	}
+	if analyticsInitializer != nil {
+		select {
+		case <-analyticsInitializer.done:
+		default:
+			return errors.New("analytics initialization is still running")
+		}
+	}
+	if vectorInitializer != nil {
+		select {
+		case <-vectorInitializer.done:
+		default:
+			return errors.New("vector initialization is still running")
+		}
+	}
+	return s.Close()
+}

--- a/cmd/msgvault/cmd/serve_analytics_test.go
+++ b/cmd/msgvault/cmd/serve_analytics_test.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/query/querytest"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestPrepareDaemonAnalyticsEngineAutoStartsWithSQLFallback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+
+	engine, mode, outcome, async, err := prepareDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
+	require.NoError(err)
+	require.NotNil(engine)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	assert.True(async)
+	assert.Equal(api.AnalyticsModeSQLFallback, mode)
+	assert.Equal(startupCacheBuildOutcomeNone, outcome)
+	assert.IsType(&query.SQLiteEngine{}, engine)
+}
+
+func TestPrepareDaemonAnalyticsEngineDuckDBKeepsGeneralSQLiteQueries(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineDuckDB
+
+	engine, mode, outcome, async, err := prepareDaemonAnalyticsEngine(
+		context.Background(), c, s, startupCacheBuildIntentNone,
+	)
+	requirements.NoError(err)
+	requirements.NotNil(engine)
+	t.Cleanup(func() { requirements.NoError(engine.Close()) })
+
+	assertions.True(async)
+	assertions.Equal(api.AnalyticsModeInitializing, mode)
+	assertions.Equal(startupCacheBuildOutcomeNone, outcome)
+	assertions.IsType(&query.SQLiteEngine{}, engine)
+}
+
+func TestStartDaemonAnalyticsInitializerAutoInstallsDuckDB(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	c.Analytics.AutoBuildCache = true
+	stubBuildCacheSubprocess(t, func(ctx context.Context, fullRebuild bool) error {
+		_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), fullRebuild)
+		return err
+	})
+
+	initial := query.NewEngine(s.DB(), false)
+	srv := api.NewServerWithOptions(api.ServerOptions{
+		Config:        c,
+		Engine:        initial,
+		AnalyticsMode: api.AnalyticsModeSQLFallback,
+		Logger:        slog.Default(),
+	})
+	h := startDaemonAnalyticsInitializer(
+		context.Background(), c, s, startupCacheBuildIntentNone, srv, nil, nil,
+	)
+	require.True(h.WaitContext(context.Background()))
+	require.NoError(h.Err())
+	assert.True(h.Swapped())
+	assert.Equal(api.AnalyticsModeDuckDB, srv.AnalyticsMode())
+	assert.IsType(&query.DuckDBEngine{}, srv.QueryEngine())
+	require.NoError(closeDaemonAnalyticsEngines(srv, initial, h))
+}
+
+func TestStartDaemonAnalyticsInitializerDuckDBFailureDoesNotInstallSQLFallback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineDuckDB
+	c.Analytics.AutoBuildCache = true
+	sentinel := errors.New("cache build failed")
+	stubBuildCacheSubprocess(t, func(context.Context, bool) error { return sentinel })
+
+	srv := api.NewServerWithOptions(api.ServerOptions{
+		Config:        c,
+		AnalyticsMode: api.AnalyticsModeInitializing,
+		Logger:        slog.Default(),
+	})
+	h := startDaemonAnalyticsInitializer(
+		context.Background(), c, s, startupCacheBuildIntentNone, srv, nil, nil,
+	)
+	require.True(h.WaitContext(context.Background()))
+	require.ErrorIs(h.Err(), sentinel)
+	assert.False(h.Swapped())
+	assert.Nil(srv.QueryEngine())
+	assert.Equal(api.AnalyticsModeInitializing, srv.AnalyticsMode())
+}
+
+func TestStartDaemonAnalyticsInitializerPublishesFatalDuckDBOutcome(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineDuckDB
+	sentinel := errors.New("explicit cache build failed")
+	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
+		return sentinel
+	})
+	owner, err := claimServeOwnership(context.Background(), c, "127.0.0.1", 8123, "v-test")
+	requirements.NoError(err, "claim serve ownership")
+	t.Cleanup(func() { requirements.NoError(owner.Close(), "close serve ownership") })
+
+	srv := api.NewServerWithOptions(api.ServerOptions{
+		Config:        c,
+		AnalyticsMode: api.AnalyticsModeInitializing,
+		Logger:        slog.Default(),
+	})
+	h := startDaemonAnalyticsInitializer(
+		context.Background(), c, s, startupCacheBuildIntentDefault, srv, owner, nil,
+	)
+	requirements.True(h.WaitContext(context.Background()))
+	requirements.ErrorIs(h.Err(), sentinel)
+
+	records, err := daemonRuntimeStore(c.Data.DataDir).List()
+	requirements.NoError(err, "list daemon runtime records")
+	requirements.Len(records, 1, "daemon runtime records")
+	assertions.Equal(
+		string(startupCacheBuildOutcomeFatal),
+		records[0].Metadata[runtimeStartupCacheBuildOutcome],
+	)
+	assertions.Equal(api.AnalyticsModeInitializing, srv.AnalyticsMode())
+}
+
+type closeOrderAnalyticsEngine struct {
+	*querytest.MockEngine
+
+	close func() error
+}
+
+func (e *closeOrderAnalyticsEngine) Close() error {
+	return e.close()
+}
+
+func TestCloseDaemonAnalyticsEnginesRequiresInitializerCompletion(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	c := lifecycleTestConfig(t.TempDir())
+	var httpShutdown bool
+	var workerDone bool
+	var closed bool
+	engine := &closeOrderAnalyticsEngine{
+		MockEngine: &querytest.MockEngine{},
+		close: func() error {
+			if !httpShutdown || !workerDone {
+				return errors.New("analytics engine closed before lifecycle barriers")
+			}
+			closed = true
+			return nil
+		},
+	}
+	srv := api.NewServerWithOptions(api.ServerOptions{
+		Config:        c,
+		Engine:        engine,
+		AnalyticsMode: api.AnalyticsModeSQLFallback,
+		Logger:        slog.Default(),
+	})
+	h := newDaemonAnalyticsInitHandle()
+
+	err := closeDaemonAnalyticsEngines(srv, engine, h)
+	require.Error(err)
+	assert.False(closed)
+
+	close(h.done)
+	httpShutdown = true
+	workerDone = true
+	require.NoError(closeDaemonAnalyticsEngines(srv, engine, h))
+	assert.True(closed)
+}
+
+func TestCloseDaemonStoreAfterAnalyticsInitSkipsRunningWorker(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	s, err := store.OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	h := newDaemonAnalyticsInitHandle()
+
+	err = closeDaemonStoreAfterInitializers(s, h, nil)
+	require.Error(err)
+	require.ErrorContains(err, "analytics initialization is still running")
+	require.NoError(s.DB().Ping(), "store must remain open while worker runs")
+
+	close(h.done)
+	require.NoError(closeDaemonStoreAfterInitializers(s, h, nil))
+	assert.Error(s.DB().Ping(), "store must close after worker joins")
+}
+
+func TestCloseDaemonStoreAfterAnalyticsInitSkipsRunningVectorWorker(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	s, err := store.OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	analytics := completedDaemonAnalyticsInitHandle()
+	vector := &vectorInitHandle{done: make(chan struct{})}
+
+	err = closeDaemonStoreAfterInitializers(s, analytics, vector)
+	require.Error(err)
+	require.ErrorContains(err, "vector initialization is still running")
+	require.NoError(s.DB().Ping(), "store must remain open while vector worker runs")
+
+	close(vector.done)
+	require.NoError(closeDaemonStoreAfterInitializers(s, analytics, vector))
+	assert.Error(s.DB().Ping(), "store must close after both workers join")
+}

--- a/cmd/msgvault/cmd/serve_ownership.go
+++ b/cmd/msgvault/cmd/serve_ownership.go
@@ -74,7 +74,20 @@ func (o *serveOwnership) SetStartupPhase(phase string) error {
 }
 
 func (o *serveOwnership) SetStartupCacheBuildOutcome(outcome startupCacheBuildOutcome) error {
-	return o.setRuntimeMetadata(runtimeStartupCacheBuildOutcome, string(outcome))
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.closed {
+		return nil
+	}
+	if outcome == startupCacheBuildOutcomeFatal {
+		if err := writeDurableStartupCacheBuildOutcome(o.dataDir, o.record, outcome); err != nil {
+			return err
+		}
+	}
+	return o.setRuntimeMetadataLocked(runtimeStartupCacheBuildOutcome, string(outcome))
 }
 
 func (o *serveOwnership) setRuntimeMetadata(key, value string) error {
@@ -86,6 +99,10 @@ func (o *serveOwnership) setRuntimeMetadata(key, value string) error {
 	if o.closed {
 		return nil
 	}
+	return o.setRuntimeMetadataLocked(key, value)
+}
+
+func (o *serveOwnership) setRuntimeMetadataLocked(key, value string) error {
 	rec := o.record
 	metadata := maps.Clone(rec.Metadata)
 	if metadata == nil {

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -148,7 +148,7 @@ func TestRunServeStartsReadOnlyWithoutOAuthConfig(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cmd := &cobra.Command{Use: "serve"}
+	cmd := &cobra.Command{Use: serveCmd.Use}
 	cmd.SetContext(ctx)
 	errCh := make(chan error, 1)
 	go func() {
@@ -166,6 +166,62 @@ func TestRunServeStartsReadOnlyWithoutOAuthConfig(t *testing.T) {
 	}
 }
 
+func TestRunServeImmediateCancellationWaitsForAPIStart(t *testing.T) {
+	require := require.New(t)
+	oldCfg := cfg
+	dataDir := t.TempDir()
+	c := lifecycleTestConfig(dataDir)
+	c.Server.APIPort = freeTCPPort(t)
+	c.Vector.Enabled = false
+	c.Analytics.Engine = config.AnalyticsEngineSQL
+	cfg = c
+	t.Cleanup(func() { cfg = oldCfg })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	oldStart := startServeAPIServer
+	startServeAPIServer = func(server *api.Server, listener net.Listener) error {
+		close(started)
+		<-release
+		return server.StartOnListener(listener)
+	}
+	t.Cleanup(func() {
+		startServeAPIServer = oldStart
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cmd := &cobra.Command{Use: "serve"}
+	cmd.SetContext(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- runServe(cmd, nil) }()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		require.FailNow("API startup seam was not entered")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		require.FailNow("runServe returned before listener-start barrier", "error: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-errCh:
+		require.NoError(err, "runServe")
+	case <-time.After(10 * time.Second):
+		require.FailNow("runServe did not stop after listener startup was released")
+	}
+}
+
 func TestRunServeAutoSelectsAPIPortWhenUnconfigured(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -178,7 +234,7 @@ func TestRunServeAutoSelectsAPIPortWhenUnconfigured(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cmd := &cobra.Command{Use: "serve"}
+	cmd := &cobra.Command{Use: serveCmd.Use}
 	cmd.SetContext(ctx)
 	errCh := make(chan error, 1)
 	serveDone := make(chan struct{})
@@ -213,6 +269,234 @@ func TestRunServeAutoSelectsAPIPortWhenUnconfigured(t *testing.T) {
 	case err := <-errCh:
 		require.NoError(err, "runServe")
 	case <-time.After(5 * time.Second):
+		require.FailNow("runServe did not stop after context cancellation")
+	}
+}
+
+func TestRunServeServesHealthWhileAnalyticsBuildBlocked(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	oldCfg := cfg
+	dataDir := t.TempDir()
+	c := lifecycleTestConfig(dataDir)
+	c.Server.APIPort = freeTCPPort(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	c.Analytics.AutoBuildCache = true
+	c.Vector.Enabled = false
+	cfg = c
+	t.Cleanup(func() { cfg = oldCfg })
+
+	buildStarted := make(chan struct{})
+	stubBuildCacheSubprocess(t, func(ctx context.Context, _ bool) error {
+		close(buildStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	t.Cleanup(cancel)
+	cmd := &cobra.Command{Use: "serve"}
+	cmd.SetContext(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runServe(cmd, nil)
+	}()
+
+	select {
+	case <-buildStarted:
+	case err := <-errCh:
+		require.NoError(err, "runServe exited before analytics build was blocked")
+	case <-time.After(5 * time.Second):
+		require.FailNow("analytics cache build did not start")
+	}
+	waitForServeHealthBounded(t, c.Server.APIPort, errCh)
+
+	healthClient := &http.Client{Timeout: time.Second}
+	resp, err := healthClient.Get(fmt.Sprintf("http://127.0.0.1:%d/health", c.Server.APIPort))
+	require.NoError(err, "GET /health")
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	var health api.HealthResponse
+	require.NoError(json.NewDecoder(resp.Body).Decode(&health))
+	assert.Equal(api.AnalyticsModeSQLFallback, health.AnalyticsEngine,
+		"auto mode must report live-SQL fallback while cache initialization is blocked")
+
+	aggregateResp, err := healthClient.Get(fmt.Sprintf(
+		"http://127.0.0.1:%d/api/v1/aggregates?view_type=senders",
+		c.Server.APIPort,
+	))
+	require.NoError(err, "GET aggregate through SQL fallback")
+	defer func() { _ = aggregateResp.Body.Close() }()
+	assert.Equal(http.StatusOK, aggregateResp.StatusCode,
+		"read-only aggregate must bypass the cache-build mutation gate")
+	var aggregates api.AggregateResponse
+	require.NoError(json.NewDecoder(aggregateResp.Body).Decode(&aggregates))
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(err, "runServe")
+	case <-time.After(10 * time.Second):
+		require.FailNow("runServe did not stop after context cancellation")
+	}
+}
+
+func TestRunServeDuckDBReportsInitializingWithoutSQLFallback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	oldCfg := cfg
+	dataDir := t.TempDir()
+	c := lifecycleTestConfig(dataDir)
+	c.Server.APIPort = freeTCPPort(t)
+	c.Analytics.Engine = config.AnalyticsEngineDuckDB
+	c.Analytics.AutoBuildCache = true
+	c.Vector.Enabled = false
+	cfg = c
+	t.Cleanup(func() { cfg = oldCfg })
+
+	buildStarted := make(chan struct{})
+	stubBuildCacheSubprocess(t, func(ctx context.Context, _ bool) error {
+		close(buildStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	t.Cleanup(cancel)
+	cmd := &cobra.Command{Use: serveCmd.Use}
+	cmd.SetContext(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- runServe(cmd, nil) }()
+
+	select {
+	case <-buildStarted:
+	case err := <-errCh:
+		require.NoError(err, "runServe exited before analytics build was blocked")
+	case <-time.After(5 * time.Second):
+		require.FailNow("analytics cache build did not start")
+	}
+	waitForServeHealthBounded(t, c.Server.APIPort, errCh)
+
+	healthClient := &http.Client{Timeout: time.Second}
+	resp, err := healthClient.Get(fmt.Sprintf("http://127.0.0.1:%d/health", c.Server.APIPort))
+	require.NoError(err, "GET /health")
+	var health api.HealthResponse
+	require.NoError(json.NewDecoder(resp.Body).Decode(&health))
+	_ = resp.Body.Close()
+	assert.Equal(api.AnalyticsModeInitializing, health.AnalyticsEngine)
+
+	resp, err = healthClient.Get(fmt.Sprintf(
+		"http://127.0.0.1:%d/api/v1/messages/filter?limit=1",
+		c.Server.APIPort,
+	))
+	require.NoError(err, "GET general archive route")
+	assert.Equal(http.StatusOK, resp.StatusCode,
+		"SQLite-backed detail routes must remain available while DuckDB initializes")
+	_ = resp.Body.Close()
+
+	resp, err = healthClient.Get(fmt.Sprintf(
+		"http://127.0.0.1:%d/api/v1/text/conversations",
+		c.Server.APIPort,
+	))
+	require.NoError(err, "GET text conversations")
+	assert.Equal(http.StatusOK, resp.StatusCode,
+		"SQLite-backed text routes must remain available while DuckDB initializes")
+	_ = resp.Body.Close()
+
+	resp, err = healthClient.Get(fmt.Sprintf("http://127.0.0.1:%d/api/v1/aggregates?view_type=senders", c.Server.APIPort))
+	require.NoError(err, "GET analytics route")
+	assert.Equal(http.StatusServiceUnavailable, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	resp, err = healthClient.Post(
+		fmt.Sprintf("http://127.0.0.1:%d/api/v1/query", c.Server.APIPort),
+		"application/json",
+		strings.NewReader(`{"sql":"SELECT 1"}`),
+	)
+	require.NoError(err, "POST SQL query")
+	assert.Equal(http.StatusServiceUnavailable, resp.StatusCode,
+		"initializing DuckDB must report SQL engine unavailable")
+	_ = resp.Body.Close()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(err, "runServe")
+	case <-time.After(10 * time.Second):
+		require.FailNow("runServe did not stop after context cancellation")
+	}
+}
+
+func TestRunServeAutoSwitchesToDuckDBAfterBackgroundBuild(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	oldCfg := cfg
+	dataDir := t.TempDir()
+	c := lifecycleTestConfig(dataDir)
+	c.Server.APIPort = freeTCPPort(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	c.Analytics.AutoBuildCache = true
+	c.Vector.Enabled = false
+	cfg = c
+	t.Cleanup(func() { cfg = oldCfg })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	t.Cleanup(cancel)
+
+	buildStarted := make(chan struct{})
+	releaseBuild := make(chan struct{})
+	stubBuildCacheSubprocess(t, func(ctx context.Context, fullRebuild bool) error {
+		close(buildStarted)
+		select {
+		case <-releaseBuild:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), fullRebuild)
+		return err
+	})
+
+	cmd := &cobra.Command{Use: serveCmd.Use}
+	cmd.SetContext(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- runServe(cmd, nil) }()
+
+	select {
+	case <-buildStarted:
+	case err := <-errCh:
+		require.NoError(err, "runServe exited before analytics build was blocked")
+	case <-time.After(5 * time.Second):
+		require.FailNow("analytics cache build did not start")
+	}
+	waitForServeHealthBounded(t, c.Server.APIPort, errCh)
+
+	healthClient := &http.Client{Timeout: time.Second}
+	readAnalyticsMode := func() string {
+		resp, err := healthClient.Get(fmt.Sprintf("http://127.0.0.1:%d/health", c.Server.APIPort))
+		if err != nil {
+			return ""
+		}
+		defer func() { _ = resp.Body.Close() }()
+		var health api.HealthResponse
+		if resp.StatusCode != http.StatusOK || json.NewDecoder(resp.Body).Decode(&health) != nil {
+			return ""
+		}
+		return health.AnalyticsEngine
+	}
+	assert.Equal(api.AnalyticsModeSQLFallback, readAnalyticsMode())
+
+	close(releaseBuild)
+	assert.Eventually(func() bool {
+		return readAnalyticsMode() == api.AnalyticsModeDuckDB
+	}, 10*time.Second, 25*time.Millisecond, "auto mode should switch to DuckDB after cache build")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(err, "runServe")
+	case <-time.After(10 * time.Second):
 		require.FailNow("runServe did not stop after context cancellation")
 	}
 }
@@ -335,6 +619,30 @@ func waitForServeHealth(t *testing.T, port int, errCh <-chan error) {
 		default:
 		}
 		resp, err := http.Get(url) //nolint:gosec // local test server
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.FailNow(t, "serve health endpoint did not become ready")
+}
+
+func waitForServeHealthBounded(t *testing.T, port int, errCh <-chan error) {
+	t.Helper()
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			require.NoError(t, err, "runServe exited before health was ready")
+			require.FailNow(t, "runServe exited before health was ready")
+		default:
+		}
+		resp, err := client.Get(url)
 		if err == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -756,7 +1064,7 @@ func TestOpenDaemonAnalyticsEngineExplicitDuckDBFailureIsFatal(t *testing.T) {
 	}
 
 	require.ErrorIs(t, err, sentinel)
-	assert.Equal(t, startupCacheBuildOutcomeFailed, outcome)
+	assert.Equal(t, startupCacheBuildOutcomeFatal, outcome)
 }
 
 func openTestDaemonAnalyticsStore(t *testing.T) (*config.Config, *store.Store) {

--- a/cmd/msgvault/cmd/serve_vector_integration_test.go
+++ b/cmd/msgvault/cmd/serve_vector_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -80,6 +81,77 @@ func TestRunServeServesHealthWhileVectorInitBlocked(t *testing.T) {
 	// and confirm a clean exit.
 	cancel()
 
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "runServe")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "runServe did not stop after context cancellation")
+	}
+}
+
+func TestRunServeGivesAnalyticsInitializationGatePriorityOverVector(t *testing.T) {
+	oldCfg := cfg
+	dataDir := t.TempDir()
+	c := lifecycleTestConfig(dataDir)
+	c.Server.APIPort = freeTCPPort(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	c.Analytics.AutoBuildCache = true
+	c.Vector.ApplyDefaults()
+	c.Vector.Enabled = true
+	c.Vector.Embeddings.Endpoint = "http://localhost:11434/v1/embeddings"
+	c.Vector.Embeddings.Model = "test-model"
+	c.Vector.Embeddings.Dimension = 768
+	cfg = c
+	t.Cleanup(func() { cfg = oldCfg })
+
+	analyticsStarted := make(chan struct{})
+	releaseAnalytics := make(chan struct{})
+	stubBuildCacheSubprocess(t, func(context.Context, bool) error {
+		close(analyticsStarted)
+		<-releaseAnalytics
+		return nil
+	})
+	vectorStarted := make(chan struct{})
+	overrideSetupVectorFeatures(t, func(ctx context.Context, _ *store.Store, _ string, _ bool) (*vectorFeatures, error) {
+		close(vectorStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := &cobra.Command{Use: "serve"}
+	cmd.SetContext(ctx)
+	errCh := make(chan error, 1)
+	go func() { errCh <- runServe(cmd, nil) }()
+
+	select {
+	case <-analyticsStarted:
+	case err := <-errCh:
+		require.NoError(t, err, "runServe exited before analytics initialization")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "analytics initialization did not start")
+	}
+	waitForServeHealth(t, c.Server.APIPort, errCh)
+	assert.Never(t, func() bool {
+		select {
+		case <-vectorStarted:
+			return true
+		default:
+			return false
+		}
+	}, 250*time.Millisecond, 10*time.Millisecond,
+		"vector initialization must wait while analytics holds the operation gate")
+
+	close(releaseAnalytics)
+	select {
+	case <-vectorStarted:
+	case err := <-errCh:
+		require.NoError(t, err, "runServe exited before vector initialization")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "vector initialization did not start after analytics released the gate")
+	}
+	cancel()
 	select {
 	case err := <-errCh:
 		require.NoError(t, err, "runServe")

--- a/cmd/msgvault/cmd/store_resolver.go
+++ b/cmd/msgvault/cmd/store_resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"slices"
@@ -294,6 +295,7 @@ func ensureLocalDaemonRuntimeWithStartupCacheIntent(
 	defer func() { _ = proc.releaseProcessTree() }()
 	stopProgress := reportLocalDaemonStartup(ctx, proc)
 	defer func() { stopProgress() }()
+	startupDeadline := time.Now().Add(localDaemonAutoStartReadyTimeout)
 	rt, ready, err := waitForBackgroundServeReadyForRun(
 		ctx, c.Data.DataDir, proc.Wait, localDaemonAutoStartReadyTimeout,
 	)
@@ -315,7 +317,24 @@ func ensureLocalDaemonRuntimeWithStartupCacheIntent(
 		)
 	}
 	if intent != startupCacheBuildIntentNone {
-		rt = refreshDaemonRuntimeRecord(c.Data.DataDir, rt)
+		outcomeTimeout := time.Until(startupDeadline)
+		if outcomeTimeout <= 0 {
+			outcomeTimeout = time.Nanosecond
+		}
+		rt, _, err = waitForStartupCacheBuildOutcome(
+			ctx, c.Data.DataDir, proc, rt, outcomeTimeout,
+		)
+		if err != nil {
+			startupErr := backgroundServeStartupError(err, proc)
+			if ctx.Err() != nil {
+				stopErr := stopBackgroundServeStartupForRun(proc)
+				if stopErr != nil {
+					startupErr = errors.Join(startupErr,
+						fmt.Errorf("stop canceled daemon startup: %w", stopErr))
+				}
+			}
+			return nil, localDaemonStartupInfo{}, startupErr
+		}
 	}
 	stopProgress()
 	stopProgress = func() {}
@@ -328,6 +347,91 @@ func ensureLocalDaemonRuntimeWithStartupCacheIntent(
 		LogPath: proc.LogPath,
 		Outcome: startupCacheBuildOutcomeFromRuntime(rt),
 	}, nil
+}
+
+// waitForStartupCacheBuildOutcome waits after HTTP readiness for a daemon
+// started with an explicit cache intent to publish its outcome. A non-empty
+// outcome means the background initializer has finished; unconsumed is
+// intentionally returned to the caller so it can issue the one HTTP build.
+func waitForStartupCacheBuildOutcome(
+	ctx context.Context,
+	dataDir string,
+	proc *backgroundServeProcess,
+	rt *DaemonRuntime,
+	timeout time.Duration,
+) (*DaemonRuntime, startupCacheBuildOutcome, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if timeout <= 0 {
+		timeout = localDaemonAutoStartReadyTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(daemonProbeTick)
+	defer ticker.Stop()
+
+	var waitCh <-chan error
+	if proc != nil {
+		waitCh = proc.Wait
+	}
+	for {
+		current := refreshDaemonRuntimeRecord(dataDir, rt)
+		current, outcome, outcomeErr := observeStartupCacheBuildOutcome(dataDir, current)
+		if outcomeErr != nil {
+			return nil, startupCacheBuildOutcomeNone, outcomeErr
+		}
+		if outcome != startupCacheBuildOutcomeNone {
+			return current, outcome, nil
+		}
+		select {
+		case err := <-waitCh:
+			current = refreshDaemonRuntimeRecord(dataDir, current)
+			current, outcome, outcomeErr = observeStartupCacheBuildOutcome(dataDir, current)
+			if outcomeErr != nil {
+				return nil, startupCacheBuildOutcomeNone, outcomeErr
+			}
+			if outcome != startupCacheBuildOutcomeNone {
+				return current, outcome, nil
+			}
+			if err == nil {
+				err = errors.New("server process exited before startup cache outcome")
+			}
+			return nil, startupCacheBuildOutcomeNone, err
+		case <-ctx.Done():
+			return nil, startupCacheBuildOutcomeNone, ctx.Err()
+		case <-ticker.C:
+		case <-timer.C:
+			return nil, startupCacheBuildOutcomeNone, fmt.Errorf(
+				"daemon did not publish startup cache outcome within %s", timeout)
+		}
+	}
+}
+
+func observeStartupCacheBuildOutcome(
+	dataDir string,
+	rt *DaemonRuntime,
+) (*DaemonRuntime, startupCacheBuildOutcome, error) {
+	if outcome := startupCacheBuildOutcomeFromRuntime(rt); outcome != startupCacheBuildOutcomeNone {
+		if outcome == startupCacheBuildOutcomeFatal && rt != nil {
+			_, _, _ = consumeDurableStartupCacheBuildOutcome(dataDir, rt.Record)
+		}
+		return rt, outcome, nil
+	}
+	if rt == nil {
+		return nil, startupCacheBuildOutcomeNone, nil
+	}
+	outcome, found, err := consumeDurableStartupCacheBuildOutcome(dataDir, rt.Record)
+	if err != nil || !found {
+		return rt, startupCacheBuildOutcomeNone, err
+	}
+	observed := *rt
+	observed.Record.Metadata = maps.Clone(rt.Record.Metadata)
+	if observed.Record.Metadata == nil {
+		observed.Record.Metadata = make(map[string]string)
+	}
+	observed.Record.Metadata[runtimeStartupCacheBuildOutcome] = string(outcome)
+	return &observed, outcome, nil
 }
 
 // refreshDaemonRuntimeRecord reloads the exact process record after readiness.

--- a/cmd/msgvault/cmd/store_resolver_test.go
+++ b/cmd/msgvault/cmd/store_resolver_test.go
@@ -236,6 +236,79 @@ func TestOpenHTTPStoreReportsFulfilledStartupCacheBuild(t *testing.T) {
 	assert.Equal(filepath.Join(dataDir, "serve.log"), info.DaemonLogPath)
 }
 
+func TestWaitForStartupCacheBuildOutcomeWaitsAfterHTTPReadiness(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dataDir := t.TempDir()
+	record := daemon.RuntimeRecord{
+		PID:      os.Getpid(),
+		Network:  daemon.NetworkTCP,
+		Address:  "127.0.0.1:1",
+		Service:  daemonService,
+		Version:  Version,
+		Metadata: map[string]string{},
+	}
+	_, err := daemonRuntimeStore(dataDir).Write(record)
+	require.NoError(err)
+	rt := &DaemonRuntime{Record: record}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		updated := record
+		updated.Metadata = map[string]string{
+			runtimeStartupCacheBuildOutcome: string(startupCacheBuildOutcomeFulfilled),
+		}
+		_, _ = daemonRuntimeStore(dataDir).Write(updated)
+	}()
+
+	gotRT, outcome, err := waitForStartupCacheBuildOutcome(
+		context.Background(), dataDir, &backgroundServeProcess{}, rt, time.Second,
+	)
+	require.NoError(err)
+	require.NotNil(gotRT)
+	assert.Equal(startupCacheBuildOutcomeFulfilled, outcome)
+}
+
+func TestWaitForStartupCacheBuildOutcomeReportsProcessExit(t *testing.T) {
+	waitCh := make(chan error, 1)
+	waitCh <- errors.New("server exited")
+	_, _, err := waitForStartupCacheBuildOutcome(
+		context.Background(), t.TempDir(), &backgroundServeProcess{Wait: waitCh},
+		&DaemonRuntime{}, time.Second,
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "server exited")
+}
+
+func TestWaitForStartupCacheBuildOutcomeConsumesFatalResultAfterDaemonExit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dataDir := t.TempDir()
+	c := lifecycleTestConfig(dataDir)
+	owner, err := claimServeOwnership(context.Background(), c, "127.0.0.1", 8123, "v-test")
+	require.NoError(err, "claim serve ownership")
+	record := owner.record
+	require.NoError(
+		owner.SetStartupCacheBuildOutcome(startupCacheBuildOutcomeFatal),
+		"publish fatal startup outcome",
+	)
+	require.NoError(owner.Close(), "close serve ownership")
+
+	waitCh := make(chan error, 1)
+	waitCh <- errors.New("server exited")
+	gotRT, outcome, err := waitForStartupCacheBuildOutcome(
+		context.Background(), dataDir, &backgroundServeProcess{Wait: waitCh},
+		&DaemonRuntime{Record: record}, time.Second,
+	)
+	require.NoError(err,
+		"durable fatal outcome must win over the process-exit notification")
+	require.NotNil(gotRT)
+	assert.Equal(startupCacheBuildOutcomeFatal, outcome)
+	assert.Equal(startupCacheBuildOutcomeFatal, startupCacheBuildOutcomeFromRuntime(gotRT))
+	_, statErr := os.Stat(durableStartupCacheBuildOutcomePath(dataDir, record))
+	assert.ErrorIs(statErr, os.ErrNotExist, "the parent must consume the one-shot result")
+}
+
 func TestOpenHTTPStoreReportsLocalDaemonStartupToStderr(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -98,6 +99,16 @@ HTTP Mode:
 			AnalyticsNotice:  notice,
 		})
 		p := tea.NewProgram(model)
+		noticeCtx, stopNoticeRefresh := context.WithCancel(cmd.Context())
+		defer stopNoticeRefresh()
+		if notice != "" {
+			go refreshAnalyticsCacheNotice(
+				noticeCtx,
+				backend.client,
+				analyticsCacheNoticeRefreshInterval,
+				p.Send,
+			)
+		}
 
 		// Swap the slog default to a file-only logger for the
 		// duration of the TUI. Bubble Tea owns the terminal in
@@ -134,22 +145,69 @@ type tuiBackend struct {
 	cleanup func()
 }
 
-// analyticsCacheNotice asks the daemon which analytics engine it actually
-// selected at startup (GET /health, no cache scans or archive access) and
-// warns when aggregate views run live SQL only because no usable cache
-// existed then. Deliberate live SQL (engine = "sql", PostgreSQL) reports a
-// different mode and stays silent, as do daemons predating the field. The
-// mode is fixed for the daemon's lifetime, so the notice stays accurate —
-// and keeps firing — after a cache build until the daemon restarts.
-// Best-effort: errors return an empty notice rather than blocking launch.
+const (
+	analyticsCacheNoticeRefreshInterval = time.Second
+	analyticsCacheFallbackNotice        = "Aggregate views are using live SQL while the analytics cache initializes or because no usable cache is available; they may load slowly. If this continues, run 'msgvault build-cache', then restart the daemon."
+)
+
+// analyticsCacheNotice asks the daemon which analytics engine currently
+// serves requests (GET /health, no cache scans or archive access). Deliberate
+// live SQL (engine = "sql", PostgreSQL) reports a different mode and stays
+// silent, as do daemons predating the field. Best-effort: errors return an
+// empty notice rather than blocking launch.
 func analyticsCacheNotice(ctx context.Context, client *daemonclient.Client) string {
+	mode, err := currentAnalyticsMode(ctx, client)
+	if err != nil || mode != api.AnalyticsModeSQLFallback {
+		return ""
+	}
+	return analyticsCacheFallbackNotice
+}
+
+func currentAnalyticsMode(ctx context.Context, client *daemonclient.Client) (string, error) {
+	if client == nil {
+		return "", errors.New("daemon client unavailable")
+	}
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	health, err := client.GetHealth(ctx)
-	if err != nil || health.AnalyticsEngine != api.AnalyticsModeSQLFallback {
-		return ""
+	if err != nil {
+		return "", err
 	}
-	return "Aggregate views are using live SQL because the daemon started without a usable analytics cache; they may load slowly. Run 'msgvault build-cache', then restart the daemon."
+	return health.AnalyticsEngine, nil
+}
+
+// refreshAnalyticsCacheNotice clears the launch notice when a background
+// cache initialization swaps the daemon to DuckDB. Health errors are
+// transient and leave the current notice unchanged.
+func refreshAnalyticsCacheNotice(
+	ctx context.Context,
+	client *daemonclient.Client,
+	interval time.Duration,
+	send func(tea.Msg),
+) {
+	if client == nil || send == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = analyticsCacheNoticeRefreshInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			mode, err := currentAnalyticsMode(ctx, client)
+			if err != nil {
+				continue
+			}
+			if mode == api.AnalyticsModeDuckDB {
+				send(tui.AnalyticsNoticeMsg{})
+				return
+			}
+		}
+	}
 }
 
 func openTUIBackend(ctx context.Context) (*tuiBackend, error) {

--- a/cmd/msgvault/cmd/tui_test.go
+++ b/cmd/msgvault/cmd/tui_test.go
@@ -10,7 +10,9 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/daemon"
@@ -18,6 +20,7 @@ import (
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/daemonclient"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/tui"
 )
 
 func TestOpenTUIEngineUsesConfiguredRemoteHTTP(t *testing.T) {
@@ -203,5 +206,46 @@ func TestAnalyticsCacheNotice(t *testing.T) {
 				assert.Empty(t, notice)
 			}
 		})
+	}
+}
+
+func TestAnalyticsCacheNoticeClearsAfterBackgroundSwap(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		mode := api.AnalyticsModeSQLFallback
+		if requests.Add(1) > 1 {
+			mode = api.AnalyticsModeDuckDB
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":           "ok",
+			"analytics_engine": mode,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := daemonclient.New(daemonclient.Config{URL: srv.URL, AllowInsecure: true})
+	require.NoError(err, "daemonclient.New")
+	assert.NotEmpty(analyticsCacheNotice(context.Background(), client),
+		"launch during initialization must show the live-SQL notice")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	messages := make(chan tea.Msg, 1)
+	go refreshAnalyticsCacheNotice(ctx, client, time.Millisecond, func(msg tea.Msg) {
+		messages <- msg
+	})
+
+	select {
+	case msg := <-messages:
+		update, ok := msg.(tui.AnalyticsNoticeMsg)
+		require.True(ok, "notice refresh message type")
+		assert.Empty(update.Notice, "DuckDB swap must clear the launch notice")
+	case <-time.After(time.Second):
+		require.FailNow("analytics notice did not clear after DuckDB swap")
 	}
 }

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -1,4 +1,5 @@
 ---
+last_edited: "2026-08-09"
 title: Web UI & API Server
 description: Daemon-served analytical Web UI and REST API for your msgvault archive, with optional background sync scheduling.
 ---
@@ -17,6 +18,15 @@ The API is registered through Huma and exposes a generated OpenAPI document at `
 Go integrations can use the generated client in `pkg/client`. The wrapper
 handles msgvault-specific response details such as deletion staging dry-runs
 returning `200` while created manifests return `201`.
+
+The HTTP listener, health endpoint, and API routing start before analytics cache
+maintenance. With `engine = "auto"`, aggregate requests initially use live SQL
+while the cache is built or opened, then switch to DuckDB after success. A
+failed automatic build or open keeps the daemon on live SQL. With
+`engine = "duckdb"`, analytics remain unavailable until the required cache is
+ready, so analytics routes return `503` during initialization; the daemon does
+not fall back to SQL. Set `auto_build_cache = false` to skip automatic startup
+maintenance.
 
 ## Quick Start
 
@@ -73,8 +83,15 @@ Health check endpoint. Does not require authentication.
 **Response:**
 
 ```json
-{"status": "ok"}
+{"status": "ok", "analytics_engine": "sql-fallback"}
 ```
+
+`analytics_engine` reports the active mode: `sql-fallback` while `engine =
+"auto"` is waiting for or cannot use a cache, `duckdb` after a successful cache
+build/open, `sql` for deliberate live SQL, `postgres` for PostgreSQL, and
+`initializing` while required DuckDB analytics are being prepared. Health stays
+available during initialization; analytics routes return `503` until the
+required engine is ready.
 
 ---
 
@@ -1650,9 +1667,14 @@ All server settings go in the `[server]` section of `config.toml`. Account sched
 | Key | Default | Description |
 |---|---|---|
 | `engine` | `auto` | Aggregate engine for Web UI, TUI, and aggregate HTTP views: `auto`, `sql`, or `duckdb` |
-| `auto_build_cache` | `true` | Build stale or missing Parquet cache files before the daemon opens DuckDB |
+| `auto_build_cache` | `true` | Build stale or missing Parquet cache files in the background during daemon startup; `false` skips automatic startup maintenance |
 
-`engine = "sql"` forces live SQL for aggregate views. `engine = "duckdb"` requires a usable Parquet cache and fails daemon startup if the cache cannot be built or opened. `auto_build_cache = false` leaves cache rebuilds to explicit `msgvault build-cache` runs. These settings replace the TUI/MCP analytics flags deprecated in 0.17.0; see [Configuration: analytics](/configuration/#analytics).
+`engine = "sql"` forces live SQL for aggregate views. `engine = "duckdb"`
+requires a usable Parquet cache and keeps analytics unavailable until it is
+ready; a build or open failure is fatal rather than a silent SQL fallback.
+`auto_build_cache = false` leaves cache rebuilds to explicit
+`msgvault build-cache` runs. These settings replace the TUI/MCP analytics flags
+deprecated in 0.17.0; see [Configuration: analytics](/configuration/#analytics).
 
 ### `[[accounts]]`
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,4 +1,5 @@
 ---
+last_edited: "2026-08-09"
 title: Data Storage
 description: Database schema, Parquet analytics cache, content-addressed attachments, and token storage.
 ---
@@ -156,10 +157,17 @@ this on the default SQLite backend with denormalized Parquet files queried by
 an embedded DuckDB engine, delivering aggregate queries hundreds of times
 faster than SQLite.
 
-The Parquet cache is disposable and can be rebuilt at any time. Aggregate views
-never trigger a build mid-session: with `auto_build_cache = true` (the default)
-the daemon builds a stale or missing cache synchronously at startup, then serves
-DuckDB over it and refreshes after scheduled syncs and ingest commands.
+The Parquet cache is disposable and can be rebuilt at any time. The daemon
+starts HTTP health and API routing before analytics cache maintenance, and
+aggregate views never trigger a build mid-session. With
+`auto_build_cache = true` (the default), a stale or missing cache is built in
+the background after HTTP is ready. In `engine = "auto"`, aggregate views use
+live SQL while that work runs and switch to DuckDB after the cache is ready and
+opens successfully; a failed build or open keeps live SQL. In
+`engine = "duckdb"`, analytics remain unavailable until the required cache is
+ready, with no SQL fallback. Set `auto_build_cache = false` to skip automatic
+startup maintenance; scheduled syncs, ingest commands, and
+`msgvault build-cache` can refresh or build the cache explicitly.
 
 Each build writes and verifies a same-filesystem staging tree before publishing
 under the exclusive cache lock. `_last_sync.json` is the commit marker: it is
@@ -175,8 +183,9 @@ Version 0.19.0 adds `relationship_activity`, `relationship_people`,
 `relationship_domains`, and `relationship_daily` datasets. These compact edges
 and rollups avoid expanding every message's participant list during people,
 domain, relationship, timeline, and file-group queries. Existing SQLite caches
-need one full rebuild after upgrading; automatic cache building performs it at
-daemon startup, or run `msgvault build-cache --full-rebuild` explicitly.
+need one full rebuild after upgrading; automatic cache building performs it in
+the background during daemon startup, or run `msgvault build-cache --full-rebuild`
+explicitly.
 
 ```bash
 # Manual build

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,5 @@
 ---
+last_edited: "2026-08-09"
 title: Configuration
 description: Configuration file reference, environment variables, and file locations.
 ---
@@ -84,9 +85,10 @@ daemon_auto_restart = "newer" # newer, never, or always
 
 [analytics]
 # Daemon-side analytics engine for Web UI, TUI, and aggregate HTTP views:
-# "auto" uses DuckDB/Parquet when usable, otherwise live SQL.
+# "auto" starts on live SQL and switches to DuckDB after cache maintenance.
 # "sql" always uses live SQL. "duckdb" requires a usable Parquet cache.
 engine = "auto"
+# Build a stale/missing cache in the background during daemon startup.
 auto_build_cache = true
 
 [backup]
@@ -351,10 +353,18 @@ Settings for daemon-side aggregate query behavior. The Web UI, TUI, MCP server, 
 
 | Key | Default | Description |
 |---|---|---|
-| `engine` | `auto` | Aggregate engine: `auto` uses DuckDB over Parquet when the cache is usable and falls back to live SQL; `sql` always uses live SQL; `duckdb` requires a usable Parquet cache |
-| `auto_build_cache` | `true` | Build a stale or missing Parquet cache before the daemon opens DuckDB for aggregate views |
+| `engine` | `auto` | Aggregate engine: `auto` starts with live SQL and switches to DuckDB after cache maintenance succeeds; `sql` always uses live SQL; `duckdb` requires a usable Parquet cache |
+| `auto_build_cache` | `true` | Build a stale or missing Parquet cache in the background during daemon startup; `false` skips automatic startup maintenance |
 
-Deprecated in 0.17.0: per-command analytics flags such as `msgvault tui --force-sql`, `msgvault mcp --force-sql`, `msgvault tui --no-cache-build`, and `--no-sqlite-scanner` were replaced by this daemon-level section. Use `engine = "sql"` for live SQL, `auto_build_cache = false` to skip automatic daemon cache builds, or `msgvault build-cache` to prebuild cache files on the daemon host. If `engine = "duckdb"` and the cache cannot be built or opened, `msgvault serve` fails instead of silently falling back.
+The daemon starts HTTP health and API routing before analytics cache
+maintenance. With `engine = "duckdb"`, analytics remain unavailable until a
+usable cache is ready; if the cache cannot be built or opened, `msgvault serve`
+fails instead of silently falling back. With `auto_build_cache = false`, use
+`msgvault build-cache` for explicit cache maintenance. Deprecated in 0.17.0:
+per-command analytics flags such as `msgvault tui --force-sql`,
+`msgvault mcp --force-sql`, `msgvault tui --no-cache-build`, and
+`--no-sqlite-scanner` were replaced by this daemon-level section. Use
+`engine = "sql"` to force live SQL.
 
 This setting governs the aggregate views (Senders/Domains/Labels/Time) and is ignored entirely when `[data].database_url` points at PostgreSQL — a PostgreSQL backend always uses live SQL for those views, and `build-cache` refuses to run against it. It does not affect the Web UI's Explore, Files, or People/domains workspaces, which require the SQLite + DuckDB/Parquet cache regardless of this setting and are unavailable on PostgreSQL; see [PostgreSQL Backend](/architecture/postgresql/) for the current scope.
 

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -1,4 +1,5 @@
 ---
+last_edited: "2026-08-09"
 title: Interactive TUI
 description: Terminal interface for exploring email, text messages, and meeting transcripts.
 ---
@@ -12,15 +13,31 @@ msgvault tui
 
 The TUI always talks to a msgvault HTTP server. Without `[remote].url`, it starts or reuses the local background daemon. The daemon owns database access, analytics engine selection, and cache rebuilds.
 
-The daemon picks its analytics engine once at startup: with `auto_build_cache = true` (the default) it first builds a stale or missing Parquet cache — incremental builds take seconds — and then serves DuckDB over it. Opening aggregate views does not trigger a cache build — the daemon refreshes a stale cache after its scheduled syncs, and `msgvault build-cache` builds one on demand. When the daemon reports it fell back to live SQL (`auto_build_cache = false` over a stale cache, or a failed startup build), `msgvault tui` prints a notice and repeats it on the TUI's info line while views load; after `msgvault build-cache`, restart the daemon to switch it onto the cache. Configure engine selection in `config.toml`:
+The daemon starts its HTTP health endpoint and API routes before analytics cache
+maintenance. Clients can connect while startup work runs.
+
+With `engine = "auto"` (the default), aggregate views initially use live SQL
+(`sql-fallback`). When `auto_build_cache = true` and the cache is stale or
+missing, the daemon builds it in the background; after the cache is ready and
+DuckDB opens successfully, aggregate views switch to DuckDB. A failed build or
+open leaves auto mode on live SQL. With `engine = "duckdb"`, analytics remain
+unavailable until the required cache is ready; analytics routes return `503`
+during initialization. `engine = "sql"` always uses live SQL. Configure engine
+selection in `config.toml`:
 
 ```toml
 [analytics]
 engine = "auto"          # auto, sql, or duckdb
-auto_build_cache = true  # build a stale cache at daemon startup; scheduled-sync refreshes ignore it
+auto_build_cache = true  # build a stale/missing cache in the background at startup
 ```
 
-Deprecated in 0.17.0: the old `msgvault tui --force-sql`, `--no-cache-build`, and `--no-sqlite-scanner` flags are hidden because these choices are now daemon configuration. Use `engine = "sql"` for live SQL, `auto_build_cache = false` to skip the automatic startup cache build, or `msgvault build-cache` to prebuild cache files on the daemon host. See [Configuration: analytics](/configuration/#analytics).
+Opening aggregate views does not trigger a build mid-session. Scheduled syncs
+and ingest commands can refresh the cache, and `msgvault build-cache` builds or
+repairs it on demand. Set `auto_build_cache = false` to skip automatic startup
+maintenance; use `msgvault build-cache` for an explicit build. Deprecated in
+0.17.0: the old `msgvault tui --force-sql`, `--no-cache-build`, and
+`--no-sqlite-scanner` flags are hidden because these choices are now daemon
+configuration. See [Configuration: analytics](/configuration/#analytics).
 
 ### Local And Remote
 

--- a/internal/api/analytics_engine_test.go
+++ b/internal/api/analytics_engine_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/query/querytest"
+)
+
+type blockingAnalyticsEngine struct {
+	*querytest.MockEngine
+
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingAnalyticsEngine) Aggregate(
+	ctx context.Context,
+	_ query.ViewType,
+	_ query.AggregateOptions,
+) ([]query.AggregateRow, error) {
+	close(e.entered)
+	select {
+	case <-e.release:
+		return e.AggregateRows, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestAnalyticsEngineSwapUpdatesHealthAndHandlers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	oldEngine := &querytest.MockEngine{
+		AggregateRows: []query.AggregateRow{{Key: "old", Count: 1}},
+	}
+	newEngine := &querytest.MockEngine{
+		AggregateRows: []query.AggregateRow{{Key: "new", Count: 2}},
+	}
+	opts := testServerOptions(t, nil)
+	opts.Engine = oldEngine
+	opts.AnalyticsMode = AnalyticsModeSQLFallback
+	srv := NewServerWithOptions(opts)
+
+	assertHealthMode := func(want string) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+		require.Equal(http.StatusOK, rec.Code)
+		var body HealthResponse
+		require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
+		assert.Equal(want, body.AnalyticsEngine)
+	}
+
+	assertHealthMode(AnalyticsModeSQLFallback)
+	srv.SetAnalyticsEngine(newEngine, AnalyticsModeDuckDB)
+	assertHealthMode(AnalyticsModeDuckDB)
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/aggregates?view_type=senders", nil))
+	require.Equal(http.StatusOK, rec.Code, rec.Body.String())
+	var body AggregateResponse
+	require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(body.Rows, 1)
+	assert.Equal("new", body.Rows[0].Key)
+}
+
+func TestAnalyticsEngineSwapDoesNotBlockHealthWhileRequestRuns(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	oldEngine := &blockingAnalyticsEngine{
+		MockEngine: &querytest.MockEngine{AggregateRows: []query.AggregateRow{{Key: "old", Count: 1}}},
+		entered:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	opts := testServerOptions(t, nil)
+	opts.Engine = oldEngine
+	opts.AnalyticsMode = AnalyticsModeSQLFallback
+	srv := NewServerWithOptions(opts)
+	t.Cleanup(func() {
+		select {
+		case <-oldEngine.release:
+		default:
+			close(oldEngine.release)
+		}
+	})
+
+	aggregateDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, httptest.NewRequest(
+			http.MethodGet,
+			"/api/v1/aggregates?view_type=senders",
+			nil,
+		))
+		aggregateDone <- rec
+	}()
+	select {
+	case <-oldEngine.entered:
+	case <-time.After(time.Second):
+		require.FailNow("aggregate request did not enter the old engine")
+	}
+
+	swapDone := make(chan struct{})
+	go func() {
+		srv.SetAnalyticsEngine(
+			&querytest.MockEngine{AggregateRows: []query.AggregateRow{{Key: "new", Count: 2}}},
+			AnalyticsModeDuckDB,
+		)
+		close(swapDone)
+	}()
+	require.Eventually(func() bool {
+		select {
+		case <-swapDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond, "engine swap waited for an in-flight request")
+
+	health := httptest.NewRecorder()
+	srv.Router().ServeHTTP(health, httptest.NewRequest(http.MethodGet, "/health", nil))
+	assert.Equal(http.StatusOK, health.Code)
+	var healthBody HealthResponse
+	require.NoError(json.Unmarshal(health.Body.Bytes(), &healthBody))
+	assert.Equal(AnalyticsModeDuckDB, healthBody.AnalyticsEngine)
+
+	close(oldEngine.release)
+	oldResponse := <-aggregateDone
+	require.Equal(http.StatusOK, oldResponse.Code, oldResponse.Body.String())
+	var oldBody AggregateResponse
+	require.NoError(json.Unmarshal(oldResponse.Body.Bytes(), &oldBody))
+	require.Len(oldBody.Rows, 1)
+	assert.Equal("old", oldBody.Rows[0].Key,
+		"the in-flight request must keep its original engine snapshot")
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1684,7 +1684,7 @@ func (s *Server) cliDedupDeleteError(err error) *apiHTTPError {
 }
 
 func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.engine == nil {
+	if s.store == nil || s.queryEngineForContext(r.Context()) == nil {
 		writeError(w, http.StatusServiceUnavailable, "store_unavailable", "Database not available")
 		return
 	}
@@ -1751,7 +1751,7 @@ func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
 		IndexState: s.ensureCLISearchIndexAsync(cliStore),
 	}
 
-	results, err := s.engine.Search(r.Context(), parsed, limit, offset)
+	results, err := s.queryEngineForContext(r.Context()).Search(r.Context(), parsed, limit, offset)
 	if err != nil {
 		s.logger.Error("CLI search failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "search_failed", err.Error())
@@ -2573,7 +2573,7 @@ func (s *Server) operationError(
 }
 
 func (s *Server) handleCLIMessage(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	if s.queryEngineForContext(r.Context()) == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -2597,7 +2597,7 @@ func (s *Server) handleCLIMessage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleCLIMessageRaw(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	if s.queryEngineForContext(r.Context()) == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -2617,7 +2617,7 @@ func (s *Server) handleCLIMessageRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	raw, err := s.engine.GetMessageRaw(r.Context(), msg.ID)
+	raw, err := s.queryEngineForContext(r.Context()).GetMessageRaw(r.Context(), msg.ID)
 	if err != nil {
 		s.logger.Error("failed to get CLI raw message", "id", msg.ID, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to retrieve raw message")
@@ -2710,14 +2710,14 @@ func (s *Server) resolveCLIMessage(r *http.Request, idStr string) (*query.Messag
 		err error
 	)
 	if id, parseErr := strconv.ParseInt(idStr, 10, 64); parseErr == nil {
-		msg, err = s.engine.GetMessage(r.Context(), id)
+		msg, err = s.queryEngineForContext(r.Context()).GetMessage(r.Context(), id)
 		if err != nil {
 			s.logger.Error("failed to get CLI message by id", "id", id, "error", err)
 			return nil, err
 		}
 	}
 	if msg == nil {
-		msg, err = s.engine.GetMessageBySourceID(r.Context(), idStr)
+		msg, err = s.queryEngineForContext(r.Context()).GetMessageBySourceID(r.Context(), idStr)
 		if err != nil {
 			s.logger.Error("failed to get CLI message by source id", "id", idStr, "error", err)
 			return nil, err

--- a/internal/api/deletions.go
+++ b/internal/api/deletions.go
@@ -149,7 +149,7 @@ type CancelDeletionResponse struct {
 }
 
 func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	if s.queryEngineForContext(r.Context()) == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -351,7 +351,8 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 		}
 		selectionRequest.IncludedKeys = selection.RowKeys
 	}
-	analyzer, ok := s.engine.(query.Explorer)
+	engine := s.queryEngineForContext(r.Context())
+	analyzer, ok := engine.(query.Explorer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return nil, nil, false
@@ -389,7 +390,7 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 			"The reviewed selection contains items that cannot be deleted from their source")
 		return nil, nil, false
 	}
-	resolver, ok := s.engine.(deletionMessageIDResolver)
+	resolver, ok := engine.(deletionMessageIDResolver)
 	if !ok {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable",
 			"selection deletion staging is not supported by this query engine")
@@ -415,7 +416,7 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 // single mailbox, so selections spanning multiple Gmail accounts must be
 // split into per-account requests (e.g. scoped with filter.source_id).
 func (s *Server) resolveStageDeletionAccount(ctx context.Context, gmailIDs []string) (string, *apiHTTPError) {
-	resolver, ok := s.engine.(deletionAccountResolver)
+	resolver, ok := s.queryEngineForContext(ctx).(deletionAccountResolver)
 	if !ok {
 		return "", newAPIHTTPError(http.StatusServiceUnavailable, "engine_unavailable",
 			"deletion staging is not supported by this query engine")
@@ -443,6 +444,7 @@ func (s *Server) resolveStageDeletionAccount(ctx context.Context, gmailIDs []str
 // resolveStageDeletionIDs unions filter-resolved and explicitly listed
 // message IDs into a deduplicated, order-preserving Gmail-ID list.
 func (s *Server) resolveStageDeletionIDs(ctx context.Context, req *StageDeletionRequest) ([]string, *apiHTTPError) {
+	engine := s.queryEngineForContext(ctx)
 	var out []string
 	seen := make(map[string]struct{})
 	appendIDs := func(ids []string) {
@@ -460,7 +462,7 @@ func (s *Server) resolveStageDeletionIDs(ctx context.Context, req *StageDeletion
 		if httpErr != nil {
 			return nil, httpErr
 		}
-		ids, err := s.engine.GetGmailIDsByFilter(ctx, mf)
+		ids, err := engine.GetGmailIDsByFilter(ctx, mf)
 		if err != nil {
 			s.logger.Error("stage deletion filter query failed", "error", err)
 			return nil, newAPIHTTPError(http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
@@ -468,7 +470,7 @@ func (s *Server) resolveStageDeletionIDs(ctx context.Context, req *StageDeletion
 		appendIDs(ids)
 	}
 	if len(req.MessageIDs) > 0 {
-		resolver, ok := s.engine.(deletionMessageIDResolver)
+		resolver, ok := engine.(deletionMessageIDResolver)
 		if !ok {
 			return nil, newAPIHTTPError(http.StatusServiceUnavailable, "engine_unavailable",
 				"message_ids staging is not supported by this query engine")

--- a/internal/api/deletions_test.go
+++ b/internal/api/deletions_test.go
@@ -287,7 +287,7 @@ func TestStageDeletionReplaysResolvedIdentityFilterOnceAfterPreflight(t *testing
 	assertions := assert.New(t)
 	fixture := newExploreIdentityAPIFixture(t)
 	st := &deletionIdentityStore{recordingMessageIdentityStore: fixture.store}
-	srv := newDeletionTestServer(t, st, fixture.server.engine)
+	srv := newDeletionTestServer(t, st, fixture.server.QueryEngine())
 	filters := `[
 		{"dimension":"source","values":["1"]},
 		{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -298,7 +298,7 @@ func (s *Server) handleExploreWithScope(w http.ResponseWriter, r *http.Request, 
 	if semanticPage {
 		prepared.query.Page = query.PageSpec{Limit: exploreMaxLimit}
 	}
-	explorer, ok := s.engine.(query.Explorer)
+	explorer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -486,7 +486,7 @@ func (s *Server) handleExploreGroups(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "search_revision_changed", "The resolved search index revision changed; restart pagination")
 		return
 	}
-	analyzer, ok := s.engine.(query.Explorer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -556,7 +556,8 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 		}
 		selectionRequest.IncludedKeys = selection.RowKeys
 	}
-	analyzer, ok := s.engine.(query.Explorer)
+	engine := s.queryEngineForContext(r.Context())
+	analyzer, ok := engine.(query.Explorer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -603,7 +604,7 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 		})
 	} else {
 		messageID := *stats.RawExportMessageID
-		raw, rawErr := s.engine.GetMessageRaw(r.Context(), messageID)
+		raw, rawErr := engine.GetMessageRaw(r.Context(), messageID)
 		if rawErr != nil {
 			s.logger.Warn("raw export preflight failed", "message_id", messageID, "error", rawErr)
 			unavailableActions = append(unavailableActions, ExploreUnavailableAction{
@@ -666,7 +667,7 @@ func (s *Server) handleExploreMatchCounts(w http.ResponseWriter, r *http.Request
 	predicate.query.Search = searchSpec
 	slices.Sort(request.RowKeys)
 	request.RowKeys = slices.Compact(request.RowKeys)
-	analyzer, ok := s.engine.(query.Explorer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return

--- a/internal/api/explore_files.go
+++ b/internal/api/explore_files.go
@@ -76,7 +76,7 @@ func (s *Server) handleExploreFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	predicate.query.Search = searchSpec
-	analyzer, ok := s.engine.(query.Explorer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -207,7 +207,7 @@ func (s *Server) handleGroupFiles(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "search_revision_changed", "The resolved search index revision changed; restart pagination")
 		return
 	}
-	grouper, ok := s.engine.(query.FileGrouper)
+	grouper, ok := s.queryEngineForContext(r.Context()).(query.FileGrouper)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -325,7 +325,7 @@ func (s *Server) handleSearchFilesWithScope(w http.ResponseWriter, r *http.Reque
 			return
 		}
 	}
-	searcher, ok := s.engine.(query.FileSearcher)
+	searcher, ok := s.queryEngineForContext(r.Context()).(query.FileSearcher)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -155,9 +155,9 @@ type OperationHealth struct {
 	StartedAt *time.Time `json:"started_at,omitempty"`
 }
 
-// Analytics engine modes reported by /health. The daemon chooses its engine
-// once at startup, so this reflects what aggregate endpoints actually use
-// for the daemon's lifetime — not what a fresh daemon would choose now.
+// Analytics engine modes reported by /health. The daemon can transition from
+// its startup engine when background cache initialization completes, so this
+// reflects the engine that aggregate endpoints use now.
 // AnalyticsModeSQLFallback distinguishes live SQL forced by a missing or
 // unusable cache from live SQL chosen deliberately (engine = "sql",
 // PostgreSQL backends).
@@ -166,6 +166,10 @@ const (
 	AnalyticsModeSQL         = "sql"
 	AnalyticsModeSQLFallback = "sql-fallback"
 	AnalyticsModePostgres    = "postgres"
+	// AnalyticsModeInitializing reports that a required DuckDB cache is being
+	// built or opened in the background. Analytics routes remain unavailable
+	// until the initializer installs the engine.
+	AnalyticsModeInitializing = "initializing"
 )
 
 const (
@@ -177,9 +181,10 @@ type HealthResponse struct {
 	Status    string           `json:"status"`
 	Vector    *VectorHealth    `json:"vector,omitempty"`
 	Operation *OperationHealth `json:"operation,omitempty"`
-	// AnalyticsEngine is the analytics mode the daemon selected at startup
-	// (one of the AnalyticsMode constants). Empty when the server was built
-	// without one (tests, embedded uses).
+	// AnalyticsEngine is the current analytics mode (one of the AnalyticsMode
+	// constants). It can change when background cache initialization installs a
+	// new engine. Empty when the server was built without one (tests, embedded
+	// uses).
 	AnalyticsEngine string `json:"analytics_engine,omitempty"`
 }
 
@@ -614,8 +619,8 @@ func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.engine != nil {
-		qMsg, err := s.engine.GetMessage(r.Context(), id)
+	if engine := s.queryEngineForContext(r.Context()); engine != nil {
+		qMsg, err := engine.GetMessage(r.Context(), id)
 		switch {
 		case err != nil && !isEngineUnsupported(err):
 			s.logger.Error("failed to get message via engine", "id", id, "error", err)
@@ -1262,8 +1267,8 @@ func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 
 	// Build source ID lookup from the engine (database sources table).
 	sourceIDs := make(map[string]int64)
-	if s.engine != nil {
-		if engineAccounts, err := s.engine.ListAccounts(r.Context()); err == nil {
+	if engine := s.queryEngineForContext(r.Context()); engine != nil {
+		if engineAccounts, err := engine.ListAccounts(r.Context()); err == nil {
 			for _, ea := range engineAccounts {
 				sourceIDs[ea.Identifier] = ea.ID
 			}
@@ -1814,7 +1819,10 @@ type QueryRequest struct {
 	SQL string `json:"sql"`
 }
 
-var errSQLQueryEngineUnavailable = errors.New("SQL query requires DuckDB engine (analytics cache may not be built)")
+// ErrSQLQueryEngineUnavailable is returned when a raw SQL request has no
+// analytics engine. Callers outside the API package use this sentinel so the
+// handler can preserve its 503 engine-unavailable response.
+var ErrSQLQueryEngineUnavailable = errors.New("SQL query requires DuckDB engine (analytics cache may not be built)")
 
 // handleQuery executes a raw SQL query against DuckDB views.
 // POST /api/v1/query.
@@ -1843,10 +1851,10 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.runSQLQuery(r.Context(), req.SQL)
 	if err != nil {
-		if errors.Is(err, errSQLQueryEngineUnavailable) {
+		if errors.Is(err, ErrSQLQueryEngineUnavailable) {
 			writeError(w, http.StatusServiceUnavailable,
 				"engine_unavailable",
-				errSQLQueryEngineUnavailable.Error())
+				ErrSQLQueryEngineUnavailable.Error())
 			return
 		}
 		if s.writeIfContextError(w, err) {
@@ -1864,14 +1872,25 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) runSQLQuery(ctx context.Context, sql string) (*query.QueryResult, error) {
+	if s.analyticsInitializingForContext(ctx) {
+		return nil, ErrSQLQueryEngineUnavailable
+	}
 	if s.sqlQueryRunner != nil {
 		return s.sqlQueryRunner(ctx, sql)
 	}
-	querier, ok := s.engine.(query.SQLQuerier)
+	querier, ok := s.queryEngineForContext(ctx).(query.SQLQuerier)
 	if !ok {
-		return nil, errSQLQueryEngineUnavailable
+		return nil, ErrSQLQueryEngineUnavailable
 	}
 	return querier.QuerySQL(ctx, sql)
+}
+
+func (s *Server) writeIfAnalyticsInitializing(ctx context.Context, w http.ResponseWriter) bool {
+	if !s.analyticsInitializingForContext(ctx) {
+		return false
+	}
+	writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Analytics engine is initializing")
+	return true
 }
 
 // ============================================================================
@@ -2432,12 +2451,13 @@ func toTextConversationRow(row query.ConversationRow) TextConversationRow {
 	}
 }
 
-func (s *Server) textEngine(w http.ResponseWriter) (query.TextEngine, bool) {
-	if s.engine == nil {
+func (s *Server) textEngine(ctx context.Context, w http.ResponseWriter) (query.TextEngine, bool) {
+	engine := s.queryEngineForContext(ctx)
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return nil, false
 	}
-	textEngine, ok := s.engine.(query.TextEngine)
+	textEngine, ok := engine.(query.TextEngine)
 	if !ok {
 		writeError(w, http.StatusServiceUnavailable, "text_engine_unavailable", "Text query engine not available")
 		return nil, false
@@ -2541,7 +2561,11 @@ func formatDeletedAt(deletedAt *time.Time) string {
 // handleAggregates returns aggregate data for a view type.
 // GET /api/v1/aggregates?view_type=senders&sort=count&direction=desc&limit=100.
 func (s *Server) handleAggregates(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	if s.writeIfAnalyticsInitializing(r.Context(), w) {
+		return
+	}
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -2563,7 +2587,7 @@ func (s *Server) handleAggregates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := s.engine.Aggregate(r.Context(), viewType, opts)
+	rows, err := engine.Aggregate(r.Context(), viewType, opts)
 	if err != nil {
 		if s.writeIfContextError(w, err) {
 			return
@@ -2587,7 +2611,11 @@ func (s *Server) handleAggregates(w http.ResponseWriter, r *http.Request) {
 // handleSubAggregates returns sub-aggregate data after drill-down.
 // GET /api/v1/aggregates/sub?view_type=labels&sender=foo@example.com.
 func (s *Server) handleSubAggregates(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	if s.writeIfAnalyticsInitializing(r.Context(), w) {
+		return
+	}
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -2621,7 +2649,7 @@ func (s *Server) handleSubAggregates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := s.engine.SubAggregate(r.Context(), filter, viewType, opts)
+	rows, err := engine.SubAggregate(r.Context(), filter, viewType, opts)
 	if err != nil {
 		if s.writeIfContextError(w, err) {
 			return
@@ -2645,7 +2673,8 @@ func (s *Server) handleSubAggregates(w http.ResponseWriter, r *http.Request) {
 // handleFilteredMessages returns a filtered list of messages.
 // GET /api/v1/messages/filter?sender=foo@example.com&offset=0&limit=500.
 func (s *Server) handleFilteredMessages(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -2669,7 +2698,7 @@ func (s *Server) handleFilteredMessages(w http.ResponseWriter, r *http.Request) 
 	requestLimit := filter.Pagination.Limit
 	filter.Pagination.Limit = requestLimit + 1
 
-	messages, err := s.engine.ListMessages(r.Context(), filter)
+	messages, err := engine.ListMessages(r.Context(), filter)
 	if err != nil {
 		if s.writeIfContextError(w, err) {
 			return
@@ -2974,7 +3003,8 @@ func changesTimePtr(value *time.Time) *string {
 }
 
 func (s *Server) handleGmailIDsByFilter(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -2984,7 +3014,7 @@ func (s *Server) handleGmailIDsByFilter(w http.ResponseWriter, r *http.Request) 
 		s.rejectBadParam(w, err)
 		return
 	}
-	ids, err := s.engine.GetGmailIDsByFilter(r.Context(), filter)
+	ids, err := engine.GetGmailIDsByFilter(r.Context(), filter)
 	if err != nil {
 		s.logger.Error("gmail id filter query failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
@@ -2998,7 +3028,8 @@ func (s *Server) handleGmailIDsByFilter(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -3010,7 +3041,7 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	att, err := s.engine.GetAttachment(r.Context(), id)
+	att, err := engine.GetAttachment(r.Context(), id)
 	if err != nil {
 		s.logger.Error("failed to get attachment", "id", id, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to retrieve attachment")
@@ -3035,7 +3066,8 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 // SHA-256 content hash. The /content suffix keeps this binary response distinct
 // from GET /attachments/{id}, which returns attachment metadata as JSON.
 func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -3047,7 +3079,7 @@ func (s *Server) handleGetAttachmentContent(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	attachments, err := s.engine.GetAttachmentsByHash(r.Context(), hash)
+	attachments, err := engine.GetAttachmentsByHash(r.Context(), hash)
 	if err != nil {
 		s.logger.Error("failed to look up attachment by hash", "error", err, "hash", hash)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to look up attachment")
@@ -3206,7 +3238,8 @@ func contentDisposition(filename string) string {
 }
 
 func (s *Server) handleSearchByDomains(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -3230,7 +3263,7 @@ func (s *Server) handleSearchByDomains(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requestLimit := filter.Pagination.Limit
-	messages, err := s.engine.SearchByDomains(
+	messages, err := engine.SearchByDomains(
 		r.Context(),
 		domains,
 		filter.After,
@@ -3280,7 +3313,11 @@ func parseDomainValues(values []string) []string {
 // handleTotalStats returns detailed stats with optional filters.
 // GET /api/v1/stats/total?source_id=1&attachments_only=true.
 func (s *Server) handleTotalStats(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	if s.writeIfAnalyticsInitializing(r.Context(), w) {
+		return
+	}
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -3334,7 +3371,7 @@ func (s *Server) handleTotalStats(w http.ResponseWriter, r *http.Request) {
 		opts.GroupBy = viewType
 	}
 
-	stats, err := s.engine.GetTotalStats(r.Context(), opts)
+	stats, err := engine.GetTotalStats(r.Context(), opts)
 	if err != nil {
 		if s.writeIfContextError(w, err) {
 			return
@@ -3368,7 +3405,8 @@ func normalizeSourceIDs(ids []int64) []int64 {
 // handleFastSearch performs fast metadata search (subject, sender, recipient).
 // GET /api/v1/search/fast?q=invoice&offset=0&limit=100.
 func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -3432,7 +3470,7 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 		limit = maxPageSize
 	}
 
-	result, err := s.engine.SearchFastWithStats(r.Context(), q, queryStr, filter, statsGroupBy, limit, offset)
+	result, err := engine.SearchFastWithStats(r.Context(), q, queryStr, filter, statsGroupBy, limit, offset)
 	if err != nil {
 		if s.writeIfContextError(w, err) {
 			return
@@ -3460,7 +3498,8 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 // search when scope=body is requested.
 // GET /api/v1/search/deep?q=invoice&scope=body&offset=0&limit=100&source_id=1&hide_deleted=true.
 func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -3522,7 +3561,7 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	// Fetch one extra row to determine has_more accurately.
 	var messages []query.MessageSummary
 	if scope == "body" {
-		bodySearcher, ok := s.engine.(query.MessageBodySearcher)
+		bodySearcher, ok := engine.(query.MessageBodySearcher)
 		if !ok {
 			writeError(w, http.StatusNotImplemented, "body_search_unavailable",
 				"Query engine does not support exact message body search")
@@ -3530,7 +3569,7 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		messages, err = bodySearcher.SearchMessageBodies(r.Context(), merged, limit+1, offset)
 	} else {
-		messages, err = s.engine.Search(r.Context(), merged, limit+1, offset)
+		messages, err = engine.Search(r.Context(), merged, limit+1, offset)
 	}
 	if err != nil {
 		if s.writeIfContextError(w, err) {
@@ -3580,7 +3619,7 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTextConversations(w http.ResponseWriter, r *http.Request) {
-	textEngine, ok := s.textEngine(w)
+	textEngine, ok := s.textEngine(r.Context(), w)
 	if !ok {
 		return
 	}
@@ -3629,7 +3668,7 @@ func (s *Server) handleTextConversations(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleTextAggregates(w http.ResponseWriter, r *http.Request) {
-	textEngine, ok := s.textEngine(w)
+	textEngine, ok := s.textEngine(r.Context(), w)
 	if !ok {
 		return
 	}
@@ -3672,7 +3711,7 @@ func (s *Server) handleTextAggregates(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTextConversationMessages(w http.ResponseWriter, r *http.Request) {
-	textEngine, ok := s.textEngine(w)
+	textEngine, ok := s.textEngine(r.Context(), w)
 	if !ok {
 		return
 	}
@@ -3726,7 +3765,7 @@ func (s *Server) handleTextConversationMessages(w http.ResponseWriter, r *http.R
 }
 
 func (s *Server) handleTextSearch(w http.ResponseWriter, r *http.Request) {
-	textEngine, ok := s.textEngine(w)
+	textEngine, ok := s.textEngine(r.Context(), w)
 	if !ok {
 		return
 	}
@@ -3785,7 +3824,7 @@ func (s *Server) handleTextSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTextStats(w http.ResponseWriter, r *http.Request) {
-	textEngine, ok := s.textEngine(w)
+	textEngine, ok := s.textEngine(r.Context(), w)
 	if !ok {
 		return
 	}
@@ -3830,7 +3869,8 @@ type archivedMessageRawReader interface {
 // query parameter so values containing `/` (legal per RFC 5322) round-trip
 // without ambiguity in the routing layer.
 func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
-	if s.engine == nil {
+	engine := s.queryEngineForContext(r.Context())
+	if engine == nil {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
@@ -3852,7 +3892,7 @@ func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 		if reader, ok := s.store.(archivedMessageRawReader); ok {
 			return reader.GetArchivedMessageRaw(ctx, id)
 		}
-		return s.engine.GetMessageRaw(ctx, id)
+		return engine.GetMessageRaw(ctx, id)
 	}
 
 	entry, err := s.inlineCache.parsed(r.Context(), id, loadRaw)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2105,7 +2105,7 @@ func TestHandleCLISearchProbeRefusesMemoizeDuringRebuild(t *testing.T) {
 		},
 	}
 	srv := newCLIHandlerTestServer(st)
-	srv.engine = engine
+	srv.SetAnalyticsEngine(engine, srv.AnalyticsMode())
 
 	rebuildDone := make(chan *httptest.ResponseRecorder, 1)
 	go func() {
@@ -6645,6 +6645,38 @@ func TestHandleQuery_SQLiteEngine503(t *testing.T) {
 	var errResp ErrorResponse
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp), "failed to decode error response")
 	assert.Equal(t, "engine_unavailable", errResp.Error, "error")
+}
+
+func TestHandleQuery_DuckDBInitializing503(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cfg := &config.Config{
+		Server: config.ServerConfig{APIPort: 8080},
+	}
+	runnerCalled := false
+	srv := NewServerWithOptions(ServerOptions{
+		Config:        cfg,
+		Engine:        &querytest.MockEngine{},
+		AnalyticsMode: AnalyticsModeInitializing,
+		SQLQueryRunner: func(context.Context, string) (*query.QueryResult, error) {
+			runnerCalled = true
+			return &query.QueryResult{}, nil
+		},
+		Logger: testLogger(),
+	})
+
+	body := `{"sql": "SELECT 1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(http.StatusServiceUnavailable, w.Code, "status (body: %s)", w.Body.String())
+	var errResp ErrorResponse
+	require.NoError(json.NewDecoder(w.Body).Decode(&errResp), "failed to decode error response")
+	assert.Equal("engine_unavailable", errResp.Error, "error")
+	assert.False(runnerCalled, "initializing DuckDB must not fall through to the SQLite query runner")
 }
 
 // fakeVectorBackend is a test stub implementing vector.Backend. Tests

--- a/internal/api/people.go
+++ b/internal/api/people.go
@@ -103,7 +103,7 @@ func (s *Server) handleSearchPeople(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	analyzer, ok := s.engine.(query.PeopleAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -136,7 +136,7 @@ func (s *Server) handleSearchDomains(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	analyzer, ok := s.engine.(query.PeopleAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -232,7 +232,7 @@ func (s *Server) handleGetPerson(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	analyzer, ok := s.engine.(query.PeopleAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -333,7 +333,7 @@ func (s *Server) handlePersonContextSummary(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return
 	}
-	analyzer, ok := s.engine.(query.PeopleAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -359,7 +359,7 @@ func (s *Server) handleGetDomain(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	analyzer, ok := s.engine.(query.PeopleAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -385,7 +385,7 @@ func (s *Server) handleDomainContextSummary(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return
 	}
-	analyzer, ok := s.engine.(query.PeopleAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return

--- a/internal/api/relationships.go
+++ b/internal/api/relationships.go
@@ -79,7 +79,7 @@ func (s *Server) handleRelationships(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	analyzer, ok := s.engine.(query.RelationshipAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.RelationshipAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return
@@ -197,7 +197,7 @@ func (s *Server) handleRelationshipTimeline(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	analyzer, ok := s.engine.(query.RelationshipAnalyzer)
+	analyzer, ok := s.queryEngineForContext(r.Context()).(query.RelationshipAnalyzer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return

--- a/internal/api/search_coverage.go
+++ b/internal/api/search_coverage.go
@@ -76,7 +76,7 @@ func (s *Server) handleSearchCoverage(w http.ResponseWriter, r *http.Request) {
 	}
 	_, backend, cfg := s.vectorComponents()
 	ctx = semanticCoverageContext(ctx, cfg.Embed.Scope.BuildScope())
-	explorer, ok := s.engine.(query.Explorer)
+	explorer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
 		writeExploreUnavailable(w, query.CacheAbsent)
 		return

--- a/internal/api/search_coverage_test.go
+++ b/internal/api/search_coverage_test.go
@@ -262,7 +262,7 @@ func TestSearchCoverageResolvesIdentityFilterOnce(t *testing.T) {
 	}
 	srv := NewServerWithOptions(ServerOptions{
 		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
-		Store:  fixture.store, Engine: fixture.server.engine, Backend: backend,
+		Store:  fixture.store, Engine: fixture.server.QueryEngine(), Backend: backend,
 		VectorStatus: VectorStatusReady, Logger: testLogger(),
 	})
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -215,12 +215,19 @@ type AttachmentBlobStore interface {
 
 type fastmailIdentityInventory = provideridentity.Inventory
 
+type analyticsEngineState struct {
+	engine query.Engine
+	mode   string
+}
+
+type analyticsEngineContextKey struct{}
+
 // Server represents the HTTP API server.
 type Server struct {
 	cfg            *config.Config
 	store          MessageStore
+	analyticsState atomic.Pointer[analyticsEngineState]
 	savedViewStore SavedViewStore
-	engine         query.Engine // Query engine for aggregates and TUI support
 	sqlQueryRunner SQLQueryRunner
 	shutdownToken  string
 	shutdownFunc   func()
@@ -239,17 +246,23 @@ type Server struct {
 	inProgressThreshold time.Duration
 	inProgressInterval  time.Duration
 	daemonVersion       string
-	analyticsMode       string
 	// lexicalCandidateCap overrides query.MaxExploreCandidateMessageIDs in
 	// resolveExploreSearch. Tests shrink it to exercise cap behavior without
 	// building 10k-row fixtures; zero means the production cap.
 	lexicalCandidateCap int
 	router              http.Handler
-	server              *http.Server
-	rateLimiter         *RateLimiter
-	changesRateLimiter  *RateLimiter
-	idleTracker         *IdleTracker
-	operationGate       OperationGate
+	// serverMu protects the HTTP server pointer and listener-start state. The
+	// daemon starts Serve in a goroutine while shutdown can begin from a
+	// cancelled root context, so Shutdown must not race the assignment below.
+	serverMu           sync.RWMutex
+	server             *http.Server
+	started            chan struct{}
+	startErr           error
+	startOnce          sync.Once
+	rateLimiter        *RateLimiter
+	changesRateLimiter *RateLimiter
+	idleTracker        *IdleTracker
+	operationGate      OperationGate
 	// ftsIndexComplete memoizes that the FTS index is fully populated so
 	// handleCLISearch stops probing on every request. NeedsFTSBackfill runs an
 	// anti-join that scans every message when the index is complete (the
@@ -414,10 +427,10 @@ type ServerOptions struct {
 	// DaemonVersion is returned by the unauthenticated kit-compatible
 	// /api/ping endpoint used for local daemon discovery. Empty is allowed.
 	DaemonVersion string
-	// AnalyticsMode is the analytics engine the daemon selected at startup
-	// (an AnalyticsMode constant), reported by /health so clients can tell
-	// whether aggregate views run on the cache or live SQL. Empty omits the
-	// field.
+	// AnalyticsMode is the analytics engine the daemon selected initially (an
+	// AnalyticsMode constant), reported by /health so clients can tell whether
+	// aggregate views run on the cache or live SQL. The daemon may replace the
+	// engine and mode at runtime. Empty omits the field.
 	AnalyticsMode string
 	// SPAHandler overrides the embedded browser application handler. Nil uses
 	// internal/web.Handler and is the production default. Tests may inject a
@@ -461,7 +474,6 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		cfg:                      opts.Config,
 		store:                    opts.Store,
 		savedViewStore:           opts.SavedViewStore,
-		engine:                   opts.Engine,
 		sqlQueryRunner:           opts.SQLQueryRunner,
 		shutdownToken:            opts.ShutdownToken,
 		shutdownFunc:             opts.ShutdownFunc,
@@ -476,7 +488,6 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		inProgressThreshold:      inProgressLogThreshold,
 		inProgressInterval:       inProgressLogInterval,
 		daemonVersion:            opts.DaemonVersion,
-		analyticsMode:            opts.AnalyticsMode,
 		idleTracker:              opts.IdleTracker,
 		operationGate:            opts.OperationGate,
 		blobStore:                opts.BlobStore,
@@ -492,7 +503,9 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		taskLinkOperations:       opts.TaskLinkOperations,
 		taskIdentityResolver:     opts.TaskIdentityResolver,
 		fastmailInventoryFactory: fastmailInventoryFactory,
+		started:                  make(chan struct{}),
 	}
+	s.analyticsState.Store(&analyticsEngineState{engine: opts.Engine, mode: opts.AnalyticsMode})
 	if s.taskIdentityResolver == nil {
 		s.taskIdentityResolver = s.resolveTaskMessageIdentity
 	}
@@ -556,6 +569,7 @@ func (s *Server) setupRouter() http.Handler {
 	// on or observe archive work. The gate still checks API auth itself so
 	// unauthenticated requests do not register as waiters.
 	var h http.Handler = mux
+	h = s.analyticsEngineMiddleware(h)
 	h = operationGateMiddleware(s.operationGate, s.apiRequestAuthorized)(h)
 	h = s.csrfMiddleware(h)
 	h = s.requestSecurityMiddleware(h)
@@ -608,9 +622,55 @@ func (s *Server) Start() error {
 	addr := net.JoinHostPort(bindAddr, strconv.Itoa(s.cfg.Server.APIPort))
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		return fmt.Errorf("listen %s: %w", addr, err)
+		listenErr := fmt.Errorf("listen %s: %w", addr, err)
+		s.signalStarted(listenErr)
+		return listenErr
 	}
 	return s.StartOnListener(ln)
+}
+
+// WaitStarted waits until StartOnListener has installed the HTTP server and
+// listener metadata, or until startup reports an error. A cancelled context
+// only cancels the wait; callers that close the reserved listener must wait
+// again without cancellation before releasing resources used by startup.
+func (s *Server) WaitStarted(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.serverMu.Lock()
+	started := s.started
+	if started == nil {
+		started = make(chan struct{})
+		s.started = started
+	}
+	s.serverMu.Unlock()
+
+	select {
+	case <-started:
+		s.serverMu.RLock()
+		err := s.startErr
+		s.serverMu.RUnlock()
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Server) signalStarted(err error) {
+	s.serverMu.Lock()
+	started := s.started
+	if started == nil {
+		started = make(chan struct{})
+		s.started = started
+	}
+	s.serverMu.Unlock()
+
+	s.startOnce.Do(func() {
+		s.serverMu.Lock()
+		s.startErr = err
+		s.serverMu.Unlock()
+		close(started)
+	})
 }
 
 // StartOnListener serves HTTP requests on an already-bound listener. The serve
@@ -618,10 +678,13 @@ func (s *Server) Start() error {
 // startup work begins.
 func (s *Server) StartOnListener(ln net.Listener) error {
 	if ln == nil {
-		return errors.New("nil listener")
+		err := errors.New("nil listener")
+		s.signalStarted(err)
+		return err
 	}
 	if err := s.cfg.Server.ValidateSecure(); err != nil {
 		_ = ln.Close()
+		s.signalStarted(err)
 		return err
 	}
 
@@ -629,27 +692,30 @@ func (s *Server) StartOnListener(ln net.Listener) error {
 		s.logger.Warn("API server running without authentication — set [server] api_key in config.toml")
 	}
 
-	if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
-		s.listenPort = tcpAddr.Port
-	}
-	s.listenerBound = true
-
 	// WriteTimeout must comfortably exceed the request-context timeout;
 	// otherwise a request whose context deadline equals the server
 	// WriteTimeout could lose the race and have its TCP connection torn down
 	// before the structured error response reaches the client.
 	writeBudget := max(s.requestTimeout, DaemonLongRequestTimeout)
 	writeTimeout := writeBudget + 5*time.Second
-	s.server = &http.Server{
+	server := &http.Server{
 		Addr:         ln.Addr().String(),
 		Handler:      s.router,
 		ReadTimeout:  s.readTimeout,
 		WriteTimeout: writeTimeout,
 		IdleTimeout:  120 * time.Second,
 	}
+	s.serverMu.Lock()
+	if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
+		s.listenPort = tcpAddr.Port
+	}
+	s.listenerBound = true
+	s.server = server
+	s.serverMu.Unlock()
+	s.signalStarted(nil)
 
 	s.logger.Info("starting API server", "addr", ln.Addr().String())
-	return s.server.Serve(ln)
+	return server.Serve(ln)
 }
 
 // Shutdown gracefully shuts down the server.
@@ -663,16 +729,113 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.sessions != nil {
 		s.sessions.Close()
 	}
-	if s.server == nil {
+	s.serverMu.RLock()
+	server := s.server
+	s.serverMu.RUnlock()
+	if server == nil {
 		return nil
 	}
 	s.logger.Info("shutting down API server")
-	return s.server.Shutdown(ctx)
+	return server.Shutdown(ctx)
 }
 
 // Router returns the HTTP router for testing.
 func (s *Server) Router() http.Handler {
 	return s.router
+}
+
+// analyticsEngineMiddleware snapshots the immutable engine/mode pair into the
+// request context. A runtime swap is one atomic pointer store, so it never
+// waits for a request and each request keeps one consistent view.
+func (s *Server) analyticsEngineMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		state := s.analyticsState.Load()
+		ctx := context.WithValue(r.Context(), analyticsEngineContextKey{}, state)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (s *Server) analyticsStateForContext(ctx context.Context) *analyticsEngineState {
+	if ctx != nil {
+		if state, ok := ctx.Value(analyticsEngineContextKey{}).(*analyticsEngineState); ok && state != nil {
+			return state
+		}
+	}
+	return s.currentAnalyticsState()
+}
+
+func (s *Server) currentAnalyticsState() *analyticsEngineState {
+	return s.analyticsState.Load()
+}
+
+func (s *Server) queryEngineForContext(ctx context.Context) query.Engine {
+	state := s.analyticsStateForContext(ctx)
+	if state == nil {
+		return nil
+	}
+	return state.engine
+}
+
+func (s *Server) analyticsModeForContext(ctx context.Context) string {
+	state := s.analyticsStateForContext(ctx)
+	if state == nil {
+		return ""
+	}
+	return state.mode
+}
+
+func (s *Server) analyticsInitializingForContext(ctx context.Context) bool {
+	return s.analyticsModeForContext(ctx) == AnalyticsModeInitializing
+}
+
+// QueryEngine returns the analytics engine currently serving API queries.
+// The daemon uses it when a request must follow a runtime engine swap.
+func (s *Server) QueryEngine() query.Engine {
+	state := s.currentAnalyticsState()
+	if state == nil {
+		return nil
+	}
+	return state.engine
+}
+
+// QueryEngineForRequest returns the engine snapshot carried by a routed
+// request context. Callbacks invoked by handlers use it to stay on the same
+// engine even if background initialization installs a new state.
+func (s *Server) QueryEngineForRequest(ctx context.Context) query.Engine {
+	return s.queryEngineForContext(ctx)
+}
+
+// AnalyticsMode returns the analytics mode currently reported by health
+// endpoints. The engine and mode come from one immutable state snapshot.
+func (s *Server) AnalyticsMode() string {
+	state := s.currentAnalyticsState()
+	if state == nil {
+		return ""
+	}
+	return state.mode
+}
+
+// SetAnalyticsEngine installs an engine and its matching health mode as one
+// state transition. It deliberately does not close the previous engine:
+// daemon-owned engines remain live until HTTP shutdown and background workers
+// have stopped.
+func (s *Server) SetAnalyticsEngine(engine query.Engine, mode string) {
+	s.analyticsState.Store(&analyticsEngineState{engine: engine, mode: mode})
+}
+
+// CloseAnalyticsEngine closes and clears the current engine after the daemon
+// has shut down HTTP handling. If HTTP shutdown fails, the daemon skips this
+// call so a late request cannot use an engine while it is being closed.
+func (s *Server) CloseAnalyticsEngine() error {
+	state := s.analyticsState.Swap(&analyticsEngineState{})
+	var engine query.Engine
+	if state != nil {
+		engine = state.engine
+	}
+	if engine == nil {
+		return nil
+	}
+	return engine.Close()
 }
 
 func (s *Server) requestUsesCLITimeoutPolicy(r *http.Request) bool {
@@ -1047,7 +1210,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		Status:          "ok",
 		Vector:          s.vectorHealth(),
 		Operation:       s.operationBusyHealth(),
-		AnalyticsEngine: s.analyticsMode,
+		AnalyticsEngine: s.analyticsModeForContext(r.Context()),
 	})
 }
 
@@ -1059,7 +1222,7 @@ func (s *Server) handleAuthenticatedHealth(w http.ResponseWriter, r *http.Reques
 		Status:          "ok",
 		Vector:          s.vectorHealth(),
 		Operation:       s.operationHealth(),
-		AnalyticsEngine: s.analyticsMode,
+		AnalyticsEngine: s.analyticsModeForContext(r.Context()),
 	})
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1475,3 +1475,86 @@ func TestMarkedCLIProtectiveRouteCanReadBodyPastOrdinaryServerTimeout(t *testing
 		assert.Equal(t, http.StatusRequestTimeout, status)
 	})
 }
+
+type blockingAddrListener struct {
+	net.Listener
+
+	addrEntered chan struct{}
+	release     chan struct{}
+	addrOnce    sync.Once
+}
+
+func (l *blockingAddrListener) Addr() net.Addr {
+	l.addrOnce.Do(func() { close(l.addrEntered) })
+	<-l.release
+	return l.Listener.Addr()
+}
+
+func TestServerWaitStartedHonorsCancellationAndReportsReadiness(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err, "listen")
+	listener := &blockingAddrListener{
+		Listener:    base,
+		addrEntered: make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		select {
+		case <-listener.release:
+		default:
+			close(listener.release)
+		}
+		_ = listener.Close()
+	})
+
+	srv := NewServerWithOptions(ServerOptions{
+		Config: config.NewDefaultConfig(),
+		Logger: testLogger(),
+	})
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.StartOnListener(listener) }()
+	select {
+	case <-listener.addrEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("server did not reach listener-start setup")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(srv.WaitStarted(ctx), context.Canceled)
+
+	close(listener.release)
+	require.NoError(srv.WaitStarted(context.Background()), "listener startup")
+	srv.serverMu.RLock()
+	server := srv.server
+	bound := srv.listenerBound
+	srv.serverMu.RUnlock()
+	assert.NotNil(server)
+	assert.True(bound)
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutdownCancel()
+	require.NoError(srv.Shutdown(shutdownCtx), "shutdown")
+	require.ErrorIs(<-serveErr, http.ErrServerClosed, "serve result")
+}
+
+func TestServerWaitStartedReportsListenError(t *testing.T) {
+	require := require.New(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err, "reserve listener")
+	defer func() { _ = listener.Close() }()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(ok, "listener address must be TCP")
+
+	c := config.NewDefaultConfig()
+	c.Server.BindAddr = "127.0.0.1"
+	c.Server.APIPort = addr.Port
+	srv := NewServerWithOptions(ServerOptions{Config: c, Logger: testLogger()})
+	startErr := srv.Start()
+	require.Error(startErr)
+	waitErr := srv.WaitStarted(context.Background())
+	require.Error(waitErr)
+	assert.EqualError(t, waitErr, startErr.Error())
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -376,6 +376,13 @@ type updateCheckMsg struct {
 	isDevBuild bool
 }
 
+// AnalyticsNoticeMsg replaces the analytics notice shown while aggregate
+// data loads. The command layer sends an empty notice after a background
+// cache initialization switches the daemon from live SQL to DuckDB.
+type AnalyticsNoticeMsg struct {
+	Notice string
+}
+
 // loadData fetches aggregate data based on current view settings.
 func (m Model) loadData() tea.Cmd {
 	requestID := m.aggregateRequestID
@@ -993,6 +1000,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleAccountsLoaded(msg)
 	case updateCheckMsg:
 		return m.handleUpdateCheck(msg)
+	case AnalyticsNoticeMsg:
+		m.analyticsNotice = msg.Notice
+		return m, nil
 	case messagesLoadedMsg:
 		return m.handleMessagesLoaded(msg)
 	case messageDetailLoadedMsg:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -30,6 +30,16 @@ func TestModel_Init_SetsLoadingState(t *testing.T) {
 	assert.True(t, model.loading, "expected loading=true for fresh model")
 }
 
+func TestModelUpdateAnalyticsNotice(t *testing.T) {
+	model := NewBuilder().Build()
+	model.analyticsNotice = "analytics cache is initializing"
+
+	updated, cmd := model.Update(AnalyticsNoticeMsg{})
+
+	assert.Nil(t, cmd)
+	assert.Empty(t, asModel(t, updated).analyticsNotice)
+}
+
 // =============================================================================
 // New (Constructor) Tests
 // =============================================================================


### PR DESCRIPTION
## What changed

- Start the API and health endpoint before automatic analytics cache inspection, build, or open work.
- In `auto` mode, serve analytics through live SQL while the cache initializes, then switch new requests to DuckDB after the cache is usable.
- In explicit `duckdb` mode, keep SQLite-backed archive, detail, search, attachment, and text routes available while DuckDB-dependent analytics return 503 until initialization completes.
- Give analytics initialization priority over vector migration work, preserve safe engine and store lifetimes through shutdown, and keep explicit startup cache-build outcomes observable without a duplicate HTTP build.
- Refresh the TUI initialization notice after the runtime switch and document the startup behavior. SQL, PostgreSQL, cache format, and schema behavior are unchanged.

## Why

A cache build that scales with archive size could keep the listener closed for minutes, so `/health` reported a failed start even though the daemon was doing valid work. Starting the listener first keeps supervised deployments healthy and makes the current analytics state explicit while the cache becomes usable.

## Usage

No usage change.

Closes #579
