### PR TITLE
fix(nix): provide bun github cache entry for kit-ui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,7 +479,7 @@ jobs:
         run: go test -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
 
   nix-build:
-    runs-on: ubuntu-latest  # TEMP: verify sandboxed build; revert before merge
+    runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,7 +479,7 @@ jobs:
         run: go test -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
 
   nix-build:
-    runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # TEMP: verify sandboxed build; revert before merge
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,10 +5,34 @@
   fetchFromGitHub,
   gitignoreSource,
   nodejs,
+  runCommand,
+  symlinkJoin,
   sqlite,
 }:
 let
   version = "0.19.3";
+
+  kitUiSrc = fetchFromGitHub {
+    owner = "kenn-io";
+    repo = "kit-ui";
+    rev = "1e9dc7d45525a471040b72b894432c4956542c38";
+    hash = "sha256-XV7CuqMC+jlhaWQyXzcDukqnF73Lycy2Kueb7rMhxz8=";
+  };
+
+  # bun2nix cannot express `github:` dependencies: the generated bun.nix names
+  # the package npm-style, so its cache entry never matches the
+  # `@GH@<owner>-<repo>-<committish>@@@1` folder bun looks up
+  # (PackageManagerDirectories cached_github_folder_name). On sandboxed
+  # builders bun then tries to download the tarball and fails with
+  # FailedToOpenSocket. Provide the exact entry bun expects, including the
+  # `.bun-tag` marker bun writes when it extracts a GitHub tarball itself.
+  kitUiBunCacheEntry = runCommand "kit-ui-bun-github-cache-entry" { } ''
+    dest="$out/share/bun-cache/@GH@kenn-io-kit-ui-1e9dc7d@@@1"
+    mkdir -p "$(dirname "$dest")"
+    cp -R ${kitUiSrc} "$dest"
+    chmod -R u+w "$dest"
+    printf 'kenn-io-kit-ui-1e9dc7d' > "$dest/.bun-tag"
+  '';
 in
 buildGoModule {
   pname = "msgvault";
@@ -19,18 +43,20 @@ buildGoModule {
   vendorHash = "sha256-jnmrZBb8rZChl/UvwMeMDjcIBj6Oyi7lmk9+jg8NnjY=";
   proxyVendor = true;
 
-  bunDeps = bun2nix.fetchBunDeps {
-    bunNix = ../web/bun.nix;
-    overrides = {
-      "@kenn-io/kit-ui@github:kenn-io/kit-ui#1e9dc7d" =
-        _:
-        fetchFromGitHub {
-          owner = "kenn-io";
-          repo = "kit-ui";
-          rev = "1e9dc7d45525a471040b72b894432c4956542c38";
-          hash = "sha256-XV7CuqMC+jlhaWQyXzcDukqnF73Lycy2Kueb7rMhxz8=";
+  bunDeps = symlinkJoin {
+    name = "msgvault-bun-deps";
+    paths = [
+      (bun2nix.fetchBunDeps {
+        bunNix = ../web/bun.nix;
+        overrides = {
+          # Replace the generated (invalid npm-registry) fetch for the
+          # github: dependency so it is never attempted; the usable cache
+          # entry comes from kitUiBunCacheEntry above.
+          "@kenn-io/kit-ui@github:kenn-io/kit-ui#1e9dc7d" = _: kitUiSrc;
         };
-    };
+      })
+      kitUiBunCacheEntry
+    ];
   };
   bunRoot = "web";
   bunInstallFlags = [

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,7 +6,6 @@
   gitignoreSource,
   nodejs,
   runCommand,
-  symlinkJoin,
   sqlite,
 }:
 let
@@ -19,20 +18,6 @@ let
     hash = "sha256-XV7CuqMC+jlhaWQyXzcDukqnF73Lycy2Kueb7rMhxz8=";
   };
 
-  # bun2nix cannot express `github:` dependencies: the generated bun.nix names
-  # the package npm-style, so its cache entry never matches the
-  # `@GH@<owner>-<repo>-<committish>@@@1` folder bun looks up
-  # (PackageManagerDirectories cached_github_folder_name). On sandboxed
-  # builders bun then tries to download the tarball and fails with
-  # FailedToOpenSocket. Provide the exact entry bun expects, including the
-  # `.bun-tag` marker bun writes when it extracts a GitHub tarball itself.
-  kitUiBunCacheEntry = runCommand "kit-ui-bun-github-cache-entry" { } ''
-    dest="$out/share/bun-cache/@GH@kenn-io-kit-ui-1e9dc7d@@@1"
-    mkdir -p "$(dirname "$dest")"
-    cp -R ${kitUiSrc} "$dest"
-    chmod -R u+w "$dest"
-    printf 'kenn-io-kit-ui-1e9dc7d' > "$dest/.bun-tag"
-  '';
 in
 buildGoModule {
   pname = "msgvault";
@@ -43,21 +28,39 @@ buildGoModule {
   vendorHash = "sha256-jnmrZBb8rZChl/UvwMeMDjcIBj6Oyi7lmk9+jg8NnjY=";
   proxyVendor = true;
 
-  bunDeps = symlinkJoin {
-    name = "msgvault-bun-deps";
-    paths = [
-      (bun2nix.fetchBunDeps {
+  # bun2nix cannot express `github:` dependencies: the generated bun.nix names
+  # the package npm-style, so its cache entry never matches the
+  # `@GH@<owner>-<repo>-<committish>@@@1` folder bun looks up
+  # (PackageManagerDirectories cached_github_folder_name). On sandboxed
+  # builders bun then tries to download the tarball and fails with
+  # FailedToOpenSocket. Add the exact entry bun expects, including the
+  # `.bun-tag` marker bun writes when it extracts a GitHub tarball itself.
+  #
+  # The entry must be a plain directory of regular files (or one top-level
+  # symlink). Merging it via symlinkJoin/lndir turns every file into a
+  # symlink, and bun's copyfile backend then silently installs an empty
+  # package.
+  bunDeps =
+    let
+      base = bun2nix.fetchBunDeps {
         bunNix = ../web/bun.nix;
         overrides = {
           # Replace the generated (invalid npm-registry) fetch for the
           # github: dependency so it is never attempted; the usable cache
-          # entry comes from kitUiBunCacheEntry above.
+          # entry is added below.
           "@kenn-io/kit-ui@github:kenn-io/kit-ui#1e9dc7d" = _: kitUiSrc;
         };
-      })
-      kitUiBunCacheEntry
-    ];
-  };
+      };
+    in
+    runCommand "msgvault-bun-deps" { } ''
+      mkdir -p "$out/share/bun-cache"
+      cp -R ${base}/share/bun-cache/. "$out/share/bun-cache/"
+      chmod -R u+w "$out/share/bun-cache"
+      dest="$out/share/bun-cache/@GH@kenn-io-kit-ui-1e9dc7d@@@1"
+      cp -R ${kitUiSrc} "$dest"
+      chmod -R u+w "$dest"
+      printf 'kenn-io-kit-ui-1e9dc7d' > "$dest/.bun-tag"
+    '';
   bunRoot = "web";
   bunInstallFlags = [
     "--linker=hoisted"


### PR DESCRIPTION
Fixes the `nix-build` failure that has hit every fork PR since #602 landed.

## What changed

- Synthesize the bun cache entry for the `github:kenn-io/kit-ui` dependency under the exact folder name bun looks up (`@GH@kenn-io-kit-ui-1e9dc7d@@@1`, per bun's `cached_github_folder_name`), including the `.bun-tag` marker, and merge it into the bun2nix cache with a plain copy.

## Why

bun2nix cannot express `github:` dependencies: the generated `bun.nix` names the package npm-style with a fabricated `registry.npmjs.org/...github:...` URL. #603's `fetchFromGitHub` override fixed that fetch, but the resulting cache entry is keyed by the npm-style name, so bun never finds it and downloads the tarball at install time. Sandboxed builders (GitHub-hosted runners, used for fork PRs) have no network, so `bun install` fails with `FailedToOpenSocket downloading tarball @kenn-io/kit-ui`. The self-hosted runner used for main pushes and same-repo PRs allows network, which masked the bug there.

Two shape constraints, both reproduced locally with bun 1.3.14 against an offline cache: the entry must be named `@GH@<owner>-<repo>-<committish>@@@1`, and it must be a plain directory of regular files (or one top-level symlink) — a symlinkJoin/lndir merge turns every file into a symlink and bun's copyfile backend then silently installs an empty package, which breaks the web build later at `@import "@kenn-io/kit-ui/theme.css"`.

Verified: `nix-build` passed on `ubuntu-latest` (sandboxed, the fork-PR path) with a temporary runner override, since reverted — see run 31658841976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)