### PR TITLE
feat(vector): support account-scoped embedding builds

### DIFF
--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -12,6 +12,8 @@ var (
 	embedFullRebuild            bool
 	embedYes                    bool
 	embedBackstop               bool
+	embedAccounts               []string
+	embedCollections            []string
 	embeddingsRetireYes         bool
 	embeddingsRetireForceActive bool
 	embeddingsActivateForce     bool
@@ -76,6 +78,10 @@ to point at a running OpenAI-compatible endpoint.`,
 	cmd.Flags().BoolVar(&embedYes, "yes", false, "Skip confirmation prompts")
 	cmd.Flags().BoolVar(&embedBackstop, "backstop", false,
 		"Full-scan pass that ignores the per-generation watermark, catching any straggler messages the incremental scan skipped (idempotent)")
+	cmd.Flags().StringArrayVar(&embedAccounts, "account", nil,
+		"Limit embedding to this account (repeatable); overrides [vector.embed.scope] accounts for this run")
+	cmd.Flags().StringArrayVar(&embedCollections, "collection", nil,
+		"Limit embedding to this collection's accounts (repeatable); overrides [vector.embed.scope] accounts for this run")
 	return cmd
 }
 
@@ -146,6 +152,10 @@ func init() {
 	embedCmd.Deprecated = "use 'msgvault embeddings build' instead"
 	embeddingsResumeCmd.Flags().BoolVar(&embedBackstop, "backstop", false,
 		"Full-scan pass that ignores the per-generation watermark, catching any straggler messages the incremental scan skipped (idempotent)")
+	embeddingsResumeCmd.Flags().StringArrayVar(&embedAccounts, "account", nil,
+		"Limit embedding to this account (repeatable); overrides [vector.embed.scope] accounts for this run")
+	embeddingsResumeCmd.Flags().StringArrayVar(&embedCollections, "collection", nil,
+		"Limit embedding to this collection's accounts (repeatable); overrides [vector.embed.scope] accounts for this run")
 	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireYes, "yes", false, "Skip confirmation prompt")
 	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireForceActive, "force-active", false, "Allow retiring the active generation")
 	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateYes, "yes", false, "Skip confirmation prompt")

--- a/cmd/msgvault/cmd/embed_scope.go
+++ b/cmd/msgvault/cmd/embed_scope.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
-	"go.kenn.io/msgvault/internal/collectionops"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 )
@@ -30,7 +30,7 @@ func resolveEmbedScopeSourceIDs(s *store.Store) error {
 		}
 		ids = resolved
 	case len(cfg.Vector.Embed.Scope.Accounts) > 0:
-		resolved, err := collectionops.ResolveAccountList(s, cfg.Vector.Embed.Scope.Accounts)
+		resolved, err := resolveEmbedAccountList(s, cfg.Vector.Embed.Scope.Accounts)
 		if err != nil {
 			return fmt.Errorf("[vector.embed.scope] accounts: %w", err)
 		}
@@ -49,20 +49,73 @@ func resolveEmbedScopeSourceIDs(s *store.Store) error {
 func resolveEmbedScopeFlags(s *store.Store) ([]int64, error) {
 	var ids []int64
 	if len(embedAccounts) > 0 {
-		accountIDs, err := collectionops.ResolveAccountList(s, embedAccounts)
+		accountIDs, err := resolveEmbedAccountList(s, embedAccounts)
 		if err != nil {
 			return nil, fmt.Errorf("--account: %w", err)
 		}
 		ids = append(ids, accountIDs...)
 	}
 	for _, name := range embedCollections {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, fmt.Errorf("--collection: collection name is required")
+		}
 		scope, err := ResolveCollectionFlag(s, name)
 		if err != nil {
 			return nil, fmt.Errorf("--collection: %w", err)
 		}
-		ids = append(ids, scope.SourceIDs()...)
+		collectionIDs := scope.SourceIDs()
+		if len(collectionIDs) == 0 {
+			return nil, fmt.Errorf("--collection %q has no accounts; refusing to widen the embedding scope", name)
+		}
+		ids = append(ids, collectionIDs...)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("explicit embedding scope matched no accounts; refusing to widen the embedding scope")
 	}
 	return ids, nil
+}
+
+// resolveEmbedAccountList resolves embedding account selectors by their
+// stable identifier or display name only. Unlike collection-management
+// inputs, durable embedding configuration must never accept numeric source
+// IDs: SQLite may reuse an ID after an account is removed.
+func resolveEmbedAccountList(s *store.Store, accounts []string) ([]int64, error) {
+	var ids []int64
+	for _, input := range accounts {
+		input = strings.TrimSpace(input)
+		if input == "" {
+			return nil, fmt.Errorf("account identifier is required")
+		}
+		scope, err := ResolveAccountFlag(s, input)
+		if err != nil {
+			return nil, err
+		}
+		accountIDs := scope.SourceIDs()
+		if len(accountIDs) == 0 {
+			return nil, fmt.Errorf("account %q matched no sources", input)
+		}
+		ids = append(ids, accountIDs...)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no account identifiers configured")
+	}
+	return ids, nil
+}
+
+// configuredEmbedBuildScope resolves the durable account configuration anew.
+// It is used by each daemon job run to detect source-ID reuse before the
+// cached worker can send any message content to the embedding endpoint.
+func configuredEmbedBuildScope(s *store.Store) (vector.BuildScope, error) {
+	messageTypes := cfg.Vector.Embed.Scope.MessageTypes
+	if len(cfg.Vector.Embed.Scope.Accounts) == 0 {
+		return vector.NewBuildScope(messageTypes, nil), nil
+	}
+	ids, err := resolveEmbedAccountList(s, cfg.Vector.Embed.Scope.Accounts)
+	if err != nil {
+		return vector.BuildScope{}, fmt.Errorf("[vector.embed.scope] accounts: %w", err)
+	}
+	return vector.NewBuildScope(messageTypes, ids), nil
 }
 
 // ensureEmbedScopeResolved resolves the configured embed-scope accounts for

--- a/cmd/msgvault/cmd/embed_scope.go
+++ b/cmd/msgvault/cmd/embed_scope.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+
+	"go.kenn.io/msgvault/internal/collectionops"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// resolveEmbedScopeSourceIDs folds the account dimension of the embedding
+// build scope into cfg.Vector.Embed.Scope.SourceIDs, so that every consumer
+// of the resolved config — generation fingerprints, coverage counts, the
+// embed worker's scan, and the vector backends' activation gates — sees the
+// same account restriction.
+//
+// The --account/--collection flags, when present, REPLACE the configured
+// [vector.embed.scope] accounts for the run (explicit operator intent);
+// configured message_types always apply, since there is no CLI override for
+// them. Unknown identifiers are a hard error: a silently skipped account
+// would quietly widen the embedded corpus beyond what the operator asked
+// for.
+func resolveEmbedScopeSourceIDs(s *store.Store) error {
+	var ids []int64
+	switch {
+	case len(embedAccounts) > 0 || len(embedCollections) > 0:
+		resolved, err := resolveEmbedScopeFlags(s)
+		if err != nil {
+			return err
+		}
+		ids = resolved
+	case len(cfg.Vector.Embed.Scope.Accounts) > 0:
+		resolved, err := collectionops.ResolveAccountList(s, cfg.Vector.Embed.Scope.Accounts)
+		if err != nil {
+			return fmt.Errorf("[vector.embed.scope] accounts: %w", err)
+		}
+		ids = resolved
+	default:
+		return nil
+	}
+	// Normalize through NewBuildScope so overlapping accounts/collections
+	// dedupe and the stored scope matches what the fingerprint derives.
+	cfg.Vector.Embed.Scope.SourceIDs = vector.NewBuildScope(nil, ids).SourceIDs
+	return nil
+}
+
+// resolveEmbedScopeFlags resolves the --account and --collection flag values
+// to their union of source IDs.
+func resolveEmbedScopeFlags(s *store.Store) ([]int64, error) {
+	var ids []int64
+	if len(embedAccounts) > 0 {
+		accountIDs, err := collectionops.ResolveAccountList(s, embedAccounts)
+		if err != nil {
+			return nil, fmt.Errorf("--account: %w", err)
+		}
+		ids = append(ids, accountIDs...)
+	}
+	for _, name := range embedCollections {
+		scope, err := ResolveCollectionFlag(s, name)
+		if err != nil {
+			return nil, fmt.Errorf("--collection: %w", err)
+		}
+		ids = append(ids, scope.SourceIDs()...)
+	}
+	return ids, nil
+}
+
+// ensureEmbedScopeResolved resolves the configured embed-scope accounts for
+// embeddings management commands (list/activate) that compute coverage or
+// compare generation fingerprints against short-lived stores of their own.
+// A no-op when no accounts are configured.
+func ensureEmbedScopeResolved() error {
+	if len(cfg.Vector.Embed.Scope.Accounts) == 0 {
+		return nil
+	}
+	s, err := store.Open(cfg.DatabaseDSN())
+	if err != nil {
+		return fmt.Errorf("open main db for embed scope resolution: %w", err)
+	}
+	defer func() { _ = s.Close() }()
+	return resolveEmbedScopeSourceIDs(s)
+}

--- a/cmd/msgvault/cmd/embed_scope_sqlitevec_test.go
+++ b/cmd/msgvault/cmd/embed_scope_sqlitevec_test.go
@@ -1,0 +1,162 @@
+//go:build sqlite_vec
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// fakeEmbeddingsServer answers OpenAI-compatible /embeddings requests with
+// one deterministic dim-4 vector per input, recording how many inputs it was
+// asked to embed.
+func fakeEmbeddingsServer(t *testing.T, embedded *int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		*embedded += len(req.Input)
+		type item struct {
+			Embedding []float32 `json:"embedding"`
+			Index     int       `json:"index"`
+		}
+		payload := struct {
+			Data  []item `json:"data"`
+			Model string `json:"model"`
+		}{Model: "test-model"}
+		for i := range req.Input {
+			payload.Data = append(payload.Data, item{Embedding: []float32{1, 0, 0, 0}, Index: i})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// seedTwoAccountMainDB builds a real main DB (via InitSchema) with one
+// message+body in each of two accounts.
+func seedTwoAccountMainDB(t *testing.T, dataDir string) {
+	t.Helper()
+	s, err := store.Open(filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(t, err, "open main db")
+	defer func() { require.NoError(t, s.Close()) }()
+	require.NoError(t, s.InitSchema(), "InitSchema")
+	_, err = s.DB().Exec(`
+INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'a@example.com'), (2, 'gmail', 'b@example.com');
+INSERT INTO conversations (id, source_id, conversation_type) VALUES (1, 1, 'email_thread'), (2, 2, 'email_thread');
+INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, subject) VALUES
+	(1, 1, 1, 'a1', 'email', 'hello from a'),
+	(2, 2, 2, 'b1', 'email', 'hello from b');
+INSERT INTO message_bodies (message_id, body_text) VALUES (1, 'body a1'), (2, 'body b1');
+`)
+	require.NoError(t, err, "seed corpus")
+}
+
+func embedGenByID(t *testing.T, dataDir string) map[int64]sql.NullInt64 {
+	t.Helper()
+	db, err := sql.Open("sqlite3", filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(t, err, "open main db handle")
+	defer func() { require.NoError(t, db.Close()) }()
+	rows, err := db.Query(`SELECT id, embed_gen FROM messages ORDER BY id`)
+	require.NoError(t, err, "read embed_gen")
+	defer func() { _ = rows.Close() }()
+	out := map[int64]sql.NullInt64{}
+	for rows.Next() {
+		var id int64
+		var gen sql.NullInt64
+		require.NoError(t, rows.Scan(&id, &gen))
+		out[id] = gen
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// TestRunEmbed_AccountScopedBuild drives the full runEmbed path (real
+// sqlitevec backend, real store, fake embeddings endpoint): a build scoped
+// to one account embeds and stamps only that account's messages and
+// activates, and a follow-up run scoped differently is refused by the
+// fingerprint mismatch with the scope visible in the error.
+func TestRunEmbed_AccountScopedBuildActivatesScopedGeneration(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var embedded int
+	srv := fakeEmbeddingsServer(t, &embedded)
+
+	dataDir := t.TempDir()
+	seedTwoAccountMainDB(t, dataDir)
+
+	oldCfg := cfg
+	c := &config.Config{}
+	c.Vector.Enabled = true
+	c.Vector.DBPath = filepath.Join(dataDir, "vectors.db")
+	c.Vector.Embeddings.Endpoint = srv.URL
+	c.Vector.Embeddings.Model = "test-model"
+	c.Vector.Embeddings.Dimension = 4
+	c.Data.DataDir = dataDir
+	cfg = c
+
+	oldRebuild, oldYes := embedFullRebuild, embedYes
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	oldBackstop := embedBackstop
+	t.Cleanup(func() {
+		cfg = oldCfg
+		embedFullRebuild, embedYes = oldRebuild, oldYes
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+		embedBackstop = oldBackstop
+	})
+	embedYes = true
+	embedBackstop = false
+
+	newCmd := func() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
+		cmd.SetOut(out)
+		cmd.SetErr(errOut)
+		return cmd, out, errOut
+	}
+
+	// Run 1: full rebuild scoped to account A.
+	embedFullRebuild = true
+	embedAccounts = []string{"a@example.com"}
+	cmd, out, errOut := newCmd()
+	require.NoError(runEmbeddingsBuildLocal(cmd), "scoped full rebuild")
+	assert.Contains(errOut.String(), "Embedding scope: src-1", "scope printed to stderr")
+	assert.Contains(out.String(), "Generation 1 activated.", "scoped generation activates")
+	assert.Equal(1, embedded, "only account A's message reached the embedding endpoint")
+
+	gens := embedGenByID(t, dataDir)
+	require.True(gens[1].Valid, "account A message stamped")
+	assert.Equal(int64(1), gens[1].Int64)
+	assert.False(gens[2].Valid, "account B message keeps embed_gen NULL")
+
+	// Run 2: same archive, scoped to account B instead — the fingerprint
+	// difference must refuse to top up the src-1 generation.
+	embedFullRebuild = false
+	embedAccounts = []string{"b@example.com"}
+	cmd, _, _ = newCmd()
+	err := runEmbeddingsBuildLocal(cmd)
+	require.Error(err, "a different account scope must not resume the src-1 generation")
+	assert.Contains(err.Error(), "src-", "stored vs configured scope is visible in the error")
+	assert.Contains(err.Error(), "full-rebuild", "error points at --full-rebuild")
+}

--- a/cmd/msgvault/cmd/embed_scope_test.go
+++ b/cmd/msgvault/cmd/embed_scope_test.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+)
+
+// TestEmbeddingsBuildAccountFlagsForwardToDaemon proves the real build
+// command's --account/--collection flags survive daemonCLIArgsFromCobra, so
+// a scope passed to a daemon-fronted `embeddings build` reaches the
+// daemon-spawned subprocess intact.
+func TestEmbeddingsBuildAccountFlagsForwardToDaemon(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cmd := embeddingsBuildCmd
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	t.Cleanup(func() {
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+		for _, name := range []string{"account", "collection"} {
+			cmd.Flags().Lookup(name).Changed = false
+		}
+	})
+
+	require.NoError(cmd.Flags().Set("account", "alice@example.com"))
+	require.NoError(cmd.Flags().Set("account", "bob@example.com"))
+	require.NoError(cmd.Flags().Set("collection", "family"))
+
+	got, err := daemonCLIArgsFromCobra(cmd, nil)
+	require.NoError(err, "daemon args")
+	assert.Equal([]string{
+		"embeddings", "build",
+		"--account=alice@example.com",
+		"--account=bob@example.com",
+		"--collection=family",
+	}, got)
+}
+
+// withEmbedScopeGlobals swaps the config and embed-scope flag globals for a
+// resolution test and restores them afterwards.
+func withEmbedScopeGlobals(t *testing.T, accounts []string) {
+	t.Helper()
+	oldCfg := cfg
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	c := &config.Config{}
+	c.Vector.Embed.Scope.Accounts = accounts
+	cfg = c
+	embedAccounts, embedCollections = nil, nil
+	t.Cleanup(func() {
+		cfg = oldCfg
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+	})
+}
+
+func TestResolveEmbedScopeSourceIDs_ConfiguredAccounts(t *testing.T) {
+	f, accountID, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{accountID})
+
+	require.NoError(t, resolveEmbedScopeSourceIDs(f.Store))
+	assert.Equal(t, []int64{f.Source.ID}, cfg.Vector.Embed.Scope.SourceIDs,
+		"configured account resolves to its source ID")
+}
+
+func TestResolveEmbedScopeSourceIDs_UnknownAccountFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{"nobody@example.com"})
+
+	err := resolveEmbedScopeSourceIDs(f.Store)
+	require.Error(err, "unknown configured account must fail loudly")
+	assert.Contains(err.Error(), "[vector.embed.scope] accounts")
+	assert.Contains(err.Error(), "nobody@example.com")
+	assert.Nil(cfg.Vector.Embed.Scope.SourceIDs, "failed resolution leaves SourceIDs unset")
+}
+
+func TestResolveEmbedScopeSourceIDs_NoScopeLeavesCorpusWide(t *testing.T) {
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, nil)
+
+	require.NoError(t, resolveEmbedScopeSourceIDs(f.Store))
+	assert.Nil(t, cfg.Vector.Embed.Scope.SourceIDs)
+}
+
+func TestResolveEmbedScopeSourceIDs_AccountFlagOverridesConfig(t *testing.T) {
+	require := require.New(t)
+	f, accountID, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{accountID})
+
+	other, err := f.Store.GetOrCreateSource("gmail", "other@example.com")
+	require.NoError(err, "GetOrCreateSource")
+	embedAccounts = []string{other.Identifier}
+
+	require.NoError(resolveEmbedScopeSourceIDs(f.Store))
+	assert.Equal(t, []int64{other.ID}, cfg.Vector.Embed.Scope.SourceIDs,
+		"--account replaces the configured accounts for the run")
+}
+
+func TestResolveEmbedScopeSourceIDs_CollectionFlagExpands(t *testing.T) {
+	require := require.New(t)
+	f, _, collectionName := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, nil)
+
+	other, err := f.Store.GetOrCreateSource("gmail", "other@example.com")
+	require.NoError(err, "GetOrCreateSource")
+	_, err = f.Store.CreateCollection("both", "", []int64{f.Source.ID, other.ID})
+	require.NoError(err, "CreateCollection both")
+	// The fixture collection covers only f.Source; "both" covers both.
+	embedCollections = []string{collectionName, "both"}
+
+	require.NoError(resolveEmbedScopeSourceIDs(f.Store))
+	assert.ElementsMatch(t, []int64{f.Source.ID, other.ID}, cfg.Vector.Embed.Scope.SourceIDs,
+		"--collection expands to the union of member sources")
+}

--- a/cmd/msgvault/cmd/embed_scope_test.go
+++ b/cmd/msgvault/cmd/embed_scope_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,4 +114,30 @@ func TestResolveEmbedScopeSourceIDs_CollectionFlagExpands(t *testing.T) {
 	require.NoError(resolveEmbedScopeSourceIDs(f.Store))
 	assert.ElementsMatch(t, []int64{f.Source.ID, other.ID}, cfg.Vector.Embed.Scope.SourceIDs,
 		"--collection expands to the union of member sources")
+}
+
+func TestResolveEmbedScopeSourceIDs_EmptyCollectionFailsClosed(t *testing.T) {
+	require := require.New(t)
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, nil)
+
+	_, err := f.Store.CreateCollection("empty", "", []int64{f.Source.ID})
+	require.NoError(err, "CreateCollection")
+	require.NoError(f.Store.RemoveSourcesFromCollection("empty", []int64{f.Source.ID}), "empty collection")
+	embedCollections = []string{"empty"}
+
+	err = resolveEmbedScopeSourceIDs(f.Store)
+	require.Error(err, "an explicit empty collection must not widen to the full archive")
+	assert.Contains(t, err.Error(), "has no accounts")
+	assert.Nil(t, cfg.Vector.Embed.Scope.SourceIDs)
+}
+
+func TestResolveEmbedScopeSourceIDs_ConfiguredNumericIDFails(t *testing.T) {
+	require := require.New(t)
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{fmt.Sprintf("%d", f.Source.ID)})
+
+	err := resolveEmbedScopeSourceIDs(f.Store)
+	require.Error(err, "durable account configuration must not accept source IDs")
+	assert.Nil(t, cfg.Vector.Embed.Scope.SourceIDs)
 }

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -44,6 +44,15 @@ func runEmbed(cmd *cobra.Command) error {
 		return fmt.Errorf("init schema: %w", err)
 	}
 
+	// Resolve the account dimension of the build scope before anything
+	// derives a fingerprint or coverage predicate from the config: the
+	// --account/--collection flags (or [vector.embed.scope] accounts)
+	// become source IDs here, and unknown identifiers fail the run loudly
+	// rather than silently widening the embedded corpus.
+	if err := resolveEmbedScopeSourceIDs(s); err != nil {
+		return err
+	}
+
 	var (
 		backend   vector.Backend
 		vectorsDB *sql.DB
@@ -125,9 +134,15 @@ func runEmbed(cmd *cobra.Command) error {
 	// this generation (embed_gen <> gen), read from the main DB coverage
 	// rather than a queue table.
 	scope := cfg.Vector.Embed.Scope.BuildScope()
-	missing, err := s.MissingCountScoped(ctx, int64(gen), scope.MessageTypes)
+	if !scope.IsEmpty() {
+		_, _ = fmt.Fprintf(errOut, "Embedding scope: %s\n", scope.Fingerprint())
+	}
+	live, _, _, missing, err := s.CoverageCountsScoped(ctx, int64(gen), scope.MessageTypes, scope.SourceIDs)
 	if err != nil {
 		return fmt.Errorf("coverage counts: %w", err)
+	}
+	if len(scope.SourceIDs) > 0 && live == 0 {
+		_, _ = fmt.Fprintln(errOut, "Embedding scope matched 0 live messages.")
 	}
 	totalPending := int(missing)
 
@@ -171,7 +186,7 @@ func runEmbed(cmd *cobra.Command) error {
 	// worker later recovers from must not block activation, and an
 	// active generation must not be re-activated.
 	if rebuildInProgress {
-		_, _, _, remaining, err := s.CoverageCountsScoped(ctx, int64(gen), scope.MessageTypes)
+		_, _, _, remaining, err := s.CoverageCountsScoped(ctx, int64(gen), scope.MessageTypes, scope.SourceIDs)
 		if err != nil {
 			return fmt.Errorf("coverage counts: %w", err)
 		}
@@ -271,7 +286,7 @@ func pickEmbedGeneration(ctx context.Context, backend vector.Backend, opts embed
 				building.ID, building.Fingerprint)
 			return building.ID, true, nil
 		}
-		return 0, false, fmt.Errorf("in-progress rebuild has fingerprint=%q, config has %q — activate or retire it before running with a different model",
+		return 0, false, fmt.Errorf("in-progress rebuild has fingerprint=%q, config has %q — activate or retire it before running with a different model or embed scope (the fingerprint folds in [vector.embed.scope] message_types/accounts and any --account/--collection flags)",
 			building.Fingerprint, opts.Fingerprint)
 	}
 

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -72,7 +72,7 @@ func fillCoverage(ctx context.Context, row *embeddingGenerationRow) error {
 	}
 	defer func() { _ = s.Close() }()
 	scope := cfg.Vector.Embed.Scope.BuildScope()
-	live, _, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes)
+	live, _, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes, scope.SourceIDs)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func fillFullCoverage(ctx context.Context, backend vector.Backend, row *embeddin
 	}
 	defer func() { _ = s.Close() }()
 	scope := cfg.Vector.Embed.Scope.BuildScope()
-	live, stamped, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes)
+	live, stamped, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes, scope.SourceIDs)
 	if err != nil {
 		return err
 	}
@@ -137,6 +137,9 @@ func runEmbeddingsList(cmd *cobra.Command, _ []string) error {
 	defer release()
 
 	if err := ensureMainSchema(); err != nil {
+		return err
+	}
+	if err := ensureEmbedScopeResolved(); err != nil {
 		return err
 	}
 	db, rebind, closeDB, err := openEmbeddingsMetadataDB(cmd.Context())
@@ -317,6 +320,9 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 	if err := ensureMainSchema(); err != nil {
 		return err
 	}
+	if err := ensureEmbedScopeResolved(); err != nil {
+		return err
+	}
 
 	db, rebind, closeDB, err := openEmbeddingsMetadataDB(cmd.Context())
 	if err != nil {
@@ -492,6 +498,9 @@ func planCLIEmbeddingsActivate(
 	force bool,
 ) (api.CLIEmbeddingsPlanResponse, error) {
 	if err := ensureMainSchema(); err != nil {
+		return api.CLIEmbeddingsPlanResponse{}, err
+	}
+	if err := ensureEmbedScopeResolved(); err != nil {
 		return api.CLIEmbeddingsPlanResponse{}, err
 	}
 	db, rebind, closeDB, err := openEmbeddingsMetadataDB(ctx)

--- a/cmd/msgvault/cmd/serve_vector.go
+++ b/cmd/msgvault/cmd/serve_vector.go
@@ -84,6 +84,14 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 	if err := cfg.Vector.Validate(); err != nil {
 		return nil, fmt.Errorf("vector config: %w", err)
 	}
+	// Resolve [vector.embed.scope] accounts to source IDs before any
+	// consumer derives a build scope or generation fingerprint from the
+	// config (backend coverage gates, the embed worker/job, the hybrid
+	// engine's expected fingerprint). Unknown accounts fail vector init
+	// loudly rather than silently embedding the full corpus.
+	if err := resolveEmbedScopeSourceIDs(mainStore); err != nil {
+		return nil, fmt.Errorf("vector embed scope: %w", err)
+	}
 	mainDB := mainStore.DB()
 
 	// Resolve the dialect once from the main DSN. The worker is

--- a/cmd/msgvault/cmd/serve_vector_init.go
+++ b/cmd/msgvault/cmd/serve_vector_init.go
@@ -178,7 +178,10 @@ func registerEmbedJob(sched *scheduler.Scheduler, vf *vectorFeatures, s *store.S
 		Fingerprint:      vf.Cfg.GenerationFingerprint(),
 		BackstopInterval: vf.Cfg.Embed.BackstopInterval,
 		BuildScope:       vf.Cfg.Embed.Scope.BuildScope(),
-		Log:              logger,
+		ResolveBuildScope: func() (vector.BuildScope, error) {
+			return configuredEmbedBuildScope(s)
+		},
+		Log: logger,
 	}
 	schedule := cfg.Vector.Embed.Schedule.Cron
 	if err := sched.SetEmbedJob(embedJob, schedule, cfg.Vector.Embed.Schedule.RunAfterSync); err != nil {

--- a/design/backlog-202608102225-msgvault_embed_account_scope-prompt.md
+++ b/design/backlog-202608102225-msgvault_embed_account_scope-prompt.md
@@ -248,4 +248,3 @@ Audit every `BuildScope()` call site listed in the map above.
 - Coverage reporting (`embeddings list`, API/MCP coverage) reflects the scope.
 - `make test` and `make lint` pass; commit the change at the end of the turn
   (repo convention: commit without asking).
-

--- a/design/backlog-202608102225-msgvault_embed_account_scope-prompt.md
+++ b/design/backlog-202608102225-msgvault_embed_account_scope-prompt.md
@@ -2,7 +2,7 @@
 
 - **Slug:** `msgvault_embed_account_scope`
 - **Created:** 2026-08-10 22:25
-- **Status:** pending
+- **Status:** implemented
 - **Area:** `internal/vector`, `internal/store`, `cmd/msgvault/cmd` (embeddings), daemon embed job, API/MCP coverage
 
 ## Task

--- a/design/backlog-202608102225-msgvault_embed_account_scope-prompt.md
+++ b/design/backlog-202608102225-msgvault_embed_account_scope-prompt.md
@@ -1,0 +1,251 @@
+# Backlog Prompt: Account-Scoped Embedding Builds
+
+- **Slug:** `msgvault_embed_account_scope`
+- **Created:** 2026-08-10 22:25
+- **Status:** pending
+- **Area:** `internal/vector`, `internal/store`, `cmd/msgvault/cmd` (embeddings), daemon embed job, API/MCP coverage
+
+## Task
+
+Add account scoping to vector embedding builds so an operator can restrict which
+accounts' messages are sent to the embedding endpoint, via both:
+
+1. CLI flags on `msgvault embeddings build` / `msgvault embeddings resume`
+   (`--account`, repeatable; `--collection` for collection expansion), and
+2. durable config (`[vector.embed.scope] accounts = [...]`) so the daemon's
+   scheduled embed job honors the same restriction without operator flags.
+
+## Motivation
+
+- **Cost control.** Embedding a multi-decade, multi-account archive is the most
+  expensive operation msgvault performs. Operators want to embed one account
+  first (e.g. a personal mailbox) before paying to embed the rest.
+- **Privacy.** Content from specific accounts must never leave for the
+  embedding endpoint. A CLI-only flag is insufficient here: the daemon's
+  scheduled embed job (`[vector.embed.schedule]`, `run_after_sync`) would still
+  embed those accounts, so the restriction must be expressible in config.
+- **Incremental rollout.** Build a scoped generation, validate search quality,
+  then widen the scope with a full rebuild.
+
+## Current state map (verified against the tree)
+
+- Build scope today is **message-types only**:
+  `internal/vector/build_scope.go` — `BuildScope{MessageTypes []string}` with
+  normalization (lowercase/trim/dedupe/sort) and `Fingerprint()` → `"mt-..."`.
+- Config: `internal/vector/config.go` — `EmbedScopeConfig{MessageTypes}` under
+  `[vector.embed.scope]`; `Config.GenerationFingerprint()` (config.go:269)
+  appends `:s<scopeFP>` when the scope fingerprint is non-empty. Scope is
+  already part of generation identity — extend, don't reinvent.
+- Scan/coverage SQL: `internal/store/embed_gen.go` —
+  `ScanForEmbeddingScoped`, `CoverageCountsScoped`, `MissingCountScoped`,
+  `countLiveMessagesScoped` all take `messageTypes []string` and build their
+  predicate via `liveMessagesWhereWithMessageTypes` (embed_gen.go:317). The
+  `messages` table has `source_id`; filtering by account means adding
+  `AND source_id IN (...)`.
+- Worker threading: `internal/vector/embed/worker.go:595` (`scanForEmbedding`)
+  re-derives the scope from `deps.BuildScope.MessageTypes` and
+  interface-asserts the scoped store method. Extend to carry source IDs.
+- CLI entry: `cmd/msgvault/cmd/embed.go` (`runEmbeddingsBuild` →
+  `runEmbeddingsBuildLocal` → `runEmbed`) and
+  `cmd/msgvault/cmd/embed_vector.go:127` (`scope := cfg.Vector.Embed.Scope.BuildScope()`).
+  Activation gate at embed_vector.go:173-188 activates a rebuild only when
+  `CoverageCountsScoped` reports `remaining == 0` **within scope** — scoped
+  generations activate correctly once scope carries source IDs.
+- Account resolution already exists:
+  `cmd/msgvault/cmd/account_scope.go` — `ResolveAccountFlag`,
+  `ResolveCollectionFlag`, `Scope.SourceIDs()` (note `AdditionalSourceIDs`: one
+  identifier can map to several source rows). Use these; do not write a new
+  resolver.
+- Daemon forwarding is automatic: `daemonCLIArgsFromCobra`
+  (`cmd/msgvault/cmd/daemon_cli_http.go:96`) visits changed local flags, and
+  `appendDaemonCLIFlag` (daemon_cli_http.go:149) handles `pflag.SliceValue`, so
+  a repeatable `--account` string flag forwards to the daemon-spawned
+  subprocess with no extra plumbing. Verify with a test.
+- Search side needs no changes for correctness: vector search already filters
+  hits by account at query time (`internal/vector/sqlitevec/backend.go:1128`
+  `inClause("m.source_id", f.SourceIDs)`; `internal/vector/hybrid/filter.go:99`
+  maps `AccountIDs` → `SourceIDs`). Out-of-scope accounts simply have no
+  vectors; BM25/hybrid degrade gracefully.
+- Consumers of the configured scope to keep consistent:
+  `cmd/msgvault/cmd/embeddings_manage.go:74,98,639,678` (list/coverage/job
+  wiring), `cmd/msgvault/cmd/serve_vector_init.go` (~line 178, daemon
+  `EmbedJob`), `internal/api/search_coverage.go:78`
+  (`semanticCoverageContext(ctx, cfg.Embed.Scope.BuildScope())`) and
+  `semanticCoverageContext` itself (search_coverage.go:317),
+  `internal/api/handlers.go:1114`, `internal/mcp/handlers.go:914`.
+
+## Design
+
+### D1 — Account scope is part of generation identity (chosen)
+
+Fold the account scope into `vector.BuildScope` and therefore into
+`Config.GenerationFingerprint()`, exactly like `message_types` today. A
+scoped build creates/resumes a scoped generation; the existing
+fingerprint-mismatch machinery (`pickEmbedGeneration`,
+`vector.ResolveActiveForFingerprint`) prevents silently mixing scopes in one
+index and forces an explicit `--full-rebuild` when the scope changes.
+
+Rejected alternative: a run-time-only scan filter that leaves the generation
+"full corpus". That breaks the activation gate (a scoped full rebuild would
+never reach `remaining == 0`), misreports coverage, and cannot express the
+privacy requirement (the daemon would still embed excluded accounts).
+
+### D2 — Extend `vector.BuildScope`
+
+```go
+type BuildScope struct {
+    MessageTypes []string
+    SourceIDs    []int64
+}
+```
+
+- `NewBuildScope(messageTypes []string, sourceIDs []int64)` normalizes both:
+  source IDs are deduped, sorted ascending, non-positive IDs dropped.
+- `Fingerprint()` gains a source segment, e.g. `"mt-email,teams:src-3,7,11"`,
+  keeping `mt-` first for readability. Source IDs are DB-local integers;
+  sorting makes the fingerprint deterministic per archive. Document that
+  deleting and re-adding an account changes its source ID and therefore the
+  fingerprint (forces a rebuild — acceptable under the existing "policy change
+  stales the index" contract).
+- Add `ContainsSource(sourceID int64)` for symmetry with `ContainsMessageType`.
+
+### D3 — Config: `[vector.embed.scope] accounts`
+
+`EmbedScopeConfig` gains `Accounts []string `toml:"accounts"`` — account
+identifiers (same syntax `--account` accepts), not source IDs, because config
+must survive archive rebuilds that renumber sources.
+
+Resolution to source IDs happens once at startup against the open store, in
+the `cmd` layer (both `runEmbed` and the daemon's vector wiring in
+`serve_vector.go` / `serve_vector_init.go` live there), reusing
+`ResolveAccountFlag` semantics. Unknown identifiers are a hard startup error,
+not a silent skip.
+
+Because `internal/api` and `internal/mcp` currently call
+`cfg.Embed.Scope.BuildScope()` directly, inject the **resolved** scope into
+the server (e.g. via `api.ServerOptions`, set during daemon wiring) so
+coverage endpoints, the CLI, and the embed job all share one scope value.
+Audit every `BuildScope()` call site listed in the map above.
+
+### D4 — CLI flags
+
+- `embeddings build` and `embeddings resume` gain:
+  - `--account <id>` (repeatable `StringArrayVar`; resolve each with
+    `ResolveAccountFlag`, unioning `Scope.SourceIDs()`),
+  - `--collection <name>` (repeatable; expand via `ResolveCollectionFlag`).
+- When any scope flag is present it **replaces** the configured scope for that
+  run (explicit operator intent); the resulting fingerprint difference is
+  surfaced by the existing mismatch errors — improve those messages to name
+  the scope difference, not just the fingerprint strings.
+- With no flags, behavior is unchanged: config scope applies.
+- `embeddings list` / coverage output prints the source-ID segment of a
+  generation's scope alongside the message types it already shows.
+- The deprecated `build-embeddings` alias shares `newEmbeddingsBuildCmd`, so
+  it inherits the flags for free.
+
+### D5 — Store and worker plumbing
+
+- `internal/store/embed_gen.go`: extend the scoped functions to carry source
+  IDs — either a new `sourceIDs []int64` parameter on
+  `ScanForEmbeddingScoped`, `CoverageCountsScoped`, `MissingCountScoped`,
+  `countLiveMessagesScoped`, or a small scope struct; the repo owns all
+  callers, so pick the form that reads best and update every call site.
+  Replace `liveMessagesWhereWithMessageTypes` with a scope-aware builder that
+  appends `AND source_id IN (?...)`.
+- `internal/vector/embed/worker.go:595` `scanForEmbedding`: thread
+  `BuildScope.SourceIDs` through the interface assertion (extend the asserted
+  signature or assert a new method); keep the unscoped fast path when the
+  scope is empty.
+- Audit the embed_gen backfill paths (`internal/vector/embed/backfill_test.go`,
+  `internal/vector/sqlitevec/backfill*.go`) for scope handling; extend or
+  explicitly document them.
+- The daemon `EmbedJob` (`serve_vector_init.go`, fingerprint near line 178)
+  must receive the resolved scope so scheduled embeds and CLI embeds target
+  the same generation.
+
+## Edge cases and invariants
+
+- **Scoped activation gate.** A scoped `--full-rebuild` activates when
+  in-scope `remaining == 0`; out-of-scope messages keep `embed_gen` untouched
+  and are never scanned. Add a test proving out-of-scope rows are neither
+  embedded nor stamped.
+- **Empty scope result.** `--account` resolving to a source with zero live
+  messages yields live=0/missing=0 and immediate activation; print a clear
+  "scope matched 0 messages" line instead of silently succeeding.
+- **Fingerprint instability.** Account delete/re-add or a restored backup can
+  renumber source IDs → new fingerprint → rebuild prompt. Note this in the
+  flag/config help text.
+- **Scope widening/narrowing is a rebuild.** Changing the account set produces
+  a new fingerprint; there is no incremental "un-embed" — `embeddings retire`
+  plus a rebuild is the escape hatch.
+- **Message-types × accounts compose.** Both filters apply (AND semantics);
+  the fingerprint carries both segments.
+- **No cross-package leak.** `internal/vector` must not import
+  `internal/store`; account-identifier → source-ID resolution stays in the
+  `cmd` layer / server wiring.
+
+## Non-goals
+
+- Per-account *generations* searched selectively (one index, scoped at build
+  time; query-time account filters already exist).
+- Removing already-embedded vectors for an account (retire + rebuild covers it).
+- TUI/web UI scope pickers (read-only coverage display updates only).
+- Changing the search ranking path.
+
+## Implementation plan
+
+1. `internal/vector/build_scope.go`: add `SourceIDs`, normalization,
+   fingerprint segment, `ContainsSource`; update `build_scope` tests.
+2. `internal/vector/config.go`: `EmbedScopeConfig.Accounts`; extend
+   `GenerationFingerprint` tests for the combined scope.
+3. `internal/store/embed_gen.go`: scope-aware WHERE builder + extended scoped
+   scan/coverage signatures; update all callers (store tests, cmd, api, mcp).
+4. `internal/vector/embed/worker.go`: thread source IDs through
+   `scanForEmbedding`; extend worker tests.
+5. `cmd/msgvault/cmd/embed.go` / `embed_vector.go`: register `--account` /
+   `--collection` on build+resume, resolve against the opened store, fold into
+   the scope passed to generation selection, coverage, and the worker; improve
+   fingerprint-mismatch error text to mention scope.
+6. Daemon wiring (`serve_vector.go`, `serve_vector_init.go`,
+   `embeddings_manage.go`): resolve configured accounts once, share the
+   resolved scope with the embed job and the API/MCP servers.
+7. `internal/api` / `internal/mcp`: consume the injected resolved scope in
+   coverage/validation paths.
+8. Docs: `docs/cli-reference.md` (new flags), the vector-search usage page
+   (`docs/usage/`, verify exact file), and `docs/internal/` design note if the
+   change grows beyond the above.
+
+## Testing requirements (repo rules — AGENTS.md / CLAUDE.md)
+
+- All Go tests use `github.com/stretchr/testify` (`assert.X` / `require.X`;
+  equality is `(t, want, got)`). Never `t.Errorf`/`t.Fatal*`.
+- Run tests with build tags: `make test` (adds `-tags "fts5 sqlite_vec"`), plus
+  the pg-tagged path if PG-facing code changed (`PG_TEST_TAGS := fts5
+  sqlite_vec pgvector`).
+- No fake TDD: exercise the real store against a real SQLite DB
+  (`internal/testutil` builders, e.g. `NewTestStore`) and assert on actual
+  scan/coverage results — do not stub the store and assert on arguments.
+- Minimum coverage:
+  - `BuildScope` normalization + fingerprint with source IDs (unit).
+  - `ScanForEmbeddingScoped` / `CoverageCountsScoped` with a source filter
+    against a real DB with two sources (integration).
+  - Worker skips out-of-scope messages and still stamps in-scope ones.
+  - CLI: `embeddings build --account X --full-rebuild` on a two-account
+    fixture activates with only X's messages embedded; a second run with a
+    different account set fails with the scope-naming mismatch error.
+  - Daemon forwarding: `--account` survives `daemonCLIArgsFromCobra` /
+    `appendDaemonCLIFlag` (slice-value path).
+
+## Acceptance criteria
+
+- `msgvault embeddings build --account A [--account B] [--collection C]`
+  builds/activates a generation covering exactly the resolved sources ×
+  configured message types; out-of-scope messages are untouched.
+- `[vector.embed.scope] accounts = [...]` makes daemon-scheduled embeds obey
+  the same scope; unknown identifiers fail startup loudly.
+- Scope appears in the generation fingerprint; changing scope requires
+  `--full-rebuild` and the error message says why.
+- Coverage reporting (`embeddings list`, API/MCP coverage) reflects the scope.
+- `make test` and `make lint` pass; commit the change at the end of the turn
+  (repo convention: commit without asking).
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,15 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
+**Features**
+
+- Scope embedding builds to selected accounts: `[vector.embed.scope] accounts`
+  keeps the daemon's scheduled embeds within the listed accounts, and
+  `msgvault embeddings build --account/--collection` overrides the account
+  scope for a single run. The account scope is part of the generation
+  fingerprint, so changing it requires a full rebuild; account-scoped indexes
+  do not gate search — out-of-scope accounts simply rank on BM25 alone.
+
 ---
 
 ## 0.19.3

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1481,8 +1481,15 @@ msgvault embeddings build [flags]
 |---|---|
 | `--full-rebuild` | Create a new index generation and rebuild from scratch. The new generation is activated atomically once coverage reaches zero. Same-model rebuilds keep serving the previous active generation in the meantime, but active-generation top-ups are frozen until activation; model or dimension changes return `index_stale` for vector/hybrid search until the new generation activates. |
 | `--yes` | Skip the confirmation prompt that `--full-rebuild` otherwise requires. |
+| `--account <id>` | Limit embedding to this account (repeatable). Overrides `[vector.embed.scope] accounts` for this run; configured `message_types` still apply. |
+| `--collection <name>` | Limit embedding to this collection's accounts (repeatable). Can be combined with `--account`; the scope is the union. |
 
 Without `--full-rebuild`, the command is incremental: it resumes any in-flight rebuild that matches the configured model, otherwise scans for live messages still missing coverage in the active generation, then exits. Safe to schedule via cron (or let `msgvault serve` do it via `[vector.embed.schedule]`).
+
+The account scope is part of the generation fingerprint, so building with a
+different `--account`/`--collection` set than the active generation requires
+`--full-rebuild`, exactly like changing the model. See
+[Scoped Generations](/usage/vector-search/#scoped-generations).
 
 ### embeddings resume
 
@@ -1490,7 +1497,7 @@ Without `--full-rebuild`, the command is incremental: it resumes any in-flight r
 msgvault embeddings resume
 ```
 
