### PR TITLE
feat(vector): support account-scoped embedding builds

### DIFF
--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -12,6 +12,8 @@ var (
 	embedFullRebuild            bool
 	embedYes                    bool
 	embedBackstop               bool
+	embedAccounts               []string
+	embedCollections            []string
 	embeddingsRetireYes         bool
 	embeddingsRetireForceActive bool
 	embeddingsActivateForce     bool
@@ -76,6 +78,10 @@ to point at a running OpenAI-compatible endpoint.`,
 	cmd.Flags().BoolVar(&embedYes, "yes", false, "Skip confirmation prompts")
 	cmd.Flags().BoolVar(&embedBackstop, "backstop", false,
 		"Full-scan pass that ignores the per-generation watermark, catching any straggler messages the incremental scan skipped (idempotent)")
+	cmd.Flags().StringArrayVar(&embedAccounts, "account", nil,
+		"Limit embedding to this account (repeatable); overrides [vector.embed.scope] accounts for this run")
+	cmd.Flags().StringArrayVar(&embedCollections, "collection", nil,
+		"Limit embedding to this collection's accounts (repeatable); overrides [vector.embed.scope] accounts for this run")
 	return cmd
 }
 
@@ -146,6 +152,10 @@ func init() {
 	embedCmd.Deprecated = "use 'msgvault embeddings build' instead"
 	embeddingsResumeCmd.Flags().BoolVar(&embedBackstop, "backstop", false,
 		"Full-scan pass that ignores the per-generation watermark, catching any straggler messages the incremental scan skipped (idempotent)")
+	embeddingsResumeCmd.Flags().StringArrayVar(&embedAccounts, "account", nil,
+		"Limit embedding to this account (repeatable); overrides [vector.embed.scope] accounts for this run")
+	embeddingsResumeCmd.Flags().StringArrayVar(&embedCollections, "collection", nil,
+		"Limit embedding to this collection's accounts (repeatable); overrides [vector.embed.scope] accounts for this run")
 	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireYes, "yes", false, "Skip confirmation prompt")
 	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireForceActive, "force-active", false, "Allow retiring the active generation")
 	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateYes, "yes", false, "Skip confirmation prompt")

--- a/cmd/msgvault/cmd/embed_manage_sqlitevec_test.go
+++ b/cmd/msgvault/cmd/embed_manage_sqlitevec_test.go
@@ -69,7 +69,7 @@ func TestFillFullCoverageUsesEmbeddingScopeForEmbeddedCount(t *testing.T) {
 	}), "upsert in-scope and out-of-scope vectors")
 
 	row := embeddingGenerationRow{ID: 2}
-	require.NoError(fillFullCoverage(ctx, backend, &row))
+	require.NoError(fillFullCoverage(ctx, backend, cfg.Vector.Embed.Scope.BuildScope(), &row))
 
 	assert.Equal(int64(1), row.LiveCount, "only sms is in scope")
 	assert.Equal(int64(1), row.EmbeddedCount, "out-of-scope email vector is excluded")

--- a/cmd/msgvault/cmd/embed_scope.go
+++ b/cmd/msgvault/cmd/embed_scope.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// resolveEmbedScopeSourceIDs folds the account dimension of the embedding
+// build scope into cfg.Vector.Embed.Scope.SourceIDs, so that every consumer
+// of the resolved config — generation fingerprints, coverage counts, the
+// embed worker's scan, and the vector backends' activation gates — sees the
+// same account restriction.
+//
+// The --account/--collection flags, when present, REPLACE the configured
+// [vector.embed.scope] accounts for the run (explicit operator intent);
+// configured message_types always apply, since there is no CLI override for
+// them. Unknown identifiers are a hard error: a silently skipped account
+// would quietly widen the embedded corpus beyond what the operator asked
+// for.
+func resolveEmbedScopeSourceIDs(s *store.Store) error {
+	var ids []int64
+	switch {
+	case len(embedAccounts) > 0 || len(embedCollections) > 0:
+		resolved, err := resolveEmbedScopeFlags(s)
+		if err != nil {
+			return err
+		}
+		ids = resolved
+	case len(cfg.Vector.Embed.Scope.Accounts) > 0:
+		resolved, err := resolveEmbedAccountList(s, cfg.Vector.Embed.Scope.Accounts, true)
+		if err != nil {
+			return fmt.Errorf("[vector.embed.scope] accounts: %w", err)
+		}
+		ids = resolved
+	default:
+		return nil
+	}
+	// Normalize through NewBuildScope so overlapping accounts/collections
+	// dedupe and the stored scope matches what the fingerprint derives.
+	cfg.Vector.Embed.Scope.SourceIDs = vector.NewBuildScope(nil, ids).SourceIDs
+	return nil
+}
+
+// resolveEmbedScopeFlags resolves the --account and --collection flag values
+// to their union of source IDs.
+func resolveEmbedScopeFlags(s *store.Store) ([]int64, error) {
+	var ids []int64
+	if len(embedAccounts) > 0 {
+		accountIDs, err := resolveEmbedAccountList(s, embedAccounts, false)
+		if err != nil {
+			return nil, fmt.Errorf("--account: %w", err)
+		}
+		ids = append(ids, accountIDs...)
+	}
+	for _, name := range embedCollections {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, errors.New("--collection: collection name is required")
+		}
+		scope, err := ResolveCollectionFlag(s, name)
+		if err != nil {
+			return nil, fmt.Errorf("--collection: %w", err)
+		}
+		collectionIDs := scope.SourceIDs()
+		if len(collectionIDs) == 0 {
+			return nil, fmt.Errorf("--collection %q has no accounts; refusing to widen the embedding scope", name)
+		}
+		ids = append(ids, collectionIDs...)
+	}
+	if len(ids) == 0 {
+		return nil, errors.New("explicit embedding scope matched no accounts; refusing to widen the embedding scope")
+	}
+	return ids, nil
+}
+
+// resolveEmbedAccountList resolves embedding account selectors. Unlike
+// collection-management inputs, durable embedding configuration must never
+// accept numeric source IDs: SQLite may reuse an ID after an account is
+// removed.
+//
+// requireIdentifier restricts matches to the account's CANONICAL identifier
+// (rejecting display-name matches) and must be set for durable
+// configuration: the drift detection that guards the privacy boundary
+// compares resolved source IDs, and a display name is not a stable
+// identity — a removed source's recycled ID plus a same-named replacement
+// account would re-resolve identically and silently send the replacement
+// account's text to the embedding endpoint. One-run --account flags may
+// stay permissive (the operator is present and the resolution is not
+// re-evaluated over time).
+func resolveEmbedAccountList(s *store.Store, accounts []string, requireIdentifier bool) ([]int64, error) {
+	var ids []int64
+	for _, input := range accounts {
+		input = strings.TrimSpace(input)
+		if input == "" {
+			return nil, opserr.Invalid(errors.New("account identifier is required"))
+		}
+		scope, err := ResolveAccountFlag(s, input)
+		if err != nil {
+			return nil, err
+		}
+		// A nil Source means the calendar-only path matched, which looks up
+		// by account email (an identifier), so only a resolved primary
+		// source can carry a display-name match.
+		if requireIdentifier && scope.Source != nil && !store.EqualIdentifier(scope.Source.Identifier, input) {
+			return nil, opserr.Invalid(fmt.Errorf(
+				"account %q matches by display name; durable embedding scope requires the account identifier %q",
+				input, scope.Source.Identifier))
+		}
+		accountIDs := scope.SourceIDs()
+		if len(accountIDs) == 0 {
+			return nil, opserr.Invalid(fmt.Errorf("account %q matched no sources", input))
+		}
+		ids = append(ids, accountIDs...)
+	}
+	if len(ids) == 0 {
+		return nil, opserr.Invalid(errors.New("no account identifiers configured"))
+	}
+	return ids, nil
+}
+
+// configuredEmbedBuildScope resolves the durable account configuration anew.
+// It is used by each daemon job run (and the search preflight's drift check)
+// to detect source-ID reuse before the cached worker can send any message
+// content to the embedding endpoint. A DETERMINISTIC resolution failure — a
+// configured account removed, ambiguous, or malformed — is wrapped with
+// vector.ErrScopeUnresolvable so callers latch vector search stale instead
+// of retrying forever against cached source IDs; transient failures (a busy
+// database) pass through unwrapped for retry.
+func configuredEmbedBuildScope(s *store.Store) (vector.BuildScope, error) {
+	messageTypes := cfg.Vector.Embed.Scope.MessageTypes
+	if len(cfg.Vector.Embed.Scope.Accounts) == 0 {
+		return vector.NewBuildScope(messageTypes, nil), nil
+	}
+	ids, err := resolveEmbedAccountList(s, cfg.Vector.Embed.Scope.Accounts, true)
+	if err != nil {
+		if kind := opserr.KindOf(err); kind == opserr.KindInvalid || kind == opserr.KindNotFound {
+			return vector.BuildScope{}, fmt.Errorf("%w: [vector.embed.scope] accounts: %w", vector.ErrScopeUnresolvable, err)
+		}
+		return vector.BuildScope{}, fmt.Errorf("[vector.embed.scope] accounts: %w", err)
+	}
+	return vector.NewBuildScope(messageTypes, ids), nil
+}
+
+// ensureEmbedScopeResolved resolves the configured embed-scope accounts for
+// embeddings management commands (list/activate) that compute coverage or
+// compare generation fingerprints against short-lived stores of their own.
+// A no-op when no accounts are configured.
+//
+// It mutates the package-global cfg, so it may only run in short-lived
+// single-goroutine CLI processes. Daemon code paths (HTTP handlers, the
+// background vector init) must use resolvedVectorConfig instead.
+func ensureEmbedScopeResolved() error {
+	if len(cfg.Vector.Embed.Scope.Accounts) == 0 {
+		return nil
+	}
+	s, err := store.Open(cfg.DatabaseDSN())
+	if err != nil {
+		return fmt.Errorf("open main db for embed scope resolution: %w", err)
+	}
+	defer func() { _ = s.Close() }()
+	return resolveEmbedScopeSourceIDs(s)
+}
+
+// resolvedVectorConfig returns a copy of the vector config with the
+// configured [vector.embed.scope] accounts resolved into Scope.SourceIDs,
+// leaving the shared package-global cfg untouched. This is the resolution
+// path for the daemon, where concurrent HTTP handler goroutines and the
+// background vector init would otherwise race on the global scope field.
+func resolvedVectorConfig(s *store.Store) (vector.Config, error) {
+	vecCfg := cfg.Vector
+	if len(vecCfg.Embed.Scope.Accounts) == 0 {
+		return vecCfg, nil
+	}
+	ids, err := resolveEmbedAccountList(s, vecCfg.Embed.Scope.Accounts, true)
+	if err != nil {
+		return vector.Config{}, fmt.Errorf("[vector.embed.scope] accounts: %w", err)
+	}
+	vecCfg.Embed.Scope.SourceIDs = vector.NewBuildScope(nil, ids).SourceIDs
+	return vecCfg, nil
+}
+
+// openResolvedVectorConfig is resolvedVectorConfig for callers without an
+// open store, such as the daemon's CLI-plan HTTP handlers.
+func openResolvedVectorConfig() (vector.Config, error) {
+	if len(cfg.Vector.Embed.Scope.Accounts) == 0 {
+		return cfg.Vector, nil
+	}
+	s, err := store.Open(cfg.DatabaseDSN())
+	if err != nil {
+		return vector.Config{}, fmt.Errorf("open main db for embed scope resolution: %w", err)
+	}
+	defer func() { _ = s.Close() }()
+	return resolvedVectorConfig(s)
+}

--- a/cmd/msgvault/cmd/embed_scope_sqlitevec_test.go
+++ b/cmd/msgvault/cmd/embed_scope_sqlitevec_test.go
@@ -1,0 +1,220 @@
+//go:build sqlite_vec
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// fakeEmbeddingsServer answers OpenAI-compatible /embeddings requests with
+// one deterministic dim-4 vector per input, recording how many inputs it was
+// asked to embed.
+func fakeEmbeddingsServer(t *testing.T, embedded *int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		*embedded += len(req.Input)
+		type item struct {
+			Embedding []float32 `json:"embedding"`
+			Index     int       `json:"index"`
+		}
+		payload := struct {
+			Data  []item `json:"data"`
+			Model string `json:"model"`
+		}{Model: "test-model"}
+		for i := range req.Input {
+			payload.Data = append(payload.Data, item{Embedding: []float32{1, 0, 0, 0}, Index: i})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// seedTwoAccountMainDB builds a real main DB (via InitSchema) with one
+// message+body in each of two accounts.
+func seedTwoAccountMainDB(t *testing.T, dataDir string) {
+	t.Helper()
+	s, err := store.Open(filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(t, err, "open main db")
+	defer func() { require.NoError(t, s.Close()) }()
+	require.NoError(t, s.InitSchema(), "InitSchema")
+	_, err = s.DB().Exec(`
+INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'a@example.com'), (2, 'gmail', 'b@example.com');
+INSERT INTO conversations (id, source_id, conversation_type) VALUES (1, 1, 'email_thread'), (2, 2, 'email_thread');
+INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, subject) VALUES
+	(1, 1, 1, 'a1', 'email', 'hello from a'),
+	(2, 2, 2, 'b1', 'email', 'hello from b');
+INSERT INTO message_bodies (message_id, body_text) VALUES (1, 'body a1'), (2, 'body b1');
+`)
+	require.NoError(t, err, "seed corpus")
+}
+
+func embedGenByID(t *testing.T, dataDir string) map[int64]sql.NullInt64 {
+	t.Helper()
+	db, err := sql.Open("sqlite3", filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(t, err, "open main db handle")
+	defer func() { require.NoError(t, db.Close()) }()
+	rows, err := db.Query(`SELECT id, embed_gen FROM messages ORDER BY id`)
+	require.NoError(t, err, "read embed_gen")
+	defer func() { _ = rows.Close() }()
+	out := map[int64]sql.NullInt64{}
+	for rows.Next() {
+		var id int64
+		var gen sql.NullInt64
+		require.NoError(t, rows.Scan(&id, &gen))
+		out[id] = gen
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// TestRunEmbed_AccountScopedBuild drives the full runEmbed path (real
+// sqlitevec backend, real store, fake embeddings endpoint): a build scoped
+// to one account embeds and stamps only that account's messages and
+// activates, and a follow-up run scoped differently is refused by the
+// fingerprint mismatch with the scope visible in the error.
+func TestRunEmbed_AccountScopedBuildActivatesScopedGeneration(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var embedded int
+	srv := fakeEmbeddingsServer(t, &embedded)
+
+	dataDir := t.TempDir()
+	seedTwoAccountMainDB(t, dataDir)
+
+	oldCfg := cfg
+	c := &config.Config{}
+	c.Vector.Enabled = true
+	c.Vector.DBPath = filepath.Join(dataDir, "vectors.db")
+	c.Vector.Embeddings.Endpoint = srv.URL
+	c.Vector.Embeddings.Model = "test-model"
+	c.Vector.Embeddings.Dimension = 4
+	c.Data.DataDir = dataDir
+	cfg = c
+
+	oldRebuild, oldYes := embedFullRebuild, embedYes
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	oldBackstop := embedBackstop
+	t.Cleanup(func() {
+		cfg = oldCfg
+		embedFullRebuild, embedYes = oldRebuild, oldYes
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+		embedBackstop = oldBackstop
+	})
+	embedYes = true
+	embedBackstop = false
+
+	newCmd := func() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
+		cmd.SetOut(out)
+		cmd.SetErr(errOut)
+		return cmd, out, errOut
+	}
+
+	// Run 1: full rebuild scoped to account A.
+	embedFullRebuild = true
+	embedAccounts = []string{"a@example.com"}
+	cmd, out, errOut := newCmd()
+	require.NoError(runEmbeddingsBuildLocal(cmd), "scoped full rebuild")
+	assert.Contains(errOut.String(), "Embedding scope: src-1", "scope printed to stderr")
+	assert.Contains(errOut.String(), "add equivalent accounts to [vector.embed.scope]", "one-off scope warns how to persist its generation")
+	assert.Contains(out.String(), "Generation 1 activated.", "scoped generation activates")
+	assert.Equal(1, embedded, "only account A's message reached the embedding endpoint")
+
+	gens := embedGenByID(t, dataDir)
+	require.True(gens[1].Valid, "account A message stamped")
+	assert.Equal(int64(1), gens[1].Int64)
+	assert.False(gens[2].Valid, "account B message keeps embed_gen NULL")
+
+	// Run 2: same archive, scoped to account B instead — the fingerprint
+	// difference must refuse to top up the src-1 generation.
+	embedFullRebuild = false
+	embedAccounts = []string{"b@example.com"}
+	cmd, _, _ = newCmd()
+	err := runEmbeddingsBuildLocal(cmd)
+	require.Error(err, "a different account scope must not resume the src-1 generation")
+	assert.Contains(err.Error(), "src-", "stored vs configured scope is visible in the error")
+	assert.Contains(err.Error(), "full-rebuild", "error points at --full-rebuild")
+}
+
+// TestRunEmbed_AccountScopedRebuildRefusesEmptyScope guards the empty-scope
+// activation hazard: a full rebuild scoped to an account that exists but has
+// no live messages (added but never synced) would immediately reach
+// remaining == 0 and activate an empty generation, retiring the working
+// index. The run must fail instead of activating.
+func TestRunEmbed_AccountScopedRebuildRefusesEmptyScope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var embedded int
+	srv := fakeEmbeddingsServer(t, &embedded)
+
+	dataDir := t.TempDir()
+	seedTwoAccountMainDB(t, dataDir)
+	s, err := store.Open(filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(err, "open main db")
+	_, err = s.DB().Exec(`INSERT INTO sources (id, source_type, identifier) VALUES (3, 'gmail', 'c@example.com')`)
+	require.NoError(err, "seed empty account")
+	require.NoError(s.Close())
+
+	oldCfg := cfg
+	c := &config.Config{}
+	c.Vector.Enabled = true
+	c.Vector.DBPath = filepath.Join(dataDir, "vectors.db")
+	c.Vector.Embeddings.Endpoint = srv.URL
+	c.Vector.Embeddings.Model = "test-model"
+	c.Vector.Embeddings.Dimension = 4
+	c.Data.DataDir = dataDir
+	cfg = c
+
+	oldRebuild, oldYes := embedFullRebuild, embedYes
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	oldBackstop := embedBackstop
+	t.Cleanup(func() {
+		cfg = oldCfg
+		embedFullRebuild, embedYes = oldRebuild, oldYes
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+		embedBackstop = oldBackstop
+	})
+	embedYes = true
+	embedBackstop = false
+	embedFullRebuild = true
+	embedAccounts = []string{"c@example.com"}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	err = runEmbeddingsBuildLocal(cmd)
+	require.Error(err, "an empty account scope must not activate")
+	assert.Contains(err.Error(), "0 live messages")
+	assert.NotContains(out.String(), "activated", "no generation may activate")
+	assert.Zero(embedded, "no message text may reach the embedding endpoint")
+}

--- a/cmd/msgvault/cmd/embed_scope_test.go
+++ b/cmd/msgvault/cmd/embed_scope_test.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// TestEmbeddingsBuildAccountFlagsForwardToDaemon proves the real build
+// command's --account/--collection flags survive daemonCLIArgsFromCobra, so
+// a scope passed to a daemon-fronted `embeddings build` reaches the
+// daemon-spawned subprocess intact.
+func TestEmbeddingsBuildAccountFlagsForwardToDaemon(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cmd := embeddingsBuildCmd
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	t.Cleanup(func() {
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+		for _, name := range []string{"account", "collection"} {
+			cmd.Flags().Lookup(name).Changed = false
+		}
+	})
+
+	require.NoError(cmd.Flags().Set("account", "alice@example.com"))
+	require.NoError(cmd.Flags().Set("account", "bob@example.com"))
+	require.NoError(cmd.Flags().Set("collection", "family"))
+
+	got, err := daemonCLIArgsFromCobra(cmd, nil)
+	require.NoError(err, "daemon args")
+	assert.Equal([]string{
+		"embeddings", "build",
+		"--account=alice@example.com",
+		"--account=bob@example.com",
+		"--collection=family",
+	}, got)
+}
+
+// withEmbedScopeGlobals swaps the config and embed-scope flag globals for a
+// resolution test and restores them afterwards.
+func withEmbedScopeGlobals(t *testing.T, accounts []string) {
+	t.Helper()
+	oldCfg := cfg
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	c := &config.Config{}
+	c.Vector.Embed.Scope.Accounts = accounts
+	cfg = c
+	embedAccounts, embedCollections = nil, nil
+	t.Cleanup(func() {
+		cfg = oldCfg
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+	})
+}
+
+func TestResolveEmbedScopeSourceIDs_ConfiguredAccounts(t *testing.T) {
+	f, accountID, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{accountID})
+
+	require.NoError(t, resolveEmbedScopeSourceIDs(f.Store))
+	assert.Equal(t, []int64{f.Source.ID}, cfg.Vector.Embed.Scope.SourceIDs,
+		"configured account resolves to its source ID")
+}
+
+func TestResolveEmbedScopeSourceIDs_UnknownAccountFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{"nobody@example.com"})
+
+	err := resolveEmbedScopeSourceIDs(f.Store)
+	require.Error(err, "unknown configured account must fail loudly")
+	assert.Contains(err.Error(), "[vector.embed.scope] accounts")
+	assert.Contains(err.Error(), "nobody@example.com")
+	assert.Nil(cfg.Vector.Embed.Scope.SourceIDs, "failed resolution leaves SourceIDs unset")
+}
+
+func TestResolveEmbedScopeSourceIDs_NoScopeLeavesCorpusWide(t *testing.T) {
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, nil)
+
+	require.NoError(t, resolveEmbedScopeSourceIDs(f.Store))
+	assert.Nil(t, cfg.Vector.Embed.Scope.SourceIDs)
+}
+
+func TestResolveEmbedScopeSourceIDs_AccountFlagOverridesConfig(t *testing.T) {
+	require := require.New(t)
+	f, accountID, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{accountID})
+
+	other, err := f.Store.GetOrCreateSource("gmail", "other@example.com")
+	require.NoError(err, "GetOrCreateSource")
+	embedAccounts = []string{other.Identifier}
+
+	require.NoError(resolveEmbedScopeSourceIDs(f.Store))
+	assert.Equal(t, []int64{other.ID}, cfg.Vector.Embed.Scope.SourceIDs,
+		"--account replaces the configured accounts for the run")
+}
+
+func TestResolveEmbedScopeSourceIDs_CollectionFlagExpands(t *testing.T) {
+	require := require.New(t)
+	f, _, collectionName := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, nil)
+
+	other, err := f.Store.GetOrCreateSource("gmail", "other@example.com")
+	require.NoError(err, "GetOrCreateSource")
+	_, err = f.Store.CreateCollection("both", "", []int64{f.Source.ID, other.ID})
+	require.NoError(err, "CreateCollection both")
+	// The fixture collection covers only f.Source; "both" covers both.
+	embedCollections = []string{collectionName, "both"}
+
+	require.NoError(resolveEmbedScopeSourceIDs(f.Store))
+	assert.ElementsMatch(t, []int64{f.Source.ID, other.ID}, cfg.Vector.Embed.Scope.SourceIDs,
+		"--collection expands to the union of member sources")
+}
+
+func TestResolveEmbedScopeSourceIDs_EmptyCollectionFailsClosed(t *testing.T) {
+	require := require.New(t)
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, nil)
+
+	_, err := f.Store.CreateCollection("empty", "", []int64{f.Source.ID})
+	require.NoError(err, "CreateCollection")
+	require.NoError(f.Store.RemoveSourcesFromCollection("empty", []int64{f.Source.ID}), "empty collection")
+	embedCollections = []string{"empty"}
+
+	err = resolveEmbedScopeSourceIDs(f.Store)
+	require.Error(err, "an explicit empty collection must not widen to the full archive")
+	assert.Contains(t, err.Error(), "has no accounts")
+	assert.Nil(t, cfg.Vector.Embed.Scope.SourceIDs)
+}
+
+// TestResolvedVectorConfigLeavesGlobalUntouched pins the daemon-side
+// resolution contract: the returned copy carries the resolved source IDs
+// while the shared package-global cfg stays unmutated, so concurrent daemon
+// goroutines can resolve without racing.
+func TestResolvedVectorConfigLeavesGlobalUntouched(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, accountID, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{accountID})
+
+	vecCfg, err := resolvedVectorConfig(f.Store)
+	require.NoError(err)
+	assert.Equal([]int64{f.Source.ID}, vecCfg.Embed.Scope.SourceIDs,
+		"the copy carries the resolved scope")
+	assert.Nil(cfg.Vector.Embed.Scope.SourceIDs,
+		"the global config must stay unmutated")
+}
+
+// TestConfiguredEmbedBuildScope_ClassifiesResolutionFailures pins the
+// transient/deterministic split the daemon's drift detection relies on: a
+// removed (or never-existing) account is ErrScopeUnresolvable — it cannot
+// heal on retry and must latch searches stale — while a resolvable
+// configuration re-resolves cleanly.
+func TestConfiguredEmbedBuildScope_ClassifiesResolutionFailures(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, accountID, _ := setupScopeFixture(t)
+
+	withEmbedScopeGlobals(t, []string{accountID})
+	scope, err := configuredEmbedBuildScope(f.Store)
+	require.NoError(err)
+	assert.Equal([]int64{f.Source.ID}, scope.SourceIDs)
+
+	cfg.Vector.Embed.Scope.Accounts = []string{"gone@example.com"}
+	_, err = configuredEmbedBuildScope(f.Store)
+	require.ErrorIs(err, vector.ErrScopeUnresolvable,
+		"a configured account that no longer exists is a deterministic failure")
+	assert.Contains(err.Error(), "gone@example.com")
+}
+
+// TestDurableEmbedScopeRejectsDisplayNames pins the identity rule for the
+// privacy boundary: drift detection compares resolved source IDs, and a
+// display name is not a stable identity — a recycled source ID plus a
+// same-named replacement account would re-resolve identically and silently
+// embed the replacement account's text. Durable configuration must name the
+// canonical identifier; the one-run --account flag stays permissive.
+func TestDurableEmbedScopeRejectsDisplayNames(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, accountID, _ := setupScopeFixture(t)
+	_, err := f.Store.DB().Exec(
+		f.Store.Rebind(`UPDATE sources SET display_name = 'Work Mail' WHERE id = ?`), f.Source.ID)
+	require.NoError(err, "set display name")
+
+	withEmbedScopeGlobals(t, []string{"Work Mail"})
+	_, err = configuredEmbedBuildScope(f.Store)
+	require.ErrorIs(err, vector.ErrScopeUnresolvable,
+		"a display name in durable config must fail closed")
+	assert.Contains(err.Error(), accountID, "the error names the canonical identifier to use")
+
+	err = resolveEmbedScopeSourceIDs(f.Store)
+	require.Error(err, "startup resolution must reject the display name too")
+
+	// The one-run --account flag still accepts the display name.
+	embedAccounts = []string{"Work Mail"}
+	require.NoError(resolveEmbedScopeSourceIDs(f.Store))
+	assert.Equal([]int64{f.Source.ID}, cfg.Vector.Embed.Scope.SourceIDs)
+}
+
+// TestEmbedScopeDriftCheck covers the daemon preflight callback end to end
+// against a real store: no drift, drift to a different account, and a
+// deterministically unresolvable account all report the right (detail, err)
+// so the API latches stale exactly when the scope no longer matches.
+func TestEmbedScopeDriftCheck(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f, accountID, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{accountID})
+	initialized := vector.NewBuildScope(nil, []int64{f.Source.ID})
+	check := embedScopeDriftCheck(f.Store, initialized)
+
+	detail, err := check(t.Context())
+	require.NoError(err)
+	assert.Empty(detail, "a matching scope must not latch")
+
+	other, err := f.Store.GetOrCreateSource("gmail", "other@example.com")
+	require.NoError(err, "GetOrCreateSource")
+	cfg.Vector.Embed.Scope.Accounts = []string{other.Identifier}
+	detail, err = check(t.Context())
+	require.NoError(err)
+	assert.Contains(detail, "src-", "a drifted scope latches with both fingerprints")
+
+	cfg.Vector.Embed.Scope.Accounts = []string{"gone@example.com"}
+	detail, err = check(t.Context())
+	require.NoError(err, "an unresolvable account is drift, not a retryable error")
+	assert.Contains(detail, "gone@example.com")
+	assert.Contains(detail, "[vector.embed.scope]")
+}
+
+func TestResolveEmbedScopeSourceIDs_ConfiguredNumericIDFails(t *testing.T) {
+	require := require.New(t)
+	f, _, _ := setupScopeFixture(t)
+	withEmbedScopeGlobals(t, []string{strconv.FormatInt(f.Source.ID, 10)})
+
+	err := resolveEmbedScopeSourceIDs(f.Store)
+	require.Error(err, "durable account configuration must not accept source IDs")
+	assert.Nil(t, cfg.Vector.Embed.Scope.SourceIDs)
+}

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -333,7 +333,7 @@ func TestFillCoverageUsesEmbeddingScope(t *testing.T) {
 	cfg.Vector.Embed.Scope.MessageTypes = []string{"sms"}
 
 	row := embeddingGenerationRow{ID: 2}
-	require.NoError(fillCoverage(t.Context(), &row))
+	require.NoError(fillCoverage(t.Context(), cfg.Vector.Embed.Scope.BuildScope(), &row))
 
 	assert.Equal(int64(1), row.LiveCount)
 	assert.Equal(int64(0), row.MissingCount)

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -45,6 +45,15 @@ func runEmbed(cmd *cobra.Command) error {
 		return fmt.Errorf("init schema: %w", err)
 	}
 
+	// Resolve the account dimension of the build scope before anything
+	// derives a fingerprint or coverage predicate from the config: the
+	// --account/--collection flags (or [vector.embed.scope] accounts)
+	// become source IDs here, and unknown identifiers fail the run loudly
+	// rather than silently widening the embedded corpus.
+	if err := resolveEmbedScopeSourceIDs(s); err != nil {
+		return err
+	}
+
 	var (
 		backend   vector.Backend
 		vectorsDB *sql.DB
@@ -118,9 +127,24 @@ func runEmbed(cmd *cobra.Command) error {
 	// this generation (embed_gen <> gen), read from the main DB coverage
 	// rather than a queue table.
 	scope := cfg.Vector.Embed.Scope.BuildScope()
-	missing, err := s.MissingCountScoped(ctx, int64(gen), scope.MessageTypes)
+	if !scope.IsEmpty() {
+		_, _ = fmt.Fprintf(errOut, "Embedding scope: %s\n", scope.Fingerprint())
+	}
+	live, _, _, missing, err := s.CoverageCountsScoped(ctx, int64(gen), scope.MessageTypes, scope.SourceIDs)
 	if err != nil {
 		return fmt.Errorf("coverage counts: %w", err)
+	}
+	if len(scope.SourceIDs) > 0 && live == 0 {
+		if rebuildInProgress {
+			// Draining a build whose scope matches nothing would reach
+			// remaining == 0 immediately and activate an EMPTY generation,
+			// auto-retiring the currently active index (on pgvector that
+			// deletes its embeddings). An existing-but-unsynced account is
+			// the likely cause, so refuse instead of destroying a working
+			// index behind a stderr notice.
+			return fmt.Errorf("embedding scope %s matched 0 live messages; activating generation %d would replace the current index with an empty one — sync the scoped account(s) first, or retire the building generation (msgvault embeddings retire %d) and fix [vector.embed.scope]/--account/--collection", scope.Fingerprint(), gen, gen)
+		}
+		_, _ = fmt.Fprintln(errOut, "Embedding scope matched 0 live messages.")
 	}
 	totalPending := int(missing)
 
@@ -147,9 +171,13 @@ func runEmbed(cmd *cobra.Command) error {
 	// worker later recovers from must not block activation, and an
 	// active generation must not be re-activated.
 	if rebuildInProgress {
-		if _, err := activateBuiltGeneration(ctx, backend, runtime.Convergence, gen,
-			cfg.Vector.Embeddings.EffectiveAPIFormat(), out, errOut); err != nil {
+		activated, err := activateBuiltGeneration(ctx, backend, runtime.Convergence, gen,
+			cfg.Vector.Embeddings.EffectiveAPIFormat(), out, errOut)
+		if err != nil {
 			return err
+		}
+		if activated && (len(embedAccounts) > 0 || len(embedCollections) > 0) {
+			_, _ = fmt.Fprintln(errOut, "This active generation was scoped with --account/--collection. To keep it usable after a daemon restart, add equivalent accounts to [vector.embed.scope] in config.toml and restart the daemon; otherwise vector search reports index_stale.")
 		}
 	}
 	return nil
@@ -253,7 +281,7 @@ type embedGenerationOpts struct {
 //     for a mismatch.
 //   - default mode with a building generation matching the configured
 //     fingerprint: resume it. Building takes precedence over active so
-//     that an in-flight rebuild for the configured model gets drained
+//     that an in-flight rebuild for the configured embedding settings gets drained
 //     to completion before the next activation, even if a stale active
 //     generation from a different model still exists.
 //   - default mode with no matching building but an active generation
@@ -311,7 +339,7 @@ func pickEmbedGeneration(ctx context.Context, backend vector.Backend, opts embed
 				building.ID, building.Fingerprint)
 			return building.ID, true, nil
 		}
-		return 0, false, fmt.Errorf("in-progress rebuild has fingerprint=%q, config has %q — activate or retire it before running with a different model",
+		return 0, false, fmt.Errorf("in-progress rebuild has fingerprint=%q, config has %q — activate or retire it before running with a different model or embed scope (the fingerprint folds in [vector.embed.scope] message_types/accounts and any --account/--collection flags)",
 			building.Fingerprint, opts.Fingerprint)
 	}
 

--- a/cmd/msgvault/cmd/embed_vector_test.go
+++ b/cmd/msgvault/cmd/embed_vector_test.go
@@ -382,7 +382,7 @@ func TestPickEmbedGeneration_ResumeFingerprintMismatch(t *testing.T) {
 // TestPickEmbedGeneration_PrefersBuildingOverActive_MatchingFingerprint
 // regression-guards the precedence bug where pickEmbedGeneration
 // targeted an existing active generation even when a building
-// generation for the configured model was in flight. The user
+// generation for the configured embedding settings was in flight. The user
 // expectation is that `msgvault embeddings build` drains the in-progress build
 // (so it can be activated) rather than continuing to top up the old
 // active generation.
@@ -467,7 +467,7 @@ func TestPickEmbedGeneration_ContextualRejectsWrongGenerationFingerprint(t *test
 // TestPickEmbedGeneration_StaleActivePlusMatchingBuilding covers the
 // "stale active + matching building" combination R51a calls out: an
 // older active generation exists with a fingerprint that no longer
-// matches the configured model, and a newer building generation
+// matches the configured embedding settings, and a newer building generation
 // matches. The configured-model build must be drained instead of the
 // stale active one being topped up — otherwise the new build stays
 // stuck in `building` indefinitely.

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -65,15 +65,15 @@ type embeddingGenerationRow struct {
 // used by the activation gate (which only needs MissingCount). It leaves
 // EmbeddedCount/BlankCount at zero — use fillFullCoverage for the display
 // table where the embedded/blank split is wanted. A failure is surfaced to
-// the caller.
-func fillCoverage(ctx context.Context, row *embeddingGenerationRow) error {
+// the caller. The scope is passed in explicitly so daemon handlers can use
+// a per-request resolved copy instead of the shared global config.
+func fillCoverage(ctx context.Context, scope vector.BuildScope, row *embeddingGenerationRow) error {
 	s, err := store.Open(cfg.DatabaseDSN())
 	if err != nil {
 		return fmt.Errorf("open main db for coverage: %w", err)
 	}
 	defer func() { _ = s.Close() }()
-	scope := cfg.Vector.Embed.Scope.BuildScope()
-	live, _, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes)
+	live, _, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes, scope.SourceIDs)
 	if err != nil {
 		return err
 	}
@@ -90,14 +90,13 @@ func fillCoverage(ctx context.Context, row *embeddingGenerationRow) error {
 // DONE but with no vector (the empty/unembeddable case). The invariant
 // live == embedded + blank + missing holds. The backend handle is passed
 // in by the caller (which already opened it for the generation listing).
-func fillFullCoverage(ctx context.Context, backend vector.Backend, row *embeddingGenerationRow) error {
+func fillFullCoverage(ctx context.Context, backend vector.Backend, scope vector.BuildScope, row *embeddingGenerationRow) error {
 	s, err := store.Open(cfg.DatabaseDSN())
 	if err != nil {
 		return fmt.Errorf("open main db for coverage: %w", err)
 	}
 	defer func() { _ = s.Close() }()
-	scope := cfg.Vector.Embed.Scope.BuildScope()
-	live, stamped, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes)
+	live, stamped, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes, scope.SourceIDs)
 	if err != nil {
 		return err
 	}
@@ -140,6 +139,9 @@ func runEmbeddingsList(cmd *cobra.Command, _ []string) error {
 	if err := ensureMainSchema(); err != nil {
 		return err
 	}
+	if err := ensureEmbedScopeResolved(); err != nil {
+		return err
+	}
 	db, rebind, closeDB, err := openEmbeddingsMetadataDB(cmd.Context())
 	if err != nil {
 		return err
@@ -177,7 +179,7 @@ func runEmbeddingsList(cmd *cobra.Command, _ []string) error {
 			if rows[i].State == vector.GenerationRetired {
 				continue
 			}
-			if err := fillFullCoverage(cmd.Context(), backend, &rows[i]); err != nil {
+			if err := fillFullCoverage(cmd.Context(), backend, cfg.Vector.Embed.Scope.BuildScope(), &rows[i]); err != nil {
 				return err
 			}
 		}
@@ -318,6 +320,9 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 	if err := ensureMainSchema(); err != nil {
 		return err
 	}
+	if err := ensureEmbedScopeResolved(); err != nil {
+		return err
+	}
 
 	db, rebind, closeDB, err := openEmbeddingsMetadataDB(cmd.Context())
 	if err != nil {
@@ -354,7 +359,7 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 			}
 			contextualSequence = &state.LatestJournalSequence
 		} else {
-			if err := fillCoverage(cmd.Context(), &row); err != nil {
+			if err := fillCoverage(cmd.Context(), cfg.Vector.Embed.Scope.BuildScope(), &row); err != nil {
 				return err
 			}
 			if row.MissingCount > 0 {
@@ -516,6 +521,13 @@ func planCLIEmbeddingsActivate(
 	if err := ensureMainSchema(); err != nil {
 		return api.CLIEmbeddingsPlanResponse{}, err
 	}
+	// This runs on daemon HTTP handler goroutines, so the account scope is
+	// resolved into a per-request config copy — mutating the shared global
+	// cfg here would race with concurrent plan requests.
+	vecCfg, err := openResolvedVectorConfig()
+	if err != nil {
+		return api.CLIEmbeddingsPlanResponse{}, err
+	}
 	db, rebind, closeDB, err := openEmbeddingsMetadataDB(ctx)
 	if err != nil {
 		return api.CLIEmbeddingsPlanResponse{}, err
@@ -529,7 +541,7 @@ func planCLIEmbeddingsActivate(
 	if row.State != vector.GenerationBuilding {
 		return api.CLIEmbeddingsPlanResponse{}, fmt.Errorf("generation %d is %q, not %q", gen, row.State, vector.GenerationBuilding)
 	}
-	expected := cfg.Vector.GenerationFingerprint()
+	expected := vecCfg.GenerationFingerprint()
 	if row.Fingerprint != expected && !force {
 		return api.CLIEmbeddingsPlanResponse{}, fmt.Errorf("generation %d fingerprint=%q does not match config=%q; pass --force to activate anyway",
 			gen, row.Fingerprint, expected)
@@ -540,7 +552,7 @@ func planCLIEmbeddingsActivate(
 				return api.CLIEmbeddingsPlanResponse{}, err
 			}
 		} else {
-			if err := fillCoverage(ctx, &row); err != nil {
+			if err := fillCoverage(ctx, vecCfg.Embed.Scope.BuildScope(), &row); err != nil {
 				return api.CLIEmbeddingsPlanResponse{}, err
 			}
 			if row.MissingCount > 0 {

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -350,7 +350,7 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 	var contextualSequence *int64
 	if !embeddingsActivateForce {
 		if cfg.Vector.Embeddings.EffectiveAPIFormat() == vector.APIFormatVoyageContextual {
-			state, err := configuredConvergenceState(cmd.Context(), gen)
+			state, err := configuredConvergenceState(cmd.Context(), cfg.Vector, gen)
 			if err != nil {
 				return err
 			}
@@ -548,7 +548,7 @@ func planCLIEmbeddingsActivate(
 	}
 	if !force {
 		if cfg.Vector.Embeddings.EffectiveAPIFormat() == vector.APIFormatVoyageContextual {
-			if err := requireConfiguredConvergence(ctx, gen); err != nil {
+			if err := requireConfiguredConvergence(ctx, vecCfg, gen); err != nil {
 				return api.CLIEmbeddingsPlanResponse{}, err
 			}
 		} else {
@@ -577,8 +577,14 @@ func planCLIEmbeddingsActivate(
 	}, nil
 }
 
-func requireConfiguredConvergence(ctx context.Context, gen vector.GenerationID) error {
-	state, err := configuredConvergenceState(ctx, gen)
+// requireConfiguredConvergence and configuredConvergenceState take the
+// vector config explicitly so daemon HTTP handlers can pass their
+// per-request resolved copy (with [vector.embed.scope] accounts folded into
+// SourceIDs): the checker's missing count is scope-aware, and building it
+// from the unresolved global would count out-of-scope messages as missing
+// and refuse to activate a completed account-scoped generation.
+func requireConfiguredConvergence(ctx context.Context, vecCfg vector.Config, gen vector.GenerationID) error {
+	state, err := configuredConvergenceState(ctx, vecCfg, gen)
 	if err != nil {
 		return err
 	}
@@ -588,7 +594,7 @@ func requireConfiguredConvergence(ctx context.Context, gen vector.GenerationID) 
 	return nil
 }
 
-func configuredConvergenceState(ctx context.Context, gen vector.GenerationID) (scheduler.ConvergenceResult, error) {
+func configuredConvergenceState(ctx context.Context, vecCfg vector.Config, gen vector.GenerationID) (scheduler.ConvergenceResult, error) {
 	mainStore, err := store.Open(cfg.DatabaseDSN())
 	if err != nil {
 		return scheduler.ConvergenceResult{}, fmt.Errorf("open main db for convergence: %w", err)
@@ -599,7 +605,7 @@ func configuredConvergenceState(ctx context.Context, gen vector.GenerationID) (s
 		return scheduler.ConvergenceResult{}, err
 	}
 	defer closeBackend()
-	checker, err := newConvergenceChecker(cfg.Vector, mainStore, backend)
+	checker, err := newConvergenceChecker(vecCfg, mainStore, backend)
 	if err != nil {
 		return scheduler.ConvergenceResult{}, err
 	}

--- a/cmd/msgvault/cmd/serve_vector.go
+++ b/cmd/msgvault/cmd/serve_vector.go
@@ -47,7 +47,7 @@ type legacyConvergenceChecker struct {
 }
 
 func (c *legacyConvergenceChecker) CheckConvergence(ctx context.Context, gen vector.GenerationID) (scheduler.ConvergenceResult, error) {
-	missing, err := c.store.MissingCountScoped(ctx, int64(gen), c.scope.MessageTypes)
+	missing, err := c.store.MissingCountScoped(ctx, int64(gen), c.scope.MessageTypes, c.scope.SourceIDs)
 	if err != nil {
 		return scheduler.ConvergenceResult{}, fmt.Errorf("message coverage: %w", err)
 	}
@@ -243,6 +243,18 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 	if err := cfg.Vector.Validate(); err != nil {
 		return nil, fmt.Errorf("vector config: %w", err)
 	}
+	// Resolve [vector.embed.scope] accounts to source IDs before any
+	// consumer derives a build scope or generation fingerprint from the
+	// config (backend coverage gates, the embed worker/job, the hybrid
+	// engine's expected fingerprint). Unknown accounts fail vector init
+	// loudly rather than silently embedding the full corpus. The resolved
+	// config is a local copy: this runs on the daemon's background init
+	// goroutine while HTTP handlers may already be reading the global cfg,
+	// so the global must stay unmutated.
+	vecCfg, err := resolvedVectorConfig(mainStore)
+	if err != nil {
+		return nil, fmt.Errorf("vector embed scope: %w", err)
+	}
 	mainDB := mainStore.DB()
 
 	// Resolve the dialect once from the main DSN. The worker is
@@ -270,8 +282,8 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 		// live alongside messages, so there is no separate vectors.db.
 		pgb, err := pgvector.Open(ctx, pgvector.Options{
 			DB:          mainDB,
-			Dimension:   cfg.Vector.Embeddings.Dimension,
-			BuildScope:  cfg.Vector.Embed.Scope.BuildScope(),
+			Dimension:   vecCfg.Embeddings.Dimension,
+			BuildScope:  vecCfg.Embed.Scope.BuildScope(),
 			SkipMigrate: readOnly,
 			// ReadOnly MUST track readOnly here: this is the MCP read-only
 			// path (store.OpenReadOnly). When set, Open performs no writes —
@@ -282,7 +294,7 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 			// pre-installed by an admin and CREATE EXTENSION would fail
 			// for the msgvault role; SkipExtensionCreate lets schema +
 			// index DDL still run. Ignored when SkipMigrate (readOnly).
-			SkipExtension: cfg.Vector.SkipExtensionCreate,
+			SkipExtension: vecCfg.SkipExtensionCreate,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("open pgvector backend: %w", err)
@@ -294,16 +306,16 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 		if err := sqlitevec.RegisterExtension(); err != nil {
 			return nil, fmt.Errorf("register sqlite-vec: %w", err)
 		}
-		vecPath := cfg.Vector.DBPath
+		vecPath := vecCfg.DBPath
 		if vecPath == "" {
 			vecPath = filepath.Join(cfg.Data.DataDir, "vectors.db")
 		}
 		sb, err := sqlitevec.Open(ctx, sqlitevec.Options{
 			Path:       vecPath,
 			MainPath:   mainPath,
-			Dimension:  cfg.Vector.Embeddings.Dimension,
+			Dimension:  vecCfg.Embeddings.Dimension,
 			MainDB:     mainDB,
-			BuildScope: cfg.Vector.Embed.Scope.BuildScope(),
+			BuildScope: vecCfg.Embed.Scope.BuildScope(),
 			// Honor the read-only signal on SQLite too: when mainDB is a
 			// query-only handle (MCP), skip the embed_gen upgrade backfill,
 			// which would write through it. Migrate still runs (vectors.db
@@ -318,7 +330,7 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 		closeFn = sb.Close
 	}
 
-	runtime, err := newEmbeddingRuntime(cfg.Vector, embeddingRuntimeDeps{
+	runtime, err := newEmbeddingRuntime(vecCfg, embeddingRuntimeDeps{
 		Backend: backend, VectorsDB: vectorsDB, MainDB: mainDB, Store: mainStore,
 		Rebind: dialect.Rebind, LastModifiedExpr: lastModifiedExpr, Log: logger,
 	})
@@ -328,16 +340,16 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 	}
 
 	engine := hybrid.NewEngine(backend, mainDB, runtime.QueryClient, hybrid.Config{
-		ExpectedFingerprint: cfg.Vector.GenerationFingerprint(),
-		RRFK:                cfg.Vector.Search.RRFK,
-		KPerSignal:          cfg.Vector.Search.KPerSignal,
-		SubjectBoost:        cfg.Vector.Search.SubjectBoost,
+		ExpectedFingerprint: vecCfg.GenerationFingerprint(),
+		RRFK:                vecCfg.Search.RRFK,
+		KPerSignal:          vecCfg.Search.KPerSignal,
+		SubjectBoost:        vecCfg.Search.SubjectBoost,
 		// BuildFilter's participant/label lookups run against mainDB with ?
 		// placeholders. On PG those must become $N or pgx rejects them, so
 		// the serve/MCP hybrid engine (shared via vectorFeatures.HybridEngine)
 		// carries the dialect's Rebind. SQLite's Rebind is identity.
 		Rebind:     dialect.Rebind,
-		BuildScope: cfg.Vector.Embed.Scope.BuildScope(),
+		BuildScope: vecCfg.Embed.Scope.BuildScope(),
 	})
 
 	// No sync-time enqueue: newly-persisted messages get embed_gen = NULL
@@ -348,7 +360,7 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 		HybridEngine: engine,
 		Runner:       runtime.Runner,
 		Convergence:  runtime.Convergence,
-		Cfg:          cfg.Vector,
+		Cfg:          vecCfg,
 		Close:        closeFn,
 	}, nil
 }

--- a/cmd/msgvault/cmd/serve_vector_init.go
+++ b/cmd/msgvault/cmd/serve_vector_init.go
@@ -218,8 +218,11 @@ func registerEmbedJob(sched embedJobRegistrar, vf *vectorFeatures, s *store.Stor
 	// Scope drift also has to reach searchers, not just the log: the
 	// installed components still match the active generation's
 	// fingerprint, so without this latch the API keeps reporting
-	// "ready" while serving the wrongly-scoped index.
-	embedJob.OnScopeDrift = apiServer.SetVectorScopeDrift
+	// "ready" while serving the wrongly-scoped index. Tests may register
+	// without an API server.
+	if apiServer != nil {
+		embedJob.OnScopeDrift = apiServer.SetVectorScopeDrift
+	}
 	schedule := cfg.Vector.Embed.Schedule.Cron
 	if err := sched.SetEmbedJob(embedJob, schedule, cfg.Vector.Embed.Schedule.RunAfterSync); err != nil {
 		return fmt.Errorf("register embed job: %w", err)

--- a/cmd/msgvault/cmd/serve_vector_init.go
+++ b/cmd/msgvault/cmd/serve_vector_init.go
@@ -136,8 +136,14 @@ func startVectorInit(
 		h.vf = vf
 		h.mu.Unlock()
 		apiServer.SetVectorFeatures(vf.HybridEngine, vf.Backend, vf.Cfg)
+		// Preflight drift detection: vector-search requests re-resolve the
+		// durable account scope (throttled) so drift latches index_stale
+		// even on daemons whose embed job never runs (empty cron,
+		// run_after_sync=false). The embed job's own per-run check remains
+		// the detection path for scheduled embeds.
+		apiServer.SetVectorScopeCheck(embedScopeDriftCheck(s, vf.Cfg.Embed.Scope.BuildScope()))
 		checkVectorIndexFreshness(ctx, apiServer, vf)
-		if err := registerEmbedJob(sched, vf, s); err != nil {
+		if err := registerEmbedJob(sched, vf, s, apiServer); err != nil {
 			// Cron was validated in precheckVectorFeatures, so this is an
 			// invariant violation, not user error; vector search still works.
 			logger.Error("register embed job failed", "error", err)
@@ -154,17 +160,47 @@ func startVectorInit(
 // index_stale. Only ErrIndexStale flips the status: a still-building or
 // not-yet-configured index (ErrIndexBuilding/ErrNotEnabled) and transient
 // backend errors leave the freshly-installed "ready" status untouched, since
-// those are not the "index does not match the configured model" failure this
+// those are not the "index does not match the configured embedding settings" failure this
 // status exists to expose.
 func checkVectorIndexFreshness(ctx context.Context, apiServer *api.Server, vf *vectorFeatures) {
 	_, err := resolveActiveGeneration(ctx, vf.Backend, vf.Cfg.GenerationFingerprint())
 	if !errors.Is(err, vector.ErrIndexStale) {
 		return
 	}
-	detail := err.Error() + "; run `msgvault embeddings build --full-rebuild` to rebuild"
-	logger.Warn("vector index does not match the configured model; vector search unavailable until rebuilt",
+	detail := err.Error() + "; if this is a one-off account-scoped generation, set matching [vector.embed.scope] accounts and restart the daemon; otherwise run `msgvault embeddings build --full-rebuild` to rebuild"
+	logger.Warn("vector index does not match configured embedding settings; vector search unavailable",
 		"detail", detail)
 	apiServer.SetVectorStale(detail)
+}
+
+// embedScopeDriftDetail is the operator-facing explanation for a latched
+// scope-drift stale: what changed and how to recover.
+func embedScopeDriftDetail(resolved, initialized vector.BuildScope) string {
+	return fmt.Sprintf(
+		"the configured embedding scope now resolves to %q but vector search was initialized with %q; restart the daemon to reinitialize, then run `msgvault embeddings build --full-rebuild` if the new scope is intended",
+		resolved.Fingerprint(), initialized.Fingerprint())
+}
+
+// embedScopeDriftCheck is the daemon's preflight scope-drift check: it
+// re-resolves the durable account configuration against the open store and
+// reports a stale-latching detail when the scope has drifted OR become
+// deterministically unresolvable (a configured account removed or
+// ambiguous). Transient resolution failures (a busy database) pass through
+// as errors so the preflight logs and retries them instead of latching.
+func embedScopeDriftCheck(s *store.Store, initialized vector.BuildScope) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) {
+		resolved, err := configuredEmbedBuildScope(s)
+		if errors.Is(err, vector.ErrScopeUnresolvable) {
+			return err.Error() + "; fix [vector.embed.scope] accounts and restart the daemon", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		if resolved.Fingerprint() == initialized.Fingerprint() {
+			return "", nil
+		}
+		return embedScopeDriftDetail(resolved, initialized), nil
+	}
 }
 
 // registerEmbedJob wires the embed worker into the scheduler (cron-driven
@@ -174,8 +210,16 @@ type embedJobRegistrar interface {
 	SetEmbedJob(job *scheduler.EmbedJob, schedule string, runAfterSync bool) error
 }
 
-func registerEmbedJob(sched embedJobRegistrar, vf *vectorFeatures, s *store.Store) error {
+func registerEmbedJob(sched embedJobRegistrar, vf *vectorFeatures, s *store.Store, apiServer *api.Server) error {
 	embedJob := newSchedulerEmbedJob(vf, s)
+	embedJob.ResolveBuildScope = func() (vector.BuildScope, error) {
+		return configuredEmbedBuildScope(s)
+	}
+	// Scope drift also has to reach searchers, not just the log: the
+	// installed components still match the active generation's
+	// fingerprint, so without this latch the API keeps reporting
+	// "ready" while serving the wrongly-scoped index.
+	embedJob.OnScopeDrift = apiServer.SetVectorScopeDrift
 	schedule := cfg.Vector.Embed.Schedule.Cron
 	if err := sched.SetEmbedJob(embedJob, schedule, cfg.Vector.Embed.Schedule.RunAfterSync); err != nil {
 		return fmt.Errorf("register embed job: %w", err)

--- a/cmd/msgvault/cmd/serve_vector_init_test.go
+++ b/cmd/msgvault/cmd/serve_vector_init_test.go
@@ -357,7 +357,7 @@ func runRegisteredContextJob(
 		Backend: backend, Runner: runner,
 		Convergence: registeredConvergenceChecker{state: state}, Cfg: vectorCfg,
 	}
-	require.NoError(t, registerEmbedJob(capture, vf, nil))
+	require.NoError(t, registerEmbedJob(capture, vf, nil, nil))
 	require.NotNil(t, capture.job)
 	capture.job.Run(t.Context())
 	return backend, runner

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,19 @@ All notable changes to msgvault, grouped by release.
 
 ## Unreleased
 
+**Features**
+
+- Scope embedding builds to selected accounts: `[vector.embed.scope] accounts`
+  keeps the daemon's scheduled embeds within the listed accounts, and
+  `msgvault embeddings build --account/--collection` overrides the account
+  scope for a single run. The account scope is part of the generation
+  fingerprint, so changing it requires a full rebuild; account-scoped indexes
+  do not gate search — out-of-scope accounts simply rank on BM25 alone.
+  Activation refuses a source scope that matches no live messages (an added
+  but never-synced account) rather than replacing the serving index with an
+  empty one, and the daemon marks vector search stale when the configured
+  accounts resolve to a different source set than it was started with.
+
 ---
 
 ## 0.19.3

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1481,8 +1481,15 @@ msgvault embeddings build [flags]
 |---|---|
 | `--full-rebuild` | Create a new index generation and rebuild from scratch. The new generation is activated atomically once coverage reaches zero. Same-model rebuilds keep serving the previous active generation in the meantime, but active-generation top-ups are frozen until activation; model or dimension changes return `index_stale` for vector/hybrid search until the new generation activates. |
 | `--yes` | Skip the confirmation prompt that `--full-rebuild` otherwise requires. |
+| `--account <identifier>` | Limit embedding to this account, by identifier or display name — numeric source IDs are rejected (repeatable). Overrides `[vector.embed.scope] accounts` for this run; configured `message_types` still apply. After activating this one-off scope, add the equivalent accounts to config and restart the daemon before searching. |
+| `--collection <name>` | Limit embedding to this collection's accounts (repeatable). Can be combined with `--account`; the scope is the union. This is a one-run override; persist the resolved accounts in config before restarting the daemon. |
 
-Without `--full-rebuild`, the command is incremental: it resumes any in-flight rebuild that matches the configured model, otherwise scans for live messages still missing coverage in the active generation, then exits. Safe to schedule via cron (or let `msgvault serve` do it via `[vector.embed.schedule]`).
+Without `--full-rebuild`, the command is incremental: it resumes any in-flight rebuild that matches the configured embedding settings, otherwise scans for live messages still missing coverage in the active generation, then exits. Safe to schedule via cron (or let `msgvault serve` do it via `[vector.embed.schedule]`).
+
+The account scope is part of the generation fingerprint, so building with a
+different `--account`/`--collection` set than the active generation requires
+`--full-rebuild`, exactly like changing the model. See
+[Scoped Generations](/usage/vector-search/#scoped-generations).
 
 ### embeddings resume
 
@@ -1490,7 +1497,7 @@ Without `--full-rebuild`, the command is incremental: it resumes any in-flight r
 msgvault embeddings resume
 ```
 
