### PR TITLE
fix(nix): make the sandboxed web build work on GitHub-hosted runners

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,6 +7,7 @@
   nodejs,
   runCommand,
   sqlite,
+  writeText,
 }:
 let
   version = "0.19.3";
@@ -18,6 +19,47 @@ let
     hash = "sha256-XV7CuqMC+jlhaWQyXzcDukqnF73Lycy2Kueb7rMhxz8=";
   };
 
+  # bun's shim linking is unreliable inside the nix sandbox: install
+  # succeeds but node_modules/.bin ends up with an incomplete subset of
+  # shims (observed: esbuild and openapi-typescript missing while acorn
+  # and js-yaml exist). Recreate any missing shims from package.json bin
+  # fields so the web build does not depend on bun's linker.
+  relinkBunBins = writeText "relink-bun-bins.js" ''
+    const fs = require('fs');
+    const path = require('path');
+    const nm = path.resolve('web/node_modules');
+    const binDir = path.join(nm, '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const pkgDirs = [];
+    for (const entry of fs.readdirSync(nm)) {
+      if (entry === '.bin') continue;
+      if (entry.startsWith('@')) {
+        for (const scoped of fs.readdirSync(path.join(nm, entry))) {
+          pkgDirs.push(path.join(nm, entry, scoped));
+        }
+      } else {
+        pkgDirs.push(path.join(nm, entry));
+      }
+    }
+    let created = 0;
+    for (const dir of pkgDirs) {
+      let pkg;
+      try { pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')); }
+      catch { continue; }
+      let bins = pkg.bin;
+      if (!bins) continue;
+      if (typeof bins === 'string') bins = { [pkg.name.split('/').pop()]: bins };
+      for (const [name, rel] of Object.entries(bins)) {
+        const shim = path.join(binDir, name);
+        const target = path.join(dir, rel);
+        if (fs.existsSync(shim) || !fs.existsSync(target)) continue;
+        fs.chmodSync(target, 0o755);
+        fs.symlinkSync(path.relative(binDir, target), shim);
+        created++;
+      }
+    }
+    console.log("relink-bun-bins: created " + created + " missing bin shims");
+  '';
 in
 buildGoModule {
   pname = "msgvault";
@@ -36,10 +78,12 @@ buildGoModule {
   # FailedToOpenSocket. Add the exact entry bun expects, including the
   # `.bun-tag` marker bun writes when it extracts a GitHub tarball itself.
   #
-  # The entry must be a plain directory of regular files (or one top-level
-  # symlink). Merging it via symlinkJoin/lndir turns every file into a
-  # symlink, and bun's copyfile backend then silently installs an empty
-  # package.
+  # Every cache entry must be a plain directory of regular files: bun's
+  # copyfile backend silently installs empty packages from entries whose
+  # files are symlinks — the shape symlinkJoin/lndir produces (and what
+  # fetchBunDeps emits). bun run masks this by resolving modules straight
+  # from the cache, so only direct node_modules consumers (CSS @import,
+  # spawning node_modules/.bin) fail. Dereference everything with cp -RL.
   bunDeps =
     let
       base = bun2nix.fetchBunDeps {
@@ -54,7 +98,7 @@ buildGoModule {
     in
     runCommand "msgvault-bun-deps" { } ''
       mkdir -p "$out/share/bun-cache"
-      cp -R ${base}/share/bun-cache/. "$out/share/bun-cache/"
+      cp -RL ${base}/share/bun-cache/. "$out/share/bun-cache/"
       chmod -R u+w "$out/share/bun-cache"
       dest="$out/share/bun-cache/@GH@kenn-io-kit-ui-1e9dc7d@@@1"
       cp -R ${kitUiSrc} "$dest"
@@ -82,6 +126,12 @@ buildGoModule {
   };
 
   preBuild = ''
+    node ${relinkBunBins}
+    # The flake disables bun2nix's shebang patching, so installed scripts
+    # keep interpreters like #!/usr/bin/env node. The Linux sandbox has no
+    # /usr/bin/env, and posix_spawn on such a script fails with ENOENT even
+    # though the file exists. Patch the installed tree instead.
+    patchShebangs web/node_modules
     bun run --cwd web generate
     bun run --cwd web build
     mkdir -p internal/web/dist


### PR DESCRIPTION
Completes the fork-PR `nix-build` fix started in #604. Three further defects, all only visible inside the Linux nix sandbox (the self-hosted runner builds without sandboxing and masked them):

- **bun's copyfile backend silently installs incomplete packages** from cache entries whose files are symlinks — the shape `symlinkJoin`/lndir produces from `fetchBunDeps`. `bun run` masks this by resolving modules straight from the global cache, so only direct `node_modules` consumers break (CSS `@import` of kit-ui `theme.css`, spawning `node_modules/.bin`). Fixed by dereferencing the merged cache to regular files (`cp -RL`). Reproduced offline against bun 1.3.14 in a Linux container.
- **bun creates only a partial set of `.bin` shims** in the sandbox even from a complete cache. Fixed by recreating missing shims from `package.json` `bin` fields before the web build.
- **Shebang scripts can't spawn**: the flake disables bun2nix's shebang patching, so bin scripts keep `#!/usr/bin/env` interpreters; the sandbox has no `/usr/bin/env` and `posix_spawn` returns ENOENT even though the script exists. Fixed with `patchShebangs` on the installed tree.

Verified end to end on the real sandboxed fork-PR path: kenn-io/msgvault#589 run [31670529892](https://github.com/kenn-io/msgvault/actions/runs/31670529892) (`nix-build` green on ubuntu-latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)