-Continue embedding work and finish the current generation. If a generation matching the configured model is building, this embeds its remaining rows and activates it once coverage reaches zero; otherwise it tops up the active generation. Equivalent to `msgvault embeddings build` with no flags, but never starts a full rebuild.
+Continue embedding work and finish the current generation. If a generation matching the configured model is building, this embeds its remaining rows and activates it once coverage reaches zero; otherwise it tops up the active generation. Equivalent to `msgvault embeddings build` with no flags, but never starts a full rebuild. Accepts the same `--account`/`--collection` scope flags as `embeddings build`.
 
 ### embeddings list
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -646,6 +646,20 @@ a scoped index must include a compatible `message_type` filter, such as
 unscoped vector/hybrid query returns `index_scope_mismatch` instead of using the
 partial index as if it covered the full archive.
 
+| Key | Default | Description |
+|---|---|---|
+| `message_types` | `[]` (all types) | Embed only messages of these types. |
+| `accounts` | `[]` (all accounts) | Embed only these accounts' messages, by identifier or display name. Resolved to source IDs at startup; an unknown identifier fails vector initialization (or the CLI command). The daemon's scheduled embeds honor this scope, so it also acts as a privacy boundary: unlisted accounts' text is never sent to the embedding endpoint. |
+
+`accounts` and `message_types` compose (both filters apply). The CLI flags
+`--account`/`--collection` on `msgvault embeddings build`/`resume` override
+`accounts` for a single run. Either scope dimension is part of the generation
+fingerprint: changing it requires `msgvault embeddings build --full-rebuild`,
+and because the fingerprint records archive-local source IDs, re-adding an
+account under a new source ID also requires a rebuild. Account-scoped indexes
+do not gate search the way message-type scopes do: out-of-scope accounts
+simply have no vector matches and rank on BM25 alone in hybrid mode.
+
 #### `[vector.embed.schedule]`
 
 Optional background scheduling for the embed worker inside `msgvault serve`. Empty config disables scheduled embedding; you can still run `msgvault embeddings build` by hand.

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -340,6 +340,40 @@ or preprocessing policy. Scoped generations are useful when you want semantic
 search for a newer corpus such as Teams or SMS without embedding decades of
 email immediately.
 
