### PR TITLE
build: bump Go to 1.26.6 for stdlib security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cd web && bun run generate && bun run build
 
 # Go build stage.
 # Pin by digest for reproducibility; update periodically.
-FROM golang:1.26-bookworm@sha256:18aedc16aa19b3fd7ded7245fc14b109e054d65d22ed53c355c899582bbb2113 AS builder
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36 AS builder
 
 # Install build dependencies for CGO (SQLite, DuckDB).
 # libsqlite3-dev provides sqlite3.h, required to compile the sqlite-vec

--- a/Makefile
+++ b/Makefile
@@ -86,14 +86,14 @@ clean:
 	rm -rf bin/
 
 # Run tests. The CLI package has nearly 1,000 tests, including heavy DuckDB
-# coverage, and its per-package wall clock can exceed 20m on contended CI
+# coverage, and its per-package wall clock can exceed 30m on contended CI
 # runners even when no individual test is stalled.
 test:
-	go test -timeout 30m -tags "$(BUILD_TAGS)" ./...
+	go test -timeout 40m -tags "$(BUILD_TAGS)" ./...
 
 # Run tests with verbose output
 test-v:
-	go test -timeout 30m -tags "$(BUILD_TAGS)" -v ./...
+	go test -timeout 40m -tags "$(BUILD_TAGS)" -v ./...
 
 # Run tests against PostgreSQL with the pgvector tag (set MSGVAULT_TEST_DB
 # first). Needs a server with the vector extension available.

--- a/flake.nix
+++ b/flake.nix
@@ -25,14 +25,14 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        # Pin Go 1.26.5 until nixpkgs-unstable ships it.
+        # Pin Go 1.26.6 until nixpkgs-unstable ships it.
         # Scoped to msgvault only — do NOT export via overlay, that would
         # invalidate every Go derivation in the transitive closure.
         goPinned = pkgs.go_1_26.overrideAttrs (_: rec {
-          version = "1.26.5";
+          version = "1.26.6";
           src = pkgs.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            hash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
+            hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
           };
         });
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/msgvault
 
-go 1.26.5
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
Go 1.26.6 patches GO-2026-6089, GO-2026-6090, GO-2026-6091, and GO-2026-6218 in the standard library. The module, Nix build, and Docker image now use that patched release consistently, so the vulnerability and container-build gates no longer retain or resolve Go 1.26.5.

The CLI test package can exceed 30 minutes when the shared CI runner is heavily contended even though no individual test is stalled. The test targets now allow 40 minutes per package; test coverage and behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
🤖 Generated with Codex
