### PR TITLE
[probe] nix-build main on ubuntu-latest — do not merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,7 +479,7 @@ jobs:
         run: go test -tags "fts5 sqlite_vec pgvector" -count=1 ./internal/vector/... ./internal/scheduler/... ./cmd/msgvault/cmd/...
 
   nix-build:
-    runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest  # PROBE: is main's nix-build green on GitHub-hosted runners right now?
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
Temporary probe: builds current main's flake on a GitHub-hosted runner to determine whether the .bin/openapi-typescript failure seen on fork PRs reproduces on main itself. Will be closed, not merged.