### PR TITLE
fix(ci): repair main build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Build
-        run: nix build
+        run: nix build --option download-attempts 10
 
   # PostgreSQL backend lane: runs the full Go test suite against a live
   # PostgreSQL service. Tests that use testutil.NewTestStore read

--- a/cmd/msgvault/cmd/store_adapter_test.go
+++ b/cmd/msgvault/cmd/store_adapter_test.go
@@ -397,7 +397,7 @@ func TestMarkedCLIRequestCancellationStopsProductionStoreWork(t *testing.T) {
 
 			select {
 			case <-requestDone:
-			case <-time.After(500 * time.Millisecond):
+			case <-time.After(2 * time.Second):
 				require.FailNow(t, "production store work continued after marked request cancellation")
 			}
 		})

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,6 +4,7 @@
   bun2nix,
   fetchFromGitHub,
   gitignoreSource,
+  nodejs,
   sqlite,
 }:
 let
@@ -40,7 +41,10 @@ buildGoModule {
   dontUseBunCheck = true;
   dontUseBunInstall = true;
 
-  nativeBuildInputs = [ bun2nix.hook ];
+  nativeBuildInputs = [
+    bun2nix.hook
+    nodejs
+  ];
   overrideModAttrs = _: previous: {
     nativeBuildInputs = builtins.filter (
       input: (input.name or "") != "bun2nix-hook"


### PR DESCRIPTION
## Summary

- Provide Node during the Nix build so the OpenAPI client generator can run.
- Increase Nix download retries for the transient source-fetch failure seen on main.
- Give the Windows cancellation assertion a two-second scheduling budget while preserving the production-store cancellation check.

## Context

The failed main run hit both a Nix source download exhaustion and two timeout failures in the Windows CLI shard. Reproducing the Nix lane after the source became available also exposed the missing Node build input, which would otherwise have failed the same job next.

Failed run: https://github.com/kenn-io/msgvault/actions/runs/31632826839