+Generations can also be scoped to selected accounts, either durably in config
+(so the daemon's scheduled embeds obey it too):
+
+```toml
+[vector.embed.scope]
+accounts = ["you@gmail.com"]
+```
+
+or per run from the CLI (overriding the configured accounts for that run):
+
+```bash
+msgvault embeddings build --full-rebuild --account you@gmail.com
+msgvault embeddings build --account you@gmail.com --account you@work.com
+msgvault embeddings build --collection family   # every account in the collection
+```
+
+Account identifiers use the same syntax as `--account` elsewhere (identifier
+or display name), and unknown identifiers fail the run instead of silently
+embedding more than requested. Account scoping keeps the named accounts'
+message text from ever being sent to the embedding endpoint, and is the
+cheapest way to pilot semantic search on one mailbox before paying to embed
+the whole archive.
+
+Two account-scope caveats:
+
+- The fingerprint records the scope as source IDs, which are archive-local.
+  Removing and re-adding an account (or restoring a backup) can renumber its
+  source ID, producing a new fingerprint and requiring a full rebuild.
+- Unlike a message-type scope, an account scope does NOT gate search:
+  unfiltered vector/hybrid queries keep working, and accounts outside the
+  scope simply have no vector matches (hybrid search ranks them on the BM25
+  signal alone). The web UI's semantic-coverage readout counts only in-scope
+  accounts as eligible.
+
 A scoped index is intentionally partial, so vector and hybrid search require an
 explicit compatible message-type filter:
 

--- a/internal/api/search_coverage.go
+++ b/internal/api/search_coverage.go
@@ -322,23 +322,40 @@ func semanticCoverageContext(ctx query.Context, scope vector.BuildScope) query.C
 		return ctx
 	}
 	ctx.Deletion = query.DeletionActive
