### PR TITLE
test(identityindex): remove platform-dependent OOM assertion

### DIFF
--- a/internal/identityindex/relationship_sql_test.go
+++ b/internal/identityindex/relationship_sql_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,15 +124,6 @@ func TestBuildStreamsRelationshipActivityUnderLowMemory(t *testing.T) {
 		conversationType: "email_thread",
 	})
 	requirements.NoError(setRelationshipTestMemoryLimit(db, "96MB"))
-
-	path := func(dataset string) string {
-		return parquetDatasetGlob(root, dataset)
-	}
-	legacyOutput := filepath.Join(t.TempDir(), "legacy.parquet")
-	_, err := db.Exec(`COPY (` + buildLegacyRelationshipActivitySQL(path) + `) TO '` +
-		quoteSQLString(legacyOutput) + `' (FORMAT PARQUET)`)
-	requirements.Error(err)
-	assertions.Contains(strings.ToLower(err.Error()), "out of memory")
 
 	result, err := Build(context.Background(), db, BuildOptions{
 		Mode:           ModeFull,


### PR DESCRIPTION
Remove the requirement that the legacy relationship activity query must exhaust a fixed DuckDB memory budget.

That assertion depends on runner-specific memory behavior and can fail before the production path is exercised. The low-memory test still runs the production relationship build under the 96 MB cap and verifies both expected one-million-row counts.

Review boundary: test-only change in `internal/identityindex/relationship_sql_test.go`.