-Continue embedding work and finish the current generation. If a generation matching the configured model is building, this embeds its remaining rows and activates it once coverage reaches zero; otherwise it tops up the active generation. Equivalent to `msgvault embeddings build` with no flags, but never starts a full rebuild.
+Continue embedding work and finish the current generation. If a generation matching the configured embedding settings is building, this embeds its remaining rows and activates it once coverage reaches zero; otherwise it tops up the active generation. Equivalent to `msgvault embeddings build` with no flags, but never starts a full rebuild. Accepts the same `--account`/`--collection` scope flags as `embeddings build`.
 
 ### embeddings list
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,9 @@ collapse_whitespace = true
 [vector.embed.scope]
 # Empty means embed the full archive. Set this for partial generations.
 message_types = ["sms", "mms"]
+# Use stable account identifiers, not numeric source IDs. This keeps a scoped
+# generation usable after a daemon restart.
+# accounts = ["you@work.example"]
 
 [[synctech_sms.sources]]
 name = "phone-backups"
@@ -615,7 +618,7 @@ External OpenAI-compatible embedding endpoint used to convert message text into 
 | `max_input_chars` | `32768` | Character cap per embedding chunk. Set below your model's context window (e.g., `2000` for Ollama's default `nomic-embed-text`). |
 | `eta_window` | `10` | Number of recent progress samples used for ETA smoothing. |
 
