### PR TITLE
fix(ci): stabilize relationship memory test

### DIFF
--- a/internal/identityindex/relationship_sql_test.go
+++ b/internal/identityindex/relationship_sql_test.go
@@ -124,7 +124,7 @@ func TestBuildStreamsRelationshipActivityUnderLowMemory(t *testing.T) {
 		messageType:      "email",
 		conversationType: "email_thread",
 	})
-	requirements.NoError(setRelationshipTestMemoryLimit(db, "128MB"))
+	requirements.NoError(setRelationshipTestMemoryLimit(db, "96MB"))
 
 	path := func(dataset string) string {
 		return parquetDatasetGlob(root, dataset)


### PR DESCRIPTION
## Why

The macOS 15 CI gate can fail even when the streamed relationship builder is healthy because DuckDB’s legacy fan-out query sits on the 128 MB spill boundary. Identical runs can therefore alternate between the expected out-of-memory result and an unexpected success.

## Behavior

Tighten the test-only memory ceiling to keep the legacy path over budget while the streamed builder still completes its million-row fixture. Production configuration and runtime behavior are unchanged.

## Review boundaries

Only the low-memory regression threshold changes.