-	if scope.IsEmpty() {
-		return ctx
-	}
-	if len(ctx.MessageTypes) == 0 {
-		ctx.MessageTypes = slices.Clone(scope.MessageTypes)
-		return ctx
-	}
-	eligible := make([]string, 0, len(ctx.MessageTypes))
-	for _, messageType := range ctx.MessageTypes {
-		if scope.ContainsMessageType(strings.ToLower(messageType)) {
-			eligible = append(eligible, messageType)
+	if len(scope.MessageTypes) > 0 {
+		if len(ctx.MessageTypes) == 0 {
+			ctx.MessageTypes = slices.Clone(scope.MessageTypes)
+		} else {
+			eligible := make([]string, 0, len(ctx.MessageTypes))
+			for _, messageType := range ctx.MessageTypes {
+				if scope.ContainsMessageType(strings.ToLower(messageType)) {
+					eligible = append(eligible, messageType)
+				}
+			}
+			if len(eligible) == 0 {
+				eligible = []string{"\x00no-semantic-eligible-message-type"}
+			}
+			ctx.MessageTypes = eligible
 		}
 	}
-	if len(eligible) == 0 {
-		eligible = []string{"\x00no-semantic-eligible-message-type"}
+	if len(scope.SourceIDs) > 0 {
+		if len(ctx.SourceIDs) == 0 {
+			ctx.SourceIDs = slices.Clone(scope.SourceIDs)
+		} else {
+			eligible := make([]int64, 0, len(ctx.SourceIDs))
+			for _, id := range ctx.SourceIDs {
+				if scope.ContainsSource(id) {
+					eligible = append(eligible, id)
+				}
+			}
+			if len(eligible) == 0 {
+				// Source IDs are positive, so the sentinel keeps the
+				// eligible set empty instead of widening to all sources.
+				eligible = []int64{-1}
+			}
+			ctx.SourceIDs = eligible
+		}
 	}
-	ctx.MessageTypes = eligible
 	return ctx
 }
 

--- a/internal/api/search_coverage_test.go
+++ b/internal/api/search_coverage_test.go
@@ -15,6 +15,45 @@ import (
 	"go.kenn.io/msgvault/internal/vector"
 )
 
+func TestSemanticCoverageContextNarrowsSources(t *testing.T) {
+	scope := vector.NewBuildScope(nil, []int64{3, 7})
+
+	t.Run("unfiltered context adopts the scope sources", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{}, scope)
+		assert.Equal(t, []int64{3, 7}, got.SourceIDs)
+	})
+
+	t.Run("account filter intersects the scope", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{SourceIDs: []int64{3, 9}}, scope)
+		assert.Equal(t, []int64{3}, got.SourceIDs)
+	})
+
+	t.Run("disjoint account filter keeps zero eligibility", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{SourceIDs: []int64{9}}, scope)
+		assert.Equal(t, []int64{-1}, got.SourceIDs,
+			"sentinel keeps the eligible set empty instead of widening to all sources")
+	})
+
+	t.Run("unscoped generation leaves sources alone", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{SourceIDs: []int64{9}}, vector.BuildScope{})
+		assert.Equal(t, []int64{9}, got.SourceIDs)
+	})
+
+	t.Run("sources-only scope leaves message types alone", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{MessageTypes: []string{"email"}}, scope)
+		assert.Equal(t, []string{"email"}, got.MessageTypes)
+	})
+
+	t.Run("message types and sources narrow together", func(t *testing.T) {
+		combined := vector.NewBuildScope([]string{"sms"}, []int64{3})
+		got := semanticCoverageContext(
+			query.Context{MessageTypes: []string{"email", "sms"}, SourceIDs: []int64{3, 9}},
+			combined)
+		assert.Equal(t, []string{"sms"}, got.MessageTypes)
+		assert.Equal(t, []int64{3}, got.SourceIDs)
+	})
+}
+
 type filteredCoverageBackend struct {
 	vector.Backend
 

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -110,6 +110,7 @@ var settingsCatalog = []settingDefinition{
 	stringSetting("vector.embed.schedule.cron", "search", nil, func(c *config.Config) string { return c.Vector.Embed.Schedule.Cron }),
 	boolSetting("vector.embed.schedule.run_after_sync", "search", func(c *config.Config) bool { return c.Vector.Embed.Schedule.RunAfterSync }),
 	stringArraySetting("vector.embed.scope.message_types", "search", func(c *config.Config) []string { return c.Vector.Embed.Scope.MessageTypes }),
+	stringArraySetting("vector.embed.scope.accounts", "search", func(c *config.Config) []string { return c.Vector.Embed.Scope.Accounts }),
 	intSetting("vector.search.rrf_k", "search", func(c *config.Config) int { return c.Vector.Search.RRFK }),
 	intSetting("vector.search.k_per_signal", "search", func(c *config.Config) int { return c.Vector.Search.KPerSignal }),
 	numberSetting("vector.search.subject_boost", "search", func(c *config.Config) float64 { return c.Vector.Search.SubjectBoost }),

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1040,7 +1040,7 @@ func (h *handlers) filterFromFindSimilarArgs(ctx context.Context, args map[strin
 		f.SourceIDs = []int64{*srcID}
 	}
 	if messageType, _ := args["message_type"].(string); messageType != "" {
-		f.MessageTypes = vector.NewBuildScope([]string{messageType}).MessageTypes
+		f.MessageTypes = vector.NewBuildScope([]string{messageType}, nil).MessageTypes
 	}
 
 	if v, ok := args["has_attachment"].(bool); ok && v {

--- a/internal/scheduler/embed_job.go
+++ b/internal/scheduler/embed_job.go
@@ -36,7 +36,7 @@ type EmbedCoverage interface {
 }
 
 type ScopedEmbedCoverage interface {
-	MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string) (int64, error)
+	MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string, sourceIDs []int64) (int64, error)
 }
 
 // Compile-time check that the production worker satisfies EmbedRunner.
@@ -235,12 +235,12 @@ func (j *EmbedJob) Run(ctx context.Context) {
 }
 
 func (j *EmbedJob) missingCount(ctx context.Context, target vector.GenerationID) (int64, error) {
-	scope := vector.NewBuildScope(j.BuildScope.MessageTypes)
+	scope := vector.NewBuildScope(j.BuildScope.MessageTypes, j.BuildScope.SourceIDs)
 	if scope.IsEmpty() {
 		return j.Store.MissingCount(ctx, int64(target))
 	}
 	if scoped, ok := j.Store.(ScopedEmbedCoverage); ok {
-		return scoped.MissingCountScoped(ctx, int64(target), scope.MessageTypes)
+		return scoped.MissingCountScoped(ctx, int64(target), scope.MessageTypes, scope.SourceIDs)
 	}
 	return 0, errors.New("embed coverage store does not support scoped missing counts")
 }

--- a/internal/scheduler/embed_job.go
+++ b/internal/scheduler/embed_job.go
@@ -91,6 +91,14 @@ type EmbedJob struct {
 	// worker scans for this generation. Empty means the full live corpus.
 	BuildScope vector.BuildScope
 
+	// ResolveBuildScope re-resolves the durable embedding scope immediately
+	// before each scheduled run. If it differs from BuildScope, Run fails
+	// closed: the worker and backend were initialized with the old scope and
+	// must be reinitialized before any embedding can resume. This prevents a
+	// reused database source ID from being treated as the formerly configured
+	// account.
+	ResolveBuildScope func() (vector.BuildScope, error)
+
 	// Now returns the current time; overridable in tests to drive the
 	// backstop interval deterministically. nil uses time.Now.
 	Now func() time.Time
@@ -134,6 +142,21 @@ func (j *EmbedJob) Run(ctx context.Context) {
 		return
 	}
 	defer j.running.Unlock()
+
+	if j.ResolveBuildScope != nil {
+		resolved, err := j.ResolveBuildScope()
+		if err != nil {
+			log.Error("embed run skipped: configured scope could not be resolved", "error", err)
+			return
+		}
+		configured := vector.NewBuildScope(j.BuildScope.MessageTypes, j.BuildScope.SourceIDs)
+		if resolved.Fingerprint() != configured.Fingerprint() {
+			log.Error("embed run skipped: configured scope changed; reinitialize vector features and rebuild before embedding",
+				"configured_scope", resolved.Fingerprint(),
+				"initialized_scope", configured.Fingerprint())
+			return
+		}
+	}
 
 	if _, err := j.Worker.ReclaimStale(ctx); err != nil {
 		if jobctx.YieldedToWaiter(ctx) {

--- a/internal/scheduler/embed_job_scope_test.go
+++ b/internal/scheduler/embed_job_scope_test.go
@@ -1,0 +1,48 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// scopedFakeCoverage records the scope arguments MissingCountScoped
+// receives so the test can prove the job forwards its full build scope.
+type scopedFakeCoverage struct {
+	messageTypes []string
+	sourceIDs    []int64
+	missing      int64
+}
+
+func (c *scopedFakeCoverage) MissingCount(context.Context, int64) (int64, error) {
+	return -1, errors.New("unscoped path must not be used for a scoped job")
+}
+
+func (c *scopedFakeCoverage) MissingCountScoped(_ context.Context, _ int64, messageTypes []string, sourceIDs []int64) (int64, error) {
+	c.messageTypes = messageTypes
+	c.sourceIDs = sourceIDs
+	return c.missing, nil
+}
+
+// TestEmbedJobMissingCountForwardsScope pins the account dimension: a job
+// built with a source-scoped BuildScope must pass those source IDs to the
+// coverage store, or the daemon's activation gate would count the whole
+// corpus and the scoped generation could never activate.
+func TestEmbedJobMissingCountForwardsScope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cov := &scopedFakeCoverage{missing: 5}
+	job := &EmbedJob{
+		Store:      cov,
+		BuildScope: vector.NewBuildScope([]string{"SMS"}, []int64{7, 3}),
+	}
+	got, err := job.missingCount(context.Background(), 12)
+	require.NoError(err)
+	assert.Equal(int64(5), got)
+	assert.Equal([]string{"sms"}, cov.messageTypes, "message types normalized")
+	assert.Equal([]int64{3, 7}, cov.sourceIDs, "source IDs normalized and forwarded")
+}

--- a/internal/scheduler/embed_job_scope_test.go
+++ b/internal/scheduler/embed_job_scope_test.go
@@ -46,3 +46,20 @@ func TestEmbedJobMissingCountForwardsScope(t *testing.T) {
 	assert.Equal([]string{"sms"}, cov.messageTypes, "message types normalized")
 	assert.Equal([]int64{3, 7}, cov.sourceIDs, "source IDs normalized and forwarded")
 }
+
+func TestEmbedJobScopeChangeFailsClosedBeforeWorkerRuns(t *testing.T) {
+	assert := assert.New(t)
+	runner := &fakeRunner{}
+	job := &EmbedJob{
+		Worker:     runner,
+		Backend:    &fakeBackend{},
+		BuildScope: vector.NewBuildScope(nil, []int64{7}),
+		ResolveBuildScope: func() (vector.BuildScope, error) {
+			return vector.NewBuildScope(nil, []int64{9}), nil
+		},
+	}
+
+	job.Run(context.Background())
+	assert.Equal(0, runner.runCalls, "changed source mapping must stop before embedding")
+	assert.Equal(0, runner.reclaimCalls, "changed source mapping must stop before any worker write")
+}

--- a/internal/store/embed_gen.go
+++ b/internal/store/embed_gen.go
@@ -33,16 +33,17 @@ var embedGenStampChunkRows = 500
 // the embeddings upsert — the worker orders the steps (upsert, then
 // stamp) and relies on idempotency, see internal/vector/embed/worker.go.
 func (s *Store) ScanForEmbedding(ctx context.Context, target int64, afterID int64, limit int) ([]int64, error) {
-	return s.ScanForEmbeddingScoped(ctx, target, afterID, limit, nil)
+	return s.ScanForEmbeddingScoped(ctx, target, afterID, limit, nil, nil)
 }
 
 // ScanForEmbeddingScoped is ScanForEmbedding limited to the supplied message
-// types. An empty messageTypes slice means the full live corpus.
-func (s *Store) ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string) ([]int64, error) {
+// types and source IDs. Empty messageTypes and sourceIDs slices mean the
+// full live corpus.
+func (s *Store) ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string, sourceIDs []int64) ([]int64, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
-	liveWhere, liveArgs := liveMessagesWhereWithMessageTypes(messageTypes)
+	liveWhere, liveArgs := liveMessagesWhereScoped(messageTypes, sourceIDs)
 	q := `SELECT id FROM messages
 	       WHERE (embed_gen IS NULL OR embed_gen <> ?)
 	         AND ` + liveWhere + `
@@ -250,18 +251,19 @@ func (s *Store) ResetEmbedGen(ctx context.Context, ids []int64) error {
 // activeGen == 0 means "no active/target generation"; then everything
 // live is missing and stamped is 0.
 func (s *Store) CoverageCounts(ctx context.Context, activeGen int64) (live, stamped, blank, missing int64, err error) {
-	return s.CoverageCountsScoped(ctx, activeGen, nil)
+	return s.CoverageCountsScoped(ctx, activeGen, nil, nil)
 }
 
-// CoverageCountsScoped is CoverageCounts limited to the supplied message types.
-// An empty messageTypes slice means the full live corpus.
-func (s *Store) CoverageCountsScoped(ctx context.Context, activeGen int64, messageTypes []string) (live, stamped, blank, missing int64, err error) {
-	live, err = s.countLiveMessagesScoped(ctx, messageTypes)
+// CoverageCountsScoped is CoverageCounts limited to the supplied message
+// types and source IDs. Empty messageTypes and sourceIDs slices mean the
+// full live corpus.
+func (s *Store) CoverageCountsScoped(ctx context.Context, activeGen int64, messageTypes []string, sourceIDs []int64) (live, stamped, blank, missing int64, err error) {
+	live, err = s.countLiveMessagesScoped(ctx, messageTypes, sourceIDs)
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}
 	if activeGen != 0 {
-		liveWhere, liveArgs := liveMessagesWhereWithMessageTypes(messageTypes)
+		liveWhere, liveArgs := liveMessagesWhereScoped(messageTypes, sourceIDs)
 		q := `SELECT COUNT(*) FROM messages
 		       WHERE embed_gen = ? AND ` + liveWhere
 		args := append([]any{activeGen}, liveArgs...)
@@ -278,13 +280,14 @@ func (s *Store) CoverageCountsScoped(ctx context.Context, activeGen int64, messa
 // activeGen). It is a thin accessor for the scheduler/CLI activation
 // gates, which only consult the missing count; missing = live - stamped.
 func (s *Store) MissingCount(ctx context.Context, activeGen int64) (int64, error) {
-	return s.MissingCountScoped(ctx, activeGen, nil)
+	return s.MissingCountScoped(ctx, activeGen, nil, nil)
 }
 
-// MissingCountScoped is MissingCount limited to the supplied message types.
-// An empty messageTypes slice means the full live corpus.
-func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string) (int64, error) {
-	live, err := s.countLiveMessagesScoped(ctx, messageTypes)
+// MissingCountScoped is MissingCount limited to the supplied message types
+// and source IDs. Empty messageTypes and sourceIDs slices mean the full
+// live corpus.
+func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string, sourceIDs []int64) (int64, error) {
+	live, err := s.countLiveMessagesScoped(ctx, messageTypes, sourceIDs)
 	if err != nil {
 		return 0, err
 	}
@@ -292,7 +295,7 @@ func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, message
 		return live, nil
 	}
 	var stamped int64
-	liveWhere, liveArgs := liveMessagesWhereWithMessageTypes(messageTypes)
+	liveWhere, liveArgs := liveMessagesWhereScoped(messageTypes, sourceIDs)
 	q := `SELECT COUNT(*) FROM messages
 	       WHERE embed_gen = ? AND ` + liveWhere
 	args := append([]any{activeGen}, liveArgs...)
@@ -304,9 +307,9 @@ func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, message
 
 // countLiveMessages returns the total live-message count. Shared by
 // CoverageCounts; kept separate so the live-predicate stays in one place.
-func (s *Store) countLiveMessagesScoped(ctx context.Context, messageTypes []string) (int64, error) {
+func (s *Store) countLiveMessagesScoped(ctx context.Context, messageTypes []string, sourceIDs []int64) (int64, error) {
 	var n int64
-	liveWhere, args := liveMessagesWhereWithMessageTypes(messageTypes)
+	liveWhere, args := liveMessagesWhereScoped(messageTypes, sourceIDs)
 	q := `SELECT COUNT(*) FROM messages WHERE ` + liveWhere
 	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
 		return 0, fmt.Errorf("count live messages: %w", err)
@@ -314,19 +317,30 @@ func (s *Store) countLiveMessagesScoped(ctx context.Context, messageTypes []stri
 	return n, nil
 }
 
-func liveMessagesWhereWithMessageTypes(messageTypes []string) (string, []any) {
+// liveMessagesWhereScoped builds the live-messages predicate narrowed by the
+// embed build scope: message_type IN (...) and/or source_id IN (...). Empty
+// slices leave that dimension unrestricted.
+func liveMessagesWhereScoped(messageTypes []string, sourceIDs []int64) (string, []any) {
 	where := LiveMessagesWhere("", true)
+	var args []any
 	types := normalizeMessageTypes(messageTypes)
-	if len(types) == 0 {
-		return where, nil
+	if len(types) > 0 {
+		placeholders := make([]string, len(types))
+		for i, typ := range types {
+			placeholders[i] = "?"
+			args = append(args, typ)
+		}
+		where += " AND message_type IN (" + strings.Join(placeholders, ",") + ")"
 	}
-	placeholders := make([]string, len(types))
-	args := make([]any, len(types))
-	for i, typ := range types {
-		placeholders[i] = "?"
-		args[i] = typ
+	ids := normalizeScopeSourceIDs(sourceIDs)
+	if len(ids) > 0 {
+		placeholders := make([]string, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		where += " AND source_id IN (" + strings.Join(placeholders, ",") + ")"
 	}
-	where += " AND message_type IN (" + strings.Join(placeholders, ",") + ")"
 	return where, args
 }
 
@@ -346,6 +360,27 @@ func normalizeMessageTypes(messageTypes []string) []string {
 		}
 		seen[typ] = struct{}{}
 		out = append(out, typ)
+	}
+	return out
+}
+
+// normalizeScopeSourceIDs de-duplicates scope source IDs and drops
+// non-positive values so the IN clause binds a minimal, valid set.
+func normalizeScopeSourceIDs(sourceIDs []int64) []int64 {
+	if len(sourceIDs) == 0 {
+		return nil
+	}
+	seen := make(map[int64]struct{}, len(sourceIDs))
+	out := make([]int64, 0, len(sourceIDs))
+	for _, id := range sourceIDs {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
 	return out
 }

--- a/internal/store/embed_gen_test.go
+++ b/internal/store/embed_gen_test.go
@@ -1,0 +1,123 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// embedScopeFixture builds two sources with three live messages each (plus
+// one soft-deleted message in the first source) so scoped scan/coverage
+// tests can prove the source filter neither leaks across accounts nor
+// counts dead rows.
+type embedScopeFixture struct {
+	srcA     *store.Source
+	srcB     *store.Source
+	msgsA    []int64
+	msgsB    []int64
+	deletedA int64
+}
+
+func seedEmbedScopeFixture(t *testing.T, st *store.Store) embedScopeFixture {
+	t.Helper()
+	var fx embedScopeFixture
+	var err error
+	fx.srcA, err = st.GetOrCreateSource("gmail", "alice@example.com")
+	require.NoError(t, err, "GetOrCreateSource alice")
+	fx.srcB, err = st.GetOrCreateSource("gmail", "bob@example.com")
+	require.NoError(t, err, "GetOrCreateSource bob")
+
+	seed := func(src *store.Source, smidPrefix string, n int) []int64 {
+		convID, err := st.EnsureConversationWithType(src.ID, "conv-"+src.Identifier, "email_thread", "Subject")
+		require.NoError(t, err, "EnsureConversationWithType")
+		ids := make([]int64, 0, n)
+		for i := 0; i < n; i++ {
+			id, err := st.UpsertMessage(&store.Message{
+				SourceID:        src.ID,
+				SourceMessageID: fmt.Sprintf("%s-%d", smidPrefix, i),
+				ConversationID:  convID,
+				MessageType:     "email",
+				Subject:         sql.NullString{String: "s", Valid: true},
+			})
+			require.NoError(t, err, "UpsertMessage")
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	fx.msgsA = seed(fx.srcA, "alice", 3)
+	fx.msgsB = seed(fx.srcB, "bob", 3)
+
+	// One soft-deleted message in source A: live predicates must exclude it.
+	fx.deletedA = seed(fx.srcA, "alice-deleted", 1)[0]
+	_, err = st.DB().Exec(st.Rebind(
+		`UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`), fx.deletedA)
+	require.NoError(t, err, "soft-delete message")
+	return fx
+}
+
+func TestScanForEmbeddingScopedFiltersBySource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fx := seedEmbedScopeFixture(t, st)
+	ctx := context.Background()
+
+	scoped, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, nil, []int64{fx.srcA.ID})
+	require.NoError(err, "ScanForEmbeddingScoped")
+	assert.Equal(fx.msgsA, scoped,
+		"only source A's live messages need embedding for gen 1")
+
+	both, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, nil, []int64{fx.srcA.ID, fx.srcB.ID})
+	require.NoError(err, "ScanForEmbeddingScoped two sources")
+	assert.Equal(append(append([]int64(nil), fx.msgsA...), fx.msgsB...), both)
+
+	unscoped, err := st.ScanForEmbedding(ctx, 1, 0, 100)
+	require.NoError(err, "ScanForEmbedding")
+	assert.Len(unscoped, 6, "unscoped scan covers both sources")
+
+	none, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, nil, []int64{9999})
+	require.NoError(err, "ScanForEmbeddingScoped unknown source")
+	assert.Empty(none, "a source with no messages scans empty")
+}
+
+func TestCoverageCountsScopedFiltersBySource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fx := seedEmbedScopeFixture(t, st)
+	ctx := context.Background()
+
+	require.NoError(st.SetEmbedGen(ctx, fx.msgsA[:2], 7), "stamp two of A's messages")
+
+	live, stamped, _, missing, err := st.CoverageCountsScoped(ctx, 7, nil, []int64{fx.srcA.ID})
+	require.NoError(err, "CoverageCountsScoped")
+	assert.Equal(int64(3), live, "live within source A (deleted row excluded)")
+	assert.Equal(int64(2), stamped, "stamped within source A")
+	assert.Equal(int64(1), missing, "missing within source A")
+
+	missingB, err := st.MissingCountScoped(ctx, 7, nil, []int64{fx.srcB.ID})
+	require.NoError(err, "MissingCountScoped")
+	assert.Equal(int64(3), missingB, "all of source B's messages are missing for gen 7")
+}
+
+func TestScopedFiltersComposeMessageTypesAndSources(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	fx := seedEmbedScopeFixture(t, st)
+	ctx := context.Background()
+
+	// Reclassify one of A's messages as a different type.
+	_, err := st.DB().Exec(st.Rebind(
+		`UPDATE messages SET message_type = 'sms' WHERE id = ?`), fx.msgsA[0])
+	require.NoError(t, err, "reclassify message type")
+
+	emailA, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, []string{"email"}, []int64{fx.srcA.ID})
+	require.NoError(t, err, "ScanForEmbeddingScoped type+source")
+	assert.Equal(t, fx.msgsA[1:], emailA,
+		"the sms-typed message drops out of the email×A intersection")
+}

--- a/internal/vector/build_scope.go
+++ b/internal/vector/build_scope.go
@@ -3,6 +3,7 @@ package vector
 import (
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -10,12 +11,19 @@ import (
 // generation. A zero-value scope means the full corpus.
 type BuildScope struct {
 	MessageTypes []string
+	// SourceIDs restricts the build to messages belonging to the given
+	// sources (accounts). Source IDs are DB-local integers: deterministic
+	// within one archive, but deleting and re-adding an account (or
+	// restoring a backup) can renumber them, which changes the scope
+	// fingerprint and forces a rebuild.
+	SourceIDs []int64
 }
 
 // NewBuildScope returns a normalized, stable scope. Message types are
-// lowercase, trimmed, de-duplicated, and sorted so fingerprints and SQL
-// bindings are deterministic.
-func NewBuildScope(messageTypes []string) BuildScope {
+// lowercase, trimmed, de-duplicated, and sorted; source IDs are
+// de-duplicated, sorted ascending, with non-positive IDs dropped — so
+// fingerprints and SQL bindings are deterministic.
+func NewBuildScope(messageTypes []string, sourceIDs []int64) BuildScope {
 	seen := make(map[string]struct{}, len(messageTypes))
 	out := make([]string, 0, len(messageTypes))
 	for _, typ := range messageTypes {
@@ -30,18 +38,49 @@ func NewBuildScope(messageTypes []string) BuildScope {
 		out = append(out, typ)
 	}
 	sort.Strings(out)
-	return BuildScope{MessageTypes: out}
+
+	idSeen := make(map[int64]struct{}, len(sourceIDs))
+	ids := make([]int64, 0, len(sourceIDs))
+	for _, id := range sourceIDs {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := idSeen[id]; ok {
+			continue
+		}
+		idSeen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return BuildScope{MessageTypes: out, SourceIDs: ids}
 }
 
 func (s BuildScope) IsEmpty() bool {
-	return len(s.MessageTypes) == 0
+	return len(s.MessageTypes) == 0 && len(s.SourceIDs) == 0
 }
 
+// Fingerprint renders the scope as "mt-<types>" and/or "src-<ids>" segments
+// joined by ":". The empty scope fingerprints to "".
 func (s BuildScope) Fingerprint() string {
 	if s.IsEmpty() {
 		return ""
 	}
-	return "mt-" + strings.Join(s.MessageTypes, ",")
+	segs := make([]string, 0, 2)
+	if len(s.MessageTypes) > 0 {
+		segs = append(segs, "mt-"+strings.Join(s.MessageTypes, ","))
+	}
+	if len(s.SourceIDs) > 0 {
+		var b strings.Builder
+		b.WriteString("src-")
+		for i, id := range s.SourceIDs {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(strconv.FormatInt(id, 10))
+		}
+		segs = append(segs, b.String())
+	}
+	return strings.Join(segs, ":")
 }
 
 func (s BuildScope) ContainsMessageType(messageType string) bool {
@@ -49,8 +88,15 @@ func (s BuildScope) ContainsMessageType(messageType string) bool {
 	return slices.Contains(s.MessageTypes, messageType)
 }
 
+func (s BuildScope) ContainsSource(sourceID int64) bool {
+	return slices.Contains(s.SourceIDs, sourceID)
+}
+
+// AllowsMessageTypes reports whether the scope's message-type dimension
+// permits all the given types. A scope with no message-type restriction
+// (including a sources-only scope) allows everything.
 func (s BuildScope) AllowsMessageTypes(messageTypes []string) bool {
-	if s.IsEmpty() {
+	if len(s.MessageTypes) == 0 {
 		return true
 	}
 	if len(messageTypes) == 0 {

--- a/internal/vector/build_scope_test.go
+++ b/internal/vector/build_scope_test.go
@@ -1,0 +1,49 @@
+package vector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBuildScopeNormalizesSourceIDs(t *testing.T) {
+	scope := NewBuildScope(nil, []int64{7, 3, 7, 0, -2, 3})
+	assert.Equal(t, []int64{3, 7}, scope.SourceIDs,
+		"source IDs are deduped, sorted ascending, and non-positive IDs dropped")
+	assert.False(t, scope.IsEmpty(), "a sources-only scope is not empty")
+}
+
+func TestBuildScopeIsEmpty(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(NewBuildScope(nil, nil).IsEmpty())
+	assert.True(NewBuildScope([]string{""}, []int64{0}).IsEmpty(),
+		"normalization dropping every entry leaves the scope empty")
+	assert.False(NewBuildScope([]string{"email"}, nil).IsEmpty())
+	assert.False(NewBuildScope(nil, []int64{1}).IsEmpty())
+}
+
+func TestBuildScopeFingerprint(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("", NewBuildScope(nil, nil).Fingerprint())
+	assert.Equal("mt-email,sms", NewBuildScope([]string{"sms", "email"}, nil).Fingerprint())
+	assert.Equal("src-3,7", NewBuildScope(nil, []int64{7, 3}).Fingerprint())
+	assert.Equal("mt-email:src-3,7",
+		NewBuildScope([]string{"email"}, []int64{7, 3}).Fingerprint(),
+		"both dimensions appear, message types first, each normalized")
+}
+
+func TestBuildScopeContainsSource(t *testing.T) {
+	assert := assert.New(t)
+	scope := NewBuildScope(nil, []int64{3, 7})
+	assert.True(scope.ContainsSource(3))
+	assert.True(scope.ContainsSource(7))
+	assert.False(scope.ContainsSource(4))
+	assert.False(NewBuildScope(nil, nil).ContainsSource(3),
+		"an unrestricted scope contains no explicit source")
+}
+
+func TestBuildScopeAllowsMessageTypesWithSourcesOnlyScope(t *testing.T) {
+	scope := NewBuildScope(nil, []int64{3})
+	assert.True(t, scope.AllowsMessageTypes([]string{"email"}),
+		"a sources-only scope imposes no message-type restriction")
+}

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -228,10 +228,21 @@ type EmbedScheduleConfig struct {
 // embedding generations. The zero value means the full corpus.
 type EmbedScopeConfig struct {
 	MessageTypes []string `toml:"message_types"`
+	// Accounts limits embedding to the given account identifiers (the same
+	// syntax the --account flag accepts). Identifiers live in config rather
+	// than source IDs so the file survives archive rebuilds that renumber
+	// sources; the command layer resolves them to SourceIDs against the
+	// open store at startup, where unknown identifiers are a hard error.
+	Accounts []string `toml:"accounts"`
+	// SourceIDs is the resolved form of Accounts (or of a CLI
+	// --account/--collection override), filled in by the command layer
+	// before the scope is used for building, coverage, or fingerprinting.
+	// It is never read from TOML.
+	SourceIDs []int64 `toml:"-"`
 }
 
 func (s EmbedScopeConfig) BuildScope() BuildScope {
-	return NewBuildScope(s.MessageTypes)
+	return NewBuildScope(s.MessageTypes, s.SourceIDs)
 }
 
 // Fingerprint returns the "<model>:<dimension>" identifier for the

--- a/internal/vector/config_test.go
+++ b/internal/vector/config_test.go
@@ -448,3 +448,27 @@ func TestConfig_GenerationFingerprint_IncludesEmbedScope(t *testing.T) {
 	assert.Contains(t, scoped.GenerationFingerprint(), ":smt-mms,sms",
 		"scope fingerprint should normalize and sort message types")
 }
+
+// TestConfig_GenerationFingerprint_IncludesEmbedScopeSources pins the account
+// dimension: resolved source IDs fold into the generation fingerprint, so an
+// account-scoped build never shares a generation with a full-corpus one.
+func TestConfig_GenerationFingerprint_IncludesEmbedScopeSources(t *testing.T) {
+	base := Config{
+		Embeddings: EmbeddingsConfig{Model: "m", Dimension: 8, MaxInputChars: 6000},
+	}
+	baseline := base.GenerationFingerprint()
+
+	scoped := base
+	scoped.Embed.Scope.SourceIDs = []int64{7, 3, 7}
+
+	assert.NotEqual(t, baseline, scoped.GenerationFingerprint(),
+		"GenerationFingerprint should change when embedding is scoped to accounts")
+	assert.Contains(t, scoped.GenerationFingerprint(), ":ssrc-3,7",
+		"scope fingerprint should normalize and sort source IDs")
+
+	combined := base
+	combined.Embed.Scope.MessageTypes = []string{"email"}
+	combined.Embed.Scope.SourceIDs = []int64{3}
+	assert.Contains(t, combined.GenerationFingerprint(), ":smt-email:src-3",
+		"message types and source IDs compose in one scope fingerprint")
+}

--- a/internal/vector/embed/testsupport_test.go
+++ b/internal/vector/embed/testsupport_test.go
@@ -25,6 +25,8 @@ const testMainSchema = `
 CREATE TABLE messages (
     id INTEGER PRIMARY KEY,
     subject TEXT,
+    source_id INTEGER,
+    message_type TEXT,
     deleted_at DATETIME,
     deleted_from_source_at DATETIME,
     embed_gen INTEGER,
@@ -67,6 +69,48 @@ func (s *testWorkStore) ScanForEmbedding(ctx context.Context, target int64, afte
 		    AND deleted_at IS NULL AND deleted_from_source_at IS NULL
 		    AND id > ?
 		  ORDER BY id LIMIT ?`, target, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// ScanForEmbeddingScoped mirrors store.Store.ScanForEmbeddingScoped: the
+// same needs-work and liveness predicates as ScanForEmbedding, narrowed by
+// message_type and/or source_id when those scope dimensions are non-empty.
+func (s *testWorkStore) ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string, sourceIDs []int64) ([]int64, error) {
+	where := `(embed_gen IS NULL OR embed_gen <> ?)
+	    AND deleted_at IS NULL AND deleted_from_source_at IS NULL
+	    AND id > ?`
+	args := []any{target, afterID}
+	if len(messageTypes) > 0 {
+		ph := make([]string, len(messageTypes))
+		for i, typ := range messageTypes {
+			ph[i] = "?"
+			args = append(args, typ)
+		}
+		where += ` AND message_type IN (` + strings.Join(ph, ",") + `)`
+	}
+	if len(sourceIDs) > 0 {
+		ph := make([]string, len(sourceIDs))
+		for i, id := range sourceIDs {
+			ph[i] = "?"
+			args = append(args, id)
+		}
+		where += ` AND source_id IN (` + strings.Join(ph, ",") + `)`
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM messages WHERE `+where+` ORDER BY id LIMIT ?`,
+		append(args, limit)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -593,17 +593,17 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 }
 
 func (w *Worker) scanForEmbedding(ctx context.Context, gen int64, afterID int64) ([]int64, error) {
-	scope := vector.NewBuildScope(w.deps.BuildScope.MessageTypes)
+	scope := vector.NewBuildScope(w.deps.BuildScope.MessageTypes, w.deps.BuildScope.SourceIDs)
 	if scope.IsEmpty() {
 		return w.deps.Store.ScanForEmbedding(ctx, gen, afterID, w.deps.BatchSize)
 	}
 	scoped, ok := w.deps.Store.(interface {
-		ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string) ([]int64, error)
+		ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string, sourceIDs []int64) ([]int64, error)
 	})
 	if !ok {
 		return nil, errors.New("work store does not support scoped embedding scans")
 	}
-	return scoped.ScanForEmbeddingScoped(ctx, gen, afterID, w.deps.BatchSize, scope.MessageTypes)
+	return scoped.ScanForEmbeddingScoped(ctx, gen, afterID, w.deps.BatchSize, scope.MessageTypes, scope.SourceIDs)
 }
 
 // advanceWatermark persists the per-gen forward-scan cursor to id after a

--- a/internal/vector/embed/worker_scope_test.go
+++ b/internal/vector/embed/worker_scope_test.go
@@ -1,0 +1,74 @@
+//go:build sqlite_vec
+
+package embed
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// insertScopedMessage adds a message (with a body, so it embeds rather than
+// skip-stamping as empty) belonging to the given source.
+func insertScopedMessage(t *testing.T, db *sql.DB, id int64, sourceID int64) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO messages (id, subject, source_id, message_type) VALUES (?, ?, ?, 'email')`,
+		id, fmt.Sprintf("msg %d", id), sourceID)
+	require.NoError(t, err, "insert message")
+	_, err = db.Exec(
+		`INSERT INTO message_bodies (message_id, body_text) VALUES (?, ?)`,
+		id, fmt.Sprintf("body %d", id))
+	require.NoError(t, err, "insert body")
+}
+
+// TestWorker_SourceScopeSkipsOutOfScopeMessages runs the drain against a
+// corpus spanning three sources with the build scope pinned to one of them:
+// only in-scope messages may be embedded and stamped, even with a batch size
+// of 1 forcing many scans past out-of-scope rows.
+func TestWorker_SourceScopeSkipsOutOfScopeMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newWorkerFixture(t, 0)
+
+	insertScopedMessage(t, f.MainDB, 1, 1)
+	insertScopedMessage(t, f.MainDB, 2, 2)
+	insertScopedMessage(t, f.MainDB, 3, 2)
+	insertScopedMessage(t, f.MainDB, 4, 3)
+
+	w := NewWorker(WorkerDeps{
+		Backend:    f.Backend,
+		VectorsDB:  f.VectorsDB,
+		MainDB:     f.MainDB,
+		Store:      f.Store,
+		Client:     f.FakeClient,
+		BatchSize:  1,
+		BuildScope: vector.NewBuildScope(nil, []int64{2}),
+	})
+	res, err := w.RunOnce(context.Background(), f.BuildingGen)
+	require.NoError(err, "RunOnce")
+	assert.Equal(2, res.Claimed, "only source 2's messages are claimed")
+	assert.Equal(2, res.Succeeded, "only source 2's messages embed")
+
+	gen := int64(f.BuildingGen)
+	for _, id := range []int64{2, 3} {
+		got, isNull := embedGenOf(t, f.MainDB, id)
+		require.False(isNull, "message %d stamped", id)
+		assert.Equal(gen, got, "message %d stamped for the building generation", id)
+	}
+	for _, id := range []int64{1, 4} {
+		_, isNull := embedGenOf(t, f.MainDB, id)
+		assert.True(isNull, "out-of-scope message %d keeps embed_gen NULL", id)
+	}
+
+	// A second run finds no remaining work for the scoped generation.
+	res, err = w.RunOnce(context.Background(), f.BuildingGen)
+	require.NoError(err, "RunOnce again")
+	assert.Equal(0, res.Claimed, "scoped drain is complete")
+}

--- a/internal/vector/hybrid/engine.go
+++ b/internal/vector/hybrid/engine.go
@@ -228,7 +228,11 @@ func (e *Engine) validateBuildScope(filter vector.Filter) error {
 // embedding index. A non-empty build scope only covers those message types, so
 // callers must make the query scope explicit and compatible before running ANN.
 func ValidateBuildScope(buildScope vector.BuildScope, filter vector.Filter) error {
-	scope := vector.NewBuildScope(buildScope.MessageTypes)
+	// Only the message-type dimension is validated. A source-scoped index
+	// simply has no vectors for out-of-scope accounts and hybrid search
+	// degrades to the BM25 signal for them — rejecting those queries would
+	// break ordinary unfiltered search against a partially-embedded corpus.
+	scope := vector.NewBuildScope(buildScope.MessageTypes, nil)
 	if scope.IsEmpty() {
 		return nil
 	}
@@ -240,7 +244,7 @@ func ValidateBuildScope(buildScope vector.BuildScope, filter vector.Filter) erro
 		return fmt.Errorf("%w: index is scoped to message_type=%s, query requested message_type=%s",
 			vector.ErrIndexScopeMismatch,
 			strings.Join(scope.MessageTypes, ","),
-			strings.Join(vector.NewBuildScope(filter.MessageTypes).MessageTypes, ","))
+			strings.Join(vector.NewBuildScope(filter.MessageTypes, nil).MessageTypes, ","))
 	}
 	return nil
 }

--- a/internal/vector/hybrid/engine_test.go
+++ b/internal/vector/hybrid/engine_test.go
@@ -168,7 +168,7 @@ func TestEngine_Hybrid_HappyPath(t *testing.T) {
 func TestEngine_ScopedIndexRequiresMatchingMessageTypeFilter(t *testing.T) {
 	ctx := context.Background()
 	f := newEngineFixture(t)
-	f.Engine.cfg.BuildScope = vector.NewBuildScope([]string{"sms", "mms"})
+	f.Engine.cfg.BuildScope = vector.NewBuildScope([]string{"sms", "mms"}, nil)
 
 	_, _, err := f.Engine.Search(ctx, SearchRequest{
 		Mode:     ModeVector,

--- a/internal/vector/pgvector/backend.go
+++ b/internal/vector/pgvector/backend.go
@@ -262,6 +262,18 @@ func isUniqueViolation(err error) bool {
 // ActivateGeneration (in-tx, single-DB on PG) and Stats. The $N ordinal
 // of the generation id is supplied by the caller.
 func (b *Backend) missingForGenExistsClause(genArg string, firstScopeArg int) (string, []any) {
+	where, args := b.missingForGenWhere(genArg, firstScopeArg)
+	return fmt.Sprintf(`EXISTS (
+		SELECT 1 FROM messages
+		 WHERE %s
+	)`, where), args
+}
+
+// missingForGenWhere is the scope-aware predicate for messages that still
+// need embedding for a generation. Keep Stats and ActivateGeneration on this
+// shared predicate so source-scoped generations never report the full corpus
+// as pending.
+func (b *Backend) missingForGenWhere(genArg string, firstScopeArg int) (string, []any) {
 	where := store.LiveMessagesWhere("", true)
 	args := make([]any, 0, len(b.scope.MessageTypes)+len(b.scope.SourceIDs))
 	nextArg := firstScopeArg
@@ -283,11 +295,7 @@ func (b *Backend) missingForGenExistsClause(genArg string, firstScopeArg int) (s
 		}
 		where += fmt.Sprintf(" AND source_id IN (%s)", strings.Join(placeholders, ","))
 	}
-	return fmt.Sprintf(`EXISTS (
-		SELECT 1 FROM messages
-		 WHERE (embed_gen IS NULL OR embed_gen <> %s)
-		   AND %s
-	)`, genArg, where), args
+	return fmt.Sprintf("(embed_gen IS NULL OR embed_gen <> %s) AND %s", genArg, where), args
 }
 
 // ActivateGeneration atomically retires the current active generation
@@ -1219,11 +1227,11 @@ func (b *Backend) Stats(ctx context.Context, gen vector.GenerationID) (vector.St
 	// generation, so it reports 0 — the StatsView consumer sums per-gen
 	// pending across the active/building generations anyway.
 	if gen != 0 {
+		pendingWhere, pendingArgs := b.missingForGenWhere("$1", 2)
+		pendingArgs = append([]any{int64(gen)}, pendingArgs...)
 		if err := b.db.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM messages
-			  WHERE (embed_gen IS NULL OR embed_gen <> $1)
-			    AND `+store.LiveMessagesWhere("", true),
-			int64(gen)).Scan(&s.PendingCount); err != nil {
+			`SELECT COUNT(*) FROM messages WHERE `+pendingWhere,
+			pendingArgs...).Scan(&s.PendingCount); err != nil {
 			return s, fmt.Errorf("count missing: %w", err)
 		}
 	}

--- a/internal/vector/pgvector/backend.go
+++ b/internal/vector/pgvector/backend.go
@@ -93,7 +93,7 @@ func Open(ctx context.Context, opts Options) (*Backend, error) {
 	}
 	b := &Backend{
 		db:    opts.DB,
-		scope: vector.NewBuildScope(opts.BuildScope.MessageTypes),
+		scope: vector.NewBuildScope(opts.BuildScope.MessageTypes, opts.BuildScope.SourceIDs),
 	}
 	if !opts.SkipMigrate {
 		// serve / build / search: full migrate incl. CREATE EXTENSION (the
@@ -263,14 +263,25 @@ func isUniqueViolation(err error) bool {
 // of the generation id is supplied by the caller.
 func (b *Backend) missingForGenExistsClause(genArg string, firstScopeArg int) (string, []any) {
 	where := store.LiveMessagesWhere("", true)
-	args := make([]any, 0, len(b.scope.MessageTypes))
-	if !b.scope.IsEmpty() {
+	args := make([]any, 0, len(b.scope.MessageTypes)+len(b.scope.SourceIDs))
+	nextArg := firstScopeArg
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
-			placeholders[i] = "$" + strconv.Itoa(firstScopeArg+i)
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
 			args = append(args, typ)
 		}
 		where += fmt.Sprintf(" AND message_type IN (%s)", strings.Join(placeholders, ","))
+	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND source_id IN (%s)", strings.Join(placeholders, ","))
 	}
 	return fmt.Sprintf(`EXISTS (
 		SELECT 1 FROM messages
@@ -1253,13 +1264,24 @@ func (b *Backend) EmbeddedMessageCount(ctx context.Context, gen vector.Generatio
 		    AND m.embed_gen = $1
 		    AND ` + store.LiveMessagesWhere("m", true)
 	args := []any{int64(gen)}
-	if !b.scope.IsEmpty() {
+	nextArg := 2
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
-			placeholders[i] = "$" + strconv.Itoa(2+i)
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
 			args = append(args, typ)
 		}
 		where += fmt.Sprintf(" AND m.message_type IN (%s)", strings.Join(placeholders, ","))
+	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND m.source_id IN (%s)", strings.Join(placeholders, ","))
 	}
 	var n int64
 	if err := b.db.QueryRowContext(ctx,

--- a/internal/vector/pgvector/coverage_test.go
+++ b/internal/vector/pgvector/coverage_test.go
@@ -154,6 +154,41 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 		"invariant: live == embedded + blank + missing")
 }
 
+func TestStats_SourceScopeExcludesOutOfScopePendingMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+	db := openPGTestDB(t)
+	b, err := Open(ctx, Options{
+		DB:         db,
+		Dimension:  8,
+		BuildScope: vector.NewBuildScope(nil, []int64{1}),
+	})
+	require.NoError(err, "Open backend")
+	t.Cleanup(func() { _ = b.Close() })
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO messages (id, source_id, embed_gen) VALUES
+			(1, 1, NULL),
+			(2, 2, NULL)
+		ON CONFLICT (id) DO UPDATE SET
+			source_id = EXCLUDED.source_id,
+			embed_gen = NULL,
+			deleted_at = NULL,
+			deleted_from_source_at = NULL`)
+	require.NoError(err, "seed in-scope and out-of-scope messages")
+
+	gen, err := b.CreateGeneration(ctx, "test-model", 8, "fp")
+	require.NoError(err, "CreateGeneration")
+	_, err = db.ExecContext(ctx, `UPDATE messages SET embed_gen = $1 WHERE id = 1`, int64(gen))
+	require.NoError(err, "stamp in-scope message")
+
+	stats, err := b.Stats(ctx, gen)
+	require.NoError(err, "Stats")
+	assert.Equal(int64(0), stats.PendingCount,
+		"an unstamped out-of-scope message must not make a source-scoped generation pending")
+}
+
 func TestFilteredCoverageRequiresLiveGenerationStampAndVector(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/vector/pgvector/coverage_test.go
+++ b/internal/vector/pgvector/coverage_test.go
@@ -100,7 +100,7 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 	b, err := Open(ctx, Options{
 		DB:         db,
 		Dimension:  8,
-		BuildScope: vector.NewBuildScope([]string{"sms"}),
+		BuildScope: vector.NewBuildScope([]string{"sms"}, nil),
 	})
 	require.NoError(err, "Open backend")
 	t.Cleanup(func() { _ = b.Close() })

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -81,7 +81,7 @@ func Open(ctx context.Context, opts Options) (*Backend, error) {
 		path:     opts.Path,
 		mainPath: opts.MainPath,
 		dim:      opts.Dimension,
-		scope:    vector.NewBuildScope(opts.BuildScope.MessageTypes),
+		scope:    vector.NewBuildScope(opts.BuildScope.MessageTypes, opts.BuildScope.SourceIDs),
 		readOnly: opts.ReadOnly,
 	}
 	// Orphaned-stamp reset (vectors.db-recreate safety): clear embed_gen for
@@ -292,13 +292,21 @@ func (b *Backend) hasMissingForGen(ctx context.Context, gen vector.GenerationID)
 func (b *Backend) missingCoverageWhere(gen int64) (string, []any) {
 	where := "(embed_gen IS NULL OR embed_gen <> ?) AND " + store.LiveMessagesWhere("", true)
 	args := []any{gen}
-	if !b.scope.IsEmpty() {
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
 			placeholders[i] = "?"
 			args = append(args, typ)
 		}
 		where += fmt.Sprintf(" AND message_type IN (%s)", strings.Join(placeholders, ","))
+	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND source_id IN (%s)", strings.Join(placeholders, ","))
 	}
 	return where, args
 }
@@ -1459,13 +1467,21 @@ func (b *Backend) EmbeddedMessageCount(ctx context.Context, gen vector.Generatio
 		    AND embed_gen = ?
 		    AND ` + store.LiveMessagesWhere("", true)
 	args := []any{string(blob), int64(gen)}
-	if !b.scope.IsEmpty() {
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
 			placeholders[i] = "?"
 			args = append(args, typ)
 		}
 		where += fmt.Sprintf(" AND message_type IN (%s)", strings.Join(placeholders, ","))
+	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND source_id IN (%s)", strings.Join(placeholders, ","))
 	}
 	var n int64
 	if err := b.mainDB.QueryRowContext(ctx,

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -396,7 +396,7 @@ func TestBackend_CreateGeneration_ScopeLimitsCoverage(t *testing.T) {
 		Path:       filepath.Join(t.TempDir(), "vectors.db"),
 		Dimension:  768,
 		MainDB:     main,
-		BuildScope: vector.NewBuildScope([]string{"sms", "mms"}),
+		BuildScope: vector.NewBuildScope([]string{"sms", "mms"}, nil),
 	})
 	require.NoError(
 		err, "Open")

--- a/internal/vector/sqlitevec/coverage_test.go
+++ b/internal/vector/sqlitevec/coverage_test.go
@@ -229,7 +229,7 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 		Path:       filepath.Join(t.TempDir(), "vectors.db"),
 		Dimension:  8,
 		MainDB:     st.DB(),
-		BuildScope: vector.NewBuildScope([]string{"sms"}),
+		BuildScope: vector.NewBuildScope([]string{"sms"}, nil),
 	})
 	require.NoError(err, "Open backend")
 	t.Cleanup(func() { _ = b.Close() })