-The index generation fingerprint includes the model, dimension, preprocessing settings, `max_input_chars`, and embedding policy. Changing those settings triggers a stale-index error on the next vector/hybrid query until you run `msgvault embeddings build --full-rebuild`.
+The index generation fingerprint includes the model, dimension, preprocessing settings, `max_input_chars`, embedding policy, and scope. Changing those settings triggers a stale-index error on the next vector/hybrid query. For an existing account-scoped generation built with CLI flags, set matching `[vector.embed.scope].accounts` and restart the daemon; otherwise run `msgvault embeddings build --full-rebuild`.
 
 #### `[vector.preprocess]`
 
@@ -657,6 +660,20 @@ a scoped index must include a compatible `message_type` filter, such as
 `msgvault search "release planning" --mode hybrid --message-type teams`; an
 unscoped vector/hybrid query returns `index_scope_mismatch` instead of using the
 partial index as if it covered the full archive.
+
+| Key | Default | Description |
+|---|---|---|
+| `message_types` | `[]` (all types) | Embed only messages of these types. |
+| `accounts` | `[]` (all accounts) | Embed only these accounts' messages, by canonical account identifier (display names are rejected here — they are not stable identities for a privacy boundary). Resolved to source IDs at startup; an unknown identifier fails vector initialization (or the CLI command). The daemon's scheduled embeds honor this scope, so it also acts as a privacy boundary: unlisted accounts' text is never sent to the embedding endpoint. |
+
+`accounts` and `message_types` compose (both filters apply). The CLI flags
+`--account`/`--collection` on `msgvault embeddings build`/`resume` override
+`accounts` for a single run. Either scope dimension is part of the generation
+fingerprint: changing it requires `msgvault embeddings build --full-rebuild`,
+and because the fingerprint records archive-local source IDs, re-adding an
+account under a new source ID also requires a rebuild. Account-scoped indexes
+do not gate search the way message-type scopes do: out-of-scope accounts
+simply have no vector matches and rank on BM25 alone in hybrid mode.
 
 #### `[vector.embed.schedule]`
 

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -340,6 +340,55 @@ or preprocessing policy. Scoped generations are useful when you want semantic
 search for a newer corpus such as Teams or SMS without embedding decades of
 email immediately.
 
+Generations can also be scoped to selected accounts, either durably in config
+(so the daemon's scheduled embeds obey it too):
+
+```toml
+[vector.embed.scope]
+accounts = ["you@gmail.com"]
+```
+
+or per run from the CLI (overriding the configured accounts for that run):
+
+```bash
+msgvault embeddings build --full-rebuild --account you@gmail.com
+msgvault embeddings build --account you@gmail.com --account you@work.com
+msgvault embeddings build --collection family   # every account in the collection
+```
+
+!!! warning
+    `--account` and `--collection` are one-run overrides. After they activate
+    a scoped generation, add the equivalent stable account identifiers under
+    `[vector.embed.scope].accounts` and restart the daemon before searching.
+    Otherwise the daemon expects a different generation fingerprint and
+    returns `index_stale`. Prefer the config form when the scoped index is
+    meant to persist.
+
+The `--account` flag accepts an identifier or display name like elsewhere,
+but the durable `[vector.embed.scope] accounts` list requires canonical
+account identifiers — display names are rejected because they are not
+stable identities for a privacy boundary. Unknown identifiers fail the run
+instead of silently embedding more than requested. Account scoping acts as a privacy boundary —
+message text from accounts *outside* the scope is never sent to the embedding
+endpoint — and is the cheapest way to pilot semantic search on one mailbox
+before paying to embed the whole archive.
+
+Account-scope caveats:
+
+- The fingerprint records the scope as source IDs, which are archive-local.
+  Removing and re-adding an account (or restoring a backup) can renumber its
+  source ID, producing a new fingerprint and requiring a full rebuild.
+- A scoped account resolves to *all* of its sources, including linked ones
+  such as a Google Calendar synced for the same account. Adding such a
+  source after a scoped generation activates changes the resolved source
+  set and therefore the fingerprint, so vector search reports `index_stale`
+  until a full rebuild.
+- Unlike a message-type scope, an account scope does NOT gate search:
+  unfiltered vector/hybrid queries keep working, and accounts outside the
+  scope simply have no vector matches (hybrid search ranks them on the BM25
+  signal alone). The web UI's semantic-coverage readout counts only in-scope
+  accounts as eligible.
+
 A scoped index is intentionally partial, so vector and hybrid search require an
 explicit compatible message-type filter:
 
@@ -445,7 +494,7 @@ body keywords.
 | Error | Meaning | Recovery |
 |---|---|---|
 | `vector_not_enabled` | The server or MCP process did not wire a vector backend, usually because `[vector] enabled = false`. | Set `enabled = true`, configure `[vector.embeddings]`, and start with a build that includes the needed backend (`sqlite_vec` or `pgvector`). |
-| `index_stale` | Active generation's fingerprint does not match the current model, dimension, preprocessing policy, `max_input_chars`, or embedding output policy. | Run `msgvault embeddings build --full-rebuild --yes`. |
+| `index_stale` | Active generation's fingerprint does not match the current embedding settings: model, dimension, preprocessing policy, `max_input_chars`, output policy, or scope. | For an existing account-scoped index built with CLI flags, set matching `[vector.embed.scope].accounts` and restart the daemon. Otherwise run `msgvault embeddings build --full-rebuild --yes`. |
 | `index_building` | No active generation yet; one is being built. | Finish running `msgvault embeddings build`, wait for the scheduler, or use the appropriate non-vector fallback. |
 | `missing_free_text` | `mode=vector` or `mode=hybrid` used with a filter-only query (no free text to embed). | Add free-text terms to `q`, or use the appropriate non-vector fallback. |
 | `index_scope_mismatch` | The active vector generation was built for selected message types and the query is unscoped or asks for a type outside that scope. | Add a compatible `message_type` filter, use the appropriate non-vector fallback, or rebuild an unscoped generation. |

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module go.kenn.io/msgvault
 
 go 1.26.5
 
+// Pinned past 1.26.5 for the stdlib fixes govulncheck enforces in CI
+// (GO-2026-6218 net/url, GO-2026-6091 html/template, and siblings). The
+// `go` directive stays at 1.26.5 so the Nix build, whose nixpkgs Go is
+// 1.26.5, keeps building; setup-go prefers this toolchain directive.
+toolchain go1.26.6
+
 require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -1417,6 +1417,12 @@ func requireCompleteCandidatePool(w http.ResponseWriter, spec query.SearchSpec) 
 }
 
 func (s *Server) resolveExploreVectorSearch(ctx context.Context, w http.ResponseWriter, request ExploreHTTPRequest) (query.SearchSpec, string, bool) {
+	// Gate BEFORE the snapshot branch: a cached candidate snapshot would
+	// otherwise keep serving a wrongly-scoped index after scope drift
+	// without touching any fingerprint check at all.
+	if !s.vectorSearchPreflight(ctx, w) {
+		return query.SearchSpec{}, "", false
+	}
 	requestHash := exploreSnapshotRequestHash(request)
 	state := s.exploreState
 	if state == nil {
@@ -1427,6 +1433,34 @@ func (s *Server) resolveExploreVectorSearch(ctx context.Context, w http.Response
 		snapshot, ok := state.snapshot(request.CandidateSnapshotID, requestHash)
 		if !ok {
 			writeError(w, http.StatusConflict, "candidate_snapshot_expired", "The semantic candidate snapshot is missing, expired, or belongs to another predicate")
+			return query.SearchSpec{}, "", false
+		}
+		// A snapshot pins the generation its candidates were drawn from, so
+		// reusing it must re-run the same active-generation check the
+		// issuing path runs: a one-off scoped rebuild (or any full rebuild)
+		// can activate a NEW generation without changing the configured
+		// scope, leaving the daemon "ready" while the snapshot's generation
+		// is retired — on pgvector its embeddings are already deleted.
+		// Fresh searches would get index_stale; a cached snapshot must not
+		// slip past that. A same-fingerprint swap invalidates the snapshot
+		// too (its candidates reference the retired generation), so the
+		// snapshot must belong to the CURRENT active generation.
+		_, backend, cfg := s.vectorComponents()
+		if backend == nil {
+			writeError(w, http.StatusServiceUnavailable, "vector_not_enabled", "Vector search is not configured")
+			return query.SearchSpec{}, "", false
+		}
+		expectedFingerprint := ""
+		if cfg.Enabled {
+			expectedFingerprint = cfg.GenerationFingerprint()
+		}
+		active, err := vector.ResolveActiveForFingerprint(ctx, backend, expectedFingerprint)
+		if err != nil {
+			s.writeExploreVectorError(w, err)
+			return query.SearchSpec{}, "", false
+		}
+		if int64(active.ID) != snapshot.Generation {
+			writeError(w, http.StatusConflict, "candidate_snapshot_expired", "The semantic candidate snapshot belongs to a retired vector generation; re-run the search")
 			return query.SearchSpec{}, "", false
 		}
 		generation := snapshot.Generation
@@ -1757,7 +1791,7 @@ func (s *Server) writeExploreVectorError(w http.ResponseWriter, err error) {
 	case errors.Is(err, vector.ErrNotEnabled):
 		writeError(w, http.StatusServiceUnavailable, "vector_not_enabled", "Vector search is not configured")
 	case errors.Is(err, vector.ErrIndexStale):
-		writeError(w, http.StatusServiceUnavailable, "index_stale", "The vector index does not match the configured model")
+		writeError(w, http.StatusServiceUnavailable, "index_stale", "The vector index does not match configured embedding settings")
 	case errors.Is(err, vector.ErrIndexBuilding):
 		writeError(w, http.StatusServiceUnavailable, "index_building", "The vector index is still being built")
 	case errors.Is(err, vector.ErrEmbeddingTimeout):

--- a/internal/api/explore_e2e_test.go
+++ b/internal/api/explore_e2e_test.go
@@ -347,6 +347,67 @@ func TestExploreSemanticPaginationFollowsSnapshotRankNotArchiveDate(t *testing.T
 	assertions.Equal(int64(2), *secondPage.Rows[0].AnchorMessageID)
 }
 
+// TestExploreSnapshotReuseRevalidatesActiveGeneration guards the cached
+// snapshot path against generation swaps: a one-off scoped rebuild (or any
+// full rebuild) can activate a new generation without changing the daemon's
+// configured scope, so the status stays ready and only the snapshot pins
+// the retired generation. Reuse must re-run the issuing path's
+// active-generation check instead of serving retired candidates.
+func TestExploreSnapshotReuseRevalidatesActiveGeneration(t *testing.T) {
+	vecCfg := vector.Config{
+		Enabled:    true,
+		Embeddings: vector.EmbeddingsConfig{Model: "test", Dimension: 2},
+	}
+	fingerprint := vecCfg.GenerationFingerprint()
+	newSnapshotServer := func(t *testing.T) (*Server, *fakeVectorBackend, string) {
+		t.Helper()
+		engine := newExploreDuckDBFixture(t)
+		backend := &fakeVectorBackend{
+			active:     &vector.Generation{ID: 7, Model: "test", Dimension: 2, Fingerprint: fingerprint, State: vector.GenerationActive},
+			searchHits: []vector.Hit{{MessageID: 1, Score: .9, Rank: 1}, {MessageID: 2, Score: .8, Rank: 2}},
+		}
+		hybridEngine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 2}, hybrid.Config{ExpectedFingerprint: fingerprint})
+		store := &mockStore{messages: []APIMessage{{ID: 1}, {ID: 2}}, total: 2, stats: &StoreStats{}}
+		srv := NewServerWithOptions(ServerOptions{
+			Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}}, Store: store, Engine: engine,
+			HybridEngine: hybridEngine, Backend: backend, VectorCfg: vecCfg, Logger: testLogger(),
+		})
+		first := postExploreJSON(t, srv, "/api/v1/explore", `{"query":"alpha","search_mode":"semantic","limit":1}`)
+		require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+		var firstPage ExploreHTTPResponse
+		require.NoError(t, json.Unmarshal(first.Body.Bytes(), &firstPage))
+		require.NotEmpty(t, firstPage.NextCursor)
+		return srv, backend, firstPage.NextCursor
+	}
+
+	t.Run("same-fingerprint generation swap expires the snapshot", func(t *testing.T) {
+		srv, backend, cursor := newSnapshotServer(t)
+		backend.active = &vector.Generation{ID: 8, Model: "test", Dimension: 2, Fingerprint: fingerprint, State: vector.GenerationActive}
+
+		second := postExploreJSON(t, srv, "/api/v1/explore", fmt.Sprintf(
+			`{"query":"alpha","search_mode":"semantic","limit":1,"cursor":%q}`, cursor))
+		assert.Equal(t, http.StatusConflict, second.Code, second.Body.String())
+		assert.Contains(t, second.Body.String(), "candidate_snapshot_expired")
+	})
+
+	t.Run("fingerprint change returns index_stale", func(t *testing.T) {
+		srv, backend, cursor := newSnapshotServer(t)
+		backend.active = &vector.Generation{ID: 8, Model: "test", Dimension: 2, Fingerprint: fingerprint + ":ssrc-3", State: vector.GenerationActive}
+
+		second := postExploreJSON(t, srv, "/api/v1/explore", fmt.Sprintf(
+			`{"query":"alpha","search_mode":"semantic","limit":1,"cursor":%q}`, cursor))
+		assert.Equal(t, http.StatusServiceUnavailable, second.Code, second.Body.String())
+		assert.Contains(t, second.Body.String(), "index_stale")
+	})
+
+	t.Run("unchanged generation keeps serving the snapshot", func(t *testing.T) {
+		srv, _, cursor := newSnapshotServer(t)
+		second := postExploreJSON(t, srv, "/api/v1/explore", fmt.Sprintf(
+			`{"query":"alpha","search_mode":"semantic","limit":1,"cursor":%q}`, cursor))
+		assert.Equal(t, http.StatusOK, second.Code, second.Body.String())
+	})
+}
+
 func TestExploreSemanticPreflightRequiresAndReusesCandidateSnapshot(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -549,7 +549,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 
 	resp := statsResponseFromStore(stats)
 	resp.VectorSearch = vs
-	s.refreshVectorStatusIfStale(r.Context())
+	s.refreshVectorStatus(r.Context())
 	if status, _ := s.VectorStatus(); status != VectorStatusDisabled {
 		resp.VectorStatus = string(status)
 	}
@@ -877,6 +877,9 @@ func (s *Server) handleHybridSearch(
 		return
 	}
 	ctx := r.Context()
+	if !s.vectorSearchPreflight(ctx, w) {
+		return
+	}
 	start := time.Now()
 
 	freeText := strings.Join(parsed.TextTerms, " ")
@@ -924,7 +927,7 @@ func (s *Server) handleHybridSearch(
 				"vector search is not configured")
 		case errors.Is(err, vector.ErrIndexStale):
 			writeError(w, http.StatusServiceUnavailable, "index_stale",
-				"the vector index does not match the configured model; run `msgvault embeddings build --full-rebuild`")
+				"the vector index does not match configured embedding settings; align [vector.embed.scope] accounts for an existing account-scoped index, or run `msgvault embeddings build --full-rebuild`")
 		case errors.Is(err, vector.ErrIndexBuilding):
 			writeError(w, http.StatusServiceUnavailable, "index_building",
 				"the initial vector index is still being built")
@@ -1074,6 +1077,9 @@ func (s *Server) handleSimilarSearch(w http.ResponseWriter, r *http.Request) {
 	_, backend, vectorCfg := s.vectorComponents()
 	if backend == nil {
 		s.writeVectorUnavailable(w)
+		return
+	}
+	if !s.vectorSearchPreflight(r.Context(), w) {
 		return
 	}
 	if s.store == nil {
@@ -1238,7 +1244,7 @@ func (s *Server) writeVectorSearchError(w http.ResponseWriter, err error, operat
 			"vector search is not configured")
 	case errors.Is(err, vector.ErrIndexStale):
 		writeError(w, http.StatusServiceUnavailable, "index_stale",
-			"the vector index does not match the configured model; run `msgvault embeddings build --full-rebuild`")
+			"the vector index does not match configured embedding settings; align [vector.embed.scope] accounts for an existing account-scoped index, or run `msgvault embeddings build --full-rebuild`")
 	case errors.Is(err, vector.ErrIndexBuilding):
 		writeError(w, http.StatusServiceUnavailable, "index_building",
 			"the initial vector index is still being built")

--- a/internal/api/search_coverage.go
+++ b/internal/api/search_coverage.go
@@ -178,7 +178,12 @@ func (s *Server) resolveSearchCoverageState(
 	backend vector.Backend,
 	cfg vector.Config,
 ) searchCoverageState {
-	s.refreshVectorStatusIfStale(ctx)
+	// Run the throttled revalidations before reading the status: the UI
+	// polls this endpoint, so on a daemon whose embed job never runs (empty
+	// cron, run_after_sync=false) coverage would otherwise keep reporting
+	// "ready" computed from obsolete startup source IDs until some vector
+	// search happened to trigger the preflight.
+	s.refreshVectorStatus(ctx)
 	status, detail := s.VectorStatus()
 	backendStatus := coverageStatusForVectorStatus(status)
 	state := searchCoverageState{status: backendStatus, detail: detail, resolvedStatus: backendStatus}
@@ -314,31 +319,58 @@ func sameCoverageGeneration(
 		got.MessageCount == want.MessageCount
 }
 
+// noSemanticEligibleMessageType is an impossible message type: forcing it
+// into a context guarantees an empty eligible population without touching
+// any other predicate.
+const noSemanticEligibleMessageType = "\x00no-semantic-eligible-message-type"
+
 func semanticCoverageContext(ctx query.Context, scope vector.BuildScope) query.Context {
 	// Vector generations cover only active archive messages.
 	if ctx.Deletion == query.DeletionDeleted {
-		ctx.MessageTypes = []string{"\x00no-semantic-eligible-message-type"}
+		ctx.MessageTypes = []string{noSemanticEligibleMessageType}
 		ctx.Deletion = query.DeletionActive
 		return ctx
 	}
 	ctx.Deletion = query.DeletionActive
-	if scope.IsEmpty() {
-		return ctx
-	}
-	if len(ctx.MessageTypes) == 0 {
-		ctx.MessageTypes = slices.Clone(scope.MessageTypes)
-		return ctx
-	}
-	eligible := make([]string, 0, len(ctx.MessageTypes))
-	for _, messageType := range ctx.MessageTypes {
-		if scope.ContainsMessageType(strings.ToLower(messageType)) {
-			eligible = append(eligible, messageType)
+	if len(scope.MessageTypes) > 0 {
+		if len(ctx.MessageTypes) == 0 {
+			ctx.MessageTypes = slices.Clone(scope.MessageTypes)
+		} else {
+			eligible := make([]string, 0, len(ctx.MessageTypes))
+			for _, messageType := range ctx.MessageTypes {
+				if scope.ContainsMessageType(strings.ToLower(messageType)) {
+					eligible = append(eligible, messageType)
+				}
+			}
+			if len(eligible) == 0 {
+				eligible = []string{noSemanticEligibleMessageType}
+			}
+			ctx.MessageTypes = eligible
 		}
 	}
-	if len(eligible) == 0 {
-		eligible = []string{"\x00no-semantic-eligible-message-type"}
+	if len(scope.SourceIDs) > 0 {
+		if len(ctx.SourceIDs) == 0 {
+			ctx.SourceIDs = slices.Clone(scope.SourceIDs)
+		} else {
+			eligible := make([]int64, 0, len(ctx.SourceIDs))
+			for _, id := range ctx.SourceIDs {
+				if scope.ContainsSource(id) {
+					eligible = append(eligible, id)
+				}
+			}
+			if len(eligible) == 0 {
+				// The source predicate cannot be rewritten to an empty
+				// sentinel: an identity filter pins Identity.SourceID to
+				// the selected source and the query validator rejects any
+				// divergence from ctx.SourceIDs. Force the empty
+				// intersection through the message-type sentinel instead
+				// and leave the sources untouched.
+				ctx.MessageTypes = []string{noSemanticEligibleMessageType}
+				return ctx
+			}
+			ctx.SourceIDs = eligible
+		}
 	}
-	ctx.MessageTypes = eligible
 	return ctx
 }
 

--- a/internal/api/search_coverage_test.go
+++ b/internal/api/search_coverage_test.go
@@ -15,6 +15,47 @@ import (
 	"go.kenn.io/msgvault/internal/vector"
 )
 
+func TestSemanticCoverageContextNarrowsSources(t *testing.T) {
+	scope := vector.NewBuildScope(nil, []int64{3, 7})
+
+	t.Run("unfiltered context adopts the scope sources", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{}, scope)
+		assert.Equal(t, []int64{3, 7}, got.SourceIDs)
+	})
+
+	t.Run("account filter intersects the scope", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{SourceIDs: []int64{3, 9}}, scope)
+		assert.Equal(t, []int64{3}, got.SourceIDs)
+	})
+
+	t.Run("disjoint account filter keeps zero eligibility", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{SourceIDs: []int64{9}}, scope)
+		assert.Equal(t, []int64{9}, got.SourceIDs,
+			"the source predicate must stay untouched so an identity pairing remains valid")
+		assert.Equal(t, []string{noSemanticEligibleMessageType}, got.MessageTypes,
+			"the sentinel keeps the eligible set empty instead of widening to all sources")
+	})
+
+	t.Run("unscoped generation leaves sources alone", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{SourceIDs: []int64{9}}, vector.BuildScope{})
+		assert.Equal(t, []int64{9}, got.SourceIDs)
+	})
+
+	t.Run("sources-only scope leaves message types alone", func(t *testing.T) {
+		got := semanticCoverageContext(query.Context{MessageTypes: []string{"email"}}, scope)
+		assert.Equal(t, []string{"email"}, got.MessageTypes)
+	})
+
+	t.Run("message types and sources narrow together", func(t *testing.T) {
+		combined := vector.NewBuildScope([]string{"sms"}, []int64{3})
+		got := semanticCoverageContext(
+			query.Context{MessageTypes: []string{"email", "sms"}, SourceIDs: []int64{3, 9}},
+			combined)
+		assert.Equal(t, []string{"sms"}, got.MessageTypes)
+		assert.Equal(t, []int64{3}, got.SourceIDs)
+	})
+}
+
 type filteredCoverageBackend struct {
 	vector.Backend
 
@@ -277,6 +318,38 @@ func TestSearchCoverageResolvesIdentityFilterOnce(t *testing.T) {
 	assertions.Equal(1, fixture.store.resolveCalls)
 }
 
+// TestSearchCoverageReportsZeroForIdentityOutsideEmbedScope guards the
+// identity/source pairing: an identity filter pins Identity.SourceID to the
+// selected source, so a disjoint embed scope must report zero eligibility
+// rather than rewrite the source predicate into something the query
+// validator rejects.
+func TestSearchCoverageReportsZeroForIdentityOutsideEmbedScope(t *testing.T) {
+	assertions := assert.New(t)
+	fixture := newExploreIdentityAPIFixture(t)
+	backend := &filteredCoverageBackend{
+		active: vector.Generation{
+			ID: 7, Fingerprint: "model:2", State: vector.GenerationActive,
+		},
+		embeddedIDs: map[int64]struct{}{2: {}},
+	}
+	cfg := &config.Config{Server: config.ServerConfig{APIPort: 8080}}
+	cfg.Vector.Embed.Scope.SourceIDs = []int64{2}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: cfg, Store: fixture.store, Engine: fixture.server.QueryEngine(), Backend: backend,
+		VectorCfg: cfg.Vector, VectorStatus: VectorStatusReady, Logger: testLogger(),
+	})
+
+	body := getSearchCoverage(t, srv, `{"filters":[
+		{"dimension":"source","values":["1"]},
+		{"dimension":"identity","values":["1","BOB@MEMBERS.EXAMPLE","recipient"]}
+	]}`)
+
+	assertions.Equal(SearchCoverageReady, body.Status)
+	assertions.Zero(body.EligibleCount)
+	assertions.Zero(body.EmbeddedCount)
+	assertions.InDelta(100.0, body.Percentage, 0.001)
+}
+
 func TestSearchCoverageOpenAPIContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -476,6 +549,33 @@ func TestSearchCoverageContextHashSeparatesEmailIdentifier(t *testing.T) {
 	assert.Equal(aliasA, aliasARepeat, "identical contexts must share a cache key")
 	assert.NotEqual(aliasA, aliasB,
 		"aliases resolving to the same participants must not share a cache key")
+}
+
+// TestSearchCoverageDetectsScopeDrift pins the coverage endpoint's drift
+// detection: the UI polls coverage, so it must be able to be the event that
+// re-resolves the embedding scope and report stale — otherwise a daemon
+// with no embed schedule keeps reporting ready coverage computed from
+// obsolete startup source IDs until some vector search fires the preflight.
+func TestSearchCoverageDetectsScopeDrift(t *testing.T) {
+	assert := assert.New(t)
+	engine := &coverageScanEngine{revision: "cache:test", total: 3}
+	backend := &filteredCoverageBackend{
+		active:   vector.Generation{ID: 7, Fingerprint: "", State: vector.GenerationActive},
+		countAll: true,
+	}
+	srv := newCoverageScanServer(t, engine, backend)
+	checks := 0
+	srv.SetVectorScopeCheck(func(context.Context) (string, error) {
+		checks++
+		return "configured embedding scope now resolves to \"src-9\" but vector search was initialized with \"src-7\"", nil
+	})
+
+	body := getSearchCoverage(t, srv, `{}`)
+
+	assert.Equal(SearchCoverageStale, body.Status,
+		"drifted scope must surface as stale, not ready")
+	assert.Contains(body.Detail, "src-9")
+	assert.Equal(1, checks, "the coverage request runs the drift check")
 }
 
 func TestSearchCoverageRejectsGenerationActivationDuringScan(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -315,6 +315,25 @@ type Server struct {
 	backend      vector.Backend
 	vectorStatus VectorStatus
 	vectorErr    string
+	// vectorStaleLatch pins a stale status that refreshVectorStatusIfStale
+	// must not clear: set when the durable embedding scope drifts from the
+	// scope the installed components were initialized with. The active
+	// generation still matches the STARTUP fingerprint in that state, so
+	// the ordinary refresh would flip straight back to ready. Only a
+	// successful reinit (SetVectorFeatures) clears the latch.
+	vectorStaleLatch bool
+	// vectorScopeCheck re-resolves the durable embedding scope on the
+	// vector-search preflight path (throttled by vectorScopeNextCheck) so
+	// drift is detected even when no embed job ever runs. Wired by the
+	// daemon; see SetVectorScopeCheck.
+	vectorScopeCheck     func(ctx context.Context) (string, error)
+	vectorScopeNextCheck time.Time
+	// vectorFreshNextCheck throttles maybeRefreshVectorFreshness, the
+	// ready→stale counterpart of refreshVectorStatusIfStale: a
+	// daemon-proxied one-off scoped build can activate a generation whose
+	// fingerprint no longer matches the installed configuration without
+	// any config change, and nothing else re-validates a ready status.
+	vectorFreshNextCheck time.Time
 	// backupFreeze tracks the single active backup freeze window opened via
 	// POST /api/v1/backup/freeze/begin. See backup_freeze.go.
 	backupFreeze backupFreezeState
@@ -1203,12 +1222,14 @@ func (s *Server) handleDaemonIdentity(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleHealth returns a simple health check response.
+// handleHealth returns a simple health check response. It is served
+// unauthenticated, so the vector view carries no detail message — init and
+// drift details can name configured account identifiers.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	s.refreshVectorStatusIfStale(r.Context())
+	s.refreshVectorStatus(r.Context())
 	writeJSON(w, http.StatusOK, HealthResponse{
 		Status:          "ok",
-		Vector:          s.vectorHealth(),
+		Vector:          s.vectorHealthPublic(),
 		Operation:       s.operationBusyHealth(),
 		AnalyticsEngine: s.analyticsModeForContext(r.Context()),
 	})
@@ -1217,7 +1238,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 // handleAuthenticatedHealth returns health details that are safe behind the
 // API-key boundary.
 func (s *Server) handleAuthenticatedHealth(w http.ResponseWriter, r *http.Request) {
-	s.refreshVectorStatusIfStale(r.Context())
+	s.refreshVectorStatus(r.Context())
 	writeJSON(w, http.StatusOK, HealthResponse{
 		Status:          "ok",
 		Vector:          s.vectorHealth(),

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -113,6 +113,7 @@ var settingsCatalog = []settingDefinition{
 	stringSetting("vector.embed.schedule.cron", "search", nil, func(c *config.Config) string { return c.Vector.Embed.Schedule.Cron }),
 	boolSetting("vector.embed.schedule.run_after_sync", "search", func(c *config.Config) bool { return c.Vector.Embed.Schedule.RunAfterSync }),
 	stringArraySetting("vector.embed.scope.message_types", "search", func(c *config.Config) []string { return c.Vector.Embed.Scope.MessageTypes }),
+	stringArraySetting("vector.embed.scope.accounts", "search", func(c *config.Config) []string { return c.Vector.Embed.Scope.Accounts }),
 	intSetting("vector.search.rrf_k", "search", func(c *config.Config) int { return c.Vector.Search.RRFK }),
 	intSetting("vector.search.k_per_signal", "search", func(c *config.Config) int { return c.Vector.Search.KPerSignal }),
 	numberSetting("vector.search.subject_boost", "search", func(c *config.Config) float64 { return c.Vector.Search.SubjectBoost }),

--- a/internal/api/vector_status.go
+++ b/internal/api/vector_status.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"time"
 
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
@@ -38,6 +40,8 @@ func (s *Server) SetVectorFeatures(engine *hybrid.Engine, backend vector.Backend
 	s.vectorCfg = cfg
 	s.vectorStatus = VectorStatusReady
 	s.vectorErr = ""
+	s.vectorStaleLatch = false
+	s.vectorFreshNextCheck = time.Time{}
 }
 
 // SetVectorInitError marks the vector subsystem as failed. The daemon keeps
@@ -56,9 +60,9 @@ func (s *Server) SetVectorInitError(err error) {
 
 // SetVectorStale marks the vector subsystem as stale: the backend
 // initialized and its components are installed, but the active index does
-// not match the configured embedding model/dimension, so vector searches
-// return index_stale until the index is rebuilt. detail should name the
-// stored vs configured fingerprint and the rebuild command. Calling with an
+// not match the configured embedding settings, so vector searches return
+// index_stale until config is aligned or the index is rebuilt. detail should
+// name the stored vs configured fingerprint and the recovery options. Calling with an
 // empty detail is a no-op — there is nothing actionable to report.
 func (s *Server) SetVectorStale(detail string) {
 	if detail == "" {
@@ -68,6 +72,25 @@ func (s *Server) SetVectorStale(detail string) {
 	defer s.vectorMu.Unlock()
 	s.vectorStatus = VectorStatusStale
 	s.vectorErr = detail
+}
+
+// SetVectorScopeDrift marks the vector subsystem stale because the durable
+// [vector.embed.scope] accounts now resolve to a different source-ID set
+// than the installed components were initialized with. Unlike SetVectorStale,
+// the resulting status is LATCHED: the active generation still matches the
+// startup fingerprint, so refreshVectorStatusIfStale would otherwise clear
+// the status on the next request while searches keep serving the
+// wrongly-scoped index. Only a successful reinit (SetVectorFeatures — in
+// practice a daemon restart) clears it. An empty detail is a no-op.
+func (s *Server) SetVectorScopeDrift(detail string) {
+	if detail == "" {
+		return
+	}
+	s.vectorMu.Lock()
+	defer s.vectorMu.Unlock()
+	s.vectorStatus = VectorStatusStale
+	s.vectorErr = detail
+	s.vectorStaleLatch = true
 }
 
 // refreshVectorStatusIfStale re-runs the generation freshness check when the
@@ -80,10 +103,14 @@ func (s *Server) SetVectorStale(detail string) {
 func (s *Server) refreshVectorStatusIfStale(ctx context.Context) {
 	s.vectorMu.RLock()
 	stale := s.vectorStatus == VectorStatusStale
+	latched := s.vectorStaleLatch
 	backend := s.backend
 	cfg := s.vectorCfg
 	s.vectorMu.RUnlock()
-	if !stale || backend == nil {
+	// A latched stale (embedding scope drift) matches the startup
+	// fingerprint by construction, so a clean resolve proves nothing;
+	// only SetVectorFeatures (reinit) may clear it.
+	if !stale || latched || backend == nil {
 		return
 	}
 	if _, err := vector.ResolveActiveForFingerprint(ctx, backend, cfg.GenerationFingerprint()); err != nil {
@@ -93,12 +120,126 @@ func (s *Server) refreshVectorStatusIfStale(ctx context.Context) {
 	}
 	s.vectorMu.Lock()
 	// Guard against clobbering a status a concurrent writer changed (e.g. a
-	// reinit that flipped to error) while we held no lock.
-	if s.vectorStatus == VectorStatusStale {
+	// reinit that flipped to error, or a scope-drift latch) while we held
+	// no lock.
+	if s.vectorStatus == VectorStatusStale && !s.vectorStaleLatch {
 		s.vectorStatus = VectorStatusReady
 		s.vectorErr = ""
 	}
 	s.vectorMu.Unlock()
+}
+
+// vectorScopeCheckInterval throttles the preflight scope-drift check: the
+// resolution queries the main DB per configured account, so it runs at most
+// once per interval across all search requests.
+const vectorScopeCheckInterval = time.Minute
+
+// SetVectorScopeCheck installs a callback that re-resolves the durable
+// [vector.embed.scope] accounts and returns a non-empty detail when they no
+// longer resolve to the source set vector search was initialized with. The
+// preflight on every vector-search entry point runs it (throttled), so
+// drift latches the stale status even on daemons whose embed job never
+// fires (empty cron, run_after_sync=false). A nil check disables the
+// preflight detection; the embed job's own detection is unaffected.
+func (s *Server) SetVectorScopeCheck(check func(ctx context.Context) (string, error)) {
+	s.vectorMu.Lock()
+	defer s.vectorMu.Unlock()
+	s.vectorScopeCheck = check
+	s.vectorScopeNextCheck = time.Time{}
+}
+
+// maybeCheckVectorScopeDrift runs the installed scope-drift check when one
+// is due. A resolution failure (possibly transient) is logged and does not
+// change the status; only a positive drift result latches stale.
+func (s *Server) maybeCheckVectorScopeDrift(ctx context.Context) {
+	s.vectorMu.Lock()
+	check := s.vectorScopeCheck
+	if check == nil || s.vectorStaleLatch || time.Now().Before(s.vectorScopeNextCheck) {
+		s.vectorMu.Unlock()
+		return
+	}
+	s.vectorScopeNextCheck = time.Now().Add(vectorScopeCheckInterval)
+	s.vectorMu.Unlock()
+	detail, err := check(ctx)
+	if err != nil {
+		s.logger.Warn("embedding scope drift check failed", "error", err)
+		return
+	}
+	if detail != "" {
+		// The public /health view hides the detail (it can name configured
+		// account identifiers), so log it for operators here.
+		s.logger.Warn("embedding scope drift detected; vector search marked stale", "detail", detail)
+		s.SetVectorScopeDrift(detail)
+	}
+}
+
+// vectorFreshnessCheckInterval throttles maybeRefreshVectorFreshness: the
+// check costs one backend generation lookup and runs on health, stats, and
+// search preflight paths, so it fires at most once per interval.
+const vectorFreshnessCheckInterval = time.Minute
+
+// maybeRefreshVectorFreshness is the ready→stale counterpart of
+// refreshVectorStatusIfStale. A daemon-proxied one-off scoped build (or any
+// CLI rebuild under a different configuration) can activate a generation
+// whose fingerprint differs from the installed one WITHOUT changing the
+// configured scope, so the drift latch never fires: searches then 503 with
+// index_stale from the query-time fingerprint check while /health and
+// /api/v1/stats keep reporting ready. Re-run the freshness check (throttled)
+// while the status is ready and flip it to stale on a fingerprint mismatch.
+// Only ErrIndexStale flips the status — building or transient backend errors
+// are not the "index does not match configured settings" condition this
+// exists to expose. The plain (unlatched) stale it sets clears through
+// refreshVectorStatusIfStale once a matching generation activates.
+func (s *Server) maybeRefreshVectorFreshness(ctx context.Context) {
+	s.vectorMu.Lock()
+	backend := s.backend
+	cfg := s.vectorCfg
+	due := s.vectorStatus == VectorStatusReady && backend != nil && cfg.Enabled &&
+		!time.Now().Before(s.vectorFreshNextCheck)
+	if due {
+		s.vectorFreshNextCheck = time.Now().Add(vectorFreshnessCheckInterval)
+	}
+	s.vectorMu.Unlock()
+	if !due {
+		return
+	}
+	_, err := vector.ResolveActiveForFingerprint(ctx, backend, cfg.GenerationFingerprint())
+	if !errors.Is(err, vector.ErrIndexStale) {
+		return
+	}
+	s.SetVectorStale(err.Error() + "; if this is a one-off account-scoped generation, set matching [vector.embed.scope] accounts and restart the daemon; otherwise run `msgvault embeddings build --full-rebuild` to rebuild")
+}
+
+// refreshVectorStatus runs every throttled revalidation that keeps the
+// reported vector status honest, in dependency order: the account-scope
+// drift check (config vs initialized scope), the fingerprint freshness
+// check (ready→stale after a foreign activation), and the clearable stale
+// refresh (stale→ready once a matching generation activates). Every
+// status-reporting or status-gated path — health, stats, coverage, and the
+// search preflight — must call this rather than a subset, so that on a
+// daemon whose embed job never runs, any of those endpoints can be the
+// event that detects a changed scope or a swapped generation.
+func (s *Server) refreshVectorStatus(ctx context.Context) {
+	s.maybeCheckVectorScopeDrift(ctx)
+	s.maybeRefreshVectorFreshness(ctx)
+	s.refreshVectorStatusIfStale(ctx)
+}
+
+// vectorSearchPreflight gates a vector-search entry point on the stale
+// status. The installed components validate the STARTUP fingerprint at
+// query time, which still matches after embedding-scope drift, so without
+// this gate searches would keep serving a wrongly-scoped index that health
+// already reports as stale. Runs the throttled revalidations first (so a
+// search can be the event that detects drift) and writes the index_stale
+// 503 when the status is (still) stale. Returns false when the response
+// has been written.
+func (s *Server) vectorSearchPreflight(ctx context.Context, w http.ResponseWriter) bool {
+	s.refreshVectorStatus(ctx)
+	if status, _ := s.VectorStatus(); status == VectorStatusStale {
+		s.writeVectorUnavailable(w)
+		return false
+	}
+	return true
 }
 
 // VectorStatus returns the vector subsystem status and, when the status is
@@ -110,13 +251,32 @@ func (s *Server) VectorStatus() (VectorStatus, string) {
 }
 
 // vectorHealth returns the health-response view of the vector subsystem,
-// or nil when vector search is disabled.
+// or nil when vector search is disabled. The detail message can carry
+// operator-sensitive material — account-resolution errors name configured
+// mailbox identifiers — so this detailed form is served only behind the
+// API-key boundary (/api/v1/health).
 func (s *Server) vectorHealth() *VectorHealth {
 	status, errMsg := s.VectorStatus()
 	if status == VectorStatusDisabled {
 		return nil
 	}
 	return &VectorHealth{Status: string(status), Error: errMsg}
+}
+
+// vectorHealthPublic is the unauthenticated /health view: it reports the
+// status (enough for monitoring) but replaces the detail with a generic
+// pointer, because init and scope-drift details embed configured account
+// identifiers from resolver errors.
+func (s *Server) vectorHealthPublic() *VectorHealth {
+	status, _ := s.VectorStatus()
+	if status == VectorStatusDisabled {
+		return nil
+	}
+	health := &VectorHealth{Status: string(status)}
+	if status == VectorStatusError || status == VectorStatusStale {
+		health.Error = "vector search is unavailable; see the authenticated health endpoint or daemon logs for details"
+	}
+	return health
 }
 
 func (s *Server) vectorComponents() (*hybrid.Engine, vector.Backend, vector.Config) {

--- a/internal/api/vector_status_test.go
+++ b/internal/api/vector_status_test.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/vector"
+	"go.kenn.io/msgvault/internal/vector/hybrid"
 )
 
 // minimalVectorBackend is a minimal vector.Backend for status tests. Embed the
@@ -150,6 +152,9 @@ func TestHealthReportsStaleVectorStatus(t *testing.T) {
 	srv := NewServerWithOptions(opts)
 	srv.SetVectorStale("active=\"old:1\" configured=\"new:2\"")
 
+	// The unauthenticated /health carries the status but hides the detail
+	// (it can name configured account identifiers); the authenticated
+	// /api/v1/health carries the full detail.
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
 	srv.Router().ServeHTTP(rec, req)
@@ -159,7 +164,16 @@ func TestHealthReportsStaleVectorStatus(t *testing.T) {
 	require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
 	require.NotNil(body.Vector)
 	assert.Equal("stale", body.Vector.Status)
-	assert.Contains(body.Vector.Error, "old:1")
+	assert.NotContains(body.Vector.Error, "old:1", "public health must not expose the stale detail")
+	assert.Contains(body.Vector.Error, "authenticated health")
+
+	rec = httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/health", nil))
+	require.Equal(http.StatusOK, rec.Code)
+	require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
+	require.NotNil(body.Vector)
+	assert.Equal("stale", body.Vector.Status)
+	assert.Contains(body.Vector.Error, "old:1", "authenticated health carries the detail")
 }
 
 // resolvingVectorBackend reports a single active generation with a fixed
@@ -204,6 +218,257 @@ func TestHealthClearsStaleAfterReactivation(t *testing.T) {
 	require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
 	require.NotNil(body.Vector)
 	assert.Equal("ready", body.Vector.Status, "stale must clear once the index matches again")
+}
+
+// TestScopeDriftStaleSurvivesRefresh pins the scope-drift latch: after
+// SetVectorScopeDrift, the active generation still matches the STARTUP
+// fingerprint, so the ordinary stale refresh would clear the status on the
+// next request while searches keep serving the wrongly-scoped index. The
+// latch must hold through health checks and clear only on reinit
+// (SetVectorFeatures).
+func TestScopeDriftStaleSurvivesRefresh(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg := vector.Config{}
+	backend := &resolvingVectorBackend{fingerprint: cfg.GenerationFingerprint()}
+	opts := testServerOptions(t, backend)
+	opts.VectorStatus = VectorStatusInitializing
+	srv := NewServerWithOptions(opts)
+	srv.SetVectorFeatures(nil, backend, cfg)
+	srv.SetVectorScopeDrift("configured embedding scope now resolves to \"src-9\" but vector search was initialized with \"src-7\"")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+
+	require.Equal(http.StatusOK, rec.Code)
+	var body HealthResponse
+	require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
+	require.NotNil(body.Vector)
+	assert.Equal("stale", body.Vector.Status,
+		"a matching startup fingerprint must not clear scope-drift stale")
+	assert.Contains(body.Vector.Error, "src-9")
+
+	srv.SetVectorFeatures(nil, backend, cfg)
+	status, errMsg := srv.VectorStatus()
+	assert.Equal(VectorStatusReady, status, "reinit clears the latch")
+	assert.Empty(errMsg)
+}
+
+// TestVectorSearchEndpointsGateOnScopeDrift pins the preflight gate: the
+// installed engine/backend validate only the STARTUP fingerprint at query
+// time, which still matches after embedding-scope drift, so every vector
+// search entry point must consult the stale status itself and 503 with
+// index_stale instead of serving the wrongly-scoped index.
+func TestVectorSearchEndpointsGateOnScopeDrift(t *testing.T) {
+	newDriftedServer := func(t *testing.T) *Server {
+		t.Helper()
+		cfg := vector.Config{}
+		backend := &resolvingVectorBackend{fingerprint: cfg.GenerationFingerprint()}
+		opts := testServerOptions(t, backend)
+		opts.VectorStatus = VectorStatusInitializing
+		opts.Store = &mockStore{}
+		srv := NewServerWithOptions(opts)
+		srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), backend, cfg)
+		srv.SetVectorScopeDrift("configured embedding scope now resolves to \"src-9\" but vector search was initialized with \"src-7\"")
+		return srv
+	}
+	assertIndexStale := func(t *testing.T, rec *httptest.ResponseRecorder) {
+		t.Helper()
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code, rec.Body.String())
+		var body struct {
+			Error string `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		assert.Equal(t, "index_stale", body.Error)
+	}
+
+	t.Run("hybrid search", func(t *testing.T) {
+		srv := newDriftedServer(t)
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search?q=hello&mode=hybrid", nil))
+		assertIndexStale(t, rec)
+	})
+
+	t.Run("similar search", func(t *testing.T) {
+		srv := newDriftedServer(t)
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/similar?message_id=1", nil))
+		assertIndexStale(t, rec)
+	})
+
+	t.Run("explore semantic including cached snapshot", func(t *testing.T) {
+		srv := newDriftedServer(t)
+		rec := httptest.NewRecorder()
+		_, _, ok := srv.resolveExploreVectorSearch(context.Background(), rec, ExploreHTTPRequest{
+			Query: "hello", SearchMode: exploreSearchModeSemantic, CandidateSnapshotID: "cached-snapshot",
+		})
+		assert.False(t, ok, "a drifted scope must not resolve a semantic search spec")
+		assertIndexStale(t, rec)
+	})
+}
+
+// TestVectorSearchPreflightDetectsScopeDrift pins the search-path drift
+// detection: with an empty embed cron and run_after_sync=false the embed
+// job never runs, so a search request must be able to be the event that
+// re-resolves the scope and latches the stale status. The check is
+// throttled to at most once per interval.
+func TestVectorSearchPreflightDetectsScopeDrift(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg := vector.Config{}
+	backend := &resolvingVectorBackend{fingerprint: cfg.GenerationFingerprint()}
+	opts := testServerOptions(t, backend)
+	opts.VectorStatus = VectorStatusInitializing
+	opts.Store = &mockStore{}
+	srv := NewServerWithOptions(opts)
+	srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), backend, cfg)
+
+	checks := 0
+	srv.SetVectorScopeCheck(func(context.Context) (string, error) {
+		checks++
+		return "configured embedding scope now resolves to \"src-9\" but vector search was initialized with \"src-7\"", nil
+	})
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/similar?message_id=1", nil))
+	require.Equal(http.StatusServiceUnavailable, rec.Code, rec.Body.String())
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal("index_stale", body.Error)
+	assert.Equal(1, checks, "the first search runs the drift check")
+
+	status, errMsg := srv.VectorStatus()
+	assert.Equal(VectorStatusStale, status, "drift found by the preflight latches stale")
+	assert.Contains(errMsg, "src-9")
+
+	rec = httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/similar?message_id=1", nil))
+	require.Equal(http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(1, checks, "a latched stale must not re-run the check")
+}
+
+// TestVectorSearchPreflightThrottlesScopeCheck pins the throttle for the
+// no-drift case: consecutive searches within the interval run the (main-DB)
+// resolution once, and a resolution error neither blocks the search nor
+// changes the status.
+func TestVectorSearchPreflightThrottlesScopeCheck(t *testing.T) {
+	assert := assert.New(t)
+
+	cfg := vector.Config{}
+	backend := &resolvingVectorBackend{fingerprint: cfg.GenerationFingerprint()}
+	opts := testServerOptions(t, backend)
+	opts.VectorStatus = VectorStatusInitializing
+	opts.Store = &mockStore{}
+	srv := NewServerWithOptions(opts)
+	srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), backend, cfg)
+
+	checks := 0
+	srv.SetVectorScopeCheck(func(context.Context) (string, error) {
+		checks++
+		return "", errors.New("database is locked")
+	})
+
+	for range 3 {
+		rec := httptest.NewRecorder()
+		srv.vectorSearchPreflight(context.Background(), rec)
+	}
+	assert.Equal(1, checks, "the scope check runs at most once per interval")
+	status, _ := srv.VectorStatus()
+	assert.Equal(VectorStatusReady, status, "a resolution error must not change the status")
+}
+
+// TestHealthFlipsReadyToStaleAfterForeignActivation pins the ready→stale
+// revalidation: a daemon-proxied one-off scoped build activates a generation
+// whose fingerprint no longer matches the installed configuration without
+// changing the configured scope, so nothing latches drift — searches 503
+// with index_stale from the query-time check while health kept reporting
+// ready. Health (and the search preflight) must re-run the freshness check
+// and flip the status. The check is throttled, and only a fingerprint
+// mismatch flips it — a matching index stays ready.
+func TestHealthFlipsReadyToStaleAfterForeignActivation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg := vector.Config{
+		Enabled:    true,
+		Embeddings: vector.EmbeddingsConfig{Model: "test", Dimension: 2},
+	}
+	backend := &resolvingVectorBackend{fingerprint: cfg.GenerationFingerprint()}
+	opts := testServerOptions(t, backend)
+	opts.VectorStatus = VectorStatusInitializing
+	srv := NewServerWithOptions(opts)
+	srv.SetVectorFeatures(nil, backend, cfg)
+
+	health := func() string {
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+		require.Equal(http.StatusOK, rec.Code)
+		var body HealthResponse
+		require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
+		require.NotNil(body.Vector)
+		return body.Vector.Status
+	}
+
+	assert.Equal("ready", health(), "matching active generation stays ready")
+
+	// A one-off scoped build activates a differently-fingerprinted
+	// generation behind the daemon's back.
+	backend.fingerprint = cfg.GenerationFingerprint() + ":ssrc-3"
+	assert.Equal("ready", health(), "throttled: the flip waits for the next check window")
+
+	srv.vectorMu.Lock()
+	srv.vectorFreshNextCheck = time.Time{}
+	srv.vectorMu.Unlock()
+	assert.Equal("stale", health(), "a mismatched active generation must flip health to stale")
+
+	status, detail := srv.VectorStatus()
+	assert.Equal(VectorStatusStale, status)
+	assert.Contains(detail, "one-off account-scoped generation", "detail explains the recovery")
+
+	// The plain stale clears through the ordinary refresh once a matching
+	// generation activates again.
+	backend.fingerprint = cfg.GenerationFingerprint()
+	assert.Equal("ready", health(), "reactivating a matching generation clears the stale")
+}
+
+// TestHealthDetectsScopeDrift pins that the status-reporting endpoints run
+// the scope-drift check themselves: with embed scheduling disabled, a
+// removed or remapped configured account must flip health to stale on the
+// next poll rather than waiting for a vector search or coverage request to
+// fire the preflight.
+func TestHealthDetectsScopeDrift(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg := vector.Config{}
+	backend := &resolvingVectorBackend{fingerprint: cfg.GenerationFingerprint()}
+	opts := testServerOptions(t, backend)
+	opts.VectorStatus = VectorStatusInitializing
+	srv := NewServerWithOptions(opts)
+	srv.SetVectorFeatures(nil, backend, cfg)
+	checks := 0
+	srv.SetVectorScopeCheck(func(context.Context) (string, error) {
+		checks++
+		return "configured embedding scope now resolves to \"src-9\" but vector search was initialized with \"src-7\"", nil
+	})
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	require.Equal(http.StatusOK, rec.Code)
+	var body HealthResponse
+	require.NoError(json.Unmarshal(rec.Body.Bytes(), &body))
+	require.NotNil(body.Vector)
+	assert.Equal("stale", body.Vector.Status, "a health poll must detect scope drift itself")
+	assert.Equal(1, checks)
+
+	status, detail := srv.VectorStatus()
+	assert.Equal(VectorStatusStale, status)
+	assert.Contains(detail, "src-9")
 }
 
 // TestHealthKeepsStaleWhenStillMismatched verifies the refresh leaves the stale
@@ -317,8 +582,10 @@ func TestHealthReportsVectorStatus(t *testing.T) {
 	}{
 		{"disabled omits vector", VectorStatusDisabled, nil, nil},
 		{"initializing", VectorStatusInitializing, nil, &VectorHealth{Status: "initializing"}},
-		{"error carries message", VectorStatusError, errors.New("migration exploded"),
-			&VectorHealth{Status: "error", Error: "migration exploded"}},
+		// The public endpoint reports the error STATUS but not the detail:
+		// init errors can name configured account identifiers.
+		{"error carries generic message", VectorStatusError, errors.New("no account found for wes@example.com"),
+			&VectorHealth{Status: "error", Error: "vector search is unavailable; see the authenticated health endpoint or daemon logs for details"}},
 		{"ready", VectorStatusReady, nil, &VectorHealth{Status: "ready"}},
 	}
 	for _, tt := range tests {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -281,8 +281,8 @@ func translateVectorErr(err error) *toolResult {
 		)
 	case errors.Is(err, vector.ErrIndexStale):
 		return toolErrorResult(
-			"index_stale: the vector index does not match the configured model; " +
-				"run `msgvault embeddings build --full-rebuild`",
+			"index_stale: the vector index does not match configured embedding settings; " +
+				"align [vector.embed.scope] accounts for an existing account-scoped index, or run `msgvault embeddings build --full-rebuild`",
 		)
 	case errors.Is(err, vector.ErrIndexBuilding):
 		return toolErrorResult(
@@ -1040,7 +1040,7 @@ func (h *handlers) filterFromFindSimilarArgs(ctx context.Context, args map[strin
 		f.SourceIDs = []int64{*srcID}
 	}
 	if messageType, _ := args["message_type"].(string); messageType != "" {
-		f.MessageTypes = vector.NewBuildScope([]string{messageType}).MessageTypes
+		f.MessageTypes = vector.NewBuildScope([]string{messageType}, nil).MessageTypes
 	}
 
 	if v, ok := args["has_attachment"].(bool); ok && v {

--- a/internal/scheduler/embed_job.go
+++ b/internal/scheduler/embed_job.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -60,7 +61,7 @@ type EmbedCoverage interface {
 }
 
 type ScopedEmbedCoverage interface {
-	MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string) (int64, error)
+	MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string, sourceIDs []int64) (int64, error)
 }
 
 // Compile-time check that the production worker satisfies EmbedRunner.
@@ -126,6 +127,25 @@ type EmbedJob struct {
 	// worker scans for this generation. Empty means the full live corpus.
 	BuildScope vector.BuildScope
 
+	// ResolveBuildScope re-resolves the durable embedding scope immediately
+	// before each scheduled run. If it differs from BuildScope, Run fails
+	// closed: the worker and backend were initialized with the old scope and
+	// must be reinitialized before any embedding can resume. This prevents a
+	// reused database source ID from being treated as the formerly configured
+	// account.
+	ResolveBuildScope func() (vector.BuildScope, error)
+
+	// OnScopeDrift is invoked (once per Run that detects it) when
+	// ResolveBuildScope returns a scope different from BuildScope, or fails
+	// deterministically (vector.ErrScopeUnresolvable — a configured account
+	// removed or ambiguous). The daemon wires this to the API server's
+	// stale latch so searches stop reporting "ready" against components
+	// initialized with the old scope — the active generation still matches
+	// the startup fingerprint, so without this signal nothing else would
+	// flag the drift. Transient resolution failures do not trigger it.
+	// May be nil.
+	OnScopeDrift func(detail string)
+
 	// Now returns the current time; overridable in tests to drive the
 	// backstop interval deterministically. nil uses time.Now.
 	Now func() time.Time
@@ -169,6 +189,34 @@ func (j *EmbedJob) Run(ctx context.Context) {
 		return
 	}
 	defer j.running.Unlock()
+
+	if j.ResolveBuildScope != nil {
+		resolved, err := j.ResolveBuildScope()
+		if err != nil {
+			log.Error("embed run skipped: configured scope could not be resolved", "error", err)
+			// A deterministic failure (a configured account removed or
+			// ambiguous — vector.ErrScopeUnresolvable) cannot heal on retry
+			// and means the initialized scope no longer matches the
+			// configuration, so it must latch searches stale like a scope
+			// change. Transient failures only skip the run.
+			if j.OnScopeDrift != nil && errors.Is(err, vector.ErrScopeUnresolvable) {
+				j.OnScopeDrift(err.Error() + "; fix [vector.embed.scope] accounts and restart the daemon")
+			}
+			return
+		}
+		configured := vector.NewBuildScope(j.BuildScope.MessageTypes, j.BuildScope.SourceIDs)
+		if resolved.Fingerprint() != configured.Fingerprint() {
+			log.Error("embed run skipped: configured scope changed; reinitialize vector features and rebuild before embedding",
+				"configured_scope", resolved.Fingerprint(),
+				"initialized_scope", configured.Fingerprint())
+			if j.OnScopeDrift != nil {
+				j.OnScopeDrift(fmt.Sprintf(
+					"the configured embedding scope now resolves to %q but vector search was initialized with %q; restart the daemon to reinitialize, then run `msgvault embeddings build --full-rebuild` if the new scope is intended",
+					resolved.Fingerprint(), configured.Fingerprint()))
+			}
+			return
+		}
+	}
 
 	if _, err := j.Worker.ReclaimStale(ctx); err != nil {
 		if jobctx.YieldedToWaiter(ctx) {
@@ -329,12 +377,12 @@ func (j *EmbedJob) activateBuilding(
 }
 
 func (j *EmbedJob) missingCount(ctx context.Context, target vector.GenerationID) (int64, error) {
-	scope := vector.NewBuildScope(j.BuildScope.MessageTypes)
+	scope := vector.NewBuildScope(j.BuildScope.MessageTypes, j.BuildScope.SourceIDs)
 	if scope.IsEmpty() {
 		return j.Store.MissingCount(ctx, int64(target))
 	}
 	if scoped, ok := j.Store.(ScopedEmbedCoverage); ok {
-		return scoped.MissingCountScoped(ctx, int64(target), scope.MessageTypes)
+		return scoped.MissingCountScoped(ctx, int64(target), scope.MessageTypes, scope.SourceIDs)
 	}
 	return 0, errors.New("embed coverage store does not support scoped missing counts")
 }

--- a/internal/scheduler/embed_job_scope_test.go
+++ b/internal/scheduler/embed_job_scope_test.go
@@ -1,0 +1,119 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// scopedFakeCoverage records the scope arguments MissingCountScoped
+// receives so the test can prove the job forwards its full build scope.
+type scopedFakeCoverage struct {
+	messageTypes []string
+	sourceIDs    []int64
+	missing      int64
+}
+
+func (c *scopedFakeCoverage) MissingCount(context.Context, int64) (int64, error) {
+	return -1, errors.New("unscoped path must not be used for a scoped job")
+}
+
+func (c *scopedFakeCoverage) MissingCountScoped(_ context.Context, _ int64, messageTypes []string, sourceIDs []int64) (int64, error) {
+	c.messageTypes = messageTypes
+	c.sourceIDs = sourceIDs
+	return c.missing, nil
+}
+
+// TestEmbedJobMissingCountForwardsScope pins the account dimension: a job
+// built with a source-scoped BuildScope must pass those source IDs to the
+// coverage store, or the daemon's activation gate would count the whole
+// corpus and the scoped generation could never activate.
+func TestEmbedJobMissingCountForwardsScope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cov := &scopedFakeCoverage{missing: 5}
+	job := &EmbedJob{
+		Store:      cov,
+		BuildScope: vector.NewBuildScope([]string{"SMS"}, []int64{7, 3}),
+	}
+	got, err := job.missingCount(context.Background(), 12)
+	require.NoError(err)
+	assert.Equal(int64(5), got)
+	assert.Equal([]string{"sms"}, cov.messageTypes, "message types normalized")
+	assert.Equal([]int64{3, 7}, cov.sourceIDs, "source IDs normalized and forwarded")
+}
+
+func TestEmbedJobScopeChangeFailsClosedBeforeWorkerRuns(t *testing.T) {
+	assert := assert.New(t)
+	runner := &fakeRunner{}
+	var driftDetail string
+	job := &EmbedJob{
+		Worker:     runner,
+		Backend:    &fakeBackend{},
+		BuildScope: vector.NewBuildScope(nil, []int64{7}),
+		ResolveBuildScope: func() (vector.BuildScope, error) {
+			return vector.NewBuildScope(nil, []int64{9}), nil
+		},
+		OnScopeDrift: func(detail string) { driftDetail = detail },
+	}
+
+	job.Run(context.Background())
+	assert.Equal(0, runner.runCalls, "changed source mapping must stop before embedding")
+	assert.Equal(0, runner.reclaimCalls, "changed source mapping must stop before any worker write")
+	assert.Contains(driftDetail, "src-9", "drift signal names the newly resolved scope")
+	assert.Contains(driftDetail, "src-7", "drift signal names the initialized scope")
+}
+
+// TestEmbedJobScopeErrorDoesNotSignalDrift pins the boundary of the drift
+// signal: a TRANSIENT scope-resolution failure (a busy database) skips the
+// run but must not latch the API stale, which only a daemon restart clears.
+func TestEmbedJobScopeErrorDoesNotSignalDrift(t *testing.T) {
+	assert := assert.New(t)
+	runner := &fakeRunner{}
+	drifts := 0
+	job := &EmbedJob{
+		Worker:     runner,
+		Backend:    &fakeBackend{},
+		BuildScope: vector.NewBuildScope(nil, []int64{7}),
+		ResolveBuildScope: func() (vector.BuildScope, error) {
+			return vector.BuildScope{}, errors.New("database is locked")
+		},
+		OnScopeDrift: func(string) { drifts++ },
+	}
+
+	job.Run(context.Background())
+	assert.Equal(0, runner.runCalls, "resolution failure must stop before embedding")
+	assert.Zero(drifts, "a transient resolution error is not scope drift")
+}
+
+// TestEmbedJobUnresolvableScopeSignalsDrift pins the deterministic branch:
+// a configured account that was removed or became ambiguous
+// (vector.ErrScopeUnresolvable) cannot heal on retry, so beyond skipping
+// the run it must latch searches stale via OnScopeDrift — otherwise the
+// daemon would keep serving vectors for cached source IDs that no longer
+// correspond to the configuration.
+func TestEmbedJobUnresolvableScopeSignalsDrift(t *testing.T) {
+	assert := assert.New(t)
+	runner := &fakeRunner{}
+	var driftDetail string
+	job := &EmbedJob{
+		Worker:     runner,
+		Backend:    &fakeBackend{},
+		BuildScope: vector.NewBuildScope(nil, []int64{7}),
+		ResolveBuildScope: func() (vector.BuildScope, error) {
+			return vector.BuildScope{}, fmt.Errorf("%w: no account found for %q",
+				vector.ErrScopeUnresolvable, "gone@example.com")
+		},
+		OnScopeDrift: func(detail string) { driftDetail = detail },
+	}
+
+	job.Run(context.Background())
+	assert.Equal(0, runner.runCalls, "unresolvable scope must stop before embedding")
+	assert.Contains(driftDetail, "gone@example.com", "the latch detail names the unresolvable account")
+	assert.Contains(driftDetail, "[vector.embed.scope]", "the latch detail names the recovery path")
+}

--- a/internal/store/embed_gen.go
+++ b/internal/store/embed_gen.go
@@ -38,16 +38,17 @@ var embedGenStampChunkRows = 500
 // the embeddings upsert — the worker orders the steps (upsert, then
 // stamp) and relies on idempotency, see internal/vector/embed/worker.go.
 func (s *Store) ScanForEmbedding(ctx context.Context, target int64, afterID int64, limit int) ([]int64, error) {
-	return s.ScanForEmbeddingScoped(ctx, target, afterID, limit, nil)
+	return s.ScanForEmbeddingScoped(ctx, target, afterID, limit, nil, nil)
 }
 
 // ScanForEmbeddingScoped is ScanForEmbedding limited to the supplied message
-// types. An empty messageTypes slice means the full live corpus.
-func (s *Store) ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string) ([]int64, error) {
+// types and source IDs. Empty messageTypes and sourceIDs slices mean the
+// full live corpus.
+func (s *Store) ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string, sourceIDs []int64) ([]int64, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
-	liveWhere, liveArgs := liveMessagesWhereWithMessageTypes(messageTypes)
+	liveWhere, liveArgs := liveMessagesWhereScoped(messageTypes, sourceIDs)
 	q := `SELECT id FROM messages
 	       WHERE (embed_gen IS NULL OR embed_gen <> ?)
 	         AND ` + liveWhere + `
@@ -471,18 +472,19 @@ func (s *Store) ResetEmbedGen(ctx context.Context, ids []int64) error {
 // activeGen == 0 means "no active/target generation"; then everything
 // live is missing and stamped is 0.
 func (s *Store) CoverageCounts(ctx context.Context, activeGen int64) (live, stamped, blank, missing int64, err error) {
-	return s.CoverageCountsScoped(ctx, activeGen, nil)
+	return s.CoverageCountsScoped(ctx, activeGen, nil, nil)
 }
 
-// CoverageCountsScoped is CoverageCounts limited to the supplied message types.
-// An empty messageTypes slice means the full live corpus.
-func (s *Store) CoverageCountsScoped(ctx context.Context, activeGen int64, messageTypes []string) (live, stamped, blank, missing int64, err error) {
-	live, err = s.countLiveMessagesScoped(ctx, messageTypes)
+// CoverageCountsScoped is CoverageCounts limited to the supplied message
+// types and source IDs. Empty messageTypes and sourceIDs slices mean the
+// full live corpus.
+func (s *Store) CoverageCountsScoped(ctx context.Context, activeGen int64, messageTypes []string, sourceIDs []int64) (live, stamped, blank, missing int64, err error) {
+	live, err = s.countLiveMessagesScoped(ctx, messageTypes, sourceIDs)
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}
 	if activeGen != 0 {
-		liveWhere, liveArgs := liveMessagesWhereWithMessageTypes(messageTypes)
+		liveWhere, liveArgs := liveMessagesWhereScoped(messageTypes, sourceIDs)
 		q := `SELECT COUNT(*) FROM messages
 		       WHERE embed_gen = ? AND ` + liveWhere
 		args := append([]any{activeGen}, liveArgs...)
@@ -547,13 +549,14 @@ func (s *Store) ContextualConvergenceCounts(ctx context.Context, activeGen int64
 // activeGen). It is a thin accessor for the scheduler/CLI activation
 // gates, which only consult the missing count; missing = live - stamped.
 func (s *Store) MissingCount(ctx context.Context, activeGen int64) (int64, error) {
-	return s.MissingCountScoped(ctx, activeGen, nil)
+	return s.MissingCountScoped(ctx, activeGen, nil, nil)
 }
 
-// MissingCountScoped is MissingCount limited to the supplied message types.
-// An empty messageTypes slice means the full live corpus.
-func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string) (int64, error) {
-	live, err := s.countLiveMessagesScoped(ctx, messageTypes)
+// MissingCountScoped is MissingCount limited to the supplied message types
+// and source IDs. Empty messageTypes and sourceIDs slices mean the full
+// live corpus.
+func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, messageTypes []string, sourceIDs []int64) (int64, error) {
+	live, err := s.countLiveMessagesScoped(ctx, messageTypes, sourceIDs)
 	if err != nil {
 		return 0, err
 	}
@@ -561,7 +564,7 @@ func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, message
 		return live, nil
 	}
 	var stamped int64
-	liveWhere, liveArgs := liveMessagesWhereWithMessageTypes(messageTypes)
+	liveWhere, liveArgs := liveMessagesWhereScoped(messageTypes, sourceIDs)
 	q := `SELECT COUNT(*) FROM messages
 	       WHERE embed_gen = ? AND ` + liveWhere
 	args := append([]any{activeGen}, liveArgs...)
@@ -573,9 +576,9 @@ func (s *Store) MissingCountScoped(ctx context.Context, activeGen int64, message
 
 // countLiveMessages returns the total live-message count. Shared by
 // CoverageCounts; kept separate so the live-predicate stays in one place.
-func (s *Store) countLiveMessagesScoped(ctx context.Context, messageTypes []string) (int64, error) {
+func (s *Store) countLiveMessagesScoped(ctx context.Context, messageTypes []string, sourceIDs []int64) (int64, error) {
 	var n int64
-	liveWhere, args := liveMessagesWhereWithMessageTypes(messageTypes)
+	liveWhere, args := liveMessagesWhereScoped(messageTypes, sourceIDs)
 	q := `SELECT COUNT(*) FROM messages WHERE ` + liveWhere
 	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
 		return 0, fmt.Errorf("count live messages: %w", err)
@@ -583,19 +586,30 @@ func (s *Store) countLiveMessagesScoped(ctx context.Context, messageTypes []stri
 	return n, nil
 }
 
-func liveMessagesWhereWithMessageTypes(messageTypes []string) (string, []any) {
+// liveMessagesWhereScoped builds the live-messages predicate narrowed by the
+// embed build scope: message_type IN (...) and/or source_id IN (...). Empty
+// slices leave that dimension unrestricted.
+func liveMessagesWhereScoped(messageTypes []string, sourceIDs []int64) (string, []any) {
 	where := LiveMessagesWhere("", true)
+	var args []any
 	types := normalizeMessageTypes(messageTypes)
-	if len(types) == 0 {
-		return where, nil
+	if len(types) > 0 {
+		placeholders := make([]string, len(types))
+		for i, typ := range types {
+			placeholders[i] = "?"
+			args = append(args, typ)
+		}
+		where += " AND message_type IN (" + strings.Join(placeholders, ",") + ")"
 	}
-	placeholders := make([]string, len(types))
-	args := make([]any, len(types))
-	for i, typ := range types {
-		placeholders[i] = "?"
-		args[i] = typ
+	ids := normalizeScopeSourceIDs(sourceIDs)
+	if len(ids) > 0 {
+		placeholders := make([]string, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		where += " AND source_id IN (" + strings.Join(placeholders, ",") + ")"
 	}
-	where += " AND message_type IN (" + strings.Join(placeholders, ",") + ")"
 	return where, args
 }
 
@@ -615,6 +629,27 @@ func normalizeMessageTypes(messageTypes []string) []string {
 		}
 		seen[typ] = struct{}{}
 		out = append(out, typ)
+	}
+	return out
+}
+
+// normalizeScopeSourceIDs de-duplicates scope source IDs and drops
+// non-positive values so the IN clause binds a minimal, valid set.
+func normalizeScopeSourceIDs(sourceIDs []int64) []int64 {
+	if len(sourceIDs) == 0 {
+		return nil
+	}
+	seen := make(map[int64]struct{}, len(sourceIDs))
+	out := make([]int64, 0, len(sourceIDs))
+	for _, id := range sourceIDs {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
 	return out
 }

--- a/internal/store/embed_gen_test.go
+++ b/internal/store/embed_gen_test.go
@@ -1,0 +1,123 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// embedScopeFixture builds two sources with three live messages each (plus
+// one soft-deleted message in the first source) so scoped scan/coverage
+// tests can prove the source filter neither leaks across accounts nor
+// counts dead rows.
+type embedScopeFixture struct {
+	srcA     *store.Source
+	srcB     *store.Source
+	msgsA    []int64
+	msgsB    []int64
+	deletedA int64
+}
+
+func seedEmbedScopeFixture(t *testing.T, st *store.Store) embedScopeFixture {
+	t.Helper()
+	var fx embedScopeFixture
+	var err error
+	fx.srcA, err = st.GetOrCreateSource("gmail", "alice@example.com")
+	require.NoError(t, err, "GetOrCreateSource alice")
+	fx.srcB, err = st.GetOrCreateSource("gmail", "bob@example.com")
+	require.NoError(t, err, "GetOrCreateSource bob")
+
+	seed := func(src *store.Source, smidPrefix string, n int) []int64 {
+		convID, err := st.EnsureConversationWithType(src.ID, "conv-"+src.Identifier, "email_thread", "Subject")
+		require.NoError(t, err, "EnsureConversationWithType")
+		ids := make([]int64, 0, n)
+		for i := range n {
+			id, err := st.UpsertMessage(&store.Message{
+				SourceID:        src.ID,
+				SourceMessageID: fmt.Sprintf("%s-%d", smidPrefix, i),
+				ConversationID:  convID,
+				MessageType:     "email",
+				Subject:         sql.NullString{String: "s", Valid: true},
+			})
+			require.NoError(t, err, "UpsertMessage")
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	fx.msgsA = seed(fx.srcA, "alice", 3)
+	fx.msgsB = seed(fx.srcB, "bob", 3)
+
+	// One soft-deleted message in source A: live predicates must exclude it.
+	fx.deletedA = seed(fx.srcA, "alice-deleted", 1)[0]
+	_, err = st.DB().Exec(st.Rebind(
+		`UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`), fx.deletedA)
+	require.NoError(t, err, "soft-delete message")
+	return fx
+}
+
+func TestScanForEmbeddingScopedFiltersBySource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fx := seedEmbedScopeFixture(t, st)
+	ctx := context.Background()
+
+	scoped, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, nil, []int64{fx.srcA.ID})
+	require.NoError(err, "ScanForEmbeddingScoped")
+	assert.Equal(fx.msgsA, scoped,
+		"only source A's live messages need embedding for gen 1")
+
+	both, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, nil, []int64{fx.srcA.ID, fx.srcB.ID})
+	require.NoError(err, "ScanForEmbeddingScoped two sources")
+	assert.Equal(append(append([]int64(nil), fx.msgsA...), fx.msgsB...), both)
+
+	unscoped, err := st.ScanForEmbedding(ctx, 1, 0, 100)
+	require.NoError(err, "ScanForEmbedding")
+	assert.Len(unscoped, 6, "unscoped scan covers both sources")
+
+	none, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, nil, []int64{9999})
+	require.NoError(err, "ScanForEmbeddingScoped unknown source")
+	assert.Empty(none, "a source with no messages scans empty")
+}
+
+func TestCoverageCountsScopedFiltersBySource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fx := seedEmbedScopeFixture(t, st)
+	ctx := context.Background()
+
+	require.NoError(st.SetEmbedGen(ctx, fx.msgsA[:2], 7), "stamp two of A's messages")
+
+	live, stamped, _, missing, err := st.CoverageCountsScoped(ctx, 7, nil, []int64{fx.srcA.ID})
+	require.NoError(err, "CoverageCountsScoped")
+	assert.Equal(int64(3), live, "live within source A (deleted row excluded)")
+	assert.Equal(int64(2), stamped, "stamped within source A")
+	assert.Equal(int64(1), missing, "missing within source A")
+
+	missingB, err := st.MissingCountScoped(ctx, 7, nil, []int64{fx.srcB.ID})
+	require.NoError(err, "MissingCountScoped")
+	assert.Equal(int64(3), missingB, "all of source B's messages are missing for gen 7")
+}
+
+func TestScopedFiltersComposeMessageTypesAndSources(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	fx := seedEmbedScopeFixture(t, st)
+	ctx := context.Background()
+
+	// Reclassify one of A's messages as a different type.
+	_, err := st.DB().Exec(st.Rebind(
+		`UPDATE messages SET message_type = 'sms' WHERE id = ?`), fx.msgsA[0])
+	require.NoError(t, err, "reclassify message type")
+
+	emailA, err := st.ScanForEmbeddingScoped(ctx, 1, 0, 100, []string{"email"}, []int64{fx.srcA.ID})
+	require.NoError(t, err, "ScanForEmbeddingScoped type+source")
+	assert.Equal(t, fx.msgsA[1:], emailA,
+		"the sms-typed message drops out of the email×A intersection")
+}

--- a/internal/vector/build_scope.go
+++ b/internal/vector/build_scope.go
@@ -2,7 +2,7 @@ package vector
 
 import (
 	"slices"
-	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -10,12 +10,19 @@ import (
 // generation. A zero-value scope means the full corpus.
 type BuildScope struct {
 	MessageTypes []string
+	// SourceIDs restricts the build to messages belonging to the given
+	// sources (accounts). Source IDs are DB-local integers: deterministic
+	// within one archive, but deleting and re-adding an account (or
+	// restoring a backup) can renumber them, which changes the scope
+	// fingerprint and forces a rebuild.
+	SourceIDs []int64
 }
 
 // NewBuildScope returns a normalized, stable scope. Message types are
-// lowercase, trimmed, de-duplicated, and sorted so fingerprints and SQL
-// bindings are deterministic.
-func NewBuildScope(messageTypes []string) BuildScope {
+// lowercase, trimmed, de-duplicated, and sorted; source IDs are
+// de-duplicated, sorted ascending, with non-positive IDs dropped — so
+// fingerprints and SQL bindings are deterministic.
+func NewBuildScope(messageTypes []string, sourceIDs []int64) BuildScope {
 	seen := make(map[string]struct{}, len(messageTypes))
 	out := make([]string, 0, len(messageTypes))
 	for _, typ := range messageTypes {
@@ -29,19 +36,50 @@ func NewBuildScope(messageTypes []string) BuildScope {
 		seen[typ] = struct{}{}
 		out = append(out, typ)
 	}
-	sort.Strings(out)
-	return BuildScope{MessageTypes: out}
+	slices.Sort(out)
+
+	idSeen := make(map[int64]struct{}, len(sourceIDs))
+	ids := make([]int64, 0, len(sourceIDs))
+	for _, id := range sourceIDs {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := idSeen[id]; ok {
+			continue
+		}
+		idSeen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return BuildScope{MessageTypes: out, SourceIDs: ids}
 }
 
 func (s BuildScope) IsEmpty() bool {
-	return len(s.MessageTypes) == 0
+	return len(s.MessageTypes) == 0 && len(s.SourceIDs) == 0
 }
 
+// Fingerprint renders the scope as "mt-<types>" and/or "src-<ids>" segments
+// joined by ":". The empty scope fingerprints to "".
 func (s BuildScope) Fingerprint() string {
 	if s.IsEmpty() {
 		return ""
 	}
-	return "mt-" + strings.Join(s.MessageTypes, ",")
+	segs := make([]string, 0, 2)
+	if len(s.MessageTypes) > 0 {
+		segs = append(segs, "mt-"+strings.Join(s.MessageTypes, ","))
+	}
+	if len(s.SourceIDs) > 0 {
+		var b strings.Builder
+		b.WriteString("src-")
+		for i, id := range s.SourceIDs {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(strconv.FormatInt(id, 10))
+		}
+		segs = append(segs, b.String())
+	}
+	return strings.Join(segs, ":")
 }
 
 func (s BuildScope) ContainsMessageType(messageType string) bool {
@@ -49,8 +87,15 @@ func (s BuildScope) ContainsMessageType(messageType string) bool {
 	return slices.Contains(s.MessageTypes, messageType)
 }
 
+func (s BuildScope) ContainsSource(sourceID int64) bool {
+	return slices.Contains(s.SourceIDs, sourceID)
+}
+
+// AllowsMessageTypes reports whether the scope's message-type dimension
+// permits all the given types. A scope with no message-type restriction
+// (including a sources-only scope) allows everything.
 func (s BuildScope) AllowsMessageTypes(messageTypes []string) bool {
-	if s.IsEmpty() {
+	if len(s.MessageTypes) == 0 {
 		return true
 	}
 	if len(messageTypes) == 0 {

--- a/internal/vector/build_scope_test.go
+++ b/internal/vector/build_scope_test.go
@@ -1,0 +1,49 @@
+package vector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBuildScopeNormalizesSourceIDs(t *testing.T) {
+	scope := NewBuildScope(nil, []int64{7, 3, 7, 0, -2, 3})
+	assert.Equal(t, []int64{3, 7}, scope.SourceIDs,
+		"source IDs are deduped, sorted ascending, and non-positive IDs dropped")
+	assert.False(t, scope.IsEmpty(), "a sources-only scope is not empty")
+}
+
+func TestBuildScopeIsEmpty(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(NewBuildScope(nil, nil).IsEmpty())
+	assert.True(NewBuildScope([]string{""}, []int64{0}).IsEmpty(),
+		"normalization dropping every entry leaves the scope empty")
+	assert.False(NewBuildScope([]string{"email"}, nil).IsEmpty())
+	assert.False(NewBuildScope(nil, []int64{1}).IsEmpty())
+}
+
+func TestBuildScopeFingerprint(t *testing.T) {
+	assert := assert.New(t)
+	assert.Empty(NewBuildScope(nil, nil).Fingerprint())
+	assert.Equal("mt-email,sms", NewBuildScope([]string{"sms", "email"}, nil).Fingerprint())
+	assert.Equal("src-3,7", NewBuildScope(nil, []int64{7, 3}).Fingerprint())
+	assert.Equal("mt-email:src-3,7",
+		NewBuildScope([]string{"email"}, []int64{7, 3}).Fingerprint(),
+		"both dimensions appear, message types first, each normalized")
+}
+
+func TestBuildScopeContainsSource(t *testing.T) {
+	assert := assert.New(t)
+	scope := NewBuildScope(nil, []int64{3, 7})
+	assert.True(scope.ContainsSource(3))
+	assert.True(scope.ContainsSource(7))
+	assert.False(scope.ContainsSource(4))
+	assert.False(NewBuildScope(nil, nil).ContainsSource(3),
+		"an unrestricted scope contains no explicit source")
+}
+
+func TestBuildScopeAllowsMessageTypesWithSourcesOnlyScope(t *testing.T) {
+	scope := NewBuildScope(nil, []int64{3})
+	assert.True(t, scope.AllowsMessageTypes([]string{"email"}),
+		"a sources-only scope imposes no message-type restriction")
+}

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -251,10 +251,21 @@ type EmbedScheduleConfig struct {
 // embedding generations. The zero value means the full corpus.
 type EmbedScopeConfig struct {
 	MessageTypes []string `toml:"message_types"`
+	// Accounts limits embedding to the given account identifiers (the same
+	// syntax the --account flag accepts). Identifiers live in config rather
+	// than source IDs so the file survives archive rebuilds that renumber
+	// sources; the command layer resolves them to SourceIDs against the
+	// open store at startup, where unknown identifiers are a hard error.
+	Accounts []string `toml:"accounts"`
+	// SourceIDs is the resolved form of Accounts (or of a CLI
+	// --account/--collection override), filled in by the command layer
+	// before the scope is used for building, coverage, or fingerprinting.
+	// It is never read from TOML.
+	SourceIDs []int64 `toml:"-"`
 }
 
 func (s EmbedScopeConfig) BuildScope() BuildScope {
-	return NewBuildScope(s.MessageTypes)
+	return NewBuildScope(s.MessageTypes, s.SourceIDs)
 }
 
 // Fingerprint returns the "<model>:<dimension>" identifier for the

--- a/internal/vector/config_test.go
+++ b/internal/vector/config_test.go
@@ -485,3 +485,27 @@ func TestConfig_GenerationFingerprint_IncludesEmbedScope(t *testing.T) {
 	assert.Contains(t, scoped.GenerationFingerprint(), ":smt-mms,sms",
 		"scope fingerprint should normalize and sort message types")
 }
+
+// TestConfig_GenerationFingerprint_IncludesEmbedScopeSources pins the account
+// dimension: resolved source IDs fold into the generation fingerprint, so an
+// account-scoped build never shares a generation with a full-corpus one.
+func TestConfig_GenerationFingerprint_IncludesEmbedScopeSources(t *testing.T) {
+	base := Config{
+		Embeddings: EmbeddingsConfig{Model: "m", Dimension: 8, MaxInputChars: 6000},
+	}
+	baseline := base.GenerationFingerprint()
+
+	scoped := base
+	scoped.Embed.Scope.SourceIDs = []int64{7, 3, 7}
+
+	assert.NotEqual(t, baseline, scoped.GenerationFingerprint(),
+		"GenerationFingerprint should change when embedding is scoped to accounts")
+	assert.Contains(t, scoped.GenerationFingerprint(), ":ssrc-3,7",
+		"scope fingerprint should normalize and sort source IDs")
+
+	combined := base
+	combined.Embed.Scope.MessageTypes = []string{"email"}
+	combined.Embed.Scope.SourceIDs = []int64{3}
+	assert.Contains(t, combined.GenerationFingerprint(), ":smt-email:src-3",
+		"message types and source IDs compose in one scope fingerprint")
+}

--- a/internal/vector/embed/assemble.go
+++ b/internal/vector/embed/assemble.go
@@ -38,8 +38,12 @@ type AssemblyPolicy struct {
 // LastModified remains dialect-native so the later coverage CAS can bind the
 // exact value read in this transaction.
 type AssemblyMessage struct {
-	ID                int64
-	ConversationID    int64
+	ID             int64
+	ConversationID int64
+	// SourceID is populated by the routing reads (MessageMeta) so scope
+	// checks can enforce the account dimension of the build scope; the
+	// body-loading queries leave it zero.
+	SourceID          int64
 	MessageType       string
 	Subject           string
 	Body              string
@@ -177,7 +181,7 @@ func (s SourceSnapshot) MessageMeta(ctx context.Context, id int64) (AssemblyMess
 		return AssemblyMessage{}, false, ErrSourceSnapshotClosed
 	}
 	query := s.state.rebind(`
-		SELECT m.id, m.conversation_id, COALESCE(m.message_type, ''),
+		SELECT m.id, m.conversation_id, m.source_id, COALESCE(m.message_type, ''),
 		       m.sent_at, m.received_at, m.internal_date
 		FROM messages m
 		WHERE m.id = ? AND m.deleted_at IS NULL
@@ -185,7 +189,7 @@ func (s SourceSnapshot) MessageMeta(ctx context.Context, id int64) (AssemblyMess
 	var row AssemblyMessage
 	var sentAt, receivedAt, internalDate sql.NullTime
 	err := s.state.tx.QueryRowContext(ctx, query, id).Scan(
-		&row.ID, &row.ConversationID, &row.MessageType, &sentAt, &receivedAt, &internalDate)
+		&row.ID, &row.ConversationID, &row.SourceID, &row.MessageType, &sentAt, &receivedAt, &internalDate)
 	if errors.Is(err, sql.ErrNoRows) {
 		return AssemblyMessage{}, false, nil
 	}
@@ -195,6 +199,30 @@ func (s SourceSnapshot) MessageMeta(ctx context.Context, id int64) (AssemblyMess
 	row.SentAt = firstValidTime(sentAt, receivedAt, internalDate)
 	row.SourceSequence = s.state.sourceSequence
 	return row, true, nil
+}
+
+// ConversationSourceID reads the owning source of a conversation, for
+// account-scope checks on conversation-level scopes (chat blocks) whose
+// selectors carry no message ID.
+func (s SourceSnapshot) ConversationSourceID(ctx context.Context, conversationID int64) (int64, bool, error) {
+	if s.state == nil {
+		return 0, false, ErrSourceSnapshotClosed
+	}
+	s.state.mu.RLock()
+	defer s.state.mu.RUnlock()
+	if s.state.closed {
+		return 0, false, ErrSourceSnapshotClosed
+	}
+	var sourceID int64
+	err := s.state.tx.QueryRowContext(ctx,
+		s.state.rebind(`SELECT source_id FROM conversations WHERE id = ?`), conversationID).Scan(&sourceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("read embedding conversation source %d: %w", conversationID, err)
+	}
+	return sourceID, true, nil
 }
 
 // Messages returns the complete live message set selected by one persisted

--- a/internal/vector/embed/context_worker.go
+++ b/internal/vector/embed/context_worker.go
@@ -649,20 +649,53 @@ func (w *ContextWorker) prepareScopes(ctx context.Context, snapshot SourceSnapsh
 	return out, nil
 }
 
+// messageTypeInScope enforces only the message-type dimension of a build
+// scope. Each dimension must be checked independently: ContainsMessageType
+// on a source-only scope (empty MessageTypes) returns false for every type
+// and would wrongly reject the whole archive.
+func messageTypeInScope(scope vector.BuildScope, messageType string) bool {
+	return len(scope.MessageTypes) == 0 || scope.ContainsMessageType(messageType)
+}
+
+// selectorInBuildScope is the authoritative scope gate: every publication
+// path funnels its selectors through prepareScopes, which uses this to
+// decide whether a scope's text may be assembled and sent to the embedding
+// provider (a disallowed scope is still published as a tombstone so
+// moved-out content is removed). Both scope dimensions are enforced —
+// message type from the selector or row, and the account dimension from
+// the message's or conversation's source.
 func (w *ContextWorker) selectorInBuildScope(
 	ctx context.Context, snapshot SourceSnapshot, selector AffectedScope,
 ) (bool, error) {
-	if w.deps.BuildScope.IsEmpty() {
+	scope := w.deps.BuildScope
+	if scope.IsEmpty() {
 		return true, nil
 	}
-	if selector.MessageID == 0 {
-		return w.deps.BuildScope.ContainsMessageType(selector.Kind), nil
+	if selector.MessageID != 0 {
+		row, found, err := snapshot.MessageMeta(ctx, selector.MessageID)
+		if err != nil {
+			return false, err
+		}
+		return found && messageTypeInScope(scope, row.MessageType) &&
+			(len(scope.SourceIDs) == 0 || scope.ContainsSource(row.SourceID)), nil
 	}
-	row, found, err := snapshot.Message(ctx, selector.MessageID)
+	if !messageTypeInScope(scope, selector.Kind) {
+		return false, nil
+	}
+	if len(scope.SourceIDs) == 0 {
+		return true, nil
+	}
+	if selector.ConversationID == 0 {
+		// No source identity to prove membership against an account-scoped
+		// build; fail closed so unattributable text cannot leak to the
+		// embedding provider.
+		return false, nil
+	}
+	sourceID, found, err := snapshot.ConversationSourceID(ctx, selector.ConversationID)
 	if err != nil {
 		return false, err
 	}
-	return found && w.deps.BuildScope.ContainsMessageType(row.MessageType), nil
+	return found && scope.ContainsSource(sourceID), nil
 }
 
 func (w *ContextWorker) publishPreparedScopes(ctx context.Context, gen vector.GenerationID, scopes []preparedScope, res *RunResult) (int, error) {
@@ -1445,7 +1478,7 @@ func (s SourceSnapshot) scopesForChanges(
 			if err != nil {
 				return nil, err
 			}
-			if buildScope.IsEmpty() || (change.OldMessageType.Valid && buildScope.ContainsMessageType(change.OldMessageType.String)) {
+			if buildScope.IsEmpty() || (change.OldMessageType.Valid && messageTypeInScope(buildScope, change.OldMessageType.String)) {
 				oldScope, ok, err := persistedMessageScope(
 					id, change.OldMessageType, change.OldConversationID, change.OldSentAt, true,
 				)
@@ -1459,7 +1492,7 @@ func (s SourceSnapshot) scopesForChanges(
 					}
 				}
 			}
-			if buildScope.IsEmpty() || (change.NewMessageType.Valid && buildScope.ContainsMessageType(change.NewMessageType.String)) {
+			if buildScope.IsEmpty() || (change.NewMessageType.Valid && messageTypeInScope(buildScope, change.NewMessageType.String)) {
 				newScope, ok, err := persistedMessageScope(
 					id, change.NewMessageType, change.NewConversationID, change.NewSentAt, true,
 				)
@@ -1473,12 +1506,12 @@ func (s SourceSnapshot) scopesForChanges(
 					}
 				}
 			}
-			if found && (buildScope.IsEmpty() || buildScope.ContainsMessageType(row.MessageType)) {
+			if found && messageTypeInScope(buildScope, row.MessageType) {
 				add(liveMessageScope(row))
 			} else if !change.OldMessageType.Valid && !change.NewMessageType.Valid {
 				return nil, fmt.Errorf("embedding change %d for missing message %d has no persisted message type", change.Sequence, id)
 			}
-			if (buildScope.IsEmpty() || buildScope.ContainsMessageType(contextualChatMessageType)) &&
+			if messageTypeInScope(buildScope, contextualChatMessageType) &&
 				(oldChat != newChat || oldChatKey != newChatKey) {
 				for _, conversation := range []sql.NullInt64{change.OldConversationID, change.NewConversationID} {
 					if conversation.Valid {
@@ -1650,7 +1683,7 @@ func (s SourceSnapshot) metadataScopesAfter(
 	afterKey string,
 	limit int,
 ) ([]contextScope, bool, error) {
-	if !buildScope.IsEmpty() && !buildScope.ContainsMessageType(contextualChatMessageType) {
+	if !messageTypeInScope(buildScope, contextualChatMessageType) {
 		return nil, false, nil
 	}
 	if limit <= 0 {
@@ -1666,6 +1699,19 @@ func (s SourceSnapshot) metadataScopesAfter(
 		`m.message_type = 'beeper'`,
 		`m.deleted_at IS NULL`,
 		`m.deleted_from_source_at IS NULL`,
+	}
+	args := make([]any, 0)
+	// Narrow metadata fan-out by the account dimension up front: an
+	// out-of-scope conversation would only be tombstoned downstream, and a
+	// title change on a large excluded archive must not enumerate (and
+	// fence) every one of its chat blocks.
+	if len(buildScope.SourceIDs) > 0 {
+		placeholders := make([]string, len(buildScope.SourceIDs))
+		for i, sourceID := range buildScope.SourceIDs {
+			placeholders[i] = "?"
+			args = append(args, sourceID)
+		}
+		where = append(where, `m.source_id IN (`+strings.Join(placeholders, ",")+`)`)
 	}
 	// Mutable remote titles and participant metadata must not invalidate an
 	// entire chat archive. Limit metadata-only fanout to the newest stable
@@ -1683,7 +1729,6 @@ func (s SourceSnapshot) metadataScopesAfter(
 	) - 1) / ` + strconv.Itoa(chatScopeMaxMessages) + `) * ` +
 		strconv.Itoa(chatScopeMaxMessages) + ` + 1)`
 	where = append(where, `m.id >= `+latestBlockStartExpr)
-	args := make([]any, 0)
 	switch change.Kind {
 	case store.EmbeddingChangeConversationTitle, store.EmbeddingChangeConversationParticipant:
 		seen := make(map[int64]struct{})
@@ -1884,13 +1929,23 @@ func (s SourceSnapshot) sourceScopesAfter(
 ) ([]contextScope, int64, bool, int, error) {
 	query := `SELECT m.id,COALESCE(m.message_type,''),m.conversation_id,COALESCE(m.sent_at,m.received_at,m.internal_date) FROM messages m WHERE m.deleted_at IS NULL AND m.deleted_from_source_at IS NULL AND m.id > ?`
 	args := []any{after}
-	if !buildScope.IsEmpty() {
+	// Each scope dimension narrows independently: gating the type filter on
+	// IsEmpty would render `IN ()` for a source-only scope, and vice versa.
+	if len(buildScope.MessageTypes) > 0 {
 		placeholders := make([]string, len(buildScope.MessageTypes))
 		for i, messageType := range buildScope.MessageTypes {
 			placeholders[i] = "?"
 			args = append(args, messageType)
 		}
 		query += ` AND m.message_type IN (` + strings.Join(placeholders, ",") + `)`
+	}
+	if len(buildScope.SourceIDs) > 0 {
+		placeholders := make([]string, len(buildScope.SourceIDs))
+		for i, sourceID := range buildScope.SourceIDs {
+			placeholders[i] = "?"
+			args = append(args, sourceID)
+		}
+		query += ` AND m.source_id IN (` + strings.Join(placeholders, ",") + `)`
 	}
 	query += ` ORDER BY m.id LIMIT ?`
 	args = append(args, limit)

--- a/internal/vector/embed/context_worker.go
+++ b/internal/vector/embed/context_worker.go
@@ -21,7 +21,7 @@ import (
 type ContextWorkStore interface {
 	ScanEmbeddingChanges(ctx context.Context, after int64, limit int) ([]store.EmbeddingChange, error)
 	LatestEmbeddingChangeSequence(ctx context.Context) (int64, error)
-	ScanForEmbeddingScoped(ctx context.Context, target, afterID int64, limit int, messageTypes []string) ([]int64, error)
+	ScanForEmbeddingScoped(ctx context.Context, target, afterID int64, limit int, messageTypes []string, sourceIDs []int64) ([]int64, error)
 	SetEmbedGenGroupIfUnchanged(ctx context.Context, stamps []store.EmbedGenStamp, metadata store.EmbedGenMetadataVersion, target int64) (bool, error)
 	ResetEmbedGen(ctx context.Context, ids []int64) error
 }
@@ -89,7 +89,7 @@ func NewContextWorker(d ContextWorkerDeps) *ContextWorker {
 	if d.MaxRunUTF8Bytes <= 0 {
 		d.MaxRunUTF8Bytes = defaultContextRunUTF8Bytes
 	}
-	d.BuildScope = vector.NewBuildScope(d.BuildScope.MessageTypes)
+	d.BuildScope = vector.NewBuildScope(d.BuildScope.MessageTypes, d.BuildScope.SourceIDs)
 	source, _ := d.Store.(*store.Store)
 	return &ContextWorker{deps: d, source: source}
 }
@@ -518,7 +518,8 @@ func (w *ContextWorker) drainOrdinaryDiscovery(ctx context.Context, gen vector.G
 	for {
 		pageAfter := after
 		ids, err := w.deps.Store.ScanForEmbeddingScoped(
-			ctx, int64(gen), after, w.deps.ChangeBatchSize, w.deps.BuildScope.MessageTypes,
+			ctx, int64(gen), after, w.deps.ChangeBatchSize,
+			w.deps.BuildScope.MessageTypes, w.deps.BuildScope.SourceIDs,
 		)
 		if err != nil {
 			return fmt.Errorf("scan contextual ordinary discovery: %w", err)

--- a/internal/vector/embed/context_worker_test.go
+++ b/internal/vector/embed/context_worker_test.go
@@ -392,7 +392,7 @@ func TestContextWorker_SourceScopeNeverSubmitsExcludedAccountBody(t *testing.T) 
 	assert.Equal(1, f.client.Documents(), "only the in-scope chat document reaches the client")
 	_, err = f.backend.GetDocument(context.Background(), f.gen,
 		fmt.Sprintf("message:%d", excludedMail))
-	assert.Error(err, "excluded ordinary message must publish no document")
+	require.Error(err, "excluded ordinary message must publish no document")
 	_ = excludedChat
 	_ = included
 
@@ -409,7 +409,7 @@ func TestContextWorker_SourceScopeNeverSubmitsExcludedAccountBody(t *testing.T) 
 	assert.Equal(1, f.client.Documents(), "journal drain must add no excluded documents")
 	_, err = f.backend.GetDocument(context.Background(), f.gen,
 		fmt.Sprintf("message:%d", journalMail))
-	assert.Error(err, "journal-delivered excluded message must publish no document")
+	require.Error(err, "journal-delivered excluded message must publish no document")
 	_ = journalChat
 }
 

--- a/internal/vector/embed/context_worker_test.go
+++ b/internal/vector/embed/context_worker_test.go
@@ -230,10 +230,14 @@ func newContextWorkerFixture(t *testing.T, mutate func(*ContextWorkerDeps)) *con
 }
 
 func (f *contextWorkerFixture) seed(kind string, conversationID int64, at time.Time, body string) int64 {
+	return f.seedForSource(f.sourceID, kind, conversationID, at, body)
+}
+
+func (f *contextWorkerFixture) seedForSource(sourceID int64, kind string, conversationID int64, at time.Time, body string) int64 {
 	f.t.Helper()
 	f.sequence++
 	id, err := f.store.UpsertMessage(&store.Message{
-		ConversationID: conversationID, SourceID: f.sourceID,
+		ConversationID: conversationID, SourceID: sourceID,
 		SourceMessageID: fmt.Sprintf("%s-%d", kind, f.sequence), MessageType: kind,
 		SentAt:   sql.NullTime{Time: at, Valid: !at.IsZero()},
 		SenderID: sql.NullInt64{Int64: f.personID, Valid: true},
@@ -355,6 +359,58 @@ func TestContextWorker_BuildScopeNeverSubmitsExcludedBody(t *testing.T) {
 	assert.Equal(1, f.client.Documents(), "only the in-scope chat document reaches the client")
 	_, err = f.backend.GetDocument(context.Background(), f.gen, fmt.Sprintf("message:%d", excludedID))
 	assert.Error(err)
+}
+
+// TestContextWorker_SourceScopeNeverSubmitsExcludedAccountBody pins the
+// account dimension of the contextual privacy boundary: with a source-only
+// build scope, an excluded account's message text must never reach the
+// embedding client (the fake errors if it does) and must publish no
+// document, while the in-scope account still converges. This also proves a
+// source-only scope is not rejected wholesale — each scope dimension is
+// enforced independently, and ContainsMessageType on an empty type list
+// would otherwise veto everything.
+func TestContextWorker_SourceScopeNeverSubmitsExcludedAccountBody(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var included int64
+	f := newContextWorkerFixture(t, nil)
+	other, err := f.store.GetOrCreateSource("test", fmt.Sprintf("excluded-%d", time.Now().UnixNano()))
+	require.NoError(err)
+	otherChat, err := f.store.EnsureConversationWithType(other.ID, "chat-excluded", "beeper", "Excluded Team")
+	require.NoError(err)
+	f.deps.BuildScope = vector.NewBuildScope(nil, []int64{f.sourceID})
+	f.restartWorker()
+
+	included = f.seed("beeper", f.chatID, time.Now().UTC(), "included chat body")
+	excludedChat := f.seedForSource(other.ID, "beeper", otherChat, time.Now().UTC(), "excluded-account-chat-body")
+	excludedMail := f.seedForSource(other.ID, "email", otherChat, time.Now().UTC(), "excluded-account-mail-body")
+	f.client.rejectText = "excluded-account"
+
+	result, err := f.run()
+	require.NoError(err, "excluded-account text reaching the client fails the run")
+	assert.True(result.Contextual.Converged, "a source-only scope must converge, not reject everything")
+	assert.Equal(1, f.client.Documents(), "only the in-scope chat document reaches the client")
+	_, err = f.backend.GetDocument(context.Background(), f.gen,
+		fmt.Sprintf("message:%d", excludedMail))
+	assert.Error(err, "excluded ordinary message must publish no document")
+	_ = excludedChat
+	_ = included
+
+	// Phase two exercises the JOURNAL path: post-convergence mutations reach
+	// scopes through scopesForChanges, whose enumeration is deliberately
+	// unfiltered by source (moved-out scopes must tombstone), so only the
+	// selectorInBuildScope gate stands between an excluded account's text
+	// and the embedding client.
+	journalMail := f.seedForSource(other.ID, "email", otherChat, time.Now().UTC(), "excluded-account-journal-mail")
+	journalChat := f.seedForSource(other.ID, "beeper", otherChat, time.Now().UTC(), "excluded-account-journal-chat")
+	result, err = f.run()
+	require.NoError(err, "journal-delivered excluded-account text must not reach the client")
+	assert.True(result.Contextual.Converged)
+	assert.Equal(1, f.client.Documents(), "journal drain must add no excluded documents")
+	_, err = f.backend.GetDocument(context.Background(), f.gen,
+		fmt.Sprintf("message:%d", journalMail))
+	assert.Error(err, "journal-delivered excluded message must publish no document")
+	_ = journalChat
 }
 
 func TestContextWorker_BuildScopeTombstonesOrdinaryMoveOutWithoutSubmitting(t *testing.T) {

--- a/internal/vector/embed/context_worker_test.go
+++ b/internal/vector/embed/context_worker_test.go
@@ -341,7 +341,7 @@ func TestContextWorker_BuildScopeNeverSubmitsExcludedBody(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	f := newContextWorkerFixture(t, func(deps *ContextWorkerDeps) {
-		deps.BuildScope = vector.NewBuildScope([]string{"beeper"})
+		deps.BuildScope = vector.NewBuildScope([]string{"beeper"}, nil)
 	})
 	conversationID, err := f.store.EnsureConversation(f.sourceID, "excluded-mail", "Excluded")
 	require.NoError(err)
@@ -361,7 +361,7 @@ func TestContextWorker_BuildScopeTombstonesOrdinaryMoveOutWithoutSubmitting(t *t
 	assert := assert.New(t)
 	require := require.New(t)
 	f := newContextWorkerFixture(t, func(deps *ContextWorkerDeps) {
-		deps.BuildScope = vector.NewBuildScope([]string{"sms"})
+		deps.BuildScope = vector.NewBuildScope([]string{"sms"}, nil)
 	})
 	conversationID, err := f.store.EnsureConversation(f.sourceID, "scoped-text", "Scoped")
 	require.NoError(err)

--- a/internal/vector/embed/testsupport_test.go
+++ b/internal/vector/embed/testsupport_test.go
@@ -25,6 +25,8 @@ const testMainSchema = `
 CREATE TABLE messages (
     id INTEGER PRIMARY KEY,
     subject TEXT,
+    source_id INTEGER,
+    message_type TEXT,
     deleted_at DATETIME,
     deleted_from_source_at DATETIME,
     embed_gen INTEGER,
@@ -67,6 +69,48 @@ func (s *testWorkStore) ScanForEmbedding(ctx context.Context, target int64, afte
 		    AND deleted_at IS NULL AND deleted_from_source_at IS NULL
 		    AND id > ?
 		  ORDER BY id LIMIT ?`, target, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// ScanForEmbeddingScoped mirrors store.Store.ScanForEmbeddingScoped: the
+// same needs-work and liveness predicates as ScanForEmbedding, narrowed by
+// message_type and/or source_id when those scope dimensions are non-empty.
+func (s *testWorkStore) ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string, sourceIDs []int64) ([]int64, error) {
+	where := `(embed_gen IS NULL OR embed_gen <> ?)
+	    AND deleted_at IS NULL AND deleted_from_source_at IS NULL
+	    AND id > ?`
+	args := []any{target, afterID}
+	if len(messageTypes) > 0 {
+		ph := make([]string, len(messageTypes))
+		for i, typ := range messageTypes {
+			ph[i] = "?"
+			args = append(args, typ)
+		}
+		where += ` AND message_type IN (` + strings.Join(ph, ",") + `)`
+	}
+	if len(sourceIDs) > 0 {
+		ph := make([]string, len(sourceIDs))
+		for i, id := range sourceIDs {
+			ph[i] = "?"
+			args = append(args, id)
+		}
+		where += ` AND source_id IN (` + strings.Join(ph, ",") + `)`
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM messages WHERE `+where+` ORDER BY id LIMIT ?`,
+		append(args, limit)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vector/embed/worker.go
+++ b/internal/vector/embed/worker.go
@@ -598,17 +598,17 @@ func (w *Worker) run(ctx context.Context, gen vector.GenerationID, backstop bool
 }
 
 func (w *Worker) scanForEmbedding(ctx context.Context, gen int64, afterID int64) ([]int64, error) {
-	scope := vector.NewBuildScope(w.deps.BuildScope.MessageTypes)
+	scope := vector.NewBuildScope(w.deps.BuildScope.MessageTypes, w.deps.BuildScope.SourceIDs)
 	if scope.IsEmpty() {
 		return w.deps.Store.ScanForEmbedding(ctx, gen, afterID, w.deps.BatchSize)
 	}
 	scoped, ok := w.deps.Store.(interface {
-		ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string) ([]int64, error)
+		ScanForEmbeddingScoped(ctx context.Context, target int64, afterID int64, limit int, messageTypes []string, sourceIDs []int64) ([]int64, error)
 	})
 	if !ok {
 		return nil, errors.New("work store does not support scoped embedding scans")
 	}
-	return scoped.ScanForEmbeddingScoped(ctx, gen, afterID, w.deps.BatchSize, scope.MessageTypes)
+	return scoped.ScanForEmbeddingScoped(ctx, gen, afterID, w.deps.BatchSize, scope.MessageTypes, scope.SourceIDs)
 }
 
 // advanceWatermark persists the per-gen forward-scan cursor to id after a

--- a/internal/vector/embed/worker_scope_test.go
+++ b/internal/vector/embed/worker_scope_test.go
@@ -1,0 +1,74 @@
+//go:build sqlite_vec
+
+package embed
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// insertScopedMessage adds a message (with a body, so it embeds rather than
+// skip-stamping as empty) belonging to the given source.
+func insertScopedMessage(t *testing.T, db *sql.DB, id int64, sourceID int64) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO messages (id, subject, source_id, message_type) VALUES (?, ?, ?, 'email')`,
+		id, fmt.Sprintf("msg %d", id), sourceID)
+	require.NoError(t, err, "insert message")
+	_, err = db.Exec(
+		`INSERT INTO message_bodies (message_id, body_text) VALUES (?, ?)`,
+		id, fmt.Sprintf("body %d", id))
+	require.NoError(t, err, "insert body")
+}
+
+// TestWorker_SourceScopeSkipsOutOfScopeMessages runs the drain against a
+// corpus spanning three sources with the build scope pinned to one of them:
+// only in-scope messages may be embedded and stamped, even with a batch size
+// of 1 forcing many scans past out-of-scope rows.
+func TestWorker_SourceScopeSkipsOutOfScopeMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newWorkerFixture(t, 0)
+
+	insertScopedMessage(t, f.MainDB, 1, 1)
+	insertScopedMessage(t, f.MainDB, 2, 2)
+	insertScopedMessage(t, f.MainDB, 3, 2)
+	insertScopedMessage(t, f.MainDB, 4, 3)
+
+	w := NewWorker(WorkerDeps{
+		Backend:    f.Backend,
+		VectorsDB:  f.VectorsDB,
+		MainDB:     f.MainDB,
+		Store:      f.Store,
+		Client:     f.FakeClient,
+		BatchSize:  1,
+		BuildScope: vector.NewBuildScope(nil, []int64{2}),
+	})
+	res, err := w.RunOnce(context.Background(), f.BuildingGen)
+	require.NoError(err, "RunOnce")
+	assert.Equal(2, res.Claimed, "only source 2's messages are claimed")
+	assert.Equal(2, res.Succeeded, "only source 2's messages embed")
+
+	gen := int64(f.BuildingGen)
+	for _, id := range []int64{2, 3} {
+		got, isNull := embedGenOf(t, f.MainDB, id)
+		require.False(isNull, "message %d stamped", id)
+		assert.Equal(gen, got, "message %d stamped for the building generation", id)
+	}
+	for _, id := range []int64{1, 4} {
+		_, isNull := embedGenOf(t, f.MainDB, id)
+		assert.True(isNull, "out-of-scope message %d keeps embed_gen NULL", id)
+	}
+
+	// A second run finds no remaining work for the scoped generation.
+	res, err = w.RunOnce(context.Background(), f.BuildingGen)
+	require.NoError(err, "RunOnce again")
+	assert.Equal(0, res.Claimed, "scoped drain is complete")
+}

--- a/internal/vector/errors.go
+++ b/internal/vector/errors.go
@@ -9,9 +9,10 @@ var (
 	// [vector] is not configured.
 	ErrNotEnabled = errors.New("vector search not enabled")
 
-	// ErrIndexStale is returned when the configured model/dimension
-	// differs from the active generation's fingerprint.
-	ErrIndexStale = errors.New("index stale: configured model does not match active generation")
+	// ErrIndexStale is returned when the configured embedding settings
+	// differ from the active generation's fingerprint. Settings include the
+	// model, preprocessing policy, and embedding scope.
+	ErrIndexStale = errors.New("index stale: configured embedding settings do not match active generation")
 
 	// ErrIndexBuilding is returned when no active generation exists and
 	// a first-ever rebuild is in progress.
@@ -46,6 +47,24 @@ var (
 	// fingerprint, so the caller can surface an actionable message
 	// instead of a raw unique-index violation.
 	ErrBuildingInProgress = errors.New("a rebuild with a different fingerprint is already in progress")
+
+	// ErrScopeUnresolvable marks a DETERMINISTIC failure to re-resolve the
+	// durable embedding scope: a configured account was removed, became
+	// ambiguous, or otherwise no longer names a source set. Unlike a
+	// transient resolution failure (a busy database), this cannot heal on
+	// retry — the daemon's drift detection latches vector search stale so
+	// queries stop serving an index whose scope no longer matches the
+	// configuration.
+	ErrScopeUnresolvable = errors.New("embedding scope unresolvable")
+
+	// ErrRefuseActivateEmptyScope is returned by ActivateGeneration when
+	// force is false and the backend's source-scoped build scope matches no
+	// live messages. Activating would swap in an empty index and auto-retire
+	// the serving generation (deleting its embeddings on pgvector), so every
+	// non-forced activation path — the CLI drain, the daemon scheduler, and
+	// `embeddings activate` — is refused at the backend gate. The usual
+	// cause is a scoped account that exists but has never been synced.
+	ErrRefuseActivateEmptyScope = errors.New("refusing to activate: the source-scoped build scope matches no live messages")
 
 	// ErrRefuseRetireActive is returned by RetireGeneration when force is
 	// false and the target generation is in state='active'. Retiring the

--- a/internal/vector/generations.go
+++ b/internal/vector/generations.go
@@ -10,9 +10,9 @@ import (
 // fingerprint matches the supplied one. Production callers pass
 // Config.GenerationFingerprint() so the preprocessing policy is part
 // of the staleness check; a mismatch means an operator changed the
-// model, dimension, or any preprocess toggle without rebuilding the
-// index, and the active vectors are no longer comparable to what new
-// queries would embed.
+// embedding settings (model, dimension, preprocessing policy, or build
+// scope) without rebuilding the index, or built a one-off scoped generation
+// without making that scope durable in config.
 //
 // Error semantics:
 //   - ErrIndexStale: an active generation exists but its fingerprint

--- a/internal/vector/hybrid/engine.go
+++ b/internal/vector/hybrid/engine.go
@@ -137,7 +137,7 @@ func (e *Engine) BuildFilter(ctx context.Context, q *search.Query) (vector.Filte
 // family of sentinel errors:
 //
 //   - ErrIndexStale: an active generation exists but its fingerprint
-//     differs from the configured model+dimension.
+//     differs from the configured embedding settings.
 //   - ErrIndexBuilding: no active yet, but a build is in progress.
 //   - ErrNotEnabled: no generation at all (vector search unused).
 //
@@ -243,7 +243,11 @@ func (e *Engine) validateBuildScope(filter vector.Filter) error {
 // embedding index. A non-empty build scope only covers those message types, so
 // callers must make the query scope explicit and compatible before running ANN.
 func ValidateBuildScope(buildScope vector.BuildScope, filter vector.Filter) error {
-	scope := vector.NewBuildScope(buildScope.MessageTypes)
+	// Only the message-type dimension is validated. A source-scoped index
+	// simply has no vectors for out-of-scope accounts and hybrid search
+	// degrades to the BM25 signal for them — rejecting those queries would
+	// break ordinary unfiltered search against a partially-embedded corpus.
+	scope := vector.NewBuildScope(buildScope.MessageTypes, nil)
 	if scope.IsEmpty() {
 		return nil
 	}
@@ -255,7 +259,7 @@ func ValidateBuildScope(buildScope vector.BuildScope, filter vector.Filter) erro
 		return fmt.Errorf("%w: index is scoped to message_type=%s, query requested message_type=%s",
 			vector.ErrIndexScopeMismatch,
 			strings.Join(scope.MessageTypes, ","),
-			strings.Join(vector.NewBuildScope(filter.MessageTypes).MessageTypes, ","))
+			strings.Join(vector.NewBuildScope(filter.MessageTypes, nil).MessageTypes, ","))
 	}
 	return nil
 }

--- a/internal/vector/hybrid/engine_test.go
+++ b/internal/vector/hybrid/engine_test.go
@@ -183,7 +183,7 @@ func TestEngine_SearchUsesEmbedQuery(t *testing.T) {
 func TestEngine_ScopedIndexRequiresMatchingMessageTypeFilter(t *testing.T) {
 	ctx := context.Background()
 	f := newEngineFixture(t)
-	f.Engine.cfg.BuildScope = vector.NewBuildScope([]string{"sms", "mms"})
+	f.Engine.cfg.BuildScope = vector.NewBuildScope([]string{"sms", "mms"}, nil)
 
 	_, _, err := f.Engine.Search(ctx, SearchRequest{
 		Mode:     ModeVector,

--- a/internal/vector/pgvector/backend.go
+++ b/internal/vector/pgvector/backend.go
@@ -95,7 +95,7 @@ func Open(ctx context.Context, opts Options) (*Backend, error) {
 	}
 	b := &Backend{
 		db:    opts.DB,
-		scope: vector.NewBuildScope(opts.BuildScope.MessageTypes),
+		scope: vector.NewBuildScope(opts.BuildScope.MessageTypes, opts.BuildScope.SourceIDs),
 	}
 	if !opts.SkipMigrate {
 		// serve / build / search: full migrate incl. CREATE EXTENSION (the
@@ -264,21 +264,61 @@ func isUniqueViolation(err error) bool {
 // ActivateGeneration (in-tx, single-DB on PG) and Stats. The $N ordinal
 // of the generation id is supplied by the caller.
 func (b *Backend) missingForGenExistsClause(genArg string, firstScopeArg int) (string, []any) {
+	where, args := b.missingForGenWhere(genArg, firstScopeArg)
+	return fmt.Sprintf(`EXISTS (
+		SELECT 1 FROM messages
+		 WHERE %s
+	)`, where), args
+}
+
+// missingForGenWhere is the scope-aware predicate for messages that still
+// need embedding for a generation. Keep Stats and ActivateGeneration on this
+// shared predicate so source-scoped generations never report the full corpus
+// as pending.
+func (b *Backend) missingForGenWhere(genArg string, firstScopeArg int) (string, []any) {
+	where, args := b.liveScopeWhere(firstScopeArg)
+	return fmt.Sprintf("(embed_gen IS NULL OR embed_gen <> %s) AND %s", genArg, where), args
+}
+
+// liveScopeWhere is the predicate for live messages inside the backend's
+// build scope — the generation's embedding universe. Shared by the
+// coverage gate (missingForGenWhere) and the empty-scope activation guard
+// so both always agree on what "in scope" means. Scope placeholders are
+// numbered from firstScopeArg.
+func (b *Backend) liveScopeWhere(firstScopeArg int) (string, []any) {
 	where := store.LiveMessagesWhere("", true)
-	args := make([]any, 0, len(b.scope.MessageTypes))
-	if !b.scope.IsEmpty() {
+	args := make([]any, 0, len(b.scope.MessageTypes)+len(b.scope.SourceIDs))
+	nextArg := firstScopeArg
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
-			placeholders[i] = "$" + strconv.Itoa(firstScopeArg+i)
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
 			args = append(args, typ)
 		}
 		where += fmt.Sprintf(" AND message_type IN (%s)", strings.Join(placeholders, ","))
 	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND source_id IN (%s)", strings.Join(placeholders, ","))
+	}
+	return where, args
+}
+
+// liveInScopeExistsClause is the empty-scope activation guard predicate:
+// true when at least one live message falls inside the backend's build
+// scope. Scope placeholders are numbered from firstScopeArg.
+func (b *Backend) liveInScopeExistsClause(firstScopeArg int) (string, []any) {
+	where, args := b.liveScopeWhere(firstScopeArg)
 	return fmt.Sprintf(`EXISTS (
 		SELECT 1 FROM messages
-		 WHERE (embed_gen IS NULL OR embed_gen <> %s)
-		   AND %s
-	)`, genArg, where), args
+		 WHERE %s
+	)`, where), args
 }
 
 // ActivateGeneration atomically retires the current active generation
@@ -357,6 +397,26 @@ func (b *Backend) activateGeneration(
 		}
 	}
 
+	// Deterministic empty-scope gate BEFORE the demote: the demote path
+	// below deletes the previous active generation's embeddings, which is
+	// corpus-sized. The rollback keeps the data safe, but the scheduler
+	// retries activation every tick (an empty scope trivially satisfies
+	// its missing==0 gate), so checking after the DELETE would turn each
+	// retry into a corpus-sized DELETE + rollback of lock and WAL churn.
+	// The gated promote below re-asserts the same predicate atomically to
+	// cover a message vanishing between this read and the flip.
+	if !force && len(b.scope.SourceIDs) > 0 {
+		var live bool
+		liveClause, liveArgs := b.liveInScopeExistsClause(1)
+		if err := tx.QueryRowContext(ctx,
+			`SELECT `+liveClause, liveArgs...).Scan(&live); err != nil {
+			return fmt.Errorf("check live messages in build scope for generation %d: %w", gen, err)
+		}
+		if !live {
+			return refuseActivateEmptyScopeError(gen)
+		}
+	}
+
 	// Demote the current active generation and capture its id in a single
 	// statement via RETURNING, so the id whose embeddings we delete below is
 	// provably the row this UPDATE retired (no separate non-locking SELECT that
@@ -389,12 +449,20 @@ func (b *Backend) activateGeneration(
 	// (missing==0) is the real gate.
 	missingClause, missingArgs := b.missingForGenExistsClause("$3", 5)
 	args := append([]any{now, now, int64(gen), force}, missingArgs...)
-	res, err := tx.ExecContext(ctx,
-		`UPDATE index_generations
+	promote := `UPDATE index_generations
 		    SET state = 'active', activated_at = $1, completed_at = COALESCE(completed_at, $2)
 		  WHERE id = $3 AND state = 'building'
-		    AND ($4 OR NOT `+missingClause+`)`,
-		args...)
+		    AND ($4 OR NOT ` + missingClause + `)`
+	// Empty-scope guard: a source scope matching no live messages trivially
+	// satisfies the no-missing gate, so the promote additionally requires at
+	// least one live in-scope message (unless force). Folded into the gated
+	// UPDATE so it is atomic with the state flip, like the coverage gate.
+	if len(b.scope.SourceIDs) > 0 {
+		liveClause, liveArgs := b.liveInScopeExistsClause(5 + len(missingArgs))
+		promote += ` AND ($4 OR ` + liveClause + `)`
+		args = append(args, liveArgs...)
+	}
+	res, err := tx.ExecContext(ctx, promote, args...)
 	if err != nil {
 		return fmt.Errorf("activate: %w", err)
 	}
@@ -439,11 +507,29 @@ func (b *Backend) activateGateError(ctx context.Context, tx *sql.Tx, gen vector.
 	if missing && !force {
 		return fmt.Errorf("generation %d still has messages needing embedding; run `msgvault embeddings resume` or pass --force", gen)
 	}
+	if !force && len(b.scope.SourceIDs) > 0 {
+		var live bool
+		liveClause, liveArgs := b.liveInScopeExistsClause(1)
+		if err := tx.QueryRowContext(ctx,
+			`SELECT `+liveClause, liveArgs...).Scan(&live); err != nil {
+			return fmt.Errorf("check live messages in build scope for generation %d: %w", gen, err)
+		}
+		if !live {
+			return refuseActivateEmptyScopeError(gen)
+		}
+	}
 	// Gen reads as building with full coverage yet the gated UPDATE still
 	// matched no rows: a concurrent transaction must have flipped its state
 	// between the promote and this re-read. Surface it rather than reporting a
 	// phantom gate.
 	return fmt.Errorf("activate generation %d: gated promote affected no rows (state=%q)", gen, state)
+}
+
+// refuseActivateEmptyScopeError is the shared refusal for a source scope
+// matching no live messages, returned by both the pre-demote gate and the
+// gated-promote fallback so the two report identically.
+func refuseActivateEmptyScopeError(gen vector.GenerationID) error {
+	return fmt.Errorf("generation %d: %w; sync the scoped account(s) or fix [vector.embed.scope], or pass --force", gen, vector.ErrRefuseActivateEmptyScope)
 }
 
 // RetireGeneration marks the given generation as retired and DELETEs its
@@ -1268,11 +1354,11 @@ func (b *Backend) Stats(ctx context.Context, gen vector.GenerationID) (vector.St
 	// generation, so it reports 0 — the StatsView consumer sums per-gen
 	// pending across the active/building generations anyway.
 	if gen != 0 {
+		pendingWhere, pendingArgs := b.missingForGenWhere("$1", 2)
+		pendingArgs = append([]any{int64(gen)}, pendingArgs...)
 		if err := b.db.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM messages
-			  WHERE (embed_gen IS NULL OR embed_gen <> $1)
-			    AND `+store.LiveMessagesWhere("", true),
-			int64(gen)).Scan(&s.PendingCount); err != nil {
+			`SELECT COUNT(*) FROM messages WHERE `+pendingWhere,
+			pendingArgs...).Scan(&s.PendingCount); err != nil {
 			return s, fmt.Errorf("count missing: %w", err)
 		}
 	}
@@ -1313,13 +1399,24 @@ func (b *Backend) EmbeddedMessageCount(ctx context.Context, gen vector.Generatio
 		    AND m.embed_gen = $1
 		    AND ` + store.LiveMessagesWhere("m", true)
 	args := []any{int64(gen)}
-	if !b.scope.IsEmpty() {
+	nextArg := 2
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
-			placeholders[i] = "$" + strconv.Itoa(2+i)
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
 			args = append(args, typ)
 		}
 		where += fmt.Sprintf(" AND m.message_type IN (%s)", strings.Join(placeholders, ","))
+	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "$" + strconv.Itoa(nextArg)
+			nextArg++
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND m.source_id IN (%s)", strings.Join(placeholders, ","))
 	}
 	var n int64
 	if err := b.db.QueryRowContext(ctx,

--- a/internal/vector/pgvector/coverage_test.go
+++ b/internal/vector/pgvector/coverage_test.go
@@ -100,7 +100,7 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 	b, err := Open(ctx, Options{
 		DB:         db,
 		Dimension:  8,
-		BuildScope: vector.NewBuildScope([]string{"sms"}),
+		BuildScope: vector.NewBuildScope([]string{"sms"}, nil),
 	})
 	require.NoError(err, "Open backend")
 	t.Cleanup(func() { _ = b.Close() })
@@ -154,6 +154,41 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 		"invariant: live == embedded + blank + missing")
 }
 
+func TestStats_SourceScopeExcludesOutOfScopePendingMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+	db := openPGTestDB(t)
+	b, err := Open(ctx, Options{
+		DB:         db,
+		Dimension:  8,
+		BuildScope: vector.NewBuildScope(nil, []int64{1}),
+	})
+	require.NoError(err, "Open backend")
+	t.Cleanup(func() { _ = b.Close() })
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO messages (id, source_id, embed_gen) VALUES
+			(1, 1, NULL),
+			(2, 2, NULL)
+		ON CONFLICT (id) DO UPDATE SET
+			source_id = EXCLUDED.source_id,
+			embed_gen = NULL,
+			deleted_at = NULL,
+			deleted_from_source_at = NULL`)
+	require.NoError(err, "seed in-scope and out-of-scope messages")
+
+	gen, err := b.CreateGeneration(ctx, "test-model", 8, "fp")
+	require.NoError(err, "CreateGeneration")
+	_, err = db.ExecContext(ctx, `UPDATE messages SET embed_gen = $1 WHERE id = 1`, int64(gen))
+	require.NoError(err, "stamp in-scope message")
+
+	stats, err := b.Stats(ctx, gen)
+	require.NoError(err, "Stats")
+	assert.Equal(int64(0), stats.PendingCount,
+		"an unstamped out-of-scope message must not make a source-scoped generation pending")
+}
+
 func TestFilteredCoverageRequiresLiveGenerationStampAndVector(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -190,4 +225,47 @@ func TestFilteredCoverageRequiresLiveGenerationStampAndVector(t *testing.T) {
 
 	_, err = b.EmbeddedMessageCountForIDs(ctx, gen, make([]int64, vector.FilteredCoverageBatchSize+1))
 	assert.ErrorIs(err, vector.ErrCoverageBatchTooLarge)
+}
+
+// TestActivateGeneration_RefusesEmptySourceScope mirrors the sqlitevec
+// empty-scope activation guard for PostgreSQL, where the guard is folded
+// into the gated promote UPDATE atomically: a source scope matching no live
+// messages must refuse a non-forced activation and leave the serving
+// generation active. force remains the operator override.
+func TestActivateGeneration_RefusesEmptySourceScope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	db := openPGTestDB(t) // skips when MSGVAULT_TEST_DB is unset
+	b, err := Open(ctx, Options{
+		DB:         db,
+		Dimension:  8,
+		BuildScope: vector.NewBuildScope(nil, []int64{99}),
+	})
+	require.NoError(err, "Open backend")
+	t.Cleanup(func() { _ = b.Close() })
+
+	// The archive's only live message belongs to source 1; the scoped
+	// source 99 has none (added but never synced).
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO messages (id, source_id) VALUES (1, 1) ON CONFLICT DO NOTHING`)
+	require.NoError(err, "insert out-of-scope message")
+
+	serving, err := b.CreateGeneration(ctx, "test-model", 8, "fp-serving")
+	require.NoError(err, "CreateGeneration serving")
+	require.NoError(b.ActivateGeneration(ctx, serving, true), "force-activate serving generation")
+
+	empty, err := b.CreateGeneration(ctx, "test-model", 8, "fp-empty")
+	require.NoError(err, "CreateGeneration empty-scope build")
+
+	err = b.ActivateGeneration(ctx, empty, false)
+	require.ErrorIs(err, vector.ErrRefuseActivateEmptyScope,
+		"an empty source scope must be refused, not activated as an empty index")
+
+	active, err := b.ActiveGeneration(ctx)
+	require.NoError(err, "ActiveGeneration")
+	assert.Equal(serving, active.ID, "the serving generation must remain active")
+
+	require.NoError(b.ActivateGeneration(ctx, empty, true), "force overrides the guard")
 }

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -503,6 +503,23 @@ func (b *Backend) ActivateGenerationIfConverged(
 	if missing != 0 {
 		return fmt.Errorf("%w: generation %d still has messages needing embedding", vector.ErrGenerationNotConverged, gen)
 	}
+	// Empty-scope guard, mirroring ActivateGeneration: a source scope
+	// matching no live messages trivially satisfies both the convergence
+	// and the no-missing gates, and activating would demote the serving
+	// generation in favor of an empty index. The fused connection sees the
+	// main schema, so the same live-scope predicate runs inside this
+	// transaction, before the demote.
+	if len(b.scope.SourceIDs) > 0 {
+		liveWhere, liveArgs := b.liveScopeWhere()
+		var live int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS (SELECT 1 FROM messages WHERE `+liveWhere+`)`, liveArgs...).Scan(&live); err != nil {
+			return fmt.Errorf("check live messages in build scope for generation %d: %w", gen, err)
+		}
+		if live == 0 {
+			return fmt.Errorf("generation %d: %w; sync the scoped account(s) or fix [vector.embed.scope], or pass --force", gen, vector.ErrRefuseActivateEmptyScope)
+		}
+	}
 
 	now := time.Now().Unix()
 	if _, err := tx.ExecContext(ctx, `

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -83,7 +83,7 @@ func Open(ctx context.Context, opts Options) (*Backend, error) {
 		path:     opts.Path,
 		mainPath: opts.MainPath,
 		dim:      opts.Dimension,
-		scope:    vector.NewBuildScope(opts.BuildScope.MessageTypes),
+		scope:    vector.NewBuildScope(opts.BuildScope.MessageTypes, opts.BuildScope.SourceIDs),
 		readOnly: opts.ReadOnly,
 	}
 	// Orphaned-stamp reset (vectors.db-recreate safety): clear embed_gen for
@@ -292,9 +292,19 @@ func (b *Backend) hasMissingForGen(ctx context.Context, gen vector.GenerationID)
 }
 
 func (b *Backend) missingCoverageWhere(gen int64) (string, []any) {
-	where := "(embed_gen IS NULL OR embed_gen <> ?) AND " + store.LiveMessagesWhere("", true)
-	args := []any{gen}
-	if !b.scope.IsEmpty() {
+	liveWhere, liveArgs := b.liveScopeWhere()
+	return "(embed_gen IS NULL OR embed_gen <> ?) AND " + liveWhere,
+		append([]any{gen}, liveArgs...)
+}
+
+// liveScopeWhere is the predicate for live messages inside the backend's
+// build scope — the generation's embedding universe. Shared by the
+// coverage gate (missingCoverageWhere) and the empty-scope activation
+// guard so both always agree on what "in scope" means.
+func (b *Backend) liveScopeWhere() (string, []any) {
+	where := store.LiveMessagesWhere("", true)
+	args := make([]any, 0, len(b.scope.MessageTypes)+len(b.scope.SourceIDs))
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
 			placeholders[i] = "?"
@@ -302,7 +312,31 @@ func (b *Backend) missingCoverageWhere(gen int64) (string, []any) {
 		}
 		where += fmt.Sprintf(" AND message_type IN (%s)", strings.Join(placeholders, ","))
 	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND source_id IN (%s)", strings.Join(placeholders, ","))
+	}
 	return where, args
+}
+
+// hasLiveInScope reports whether any live message falls inside the
+// backend's build scope.
+func (b *Backend) hasLiveInScope(ctx context.Context) (bool, error) {
+	where, args := b.liveScopeWhere()
+	var exists int
+	err := b.mainDB.QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM messages
+			 WHERE `+where+`
+		)`, args...).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check live messages in build scope: %w", err)
+	}
+	return exists == 1, nil
 }
 
 // ActivateGeneration atomically retires the current active generation
@@ -341,6 +375,20 @@ func (b *Backend) ActivateGeneration(ctx context.Context, gen vector.GenerationI
 		}
 		if missing {
 			return fmt.Errorf("generation %d still has messages needing embedding; run `msgvault embeddings resume` or pass --force", gen)
+		}
+		// Empty-scope guard: a source scope matching no live messages
+		// trivially satisfies the no-missing gate, so without this check
+		// every non-forced path (CLI drain, scheduler, `embeddings
+		// activate`) would swap in an empty index and retire the serving
+		// generation.
+		if len(b.scope.SourceIDs) > 0 {
+			live, err := b.hasLiveInScope(ctx)
+			if err != nil {
+				return err
+			}
+			if !live {
+				return fmt.Errorf("generation %d: %w; sync the scoped account(s) or fix [vector.embed.scope], or pass --force", gen, vector.ErrRefuseActivateEmptyScope)
+			}
 		}
 	}
 
@@ -1571,13 +1619,21 @@ func (b *Backend) EmbeddedMessageCount(ctx context.Context, gen vector.Generatio
 		    AND embed_gen = ?
 		    AND ` + store.LiveMessagesWhere("", true)
 	args := []any{string(blob), int64(gen)}
-	if !b.scope.IsEmpty() {
+	if len(b.scope.MessageTypes) > 0 {
 		placeholders := make([]string, len(b.scope.MessageTypes))
 		for i, typ := range b.scope.MessageTypes {
 			placeholders[i] = "?"
 			args = append(args, typ)
 		}
 		where += fmt.Sprintf(" AND message_type IN (%s)", strings.Join(placeholders, ","))
+	}
+	if len(b.scope.SourceIDs) > 0 {
+		placeholders := make([]string, len(b.scope.SourceIDs))
+		for i, id := range b.scope.SourceIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		where += fmt.Sprintf(" AND source_id IN (%s)", strings.Join(placeholders, ","))
 	}
 	var n int64
 	if err := b.mainDB.QueryRowContext(ctx,

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -106,6 +106,59 @@ func TestBackend_ActivateGenerationIfConvergedRejectsStaleJournal(t *testing.T) 
 	assert.Equal(t, vector.GenerationActive, genStateSV(t, b, gen))
 }
 
+// TestBackend_ActivateGenerationIfConvergedRefusesEmptySourceScope pins the
+// contextual counterpart of the ordinary empty-scope activation guard: a
+// source scope matching no live messages satisfies both the convergence and
+// the no-missing gates trivially, and the sequence-bound activation must
+// refuse rather than demote the serving generation for an empty index.
+func TestBackend_ActivateGenerationIfConvergedRefusesEmptySourceScope(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.db")
+	mainDB, err := sql.Open("sqlite3", mainPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mainDB.Close() })
+	_, err = mainDB.Exec(`
+		CREATE TABLE messages (
+			id INTEGER PRIMARY KEY,
+			source_id INTEGER NOT NULL DEFAULT 0,
+			message_type TEXT,
+			deleted_at DATETIME,
+			deleted_from_source_at DATETIME,
+			embed_gen INTEGER
+		);
+		CREATE TABLE embedding_change_clock (
+			singleton INTEGER PRIMARY KEY,
+			sequence INTEGER NOT NULL
+		);
+		INSERT INTO embedding_change_clock (singleton, sequence) VALUES (1, 0);
+		INSERT INTO messages (id, source_id, message_type) VALUES (1, 1, 'beeper');`)
+	require.NoError(t, err)
+
+	b, err := Open(t.Context(), Options{
+		Path: filepath.Join(dir, "vectors.db"), MainPath: mainPath,
+		Dimension: 4, MainDB: mainDB,
+		BuildScope: vector.NewBuildScope(nil, []int64{99}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+	gen, err := b.CreateGeneration(t.Context(), "m", 4, "")
+	require.NoError(t, err)
+	require.NoError(t, b.AdvanceDocumentChangeWatermark(t.Context(), gen, 0))
+	require.NoError(t, b.SetDocumentReconcileCursor(t.Context(), gen, "done:0"))
+
+	err = b.ActivateGenerationIfConverged(t.Context(), gen, 0)
+	require.ErrorIs(t, err, vector.ErrRefuseActivateEmptyScope,
+		"an empty source scope must be refused, not activated as an empty index")
+	assert.Equal(t, vector.GenerationBuilding, genStateSV(t, b, gen))
+
+	// A live in-scope message (stamped, so coverage stays complete) lifts
+	// the guard and the converged activation proceeds.
+	_, err = mainDB.Exec(`INSERT INTO messages (id, source_id, message_type, embed_gen) VALUES (2, 99, 'beeper', ?)`, int64(gen))
+	require.NoError(t, err)
+	require.NoError(t, b.ActivateGenerationIfConverged(t.Context(), gen, 0))
+	assert.Equal(t, vector.GenerationActive, genStateSV(t, b, gen))
+}
+
 // missingCountSV returns the number of live messages still needing
 // embedding for gen (embed_gen <> gen) in the backend's main DB. This is
 // the scan-and-fill coverage count that replaced pending_embeddings.

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -446,7 +446,7 @@ func TestBackend_CreateGeneration_ScopeLimitsCoverage(t *testing.T) {
 		Path:       filepath.Join(t.TempDir(), "vectors.db"),
 		Dimension:  768,
 		MainDB:     main,
-		BuildScope: vector.NewBuildScope([]string{"sms", "mms"}),
+		BuildScope: vector.NewBuildScope([]string{"sms", "mms"}, nil),
 	})
 	require.NoError(
 		err, "Open")

--- a/internal/vector/sqlitevec/coverage_test.go
+++ b/internal/vector/sqlitevec/coverage_test.go
@@ -229,7 +229,7 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 		Path:       filepath.Join(t.TempDir(), "vectors.db"),
 		Dimension:  8,
 		MainDB:     st.DB(),
-		BuildScope: vector.NewBuildScope([]string{"sms"}),
+		BuildScope: vector.NewBuildScope([]string{"sms"}, nil),
 	})
 	require.NoError(err, "Open backend")
 	t.Cleanup(func() { _ = b.Close() })
@@ -264,7 +264,7 @@ func TestCoverageSplit_ScopedEmbeddedHoldsInvariant(t *testing.T) {
 	}), "Upsert embedded vectors")
 	require.NoError(st.SetEmbedGen(ctx, []int64{outOfScopeEmail, inScopeSMS}, int64(gen)), "stamp embedded")
 
-	live, stamped, _, missingCount, err := st.CoverageCountsScoped(ctx, int64(gen), []string{"sms"})
+	live, stamped, _, missingCount, err := st.CoverageCountsScoped(ctx, int64(gen), []string{"sms"}, nil)
 	require.NoError(err, "CoverageCountsScoped")
 	embedded, err := b.EmbeddedMessageCount(ctx, gen)
 	require.NoError(err, "EmbeddedMessageCount")
@@ -332,4 +332,130 @@ func TestFilteredCoverageRequiresLiveGenerationStampAndVector(t *testing.T) {
 
 	_, err = b.EmbeddedMessageCountForIDs(ctx, gen, make([]int64, vector.FilteredCoverageBatchSize+1))
 	assert.ErrorIs(err, vector.ErrCoverageBatchTooLarge)
+}
+
+// TestCoverageSplit_SourceScopedEmbeddedHoldsInvariant mirrors the
+// message-type scoped invariant for the account dimension: coverage and the
+// embedded split count only the scoped sources, and the activation gate
+// ignores out-of-scope messages entirely — a generation covering one account
+// activates even while another account's messages are unstamped.
+func TestCoverageSplit_SourceScopedEmbeddedHoldsInvariant(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	st := testutil.NewSQLiteTestStore(t)
+	srcA, err := st.GetOrCreateSource("gmail", "a@example.com")
+	require.NoError(err, "GetOrCreateSource a")
+	srcB, err := st.GetOrCreateSource("gmail", "b@example.com")
+	require.NoError(err, "GetOrCreateSource b")
+
+	b, err := Open(ctx, Options{
+		Path:       filepath.Join(t.TempDir(), "vectors.db"),
+		Dimension:  8,
+		MainDB:     st.DB(),
+		BuildScope: vector.NewBuildScope(nil, []int64{srcB.ID}),
+	})
+	require.NoError(err, "Open backend")
+	t.Cleanup(func() { _ = b.Close() })
+
+	makeMsg := func(src *store.Source, srcMsgID string) int64 {
+		convID, err := st.EnsureConversationWithType(src.ID, "conv-"+srcMsgID, "email_thread", "S")
+		require.NoError(err, "EnsureConversationWithType")
+		id, err := st.UpsertMessage(&store.Message{
+			SourceID:        src.ID,
+			SourceMessageID: srcMsgID,
+			ConversationID:  convID,
+			MessageType:     "email",
+			Subject:         sql.NullString{String: "s-" + srcMsgID, Valid: true},
+		})
+		require.NoErrorf(err, "UpsertMessage %s", srcMsgID)
+		return id
+	}
+	outOfScopeA := makeMsg(srcA, "a-unstamped")
+	inScopeB := makeMsg(srcB, "b-embedded")
+
+	gen, err := b.CreateGeneration(ctx, "test-model", 8, "fp")
+	require.NoError(err, "CreateGeneration")
+	require.NoError(b.Upsert(ctx, gen, []vector.Chunk{
+		{MessageID: outOfScopeA, Vector: []float32{1, 0, 0, 0, 0, 0, 0, 0}},
+		{MessageID: inScopeB, Vector: []float32{0, 1, 0, 0, 0, 0, 0, 0}},
+	}), "Upsert embedded vectors")
+	require.NoError(st.SetEmbedGen(ctx, []int64{inScopeB}, int64(gen)), "stamp only the in-scope message")
+
+	live, stamped, _, missingCount, err := st.CoverageCountsScoped(ctx, int64(gen), nil, []int64{srcB.ID})
+	require.NoError(err, "CoverageCountsScoped")
+	embedded, err := b.EmbeddedMessageCount(ctx, gen)
+	require.NoError(err, "EmbeddedMessageCount")
+	blank := max(stamped-embedded, 0)
+
+	assert.Equal(int64(1), live, "only source B is in scope")
+	assert.Equal(int64(1), stamped)
+	assert.Equal(int64(1), embedded, "out-of-scope source A vector excluded")
+	assert.Equal(int64(0), blank)
+	assert.Equal(int64(0), missingCount)
+	assert.Equal(live, embedded+blank+missingCount,
+		"invariant: live == embedded + blank + missing")
+
+	// The activation gate is source-scoped too: source A's unstamped message
+	// must not block activation of the scoped generation.
+	require.NoError(b.ActivateGeneration(ctx, gen, false),
+		"scoped generation activates with out-of-scope messages unstamped")
+}
+
+// TestActivateGeneration_RefusesEmptySourceScope pins the empty-scope
+// activation guard: a source scope matching no live messages trivially
+// satisfies the no-missing gate, so without the guard every non-forced
+// activation path (CLI drain, daemon scheduler, `embeddings activate`)
+// would swap in an empty index and retire the serving generation. force
+// remains the operator override.
+func TestActivateGeneration_RefusesEmptySourceScope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	st := testutil.NewSQLiteTestStore(t)
+	srcA, err := st.GetOrCreateSource("gmail", "a@example.com")
+	require.NoError(err, "GetOrCreateSource a")
+	srcB, err := st.GetOrCreateSource("gmail", "b@example.com")
+	require.NoError(err, "GetOrCreateSource b")
+
+	// Source A holds the archive's only live message; source B — the scoped
+	// account — has none (added but never synced).
+	convID, err := st.EnsureConversationWithType(srcA.ID, "conv-a", "email_thread", "S")
+	require.NoError(err, "EnsureConversationWithType")
+	_, err = st.UpsertMessage(&store.Message{
+		SourceID:        srcA.ID,
+		SourceMessageID: "a-1",
+		ConversationID:  convID,
+		MessageType:     "email",
+		Subject:         sql.NullString{String: "s", Valid: true},
+	})
+	require.NoError(err, "UpsertMessage")
+
+	b, err := Open(ctx, Options{
+		Path:       filepath.Join(t.TempDir(), "vectors.db"),
+		Dimension:  8,
+		MainDB:     st.DB(),
+		BuildScope: vector.NewBuildScope(nil, []int64{srcB.ID}),
+	})
+	require.NoError(err, "Open backend")
+	t.Cleanup(func() { _ = b.Close() })
+
+	serving, err := b.CreateGeneration(ctx, "test-model", 8, "fp-serving")
+	require.NoError(err, "CreateGeneration serving")
+	require.NoError(b.ActivateGeneration(ctx, serving, true), "force-activate serving generation")
+
+	empty, err := b.CreateGeneration(ctx, "test-model", 8, "fp-empty")
+	require.NoError(err, "CreateGeneration empty-scope build")
+
+	err = b.ActivateGeneration(ctx, empty, false)
+	require.ErrorIs(err, vector.ErrRefuseActivateEmptyScope,
+		"an empty source scope must be refused, not activated as an empty index")
+
+	active, err := b.ActiveGeneration(ctx)
+	require.NoError(err, "ActiveGeneration")
+	assert.Equal(serving, active.ID, "the serving generation must remain active")
+
+	require.NoError(b.ActivateGeneration(ctx, empty, true), "force overrides the guard")
 }

--- a/web/src/lib/settings/catalog.test.ts
+++ b/web/src/lib/settings/catalog.test.ts
@@ -16,6 +16,7 @@ describe('settings catalog', () => {
       'openai',
       'voyage-contextual'
     ]);
+    expect(settingsCatalog['vector.embed.scope.accounts'].group).toBe('search');
     expect(settingsCatalog['beeper.schedule'].group).toBe('sources');
     expect(settingsCatalog['integrations.tasks.api_key'].secret).toBe(true);
   });

--- a/web/src/lib/settings/catalog.ts
+++ b/web/src/lib/settings/catalog.ts
@@ -80,6 +80,11 @@ export const settingsCatalog: Record<string, CatalogEntry> = {
   'vector.embed.schedule.cron': entry('search', 'Embedding schedule', 'Cron schedule for background embedding.'),
   'vector.embed.schedule.run_after_sync': entry('search', 'Embed after sync', 'Run embedding after a successful source sync.'),
   'vector.embed.scope.message_types': entry('search', 'Embedded message types', 'Optional message-type scope.'),
+  'vector.embed.scope.accounts': entry(
+    'search',
+    'Embedded accounts',
+    'Optional account scope; only listed accounts are embedded.'
+  ),
   'vector.search.rrf_k': entry('search', 'RRF constant', 'Reciprocal rank fusion constant.'),
   'vector.search.k_per_signal': entry('search', 'Candidates per signal', 'Candidate count contributed by each hybrid signal.'),
   'vector.search.subject_boost': entry('search', 'Subject boost', 'Hybrid ranking weight for subject matches.'),


### PR DESCRIPTION
Add account and collection scoping to embedding builds, including durable `[vector.embed.scope] accounts` configuration for daemon jobs.

Scope is part of generation identity, preventing vectors from different account policies being mixed. Explicit empty collections fail closed, durable scope configuration resolves identifiers rather than unstable source IDs, and daemon jobs verify account-to-source mappings before embedding.

Coverage and generation reporting honor the resolved scope across SQLite and pgvector. The CLI documents repeatable `--account` and `--collection` flags.