@@ -264,7 +264,7 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 	}), "Upsert embedded vectors")
 	require.NoError(st.SetEmbedGen(ctx, []int64{outOfScopeEmail, inScopeSMS}, int64(gen)), "stamp embedded")
 
-	live, stamped, _, missingCount, err := st.CoverageCountsScoped(ctx, int64(gen), []string{"sms"})
+	live, stamped, _, missingCount, err := st.CoverageCountsScoped(ctx, int64(gen), []string{"sms"}, nil)
 	require.NoError(err, "CoverageCountsScoped")
 	embedded, err := b.EmbeddedMessageCount(ctx, gen)
 	require.NoError(err, "EmbeddedMessageCount")
@@ -332,4 +332,73 @@ func TestFilteredCoverageRequiresLiveGenerationStampAndVector(t *testing.T) {
 
 	_, err = b.EmbeddedMessageCountForIDs(ctx, gen, make([]int64, vector.FilteredCoverageBatchSize+1))
 	assert.ErrorIs(err, vector.ErrCoverageBatchTooLarge)
+}
+
+// TestCoverageSplit_SourceScopedEmbeddedHoldsInvariant mirrors the
+// message-type scoped invariant for the account dimension: coverage and the
+// embedded split count only the scoped sources, and the activation gate
+// ignores out-of-scope messages entirely — a generation covering one account
+// activates even while another account's messages are unstamped.
+func TestCoverageSplit_SourceScopedEmbeddedHoldsInvariant(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	st := testutil.NewSQLiteTestStore(t)
+	srcA, err := st.GetOrCreateSource("gmail", "a@example.com")
+	require.NoError(err, "GetOrCreateSource a")
+	srcB, err := st.GetOrCreateSource("gmail", "b@example.com")
+	require.NoError(err, "GetOrCreateSource b")
+
+	b, err := Open(ctx, Options{
+		Path:       filepath.Join(t.TempDir(), "vectors.db"),
+		Dimension:  8,
+		MainDB:     st.DB(),
+		BuildScope: vector.NewBuildScope(nil, []int64{srcB.ID}),
+	})
+	require.NoError(err, "Open backend")
+	t.Cleanup(func() { _ = b.Close() })
+
+	makeMsg := func(src *store.Source, srcMsgID string) int64 {
+		convID, err := st.EnsureConversationWithType(src.ID, "conv-"+srcMsgID, "email_thread", "S")
+		require.NoError(err, "EnsureConversationWithType")
+		id, err := st.UpsertMessage(&store.Message{
+			SourceID:        src.ID,
+			SourceMessageID: srcMsgID,
+			ConversationID:  convID,
+			MessageType:     "email",
+			Subject:         sql.NullString{String: "s-" + srcMsgID, Valid: true},
+		})
+		require.NoErrorf(err, "UpsertMessage %s", srcMsgID)
+		return id
+	}
+	outOfScopeA := makeMsg(srcA, "a-unstamped")
+	inScopeB := makeMsg(srcB, "b-embedded")
+
+	gen, err := b.CreateGeneration(ctx, "test-model", 8, "fp")
+	require.NoError(err, "CreateGeneration")
+	require.NoError(b.Upsert(ctx, gen, []vector.Chunk{
+		{MessageID: outOfScopeA, Vector: []float32{1, 0, 0, 0, 0, 0, 0, 0}},
+		{MessageID: inScopeB, Vector: []float32{0, 1, 0, 0, 0, 0, 0, 0}},
+	}), "Upsert embedded vectors")
+	require.NoError(st.SetEmbedGen(ctx, []int64{inScopeB}, int64(gen)), "stamp only the in-scope message")
+
+	live, stamped, _, missingCount, err := st.CoverageCountsScoped(ctx, int64(gen), nil, []int64{srcB.ID})
+	require.NoError(err, "CoverageCountsScoped")
+	embedded, err := b.EmbeddedMessageCount(ctx, gen)
+	require.NoError(err, "EmbeddedMessageCount")
+	blank := max(stamped-embedded, 0)
+
+	assert.Equal(int64(1), live, "only source B is in scope")
+	assert.Equal(int64(1), stamped)
+	assert.Equal(int64(1), embedded, "out-of-scope source A vector excluded")
+	assert.Equal(int64(0), blank)
+	assert.Equal(int64(0), missingCount)
+	assert.Equal(live, embedded+blank+missingCount,
+		"invariant: live == embedded + blank + missing")
+
+	// The activation gate is source-scoped too: source A's unstamped message
+	// must not block activation of the scoped generation.
+	require.NoError(b.ActivateGeneration(ctx, gen, false),
+		"scoped generation activates with out-of-scope messages unstamped")
 }


### PR DESCRIPTION
Add account and collection scoping to embedding builds, including durable `[vector.embed.scope] accounts` configuration for daemon jobs. Scope becomes part of generation identity, so changing the selected accounts requires an explicit rebuild and cannot mix vectors across policies.

Coverage and generation reporting now honor the resolved scope, and the CLI documents repeatable `--account` / `--collection` flags.

Verified with the SQLite-vector end-to-end two-account build path and a local scoped build against a configured embedding endpoint: only the selected account was embedded, and its generation activated successfully.