### PR TITLE
feat(search): index document attachments with Mistral

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1878,6 +1878,244 @@ components:
         - rejected
         - applied
       type: object
+    DocumentIndexRebuildStatus:
+      additionalProperties: true
+      properties:
+        remaining_owners:
+          format: int64
+          type: integer
+        snapshot_owners:
+          format: int64
+          type: integer
+      required:
+        - snapshot_owners
+        - remaining_owners
+      type: object
+    DocumentIndexStatus:
+      additionalProperties: true
+      properties:
+        average_provider_latency_millis:
+          format: double
+          type: number
+        eligible_bytes:
+          format: int64
+          type: integer
+        eligible_occurrences:
+          format: int64
+          type: integer
+        eligible_owners:
+          format: int64
+          type: integer
+        exact_consent:
+          type: boolean
+        extraction_attempts:
+          format: int64
+          type: integer
+        failed_attempts:
+          format: int64
+          type: integer
+        ineligible_role_occurrences:
+          format: int64
+          type: integer
+        missing_owners:
+          format: int64
+          type: integer
+        missing_provider_byte_reports:
+          format: int64
+          type: integer
+        processed_provider_units:
+          format: int64
+          type: integer
+        profile_enabled:
+          type: boolean
+        profile_exists:
+          type: boolean
+        provider_latency_millis:
+          format: int64
+          type: integer
+        provider_requests:
+          format: int64
+          type: integer
+        provider_retries:
+          format: int64
+          type: integer
+        ready_owners:
+          format: int64
+          type: integer
+        reported_provider_bytes:
+          format: int64
+          type: integer
+        retry_owners:
+          format: int64
+          type: integer
+        staging_owners:
+          format: int64
+          type: integer
+        stored_plaintext_chunks:
+          format: int64
+          type: integer
+        successful_attempts:
+          format: int64
+          type: integer
+        terminal_owners:
+          format: int64
+          type: integer
+        unknown_role_occurrences:
+          format: int64
+          type: integer
+        verified_upload_bytes:
+          format: int64
+          type: integer
+      required:
+        - profile_exists
+        - profile_enabled
+        - exact_consent
+        - extraction_attempts
+        - successful_attempts
+        - failed_attempts
+        - provider_requests
+        - provider_retries
+        - provider_latency_millis
+        - average_provider_latency_millis
+        - verified_upload_bytes
+        - processed_provider_units
+        - reported_provider_bytes
+        - missing_provider_byte_reports
+        - eligible_occurrences
+        - eligible_owners
+        - eligible_bytes
+        - unknown_role_occurrences
+        - ineligible_role_occurrences
+        - ready_owners
+        - staging_owners
+        - retry_owners
+        - terminal_owners
+        - missing_owners
+        - stored_plaintext_chunks
+      type: object
+    DocumentIndexStatusResponse:
+      additionalProperties: true
+      properties:
+        active_rebuild:
+          $ref: "#/components/schemas/DocumentIndexRebuildStatus"
+        status:
+          $ref: "#/components/schemas/DocumentIndexStatus"
+      required:
+        - status
+      type: object
+    DocumentSearchResponse:
+      additionalProperties: true
+      properties:
+        next_cursor:
+          type: string
+        results:
+          items:
+            $ref: "#/components/schemas/DocumentSearchResult"
+          type:
+            - array
+            - "null"
+        revision:
+          format: int64
+          type: integer
+        truncated:
+          type: boolean
+      required:
+        - results
+        - revision
+      type: object
+    DocumentSearchResult:
+      additionalProperties: true
+      properties:
+        attachment_id:
+          format: int64
+          type: integer
+        canonical_blob_hash:
+          type: string
+        chunk_key:
+          type: string
+        chunk_ordinal:
+          format: int64
+          type: integer
+        containing_title:
+          type: string
+        excerpt:
+          type: string
+        extraction_id:
+          type: string
+        filename:
+          type: string
+        first_unit_index:
+          format: int64
+          type: integer
+        heading_path:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        highlight_end:
+          format: int64
+          type: integer
+        highlight_start:
+          format: int64
+          type: integer
+        last_unit_index:
+          format: int64
+          type: integer
+        matched_signals:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        message_id:
+          format: int64
+          type: integer
+        mime_type:
+          type: string
+        model:
+          type: string
+        occurrence_key:
+          type: string
+        other_live_copies:
+          format: int64
+          type: integer
+        profile_id:
+          type: string
+        provider:
+          type: string
+        rank:
+          format: int64
+          type: integer
+        source_id:
+          format: int64
+          type: integer
+        source_part_key:
+          type: string
+        truncated:
+          type: boolean
+      required:
+        - attachment_id
+        - message_id
+        - source_id
+        - occurrence_key
+        - canonical_blob_hash
+        - other_live_copies
+        - chunk_key
+        - chunk_ordinal
+        - first_unit_index
+        - last_unit_index
+        - excerpt
+        - highlight_start
+        - highlight_end
+        - profile_id
+        - extraction_id
+        - provider
+        - model
+        - matched_signals
+        - truncated
+        - rank
+      type: object
     DomainContextSummaryHTTPResponse:
       additionalProperties: true
       properties:
@@ -6608,7 +6846,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.39.0
+  version: 1.40.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -9061,6 +9299,151 @@ paths:
       security:
         - apiKey: []
       summary: Inspect a staged deletion manifest
+      tags:
+        - API
+  /api/v1/documents/search:
+    get:
+      operationId: searchDocuments
+      parameters:
+        - description: Extracted document content or filename query
+          in: query
+          name: q
+          required: true
+          schema:
+            type: string
+        - description: Source IDs to include; repeat or comma-separate values
+          in: query
+          name: source_id
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
+        - description: Message types to include; repeat or comma-separate values
+          in: query
+          name: message_type
+          schema:
+            items:
+              type: string
+            type: array
+        - description: Exact attachment occurrence ID
+          in: query
+          name: attachment_id
+          schema:
+            format: int64
+            type: integer
+        - description: Exact containing message ID
+          in: query
+          name: message_id
+          schema:
+            format: int64
+            type: integer
+        - description: Maximum results to return (default 20, max 100)
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+        - description: Opaque cursor from the previous document search page
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentSearchResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Search extracted document attachments
+      tags:
+        - API
+  /api/v1/documents/status:
+    get:
+      operationId: getDocumentIndexStatus
+      parameters:
+        - description: Exact document extraction profile ID
+          in: query
+          name: profile_id
+          required: true
+          schema:
+            type: string
+        - description: Exact extraction input key
+          in: query
+          name: input_key
+          required: true
+          schema:
+            type: string
+        - description: Allowed document media types
+          in: query
+          name: media_type
+          required: true
+          schema:
+            items:
+              type: string
+            type: array
+        - description: Allowed message types
+          in: query
+          name: message_type
+          schema:
+            items:
+              type: string
+            type: array
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentIndexStatusResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get extracted document index status
       tags:
         - API
   /api/v1/domains/search:

--- a/cmd/msgvault/cmd/backup.go
+++ b/cmd/msgvault/cmd/backup.go
@@ -153,7 +153,7 @@ func printBackupSnapshots(w io.Writer, snapshots []*backup.Manifest) error {
 		return nil
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "SNAPSHOT\tCREATED\tMESSAGES\tBYTES ADDED\tTAG")
+	_, _ = fmt.Fprintln(tw, "SNAPSHOT\tCREATED\tMESSAGES\tDOCUMENT TEXT\tBYTES ADDED\tTAG")
 	for _, m := range snapshots {
 		tag := m.Options.Tag
 		if tag == "" {
@@ -163,8 +163,12 @@ func printBackupSnapshots(w io.Writer, snapshots []*backup.Manifest) error {
 		if err != nil {
 			return fmt.Errorf("snapshot %s: parsing manifest stats: %w", m.SnapshotID, err)
 		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
-			m.SnapshotID, m.CreatedAt, formatCount(st.Messages), formatSize(m.BytesAdded), tag)
+		documentText := "no"
+		if backupapp.ManifestContainsDocumentPlaintext(m) {
+			documentText = "normalized plaintext"
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			m.SnapshotID, m.CreatedAt, formatCount(st.Messages), documentText, formatSize(m.BytesAdded), tag)
 	}
 	if err := tw.Flush(); err != nil {
 		return fmt.Errorf("write backup list output: %w", err)
@@ -260,6 +264,7 @@ func runBackupRestore(cmd *cobra.Command, args []string) error {
 		Progress:           renderer.handle,
 		PackedContent:      backupRestorePackedContentTarget(looseAttachments),
 		TargetCoordinator:  targetCoordinatorOption,
+		AuxiliaryTarget:    backupapp.NewDocumentAuxiliaryTarget(),
 	})
 	if err != nil {
 		return fmt.Errorf("restoring snapshot: %w", err)

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -124,7 +124,7 @@ func writeDeletionsJSON(w io.Writer, groups ...[]*deletion.Manifest) error {
 		for _, m := range manifests {
 			out = append(out, map[string]any{
 				"id":            m.ID,
-				"status":        m.Status,
+				statusValue:     m.Status,
 				"message_count": len(m.GmailIDs),
 				"description":   m.Description,
 				"account":       m.Filters.Account,

--- a/cmd/msgvault/cmd/documents.go
+++ b/cmd/msgvault/cmd/documents.go
@@ -1,0 +1,1129 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/attachmentstore"
+	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/documentindex/mistral"
+	"go.kenn.io/msgvault/internal/fileutil"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const documentBuildSubcommand = "build"
+
+type documentBuildMode int
+
+const (
+	documentBuildIncremental documentBuildMode = iota
+	documentBuildStartRebuild
+	documentBuildResume
+)
+
+type documentStatusOutput struct {
+	ProfileID                  string                    `json:"profile_id"`
+	AuthenticatedFormats       int                       `json:"authenticated_formats"`
+	Provider                   string                    `json:"provider"`
+	Endpoint                   string                    `json:"endpoint"`
+	Region                     string                    `json:"region"`
+	Model                      string                    `json:"model"`
+	RetentionPosture           string                    `json:"retention_posture"`
+	TrainingPosture            string                    `json:"training_posture"`
+	StoresPlaintext            bool                      `json:"stores_normalized_plaintext"`
+	BackupsMayContainText      bool                      `json:"backups_may_contain_normalized_plaintext"`
+	HostedTextEmbeddings       bool                      `json:"hosted_text_embeddings_enabled"`
+	PricingAssumptionOn        string                    `json:"pricing_assumption_on,omitempty"`
+	EstimatedSuccessfulCostUSD *float64                  `json:"estimated_successful_cost_usd,omitempty"`
+	SpoolQuotaBytes            int64                     `json:"spool_quota_bytes"`
+	MinFreeSpaceBytes          int64                     `json:"min_free_space_bytes"`
+	ActiveRebuild              *documentRebuildStatus    `json:"active_rebuild,omitempty"`
+	Status                     store.DocumentIndexStatus `json:"status"`
+}
+
+type documentRebuildStatus struct {
+	SnapshotOwners  int64 `json:"snapshot_owners"`
+	RemainingOwners int64 `json:"remaining_owners"`
+}
+
+type documentBuildResult struct {
+	Reconciled int
+	Changes    int
+	Processed  int
+	Units      int
+	Skipped    int
+	Failed     int
+	RebuildID  string
+	Remaining  int64
+	Completed  bool
+}
+
+type documentsCommandDeps struct {
+	newMistralProcessor func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error)
+	loadProbeFixtures   func(context.Context, string, int64) (map[string]mistral.Document, func() error, error)
+	openStore           func() (*store.Store, func(), error)
+	openAttachments     func(*store.Store) (documentindex.DocumentAttachmentOpener, func() error, error)
+	openReadClient      func(context.Context) (documentReadClient, func(), error)
+}
+
+type documentReadClient interface {
+	SearchDocuments(
+		ctx context.Context,
+		request store.DocumentSearchRequest,
+	) (store.DocumentSearchResponse, error)
+	GetDocumentIndexStatus(
+		ctx context.Context,
+		request store.DocumentIndexStatusRequest,
+	) (store.DocumentIndexStatusResponse, error)
+}
+
+func defaultDocumentsCommandDeps() documentsCommandDeps {
+	return documentsCommandDeps{
+		newMistralProcessor: newConfiguredMistralProcessor,
+		loadProbeFixtures:   mistral.LoadProbeFixtures,
+		openStore:           openWritableStoreAndInit,
+		openAttachments:     openDocumentAttachments,
+		openReadClient: func(ctx context.Context) (documentReadClient, func(), error) {
+			client, _, err := OpenHTTPStore(ctx)
+			if err != nil {
+				return nil, func() {}, err
+			}
+			return client, func() { _ = client.Close() }, nil
+		},
+	}
+}
+
+func newDocumentsCmd(deps documentsCommandDeps) *cobra.Command {
+	parent := &cobra.Command{
+		Use:   "documents",
+		Short: "Manage document attachment indexing",
+	}
+	parent.AddCommand(newProbeMistralCmd(deps))
+	parent.AddCommand(newConsentMistralCmd(deps))
+	parent.AddCommand(newBuildDocumentsCmd(deps))
+	parent.AddCommand(newResumeDocumentsCmd(deps))
+	parent.AddCommand(newSearchDocumentsCmd(deps))
+	parent.AddCommand(newDocumentStatusCmd(deps))
+	parent.AddCommand(newRetryDocumentCmd(deps))
+	parent.AddCommand(newRetireDocumentProfileCmd(deps))
+	parent.AddCommand(newPurgeDocumentDerivedCmd(deps))
+	return parent
+}
+
+func newSearchDocumentsCmd(deps documentsCommandDeps) *cobra.Command {
+	var request store.DocumentSearchRequest
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search extracted document attachments",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			request.Query = strings.Join(args, " ")
+			return runSearchDocuments(command, request, jsonOutput, deps)
+		},
+	}
+	command.Flags().Int64SliceVar(&request.SourceIDs, "source-id", nil, "Limit results to source IDs")
+	command.Flags().StringSliceVar(&request.MessageTypes, "message-type", nil, "Limit results to message types")
+	command.Flags().Int64Var(&request.AttachmentID, "attachment-id", 0, "Limit results to one attachment occurrence")
+	command.Flags().Int64Var(&request.MessageID, "message-id", 0, "Limit results to one containing message")
+	command.Flags().IntVarP(&request.PageSize, "limit", "n", 20, "Maximum results to return")
+	command.Flags().StringVar(&request.Cursor, "cursor", "", "Opaque cursor from the previous page")
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	return command
+}
+
+func newProbeMistralCmd(deps documentsCommandDeps) *cobra.Command {
+	var fixtureDirectory string
+	var validateOnly bool
+	command := &cobra.Command{
+		Use:   "probe-mistral",
+		Short: "Probe stateless Mistral OCR document format support",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runProbeMistral(command, fixtureDirectory, validateOnly, deps)
+		},
+	}
+	command.Flags().StringVar(&fixtureDirectory, "fixtures", "", "Directory containing the complete synthetic fixture matrix")
+	command.Flags().BoolVar(&validateOnly, "validate-only", false, "Validate private fixtures locally without a provider request")
+	_ = command.MarkFlagRequired("fixtures")
+	return command
+}
+
+func newConsentMistralCmd(deps documentsCommandDeps) *cobra.Command {
+	var capabilityPath string
+	var confirmed bool
+	command := &cobra.Command{
+		Use:   "consent-mistral",
+		Short: "Record consent for the exact Mistral document policy",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runConsentMistral(command, capabilityPath, confirmed, deps)
+		},
+	}
+	command.Flags().StringVar(&capabilityPath, "capabilities", "", "Authenticated Mistral capability manifest")
+	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm the configured upload and provider privacy policy")
+	_ = command.MarkFlagRequired("capabilities")
+	return command
+}
+
+func newBuildDocumentsCmd(deps documentsCommandDeps) *cobra.Command {
+	var capabilityPath string
+	var limit int
+	var fullRebuild bool
+	var confirmed bool
+	command := &cobra.Command{
+		Use:   documentBuildSubcommand,
+		Short: "Extract and index eligible document attachments",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			mode := documentBuildIncremental
+			if fullRebuild {
+				mode = documentBuildStartRebuild
+			}
+			return runBuildDocuments(command, capabilityPath, limit, mode, confirmed, deps)
+		},
+	}
+	command.Flags().StringVar(&capabilityPath, "capabilities", "", "Authenticated Mistral capability manifest")
+	command.Flags().IntVar(&limit, "limit", 100, "Maximum canonical documents to process")
+	command.Flags().BoolVar(&fullRebuild, "full-rebuild", false, "Replace current extractions for all eligible documents")
+	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm the disclosed provider uploads for this build")
+	_ = command.MarkFlagRequired("capabilities")
+	return command
+}
+
+func newResumeDocumentsCmd(deps documentsCommandDeps) *cobra.Command {
+	var capabilityPath string
+	var limit int
+	var confirmed bool
+	command := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume pending and retry-ready document extraction",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runBuildDocuments(command, capabilityPath, limit, documentBuildResume, confirmed, deps)
+		},
+	}
+	command.Flags().StringVar(&capabilityPath, "capabilities", "", "Authenticated Mistral capability manifest")
+	command.Flags().IntVar(&limit, "limit", 100, "Maximum canonical documents to process")
+	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm the disclosed provider uploads for this resume pass")
+	_ = command.MarkFlagRequired("capabilities")
+	return command
+}
+
+func newDocumentStatusCmd(deps documentsCommandDeps) *cobra.Command {
+	var capabilityPath string
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   statusValue,
+		Short: "Show document attachment indexing status",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runDocumentStatus(command, capabilityPath, jsonOutput, deps)
+		},
+	}
+	command.Flags().StringVar(&capabilityPath, "capabilities", "", "Authenticated Mistral capability manifest")
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	_ = command.MarkFlagRequired("capabilities")
+	return command
+}
+
+func newRetryDocumentCmd(deps documentsCommandDeps) *cobra.Command {
+	var capabilityPath string
+	var canonicalBlobHash string
+	command := &cobra.Command{
+		Use:   "retry",
+		Short: "Retry one terminal document extraction",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runRetryDocument(command, capabilityPath, canonicalBlobHash, deps)
+		},
+	}
+	command.Flags().StringVar(&capabilityPath, "capabilities", "", "Authenticated Mistral capability manifest")
+	command.Flags().StringVar(&canonicalBlobHash, "hash", "", "Exact lowercase attachment SHA-256")
+	_ = command.MarkFlagRequired("capabilities")
+	_ = command.MarkFlagRequired("hash")
+	return command
+}
+
+func newRetireDocumentProfileCmd(deps documentsCommandDeps) *cobra.Command {
+	var confirmed bool
+	command := &cobra.Command{
+		Use:   "retire <profile-id>",
+		Short: "Retire one exact document extraction profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			return runRetireDocumentProfile(command, args[0], confirmed, deps)
+		},
+	}
+	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm the profile retirement")
+	return command
+}
+
+func newPurgeDocumentDerivedCmd(deps documentsCommandDeps) *cobra.Command {
+	var canonicalBlobHash string
+	var confirmed bool
+	command := &cobra.Command{
+		Use:   "purge-derived",
+		Short: "Delete local document derivatives for one exact attachment hash",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runPurgeDocumentDerived(command, canonicalBlobHash, confirmed, deps)
+		},
+	}
+	command.Flags().StringVar(&canonicalBlobHash, "hash", "", "Exact lowercase attachment SHA-256")
+	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm permanent deletion of local document derivatives")
+	_ = command.MarkFlagRequired("hash")
+	return command
+}
+
+func runProbeMistral(
+	command *cobra.Command,
+	fixtureDirectory string,
+	validateOnly bool,
+	deps documentsCommandDeps,
+) (runErr error) {
+	if cfg == nil {
+		return errors.New("document probe requires loaded configuration")
+	}
+	documentsConfig := &cfg.Attachments.Documents
+	if validateOnly {
+		documents, cleanup, err := deps.loadProbeFixtures(
+			command.Context(), fixtureDirectory, documentsConfig.MaxFileBytes,
+		)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			runErr = errors.Join(runErr, cleanup())
+		}()
+		_, _ = fmt.Fprintf(command.OutOrStdout(),
+			"Validated %d private Mistral fixture(s) locally; no provider requests were made.\n",
+			len(documents))
+		return nil
+	}
+	if !documentsConfig.Enabled {
+		return errors.New("document probe requires attachments.documents.enabled=true")
+	}
+	if documentsConfig.RetentionPosture == documentindex.RetentionUnknown ||
+		documentsConfig.TrainingPosture == documentindex.TrainingUnknown {
+		return errors.New("document probe requires explicit retention_posture and training_posture")
+	}
+
+	mediaTypes := make([]string, 0, len(mistral.CandidateFormats()))
+	for _, candidate := range mistral.CandidateFormats() {
+		mediaTypes = append(mediaTypes, candidate.MediaType)
+	}
+	processor, err := deps.newMistralProcessor(documentsConfig, mediaTypes)
+	if err != nil {
+		return err
+	}
+	documents, cleanup, err := deps.loadProbeFixtures(
+		command.Context(), fixtureDirectory, documentsConfig.MaxFileBytes,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		runErr = errors.Join(runErr, cleanup())
+	}()
+
+	manifest, err := mistral.RunCapabilityProbe(command.Context(), processor, documents, mistral.ProbeConfig{
+		MaxPages: documentsConfig.MaxPagesPerDocument,
+	})
+	if err != nil {
+		return err
+	}
+	if err := mistral.EncodeCapabilityManifest(command.OutOrStdout(), manifest); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runConsentMistral(
+	command *cobra.Command,
+	capabilityPath string,
+	confirmed bool,
+	deps documentsCommandDeps,
+) error {
+	documentsConfig, manifest, allowedMediaTypes, profile, err := configuredDocumentProfile(capabilityPath)
+	if err != nil {
+		return err
+	}
+	if !documentsConfig.Enabled {
+		return errors.New("document consent requires attachments.documents.enabled=true")
+	}
+	printDocumentConsentDisclosure(
+		command.OutOrStdout(), documentsConfig, profile, len(allowedMediaTypes),
+	)
+	if !confirmed {
+		return errors.New("document consent requires --yes after reviewing the configured retention and training postures")
+	}
+	if manifest.MaxPages < documentsConfig.MaxPagesPerDocument || len(allowedMediaTypes) == 0 {
+		return errors.New("document capability manifest does not authorize the configured policy")
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := st.EnsureDocumentExtractionProfile(command.Context(), profile); err != nil {
+		return err
+	}
+	if err := st.RecordDocumentProviderConsent(command.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+	}); err != nil {
+		return err
+	}
+	if err := bootstrapDocumentOccurrencesIfConsented(command.Context(), st); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(),
+		"Recorded Mistral document consent for profile %s (%d authenticated format(s), retention=%s, training=%s).\n",
+		profile.ID, len(allowedMediaTypes), profile.RetentionPosture, profile.TrainingPosture)
+	return nil
+}
+
+func repairHistoricalAttachmentRoles(ctx context.Context, st *store.Store) error {
+	const batchSize = 1000
+	for {
+		progress, err := st.RepairHistoricalAttachmentRolesBatch(ctx, batchSize)
+		if err != nil {
+			return fmt.Errorf("repair historical attachment roles: %w", err)
+		}
+		if progress.Completed {
+			return nil
+		}
+	}
+}
+
+func printDocumentConsentDisclosure(
+	w io.Writer,
+	documentsConfig *documentindex.DocumentsConfig,
+	profile store.DocumentExtractionProfile,
+	authenticatedFormats int,
+) {
+	_, _ = fmt.Fprintln(w, "Hosted document extraction disclosure:")
+	_, _ = fmt.Fprintf(w,
+		"- Complete original document bytes and their media type will be sent to %s (%s).\n",
+		profile.Endpoint, profile.Region)
+	_, _ = fmt.Fprintf(w,
+		"- The exact authenticated policy allows %d format(s), at most %s and %d provider unit(s) per document.\n",
+		authenticatedFormats, formatSize(documentsConfig.MaxFileBytes), documentsConfig.MaxPagesPerDocument)
+	_, _ = fmt.Fprintf(w, "- Private temporary spools are capped at %s and preserve %s of free disk space.\n",
+		formatSize(documentsConfig.MaxSpoolBytes), formatSize(documentsConfig.MinFreeSpaceBytes))
+	_, _ = fmt.Fprintf(w, "- Provider assertions: retention=%s, training=%s.\n",
+		profile.RetentionPosture, profile.TrainingPosture)
+	_, _ = fmt.Fprintln(w,
+		"- Normalized plaintext units and chunks will be stored in the local archive database and may be included in disclosed full backups.")
+	_, _ = fmt.Fprintln(w,
+		"- Raw provider JSON and full provider Markdown are transient; this consent does not enable hosted document text embeddings.")
+	if documentsConfig.EstimatedCostUSDPerKUnits > 0 {
+		_, _ = fmt.Fprintf(w,
+			"- Cost planning uses %.6g USD per 1,000 provider unit(s), assumed on %s, with a %.2f USD run cap.\n",
+			documentsConfig.EstimatedCostUSDPerKUnits, documentsConfig.PricingAssumptionOn,
+			documentsConfig.MaxEstimatedCostUSDPerRun)
+	} else {
+		_, _ = fmt.Fprintln(w,
+			"- No current provider-unit price assumption is configured; manual requests may still incur provider charges.")
+	}
+}
+
+func runBuildDocuments(
+	command *cobra.Command,
+	capabilityPath string,
+	limit int,
+	mode documentBuildMode,
+	confirmed bool,
+	deps documentsCommandDeps,
+) (runErr error) {
+	if limit <= 0 || limit > 10_000 {
+		return errors.New("document build limit must be between 1 and 10000")
+	}
+	documentsConfig, manifest, allowedMediaTypes, profile, err := configuredDocumentProfile(capabilityPath)
+	if err != nil {
+		return err
+	}
+	if !documentsConfig.Enabled {
+		return errors.New("document build requires attachments.documents.enabled=true")
+	}
+	limit, err = documentsConfig.MaxDocumentsWithinRunBudget(limit)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		_, _ = fmt.Fprintln(command.OutOrStdout(), "Document build upload preflight:")
+		printDocumentConsentDisclosure(
+			command.OutOrStdout(), documentsConfig, profile, len(allowedMediaTypes),
+		)
+		return errors.New("document build requires --yes after reviewing the provider upload preflight")
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := st.EnsureDocumentExtractionProfile(command.Context(), profile); err != nil {
+		return err
+	}
+	consentStatus, err := st.GetDocumentIndexStatus(command.Context(), profile.ID)
+	if err != nil {
+		return err
+	}
+	if !consentStatus.ProfileEnabled || !consentStatus.ExactConsent {
+		return errors.New("document build requires exact consent; run `msgvault documents consent-mistral --capabilities <manifest> --yes`")
+	}
+	if err := repairHistoricalAttachmentRoles(command.Context(), st); err != nil {
+		return err
+	}
+	reconciler, err := documentindex.NewReconciler(st, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 1000, ChangePageSize: 1000,
+	})
+	if err != nil {
+		return err
+	}
+	reconcileResult, err := reconciler.Reconcile(command.Context())
+	if err != nil {
+		return err
+	}
+	status, err := st.GetDocumentIndexStatusForScope(
+		command.Context(), profile.ID, "original", allowedMediaTypes, documentsConfig.Scope.MessageTypes,
+	)
+	if err != nil {
+		return err
+	}
+	printDocumentBuildPreflight(
+		command.OutOrStdout(), documentsConfig, profile, len(allowedMediaTypes), status, limit, mode,
+	)
+	attachments, closeAttachments, err := deps.openAttachments(st)
+	if err != nil {
+		return err
+	}
+	defer func() { runErr = errors.Join(runErr, closeAttachments()) }()
+	processor, err := deps.newMistralProcessor(documentsConfig, allowedMediaTypes)
+	if err != nil {
+		return err
+	}
+	result, err := executeDocumentBuild(
+		command.Context(), st, attachments, processor, documentsConfig, manifest,
+		allowedMediaTypes, profile, limit, "documents-cli", cfg.Data.DataDir, mode, &reconcileResult,
+	)
+	_, _ = fmt.Fprintf(command.OutOrStdout(),
+		"Reconciled %d attachment(s), consumed %d change(s); indexed %d document(s), %d unit(s), skipped %d, failed %d.\n",
+		result.Reconciled, result.Changes, result.Processed, result.Units, result.Skipped, result.Failed)
+	if result.RebuildID != "" {
+		if result.Completed {
+			_, _ = fmt.Fprintln(command.OutOrStdout(), "Full document rebuild completed.")
+		} else {
+			_, _ = fmt.Fprintf(command.OutOrStdout(),
+				"Full document rebuild has %d current owner(s) remaining; run `msgvault documents resume --capabilities <manifest>` with the same capability manifest.\n",
+				result.Remaining)
+		}
+	}
+	return err
+}
+
+func printDocumentBuildPreflight(
+	w io.Writer,
+	documentsConfig *documentindex.DocumentsConfig,
+	profile store.DocumentExtractionProfile,
+	authenticatedFormats int,
+	status store.DocumentIndexStatus,
+	limit int,
+	mode documentBuildMode,
+) {
+	var modeName string
+	switch mode {
+	case documentBuildIncremental:
+		modeName = "incremental"
+	case documentBuildStartRebuild:
+		modeName = "full rebuild"
+	case documentBuildResume:
+		modeName = "resume"
+	}
+	_, _ = fmt.Fprintln(w, "Document build upload preflight:")
+	_, _ = fmt.Fprintf(w,
+		"- The current scope contains %d eligible attachment occurrence(s), %d unique canonical document(s), and %s of original bytes.\n",
+		status.EligibleOccurrences, status.EligibleOwners, formatSize(status.EligibleBytes))
+	_, _ = fmt.Fprintf(w,
+		"- This %s pass will process at most %d canonical document(s) and %d provider unit(s).\n",
+		modeName, limit, documentsConfig.MaxPagesPerRun)
+	printDocumentConsentDisclosure(w, documentsConfig, profile, authenticatedFormats)
+}
+
+func executeDocumentBuild(
+	ctx context.Context,
+	st *store.Store,
+	attachments documentindex.DocumentAttachmentOpener,
+	processor mistral.Processor,
+	documentsConfig *documentindex.DocumentsConfig,
+	manifest mistral.CapabilityManifest,
+	allowedMediaTypes []string,
+	profile store.DocumentExtractionProfile,
+	limit int,
+	leaseOwner string,
+	dataDirectory string,
+	mode documentBuildMode,
+	preReconciled *documentindex.ReconcileResult,
+) (documentBuildResult, error) {
+	result := documentBuildResult{}
+	var reconcileResult documentindex.ReconcileResult
+	if preReconciled != nil {
+		reconcileResult = *preReconciled
+	} else {
+		reconciler, err := documentindex.NewReconciler(st, documentindex.ReconcilerConfig{
+			AttachmentPageSize: 1000, ChangePageSize: 1000,
+		})
+		if err != nil {
+			return result, err
+		}
+		reconcileResult, err = reconciler.Reconcile(ctx)
+		if err != nil {
+			return result, err
+		}
+	}
+	result.Reconciled = reconcileResult.AttachmentsExamined
+	result.Changes = reconcileResult.ChangesConsumed
+	var rebuild *store.DocumentExtractionRebuild
+	switch mode {
+	case documentBuildStartRebuild:
+		rebuildID, rebuildErr := newDocumentRebuildID()
+		if rebuildErr != nil {
+			return result, rebuildErr
+		}
+		started, rebuildErr := st.StartDocumentExtractionRebuild(
+			ctx, rebuildID, profile.ID, "original", allowedMediaTypes, documentsConfig.Scope.MessageTypes,
+		)
+		if rebuildErr != nil {
+			return result, rebuildErr
+		}
+		rebuild = &started
+	case documentBuildResume:
+		active, rebuildErr := st.GetActiveDocumentExtractionRebuild(ctx, profile.ID, "original")
+		if rebuildErr == nil {
+			rebuild = &active
+		} else if !errors.Is(rebuildErr, store.ErrDocumentExtractionRebuildMissing) {
+			return result, rebuildErr
+		}
+	case documentBuildIncremental:
+	default:
+		return result, errors.New("document build mode is invalid")
+	}
+	if dataDirectory == "" {
+		return result, errors.New("document build requires a data directory")
+	}
+	spoolDirectory := filepath.Join(dataDirectory, "tmp", "document-index")
+	if err := fileutil.SecureMkdirAll(spoolDirectory, 0o700); err != nil {
+		return result, fmt.Errorf("create private document spool directory: %w", err)
+	}
+	if _, err := mistral.ScavengeSpoolDirectory(
+		spoolDirectory, time.Now().UTC().Add(-2*time.Hour),
+	); err != nil {
+		return result, err
+	}
+	workerConfig := documentindex.MistralWorkerConfig{
+		ProfileID: profile.ID, LeaseOwner: leaseOwner, LeaseDuration: documentsConfig.RequestTimeout + time.Minute,
+		RetryDelay: 15 * time.Minute, SpoolDirectory: spoolDirectory,
+		MaxFileBytes: documentsConfig.MaxFileBytes, MaxPages: documentsConfig.MaxPagesPerDocument,
+		MaxSpoolBytes: documentsConfig.MaxSpoolBytes, MinFreeBytes: documentsConfig.MinFreeSpaceBytes,
+		MessageTypes:     documentsConfig.Scope.MessageTypes,
+		NormalizePolicy:  documentindex.DefaultNormalizePolicy(documentsConfig.MaxNormalizedChars),
+		CapabilityPolicy: manifest,
+	}
+	if rebuild != nil {
+		workerConfig.RebuildID = rebuild.ID
+		workerConfig.ReplaceCurrent = true
+		result.RebuildID = rebuild.ID
+	}
+	worker, err := documentindex.NewMistralWorker(st, attachments, processor, workerConfig)
+	if err != nil {
+		return result, err
+	}
+	candidates, err := st.ListDocumentExtractionCandidates(
+		ctx, profile.ID, "original", allowedMediaTypes, documentsConfig.Scope.MessageTypes, rebuild, limit,
+	)
+	if err != nil {
+		return result, err
+	}
+	for _, candidate := range candidates {
+		if len(documentsConfig.Scope.MessageTypes) > 0 &&
+			!slices.Contains(documentsConfig.Scope.MessageTypes, candidate.MessageType) {
+			result.Skipped++
+			continue
+		}
+		extraction, processErr := worker.ProcessCandidate(ctx, candidate)
+		if errors.Is(processErr, context.Canceled) || errors.Is(processErr, context.DeadlineExceeded) {
+			return result, processErr
+		}
+		if errors.Is(processErr, store.ErrDocumentExtractionClaimed) ||
+			errors.Is(processErr, store.ErrDocumentExtractionCurrent) {
+			result.Skipped++
+			continue
+		}
+		if processErr != nil {
+			result.Failed++
+			continue
+		}
+		result.Processed++
+		result.Units += extraction.Units
+		if result.Units > documentsConfig.MaxPagesPerRun {
+			return result, errors.New("document provider output exceeded max_pages_per_run")
+		}
+	}
+	if rebuild != nil {
+		result.Remaining, err = st.CountIncompleteDocumentExtractionRebuild(
+			ctx, *rebuild, allowedMediaTypes, documentsConfig.Scope.MessageTypes,
+		)
+		if err != nil {
+			return result, err
+		}
+		if result.Remaining == 0 && result.Failed == 0 {
+			if err := st.CompleteDocumentExtractionRebuild(ctx, rebuild.ID); err != nil {
+				return result, err
+			}
+			result.Completed = true
+		}
+	}
+	if result.Failed > 0 {
+		return result, fmt.Errorf("document build completed with %d extraction failure(s)", result.Failed)
+	}
+	return result, nil
+}
+
+func newDocumentRebuildID() (string, error) {
+	var entropy [16]byte
+	if _, err := rand.Read(entropy[:]); err != nil {
+		return "", fmt.Errorf("create document rebuild ID: %w", err)
+	}
+	return "document-rebuild-" + hex.EncodeToString(entropy[:]), nil
+}
+
+func runDocumentStatus(
+	command *cobra.Command,
+	capabilityPath string,
+	jsonOutput bool,
+	deps documentsCommandDeps,
+) error {
+	documentsConfig, _, allowedMediaTypes, profile, err := configuredDocumentProfile(capabilityPath)
+	if err != nil {
+		return err
+	}
+	response, cleanup, err := readDocumentStatus(command.Context(), store.DocumentIndexStatusRequest{
+		ProfileID: profile.ID, ExtractionInputKey: "original",
+		AllowedMediaTypes: allowedMediaTypes, AllowedMessageTypes: documentsConfig.Scope.MessageTypes,
+	}, deps)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	status := response.Status
+	var rebuildStatus *documentRebuildStatus
+	if response.ActiveRebuild != nil {
+		rebuildStatus = &documentRebuildStatus{
+			SnapshotOwners:  response.ActiveRebuild.SnapshotOwners,
+			RemainingOwners: response.ActiveRebuild.RemainingOwners,
+		}
+	}
+	storesPlaintext := status.StoredPlaintextChunks > 0
+	var estimatedSuccessfulCost *float64
+	if documentsConfig.EstimatedCostUSDPerKUnits > 0 {
+		cost := float64(status.ProcessedProviderUnits) / 1000 * documentsConfig.EstimatedCostUSDPerKUnits
+		estimatedSuccessfulCost = &cost
+	}
+	output := documentStatusOutput{
+		ProfileID: profile.ID, AuthenticatedFormats: len(allowedMediaTypes),
+		Provider: profile.Provider, Endpoint: profile.Endpoint, Region: profile.Region, Model: profile.Model,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+		StoresPlaintext: storesPlaintext, BackupsMayContainText: storesPlaintext,
+		HostedTextEmbeddings:       documentsConfig.Index.Embeddings.Enabled,
+		PricingAssumptionOn:        documentsConfig.PricingAssumptionOn,
+		EstimatedSuccessfulCostUSD: estimatedSuccessfulCost,
+		SpoolQuotaBytes:            documentsConfig.MaxSpoolBytes, MinFreeSpaceBytes: documentsConfig.MinFreeSpaceBytes,
+		ActiveRebuild: rebuildStatus, Status: status,
+	}
+	if jsonOutput {
+		return json.NewEncoder(command.OutOrStdout()).Encode(output)
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(),
+		"Profile: %s\nProvider: %s %s (%s, %s)\nFormats: %d authenticated\nRetention: %s\nTraining: %s\nPrivate spool: %s quota, %s free-space reserve\nEnabled: %t\nExact consent: %t\nEligible: %d occurrence(s), %d unique document(s), %s\nExcluded roles: %d unknown, %d ineligible\nCoverage: %d ready, %d staging, %d retrying, %d terminal, %d missing\nExtraction accounting: %d attempt(s), %d successful, %d failed, %s verified upload bytes\nProvider accounting: %d request(s), %d internal retry(s), %d ms total latency (%.1f ms average), %d processed unit(s), %s reported bytes, %d successful response(s) without provider bytes\nNormalized plaintext stored: %t\nBackups may contain normalized plaintext: %t\nHosted document text embeddings: %t\n",
+		profile.ID, profile.Provider, profile.Model, profile.Region, profile.Endpoint,
+		len(allowedMediaTypes), profile.RetentionPosture, profile.TrainingPosture,
+		formatSize(documentsConfig.MaxSpoolBytes), formatSize(documentsConfig.MinFreeSpaceBytes),
+		status.ProfileEnabled, status.ExactConsent, status.EligibleOccurrences,
+		status.EligibleOwners, formatSize(status.EligibleBytes), status.UnknownRoleOccurrences,
+		status.IneligibleRoleOccurrences, status.ReadyOwners, status.StagingOwners,
+		status.RetryOwners, status.TerminalOwners, status.MissingOwners,
+		status.ExtractionAttempts, status.SuccessfulAttempts, status.FailedAttempts,
+		formatSize(status.VerifiedUploadBytes), status.ProviderRequests, status.ProviderRetries,
+		status.ProviderLatencyMillis, status.AverageProviderLatencyMS, status.ProcessedProviderUnits,
+		formatSize(status.ReportedProviderBytes), status.MissingProviderByteReports,
+		output.StoresPlaintext, output.BackupsMayContainText, output.HostedTextEmbeddings)
+	if estimatedSuccessfulCost != nil {
+		_, _ = fmt.Fprintf(command.OutOrStdout(),
+			"Minimum estimated successful cost: %.6g USD (pricing assumption %s; excludes failed and provider-internal retry charges)\n",
+			*estimatedSuccessfulCost, documentsConfig.PricingAssumptionOn)
+	}
+	if rebuildStatus != nil {
+		_, _ = fmt.Fprintf(command.OutOrStdout(), "Active full rebuild: %d of %d owner(s) remaining\n",
+			rebuildStatus.RemainingOwners, rebuildStatus.SnapshotOwners)
+	}
+	return nil
+}
+
+func runRetryDocument(
+	command *cobra.Command,
+	capabilityPath string,
+	canonicalBlobHash string,
+	deps documentsCommandDeps,
+) error {
+	profile, err := configuredDocumentProfileOnly(capabilityPath)
+	if err != nil {
+		return err
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	changed, err := st.RetryDocumentExtraction(command.Context(), profile.ID, canonicalBlobHash)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return errors.New("no terminal or retryable document extraction matched the exact profile and hash")
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Scheduled document %s for retry under profile %s.\n",
+		canonicalBlobHash, profile.ID)
+	return nil
+}
+
+func configuredDocumentProfileOnly(capabilityPath string) (store.DocumentExtractionProfile, error) {
+	documentsConfig, manifest, allowedMediaTypes, profile, err := configuredDocumentProfile(capabilityPath)
+	_ = documentsConfig
+	_ = manifest
+	_ = allowedMediaTypes
+	return profile, err
+}
+
+func runRetireDocumentProfile(
+	command *cobra.Command,
+	profileID string,
+	confirmed bool,
+	deps documentsCommandDeps,
+) error {
+	if !confirmed {
+		return errors.New("document profile retirement requires --yes")
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	changed, err := st.RetireDocumentExtractionProfile(command.Context(), profileID)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return errors.New("document extraction profile was not found or is already retired")
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Retired document extraction profile %s.\n", profileID)
+	return nil
+}
+
+func runPurgeDocumentDerived(
+	command *cobra.Command,
+	canonicalBlobHash string,
+	confirmed bool,
+	deps documentsCommandDeps,
+) error {
+	if !confirmed {
+		return errors.New("document derivative purge requires --yes")
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	result, err := st.PurgeDocumentDerivedByHash(command.Context(), canonicalBlobHash)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(),
+		"Purged %d extraction(s) and %d current head(s) for document %s.\n",
+		result.ExtractionsRemoved, result.HeadsRemoved, canonicalBlobHash)
+	return nil
+}
+
+func runSearchDocuments(
+	command *cobra.Command,
+	request store.DocumentSearchRequest,
+	jsonOutput bool,
+	deps documentsCommandDeps,
+) error {
+	reader, cleanup, err := openDocumentReadClient(command.Context(), deps)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	response, err := reader.SearchDocuments(command.Context(), request)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return json.NewEncoder(command.OutOrStdout()).Encode(response)
+	}
+	writer := tabwriter.NewWriter(command.OutOrStdout(), 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "RANK\tATTACHMENT\tMESSAGE\tFILE\tMATCH\tEXCERPT")
+	for _, result := range response.Results {
+		_, _ = fmt.Fprintf(writer, "%d\t%d\t%d\t%s\t%s\t%s\n",
+			result.Rank, result.AttachmentID, result.MessageID, result.Filename,
+			strings.Join(result.MatchedSignals, "+"), strings.Join(strings.Fields(result.Excerpt), " "))
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write document search results: %w", err)
+	}
+	if response.NextCursor != "" {
+		_, _ = fmt.Fprintf(command.OutOrStdout(), "Next cursor: %s\n", response.NextCursor)
+	}
+	return nil
+}
+
+func openDocumentReadClient(
+	ctx context.Context,
+	deps documentsCommandDeps,
+) (documentReadClient, func(), error) {
+	if deps.openReadClient != nil {
+		return deps.openReadClient(ctx)
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return localDocumentReadClient{store: st}, cleanup, nil
+}
+
+func readDocumentStatus(
+	ctx context.Context,
+	request store.DocumentIndexStatusRequest,
+	deps documentsCommandDeps,
+) (store.DocumentIndexStatusResponse, func(), error) {
+	reader, cleanup, err := openDocumentReadClient(ctx, deps)
+	if err != nil {
+		return store.DocumentIndexStatusResponse{}, func() {}, err
+	}
+	response, err := reader.GetDocumentIndexStatus(ctx, request)
+	if err != nil {
+		cleanup()
+		return store.DocumentIndexStatusResponse{}, func() {}, err
+	}
+	return response, cleanup, nil
+}
+
+type localDocumentReadClient struct{ store *store.Store }
+
+func (c localDocumentReadClient) SearchDocuments(
+	ctx context.Context,
+	request store.DocumentSearchRequest,
+) (store.DocumentSearchResponse, error) {
+	if err := reconcileDocumentOccurrencesIfEnabled(ctx, c.store); err != nil {
+		return store.DocumentSearchResponse{}, err
+	}
+	return c.store.SearchDocuments(ctx, request)
+}
+
+func (c localDocumentReadClient) GetDocumentIndexStatus(
+	ctx context.Context,
+	request store.DocumentIndexStatusRequest,
+) (store.DocumentIndexStatusResponse, error) {
+	if err := reconcileDocumentOccurrencesIfEnabled(ctx, c.store); err != nil {
+		return store.DocumentIndexStatusResponse{}, err
+	}
+	status, err := c.store.GetDocumentIndexStatusForScope(
+		ctx, request.ProfileID, request.ExtractionInputKey,
+		request.AllowedMediaTypes, request.AllowedMessageTypes,
+	)
+	if err != nil {
+		return store.DocumentIndexStatusResponse{}, err
+	}
+	response := store.DocumentIndexStatusResponse{Status: status}
+	active, err := c.store.GetActiveDocumentExtractionRebuild(
+		ctx, request.ProfileID, request.ExtractionInputKey,
+	)
+	if errors.Is(err, store.ErrDocumentExtractionRebuildMissing) {
+		return response, nil
+	}
+	if err != nil {
+		return store.DocumentIndexStatusResponse{}, err
+	}
+	remaining, err := c.store.CountIncompleteDocumentExtractionRebuild(
+		ctx, active, request.AllowedMediaTypes, request.AllowedMessageTypes,
+	)
+	if err != nil {
+		return store.DocumentIndexStatusResponse{}, err
+	}
+	response.ActiveRebuild = &store.DocumentIndexRebuildStatus{
+		SnapshotOwners: active.SnapshotOwners, RemainingOwners: remaining,
+	}
+	return response, nil
+}
+
+func reconcileDocumentOccurrencesIfEnabled(ctx context.Context, st *store.Store) error {
+	if _, err := st.GetAttachmentChangeConsumer(
+		ctx, documentindex.DocumentAttachmentConsumerKey,
+	); errors.Is(err, store.ErrAttachmentChangeConsumerMissing) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	reconciler, err := documentindex.NewReconciler(st, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 1000,
+		ChangePageSize:     1000,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = reconciler.Reconcile(ctx)
+	return err
+}
+
+func bootstrapDocumentOccurrencesIfConsented(ctx context.Context, st *store.Store) error {
+	consented, err := st.HasActiveDocumentProviderConsent(ctx)
+	if err != nil || !consented {
+		return err
+	}
+	reconciler, err := documentindex.NewReconciler(st, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 1000,
+		ChangePageSize:     1000,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = reconciler.Reconcile(ctx)
+	return err
+}
+
+func configuredDocumentProfile(
+	capabilityPath string,
+) (*documentindex.DocumentsConfig, mistral.CapabilityManifest, []string, store.DocumentExtractionProfile, error) {
+	if cfg == nil {
+		return nil, mistral.CapabilityManifest{}, nil, store.DocumentExtractionProfile{},
+			errors.New("document operation requires loaded configuration")
+	}
+	documentsConfig := &cfg.Attachments.Documents
+	if documentsConfig.RetentionPosture == documentindex.RetentionUnknown ||
+		documentsConfig.TrainingPosture == documentindex.TrainingUnknown {
+		return nil, mistral.CapabilityManifest{}, nil, store.DocumentExtractionProfile{},
+			errors.New("document operation requires explicit retention_posture and training_posture")
+	}
+	manifest, err := loadDocumentCapabilityManifest(capabilityPath)
+	if err != nil {
+		return nil, mistral.CapabilityManifest{}, nil, store.DocumentExtractionProfile{}, err
+	}
+	allowedMediaTypes, profile, err := documentProfileForConfig(documentsConfig, manifest)
+	if err != nil {
+		return nil, mistral.CapabilityManifest{}, nil, store.DocumentExtractionProfile{}, err
+	}
+	return documentsConfig, manifest, allowedMediaTypes, profile, nil
+}
+
+func loadDocumentCapabilityManifest(capabilityPath string) (mistral.CapabilityManifest, error) {
+	file, err := os.Open(capabilityPath)
+	if err != nil {
+		return mistral.CapabilityManifest{}, errors.New("open configured Mistral capability manifest")
+	}
+	manifest, decodeErr := mistral.DecodeCapabilityManifest(file)
+	closeErr := file.Close()
+	if decodeErr != nil || closeErr != nil {
+		return mistral.CapabilityManifest{}, errors.Join(decodeErr, closeErr)
+	}
+	return manifest, nil
+}
+
+func documentProfileForConfig(
+	documentsConfig *documentindex.DocumentsConfig,
+	manifest mistral.CapabilityManifest,
+) ([]string, store.DocumentExtractionProfile, error) {
+	allowedMediaTypes, err := manifest.AllowedMediaTypes()
+	if err != nil {
+		return nil, store.DocumentExtractionProfile{}, err
+	}
+	if documentsConfig.MaxPagesPerDocument > manifest.MaxPages {
+		return nil, store.DocumentExtractionProfile{},
+			errors.New("configured max_pages_per_document exceeds the authenticated capability probe")
+	}
+	fingerprint, err := documentsConfig.ProfileFingerprint(allowedMediaTypes)
+	if err != nil {
+		return nil, store.DocumentExtractionProfile{}, err
+	}
+	policyJSON, err := documentsConfig.ProfilePolicyJSON(allowedMediaTypes)
+	if err != nil {
+		return nil, store.DocumentExtractionProfile{}, err
+	}
+	endpoint, err := documentsConfig.Endpoint()
+	if err != nil {
+		return nil, store.DocumentExtractionProfile{}, err
+	}
+	profile := store.DocumentExtractionProfile{
+		ID: "documents-v1:" + fingerprint, Fingerprint: fingerprint,
+		Provider: documentsConfig.Provider, Endpoint: endpoint, Region: documentsConfig.Region,
+		Model: documentsConfig.Model, RetentionPosture: documentsConfig.RetentionPosture,
+		TrainingPosture:   documentsConfig.TrainingPosture,
+		AllowedMediaTypes: allowedMediaTypes, PolicyJSON: policyJSON,
+	}
+	return allowedMediaTypes, profile, nil
+}
+
+func openDocumentAttachments(
+	st *store.Store,
+) (documentindex.DocumentAttachmentOpener, func() error, error) {
+	attachments, err := attachmentstore.New(store.NewPackCatalog(st), cfg.AttachmentsDir())
+	if err != nil {
+		return nil, nil, err
+	}
+	return attachments, attachments.Close, nil
+}
+
+func newConfiguredMistralProcessor(
+	documentsConfig *documentindex.DocumentsConfig,
+	allowedMediaTypes []string,
+) (mistral.Processor, error) {
+	apiKey, err := documentsConfig.ResolveAPIKey()
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := documentsConfig.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	client, err := mistral.NewClient(mistral.Config{
+		Endpoint:          endpoint,
+		APIKey:            apiKey,
+		Model:             documentsConfig.Model,
+		AllowedMediaTypes: allowedMediaTypes,
+		Timeout:           documentsConfig.RequestTimeout,
+		MaxDocumentBytes:  documentsConfig.MaxFileBytes,
+		MaxResponseBytes:  documentsConfig.MaxResponseBytes,
+		MaxUnits:          documentsConfig.MaxPagesPerDocument,
+		MaxRetries:        documentsConfig.MaxRetries,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure mistral document probe: %w", err)
+	}
+	return client, nil
+}
+
+func init() {
+	rootCmd.AddCommand(newDocumentsCmd(defaultDocumentsCommandDeps()))
+}

--- a/cmd/msgvault/cmd/documents_scheduler.go
+++ b/cmd/msgvault/cmd/documents_scheduler.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/documentindex/mistral"
+	"go.kenn.io/msgvault/internal/scheduler"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	documentFullReconcileJob         = "document-index-full-reconcile"
+	documentExtractionJob            = "document-index-extract"
+	documentFullReconcileCron        = "43 3 * * 0"
+	documentDerivativeRecoveryWindow = 7 * 24 * time.Hour
+	documentDerivativeGCBatch        = 1000
+	documentRoleRepairBatch          = 1000
+)
+
+type scheduledDocumentDeps struct {
+	newProcessor    func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error)
+	openAttachments func(*store.Store) (documentindex.DocumentAttachmentOpener, func() error, error)
+	dataDirectory   string
+}
+
+func configureDocumentReconcileJob(
+	ctx context.Context,
+	sched *scheduler.Scheduler,
+	st *store.Store,
+	enabled bool,
+) error {
+	if !enabled {
+		return st.UnregisterAttachmentChangeConsumer(ctx, documentindex.DocumentAttachmentConsumerKey)
+	}
+	reconciler, err := documentindex.NewReconciler(st, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 1000,
+		ChangePageSize:     1000,
+	})
+	if err != nil {
+		return err
+	}
+	if err := bootstrapDocumentOccurrencesIfConsented(ctx, st); err != nil {
+		return fmt.Errorf("bootstrap document reconciliation: %w", err)
+	}
+	return sched.AddJob(scheduler.Job{
+		Name:     documentFullReconcileJob,
+		Schedule: documentFullReconcileCron,
+		Run: func(ctx context.Context) error {
+			_, err := st.GetAttachmentChangeConsumer(ctx, documentindex.DocumentAttachmentConsumerKey)
+			if errors.Is(err, store.ErrAttachmentChangeConsumerMissing) {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("read document reconciliation registration: %w", err)
+			}
+			if _, err = reconciler.FullReconcile(ctx); err != nil {
+				return err
+			}
+			for {
+				result, gcErr := st.GarbageCollectDocumentDerivatives(
+					ctx, time.Now().UTC().Add(-documentDerivativeRecoveryWindow),
+					documentDerivativeGCBatch,
+				)
+				if gcErr != nil {
+					return fmt.Errorf("garbage collect document derivatives: %w", gcErr)
+				}
+				if result.ExtractionsRemoved < documentDerivativeGCBatch {
+					return nil
+				}
+			}
+		},
+	})
+}
+
+func configureDocumentExtractionJob(
+	sched *scheduler.Scheduler,
+	st *store.Store,
+	documentsConfig documentindex.DocumentsConfig,
+	deps scheduledDocumentDeps,
+) error {
+	if !documentsConfig.Enabled || documentsConfig.Schedule == "" {
+		return nil
+	}
+	if deps.newProcessor == nil || deps.openAttachments == nil || deps.dataDirectory == "" {
+		return errors.New("scheduled document extraction dependencies are incomplete")
+	}
+	return sched.AddJob(scheduler.Job{
+		Name: documentExtractionJob, Schedule: documentsConfig.Schedule,
+		Run: func(ctx context.Context) (runErr error) {
+			manifest, err := loadDocumentCapabilityManifest(documentsConfig.CapabilityManifest)
+			if err != nil {
+				return err
+			}
+			allowedMediaTypes, profile, err := documentProfileForConfig(&documentsConfig, manifest)
+			if err != nil {
+				return err
+			}
+			if _, err = st.RepairHistoricalAttachmentRolesBatch(ctx, documentRoleRepairBatch); err != nil {
+				return fmt.Errorf("repair historical attachment roles before scheduled extraction: %w", err)
+			}
+			status, err := st.GetDocumentIndexStatus(ctx, profile.ID)
+			if err != nil {
+				return err
+			}
+			if !status.ProfileEnabled || !status.ExactConsent {
+				return errors.New("scheduled document extraction requires exact provider consent")
+			}
+			limit, err := documentsConfig.MaxDocumentsWithinRunBudget(10_000)
+			if err != nil {
+				return err
+			}
+			processor, err := deps.newProcessor(&documentsConfig, allowedMediaTypes)
+			if err != nil {
+				return err
+			}
+			attachments, closeAttachments, err := deps.openAttachments(st)
+			if err != nil {
+				return err
+			}
+			defer func() { runErr = errors.Join(runErr, closeAttachments()) }()
+			_, err = executeDocumentBuild(
+				ctx, st, attachments, processor, &documentsConfig, manifest,
+				allowedMediaTypes, profile, limit, "documents-daemon", deps.dataDirectory,
+				documentBuildIncremental, nil,
+			)
+			return err
+		},
+	})
+}

--- a/cmd/msgvault/cmd/documents_test.go
+++ b/cmd/msgvault/cmd/documents_test.go
@@ -1,0 +1,1060 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/documentindex/mistral"
+	internalmime "go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/scheduler"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestProbeMistralCommandWritesCompleteSanitizedManifest(t *testing.T) {
+	assert := assert.New(t)
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	cfg.Attachments.Documents.Enabled = true
+	cfg.Attachments.Documents.RetentionPosture = documentindex.RetentionStandard
+	cfg.Attachments.Documents.TrainingPosture = documentindex.TrainingOptedOut
+
+	processor := &commandProbeProcessor{}
+	loaderCalled := false
+	cleanupCalled := false
+	deps := documentsCommandDeps{
+		newMistralProcessor: func(got *documentindex.DocumentsConfig, mediaTypes []string) (mistral.Processor, error) {
+			assert.Same(&cfg.Attachments.Documents, got)
+			assert.Len(mediaTypes, len(mistral.CandidateFormats()))
+			return processor, nil
+		},
+		loadProbeFixtures: func(_ context.Context, directory string, maxBytes int64) (map[string]mistral.Document, func() error, error) {
+			loaderCalled = true
+			assert.Equal("synthetic-fixtures", directory)
+			assert.Equal(cfg.Attachments.Documents.MaxFileBytes, maxBytes)
+			documents := make(map[string]mistral.Document, len(mistral.CandidateFormats()))
+			for _, candidate := range mistral.CandidateFormats() {
+				documents[candidate.ID] = mistral.Document{
+					Path: candidate.ID, MediaType: candidate.MediaType, Size: 1, SHA256: strings.Repeat("0", 64),
+				}
+			}
+			return documents, func() error { cleanupCalled = true; return nil }, nil
+		},
+	}
+	command := newDocumentsCmd(deps)
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"probe-mistral", "--fixtures", "synthetic-fixtures"})
+
+	require.NoError(t, command.ExecuteContext(t.Context()))
+	assert.True(loaderCalled)
+	assert.True(cleanupCalled)
+	manifest, err := mistral.DecodeCapabilityManifest(bytes.NewReader(output.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, manifest.Results, len(mistral.CandidateFormats()))
+	assert.Equal(mistral.ProbeStatusPassed, manifest.Results[0].Status)
+	assert.NotContains(output.String(), "synthetic-fixtures")
+}
+
+func TestProbeMistralValidateOnlyNeedsNoProviderConfiguration(t *testing.T) {
+	assert := assert.New(t)
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	providerCalled := false
+	cleanupCalled := false
+	deps := documentsCommandDeps{
+		newMistralProcessor: func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error) {
+			providerCalled = true
+			return &commandProbeProcessor{}, nil
+		},
+		loadProbeFixtures: func(_ context.Context, directory string, maxBytes int64) (map[string]mistral.Document, func() error, error) {
+			assert.Equal("synthetic-fixtures", directory)
+			assert.Equal(cfg.Attachments.Documents.MaxFileBytes, maxBytes)
+			documents := make(map[string]mistral.Document, len(mistral.CandidateFormats()))
+			for _, candidate := range mistral.CandidateFormats() {
+				documents[candidate.ID] = mistral.Document{MediaType: candidate.MediaType}
+			}
+			return documents, func() error { cleanupCalled = true; return nil }, nil
+		},
+	}
+	command := newDocumentsCmd(deps)
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"probe-mistral", "--fixtures", "synthetic-fixtures", "--validate-only"})
+
+	require.NoError(t, command.ExecuteContext(t.Context()))
+	assert.False(providerCalled)
+	assert.True(cleanupCalled)
+	assert.Contains(output.String(), "Validated 26 private Mistral fixture(s) locally")
+	assert.Contains(output.String(), "no provider requests")
+	assert.NotContains(output.String(), "synthetic-fixtures")
+}
+
+func TestDocumentsConsentBuildAndStatusUseExactAuthenticatedProfile(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	cfg.Data.DataDir = t.TempDir()
+	cfg.Attachments.Documents.Enabled = true
+	cfg.Attachments.Documents.RetentionPosture = documentindex.RetentionStandard
+	cfg.Attachments.Documents.TrainingPosture = documentindex.TrainingOptedOut
+	cfg.Attachments.Documents.EstimatedCostUSDPerKUnits = 4
+	cfg.Attachments.Documents.PricingAssumptionOn = "2026-08-13"
+
+	fixture := storetest.New(t)
+	content := []byte("%PDF-1.7\nsynthetic document")
+	hash := sha256.Sum256(content)
+	digest := hex.EncodeToString(hash[:])
+	messageID := fixture.CreateMessage("documents-command")
+	require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: int64(len(content)),
+		StoragePath: digest[:2] + "/" + digest, ContentHash: digest,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: "part:1",
+	}))
+	manifestPath := writeCommandCapabilityManifest(t, cfg.Attachments.Documents.MaxPagesPerDocument)
+	processor := &commandBuildProcessor{}
+	attachmentOpened := false
+	deps := documentsCommandDeps{
+		newMistralProcessor: func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error) {
+			return processor, nil
+		},
+		loadProbeFixtures: mistral.LoadProbeFixtures,
+		openStore: func() (*store.Store, func(), error) {
+			return fixture.Store, func() {}, nil
+		},
+		openAttachments: func(*store.Store) (documentindex.DocumentAttachmentOpener, func() error, error) {
+			attachmentOpened = true
+			return commandAttachmentOpener{content: content}, func() error { return nil }, nil
+		},
+	}
+
+	unconfirmedConsent := newDocumentsCmd(deps)
+	var disclosureOutput bytes.Buffer
+	unconfirmedConsent.SetOut(&disclosureOutput)
+	unconfirmedConsent.SetErr(&bytes.Buffer{})
+	unconfirmedConsent.SetArgs([]string{"consent-mistral", "--capabilities", manifestPath})
+	require.ErrorContains(unconfirmedConsent.ExecuteContext(t.Context()), "requires --yes")
+	assert.Contains(disclosureOutput.String(), "Complete original document bytes")
+	assert.Contains(disclosureOutput.String(), "retention=standard, training=opted-out")
+	assert.Contains(disclosureOutput.String(), "local archive database")
+	assert.Contains(disclosureOutput.String(), "does not enable hosted document text embeddings")
+	assert.NotContains(disclosureOutput.String(), manifestPath)
+
+	consent := newDocumentsCmd(deps)
+	var consentOutput bytes.Buffer
+	consent.SetOut(&consentOutput)
+	consent.SetErr(&bytes.Buffer{})
+	consent.SetArgs([]string{"consent-mistral", "--capabilities", manifestPath, "--yes"})
+	require.NoError(consent.ExecuteContext(t.Context()))
+	assert.Contains(consentOutput.String(), "Recorded Mistral document consent")
+	assert.NotContains(consentOutput.String(), manifestPath)
+	assert.Equal(1, commandDocumentOccurrenceCount(t, fixture.Store),
+		"consent must bootstrap historical attachment occurrences before the first build")
+
+	build := newDocumentsCmd(deps)
+	var buildOutput bytes.Buffer
+	build.SetOut(&buildOutput)
+	build.SetErr(&bytes.Buffer{})
+	build.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath, "--limit", "5"})
+	require.ErrorContains(build.ExecuteContext(t.Context()), "requires --yes")
+	assert.Contains(buildOutput.String(), "Document build upload preflight")
+	assert.Contains(buildOutput.String(), "Complete original document bytes")
+	assert.False(attachmentOpened)
+	assert.Zero(processor.calls)
+
+	build = newDocumentsCmd(deps)
+	buildOutput.Reset()
+	build.SetOut(&buildOutput)
+	build.SetErr(&bytes.Buffer{})
+	build.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath, "--limit", "5", "--yes"})
+	require.NoError(build.ExecuteContext(t.Context()))
+	assert.Contains(buildOutput.String(), "indexed 1 document(s), 1 unit(s), skipped 0, failed 0")
+	assert.Equal(1, processor.calls)
+
+	search := newDocumentsCmd(deps)
+	var searchOutput bytes.Buffer
+	search.SetOut(&searchOutput)
+	search.SetErr(&bytes.Buffer{})
+	search.SetArgs([]string{"search", "Synthetic", "--json"})
+	require.NoError(search.ExecuteContext(t.Context()))
+	var searchResponse store.DocumentSearchResponse
+	require.NoError(json.Unmarshal(searchOutput.Bytes(), &searchResponse))
+	require.Len(searchResponse.Results, 1)
+	assert.Equal(messageID, searchResponse.Results[0].MessageID)
+	assert.Equal("synthetic.pdf", searchResponse.Results[0].Filename)
+	assert.Contains(searchResponse.Results[0].MatchedSignals, "content")
+
+	resume := newDocumentsCmd(deps)
+	var resumeOutput bytes.Buffer
+	resume.SetOut(&resumeOutput)
+	resume.SetErr(&bytes.Buffer{})
+	resume.SetArgs([]string{"resume", "--capabilities", manifestPath, "--limit", "5", "--yes"})
+	require.NoError(resume.ExecuteContext(t.Context()))
+	assert.Contains(resumeOutput.String(), "indexed 0 document(s)")
+	assert.Equal(1, processor.calls)
+
+	rebuild := newDocumentsCmd(deps)
+	rebuild.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath, "--full-rebuild"})
+	require.ErrorContains(rebuild.ExecuteContext(t.Context()), "requires --yes")
+	assert.Equal(1, processor.calls)
+	rebuild = newDocumentsCmd(deps)
+	var rebuildOutput bytes.Buffer
+	rebuild.SetOut(&rebuildOutput)
+	rebuild.SetErr(&bytes.Buffer{})
+	rebuild.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath, "--full-rebuild", "--yes"})
+	require.NoError(rebuild.ExecuteContext(t.Context()))
+	assert.Contains(rebuildOutput.String(), "indexed 1 document(s)")
+	assert.Equal(2, processor.calls)
+	search = newDocumentsCmd(deps)
+	searchOutput.Reset()
+	search.SetOut(&searchOutput)
+	search.SetErr(&bytes.Buffer{})
+	search.SetArgs([]string{"search", "Replacement", "--json"})
+	require.NoError(search.ExecuteContext(t.Context()))
+	require.NoError(json.Unmarshal(searchOutput.Bytes(), &searchResponse))
+	require.Len(searchResponse.Results, 1)
+	assert.Equal(messageID, searchResponse.Results[0].MessageID)
+
+	status := newDocumentsCmd(deps)
+	var statusOutput bytes.Buffer
+	status.SetOut(&statusOutput)
+	status.SetErr(&bytes.Buffer{})
+	status.SetArgs([]string{"status", "--capabilities", manifestPath})
+	require.NoError(status.ExecuteContext(t.Context()))
+	assert.Contains(statusOutput.String(), "Exact consent: true")
+	assert.Contains(statusOutput.String(), "Coverage: 1 ready")
+	assert.Contains(statusOutput.String(), "Extraction accounting: 2 attempt(s), 2 successful, 0 failed")
+	assert.Contains(statusOutput.String(), "Provider accounting: 2 request(s), 0 internal retry(s)")
+	assert.Contains(statusOutput.String(), "Normalized plaintext stored: true")
+	assert.Contains(statusOutput.String(), "Hosted document text embeddings: false")
+
+	statusJSON := newDocumentsCmd(deps)
+	var statusJSONOutput bytes.Buffer
+	statusJSON.SetOut(&statusJSONOutput)
+	statusJSON.SetErr(&bytes.Buffer{})
+	statusJSON.SetArgs([]string{"status", "--capabilities", manifestPath, "--json"})
+	require.NoError(statusJSON.ExecuteContext(t.Context()))
+	var structuredStatus documentStatusOutput
+	require.NoError(json.Unmarshal(statusJSONOutput.Bytes(), &structuredStatus))
+	assert.Equal(len(mistral.CandidateFormats()), structuredStatus.AuthenticatedFormats)
+	assert.True(structuredStatus.Status.ExactConsent)
+	assert.Equal(int64(1), structuredStatus.Status.ReadyOwners)
+	assert.Equal(int64(1), structuredStatus.Status.EligibleOwners)
+	assert.Equal(int64(len(content)), structuredStatus.Status.EligibleBytes)
+	assert.Equal(int64(2), structuredStatus.Status.ExtractionAttempts)
+	assert.Equal(int64(2), structuredStatus.Status.SuccessfulAttempts)
+	assert.Equal(int64(2), structuredStatus.Status.ProviderRequests)
+	assert.Zero(structuredStatus.Status.ProviderRetries)
+	assert.Positive(structuredStatus.Status.ProviderLatencyMillis)
+	assert.Positive(structuredStatus.Status.AverageProviderLatencyMS)
+	assert.Equal(int64(2*len(content)), structuredStatus.Status.VerifiedUploadBytes)
+	assert.Equal(int64(2), structuredStatus.Status.ProcessedProviderUnits)
+	assert.Equal(int64(2), structuredStatus.Status.MissingProviderByteReports)
+	assert.Equal(documentindex.ModelMistralOCR, structuredStatus.Model)
+	assert.Equal(documentindex.RetentionStandard, structuredStatus.RetentionPosture)
+	assert.True(structuredStatus.StoresPlaintext)
+	assert.True(structuredStatus.BackupsMayContainText)
+	assert.False(structuredStatus.HostedTextEmbeddings)
+	assert.Equal("2026-08-13", structuredStatus.PricingAssumptionOn)
+	require.NotNil(structuredStatus.EstimatedSuccessfulCostUSD)
+	assert.InDelta(0.008, *structuredStatus.EstimatedSuccessfulCostUSD, 0.000001)
+
+	profile, err := configuredDocumentProfileOnly(manifestPath)
+	require.NoError(err)
+	retry := newDocumentsCmd(deps)
+	retry.SetArgs([]string{"retry", "--capabilities", manifestPath, "--hash", digest})
+	require.ErrorContains(retry.ExecuteContext(t.Context()), "already current")
+
+	retire := newDocumentsCmd(deps)
+	retire.SetArgs([]string{"retire", profile.ID})
+	require.ErrorContains(retire.ExecuteContext(t.Context()), "requires --yes")
+	retire = newDocumentsCmd(deps)
+	var retireOutput bytes.Buffer
+	retire.SetOut(&retireOutput)
+	retire.SetErr(&bytes.Buffer{})
+	retire.SetArgs([]string{"retire", profile.ID, "--yes"})
+	require.NoError(retire.ExecuteContext(t.Context()))
+	assert.Contains(retireOutput.String(), "Retired document extraction profile")
+
+	search = newDocumentsCmd(deps)
+	searchOutput.Reset()
+	search.SetOut(&searchOutput)
+	search.SetErr(&bytes.Buffer{})
+	search.SetArgs([]string{"search", "Synthetic", "--json"})
+	require.NoError(search.ExecuteContext(t.Context()))
+	require.NoError(json.Unmarshal(searchOutput.Bytes(), &searchResponse))
+	assert.Empty(searchResponse.Results)
+
+	purge := newDocumentsCmd(deps)
+	purge.SetArgs([]string{"purge-derived", "--hash", digest})
+	require.ErrorContains(purge.ExecuteContext(t.Context()), "requires --yes")
+	purge = newDocumentsCmd(deps)
+	var purgeOutput bytes.Buffer
+	purge.SetOut(&purgeOutput)
+	purge.SetErr(&bytes.Buffer{})
+	purge.SetArgs([]string{"purge-derived", "--hash", digest, "--yes"})
+	require.NoError(purge.ExecuteContext(t.Context()))
+	assert.Contains(purgeOutput.String(), "Purged 2 extraction(s) and 1 current head(s)")
+}
+
+func TestDocumentBuildRepairsHistoricalMIMERolesBeforePreflight(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	cfg.Data.DataDir = t.TempDir()
+	cfg.Attachments.Documents.Enabled = true
+	cfg.Attachments.Documents.RetentionPosture = documentindex.RetentionStandard
+	cfg.Attachments.Documents.TrainingPosture = documentindex.TrainingOptedOut
+
+	fixture := storetest.New(t)
+	messageID := fixture.CreateMessage("documents-historical-role")
+	raw := []byte("From: sender@example.test\r\nTo: recipient@example.test\r\n" +
+		"MIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=doc\r\n\r\n" +
+		"--doc\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+		"--doc\r\nContent-Type: application/pdf\r\n" +
+		"Content-Disposition: attachment; filename=archive.pdf\r\n\r\n%PDF-synthetic\r\n" +
+		"--doc--\r\n")
+	require.NoError(fixture.Store.UpsertMessageRaw(messageID, raw))
+	parsed, err := internalmime.Parse(raw)
+	require.NoError(err)
+	require.Len(parsed.Attachments, 1)
+	attachment := parsed.Attachments[0]
+	_, err = fixture.Store.DB().Exec(fixture.Store.Rebind(`
+		INSERT INTO attachments
+			(message_id, filename, mime_type, storage_path, content_hash, size, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`),
+		messageID, attachment.Filename, attachment.ContentType,
+		attachment.ContentHash[:2]+"/"+attachment.ContentHash,
+		attachment.ContentHash, len(attachment.Content))
+	require.NoError(err)
+
+	manifestPath := writeCommandCapabilityManifest(t, cfg.Attachments.Documents.MaxPagesPerDocument)
+	deps := documentsCommandDeps{
+		openStore: func() (*store.Store, func(), error) { return fixture.Store, func() {}, nil },
+		openAttachments: func(*store.Store) (documentindex.DocumentAttachmentOpener, func() error, error) {
+			return nil, func() error { return nil }, errors.New("synthetic stop after repair")
+		},
+	}
+	command := newDocumentsCmd(deps)
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath})
+	require.ErrorContains(command.ExecuteContext(t.Context()), "requires --yes")
+
+	var role, roleSource string
+	var partKey *string
+	require.NoError(fixture.Store.DB().QueryRow(fixture.Store.Rebind(`
+		SELECT attachment_role, role_source, source_part_key
+		FROM attachments WHERE message_id = ?`), messageID).Scan(&role, &roleSource, &partKey))
+	assert.Equal("unknown", role, "declining build must not mutate historical attachment roles")
+	assert.Equal("unknown", roleSource)
+	assert.Nil(partKey)
+
+	consent := newDocumentsCmd(deps)
+	consent.SetOut(&bytes.Buffer{})
+	consent.SetErr(&bytes.Buffer{})
+	consent.SetArgs([]string{"consent-mistral", "--capabilities", manifestPath, "--yes"})
+	require.NoError(consent.ExecuteContext(t.Context()))
+	command = newDocumentsCmd(deps)
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath, "--yes"})
+	require.ErrorContains(command.ExecuteContext(t.Context()), "synthetic stop after repair")
+
+	require.NoError(fixture.Store.DB().QueryRow(fixture.Store.Rebind(`
+		SELECT attachment_role, role_source, source_part_key
+		FROM attachments WHERE message_id = ?`), messageID).Scan(&role, &roleSource, &partKey))
+	assert.Equal("standalone", role)
+	assert.Equal("raw_mime_repair", roleSource)
+	require.NotNil(partKey)
+	assert.NotEmpty(*partKey)
+}
+
+func TestDocumentsSearchDoesNotRegisterUnconsentedJournalConsumer(t *testing.T) {
+	require := require.New(t)
+	fixture := storetest.New(t)
+	deps := documentsCommandDeps{
+		openStore: func() (*store.Store, func(), error) { return fixture.Store, func() {}, nil },
+	}
+	command := newDocumentsCmd(deps)
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"search", "nothing", "--json"})
+	require.NoError(command.ExecuteContext(t.Context()))
+	var response store.DocumentSearchResponse
+	require.NoError(json.Unmarshal(output.Bytes(), &response))
+	assert.Empty(t, response.Results)
+	_, err := fixture.Store.GetAttachmentChangeConsumer(
+		t.Context(), documentindex.DocumentAttachmentConsumerKey,
+	)
+	require.ErrorIs(err, store.ErrAttachmentChangeConsumerMissing)
+}
+
+func TestDocumentsSearchUsesConfiguredReadClient(t *testing.T) {
+	openStoreCalled := false
+	cleanupCalled := false
+	reader := commandDocumentReadClient{
+		search: func(
+			_ context.Context,
+			request store.DocumentSearchRequest,
+		) (store.DocumentSearchResponse, error) {
+			assert.Equal(t, "damage report", request.Query)
+			return store.DocumentSearchResponse{Results: []store.DocumentSearchResult{{
+				AttachmentID: 3, MessageID: 4, Filename: "report.pdf", Rank: 1,
+			}}}, nil
+		},
+	}
+	command := newDocumentsCmd(documentsCommandDeps{
+		openStore: func() (*store.Store, func(), error) {
+			openStoreCalled = true
+			return nil, func() {}, errors.New("local store must not be opened")
+		},
+		openReadClient: func(context.Context) (documentReadClient, func(), error) {
+			return reader, func() { cleanupCalled = true }, nil
+		},
+	})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"search", "damage report", "--json"})
+	require.NoError(t, command.ExecuteContext(t.Context()))
+	assert.False(t, openStoreCalled)
+	assert.True(t, cleanupCalled)
+	assert.Contains(t, output.String(), "report.pdf")
+}
+
+func TestDocumentsStatusUsesConfiguredReadClient(t *testing.T) {
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	cfg.Attachments.Documents.Enabled = true
+	cfg.Attachments.Documents.RetentionPosture = documentindex.RetentionStandard
+	cfg.Attachments.Documents.TrainingPosture = documentindex.TrainingOptedOut
+	manifestPath := writeCommandCapabilityManifest(t, cfg.Attachments.Documents.MaxPagesPerDocument)
+	openStoreCalled := false
+	cleanupCalled := false
+	reader := commandDocumentReadClient{
+		status: func(
+			_ context.Context,
+			request store.DocumentIndexStatusRequest,
+		) (store.DocumentIndexStatusResponse, error) {
+			assert.NotEmpty(t, request.ProfileID)
+			assert.Equal(t, "original", request.ExtractionInputKey)
+			assert.NotEmpty(t, request.AllowedMediaTypes)
+			return store.DocumentIndexStatusResponse{Status: store.DocumentIndexStatus{
+				ProfileExists: true, ReadyOwners: 3,
+			}}, nil
+		},
+	}
+	command := newDocumentsCmd(documentsCommandDeps{
+		openStore: func() (*store.Store, func(), error) {
+			openStoreCalled = true
+			return nil, func() {}, errors.New("local store must not be opened")
+		},
+		openReadClient: func(context.Context) (documentReadClient, func(), error) {
+			return reader, func() { cleanupCalled = true }, nil
+		},
+	})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"status", "--capabilities", manifestPath, "--json"})
+	require.NoError(t, command.ExecuteContext(t.Context()))
+	assert.False(t, openStoreCalled)
+	assert.True(t, cleanupCalled)
+	assert.Contains(t, output.String(), `"ready_owners":3`)
+}
+
+func TestDocumentsBuildRefusesAPIUseBeforeExactConsent(t *testing.T) {
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	cfg.Data.DataDir = t.TempDir()
+	cfg.Attachments.Documents.Enabled = true
+	cfg.Attachments.Documents.RetentionPosture = documentindex.RetentionStandard
+	cfg.Attachments.Documents.TrainingPosture = documentindex.TrainingOptedOut
+	fixture := storetest.New(t)
+	providerCalled := false
+	deps := documentsCommandDeps{
+		newMistralProcessor: func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error) {
+			providerCalled = true
+			return &commandProbeProcessor{}, nil
+		},
+		openStore: func() (*store.Store, func(), error) { return fixture.Store, func() {}, nil },
+	}
+	manifestPath := writeCommandCapabilityManifest(t, cfg.Attachments.Documents.MaxPagesPerDocument)
+	command := newDocumentsCmd(deps)
+	command.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath, "--yes"})
+	err := command.ExecuteContext(t.Context())
+	require.ErrorContains(t, err, "requires exact consent")
+	assert.False(t, providerCalled)
+}
+
+func TestDocumentFullRebuildResumesDurableTargetSnapshot(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	cfg.Data.DataDir = t.TempDir()
+	cfg.Attachments.Documents.Enabled = true
+	cfg.Attachments.Documents.RetentionPosture = documentindex.RetentionStandard
+	cfg.Attachments.Documents.TrainingPosture = documentindex.TrainingOptedOut
+	fixture := storetest.New(t)
+	contents := make(map[string][]byte)
+	for index, content := range [][]byte{
+		[]byte("%PDF-1.7\nfirst rebuild document"),
+		[]byte("%PDF-1.7\nsecond rebuild document"),
+	} {
+		digestBytes := sha256.Sum256(content)
+		digest := hex.EncodeToString(digestBytes[:])
+		contents[digest] = content
+		messageID := fixture.CreateMessage("documents-rebuild-" + string(rune('a'+index)))
+		require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+			Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: int64(len(content)),
+			StoragePath: digest[:2] + "/" + digest, ContentHash: digest,
+			Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+			SourcePartKey: "part:" + string(rune('1'+index)),
+		}))
+	}
+	manifestPath := writeCommandCapabilityManifest(t, cfg.Attachments.Documents.MaxPagesPerDocument)
+	processor := &commandBuildProcessor{}
+	deps := documentsCommandDeps{
+		newMistralProcessor: func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error) {
+			return processor, nil
+		},
+		openStore: func() (*store.Store, func(), error) { return fixture.Store, func() {}, nil },
+		openAttachments: func(*store.Store) (documentindex.DocumentAttachmentOpener, func() error, error) {
+			return commandAttachmentMapOpener{contents: contents}, func() error { return nil }, nil
+		},
+	}
+	consent := newDocumentsCmd(deps)
+	consent.SetArgs([]string{"consent-mistral", "--capabilities", manifestPath, "--yes"})
+	require.NoError(consent.ExecuteContext(t.Context()))
+	initial := newDocumentsCmd(deps)
+	initial.SetArgs([]string{documentBuildSubcommand, "--capabilities", manifestPath, "--limit", "2", "--yes"})
+	require.NoError(initial.ExecuteContext(t.Context()))
+	assert.Equal(2, processor.calls)
+
+	rebuild := newDocumentsCmd(deps)
+	var rebuildOutput bytes.Buffer
+	rebuild.SetOut(&rebuildOutput)
+	rebuild.SetErr(&bytes.Buffer{})
+	rebuild.SetArgs([]string{
+		documentBuildSubcommand, "--capabilities", manifestPath,
+		"--full-rebuild", "--yes", "--limit", "1",
+	})
+	require.NoError(rebuild.ExecuteContext(t.Context()))
+	assert.Contains(rebuildOutput.String(), "1 current owner(s) remaining")
+	assert.Equal(3, processor.calls)
+	status := newDocumentsCmd(deps)
+	var statusOutput bytes.Buffer
+	status.SetOut(&statusOutput)
+	status.SetErr(&bytes.Buffer{})
+	status.SetArgs([]string{"status", "--capabilities", manifestPath, "--json"})
+	require.NoError(status.ExecuteContext(t.Context()))
+	var structuredStatus documentStatusOutput
+	require.NoError(json.Unmarshal(statusOutput.Bytes(), &structuredStatus))
+	require.NotNil(structuredStatus.ActiveRebuild)
+	assert.Equal(int64(2), structuredStatus.ActiveRebuild.SnapshotOwners)
+	assert.Equal(int64(1), structuredStatus.ActiveRebuild.RemainingOwners)
+
+	resume := newDocumentsCmd(deps)
+	var resumeOutput bytes.Buffer
+	resume.SetOut(&resumeOutput)
+	resume.SetErr(&bytes.Buffer{})
+	resume.SetArgs([]string{"resume", "--capabilities", manifestPath, "--limit", "1", "--yes"})
+	require.NoError(resume.ExecuteContext(t.Context()))
+	assert.Contains(resumeOutput.String(), "Full document rebuild completed")
+	assert.Equal(4, processor.calls)
+	profile, err := configuredDocumentProfileOnly(manifestPath)
+	require.NoError(err)
+	_, err = fixture.Store.GetActiveDocumentExtractionRebuild(t.Context(), profile.ID, "original")
+	require.ErrorIs(err, store.ErrDocumentExtractionRebuildMissing)
+}
+
+func TestDocumentBuildContinuesAfterOneExtractionFailure(t *testing.T) {
+	require := require.New(t)
+	fixture := storetest.New(t)
+	contents := make(map[string][]byte)
+	for index, content := range [][]byte{
+		[]byte("%PDF-1.7\nmalformed synthetic document"),
+		[]byte("%PDF-1.7\nsearchable synthetic document"),
+	} {
+		digestBytes := sha256.Sum256(content)
+		digest := hex.EncodeToString(digestBytes[:])
+		contents[digest] = content
+		messageID := fixture.CreateMessage("documents-isolated-" + string(rune('a'+index)))
+		require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+			Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: int64(len(content)),
+			StoragePath: digest[:2] + "/" + digest, ContentHash: digest,
+			Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+			SourcePartKey: "part:" + string(rune('1'+index)),
+		}))
+	}
+	documentsConfig := documentindex.DefaultDocumentsConfig()
+	documentsConfig.Enabled = true
+	documentsConfig.RetentionPosture = documentindex.RetentionStandard
+	documentsConfig.TrainingPosture = documentindex.TrainingOptedOut
+	manifestPath := writeCommandCapabilityManifest(t, documentsConfig.MaxPagesPerDocument)
+	manifest, err := loadDocumentCapabilityManifest(manifestPath)
+	require.NoError(err)
+	allowed, profile, err := documentProfileForConfig(&documentsConfig, manifest)
+	require.NoError(err)
+	_, err = fixture.Store.EnsureDocumentExtractionProfile(t.Context(), profile)
+	require.NoError(err)
+	require.NoError(fixture.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+	}))
+
+	result, err := executeDocumentBuild(
+		t.Context(), fixture.Store, commandAttachmentMapOpener{contents: contents},
+		&commandFailFirstProcessor{}, &documentsConfig, manifest, allowed, profile, 2,
+		"documents-isolation-test", t.TempDir(), documentBuildIncremental, nil,
+	)
+	require.ErrorContains(err, "1 extraction failure")
+	assert.Equal(t, 1, result.Processed)
+	assert.Equal(t, 1, result.Failed)
+	response, searchErr := fixture.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "Synthetic"})
+	require.NoError(searchErr)
+	require.Len(response.Results, 1, "the second document must publish after the first is rejected")
+}
+
+func TestDocumentBuildStopsOnCancellation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := storetest.New(t)
+	content := []byte("%PDF-1.7\nsynthetic canceled document")
+	digestBytes := sha256.Sum256(content)
+	digest := hex.EncodeToString(digestBytes[:])
+	messageID := fixture.CreateMessage("documents-canceled")
+	require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: int64(len(content)),
+		StoragePath: digest[:2] + "/" + digest, ContentHash: digest,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: "part:1",
+	}))
+	documentsConfig := documentindex.DefaultDocumentsConfig()
+	documentsConfig.Enabled = true
+	documentsConfig.RetentionPosture = documentindex.RetentionStandard
+	documentsConfig.TrainingPosture = documentindex.TrainingOptedOut
+	manifestPath := writeCommandCapabilityManifest(t, documentsConfig.MaxPagesPerDocument)
+	manifest, err := loadDocumentCapabilityManifest(manifestPath)
+	require.NoError(err)
+	allowed, profile, err := documentProfileForConfig(&documentsConfig, manifest)
+	require.NoError(err)
+	_, err = fixture.Store.EnsureDocumentExtractionProfile(t.Context(), profile)
+	require.NoError(err)
+	require.NoError(fixture.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+	}))
+
+	result, err := executeDocumentBuild(
+		t.Context(), fixture.Store, commandAttachmentMapOpener{contents: map[string][]byte{digest: content}},
+		commandCancelingProcessor{}, &documentsConfig, manifest, allowed, profile, 1,
+		"documents-cancellation-test", t.TempDir(), documentBuildIncremental, nil,
+	)
+	require.ErrorIs(err, context.Canceled)
+	assert.Zero(result.Failed)
+	assert.Zero(result.Processed)
+	status, err := fixture.Store.GetDocumentIndexStatus(t.Context(), profile.ID)
+	require.NoError(err)
+	assert.Zero(status.StagingOwners, "provider cancellation must release the claim")
+	assert.Equal(int64(1), status.RetryOwners)
+}
+
+func TestScheduledDocumentFullReconcileRepairsMissedLifecycleEvent(t *testing.T) {
+	require := require.New(t)
+	fixture := storetest.New(t)
+	messageID := fixture.CreateMessage("documents-scheduled-reconcile")
+	hash := strings.Repeat("e", 64)
+	require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: 64,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: "part:1",
+	}))
+	reconciler, err := documentindex.NewReconciler(fixture.Store, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 10, ChangePageSize: 10,
+	})
+	require.NoError(err)
+	_, err = reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	assert.Equal(t, 1, commandDocumentOccurrenceCount(t, fixture.Store))
+
+	_, err = fixture.Store.DB().Exec(fixture.Store.Rebind(
+		`UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP WHERE id = ?`), messageID)
+	require.NoError(err)
+	_, err = fixture.Store.DB().Exec(`DELETE FROM attachment_change_log`)
+	require.NoError(err)
+
+	sched := scheduler.New(func(context.Context, string) error { return nil })
+	t.Cleanup(func() { <-sched.Stop().Done() })
+	require.NoError(configureDocumentReconcileJob(t.Context(), sched, fixture.Store, true))
+	assert.True(t, sched.IsJobScheduled(documentFullReconcileJob))
+	require.NoError(sched.TriggerJob(documentFullReconcileJob))
+	assert.Zero(t, commandDocumentOccurrenceCount(t, fixture.Store))
+}
+
+func TestLocalDocumentStatusReconcilesAttachmentJournalBeforeCounting(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := storetest.New(t)
+	reconciler, err := documentindex.NewReconciler(fixture.Store, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 10,
+		ChangePageSize:     10,
+	})
+	require.NoError(err)
+	_, err = reconciler.Reconcile(t.Context())
+	require.NoError(err)
+
+	messageID := fixture.CreateMessage("documents-status-freshness")
+	hash := strings.Repeat("f", 64)
+	require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "fresh.pdf", MIMEType: "application/pdf", Size: 64,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: "part:fresh",
+	}))
+	assert.Zero(commandDocumentOccurrenceCount(t, fixture.Store))
+
+	response, err := (localDocumentReadClient{store: fixture.Store}).GetDocumentIndexStatus(
+		t.Context(), store.DocumentIndexStatusRequest{
+			ProfileID: "missing-profile", ExtractionInputKey: "original",
+			AllowedMediaTypes: []string{"application/pdf"},
+		},
+	)
+	require.NoError(err)
+	assert.Equal(int64(1), response.Status.EligibleOccurrences)
+	assert.Equal(1, commandDocumentOccurrenceCount(t, fixture.Store))
+}
+
+func TestScheduledDocumentReconcileDoesNotEnableUnconsentedConsumer(t *testing.T) {
+	fixture := storetest.New(t)
+	sched := scheduler.New(func(context.Context, string) error { return nil })
+	t.Cleanup(func() { <-sched.Stop().Done() })
+	require.NoError(t, configureDocumentReconcileJob(t.Context(), sched, fixture.Store, true))
+	require.NoError(t, sched.TriggerJob(documentFullReconcileJob))
+	_, err := fixture.Store.GetAttachmentChangeConsumer(
+		t.Context(), documentindex.DocumentAttachmentConsumerKey,
+	)
+	require.ErrorIs(t, err, store.ErrAttachmentChangeConsumerMissing)
+}
+
+func TestScheduledDocumentReconcileBootstrapsExistingConsent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := storetest.New(t)
+	messageID := fixture.CreateMessage("documents-scheduler-bootstrap")
+	hash := strings.Repeat("a", 64)
+	require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "existing.pdf", MIMEType: "application/pdf", Size: 64,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: "part:existing",
+	}))
+	fingerprint := strings.Repeat("b", 64)
+	profile := store.DocumentExtractionProfile{
+		ID: "profile-" + fingerprint, Fingerprint: fingerprint,
+		Provider: "mistral", Endpoint: "https://api.mistral.ai/v1/ocr",
+		Region: "eu", Model: documentindex.ModelMistralOCR,
+		RetentionPosture:  string(documentindex.RetentionStandard),
+		TrainingPosture:   string(documentindex.TrainingOptedOut),
+		AllowedMediaTypes: []string{"application/pdf"},
+		PolicyJSON:        []byte(`{"normalization":1}`),
+	}
+	_, err := fixture.Store.EnsureDocumentExtractionProfile(t.Context(), profile)
+	require.NoError(err)
+	require.NoError(fixture.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+	}))
+
+	sched := scheduler.New(func(context.Context, string) error { return nil })
+	t.Cleanup(func() { <-sched.Stop().Done() })
+	require.NoError(configureDocumentReconcileJob(t.Context(), sched, fixture.Store, true))
+	assert.Equal(1, commandDocumentOccurrenceCount(t, fixture.Store))
+}
+
+func TestScheduledDocumentExtractionUsesExactManifestConsentAndRunBudget(t *testing.T) {
+	require := require.New(t)
+	fixture := storetest.New(t)
+	content := []byte("%PDF-1.7\nscheduled synthetic document")
+	hash := sha256.Sum256(content)
+	digest := hex.EncodeToString(hash[:])
+	messageID := fixture.CreateMessage("documents-scheduled-build")
+	require.NoError(fixture.Store.UpsertMessageRaw(messageID, []byte(
+		"From: sender@example.com\r\nTo: recipient@example.com\r\n"+
+			"MIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=scheduled\r\n\r\n"+
+			"--scheduled\r\nContent-Type: text/plain\r\n\r\nbody\r\n"+
+			"--scheduled\r\nContent-Type: application/pdf\r\n"+
+			"Content-Disposition: attachment; filename=scheduled.pdf\r\n\r\n"+
+			string(content)+"\r\n--scheduled--\r\n")))
+	require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "scheduled.pdf", MIMEType: "application/pdf", Size: int64(len(content)),
+		StoragePath: digest[:2] + "/" + digest, ContentHash: digest,
+	}))
+
+	documentsConfig := documentindex.DefaultDocumentsConfig()
+	documentsConfig.Enabled = true
+	documentsConfig.RetentionPosture = documentindex.RetentionStandard
+	documentsConfig.TrainingPosture = documentindex.TrainingOptedOut
+	documentsConfig.Schedule = "17 * * * *"
+	documentsConfig.EstimatedCostUSDPerKUnits = 4
+	documentsConfig.PricingAssumptionOn = "2026-08-13"
+	documentsConfig.CapabilityManifest = writeCommandCapabilityManifest(
+		t, documentsConfig.MaxPagesPerDocument,
+	)
+	require.NoError(documentsConfig.Validate())
+	manifest, err := loadDocumentCapabilityManifest(documentsConfig.CapabilityManifest)
+	require.NoError(err)
+	_, profile, err := documentProfileForConfig(&documentsConfig, manifest)
+	require.NoError(err)
+	_, err = fixture.Store.EnsureDocumentExtractionProfile(t.Context(), profile)
+	require.NoError(err)
+	require.NoError(fixture.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+	}))
+
+	processor := &commandBuildProcessor{}
+	sched := scheduler.New(func(context.Context, string) error { return nil })
+	t.Cleanup(func() { <-sched.Stop().Done() })
+	require.NoError(configureDocumentExtractionJob(sched, fixture.Store, documentsConfig, scheduledDocumentDeps{
+		newProcessor: func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error) {
+			return processor, nil
+		},
+		openAttachments: func(*store.Store) (documentindex.DocumentAttachmentOpener, func() error, error) {
+			return commandAttachmentOpener{content: content}, func() error { return nil }, nil
+		},
+		dataDirectory: t.TempDir(),
+	}))
+	assert.True(t, sched.IsJobScheduled(documentExtractionJob))
+	require.NoError(sched.TriggerJob(documentExtractionJob))
+	assert.Equal(t, 1, processor.calls)
+	response, err := fixture.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "Synthetic"})
+	require.NoError(err)
+	require.Len(response.Results, 1)
+	assert.Equal(t, messageID, response.Results[0].MessageID)
+}
+
+func TestProbeMistralCommandRequiresExplicitEnablementAndPosture(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	previousConfig := cfg
+	t.Cleanup(func() { cfg = previousConfig })
+	cfg = config.NewDefaultConfig()
+	providerCalled := false
+	deps := documentsCommandDeps{
+		newMistralProcessor: func(*documentindex.DocumentsConfig, []string) (mistral.Processor, error) {
+			providerCalled = true
+			return &commandProbeProcessor{}, nil
+		},
+		loadProbeFixtures: mistral.LoadProbeFixtures,
+	}
+
+	command := newDocumentsCmd(deps)
+	command.SetArgs([]string{"probe-mistral", "--fixtures", "synthetic-fixtures"})
+	err := command.ExecuteContext(t.Context())
+	require.ErrorContains(err, "enabled=true")
+	assert.False(providerCalled)
+
+	cfg.Attachments.Documents.Enabled = true
+	command = newDocumentsCmd(deps)
+	command.SetArgs([]string{"probe-mistral", "--fixtures", "synthetic-fixtures"})
+	err = command.ExecuteContext(t.Context())
+	require.ErrorContains(err, "explicit retention_posture and training_posture")
+	assert.False(providerCalled)
+}
+
+type commandProbeProcessor struct{}
+
+type commandDocumentReadClient struct {
+	search func(context.Context, store.DocumentSearchRequest) (store.DocumentSearchResponse, error)
+	status func(context.Context, store.DocumentIndexStatusRequest) (store.DocumentIndexStatusResponse, error)
+}
+
+func (c commandDocumentReadClient) SearchDocuments(
+	ctx context.Context,
+	request store.DocumentSearchRequest,
+) (store.DocumentSearchResponse, error) {
+	if c.search == nil {
+		return store.DocumentSearchResponse{}, errors.New("unexpected document search")
+	}
+	return c.search(ctx, request)
+}
+
+func (c commandDocumentReadClient) GetDocumentIndexStatus(
+	ctx context.Context,
+	request store.DocumentIndexStatusRequest,
+) (store.DocumentIndexStatusResponse, error) {
+	if c.status == nil {
+		return store.DocumentIndexStatusResponse{}, errors.New("unexpected document status read")
+	}
+	return c.status(ctx, request)
+}
+
+func (p *commandProbeProcessor) Target() mistral.ProcessorTarget {
+	return mistral.ProcessorTarget{
+		Endpoint: "https://api.mistral.ai/v1/ocr",
+		Region:   documentindex.RegionMistralEU,
+		Model:    documentindex.ModelMistralOCR,
+	}
+}
+
+type commandBuildProcessor struct {
+	calls int
+}
+
+type commandFailFirstProcessor struct {
+	calls int
+}
+
+type commandCancelingProcessor struct{}
+
+func (commandCancelingProcessor) Target() mistral.ProcessorTarget {
+	return (&commandProbeProcessor{}).Target()
+}
+
+func (commandCancelingProcessor) Process(
+	context.Context,
+	mistral.Document,
+	mistral.Options,
+) (mistral.Result, error) {
+	return mistral.Result{}, context.Canceled
+}
+
+func (p *commandFailFirstProcessor) Target() mistral.ProcessorTarget {
+	return (&commandProbeProcessor{}).Target()
+}
+
+func (p *commandFailFirstProcessor) Process(
+	context.Context,
+	mistral.Document,
+	mistral.Options,
+) (mistral.Result, error) {
+	p.calls++
+	if p.calls == 1 {
+		return mistral.Result{}, mistral.ErrPermanentResponse
+	}
+	return mistral.Result{
+		Model:     documentindex.ModelMistralOCR,
+		Pages:     []mistral.Page{{Index: 0, Markdown: "# Indexed\nSynthetic evidence"}},
+		UsageInfo: &mistral.Usage{PagesProcessed: 1},
+	}, nil
+}
+
+func (p *commandBuildProcessor) Target() mistral.ProcessorTarget {
+	return (&commandProbeProcessor{}).Target()
+}
+
+func (p *commandBuildProcessor) Process(
+	context.Context,
+	mistral.Document,
+	mistral.Options,
+) (mistral.Result, error) {
+	p.calls++
+	text := "# Indexed\nSynthetic evidence"
+	if p.calls > 1 {
+		text = "# Indexed\nReplacement evidence"
+	}
+	return mistral.Result{
+		Model:     documentindex.ModelMistralOCR,
+		Pages:     []mistral.Page{{Index: 0, Markdown: text}},
+		UsageInfo: &mistral.Usage{PagesProcessed: 1},
+	}, nil
+}
+
+type commandAttachmentOpener struct {
+	content []byte
+}
+
+type commandAttachmentMapOpener struct {
+	contents map[string][]byte
+}
+
+func (o commandAttachmentMapOpener) OpenStream(_ context.Context, hash string) (io.ReadCloser, int64, error) {
+	content, ok := o.contents[hash]
+	if !ok {
+		return nil, 0, errors.New("synthetic attachment was not found")
+	}
+	return io.NopCloser(bytes.NewReader(content)), int64(len(content)), nil
+}
+
+func (o commandAttachmentOpener) OpenStream(context.Context, string) (io.ReadCloser, int64, error) {
+	return io.NopCloser(bytes.NewReader(o.content)), int64(len(o.content)), nil
+}
+
+func writeCommandCapabilityManifest(t *testing.T, maxPages int) string {
+	t.Helper()
+	documents := make(map[string]mistral.Document, len(mistral.CandidateFormats()))
+	for _, candidate := range mistral.CandidateFormats() {
+		documents[candidate.ID] = mistral.Document{
+			Path: candidate.ID, MediaType: candidate.MediaType, Size: 1, SHA256: strings.Repeat("0", 64),
+		}
+	}
+	manifest, err := mistral.RunCapabilityProbe(t.Context(), &commandProbeProcessor{}, documents, mistral.ProbeConfig{
+		ObservedAt: time.Now().UTC(), MaxPages: maxPages,
+	})
+	require.NoError(t, err)
+	var encoded bytes.Buffer
+	require.NoError(t, mistral.EncodeCapabilityManifest(&encoded, manifest))
+	path := filepath.Join(t.TempDir(), "capabilities.json")
+	require.NoError(t, os.WriteFile(path, encoded.Bytes(), 0o600))
+	return path
+}
+
+func commandDocumentOccurrenceCount(t *testing.T, st *store.Store) int {
+	t.Helper()
+	var count int
+	require.NoError(t, st.DB().QueryRow(`SELECT COUNT(*) FROM document_occurrences`).Scan(&count))
+	return count
+}
+
+func (p *commandProbeProcessor) Process(
+	_ context.Context,
+	document mistral.Document,
+	_ mistral.Options,
+) (mistral.Result, error) {
+	candidate, ok := mistral.CandidateFormatByMediaType(document.MediaType)
+	if !ok {
+		return mistral.Result{}, errors.New("synthetic processor received unknown media type")
+	}
+	sentinel, err := mistral.ProbeFixtureSentinel(candidate.ID)
+	if err != nil {
+		return mistral.Result{}, err
+	}
+	return mistral.Result{
+		Model: documentindex.ModelMistralOCR,
+		Pages: []mistral.Page{{Index: 0, Markdown: sentinel}},
+		UsageInfo: &mistral.Usage{
+			PagesProcessed: 1,
+		},
+	}, nil
+}

--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -27,7 +27,7 @@ var mcpCmd = &cobra.Command{
 	Long: `Start an MCP (Model Context Protocol) server over stdio.
 
 This allows Claude Desktop (or any MCP client) to query your archive
-using tools like search_metadata, search_message_bodies, semantic_search_messages, get_message, list_messages, get_stats,
+using tools like search_metadata, search_message_bodies, search_document_attachments, semantic_search_messages, get_message, list_messages, get_stats,
 aggregate, and stage_deletion.
 
 Add to Claude Desktop config:
@@ -83,6 +83,7 @@ func daemonMCPServeOptions(ctx context.Context, st *daemonclient.Client) (mcpser
 		AttachmentsDir:   cfg.AttachmentsDir(),
 		AttachmentReader: st,
 		ManifestSaver:    daemonMCPManifestSaver{client: st},
+		DocumentSearcher: st,
 		DataDir:          cfg.Data.DataDir,
 	}
 

--- a/cmd/msgvault/cmd/mcp_test.go
+++ b/cmd/msgvault/cmd/mcp_test.go
@@ -134,6 +134,7 @@ func TestDaemonMCPServeOptionsDisablesVectorToolsWhenDaemonVectorUnavailable(t *
 	assert.NotNil(opts.Engine, "engine")
 	assert.NotNil(opts.AttachmentReader, "attachment reader")
 	assert.NotNil(opts.ManifestSaver, "manifest saver")
+	assert.NotNil(opts.DocumentSearcher, "document searcher")
 	assert.Nil(opts.HybridSearcher, "hybrid searcher")
 	assert.Nil(opts.SimilarSearcher, "similar searcher")
 }

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/discord"
+	"go.kenn.io/msgvault/internal/documentindex"
 	"go.kenn.io/msgvault/internal/gmail"
 	"go.kenn.io/msgvault/internal/granola"
 	"go.kenn.io/msgvault/internal/meetingimport"
@@ -401,6 +402,19 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	if err := registerAttachmentMaintenanceJob(sched, attachmentMaint); err != nil {
 		return fmt.Errorf("schedule attachment maintenance: %w", err)
+	}
+	if err := configureDocumentReconcileJob(
+		ctx, sched, s, cfg.Attachments.Documents.Enabled,
+	); err != nil {
+		return fmt.Errorf("configure document reconciliation: %w", err)
+	}
+	if err := configureDocumentExtractionJob(
+		sched, s, cfg.Attachments.Documents, scheduledDocumentDeps{
+			newProcessor: newConfiguredMistralProcessor, openAttachments: openDocumentAttachments,
+			dataDirectory: cfg.Data.DataDir,
+		},
+	); err != nil {
+		return fmt.Errorf("configure document extraction: %w", err)
 	}
 
 	if cfg.Beeper.Enabled && cfg.Beeper.Schedule == "" {
@@ -1106,6 +1120,8 @@ var _ api.ClusterLookupStore = (*storeAPIAdapter)(nil)
 var _ api.ConversationWindowStore = (*storeAPIAdapter)(nil)
 var _ api.ChangedMessageLister = (*storeAPIAdapter)(nil)
 var _ api.ArchiveIdentifier = (*storeAPIAdapter)(nil)
+var _ api.DocumentSearchStore = (*storeAPIAdapter)(nil)
+var _ api.DocumentStatusStore = (*storeAPIAdapter)(nil)
 
 func (a *storeAPIAdapter) ConversationExistsContext(ctx context.Context, conversationID int64) (bool, error) {
 	return a.store.ConversationExistsContext(ctx, conversationID)
@@ -1137,6 +1153,64 @@ func (a *storeAPIAdapter) ListChangedMessages(
 // reports itself unavailable on every production request.
 func (a *storeAPIAdapter) ArchiveUIDContext(ctx context.Context) (string, error) {
 	return a.store.ArchiveUIDContext(ctx)
+}
+
+func (a *storeAPIAdapter) SearchDocuments(
+	ctx context.Context,
+	request store.DocumentSearchRequest,
+) (store.DocumentSearchResponse, error) {
+	if _, err := a.store.GetAttachmentChangeConsumer(
+		ctx, documentindex.DocumentAttachmentConsumerKey,
+	); err == nil {
+		reconciler, reconcileErr := documentindex.NewReconciler(a.store, documentindex.ReconcilerConfig{
+			AttachmentPageSize: 1000,
+			ChangePageSize:     1000,
+		})
+		if reconcileErr != nil {
+			return store.DocumentSearchResponse{}, reconcileErr
+		}
+		if _, reconcileErr = reconciler.Reconcile(ctx); reconcileErr != nil {
+			return store.DocumentSearchResponse{}, reconcileErr
+		}
+	} else if !errors.Is(err, store.ErrAttachmentChangeConsumerMissing) {
+		return store.DocumentSearchResponse{}, err
+	}
+	return a.store.SearchDocuments(ctx, request)
+}
+
+func (a *storeAPIAdapter) ReconcileDocumentOccurrences(ctx context.Context) error {
+	return reconcileDocumentOccurrencesIfEnabled(ctx, a.store)
+}
+
+func (a *storeAPIAdapter) GetDocumentIndexStatusForScope(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (store.DocumentIndexStatus, error) {
+	return a.store.GetDocumentIndexStatusForScope(
+		ctx, profileID, extractionInputKey, allowedMediaTypes, allowedMessageTypes,
+	)
+}
+
+func (a *storeAPIAdapter) GetActiveDocumentExtractionRebuild(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+) (store.DocumentExtractionRebuild, error) {
+	return a.store.GetActiveDocumentExtractionRebuild(ctx, profileID, extractionInputKey)
+}
+
+func (a *storeAPIAdapter) CountIncompleteDocumentExtractionRebuild(
+	ctx context.Context,
+	rebuild store.DocumentExtractionRebuild,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (int64, error) {
+	return a.store.CountIncompleteDocumentExtractionRebuild(
+		ctx, rebuild, allowedMediaTypes, allowedMessageTypes,
+	)
 }
 
 func (a *storeAPIAdapter) GetStats() (*api.StoreStats, error) {

--- a/cmd/msgvault/cmd/serve_api_wiring_test.go
+++ b/cmd/msgvault/cmd/serve_api_wiring_test.go
@@ -5,13 +5,17 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/api"
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
 
 func TestServeRuntimeConfigCarriesVectorScopeBeforeInitialization(t *testing.T) {
@@ -37,6 +41,37 @@ func TestStoreAPIAdapterExposesFileMetadataCatalog(t *testing.T) {
 	files, err := adapter.GetFileMetadataBatch(t.Context(), nil)
 	requirements.NoError(err)
 	assertions.Empty(files)
+}
+
+func TestStoreAPIAdapterReconcilesEnabledDocumentSearchConsumer(t *testing.T) {
+	fixture := storetest.New(t)
+	messageID := fixture.CreateMessage("document-search-adapter")
+	hash := strings.Repeat("a", 64)
+	require.NoError(t, fixture.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "evidence.pdf", MIMEType: "application/pdf", Size: 128,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: "part:1",
+	}))
+	_, created, err := fixture.Store.RegisterAttachmentChangeConsumer(
+		t.Context(), documentindex.DocumentAttachmentConsumerKey,
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	adapter := &storeAPIAdapter{store: fixture.Store}
+	_, err = adapter.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "absent"})
+	require.NoError(t, err)
+	consumer, err := fixture.Store.GetAttachmentChangeConsumer(
+		t.Context(), documentindex.DocumentAttachmentConsumerKey,
+	)
+	require.NoError(t, err)
+	assert.True(t, consumer.ReconciliationComplete)
+	var occurrences int
+	require.NoError(t, fixture.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM document_occurrences`,
+	).Scan(&occurrences))
+	assert.Equal(t, 1, occurrences)
 }
 
 func TestStoreAPIAdapterServesProfileAndCommunicationServiceRoutes(t *testing.T) {

--- a/cmd/msgvault/cmd/serve_lifecycle.go
+++ b/cmd/msgvault/cmd/serve_lifecycle.go
@@ -22,6 +22,8 @@ import (
 	"go.kenn.io/msgvault/internal/config"
 )
 
+const statusValue = "status"
+
 const (
 	backgroundServeReadyTimeout = 5 * time.Second
 	serveAPIShutdownTimeout     = 10 * time.Second
@@ -63,7 +65,7 @@ func newLifecycleCommand(name string, hidden bool) *cobra.Command {
 		cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 			return runServeStart(cmd, cfg)
 		}
-	case "status":
+	case statusValue:
 		cmd.Short = "Show msgvault daemon status"
 		cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 			return runServeStatusWithAPIKey(cmd, cfg.Data.DataDir, cfg.Server.APIKey)
@@ -85,7 +87,7 @@ func newLifecycleCommand(name string, hidden bool) *cobra.Command {
 }
 
 func addServeLifecycleCommands(parent *cobra.Command) {
-	for _, name := range []string{"start", "status", "stop", "restart"} {
+	for _, name := range []string{"start", statusValue, "stop", "restart"} {
 		parent.AddCommand(newLifecycleCommand(name, true))
 	}
 }
@@ -96,7 +98,7 @@ func newDaemonCommand() *cobra.Command {
 		Short: "Manage the background daemon",
 		Args:  cobra.NoArgs,
 	}
-	for _, name := range []string{"start", "status", "stop", "restart"} {
+	for _, name := range []string{"start", statusValue, "stop", "restart"} {
 		cmd.AddCommand(newLifecycleCommand(name, false))
 	}
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/yuin/goldmark v1.7.17
 	go.kenn.io/kit v0.18.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
@@ -131,7 +132,6 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect

--- a/internal/api/document_search.go
+++ b/internal/api/document_search.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// DocumentSearchStore is the optional dedicated extracted-document search
+// surface. It stays separate from MessageStore so lightweight API consumers
+// do not have to implement document indexing.
+type DocumentSearchStore interface {
+	SearchDocuments(ctx context.Context, request store.DocumentSearchRequest) (store.DocumentSearchResponse, error)
+}
+
+// DocumentStatusStore is the optional scoped status surface for extracted
+// documents. Keeping it separate lets the daemon expose the same read path as
+// the CLI without expanding the core MessageStore contract.
+type DocumentStatusStore interface {
+	GetDocumentIndexStatusForScope(
+		ctx context.Context,
+		profileID string,
+		extractionInputKey string,
+		allowedMediaTypes []string,
+		allowedMessageTypes []string,
+	) (store.DocumentIndexStatus, error)
+	GetActiveDocumentExtractionRebuild(
+		ctx context.Context,
+		profileID string,
+		extractionInputKey string,
+	) (store.DocumentExtractionRebuild, error)
+	CountIncompleteDocumentExtractionRebuild(
+		ctx context.Context,
+		rebuild store.DocumentExtractionRebuild,
+		allowedMediaTypes []string,
+		allowedMessageTypes []string,
+	) (int64, error)
+}
+
+type documentOccurrenceSearchCatalog interface {
+	documentindex.DocumentOccurrenceCatalog
+	GetAttachmentChangeConsumer(
+		ctx context.Context,
+		consumerKey string,
+	) (store.AttachmentChangeConsumer, error)
+}
+
+type documentOccurrenceStatusReconciler interface {
+	ReconcileDocumentOccurrences(ctx context.Context) error
+}
+
+var _ DocumentSearchStore = (*store.Store)(nil)
+var _ DocumentStatusStore = (*store.Store)(nil)
+
+func (s *Server) registerDocumentSearchRoute(api huma.API) {
+	registerAPIV1RawHumaJSONRouteWithErrors[store.DocumentSearchResponse](
+		api, "searchDocuments", http.MethodGet, "/documents/search",
+		"Search extracted document attachments", s.handleDocumentSearch,
+		http.StatusBadRequest, http.StatusConflict, http.StatusServiceUnavailable,
+	)
+	registerAPIV1RawHumaJSONRouteWithErrors[store.DocumentIndexStatusResponse](
+		api, "getDocumentIndexStatus", http.MethodGet, "/documents/status",
+		"Get extracted document index status", s.handleDocumentIndexStatus,
+		http.StatusBadRequest, http.StatusServiceUnavailable,
+	)
+}
+
+func (s *Server) handleDocumentIndexStatus(w http.ResponseWriter, r *http.Request) {
+	statusStore, ok := s.store.(DocumentStatusStore)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "document_status_unavailable",
+			"Document attachment status is unavailable")
+		return
+	}
+	request, err := parseDocumentIndexStatusRequest(r)
+	if err != nil {
+		s.rejectBadParam(w, err)
+		return
+	}
+	if reconciler, ok := s.store.(documentOccurrenceStatusReconciler); ok {
+		if err := reconciler.ReconcileDocumentOccurrences(r.Context()); err != nil {
+			s.logger.Error("reconcile document status index", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Document status failed")
+			return
+		}
+	}
+	status, err := statusStore.GetDocumentIndexStatusForScope(
+		r.Context(), request.ProfileID, request.ExtractionInputKey,
+		request.AllowedMediaTypes, request.AllowedMessageTypes,
+	)
+	if err != nil {
+		s.logger.Error("read document index status", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Document status failed")
+		return
+	}
+	response := store.DocumentIndexStatusResponse{Status: status}
+	active, err := statusStore.GetActiveDocumentExtractionRebuild(
+		r.Context(), request.ProfileID, request.ExtractionInputKey,
+	)
+	if err == nil {
+		remaining, countErr := statusStore.CountIncompleteDocumentExtractionRebuild(
+			r.Context(), active, request.AllowedMediaTypes, request.AllowedMessageTypes,
+		)
+		if countErr != nil {
+			s.logger.Error("count document rebuild status", "error", countErr)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Document status failed")
+			return
+		}
+		response.ActiveRebuild = &store.DocumentIndexRebuildStatus{
+			SnapshotOwners: active.SnapshotOwners, RemainingOwners: remaining,
+		}
+	} else if !errors.Is(err, store.ErrDocumentExtractionRebuildMissing) {
+		s.logger.Error("read document rebuild status", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Document status failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func parseDocumentIndexStatusRequest(r *http.Request) (store.DocumentIndexStatusRequest, error) {
+	request := store.DocumentIndexStatusRequest{
+		ProfileID:           r.URL.Query().Get("profile_id"),
+		ExtractionInputKey:  r.URL.Query().Get("input_key"),
+		AllowedMediaTypes:   append([]string(nil), r.URL.Query()["media_type"]...),
+		AllowedMessageTypes: append([]string(nil), r.URL.Query()["message_type"]...),
+	}
+	if request.ProfileID == "" || request.ExtractionInputKey == "" || len(request.AllowedMediaTypes) == 0 {
+		return request, errors.New("profile_id, input_key, and at least one media_type are required")
+	}
+	return request, nil
+}
+
+func (s *Server) handleDocumentSearch(w http.ResponseWriter, r *http.Request) {
+	searcher, ok := s.store.(DocumentSearchStore)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "document_search_unavailable",
+			"Document attachment search is unavailable")
+		return
+	}
+	request, err := parseDocumentSearchRequest(r)
+	if err != nil {
+		s.rejectBadParam(w, err)
+		return
+	}
+	if catalog, ok := s.store.(documentOccurrenceSearchCatalog); ok {
+		if _, lookupErr := catalog.GetAttachmentChangeConsumer(
+			r.Context(), documentindex.DocumentAttachmentConsumerKey,
+		); lookupErr == nil {
+			reconciler, reconcileErr := documentindex.NewReconciler(catalog, documentindex.ReconcilerConfig{
+				AttachmentPageSize: 1000,
+				ChangePageSize:     1000,
+			})
+			if reconcileErr != nil {
+				s.logger.Error("configure document search reconciliation", "error", reconcileErr)
+				writeError(w, http.StatusInternalServerError, "internal_error", "Document search failed")
+				return
+			}
+			if _, reconcileErr = reconciler.Reconcile(r.Context()); reconcileErr != nil {
+				s.logger.Error("reconcile document search index", "error", reconcileErr)
+				writeError(w, http.StatusInternalServerError, "internal_error", "Document search failed")
+				return
+			}
+		} else if !errors.Is(lookupErr, store.ErrAttachmentChangeConsumerMissing) {
+			s.logger.Error("read document search reconciliation state", "error", lookupErr)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Document search failed")
+			return
+		}
+	}
+	response, err := searcher.SearchDocuments(r.Context(), request)
+	if err != nil {
+		s.writeDocumentSearchError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) writeDocumentSearchError(w http.ResponseWriter, err error) {
+	switch {
+	case s.writeIfContextError(w, err):
+		return
+	case errors.Is(err, store.ErrDocumentSearchInvalidCursor):
+		writeError(w, http.StatusBadRequest, "invalid_cursor", "The document search cursor is invalid")
+	case errors.Is(err, store.ErrDocumentSearchCursorStale):
+		writeError(w, http.StatusConflict, "document_index_changed",
+			"The document index changed; restart pagination")
+	case errors.Is(err, store.ErrDocumentSearchInvalidRequest):
+		writeError(w, http.StatusBadRequest, "invalid_document_search", err.Error())
+	case errors.Is(err, store.ErrDocumentSearchUnavailable):
+		writeError(w, http.StatusServiceUnavailable, "document_search_unavailable",
+			"Document search requires full-text search support")
+	default:
+		s.logger.Error("document search failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Document search failed")
+	}
+}
+
+func parseDocumentSearchRequest(r *http.Request) (store.DocumentSearchRequest, error) {
+	request := store.DocumentSearchRequest{
+		Query:  r.URL.Query().Get("q"),
+		Cursor: r.URL.Query().Get("cursor"),
+	}
+	var err error
+	request.SourceIDs, _, err = queryInt64s(r, "source_id")
+	if err != nil {
+		return request, err
+	}
+	for _, raw := range r.URL.Query()["message_type"] {
+		for value := range strings.SplitSeq(raw, ",") {
+			request.MessageTypes = append(request.MessageTypes, strings.TrimSpace(value))
+		}
+	}
+	if request.PageSize, _, err = queryInt(r, "limit"); err != nil {
+		return request, err
+	}
+	if request.AttachmentID, _, err = queryInt64(r, "attachment_id"); err != nil {
+		return request, err
+	}
+	if request.MessageID, _, err = queryInt64(r, "message_id"); err != nil {
+		return request, err
+	}
+	return request, nil
+}

--- a/internal/api/document_search_test.go
+++ b/internal/api/document_search_test.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestDocumentSearchHTTPPreservesDedicatedContract(t *testing.T) {
+	assert := assert.New(t)
+	server, catalog := newTestServerWithMockStore(t)
+	catalog.documentSearchFunc = func(
+		_ context.Context,
+		request store.DocumentSearchRequest,
+	) (store.DocumentSearchResponse, error) {
+		assert.Equal("shipping damage", request.Query)
+		assert.Equal([]int64{4, 9}, request.SourceIDs)
+		assert.Equal([]string{"email", "mms"}, request.MessageTypes)
+		assert.Equal(int64(41), request.AttachmentID)
+		assert.Equal(int64(42), request.MessageID)
+		assert.Equal(7, request.PageSize)
+		assert.Equal("opaque", request.Cursor)
+		return store.DocumentSearchResponse{
+			Revision: 12, NextCursor: "next",
+			Results: []store.DocumentSearchResult{{
+				AttachmentID: 41, MessageID: 42, Filename: "damage-photo.docx",
+				Excerpt: "shipping damage", MatchedSignals: []string{"content"}, Rank: 1,
+			}},
+		}, nil
+	}
+	request := httptest.NewRequest(http.MethodGet,
+		"/api/v1/documents/search?q=shipping+damage&source_id=4,9&message_type=email,mms&attachment_id=41&message_id=42&limit=7&cursor=opaque",
+		nil)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code)
+	var body store.DocumentSearchResponse
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	require.Len(t, body.Results, 1)
+	assert.Equal("damage-photo.docx", body.Results[0].Filename)
+	assert.Equal("next", body.NextCursor)
+}
+
+func TestDocumentSearchHTTPMapsCursorRevisionConflict(t *testing.T) {
+	server, catalog := newTestServerWithMockStore(t)
+	catalog.documentSearchFunc = func(
+		context.Context,
+		store.DocumentSearchRequest,
+	) (store.DocumentSearchResponse, error) {
+		return store.DocumentSearchResponse{}, store.ErrDocumentSearchCursorStale
+	}
+	request := httptest.NewRequest(http.MethodGet,
+		"/api/v1/documents/search?q=evidence&cursor=stale", nil)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	assert.Equal(t, http.StatusConflict, response.Code)
+	assert.Contains(t, response.Body.String(), "document_index_changed")
+}
+
+func TestDocumentSearchHTTPMapsUnavailableFTS(t *testing.T) {
+	server, catalog := newTestServerWithMockStore(t)
+	catalog.documentSearchFunc = func(
+		context.Context,
+		store.DocumentSearchRequest,
+	) (store.DocumentSearchResponse, error) {
+		return store.DocumentSearchResponse{}, store.ErrDocumentSearchUnavailable
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/documents/search?q=evidence", nil)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code)
+	assert.Contains(t, response.Body.String(), "document_search_unavailable")
+}
+
+func TestDocumentSearchHTTPDoesNotRegisterUnconsentedJournalConsumer(t *testing.T) {
+	fixture := storetest.New(t)
+	server := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{}, Store: fixture.Store, Logger: slog.New(slog.DiscardHandler),
+	})
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/documents/search?q=evidence", nil)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	_, err := fixture.Store.GetAttachmentChangeConsumer(
+		t.Context(), documentindex.DocumentAttachmentConsumerKey,
+	)
+	require.ErrorIs(t, err, store.ErrAttachmentChangeConsumerMissing)
+}
+
+func TestOpenAPIDocumentSearchParameters(t *testing.T) {
+	document := OpenAPIDocument()
+	operation := document.Paths["/api/v1/documents/search"].Get
+	require.NotNil(t, operation)
+	names := make([]string, 0, len(operation.Parameters))
+	for _, parameter := range operation.Parameters {
+		names = append(names, parameter.Name)
+	}
+	assert.ElementsMatch(t,
+		[]string{"q", "source_id", "message_type", "attachment_id", "message_id", "limit", "cursor"},
+		names)
+}
+
+func TestDocumentStatusHTTPPreservesScopedContract(t *testing.T) {
+	assert := assert.New(t)
+	server, catalog := newTestServerWithMockStore(t)
+	reconciled := false
+	catalog.documentReconcileFunc = func(context.Context) error {
+		reconciled = true
+		return nil
+	}
+	catalog.documentStatusFunc = func(
+		_ context.Context,
+		profileID string,
+		inputKey string,
+		mediaTypes []string,
+		messageTypes []string,
+	) (store.DocumentIndexStatus, error) {
+		assert.True(reconciled, "status must reconcile attachment changes before reading counts")
+		assert.Equal("profile", profileID)
+		assert.Equal("original", inputKey)
+		assert.Equal([]string{"application/pdf", "application/epub+zip"}, mediaTypes)
+		assert.Equal([]string{"email", "mms"}, messageTypes)
+		return store.DocumentIndexStatus{ProfileExists: true, ReadyOwners: 4}, nil
+	}
+	catalog.documentRebuildFunc = func(
+		_ context.Context,
+		profileID string,
+		inputKey string,
+	) (store.DocumentExtractionRebuild, error) {
+		assert.Equal("profile", profileID)
+		assert.Equal("original", inputKey)
+		return store.DocumentExtractionRebuild{ID: "rebuild", SnapshotOwners: 6}, nil
+	}
+	catalog.documentRemainingFunc = func(
+		_ context.Context,
+		rebuild store.DocumentExtractionRebuild,
+		mediaTypes []string,
+		messageTypes []string,
+	) (int64, error) {
+		assert.Equal("rebuild", rebuild.ID)
+		assert.Equal([]string{"application/pdf", "application/epub+zip"}, mediaTypes)
+		assert.Equal([]string{"email", "mms"}, messageTypes)
+		return 2, nil
+	}
+	request := httptest.NewRequest(http.MethodGet,
+		"/api/v1/documents/status?profile_id=profile&input_key=original&"+
+			"media_type=application%2Fpdf&media_type=application%2Fepub%2Bzip&"+
+			"message_type=email&message_type=mms", nil)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code)
+	var body store.DocumentIndexStatusResponse
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	assert.True(body.Status.ProfileExists)
+	assert.Equal(int64(4), body.Status.ReadyOwners)
+	require.NotNil(t, body.ActiveRebuild)
+	assert.Equal(int64(6), body.ActiveRebuild.SnapshotOwners)
+	assert.Equal(int64(2), body.ActiveRebuild.RemainingOwners)
+}
+
+func TestOpenAPIDocumentStatusParameters(t *testing.T) {
+	document := OpenAPIDocument()
+	operation := document.Paths["/api/v1/documents/status"].Get
+	require.NotNil(t, operation)
+	names := make([]string, 0, len(operation.Parameters))
+	for _, parameter := range operation.Parameters {
+		names = append(names, parameter.Name)
+	}
+	assert.ElementsMatch(t, []string{"profile_id", "input_key", "media_type", "message_type"}, names)
+	for _, parameter := range operation.Parameters {
+		if parameter.Name == "media_type" {
+			assert.True(t, parameter.Required)
+		}
+	}
+}

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -188,7 +188,9 @@ import (
 // one canonical edge with endpoint-aware presentation, optimistic PATCH and
 // delete operations, and unresolved RELATED review listing. Additive (minor
 // bump): existing endpoints and response fields are unchanged.
-const APISchemaVersion = "1.39.0"
+// 1.40.0 adds dedicated extracted-document search and status routes. Additive
+// (minor bump): existing message, file, profile, and media routes are unchanged.
+const APISchemaVersion = "1.40.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -265,8 +265,8 @@ func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("1.39.0", APISchemaVersion,
-		"structured profiles are additive to the attribute schema release")
+	assert.Equal("1.40.0", APISchemaVersion,
+		"document search is additive to the attribute schema release")
 
 	doc := OpenAPIDocument()
 	definitions := doc.Paths["/api/v1/attribute-definitions"]
@@ -339,8 +339,8 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("1.39.0", APISchemaVersion,
-		"raw profile media content is an additive schema release")
+	assert.Equal("1.40.0", APISchemaVersion,
+		"document search is additive to the profile media schema release")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/persons/{id}/profile/media/{media_id}/content"]
 	require.NotNil(path)
@@ -372,8 +372,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// shipped in 1.33.0; the feed added in 1.34.0, the attributes added in
 	// 1.35.0, source-scoped identities added in 1.36.0, and structured profiles
 	// added in 1.37.0, raw profile media added in 1.38.0, and typed temporal
-	// person relationships added in 1.39.0 did not touch it.
-	assert.Equal("1.39.0", APISchemaVersion, "meeting import is an additive schema release")
+	// person relationships added in 1.39.0 and document search added in 1.40.0
+	// did not touch it.
+	assert.Equal("1.40.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/operation_gate.go
+++ b/internal/api/operation_gate.go
@@ -454,10 +454,12 @@ func operationGateRequest(r *http.Request) (bool, string, error) {
 // cliRunReadOnlyCommands are proxied CLI commands that only read. Keys are
 // the leading command-path words of CLIRunRequest args (flags follow them).
 var cliRunReadOnlyCommands = map[string]bool{
-	"logs":            true,
-	"list-deletions":  true,
-	"show-deletion":   true,
-	"embeddings list": true,
+	"logs":             true,
+	"list-deletions":   true,
+	"show-deletion":    true,
+	"embeddings list":  true,
+	"documents search": true,
+	"documents status": true,
 }
 
 // cliRunSelfGatedCommands are proxied CLI commands that acquire the
@@ -504,6 +506,7 @@ func cliRunGateDecision(r *http.Request) (label string, skip bool, err error) {
 var cliRunCommandGroups = map[string]bool{
 	"embeddings": true,
 	"backup":     true,
+	"documents":  true,
 }
 
 // cliRunCommandWords extracts the command path from proxied args. Positional

--- a/internal/api/operation_gate_test.go
+++ b/internal/api/operation_gate_test.go
@@ -218,6 +218,35 @@ func TestOperationGateMiddlewareStillGatesMutatingCLIRun(t *testing.T) {
 	assert.Equal(1, done, "done calls")
 }
 
+func TestOperationGateMiddlewareStillGatesMutatingDocumentCommands(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"build", `{"args":["documents","build","--capabilities","manifest.json"]}`},
+		{"consent", `{"args":["documents","consent-mistral","--yes"]}`},
+		{"retry", `{"args":["documents","retry","--hash","abc"]}`},
+		{"retire", `{"args":["documents","retire","profile","--yes"]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gate := &recordingOperationGate{allow: true}
+			handler := operationGateMiddleware(gate, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/run", strings.NewReader(tc.body))
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusNoContent, resp.Code)
+			begin, done := gate.counts()
+			assert.Equal(t, 1, begin)
+			assert.Equal(t, 1, done)
+		})
+	}
+}
+
 func TestOperationGateMiddlewareGatesMessageExport(t *testing.T) {
 	assert := assert.New(t)
 	gate := &recordingOperationGate{allow: true}
@@ -558,6 +587,8 @@ func TestOperationGateMiddlewareSkipsReadOnlyCLIRunCommands(t *testing.T) {
 		body string
 	}{
 		{"embeddings list", `{"args":["embeddings","list"]}`},
+		{"documents search", `{"args":["documents","search","shipping damage"]}`},
+		{"documents status", `{"args":["documents","status","--capabilities","manifest.json"]}`},
 		{"list-deletions", `{"args":["list-deletions"]}`},
 		{"show-deletion with id", `{"args":["show-deletion","batch-123"]}`},
 	}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -221,6 +221,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	s.registerSavedViewRoutes(apiV1)
 	s.registerExploreRoutes(apiV1)
 	s.registerFilesRoutes(apiV1)
+	s.registerDocumentSearchRoute(apiV1)
 	s.registerPersonProfileRoutes(apiV1)
 	s.registerPersonProfileValueRoutes(apiV1)
 	s.registerCommunicationServiceRoutes(apiV1)
@@ -569,6 +570,25 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryIntegerParam("offset", "Zero-based row offset"),
 			queryStringParam("message_type", "Message type filter; repeat or comma-separate for multiple values", false),
 		}, scopeParams()...)
+	case "searchDocuments":
+		return []*huma.Param{
+			queryStringParam("q", "Extracted document content or filename query", true),
+			queryIntegerArrayParam("source_id", "Source IDs to include; repeat or comma-separate values"),
+			queryRefArrayParam("message_type", "Message types to include; repeat or comma-separate values"),
+			queryIntegerParam("attachment_id", "Exact attachment occurrence ID"),
+			queryIntegerParam("message_id", "Exact containing message ID"),
+			queryIntegerParam("limit", "Maximum results to return (default 20, max 100)"),
+			queryStringParam("cursor", "Opaque cursor from the previous document search page", false),
+		}
+	case "getDocumentIndexStatus":
+		mediaTypes := queryRefArrayParam("media_type", "Allowed document media types")
+		mediaTypes.Required = true
+		return []*huma.Param{
+			queryStringParam("profile_id", "Exact document extraction profile ID", true),
+			queryStringParam("input_key", "Exact extraction input key", true),
+			mediaTypes,
+			queryRefArrayParam("message_type", "Allowed message types"),
+		}
 	case "getCLIMessage", "getCLIMessageRaw":
 		return []*huma.Param{queryStringParam("id", "Message numeric ID or source message ID", true)}
 	case "getCLIAttachment":

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -265,19 +265,26 @@ type mockStore struct {
 	needsFTSBackfillQuick bool
 	// needsFTSBackfillFunc overrides the needsFTSBackfill field when set, so
 	// tests can block inside the probe or vary its answer per call.
-	needsFTSBackfillFunc func() bool
-	backfillFTSFunc      func(func(done, total int64)) (int64, error)
-	rebuildFTSFunc       func(func(done, total int64)) (int64, error)
-	buildCacheFunc       func(context.Context, bool, func(CLICacheBuildEvent) error) error
-	syncFunc             func(context.Context, CLISyncRequest, func(CLISyncEvent) error) error
-	verifyFunc           func(context.Context, CLIVerifyRequest, func(CLIVerifyEvent) error) error
-	repairFunc           func(context.Context, func(CLIRepairEncodingEvent) error) error
-	runFunc              func(context.Context, CLIRunRequest, func(CLIRunEvent) error) error
-	planCalendarFunc     func(context.Context, CLIAddCalendarPlanRequest) (CLIAddCalendarPlanResponse, error)
-	planEmbedsFunc       func(context.Context, CLIEmbeddingsPlanRequest) (CLIEmbeddingsPlanResponse, error)
-	planDeleteFunc       func(context.Context, CLIDeleteStagedPlanRequest) (CLIDeleteStagedPlanResponse, error)
-	planDedupFunc        func(context.Context, CLIDeduplicatePlanRequest) (CLIDeduplicatePlanResponse, error)
-	saveManifestFunc     func(context.Context, *deletion.Manifest) error
+	needsFTSBackfillFunc  func() bool
+	backfillFTSFunc       func(func(done, total int64)) (int64, error)
+	rebuildFTSFunc        func(func(done, total int64)) (int64, error)
+	buildCacheFunc        func(context.Context, bool, func(CLICacheBuildEvent) error) error
+	syncFunc              func(context.Context, CLISyncRequest, func(CLISyncEvent) error) error
+	verifyFunc            func(context.Context, CLIVerifyRequest, func(CLIVerifyEvent) error) error
+	repairFunc            func(context.Context, func(CLIRepairEncodingEvent) error) error
+	runFunc               func(context.Context, CLIRunRequest, func(CLIRunEvent) error) error
+	planCalendarFunc      func(context.Context, CLIAddCalendarPlanRequest) (CLIAddCalendarPlanResponse, error)
+	planEmbedsFunc        func(context.Context, CLIEmbeddingsPlanRequest) (CLIEmbeddingsPlanResponse, error)
+	planDeleteFunc        func(context.Context, CLIDeleteStagedPlanRequest) (CLIDeleteStagedPlanResponse, error)
+	planDedupFunc         func(context.Context, CLIDeduplicatePlanRequest) (CLIDeduplicatePlanResponse, error)
+	saveManifestFunc      func(context.Context, *deletion.Manifest) error
+	documentSearchFunc    func(context.Context, store.DocumentSearchRequest) (store.DocumentSearchResponse, error)
+	documentStatusFunc    func(context.Context, string, string, []string, []string) (store.DocumentIndexStatus, error)
+	documentRebuildFunc   func(context.Context, string, string) (store.DocumentExtractionRebuild, error)
+	documentRemainingFunc func(
+		context.Context, store.DocumentExtractionRebuild, []string, []string,
+	) (int64, error)
+	documentReconcileFunc func(context.Context) error
 
 	// Error injection for the context-aware read paths, used to verify
 	// handlers map context deadline/cancellation to a structured 503.
@@ -305,6 +312,61 @@ type mockStore struct {
 	sourcesByLookup    map[string][]*store.Source
 	sourcesByLookupErr error
 	collections        map[string]*store.CollectionWithSources
+}
+
+func (m *mockStore) ReconcileDocumentOccurrences(ctx context.Context) error {
+	if m.documentReconcileFunc == nil {
+		return nil
+	}
+	return m.documentReconcileFunc(ctx)
+}
+
+func (m *mockStore) SearchDocuments(
+	ctx context.Context,
+	request store.DocumentSearchRequest,
+) (store.DocumentSearchResponse, error) {
+	if m.documentSearchFunc == nil {
+		return store.DocumentSearchResponse{}, nil
+	}
+	return m.documentSearchFunc(ctx, request)
+}
+
+func (m *mockStore) GetDocumentIndexStatusForScope(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (store.DocumentIndexStatus, error) {
+	if m.documentStatusFunc == nil {
+		return store.DocumentIndexStatus{}, nil
+	}
+	return m.documentStatusFunc(
+		ctx, profileID, extractionInputKey, allowedMediaTypes, allowedMessageTypes,
+	)
+}
+
+func (m *mockStore) GetActiveDocumentExtractionRebuild(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+) (store.DocumentExtractionRebuild, error) {
+	if m.documentRebuildFunc == nil {
+		return store.DocumentExtractionRebuild{}, store.ErrDocumentExtractionRebuildMissing
+	}
+	return m.documentRebuildFunc(ctx, profileID, extractionInputKey)
+}
+
+func (m *mockStore) CountIncompleteDocumentExtractionRebuild(
+	ctx context.Context,
+	rebuild store.DocumentExtractionRebuild,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (int64, error) {
+	if m.documentRemainingFunc == nil {
+		return 0, nil
+	}
+	return m.documentRemainingFunc(ctx, rebuild, allowedMediaTypes, allowedMessageTypes)
 }
 
 func (m *mockStore) GetStats() (*StoreStats, error) {

--- a/internal/backupapp/document_disclosure.go
+++ b/internal/backupapp/document_disclosure.go
@@ -1,0 +1,211 @@
+package backupapp
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"go.kenn.io/kit/backup"
+)
+
+const (
+	documentDisclosureName   = "document-derivatives"
+	documentDisclosureFormat = "application/vnd.msgvault.document-derivatives+json; contains-normalized-plaintext=true"
+	documentDisclosureSchema = 2
+)
+
+// DocumentDisclosure is a bounded, content-free declaration that a snapshot's
+// database contains locally normalized attachment text. It deliberately
+// records counts only; excerpts, filenames, paths, hashes, and provider output
+// never leave the database through this artifact.
+type DocumentDisclosure struct {
+	SchemaVersion               int   `json:"schema_version"`
+	ContainsNormalizedPlaintext bool  `json:"contains_normalized_attachment_plaintext"`
+	Chunks                      int64 `json:"chunks"`
+	Characters                  int64 `json:"characters"`
+	Profiles                    int64 `json:"profiles"`
+	EnabledProfiles             int64 `json:"enabled_profiles"`
+	ConsentedProfiles           int64 `json:"consented_profiles"`
+	Extractions                 int64 `json:"extractions"`
+	CurrentHeads                int64 `json:"current_heads"`
+}
+
+func (v *frozenView) AuxiliaryArtifacts(ctx context.Context) ([]backup.AuxiliaryArtifact, error) {
+	postgres := documentDisclosureUsesPostgres(ctx, v.tx)
+	tableExists, err := documentDisclosureTableExists(ctx, v.tx, "document_chunks", postgres)
+	if err != nil {
+		return nil, err
+	}
+	if !tableExists {
+		return nil, nil
+	}
+	disclosure := DocumentDisclosure{SchemaVersion: documentDisclosureSchema}
+	if err := v.tx.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(SUM(char_count), 0)
+		FROM document_chunks`).Scan(&disclosure.Chunks, &disclosure.Characters); err != nil {
+		return nil, fmt.Errorf("backupapp: count document derivatives: %w", err)
+	}
+	if disclosure.Chunks == 0 {
+		return nil, nil
+	}
+	profilesExist, err := documentDisclosureTableExists(ctx, v.tx, "document_extraction_profiles", postgres)
+	if err != nil {
+		return nil, err
+	}
+	if profilesExist {
+		if err := v.tx.QueryRowContext(ctx, `
+			SELECT COUNT(*), COALESCE(SUM(CASE WHEN enabled = TRUE AND retired_at IS NULL THEN 1 ELSE 0 END), 0)
+			FROM document_extraction_profiles`).Scan(&disclosure.Profiles, &disclosure.EnabledProfiles); err != nil {
+			return nil, fmt.Errorf("backupapp: count document extraction profiles: %w", err)
+		}
+	}
+	consentsExist, err := documentDisclosureTableExists(ctx, v.tx, "document_provider_consents", postgres)
+	if err != nil {
+		return nil, err
+	}
+	if consentsExist {
+		if err := v.tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM document_provider_consents`).Scan(
+			&disclosure.ConsentedProfiles,
+		); err != nil {
+			return nil, fmt.Errorf("backupapp: count document provider consents: %w", err)
+		}
+	}
+	extractionsExist, err := documentDisclosureTableExists(ctx, v.tx, "document_extractions", postgres)
+	if err != nil {
+		return nil, err
+	}
+	if extractionsExist {
+		if err := v.tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM document_extractions`).Scan(
+			&disclosure.Extractions,
+		); err != nil {
+			return nil, fmt.Errorf("backupapp: count document extractions: %w", err)
+		}
+	}
+	headsExist, err := documentDisclosureTableExists(ctx, v.tx, "document_extraction_heads", postgres)
+	if err != nil {
+		return nil, err
+	}
+	if headsExist {
+		if err := v.tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM document_extraction_heads`).Scan(
+			&disclosure.CurrentHeads,
+		); err != nil {
+			return nil, fmt.Errorf("backupapp: count current document extraction heads: %w", err)
+		}
+	}
+	disclosure.ContainsNormalizedPlaintext = true
+	payload, err := json.Marshal(disclosure)
+	if err != nil {
+		return nil, fmt.Errorf("backupapp: encode document derivative disclosure: %w", err)
+	}
+	return []backup.AuxiliaryArtifact{{
+		Name: documentDisclosureName, Format: documentDisclosureFormat,
+		Open: func(context.Context) (io.ReadCloser, int64, error) {
+			return io.NopCloser(bytes.NewReader(payload)), int64(len(payload)), nil
+		},
+	}}, nil
+}
+
+// documentDisclosureUsesPostgres probes PostgreSQL first. The probe succeeds
+// without special privileges there; SQLite treats the unknown function as a
+// statement-local error and keeps its read transaction usable.
+func documentDisclosureUsesPostgres(ctx context.Context, tx *sql.Tx) bool {
+	var version string
+	return tx.QueryRowContext(ctx, `SELECT current_setting('server_version_num')`).Scan(&version) == nil
+}
+
+func documentDisclosureTableExists(
+	ctx context.Context,
+	tx *sql.Tx,
+	table string,
+	postgres bool,
+) (bool, error) {
+	query := `
+		SELECT EXISTS (
+			SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?
+		)`
+	if postgres {
+		query = `
+			SELECT EXISTS (
+				SELECT 1 FROM information_schema.tables
+				WHERE table_schema = current_schema() AND table_name = $1
+			)`
+	}
+	var exists bool
+	if err := tx.QueryRowContext(ctx, query, table).Scan(&exists); err != nil {
+		return false, fmt.Errorf("backupapp: inspect %s schema: %w", table, err)
+	}
+	return exists, nil
+}
+
+// ManifestContainsDocumentPlaintext reports the explicit manifest-level
+// disclosure without reading the opaque artifact payload.
+func ManifestContainsDocumentPlaintext(manifest *backup.Manifest) bool {
+	if manifest == nil {
+		return false
+	}
+	for _, artifact := range manifest.Auxiliary {
+		if artifact.Name == documentDisclosureName && artifact.Format == documentDisclosureFormat {
+			return true
+		}
+	}
+	return false
+}
+
+// DocumentAuxiliaryTarget validates the disclosure artifact restored by Kit.
+// The authoritative derivatives already live in the restored database, so a
+// successful transaction has no additional files to publish.
+type DocumentAuxiliaryTarget struct{}
+
+func NewDocumentAuxiliaryTarget() *DocumentAuxiliaryTarget { return &DocumentAuxiliaryTarget{} }
+
+func (t *DocumentAuxiliaryTarget) StageAuxiliary(
+	_ context.Context,
+	artifacts []backup.RestoredAuxiliary,
+) (backup.AuxiliaryRestore, error) {
+	if t == nil {
+		return nil, errors.New("backupapp: document auxiliary target is nil")
+	}
+	if len(artifacts) == 0 {
+		return documentAuxiliaryRestore{}, nil
+	}
+	if len(artifacts) != 1 || artifacts[0].Name != documentDisclosureName ||
+		artifacts[0].Format != documentDisclosureFormat {
+		return nil, errors.New("backupapp: restored auxiliary artifact set is unsupported")
+	}
+	var disclosure DocumentDisclosure
+	decoder := json.NewDecoder(bytes.NewReader(artifacts[0].Data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&disclosure); err != nil {
+		return nil, fmt.Errorf("backupapp: decode document derivative disclosure: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, errors.New("backupapp: document derivative disclosure has trailing data")
+	}
+	if (disclosure.SchemaVersion != 1 && disclosure.SchemaVersion != documentDisclosureSchema) ||
+		!disclosure.ContainsNormalizedPlaintext || disclosure.Chunks <= 0 || disclosure.Characters < 0 {
+		return nil, errors.New("backupapp: document derivative disclosure is invalid")
+	}
+	if disclosure.SchemaVersion == documentDisclosureSchema &&
+		(disclosure.Profiles < 0 || disclosure.EnabledProfiles < 0 ||
+			disclosure.ConsentedProfiles < 0 || disclosure.Extractions < 0 ||
+			disclosure.CurrentHeads < 0 || disclosure.EnabledProfiles > disclosure.Profiles ||
+			disclosure.ConsentedProfiles > disclosure.Profiles || disclosure.CurrentHeads > disclosure.Extractions) {
+		return nil, errors.New("backupapp: document derivative disclosure counts are invalid")
+	}
+	return documentAuxiliaryRestore{}, nil
+}
+
+type documentAuxiliaryRestore struct{}
+
+func (documentAuxiliaryRestore) Commit(context.Context) error   { return nil }
+func (documentAuxiliaryRestore) Rollback(context.Context) error { return nil }
+
+var (
+	_ backup.AuxiliarySource = (*frozenView)(nil)
+	_ backup.AuxiliaryTarget = (*DocumentAuxiliaryTarget)(nil)
+)

--- a/internal/backupapp/document_disclosure_pg_test.go
+++ b/internal/backupapp/document_disclosure_pg_test.go
@@ -1,0 +1,34 @@
+package backupapp
+
+import (
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocumentDisclosureTableExistsUsesPostgresCatalog(t *testing.T) {
+	require := require.New(t)
+	databaseURL := os.Getenv("MSGVAULT_TEST_DB")
+	if !strings.HasPrefix(databaseURL, "postgres://") && !strings.HasPrefix(databaseURL, "postgresql://") {
+		t.Skip("PG-only: requires MSGVAULT_TEST_DB pointing at PostgreSQL")
+	}
+	database, err := sql.Open("pgx", databaseURL)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+	tx, err := database.BeginTx(t.Context(), &sql.TxOptions{ReadOnly: true})
+	require.NoError(err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	require.True(documentDisclosureUsesPostgres(t.Context(), tx))
+	exists, err := documentDisclosureTableExists(
+		t.Context(), tx, "msgvault_document_disclosure_missing_table", true,
+	)
+	require.NoError(err)
+	assert.False(t, exists)
+	require.NoError(tx.Rollback())
+}

--- a/internal/backupapp/document_disclosure_test.go
+++ b/internal/backupapp/document_disclosure_test.go
@@ -1,0 +1,141 @@
+package backupapp_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/backup"
+	"go.kenn.io/msgvault/internal/backupapp"
+)
+
+func TestBackupManifestDisclosesAndRestoresDocumentPlaintext(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	archive := t.TempDir()
+	databasePath, attachmentsDirectory := seedCompatArchive(t, archive)
+	database, err := sql.Open("sqlite3", databasePath)
+	require.NoError(err)
+	_, err = database.Exec(`
+		CREATE TABLE document_chunks (
+			id INTEGER PRIMARY KEY,
+			text TEXT NOT NULL,
+			char_count INTEGER NOT NULL
+		);
+		INSERT INTO document_chunks(text, char_count)
+		VALUES ('synthetic normalized attachment evidence', 40);
+		CREATE TABLE document_extraction_profiles (
+			id TEXT PRIMARY KEY, enabled BOOLEAN NOT NULL, retired_at DATETIME
+		);
+		INSERT INTO document_extraction_profiles(id, enabled, retired_at)
+		VALUES ('active', TRUE, NULL), ('retired', FALSE, CURRENT_TIMESTAMP);
+		CREATE TABLE document_provider_consents (profile_id TEXT PRIMARY KEY);
+		INSERT INTO document_provider_consents(profile_id) VALUES ('active');
+		CREATE TABLE document_extractions (id TEXT PRIMARY KEY);
+		INSERT INTO document_extractions(id) VALUES ('one'), ('two'), ('three');
+		CREATE TABLE document_extraction_heads (extraction_id TEXT PRIMARY KEY);
+		INSERT INTO document_extraction_heads(extraction_id) VALUES ('one'), ('two')`)
+	require.NoError(err)
+	require.NoError(database.Close())
+
+	repository, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(err)
+	app := backupapp.New("document-disclosure-test")
+	manifest, err := backup.Create(t.Context(), repository, app, backup.CreateOptions{
+		DBPath: databasePath, ContentDir: attachmentsDirectory, DataDir: archive,
+	})
+	require.NoError(err)
+	assert.True(backupapp.ManifestContainsDocumentPlaintext(manifest))
+	require.Len(manifest.Auxiliary, 1)
+	assert.Equal("document-derivatives", manifest.Auxiliary[0].Name)
+	assert.Contains(manifest.Auxiliary[0].Format, "contains-normalized-plaintext=true")
+	assert.Greater(manifest.MinReaderVersion, 2,
+		"pre-auxiliary readers must refuse a snapshot carrying the disclosure")
+
+	restoreDirectory := filepath.Join(t.TempDir(), "restore")
+	capture := &capturingDocumentAuxiliaryTarget{}
+	_, err = backup.Restore(t.Context(), repository, app, backup.RestoreOptions{
+		TargetDir: restoreDirectory, AuxiliaryTarget: capture,
+	})
+	require.NoError(err)
+	require.Len(capture.artifacts, 1)
+	var disclosure backupapp.DocumentDisclosure
+	require.NoError(json.Unmarshal(capture.artifacts[0].Data, &disclosure))
+	assert.Equal(2, disclosure.SchemaVersion)
+	assert.Equal(int64(2), disclosure.Profiles)
+	assert.Equal(int64(1), disclosure.EnabledProfiles)
+	assert.Equal(int64(1), disclosure.ConsentedProfiles)
+	assert.Equal(int64(3), disclosure.Extractions)
+	assert.Equal(int64(2), disclosure.CurrentHeads)
+	staged, err := backupapp.NewDocumentAuxiliaryTarget().StageAuxiliary(t.Context(), capture.artifacts)
+	require.NoError(err)
+	require.NoError(staged.Commit(t.Context()))
+	restored, err := sql.Open("sqlite3", filepath.Join(restoreDirectory, "msgvault.db"))
+	require.NoError(err)
+	defer func() { require.NoError(restored.Close()) }()
+	var text string
+	require.NoError(restored.QueryRow(`SELECT text FROM document_chunks`).Scan(&text))
+	assert.Equal("synthetic normalized attachment evidence", text)
+}
+
+func TestDocumentAuxiliaryTargetRejectsUndisclosedArtifacts(t *testing.T) {
+	target := backupapp.NewDocumentAuxiliaryTarget()
+	_, err := target.StageAuxiliary(context.Background(), []backup.RestoredAuxiliary{{
+		Name: "unexpected", Format: "application/json", Data: []byte(`{}`),
+	}})
+	require.ErrorContains(t, err, "unsupported")
+}
+
+func TestDocumentAuxiliaryTargetRestoresSnapshotWithoutDisclosure(t *testing.T) {
+	require := require.New(t)
+	archive := t.TempDir()
+	databasePath, attachmentsDirectory := seedCompatArchive(t, archive)
+	repository, err := backup.Init(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(err)
+	app := backupapp.New("document-disclosure-compat-test")
+	manifest, err := backup.Create(t.Context(), repository, app, backup.CreateOptions{
+		DBPath: databasePath, ContentDir: attachmentsDirectory, DataDir: archive,
+	})
+	require.NoError(err)
+	require.Empty(manifest.Auxiliary)
+
+	restoreDirectory := filepath.Join(t.TempDir(), "restore")
+	_, err = backup.Restore(t.Context(), repository, app, backup.RestoreOptions{
+		TargetDir: restoreDirectory, AuxiliaryTarget: backupapp.NewDocumentAuxiliaryTarget(),
+	})
+	require.NoError(err)
+	require.FileExists(filepath.Join(restoreDirectory, "msgvault.db"))
+}
+
+func TestDocumentAuxiliaryTargetAcceptsLegacyDisclosureSchema(t *testing.T) {
+	target := backupapp.NewDocumentAuxiliaryTarget()
+	staged, err := target.StageAuxiliary(t.Context(), []backup.RestoredAuxiliary{{
+		Name:   "document-derivatives",
+		Format: "application/vnd.msgvault.document-derivatives+json; contains-normalized-plaintext=true",
+		Data:   []byte(`{"schema_version":1,"contains_normalized_attachment_plaintext":true,"chunks":1,"characters":4}`),
+	}})
+	require.NoError(t, err)
+	require.NoError(t, staged.Commit(t.Context()))
+}
+
+type capturingDocumentAuxiliaryTarget struct {
+	artifacts []backup.RestoredAuxiliary
+}
+
+func (t *capturingDocumentAuxiliaryTarget) StageAuxiliary(
+	_ context.Context,
+	artifacts []backup.RestoredAuxiliary,
+) (backup.AuxiliaryRestore, error) {
+	t.artifacts = append(t.artifacts, artifacts...)
+	return noOpDocumentAuxiliaryRestore{}, nil
+}
+
+type noOpDocumentAuxiliaryRestore struct{}
+
+func (noOpDocumentAuxiliaryRestore) Commit(context.Context) error   { return nil }
+func (noOpDocumentAuxiliaryRestore) Rollback(context.Context) error { return nil }

--- a/internal/beeper/media.go
+++ b/internal/beeper/media.go
@@ -14,7 +14,10 @@ import (
 
 // defaultMaxMediaBytes caps individual attachment downloads (config
 // max_media_mb overrides).
-const defaultMaxMediaBytes = int64(100 << 20)
+const (
+	defaultMaxMediaBytes      = int64(100 << 20)
+	beeperAttachmentTypeImage = "img"
+)
 
 // beeperAttachmentID namespaces Beeper-managed attachment rows in
 // attachments.source_attachment_id.
@@ -33,7 +36,7 @@ func mediaTypeOf(att *Attachment) string {
 		return "voice_note"
 	}
 	switch att.Type {
-	case "img":
+	case beeperAttachmentTypeImage:
 		return "image"
 	case "video":
 		return "video"
@@ -105,6 +108,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 		maxBytes = defaultMaxMediaBytes
 	}
 	shareMeta := shareMetadata(m)
+	isPreview := shareMeta != ""
 	refs := make([]store.AttachmentRef, 0, len(m.Attachments))
 	for i := range m.Attachments {
 		att := &m.Attachments[i]
@@ -118,6 +122,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			// refresh the share marker, so re-running over an existing archive
 			// classifies rows stored before this was recorded.
 			prev.Metadata = shareMeta
+			setBeeperAttachmentRole(&prev, att, isPreview)
 			refs = append(refs, prev)
 			continue
 		}
@@ -175,6 +180,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			DurationMS:         int64(att.Duration * 1000),
 			Metadata:           shareMeta,
 		}
+		setBeeperAttachmentRole(&stored, att, isPreview)
 		if att.Size != nil {
 			stored.Width = int64(att.Size.Width)
 			stored.Height = int64(att.Size.Height)
@@ -189,6 +195,21 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 	if err := imp.store.RecomputeMessageAttachmentStats(messageID); err != nil {
 		sum.Errors++
 	}
+}
+
+func setBeeperAttachmentRole(ref *store.AttachmentRef, att *Attachment, isPreview bool) {
+	if att.IsSticker {
+		ref.Role = store.AttachmentRoleSticker
+		ref.RoleSource = store.AttachmentRoleSourceProviderExplicit
+		return
+	}
+	if isPreview {
+		ref.Role = store.AttachmentRolePreview
+		ref.RoleSource = store.AttachmentRoleSourceImporterSemantics
+		return
+	}
+	ref.Role = store.AttachmentRoleStandalone
+	ref.RoleSource = store.AttachmentRoleSourceImporterSemantics
 }
 
 // clearPendingMarkers removes a message's pending Beeper markers while

--- a/internal/beeper/media_test.go
+++ b/internal/beeper/media_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 // mediaChat builds a chat with one image message whose asset may or may not
@@ -70,19 +71,22 @@ func TestImportDownloadsAttachment(t *testing.T) {
 	assert.EqualValues(1, sum.AttachmentsDownloaded)
 	assert.EqualValues(0, sum.AttachmentsPending)
 
-	var filename, mimeType, storagePath, contentHash, mediaType string
+	var filename, mimeType, storagePath, contentHash, mediaType, role, roleSource string
 	var width, height int64
 	require.NoError(st.DB().QueryRow(st.Rebind(`
-		SELECT a.filename, a.mime_type, a.storage_path, a.content_hash, a.media_type, a.width, a.height
+		SELECT a.filename, a.mime_type, a.storage_path, a.content_hash, a.media_type,
+		       a.width, a.height, a.attachment_role, a.role_source
 		FROM attachments a JOIN messages m ON m.id = a.message_id
 		WHERE m.source_message_id = ?`), "p0").
-		Scan(&filename, &mimeType, &storagePath, &contentHash, &mediaType, &width, &height))
+		Scan(&filename, &mimeType, &storagePath, &contentHash, &mediaType, &width, &height, &role, &roleSource))
 	assert.Equal("photo.png", filename)
 	assert.Equal("image/png", mimeType)
 	assert.NotEmpty(contentHash)
 	assert.Equal("image", mediaType)
 	assert.EqualValues(640, width)
 	assert.EqualValues(480, height)
+	assert.Equal("standalone", role)
+	assert.Equal("importer_semantics", roleSource)
 
 	// Bytes are content-addressed on disk.
 	data, err := os.ReadFile(filepath.Join(opts.AttachmentsDir, filepath.FromSlash(storagePath)))
@@ -109,6 +113,41 @@ func TestImportDownloadsAttachment(t *testing.T) {
 		SELECT a.media_type FROM attachments a JOIN messages m ON m.id = a.message_id
 		WHERE m.source_message_id = ?`), "p0").Scan(&keptMediaType))
 	assert.Equal("image", keptMediaType)
+}
+
+func TestSetBeeperAttachmentRoleUsesSourceSemantics(t *testing.T) {
+	tests := []struct {
+		name       string
+		attachment Attachment
+		isPreview  bool
+		wantRole   store.AttachmentRole
+		wantSource store.AttachmentRoleSource
+	}{
+		{
+			name: "shared media", attachment: Attachment{Type: beeperAttachmentTypeImage},
+			wantRole: store.AttachmentRoleStandalone, wantSource: store.AttachmentRoleSourceImporterSemantics,
+		},
+		{
+			name: "sticker", attachment: Attachment{Type: beeperAttachmentTypeImage, IsSticker: true},
+			wantRole: store.AttachmentRoleSticker, wantSource: store.AttachmentRoleSourceProviderExplicit,
+		},
+		{
+			name: "link preview", attachment: Attachment{Type: beeperAttachmentTypeImage}, isPreview: true,
+			wantRole: store.AttachmentRolePreview, wantSource: store.AttachmentRoleSourceImporterSemantics,
+		},
+		{
+			name: "sticker wins over preview", attachment: Attachment{Type: beeperAttachmentTypeImage, IsSticker: true}, isPreview: true,
+			wantRole: store.AttachmentRoleSticker, wantSource: store.AttachmentRoleSourceProviderExplicit,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ref store.AttachmentRef
+			setBeeperAttachmentRole(&ref, &tt.attachment, tt.isPreview)
+			assert.Equal(t, tt.wantRole, ref.Role)
+			assert.Equal(t, tt.wantSource, ref.RoleSource)
+		})
+	}
 }
 
 func TestImportMediaFailureLeavesMarkerAndBackfillRepairs(t *testing.T) {
@@ -530,12 +569,12 @@ func TestMediaTypeOf(t *testing.T) {
 		att  Attachment
 		want string
 	}{
-		{"image", Attachment{Type: "img"}, "image"},
+		{"image", Attachment{Type: beeperAttachmentTypeImage}, "image"},
 		{"video", Attachment{Type: "video"}, "video"},
 		{"audio", Attachment{Type: "audio"}, "audio"},
 		{"unknown type", Attachment{Type: "something"}, "document"},
 		// Flags outrank the base type: a sticker served as img is a sticker.
-		{"sticker wins over img", Attachment{Type: "img", IsSticker: true}, "sticker"},
+		{"sticker wins over img", Attachment{Type: beeperAttachmentTypeImage, IsSticker: true}, "sticker"},
 		{"gif wins over video", Attachment{Type: "video", IsGif: true}, "gif"},
 		{"voice note wins over audio", Attachment{Type: "audio", IsVoiceNote: true}, "voice_note"},
 	}

--- a/internal/beeper/repair.go
+++ b/internal/beeper/repair.go
@@ -22,7 +22,8 @@ const rawArchiveFormat = "beeper_json"
 //	v1 — plain-text conversion of HTML message text; link-preview classification.
 //	v2 — refresh snippets and the search index even when body text is current.
 //	v3 — exclude Matrix reply fallbacks from body text, snippets, and search.
-const rederiveVersion = "v3"
+//	v4 — keep link-preview media out of standalone document processing.
+const rederiveVersion = "v4"
 
 // repairBatchSize bounds how many archived messages are held in memory per
 // pass of the walk.
@@ -122,7 +123,8 @@ func (imp *Importer) repairMessage(item *store.ArchivedRawMessage, sourceID int6
 	if len(m.Attachments) == 0 {
 		return
 	}
-	changed, err := imp.store.SetBeeperAttachmentMetadata(item.MessageID, shareMetadata(&m))
+	metadata := shareMetadata(&m)
+	changed, err := imp.store.SetBeeperAttachmentClassification(item.MessageID, metadata, metadata != "")
 	if err != nil {
 		sum.Errors++
 		return

--- a/internal/beeper/repair_test.go
+++ b/internal/beeper/repair_test.go
@@ -37,7 +37,11 @@ func TestRepairArchiveRewritesStaleDerivedRows(t *testing.T) {
 		WHERE message_id = (SELECT id FROM messages WHERE source_message_id = 'html1')`),
 		`<p>hello <a href="https://example.com" rel="noopener noreferrer">there</a></p>`)
 	require.NoError(err)
-	_, err = st.DB().Exec(`UPDATE attachments SET attachment_metadata = NULL`)
+	_, err = st.DB().Exec(`
+		UPDATE attachments
+		SET attachment_metadata = NULL,
+		    attachment_role = 'standalone',
+		    role_source = 'importer_semantics'`)
 	require.NoError(err)
 
 	sum, err := imp.RepairSource(context.Background(), beeperSourceID(t, st), nil)
@@ -53,16 +57,21 @@ func TestRepairArchiveRewritesStaleDerivedRows(t *testing.T) {
 	assert.Equal("hello there", body, "HTML must be converted to plain text")
 	assert.Equal("hello there", snippet)
 
-	// The forwarded link keeps its share URL; the photo stays unclassified.
-	var shareMeta, photoMeta string
-	require.NoError(st.DB().QueryRow(`SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+	// The forwarded link keeps its share URL and is excluded from standalone
+	// processing; the composed photo remains standalone.
+	var shareMeta, shareRole, photoMeta, photoRole string
+	require.NoError(st.DB().QueryRow(`SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), ''),
+		a.attachment_role
 		FROM attachments a JOIN messages m ON m.id = a.message_id
-		WHERE m.source_message_id = 'share1'`).Scan(&shareMeta))
-	require.NoError(st.DB().QueryRow(`SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+		WHERE m.source_message_id = 'share1'`).Scan(&shareMeta, &shareRole))
+	require.NoError(st.DB().QueryRow(`SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), ''),
+		a.attachment_role
 		FROM attachments a JOIN messages m ON m.id = a.message_id
-		WHERE m.source_message_id = 'photo1'`).Scan(&photoMeta))
+		WHERE m.source_message_id = 'photo1'`).Scan(&photoMeta, &photoRole))
 	assert.JSONEq(`{"shared_url":"https://www.instagram.com/p/ABC/"}`, shareMeta)
+	assert.Equal("preview", shareRole)
 	assert.Empty(photoMeta, "media the sender composed is not a share")
+	assert.Equal("standalone", photoRole)
 
 	// Re-running must be a no-op: nothing left differing from the archive.
 	again, err := imp.RepairSource(context.Background(), beeperSourceID(t, st), nil)
@@ -249,12 +258,12 @@ func shareAndHTMLChat() *fakeChat {
 				ID: "share1", SortKey: 2, Timestamp: base.Add(time.Minute), Type: typeImage,
 				Text:     `<a href="https://www.instagram.com/p/ABC/" rel="noopener noreferrer">https://www.instagram.com/p/ABC/</a>`,
 				SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
-				Attachments: []map[string]any{{"id": "mxc://x/share1", "type": "img", "mimeType": "image/jpeg"}},
+				Attachments: []map[string]any{{"id": "mxc://x/share1", "type": beeperAttachmentTypeImage, "mimeType": "image/jpeg"}},
 			},
 			{
 				ID: "photo1", SortKey: 3, Timestamp: base.Add(2 * time.Minute), Type: typeImage,
 				SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
-				Attachments: []map[string]any{{"id": "mxc://x/photo1", "type": "img", "mimeType": "image/jpeg"}},
+				Attachments: []map[string]any{{"id": "mxc://x/photo1", "type": beeperAttachmentTypeImage, "mimeType": "image/jpeg"}},
 			},
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"go.kenn.io/msgvault/internal/documentindex"
 	"go.kenn.io/msgvault/internal/duckdbutil"
 	"go.kenn.io/msgvault/internal/fileutil"
 	"go.kenn.io/msgvault/internal/identityops"
@@ -366,29 +367,30 @@ func (b *BackupConfig) Validate() error {
 }
 
 type Config struct {
-	Data         DataConfig         `toml:"data"`
-	Log          LogConfig          `toml:"log"`
-	OAuth        OAuthConfig        `toml:"oauth"`
-	Microsoft    MicrosoftConfig    `toml:"microsoft"`
-	Sync         SyncConfig         `toml:"sync"`
-	Chat         ChatConfig         `toml:"chat"`
-	Server       ServerConfig       `toml:"server"`
-	Analytics    AnalyticsConfig    `toml:"analytics"`
-	Web          WebConfig          `toml:"web"`
-	Integrations IntegrationsConfig `toml:"integrations"`
-	Remote       RemoteConfig       `toml:"remote"`
-	Vector       vector.Config      `toml:"vector"`
-	Identity     IdentityConfig     `toml:"identity"`
-	Fastmail     []FastmailSource   `toml:"fastmail"`
-	Accounts     []AccountSchedule  `toml:"accounts"`
-	SynctechSMS  SynctechSMSConfig  `toml:"synctech_sms"`
-	GCal         []GCalSource       `toml:"gcal"`
-	Beeper       BeeperConfig       `toml:"beeper"`
-	Slack        SlackConfig        `toml:"slack"`
-	Granola      []GranolaSource    `toml:"granola"`
-	Circleback   []CirclebackSource `toml:"circleback"`
-	Backup       BackupConfig       `toml:"backup"`
-	Discord      DiscordConfig      `toml:"discord"`
+	Data         DataConfig                      `toml:"data"`
+	Log          LogConfig                       `toml:"log"`
+	OAuth        OAuthConfig                     `toml:"oauth"`
+	Microsoft    MicrosoftConfig                 `toml:"microsoft"`
+	Sync         SyncConfig                      `toml:"sync"`
+	Chat         ChatConfig                      `toml:"chat"`
+	Server       ServerConfig                    `toml:"server"`
+	Analytics    AnalyticsConfig                 `toml:"analytics"`
+	Web          WebConfig                       `toml:"web"`
+	Integrations IntegrationsConfig              `toml:"integrations"`
+	Remote       RemoteConfig                    `toml:"remote"`
+	Vector       vector.Config                   `toml:"vector"`
+	Identity     IdentityConfig                  `toml:"identity"`
+	Fastmail     []FastmailSource                `toml:"fastmail"`
+	Accounts     []AccountSchedule               `toml:"accounts"`
+	SynctechSMS  SynctechSMSConfig               `toml:"synctech_sms"`
+	GCal         []GCalSource                    `toml:"gcal"`
+	Beeper       BeeperConfig                    `toml:"beeper"`
+	Slack        SlackConfig                     `toml:"slack"`
+	Granola      []GranolaSource                 `toml:"granola"`
+	Circleback   []CirclebackSource              `toml:"circleback"`
+	Backup       BackupConfig                    `toml:"backup"`
+	Discord      DiscordConfig                   `toml:"discord"`
+	Attachments  documentindex.AttachmentsConfig `toml:"attachments"`
 
 	// Computed paths (not from config file)
 	HomeDir    string `toml:"-"`
@@ -579,6 +581,7 @@ func NewDefaultConfig() *Config {
 		SynctechSMS: SynctechSMSConfig{Sources: []SynctechSMSSource{}},
 		GCal:        []GCalSource{},
 	}
+	cfg.Attachments.Documents = documentindex.DefaultDocumentsConfig()
 	cfg.Vector.ApplyDefaults()
 	cfg.Server.ApplyDefaults()
 	cfg.Discord.ApplyDefaults()
@@ -679,6 +682,7 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	cfg.OAuth.ServiceAccountKey = expandPath(cfg.OAuth.ServiceAccountKey)
 	cfg.Vector.DBPath = expandPath(cfg.Vector.DBPath)
 	cfg.Backup.Repo = expandPath(cfg.Backup.Repo)
+	cfg.Attachments.Documents.CapabilityManifest = expandPath(cfg.Attachments.Documents.CapabilityManifest)
 	for name, app := range cfg.OAuth.Apps {
 		app.ClientSecrets = expandPath(app.ClientSecrets)
 		app.ServiceAccountKey = expandPath(app.ServiceAccountKey)
@@ -694,6 +698,9 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 		cfg.OAuth.ServiceAccountKey = resolveRelative(cfg.OAuth.ServiceAccountKey, cfg.HomeDir)
 		cfg.Vector.DBPath = resolveRelative(cfg.Vector.DBPath, cfg.HomeDir)
 		cfg.Backup.Repo = resolveRelative(cfg.Backup.Repo, cfg.HomeDir)
+		cfg.Attachments.Documents.CapabilityManifest = resolveRelative(
+			cfg.Attachments.Documents.CapabilityManifest, cfg.HomeDir,
+		)
 		for name, app := range cfg.OAuth.Apps {
 			app.ClientSecrets = resolveRelative(app.ClientSecrets, cfg.HomeDir)
 			app.ServiceAccountKey = resolveRelative(app.ServiceAccountKey, cfg.HomeDir)
@@ -706,6 +713,10 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	// Preprocess booleans are *bool so pointer-nil still means "default";
 	// an explicit false in the file stays false.
 	cfg.Vector.ApplyDefaults()
+	cfg.Attachments.Documents.ApplyDefaults()
+	if err := cfg.Attachments.Documents.Validate(); err != nil {
+		return nil, err
+	}
 	cfg.Server.ApplyDefaults()
 	cfg.Discord.ApplyDefaults()
 	if err := cfg.Server.Validate(); err != nil {

--- a/internal/config/documentindex_config_test.go
+++ b/internal/config/documentindex_config_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDocumentAttachmentConfig(t *testing.T) {
+	assert := assert.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := []byte(`
+[attachments.documents]
+enabled = true
+provider = "mistral"
+region = "eu"
+api_key_env = "PRIVATE_MISTRAL_KEY"
+model = "mistral-ocr-4-0"
+retention_posture = "zdr"
+training_posture = "opted-out"
+max_file_bytes = 1048576
+max_pages_per_document = 20
+max_response_bytes = 2097152
+max_normalized_chars = 100000
+max_spool_bytes = 8388608
+min_free_space_bytes = 4194304
+request_timeout = "2m"
+max_retries = 2
+max_pages_per_run = 100
+max_estimated_cost_usd_per_run = 3.5
+estimated_cost_usd_per_1000_units = 4.25
+pricing_assumption_on = "2026-08-13"
+schedule = "17 * * * *"
+capability_manifest = "/private/mistral-capabilities.json"
+
+[attachments.documents.scope]
+message_types = ["EMAIL", "chat", "email"]
+
+[attachments.documents.index]
+lexical = true
+store_chunk_text = true
+`)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+
+	loaded, err := Load(path, "")
+	require.NoError(t, err)
+	documents := loaded.Attachments.Documents
+	assert.True(documents.Enabled)
+	assert.Equal("PRIVATE_MISTRAL_KEY", documents.APIKeyEnv)
+	assert.Equal(2*time.Minute, documents.RequestTimeout)
+	assert.Equal(int64(8388608), documents.MaxSpoolBytes)
+	assert.Equal(int64(4194304), documents.MinFreeSpaceBytes)
+	assert.InDelta(4.25, documents.EstimatedCostUSDPerKUnits, 0.0001)
+	assert.Equal("17 * * * *", documents.Schedule)
+	assert.Equal([]string{"chat", "email"}, documents.Scope.MessageTypes)
+	assert.True(documents.LexicalEnabled())
+	assert.True(documents.StoresChunkText())
+}
+
+func TestLoadRejectsInvalidDocumentAttachmentConfigWithoutResolvingKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[attachments.documents]
+enabled = false
+region = "untrusted"
+api_key_env = "MISSING_KEY_IS_NOT_READ"
+`), 0o600))
+
+	_, err := Load(path, "")
+	assert.ErrorContains(t, err, "unknown region")
+}
+
+func TestLoadRejectsExplicitZeroDocumentLimits(t *testing.T) {
+	for _, field := range []string{
+		"max_file_bytes = 0",
+		"max_pages_per_document = 0",
+		"max_estimated_cost_usd_per_run = 0",
+	} {
+		t.Run(field, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			content := "[attachments.documents]\n" + field + "\n"
+			require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+			_, err := Load(path, "")
+			assert.ErrorContains(t, err, "must be")
+		})
+	}
+}
+
+func TestLoadResolvesRelativeDocumentCapabilityManifest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[attachments.documents]
+capability_manifest = "private/capabilities.json"
+`), 0o600))
+
+	loaded, err := Load(path, "")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "private", "capabilities.json"),
+		loaded.Attachments.Documents.CapabilityManifest)
+}

--- a/internal/daemonclient/documents.go
+++ b/internal/daemonclient/documents.go
@@ -1,0 +1,124 @@
+package daemonclient
+
+import (
+	"context"
+
+	"go.kenn.io/msgvault/internal/store"
+	apiclient "go.kenn.io/msgvault/pkg/client"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+// SearchDocuments runs dedicated extracted-document search through the daemon.
+func (c *Client) SearchDocuments(
+	ctx context.Context,
+	request store.DocumentSearchRequest,
+) (store.DocumentSearchResponse, error) {
+	response, err := APIResponse(c, func(client *apiclient.Client) (*generated.SearchDocumentsResp, error) {
+		return client.SearchDocumentsWithResponse(ctx, &generated.SearchDocumentsRequestOptions{
+			Query: &generated.SearchDocumentsQuery{
+				Q: request.Query, SourceID: request.SourceIDs, MessageType: request.MessageTypes,
+				AttachmentID: optionalPositiveInt64Value(request.AttachmentID),
+				MessageID:    optionalPositiveInt64Value(request.MessageID),
+				Limit:        optionalPositiveInt64(request.PageSize), Cursor: optionalString(request.Cursor),
+			},
+		})
+	})
+	if err != nil {
+		return store.DocumentSearchResponse{}, err
+	}
+	return documentSearchFromGenerated(response.JSON200), nil
+}
+
+// GetDocumentIndexStatus reads scoped document coverage through the selected daemon.
+func (c *Client) GetDocumentIndexStatus(
+	ctx context.Context,
+	request store.DocumentIndexStatusRequest,
+) (store.DocumentIndexStatusResponse, error) {
+	response, err := APIResponse(c, func(client *apiclient.Client) (*generated.GetDocumentIndexStatusResp, error) {
+		return client.GetDocumentIndexStatusWithResponse(ctx, &generated.GetDocumentIndexStatusRequestOptions{
+			Query: &generated.GetDocumentIndexStatusQuery{
+				ProfileID: request.ProfileID, InputKey: request.ExtractionInputKey,
+				MediaType: request.AllowedMediaTypes, MessageType: request.AllowedMessageTypes,
+			},
+		})
+	})
+	if err != nil {
+		return store.DocumentIndexStatusResponse{}, err
+	}
+	return documentIndexStatusFromGenerated(response.JSON200), nil
+}
+
+func optionalPositiveInt64Value(value int64) *int64 {
+	if value <= 0 {
+		return nil
+	}
+	return &value
+}
+
+func documentSearchFromGenerated(response *generated.DocumentSearchResponse) store.DocumentSearchResponse {
+	if response == nil {
+		return store.DocumentSearchResponse{Results: []store.DocumentSearchResult{}}
+	}
+	result := store.DocumentSearchResponse{
+		Revision: response.Revision,
+		Results:  make([]store.DocumentSearchResult, len(response.Results)),
+	}
+	if response.Truncated != nil {
+		result.Truncated = *response.Truncated
+	}
+	if response.NextCursor != nil {
+		result.NextCursor = *response.NextCursor
+	}
+	for index, row := range response.Results {
+		result.Results[index] = store.DocumentSearchResult{
+			AttachmentID: row.AttachmentID, MessageID: row.MessageID, SourceID: row.SourceID,
+			OccurrenceKey: row.OccurrenceKey, SourcePartKey: stringValue(row.SourcePartKey),
+			Filename: stringValue(row.Filename), ContainingTitle: stringValue(row.ContainingTitle),
+			MIMEType: stringValue(row.MimeType), CanonicalBlobHash: row.CanonicalBlobHash,
+			OtherLiveCopies: int(row.OtherLiveCopies), ChunkKey: row.ChunkKey,
+			ChunkOrdinal: int(row.ChunkOrdinal), HeadingPath: row.HeadingPath,
+			FirstUnitIndex: int(row.FirstUnitIndex), LastUnitIndex: int(row.LastUnitIndex),
+			Excerpt: row.Excerpt, HighlightStart: int(row.HighlightStart), HighlightEnd: int(row.HighlightEnd),
+			ProfileID: row.ProfileID, ExtractionID: row.ExtractionID,
+			Provider: row.Provider, Model: row.Model, MatchedSignals: row.MatchedSignals,
+			Truncated: row.Truncated, Rank: int(row.Rank),
+		}
+	}
+	return result
+}
+
+func documentIndexStatusFromGenerated(
+	response *generated.DocumentIndexStatusResponse,
+) store.DocumentIndexStatusResponse {
+	if response == nil {
+		return store.DocumentIndexStatusResponse{}
+	}
+	generatedStatus := response.Status
+	result := store.DocumentIndexStatusResponse{Status: store.DocumentIndexStatus{
+		ProfileExists: generatedStatus.ProfileExists, ProfileEnabled: generatedStatus.ProfileEnabled,
+		ExactConsent: generatedStatus.ExactConsent, ExtractionAttempts: generatedStatus.ExtractionAttempts,
+		SuccessfulAttempts: generatedStatus.SuccessfulAttempts, FailedAttempts: generatedStatus.FailedAttempts,
+		ProviderRequests: generatedStatus.ProviderRequests, ProviderRetries: generatedStatus.ProviderRetries,
+		ProviderLatencyMillis:      generatedStatus.ProviderLatencyMillis,
+		AverageProviderLatencyMS:   generatedStatus.AverageProviderLatencyMillis,
+		VerifiedUploadBytes:        generatedStatus.VerifiedUploadBytes,
+		ProcessedProviderUnits:     generatedStatus.ProcessedProviderUnits,
+		ReportedProviderBytes:      generatedStatus.ReportedProviderBytes,
+		MissingProviderByteReports: generatedStatus.MissingProviderByteReports,
+		EligibleOccurrences:        generatedStatus.EligibleOccurrences, EligibleOwners: generatedStatus.EligibleOwners,
+		EligibleBytes:             generatedStatus.EligibleBytes,
+		UnknownRoleOccurrences:    generatedStatus.UnknownRoleOccurrences,
+		IneligibleRoleOccurrences: generatedStatus.IneligibleRoleOccurrences,
+		ReadyOwners:               generatedStatus.ReadyOwners, StagingOwners: generatedStatus.StagingOwners,
+		RetryOwners: generatedStatus.RetryOwners, TerminalOwners: generatedStatus.TerminalOwners,
+		MissingOwners:         generatedStatus.MissingOwners,
+		StoredPlaintextChunks: generatedStatus.StoredPlaintextChunks,
+	}}
+	if response.ActiveRebuild != nil {
+		result.ActiveRebuild = &store.DocumentIndexRebuildStatus{
+			SnapshotOwners:  response.ActiveRebuild.SnapshotOwners,
+			RemainingOwners: response.ActiveRebuild.RemainingOwners,
+		}
+	}
+	return result
+}

--- a/internal/daemonclient/documents_test.go
+++ b/internal/daemonclient/documents_test.go
@@ -1,0 +1,87 @@
+package daemonclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestSearchDocumentsUsesGeneratedDaemonContract(t *testing.T) {
+	assert := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/documents/search", r.URL.Path)
+		assert.Equal("damaged carton", r.URL.Query().Get("q"))
+		assert.ElementsMatch([]string{"3", "7"}, r.URL.Query()["source_id"])
+		assert.Equal("22", r.URL.Query().Get("attachment_id"))
+		assert.Equal("5", r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(store.DocumentSearchResponse{
+			Revision: 9, Truncated: true,
+			Results: []store.DocumentSearchResult{{
+				AttachmentID: 22, MessageID: 23, SourceID: 3,
+				OccurrenceKey: "occurrence", CanonicalBlobHash: "hash", ChunkKey: "chunk",
+				Filename: "claim.docx", Excerpt: "damaged carton", ProfileID: "profile",
+				ExtractionID: "extraction", Provider: "mistral", Model: "ocr",
+				MatchedSignals: []string{"content"}, Rank: 1,
+			}},
+		}))
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Config{URL: server.URL, AllowInsecure: true})
+	require.NoError(t, err)
+	response, err := client.SearchDocuments(context.Background(), store.DocumentSearchRequest{
+		Query: "damaged carton", SourceIDs: []int64{3, 7}, AttachmentID: 22, PageSize: 5,
+	})
+	require.NoError(t, err)
+	assert.Equal(int64(9), response.Revision)
+	assert.True(response.Truncated)
+	require.Len(t, response.Results, 1)
+	assert.Equal("claim.docx", response.Results[0].Filename)
+	assert.Equal([]string{"content"}, response.Results[0].MatchedSignals)
+}
+
+func TestDocumentIndexStatusUsesGeneratedDaemonContract(t *testing.T) {
+	assert := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/documents/status", r.URL.Path)
+		assert.Equal("profile", r.URL.Query().Get("profile_id"))
+		assert.Equal("original", r.URL.Query().Get("input_key"))
+		assert.ElementsMatch(
+			[]string{"application/pdf", "application/epub+zip"},
+			r.URL.Query()["media_type"],
+		)
+		assert.ElementsMatch([]string{"email", "mms"}, r.URL.Query()["message_type"])
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(store.DocumentIndexStatusResponse{
+			Status: store.DocumentIndexStatus{
+				ProfileExists: true, ExactConsent: true, ReadyOwners: 4,
+				AverageProviderLatencyMS: 12.5,
+			},
+			ActiveRebuild: &store.DocumentIndexRebuildStatus{
+				SnapshotOwners: 6, RemainingOwners: 2,
+			},
+		}))
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Config{URL: server.URL, AllowInsecure: true})
+	require.NoError(t, err)
+	response, err := client.GetDocumentIndexStatus(context.Background(), store.DocumentIndexStatusRequest{
+		ProfileID: "profile", ExtractionInputKey: "original",
+		AllowedMediaTypes:   []string{"application/pdf", "application/epub+zip"},
+		AllowedMessageTypes: []string{"email", "mms"},
+	})
+	require.NoError(t, err)
+	assert.True(response.Status.ProfileExists)
+	assert.True(response.Status.ExactConsent)
+	assert.Equal(int64(4), response.Status.ReadyOwners)
+	assert.InDelta(12.5, response.Status.AverageProviderLatencyMS, 0.001)
+	require.NotNil(t, response.ActiveRebuild)
+	assert.Equal(int64(6), response.ActiveRebuild.SnapshotOwners)
+	assert.Equal(int64(2), response.ActiveRebuild.RemainingOwners)
+}

--- a/internal/discord/media.go
+++ b/internal/discord/media.go
@@ -198,6 +198,8 @@ func (m *MediaArchiver) persistAttachments(
 			if store.IsDiscordAttachmentDownloaded(previous) {
 				ref.StoragePath = previous.StoragePath
 				ref.ContentHash = previous.ContentHash
+				ref.Role = store.AttachmentRoleStandalone
+				ref.RoleSource = store.AttachmentRoleSourceProviderExplicit
 				item.download = false
 				item.report = retryExisting
 			} else if !retryExisting {
@@ -488,6 +490,8 @@ func (m *MediaArchiver) downloadAttachment(
 	marker.StoragePath = storagePath
 	marker.ContentHash = mimeAttachment.ContentHash
 	marker.Size = len(content)
+	marker.Role = store.AttachmentRoleStandalone
+	marker.RoleSource = store.AttachmentRoleSourceProviderExplicit
 	return marker, nil
 }
 

--- a/internal/discord/media_test.go
+++ b/internal/discord/media_test.go
@@ -133,6 +133,8 @@ func TestMediaArchiverStoresAttachmentAfterDurableMarker(t *testing.T) {
 	assert.NotEmpty(ref.ContentHash)
 	assert.Equal(len(content), ref.Size)
 	assert.Equal("image", ref.MediaType)
+	assert.Equal(store.AttachmentRoleStandalone, ref.Role)
+	assert.Equal(store.AttachmentRoleSourceProviderExplicit, ref.RoleSource)
 	assert.EqualValues(640, ref.Width)
 	assert.EqualValues(480, ref.Height)
 	stored, err := os.ReadFile(filepath.Join(f.dir, filepath.FromSlash(ref.StoragePath)))
@@ -310,6 +312,9 @@ func TestMediaArchiverPersistsPendingMetadataForEmptyURL(t *testing.T) {
 		Filename: "unavailable.bin", MimeType: "application/octet-stream", Size: 42,
 		StoragePath: "discord:pending:401", SourceAttachmentID: "discord:401", MediaType: "document",
 		Width: 640, Height: 480,
+		Role:          store.AttachmentRoleUnknown,
+		RoleSource:    store.AttachmentRoleSourceUnknown,
+		SourcePartKey: "discord:401",
 	}, refs["discord:401"])
 	pending, err := f.store.ListDiscordPendingAttachmentMessages(f.sourceID)
 	require.NoError(err)

--- a/internal/documentindex/config.go
+++ b/internal/documentindex/config.go
@@ -1,0 +1,403 @@
+// Package documentindex owns the opt-in document attachment indexing policy.
+package documentindex
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	ProviderMistral = "mistral"
+	ModelMistralOCR = "mistral-ocr-4-0"
+	RegionMistralEU = "eu"
+
+	RetentionUnknown  = "unknown"
+	RetentionStandard = "standard"
+	RetentionZDR      = "zdr"
+
+	TrainingUnknown       = "unknown"
+	TrainingDefaultOptOut = "default-opt-out"
+	TrainingOptedOut      = "opted-out"
+
+	defaultAPIKeyEnv                 = "MISTRAL_API_KEY" // #nosec G101 -- environment variable name, not a credential.
+	defaultMaxFileBytes        int64 = 50 << 20
+	defaultMaxPages                  = 500
+	defaultMaxResponseBytes    int64 = 64 << 20
+	defaultMaxNormalizedChars        = 25_000_000
+	defaultMaxSpoolBytes       int64 = 512 << 20
+	defaultMinFreeSpaceBytes   int64 = 1 << 30
+	defaultMaxRetries                = 3
+	defaultMaxPagesPerRun            = 10_000
+	defaultMaxEstimatedCostUSD       = 50.0
+	profilePolicyVersion             = 1
+	hardMaxFileBytes           int64 = 500 << 20
+	hardMaxPages                     = 5_000
+	hardMaxResponseBytes       int64 = 512 << 20
+	hardMaxNormalizedChars           = 100_000_000
+	hardMaxSpoolBytes          int64 = 100 << 30
+	hardMaxFreeSpaceBytes      int64 = 1 << 40
+	hardMaxRequestTimeout            = 30 * time.Minute
+	hardMaxRetries                   = 10
+	hardMaxPagesPerRun               = 1_000_000
+	hardMaxEstimatedCostUSD          = 1_000_000.0
+)
+
+var envNamePattern = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
+
+// DefaultDocumentsConfig returns the complete safe policy used as the decode
+// target. Decoding over populated defaults distinguishes an omitted numeric
+// field from an explicit zero, which Validate must reject.
+func DefaultDocumentsConfig() DocumentsConfig {
+	config := DocumentsConfig{
+		MaxFileBytes:              defaultMaxFileBytes,
+		MaxPagesPerDocument:       defaultMaxPages,
+		MaxResponseBytes:          defaultMaxResponseBytes,
+		MaxNormalizedChars:        defaultMaxNormalizedChars,
+		MaxSpoolBytes:             defaultMaxSpoolBytes,
+		MinFreeSpaceBytes:         defaultMinFreeSpaceBytes,
+		RequestTimeout:            5 * time.Minute,
+		MaxRetries:                defaultMaxRetries,
+		MaxPagesPerRun:            defaultMaxPagesPerRun,
+		MaxEstimatedCostUSDPerRun: defaultMaxEstimatedCostUSD,
+	}
+	config.ApplyDefaults()
+	return config
+}
+
+// AttachmentsConfig groups independently consented attachment processing
+// lanes. Visual indexing is intentionally not configured through Documents.
+type AttachmentsConfig struct {
+	Documents DocumentsConfig `toml:"documents"`
+}
+
+// DocumentsConfig controls hosted Mistral extraction and local indexing.
+// Supplying an API key or setting Enabled never records provider consent.
+type DocumentsConfig struct {
+	Enabled                   bool          `toml:"enabled"`
+	Provider                  string        `toml:"provider"`
+	Region                    string        `toml:"region"`
+	APIKeyEnv                 string        `toml:"api_key_env"`
+	Model                     string        `toml:"model"`
+	RetentionPosture          string        `toml:"retention_posture"`
+	TrainingPosture           string        `toml:"training_posture"`
+	MaxFileBytes              int64         `toml:"max_file_bytes"`
+	MaxPagesPerDocument       int           `toml:"max_pages_per_document"`
+	MaxResponseBytes          int64         `toml:"max_response_bytes"`
+	MaxNormalizedChars        int           `toml:"max_normalized_chars"`
+	MaxSpoolBytes             int64         `toml:"max_spool_bytes"`
+	MinFreeSpaceBytes         int64         `toml:"min_free_space_bytes"`
+	RequestTimeout            time.Duration `toml:"request_timeout"`
+	MaxRetries                int           `toml:"max_retries"`
+	MaxPagesPerRun            int           `toml:"max_pages_per_run"`
+	MaxEstimatedCostUSDPerRun float64       `toml:"max_estimated_cost_usd_per_run"`
+	EstimatedCostUSDPerKUnits float64       `toml:"estimated_cost_usd_per_1000_units"`
+	PricingAssumptionOn       string        `toml:"pricing_assumption_on"`
+	Schedule                  string        `toml:"schedule"`
+	CapabilityManifest        string        `toml:"capability_manifest"`
+	Scope                     ScopeConfig   `toml:"scope"`
+	Index                     IndexConfig   `toml:"index"`
+	defaultsApplied           bool
+}
+
+// ScopeConfig limits extraction to selected message families. Empty includes
+// every source whose attachment role is authoritatively standalone.
+type ScopeConfig struct {
+	MessageTypes []string `toml:"message_types"`
+}
+
+// IndexConfig describes the local index shape. The first release requires
+// lexical plaintext because it has no vector-only serving path yet.
+// Embeddings require a separate explicit opt-in and are implemented only
+// after the text-vector publication contract lands.
+type IndexConfig struct {
+	Lexical        *bool                    `toml:"lexical"`
+	StoreChunkText *bool                    `toml:"store_chunk_text"`
+	Embeddings     DocumentEmbeddingsConfig `toml:"embeddings"`
+}
+
+type DocumentEmbeddingsConfig struct {
+	Enabled bool   `toml:"enabled"`
+	Profile string `toml:"profile"`
+}
+
+// ApplyDefaults restores safe v1 settings after TOML decoding. Pointer
+// booleans preserve an explicit false.
+func (c *DocumentsConfig) ApplyDefaults() {
+	if !c.defaultsApplied {
+		if c.Provider == "" {
+			c.Provider = ProviderMistral
+		}
+		if c.Region == "" {
+			c.Region = RegionMistralEU
+		}
+		if c.APIKeyEnv == "" {
+			c.APIKeyEnv = defaultAPIKeyEnv
+		}
+		if c.Model == "" {
+			c.Model = ModelMistralOCR
+		}
+		if c.RetentionPosture == "" {
+			c.RetentionPosture = RetentionUnknown
+		}
+		if c.TrainingPosture == "" {
+			c.TrainingPosture = TrainingUnknown
+		}
+		if c.Index.Lexical == nil {
+			value := true
+			c.Index.Lexical = &value
+		}
+		if c.Index.StoreChunkText == nil {
+			value := true
+			c.Index.StoreChunkText = &value
+		}
+		if c.Index.Embeddings.Profile == "" {
+			c.Index.Embeddings.Profile = "vector.embeddings"
+		}
+		c.defaultsApplied = true
+	}
+	for i := range c.Scope.MessageTypes {
+		c.Scope.MessageTypes[i] = strings.ToLower(strings.TrimSpace(c.Scope.MessageTypes[i]))
+	}
+	slices.Sort(c.Scope.MessageTypes)
+	c.Scope.MessageTypes = slices.Compact(c.Scope.MessageTypes)
+}
+
+func (c *DocumentsConfig) LexicalEnabled() bool {
+	return c.Index.Lexical != nil && *c.Index.Lexical
+}
+
+func (c *DocumentsConfig) StoresChunkText() bool {
+	return c.Index.StoreChunkText != nil && *c.Index.StoreChunkText
+}
+
+// MaxDocumentsWithinRunBudget reserves the full per-document unit allowance
+// before any hosted request. Container unit counts are not authoritative until
+// Mistral responds, so this is a conservative scheduling guard rather than a
+// billing guarantee for an individual container.
+func (c *DocumentsConfig) MaxDocumentsWithinRunBudget(requested int) (int, error) {
+	if requested <= 0 || requested > 10_000 || c.MaxPagesPerDocument <= 0 || c.MaxPagesPerRun <= 0 {
+		return 0, errors.New("document run budget has invalid bounds")
+	}
+	limit := min(requested, c.MaxPagesPerRun/c.MaxPagesPerDocument)
+	if c.EstimatedCostUSDPerKUnits > 0 {
+		costPerDocument := float64(c.MaxPagesPerDocument) * c.EstimatedCostUSDPerKUnits / 1000
+		limit = min(limit, int(math.Floor(c.MaxEstimatedCostUSDPerRun/costPerDocument)))
+	}
+	if limit <= 0 {
+		return 0, errors.New("document run budget is smaller than one worst-case document request")
+	}
+	return limit, nil
+}
+
+// Endpoint returns the one documented v1 regional endpoint currently shipped.
+// More regions require an explicit documented-host addition and new consent.
+func (c *DocumentsConfig) Endpoint() (string, error) {
+	switch c.Region {
+	case RegionMistralEU:
+		return "https://api.mistral.ai/v1/ocr", nil
+	default:
+		return "", fmt.Errorf("attachments.documents.region: unknown region %q (supported: %q)", c.Region, RegionMistralEU)
+	}
+}
+
+// Validate checks the complete effective policy without resolving credentials.
+// Disabled configurations are validated too so enabling later cannot expose
+// bytes under an already-invalid policy.
+func (c *DocumentsConfig) Validate() error {
+	if c.Provider != ProviderMistral {
+		return fmt.Errorf("attachments.documents.provider: must be %q", ProviderMistral)
+	}
+	if c.Model != ModelMistralOCR {
+		return fmt.Errorf("attachments.documents.model: must be pinned to %q", ModelMistralOCR)
+	}
+	if _, err := c.Endpoint(); err != nil {
+		return err
+	}
+	if !envNamePattern.MatchString(c.APIKeyEnv) {
+		return fmt.Errorf("attachments.documents.api_key_env: invalid environment variable name %q", c.APIKeyEnv)
+	}
+	if !slices.Contains([]string{RetentionUnknown, RetentionStandard, RetentionZDR}, c.RetentionPosture) {
+		return fmt.Errorf("attachments.documents.retention_posture: invalid value %q", c.RetentionPosture)
+	}
+	if !slices.Contains([]string{TrainingUnknown, TrainingDefaultOptOut, TrainingOptedOut}, c.TrainingPosture) {
+		return fmt.Errorf("attachments.documents.training_posture: invalid value %q", c.TrainingPosture)
+	}
+	positive := []struct {
+		name  string
+		value int64
+	}{
+		{name: "max_file_bytes", value: c.MaxFileBytes},
+		{name: "max_pages_per_document", value: int64(c.MaxPagesPerDocument)},
+		{name: "max_response_bytes", value: c.MaxResponseBytes},
+		{name: "max_normalized_chars", value: int64(c.MaxNormalizedChars)},
+		{name: "max_spool_bytes", value: c.MaxSpoolBytes},
+		{name: "min_free_space_bytes", value: c.MinFreeSpaceBytes},
+		{name: "request_timeout", value: int64(c.RequestTimeout)},
+		{name: "max_retries", value: int64(c.MaxRetries)},
+		{name: "max_pages_per_run", value: int64(c.MaxPagesPerRun)},
+	}
+	for _, field := range positive {
+		if field.value <= 0 {
+			return fmt.Errorf("attachments.documents.%s: must be positive", field.name)
+		}
+	}
+	bounded := []struct {
+		name  string
+		value int64
+		limit int64
+	}{
+		{name: "max_file_bytes", value: c.MaxFileBytes, limit: hardMaxFileBytes},
+		{name: "max_pages_per_document", value: int64(c.MaxPagesPerDocument), limit: hardMaxPages},
+		{name: "max_response_bytes", value: c.MaxResponseBytes, limit: hardMaxResponseBytes},
+		{name: "max_normalized_chars", value: int64(c.MaxNormalizedChars), limit: hardMaxNormalizedChars},
+		{name: "max_spool_bytes", value: c.MaxSpoolBytes, limit: hardMaxSpoolBytes},
+		{name: "min_free_space_bytes", value: c.MinFreeSpaceBytes, limit: hardMaxFreeSpaceBytes},
+		{name: "request_timeout", value: int64(c.RequestTimeout), limit: int64(hardMaxRequestTimeout)},
+		{name: "max_retries", value: int64(c.MaxRetries), limit: hardMaxRetries},
+		{name: "max_pages_per_run", value: int64(c.MaxPagesPerRun), limit: hardMaxPagesPerRun},
+	}
+	for _, field := range bounded {
+		if field.value > field.limit {
+			return fmt.Errorf("attachments.documents.%s: exceeds hard safety limit", field.name)
+		}
+	}
+	if c.MaxSpoolBytes < c.MaxFileBytes {
+		return errors.New("attachments.documents.max_spool_bytes: must be at least max_file_bytes")
+	}
+	if math.IsNaN(c.MaxEstimatedCostUSDPerRun) || math.IsInf(c.MaxEstimatedCostUSDPerRun, 0) || c.MaxEstimatedCostUSDPerRun <= 0 {
+		return errors.New("attachments.documents.max_estimated_cost_usd_per_run: must be finite and positive")
+	}
+	if c.MaxEstimatedCostUSDPerRun > hardMaxEstimatedCostUSD {
+		return errors.New("attachments.documents.max_estimated_cost_usd_per_run: exceeds hard safety limit")
+	}
+	if math.IsNaN(c.EstimatedCostUSDPerKUnits) || math.IsInf(c.EstimatedCostUSDPerKUnits, 0) ||
+		c.EstimatedCostUSDPerKUnits < 0 {
+		return errors.New("attachments.documents.estimated_cost_usd_per_1000_units: must be finite and nonnegative")
+	}
+	if (c.EstimatedCostUSDPerKUnits == 0) != (c.PricingAssumptionOn == "") {
+		return errors.New("attachments.documents pricing assumption requires both estimated_cost_usd_per_1000_units and pricing_assumption_on")
+	}
+	if c.PricingAssumptionOn != "" {
+		if _, err := time.Parse(time.DateOnly, c.PricingAssumptionOn); err != nil {
+			return errors.New("attachments.documents.pricing_assumption_on: must use YYYY-MM-DD")
+		}
+	}
+	if c.Schedule != "" {
+		if strings.TrimSpace(c.CapabilityManifest) == "" {
+			return errors.New("attachments.documents.schedule requires capability_manifest")
+		}
+		if c.EstimatedCostUSDPerKUnits <= 0 {
+			return errors.New("attachments.documents.schedule requires an explicit pricing assumption")
+		}
+	}
+	if !c.LexicalEnabled() || !c.StoresChunkText() {
+		return errors.New("attachments.documents.index.lexical and store_chunk_text must both be true until document vector publication lands")
+	}
+	if c.Index.Embeddings.Enabled {
+		return errors.New("attachments.documents.index.embeddings.enabled is not available until document vector publication lands")
+	}
+	if slices.Contains(c.Scope.MessageTypes, "") {
+		return errors.New("attachments.documents.scope.message_types contains an empty value")
+	}
+	return nil
+}
+
+// ResolveAPIKey is called only by an explicit provider operation. Merely
+// loading configuration never resolves or validates the secret.
+func (c *DocumentsConfig) ResolveAPIKey() (string, error) {
+	value, ok := os.LookupEnv(c.APIKeyEnv)
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("document extraction requires nonempty environment variable %s", c.APIKeyEnv)
+	}
+	return value, nil
+}
+
+// ProfileFingerprint binds consent and immutable extraction output to every
+// policy field that can change uploaded bytes, output, or privacy posture.
+func (c *DocumentsConfig) ProfileFingerprint(allowedMediaTypes []string) (string, error) {
+	encoded, err := c.ProfilePolicyJSON(allowedMediaTypes)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(encoded)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+// ProfilePolicyJSON is the canonical non-secret policy persisted with an
+// immutable extraction profile. Its digest is the consent fingerprint.
+func (c *DocumentsConfig) ProfilePolicyJSON(allowedMediaTypes []string) ([]byte, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	mediaTypes := slices.Clone(allowedMediaTypes)
+	slices.Sort(mediaTypes)
+	mediaTypes = slices.Compact(mediaTypes)
+	endpoint, err := c.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	normalizePolicy := DefaultNormalizePolicy(c.MaxNormalizedChars)
+	payload := struct {
+		Version                   int      `json:"version"`
+		Provider                  string   `json:"provider"`
+		Endpoint                  string   `json:"endpoint"`
+		Model                     string   `json:"model"`
+		Retention                 string   `json:"retention"`
+		Training                  string   `json:"training"`
+		MaxFileBytes              int64    `json:"max_file_bytes"`
+		MaxPagesPerDocument       int      `json:"max_pages_per_document"`
+		MaxResponseBytes          int64    `json:"max_response_bytes"`
+		MaxNormalizedChars        int      `json:"max_normalized_chars"`
+		MaxSpoolBytes             int64    `json:"max_spool_bytes"`
+		MinFreeSpaceBytes         int64    `json:"min_free_space_bytes"`
+		RequestTimeoutNanos       int64    `json:"request_timeout_nanos"`
+		MaxRetries                int      `json:"max_retries"`
+		MaxPagesPerRun            int      `json:"max_pages_per_run"`
+		MaxEstimatedCostUSDPerRun float64  `json:"max_estimated_cost_usd_per_run"`
+		MessageTypes              []string `json:"message_types"`
+		AllowedMediaTypes         []string `json:"allowed_media_types"`
+		Lexical                   bool     `json:"lexical"`
+		StoreChunkText            bool     `json:"store_chunk_text"`
+		ExtractHeader             bool     `json:"extract_header"`
+		ExtractFooter             bool     `json:"extract_footer"`
+		NormalizationVersion      int      `json:"normalization_version"`
+		MaxUnitChars              int      `json:"max_unit_chars"`
+		MaxSourceUnitBytes        int      `json:"max_source_unit_bytes"`
+		MaxMetadataSourceBytes    int      `json:"max_metadata_source_bytes"`
+		MaxLinkChars              int      `json:"max_link_chars"`
+		MaxChunkRunes             int      `json:"max_chunk_runes"`
+		ChunkOverlap              int      `json:"chunk_overlap"`
+		MaxChunks                 int      `json:"max_chunks"`
+	}{
+		Version: profilePolicyVersion, Provider: c.Provider, Endpoint: endpoint,
+		Model: c.Model, Retention: c.RetentionPosture, Training: c.TrainingPosture,
+		MaxFileBytes: c.MaxFileBytes, MaxPagesPerDocument: c.MaxPagesPerDocument,
+		MaxResponseBytes: c.MaxResponseBytes, MaxNormalizedChars: c.MaxNormalizedChars,
+		MaxSpoolBytes: c.MaxSpoolBytes, MinFreeSpaceBytes: c.MinFreeSpaceBytes,
+		RequestTimeoutNanos: int64(c.RequestTimeout), MaxRetries: c.MaxRetries,
+		MaxPagesPerRun:            c.MaxPagesPerRun,
+		MaxEstimatedCostUSDPerRun: c.MaxEstimatedCostUSDPerRun,
+		MessageTypes:              slices.Clone(c.Scope.MessageTypes), AllowedMediaTypes: mediaTypes,
+		Lexical: c.LexicalEnabled(), StoreChunkText: c.StoresChunkText(),
+		ExtractHeader: true, ExtractFooter: true,
+		NormalizationVersion: normalizationPolicyVersion,
+		MaxUnitChars:         normalizePolicy.MaxUnitChars, MaxSourceUnitBytes: normalizePolicy.MaxSourceUnitBytes,
+		MaxMetadataSourceBytes: normalizePolicy.MaxMetadataSourceBytes, MaxLinkChars: normalizePolicy.MaxLinkChars,
+		MaxChunkRunes: normalizePolicy.MaxChunkRunes, ChunkOverlap: normalizePolicy.ChunkOverlap,
+		MaxChunks: normalizePolicy.MaxChunks,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode document extraction profile: %w", err)
+	}
+	return encoded, nil
+}

--- a/internal/documentindex/config_test.go
+++ b/internal/documentindex/config_test.go
@@ -1,0 +1,160 @@
+package documentindex
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocumentsConfigDefaultsAreValidAndOptIn(t *testing.T) {
+	assert := assert.New(t)
+	config := DefaultDocumentsConfig()
+
+	require.NoError(t, config.Validate())
+	assert.False(config.Enabled)
+	assert.Equal(ProviderMistral, config.Provider)
+	assert.Equal(RegionMistralEU, config.Region)
+	assert.Equal(ModelMistralOCR, config.Model)
+	assert.Equal(RetentionUnknown, config.RetentionPosture)
+	assert.Equal(TrainingUnknown, config.TrainingPosture)
+	assert.True(config.LexicalEnabled())
+	assert.True(config.StoresChunkText())
+	assert.False(config.Index.Embeddings.Enabled)
+	assert.Equal("vector.embeddings", config.Index.Embeddings.Profile)
+	assert.Equal(int64(512<<20), config.MaxSpoolBytes)
+	assert.Equal(int64(1<<30), config.MinFreeSpaceBytes)
+	endpoint, err := config.Endpoint()
+	require.NoError(t, err)
+	assert.Equal("https://api.mistral.ai/v1/ocr", endpoint)
+}
+
+func TestDocumentsConfigDoesNotDefaultExplicitZeroSafetyLimits(t *testing.T) {
+	config := DefaultDocumentsConfig()
+	config.MaxFileBytes = 0
+	config.ApplyDefaults()
+
+	require.ErrorContains(t, config.Validate(), "max_file_bytes: must be positive")
+	assert.Zero(t, config.MaxFileBytes)
+}
+
+func TestDocumentsConfigRejectsUnavailableIndexOptOut(t *testing.T) {
+	lexical := false
+	store := false
+	config := DefaultDocumentsConfig()
+	config.Index = IndexConfig{Lexical: &lexical, StoreChunkText: &store}
+
+	require.ErrorContains(t, config.Validate(), "must both be true")
+	assert.False(t, config.LexicalEnabled())
+	assert.False(t, config.StoresChunkText())
+}
+
+func TestDocumentsConfigRejectsUnsafePolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*DocumentsConfig)
+		want   string
+	}{
+		{name: "provider", mutate: func(c *DocumentsConfig) { c.Provider = "other" }, want: "provider"},
+		{name: "model", mutate: func(c *DocumentsConfig) { c.Model = "latest" }, want: "pinned"},
+		{name: "region", mutate: func(c *DocumentsConfig) { c.Region = "us" }, want: "unknown region"},
+		{name: "environment", mutate: func(c *DocumentsConfig) { c.APIKeyEnv = "bad-name" }, want: "environment variable"},
+		{name: "negative cap", mutate: func(c *DocumentsConfig) { c.MaxFileBytes = -1 }, want: "must be positive"},
+		{name: "unbounded cap", mutate: func(c *DocumentsConfig) { c.MaxResponseBytes = hardMaxResponseBytes + 1 }, want: "hard safety limit"},
+		{name: "spool below file", mutate: func(c *DocumentsConfig) { c.MaxSpoolBytes = c.MaxFileBytes - 1 }, want: "at least max_file_bytes"},
+		{name: "spool hard cap", mutate: func(c *DocumentsConfig) { c.MaxSpoolBytes = hardMaxSpoolBytes + 1 }, want: "hard safety limit"},
+		{name: "free space hard cap", mutate: func(c *DocumentsConfig) { c.MinFreeSpaceBytes = hardMaxFreeSpaceBytes + 1 }, want: "hard safety limit"},
+		{name: "timeout", mutate: func(c *DocumentsConfig) { c.RequestTimeout = hardMaxRequestTimeout + time.Second }, want: "hard safety limit"},
+		{name: "cost", mutate: func(c *DocumentsConfig) { c.MaxEstimatedCostUSDPerRun = hardMaxEstimatedCostUSD + 1 }, want: "hard safety limit"},
+		{name: "pricing pair", mutate: func(c *DocumentsConfig) { c.EstimatedCostUSDPerKUnits = 4 }, want: "pricing assumption requires both"},
+		{name: "pricing date", mutate: func(c *DocumentsConfig) { c.EstimatedCostUSDPerKUnits = 4; c.PricingAssumptionOn = "today" }, want: "YYYY-MM-DD"},
+		{name: "schedule manifest", mutate: func(c *DocumentsConfig) {
+			c.Schedule = "0 * * * *"
+			c.EstimatedCostUSDPerKUnits = 4
+			c.PricingAssumptionOn = "2026-08-13"
+		}, want: "requires capability_manifest"},
+		{name: "schedule pricing", mutate: func(c *DocumentsConfig) {
+			c.Schedule = "0 * * * *"
+			c.CapabilityManifest = "/private/capabilities.json"
+		}, want: "pricing assumption"},
+		{name: "retention", mutate: func(c *DocumentsConfig) { c.RetentionPosture = "no-retention" }, want: "retention_posture"},
+		{name: "training", mutate: func(c *DocumentsConfig) { c.TrainingPosture = "never" }, want: "training_posture"},
+		{name: "lexical without text", mutate: func(c *DocumentsConfig) { disabled := false; c.Index.StoreChunkText = &disabled }, want: "must both be true"},
+		{name: "stored text without lexical", mutate: func(c *DocumentsConfig) { disabled := false; c.Index.Lexical = &disabled }, want: "must both be true"},
+		{name: "premature vectors", mutate: func(c *DocumentsConfig) { c.Index.Embeddings.Enabled = true }, want: "not available"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := DefaultDocumentsConfig()
+			test.mutate(&config)
+			require.ErrorContains(t, config.Validate(), test.want)
+		})
+	}
+}
+
+func TestDocumentsConfigReservesWorstCaseRunBudget(t *testing.T) {
+	config := DefaultDocumentsConfig()
+	config.MaxPagesPerDocument = 500
+	config.MaxPagesPerRun = 2_000
+	config.MaxEstimatedCostUSDPerRun = 3
+	config.EstimatedCostUSDPerKUnits = 4
+	config.PricingAssumptionOn = "2026-08-13"
+
+	limit, err := config.MaxDocumentsWithinRunBudget(100)
+	require.NoError(t, err)
+	assert.Equal(t, 1, limit, "the cost cap reserves two dollars for every worst-case request")
+	config.MaxEstimatedCostUSDPerRun = 1
+	_, err = config.MaxDocumentsWithinRunBudget(100)
+	require.ErrorContains(t, err, "smaller than one")
+}
+
+func TestDocumentsProfileFingerprintIsDeterministicAndPolicyBound(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	config := DefaultDocumentsConfig()
+	config.Scope.MessageTypes = []string{"email", "chat"}
+	config.ApplyDefaults()
+
+	first, err := config.ProfileFingerprint([]string{"text/csv", "application/pdf", "text/csv"})
+	require.NoError(err)
+	second, err := config.ProfileFingerprint([]string{"application/pdf", "text/csv"})
+	require.NoError(err)
+	assert.Equal(first, second)
+	assert.Regexp(`^[0-9a-f]{64}$`, first)
+
+	changed := config
+	changed.RetentionPosture = RetentionZDR
+	third, err := changed.ProfileFingerprint([]string{"application/pdf", "text/csv"})
+	require.NoError(err)
+	assert.NotEqual(first, third)
+
+	fourth, err := config.ProfileFingerprint([]string{"application/pdf"})
+	require.NoError(err)
+	assert.NotEqual(first, fourth)
+
+	changed = config
+	changed.MaxSpoolBytes++
+	fifth, err := changed.ProfileFingerprint([]string{"application/pdf", "text/csv"})
+	require.NoError(err)
+	assert.NotEqual(first, fifth)
+
+	changed = config
+	changed.MinFreeSpaceBytes++
+	sixth, err := changed.ProfileFingerprint([]string{"application/pdf", "text/csv"})
+	require.NoError(err)
+	assert.NotEqual(first, sixth)
+}
+
+func TestDocumentsConfigResolvesAPIKeyOnlyOnDemand(t *testing.T) {
+	config := DefaultDocumentsConfig()
+	t.Setenv(config.APIKeyEnv, "synthetic-secret")
+
+	key, err := config.ResolveAPIKey()
+	require.NoError(t, err)
+	assert.Equal(t, "synthetic-secret", key)
+
+	config.APIKeyEnv = "MISSING_SYNTHETIC_MISTRAL_KEY"
+	_, err = config.ResolveAPIKey()
+	require.ErrorContains(t, err, config.APIKeyEnv)
+}

--- a/internal/documentindex/mistral/capabilities.go
+++ b/internal/documentindex/mistral/capabilities.go
@@ -1,0 +1,229 @@
+package mistral
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	CapabilitySchemaVersion   = 2
+	probeFixtureContract      = 1
+	requestFingerprintVersion = 2
+	mediaTypePDF              = "application/pdf"
+	ProbeStatusPassed         = "passed"
+	ProbeStatusRejected       = "provider_rejected"
+	ProbeStatusFailed         = "probe_failed"
+)
+
+// CandidateFormat is a documented non-visual format that must be tested
+// against the stateless endpoint. Documentation alone never makes it eligible.
+type CandidateFormat struct {
+	ID        string `json:"id"`
+	Family    string `json:"family"`
+	MediaType string `json:"media_type"`
+	UnitKind  string `json:"unit_kind"`
+}
+
+var candidateFormats = []CandidateFormat{
+	{ID: "pdf", Family: "pdf", MediaType: mediaTypePDF, UnitKind: "page"},
+	{ID: "docx", Family: "word", MediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", UnitKind: "page"},
+	{ID: "doc", Family: "word", MediaType: "application/msword", UnitKind: "page"},
+	{ID: "odt", Family: "word", MediaType: "application/vnd.oasis.opendocument.text", UnitKind: "page"},
+	{ID: "rtf", Family: "word", MediaType: "application/rtf", UnitKind: "page"},
+	{ID: "pptx", Family: "presentation", MediaType: "application/vnd.openxmlformats-officedocument.presentationml.presentation", UnitKind: "slide"},
+	{ID: "ppt", Family: "presentation", MediaType: "application/vnd.ms-powerpoint", UnitKind: "slide"},
+	{ID: "xlsx", Family: "spreadsheet", MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", UnitKind: "sheet"},
+	{ID: "xls", Family: "spreadsheet", MediaType: "application/vnd.ms-excel", UnitKind: "sheet"},
+	{ID: "ods", Family: "spreadsheet", MediaType: "application/vnd.oasis.opendocument.spreadsheet", UnitKind: "sheet"},
+	{ID: "numbers", Family: "spreadsheet", MediaType: "application/vnd.apple.numbers", UnitKind: "sheet"},
+	{ID: "csv", Family: "spreadsheet", MediaType: "text/csv", UnitKind: "record"},
+	{ID: "epub", Family: "ebook", MediaType: "application/epub+zip", UnitKind: "spine"},
+	{ID: "txt", Family: "text", MediaType: "text/plain", UnitKind: "section"},
+	{ID: "markdown", Family: "text", MediaType: "text/markdown", UnitKind: "section"},
+	{ID: "rst", Family: "text", MediaType: "text/x-rst", UnitKind: "section"},
+	{ID: "latex", Family: "text", MediaType: "application/x-tex", UnitKind: "section"},
+	{ID: "json", Family: "structured", MediaType: "application/json", UnitKind: "record"},
+	{ID: "jsonl", Family: "structured", MediaType: "application/x-ndjson", UnitKind: "record"},
+	{ID: "xml", Family: "structured", MediaType: "application/xml", UnitKind: "record"},
+	{ID: "yaml", Family: "structured", MediaType: "application/yaml", UnitKind: "record"},
+	{ID: "go", Family: "source", MediaType: "text/x-go", UnitKind: "section"},
+	{ID: "python", Family: "source", MediaType: "text/x-python", UnitKind: "section"},
+	{ID: "javascript", Family: "source", MediaType: "text/javascript", UnitKind: "section"},
+	{ID: "eml", Family: "mail", MediaType: "message/rfc822", UnitKind: "message"},
+	{ID: "msg", Family: "mail", MediaType: "application/vnd.ms-outlook", UnitKind: "message"},
+}
+
+// CandidateFormats returns a defensive copy in stable probe order.
+func CandidateFormats() []CandidateFormat {
+	return slices.Clone(candidateFormats)
+}
+
+func CandidateFormatByID(id string) (CandidateFormat, bool) {
+	for _, candidate := range candidateFormats {
+		if candidate.ID == id {
+			return candidate, true
+		}
+	}
+	return CandidateFormat{}, false
+}
+
+func CandidateFormatByMediaType(mediaType string) (CandidateFormat, bool) {
+	for _, candidate := range candidateFormats {
+		if candidate.MediaType == mediaType {
+			return candidate, true
+		}
+	}
+	return CandidateFormat{}, false
+}
+
+// CapabilityManifest is safe to commit: it contains no filenames, extracted
+// content, raw provider responses, keys, URLs supplied by users, or full source
+// hashes.
+type CapabilityManifest struct {
+	SchemaVersion        int                `json:"schema_version"`
+	ProbeFixtureContract int                `json:"probe_fixture_contract"`
+	ObservedOn           string             `json:"observed_on"`
+	Endpoint             string             `json:"endpoint"`
+	Region               string             `json:"region"`
+	RequestedModel       string             `json:"requested_model"`
+	MaxPages             int                `json:"max_pages"`
+	Results              []CapabilityResult `json:"results"`
+}
+
+type CapabilityResult struct {
+	FormatID           string `json:"format_id"`
+	Family             string `json:"family"`
+	MediaType          string `json:"media_type"`
+	UnitKind           string `json:"unit_kind"`
+	Status             string `json:"status"`
+	ReasonCode         string `json:"reason_code,omitempty"`
+	FixtureDigest      string `json:"fixture_digest"`
+	RequestFingerprint string `json:"request_fingerprint"`
+	ReturnedModel      string `json:"returned_model,omitempty"`
+	UnitCount          int    `json:"unit_count,omitempty"`
+	UnitsProcessed     int    `json:"units_processed,omitempty"`
+	ProviderBytes      *int64 `json:"provider_bytes,omitempty"`
+}
+
+// ValidateComplete rejects partial, duplicated, reordered, or privacy-unsafe
+// manifests before they can become runtime upload authority.
+func (m CapabilityManifest) ValidateComplete() error {
+	if m.SchemaVersion != CapabilitySchemaVersion {
+		return fmt.Errorf("mistral capability manifest schema must be %d", CapabilitySchemaVersion)
+	}
+	if m.ProbeFixtureContract != probeFixtureContract {
+		return fmt.Errorf("mistral capability manifest fixture contract must be %d", probeFixtureContract)
+	}
+	observed, err := time.Parse(time.DateOnly, m.ObservedOn)
+	if err != nil || observed.After(time.Now().UTC().Add(24*time.Hour)) {
+		return errors.New("mistral capability manifest has invalid observation date")
+	}
+	if m.Endpoint != defaultEndpoint || m.Region != "eu" || m.RequestedModel != defaultModel {
+		return errors.New("mistral capability manifest endpoint, region, or model is not pinned")
+	}
+	if m.MaxPages <= 0 || m.MaxPages > 5_000 {
+		return errors.New("mistral capability manifest has invalid page limit")
+	}
+	if len(m.Results) != len(candidateFormats) {
+		return fmt.Errorf("mistral capability manifest has %d results, want %d", len(m.Results), len(candidateFormats))
+	}
+	for i, result := range m.Results {
+		candidate := candidateFormats[i]
+		if result.FormatID != candidate.ID || result.Family != candidate.Family ||
+			result.MediaType != candidate.MediaType || result.UnitKind != candidate.UnitKind {
+			return fmt.Errorf("mistral capability manifest result %d does not match candidate %q", i, candidate.ID)
+		}
+		if !slices.Contains([]string{ProbeStatusPassed, ProbeStatusRejected, ProbeStatusFailed}, result.Status) {
+			return fmt.Errorf("mistral capability manifest result %q has invalid status", result.FormatID)
+		}
+		if len(result.FixtureDigest) != 16 || !lowerHex(result.FixtureDigest) {
+			return fmt.Errorf("mistral capability manifest result %q has invalid fixture digest", result.FormatID)
+		}
+		if len(result.RequestFingerprint) != 64 || !lowerHex(result.RequestFingerprint) {
+			return fmt.Errorf("mistral capability manifest result %q has invalid request fingerprint", result.FormatID)
+		}
+		options := DefaultOptions()
+		if candidate.Family == "pdf" {
+			options.Pages = fmt.Sprintf("0-%d", m.MaxPages-1)
+		}
+		if result.RequestFingerprint != requestFingerprint(candidate, options) {
+			return fmt.Errorf("mistral capability manifest result %q has mismatched request fingerprint", result.FormatID)
+		}
+		if result.Status == ProbeStatusPassed {
+			if result.ReasonCode != "" || result.ReturnedModel != m.RequestedModel ||
+				result.UnitCount <= 0 || result.UnitsProcessed != result.UnitCount {
+				return fmt.Errorf("mistral capability manifest passing result %q is incomplete", result.FormatID)
+			}
+		} else if result.ReasonCode == "" || result.ReturnedModel != "" || result.UnitCount != 0 ||
+			result.UnitsProcessed != 0 || result.ProviderBytes != nil {
+			return fmt.Errorf("mistral capability manifest non-passing result %q is not scrubbed", result.FormatID)
+		}
+	}
+	return nil
+}
+
+// ProbeFixtureSentinel returns the exact synthetic phrase that a private
+// fixture must contain for one candidate format. The authenticated probe only
+// passes a format when Mistral returns this phrase from that format's bytes.
+func ProbeFixtureSentinel(formatID string) (string, error) {
+	if _, ok := CandidateFormatByID(formatID); !ok {
+		return "", fmt.Errorf("unknown Mistral probe format %q", formatID)
+	}
+	return "msgvault probe " + formatID + " cedar 7319", nil
+}
+
+// AllowedMediaTypes returns only formats proven by this exact complete
+// manifest. Failed and provider-rejected candidates remain visible but cannot
+// be uploaded by product code.
+func (m CapabilityManifest) AllowedMediaTypes() ([]string, error) {
+	if err := m.ValidateComplete(); err != nil {
+		return nil, err
+	}
+	allowed := make([]string, 0, len(m.Results))
+	for _, result := range m.Results {
+		if result.Status == ProbeStatusPassed {
+			allowed = append(allowed, result.MediaType)
+		}
+	}
+	return allowed, nil
+}
+
+type fingerprintPayload struct {
+	Version   int             `json:"version"`
+	Endpoint  string          `json:"endpoint"`
+	Model     string          `json:"model"`
+	Candidate CandidateFormat `json:"candidate"`
+	Options   Options         `json:"options"`
+}
+
+func requestFingerprint(candidate CandidateFormat, options Options) string {
+	payload, err := json.Marshal(fingerprintPayload{
+		Version: requestFingerprintVersion, Endpoint: defaultEndpoint, Model: defaultModel, Candidate: candidate, Options: options,
+	})
+	if err != nil {
+		panic(err)
+	}
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:])
+}
+
+func shortFixtureDigest(fullSHA256 string) (string, error) {
+	if len(fullSHA256) != sha256.Size*2 || !lowerHex(fullSHA256) {
+		return "", errors.New("fixture SHA-256 must be lowercase hexadecimal")
+	}
+	return fullSHA256[:16], nil
+}
+
+func lowerHex(value string) bool {
+	if value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/internal/documentindex/mistral/client.go
+++ b/internal/documentindex/mistral/client.go
@@ -1,0 +1,615 @@
+// Package mistral implements the bounded stateless Mistral OCR transport used
+// by document attachment indexing.
+package mistral
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/msgvault/internal/httpretry"
+)
+
+const (
+	defaultEndpoint         = "https://api.mistral.ai/v1/ocr"
+	defaultModel            = "mistral-ocr-4-0"
+	defaultMaxDocumentBytes = int64(50 << 20)
+	defaultMaxResponseBytes = int64(64 << 20)
+	defaultMaxUnits         = 1000
+	defaultMaxRetries       = 3
+	defaultMaxRetryDelay    = 30 * time.Second
+)
+
+var (
+	// ErrPermanentResponse marks a provider 4xx other than rate limiting.
+	ErrPermanentResponse = errors.New("mistral OCR permanent response")
+	// ErrResponseTooLarge marks a response that exceeds MaxResponseBytes.
+	ErrResponseTooLarge = errors.New("mistral OCR response too large")
+	// ErrTransientResponse marks an exhausted retryable provider or transport failure.
+	ErrTransientResponse = errors.New("mistral OCR transient response")
+)
+
+// Config controls the stateless OCR client.
+type Config struct {
+	Endpoint          string
+	APIKey            string
+	Model             string
+	AllowedHosts      []string
+	AllowedMediaTypes []string
+	Timeout           time.Duration
+	MaxDocumentBytes  int64
+	MaxResponseBytes  int64
+	MaxUnits          int
+	MaxRetries        int
+	MaxRetryDelay     time.Duration
+	HTTPClient        *http.Client
+}
+
+// Document identifies a private verified spool. Process re-verifies its size,
+// media type, and lowercase SHA-256 before any request bytes are sent.
+type Document struct {
+	Path      string
+	MediaType string
+	Size      int64
+	SHA256    string
+}
+
+// Options controls format-specific OCR request fields. Pages is omitted when
+// empty; callers set it only for formats whose authenticated probe establishes
+// page semantics.
+type Options struct {
+	Pages         string `json:"pages"`
+	ExtractHeader bool   `json:"extract_header"`
+	ExtractFooter bool   `json:"extract_footer"`
+}
+
+// DefaultOptions returns the output-bearing extraction policy shared by
+// authenticated capability probes and production document processing.
+func DefaultOptions() Options {
+	return Options{ExtractHeader: true, ExtractFooter: true}
+}
+
+// Result is the validated provider response.
+type Result struct {
+	Model     string         `json:"model"`
+	Pages     []Page         `json:"pages"`
+	UsageInfo *Usage         `json:"usage_info"`
+	Metrics   RequestMetrics `json:"-"`
+}
+
+// RequestMetrics describes actual provider HTTP work, including retries
+// performed inside one logical extraction attempt.
+type RequestMetrics struct {
+	Requests int
+	Retries  int
+	Latency  time.Duration
+}
+
+type processError struct {
+	err     error
+	metrics RequestMetrics
+}
+
+func (e *processError) Error() string { return e.err.Error() }
+func (e *processError) Unwrap() error { return e.err }
+
+// MetricsFromError recovers bounded provider request accounting from an error
+// returned by Process. Pre-request validation failures carry zero metrics.
+func MetricsFromError(err error) RequestMetrics {
+	var processErr *processError
+	if errors.As(err, &processErr) {
+		return processErr.metrics
+	}
+	return RequestMetrics{}
+}
+
+// Page is one provider-ordered source unit. Mistral uses the pages array for
+// both paginated and converted document formats.
+type Page struct {
+	Index        int        `json:"index"`
+	Markdown     string     `json:"markdown"`
+	Header       string     `json:"header"`
+	Footer       string     `json:"footer"`
+	Dimensions   Dimensions `json:"dimensions"`
+	indexPresent bool
+}
+
+// Dimensions records provider unit dimensions when present.
+type Dimensions struct {
+	DPI    int `json:"dpi"`
+	Height int `json:"height"`
+	Width  int `json:"width"`
+}
+
+// Usage contains bounded accounting fields returned by Mistral.
+type Usage struct {
+	PagesProcessed        int    `json:"pages_processed"`
+	DocSizeBytes          *int64 `json:"doc_size_bytes"`
+	pagesProcessedPresent bool
+}
+
+// Client calls one allowlisted HTTPS /v1/ocr endpoint.
+type Client struct {
+	endpoint          string
+	apiKey            string
+	model             string
+	allowedMediaTypes map[string]struct{}
+	maxDocumentBytes  int64
+	maxResponseBytes  int64
+	maxUnits          int
+	maxRetries        int
+	maxRetryDelay     time.Duration
+	http              *http.Client
+}
+
+type ProcessorTarget struct {
+	Endpoint string
+	Region   string
+	Model    string
+}
+
+// Target exposes immutable, non-secret request authority for probe manifests.
+func (c *Client) Target() ProcessorTarget {
+	return ProcessorTarget{Endpoint: c.endpoint, Region: "eu", Model: c.model}
+}
+
+// NewClient validates the endpoint and applies conservative defaults.
+func NewClient(cfg Config) (*Client, error) {
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = defaultEndpoint
+	}
+	if cfg.Model == "" {
+		cfg.Model = defaultModel
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Minute
+	}
+	if cfg.MaxDocumentBytes <= 0 {
+		cfg.MaxDocumentBytes = defaultMaxDocumentBytes
+	}
+	if cfg.MaxResponseBytes <= 0 {
+		cfg.MaxResponseBytes = defaultMaxResponseBytes
+	}
+	if cfg.MaxUnits <= 0 {
+		cfg.MaxUnits = defaultMaxUnits
+	}
+	if cfg.MaxRetries < 0 {
+		return nil, errors.New("mistral OCR max retries cannot be negative")
+	}
+	if cfg.MaxRetries == 0 {
+		cfg.MaxRetries = defaultMaxRetries
+	}
+	if cfg.MaxRetryDelay <= 0 {
+		cfg.MaxRetryDelay = defaultMaxRetryDelay
+	}
+
+	endpoint, err := url.Parse(cfg.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parse Mistral OCR endpoint: %w", err)
+	}
+	if endpoint.Scheme != "https" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return nil, errors.New("mistral OCR endpoint must be an HTTPS URL without userinfo, query, or fragment")
+	}
+	if endpoint.Path != "/v1/ocr" {
+		return nil, errors.New("mistral OCR endpoint path must be /v1/ocr")
+	}
+	allowedHosts := cfg.AllowedHosts
+	if len(allowedHosts) == 0 {
+		allowedHosts = []string{"api.mistral.ai"}
+	}
+	if !slices.Contains(allowedHosts, endpoint.Hostname()) {
+		return nil, fmt.Errorf("mistral OCR endpoint host %q is not allowlisted", endpoint.Hostname())
+	}
+	allowedMediaTypes := make(map[string]struct{}, len(cfg.AllowedMediaTypes))
+	for _, mediaType := range cfg.AllowedMediaTypes {
+		parsed, parameters, parseErr := mime.ParseMediaType(mediaType)
+		if parseErr != nil || len(parameters) != 0 || parsed != mediaType || parsed != strings.ToLower(parsed) {
+			return nil, fmt.Errorf("invalid allowlisted Mistral OCR media type %q", mediaType)
+		}
+		allowedMediaTypes[parsed] = struct{}{}
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: cfg.Timeout}
+	} else {
+		clone := *httpClient
+		httpClient = &clone
+		if httpClient.Timeout == 0 || httpClient.Timeout > cfg.Timeout {
+			httpClient.Timeout = cfg.Timeout
+		}
+	}
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	return &Client{
+		endpoint:          endpoint.String(),
+		apiKey:            cfg.APIKey,
+		model:             cfg.Model,
+		allowedMediaTypes: allowedMediaTypes,
+		maxDocumentBytes:  cfg.MaxDocumentBytes,
+		maxResponseBytes:  cfg.MaxResponseBytes,
+		maxUnits:          cfg.MaxUnits,
+		maxRetries:        cfg.MaxRetries,
+		maxRetryDelay:     cfg.MaxRetryDelay,
+		http:              httpClient,
+	}, nil
+}
+
+// Process verifies document and sends it as an inline base64 data URL. It does
+// not create Mistral Files, Libraries, or public URLs.
+func (c *Client) Process(ctx context.Context, document Document, options Options) (Result, error) {
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	if document.Size > c.maxDocumentBytes {
+		return Result{}, fmt.Errorf("mistral OCR document is %d bytes, limit %d", document.Size, c.maxDocumentBytes)
+	}
+	if _, allowed := c.allowedMediaTypes[document.MediaType]; !allowed {
+		return Result{}, fmt.Errorf("mistral OCR media type %q is not allowlisted", document.MediaType)
+	}
+
+	prefix, suffix, encodedLength, err := requestEnvelope(c.model, document.MediaType, document.Size, options)
+	if err != nil {
+		return Result{}, err
+	}
+	requests := 0
+	var providerLatency time.Duration
+	for attempt := 0; attempt <= c.maxRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return Result{}, newProcessError(err, requests, providerLatency)
+		}
+		result, retryAfter, requested, requestLatency, processErr := c.processOnce(
+			ctx, document, prefix, suffix, encodedLength,
+		)
+		if requested {
+			requests++
+			providerLatency += requestLatency
+		}
+		if processErr == nil {
+			result.Metrics = requestMetrics(requests, providerLatency)
+			return result, nil
+		}
+		var transient *transientError
+		if !errors.As(processErr, &transient) {
+			return Result{}, newProcessError(processErr, requests, providerLatency)
+		}
+		if attempt == c.maxRetries {
+			err := fmt.Errorf("%w after %d attempts: %w", ErrTransientResponse, attempt+1, transient)
+			return Result{}, newProcessError(err, requests, providerLatency)
+		}
+		wait := httpretry.RetryAfter(retryAfter, attempt, c.maxRetryDelay)
+		if err := waitContext(ctx, wait); err != nil {
+			return Result{}, newProcessError(err, requests, providerLatency)
+		}
+	}
+	return Result{}, ErrTransientResponse
+}
+
+func newProcessError(err error, requests int, providerLatency time.Duration) error {
+	if requests == 0 {
+		return err
+	}
+	return &processError{err: err, metrics: requestMetrics(requests, providerLatency)}
+}
+
+func requestMetrics(requests int, providerLatency time.Duration) RequestMetrics {
+	return RequestMetrics{
+		Requests: requests,
+		Retries:  max(requests-1, 0),
+		Latency:  providerLatency,
+	}
+}
+
+func (c *Client) processOnce(
+	ctx context.Context,
+	document Document,
+	prefix, suffix []byte,
+	encodedLength int64,
+) (Result, string, bool, time.Duration, error) {
+	file, err := openVerifiedDocument(document)
+	if err != nil {
+		return Result{}, "", false, 0, err
+	}
+	defer func() { _ = file.Close() }()
+
+	reader := streamRequest(file, document.Size, prefix, suffix)
+	defer func() { _ = reader.Close() }()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, reader)
+	if err != nil {
+		return Result{}, "", false, 0, fmt.Errorf("build Mistral OCR request: %w", err)
+	}
+	req.ContentLength = encodedLength
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	requestStarted := time.Now()
+	response, err := c.http.Do(req)
+	requestLatency := time.Since(requestStarted)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return Result{}, "", true, requestLatency, ctxErr
+		}
+		return Result{}, "", true, requestLatency, &transientError{cause: fmt.Errorf("send Mistral OCR request: %w", err)}
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError {
+		return Result{}, response.Header.Get("Retry-After"), true, requestLatency, &transientError{status: response.StatusCode}
+	}
+	if response.StatusCode >= http.StatusBadRequest {
+		return Result{}, "", true, requestLatency, fmt.Errorf("mistral OCR HTTP %d: %w", response.StatusCode, ErrPermanentResponse)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return Result{}, "", true, requestLatency, fmt.Errorf("mistral OCR unexpected HTTP %d", response.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return Result{}, "", true, requestLatency, errors.New("mistral OCR returned non-JSON content type")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, c.maxResponseBytes+1))
+	requestLatency = time.Since(requestStarted)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return Result{}, "", true, requestLatency, ctxErr
+		}
+		return Result{}, "", true, requestLatency, &transientError{cause: fmt.Errorf("read Mistral OCR response: %w", err)}
+	}
+	if int64(len(body)) > c.maxResponseBytes {
+		return Result{}, "", true, requestLatency, ErrResponseTooLarge
+	}
+	if !utf8.Valid(body) {
+		return Result{}, "", true, requestLatency, errors.New("mistral OCR response contains invalid UTF-8")
+	}
+	var result Result
+	if err := json.Unmarshal(body, &result); err != nil {
+		return Result{}, "", true, requestLatency, fmt.Errorf("decode Mistral OCR response: %w", err)
+	}
+	if err := validateResult(result, c.model, document.Size, c.maxUnits); err != nil {
+		return Result{}, "", true, requestLatency, err
+	}
+	return result, "", true, requestLatency, nil
+}
+
+type transientError struct {
+	status int
+	cause  error
+}
+
+func (e *transientError) Error() string {
+	if e.cause != nil {
+		return e.cause.Error()
+	}
+	return fmt.Sprintf("Mistral OCR transient HTTP %d", e.status)
+}
+
+func waitContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func streamRequest(file *os.File, size int64, prefix, suffix []byte) *io.PipeReader {
+	reader, writer := io.Pipe()
+	go func() {
+		if _, err := writer.Write(prefix); err != nil {
+			_ = writer.CloseWithError(err)
+			return
+		}
+		encoder := base64.NewEncoder(base64.StdEncoding, writer)
+		written, err := io.Copy(encoder, file)
+		if closeErr := encoder.Close(); err == nil {
+			err = closeErr
+		}
+		if err == nil && written != size {
+			err = errors.New("mistral OCR spool size changed during request")
+		}
+		if err == nil {
+			_, err = writer.Write(suffix)
+		}
+		_ = writer.CloseWithError(err)
+	}()
+	return reader
+}
+
+func openVerifiedDocument(document Document) (*os.File, error) {
+	if document.Path == "" || document.Size < 0 {
+		return nil, errors.New("invalid mistral OCR document metadata")
+	}
+	parsedMediaType, _, err := mime.ParseMediaType(document.MediaType)
+	if err != nil || parsedMediaType == "" || parsedMediaType != strings.ToLower(parsedMediaType) {
+		return nil, errors.New("invalid mistral OCR document media type")
+	}
+	if len(document.SHA256) != sha256.Size*2 || strings.ToLower(document.SHA256) != document.SHA256 {
+		return nil, errors.New("invalid mistral OCR document SHA-256")
+	}
+	if _, err := hex.DecodeString(document.SHA256); err != nil {
+		return nil, fmt.Errorf("invalid Mistral OCR document SHA-256: %w", err)
+	}
+	info, err := os.Lstat(document.Path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect Mistral OCR spool: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("mistral OCR spool must be a regular file")
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return nil, errors.New("mistral OCR spool permissions must be private")
+	}
+	if info.Size() != document.Size {
+		return nil, errors.New("mistral OCR spool size changed")
+	}
+
+	file, err := os.Open(document.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open Mistral OCR spool: %w", err)
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("inspect opened Mistral OCR spool: %w", err)
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		_ = file.Close()
+		return nil, errors.New("mistral OCR spool changed while opening")
+	}
+	hash := sha256.New()
+	written, err := io.Copy(hash, file)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("verify Mistral OCR spool: %w", err)
+	}
+	if written != document.Size || hex.EncodeToString(hash.Sum(nil)) != document.SHA256 {
+		_ = file.Close()
+		return nil, errors.New("mistral OCR spool hash mismatch")
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("rewind Mistral OCR spool: %w", err)
+	}
+	return file, nil
+}
+
+func requestEnvelope(model, mediaType string, size int64, options Options) ([]byte, []byte, int64, error) {
+	const maxBase64Input = (math.MaxInt64 / 4 * 3) - 2
+	if size < 0 || size > maxBase64Input {
+		return nil, nil, 0, errors.New("mistral OCR document size is not representable")
+	}
+	modelJSON, err := json.Marshal(model)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("encode Mistral OCR model: %w", err)
+	}
+	dataPrefixJSON, err := json.Marshal("data:" + mediaType + ";base64,")
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("encode Mistral OCR media type: %w", err)
+	}
+	prefix := append([]byte(`{"model":`), modelJSON...)
+	prefix = append(prefix, []byte(`,"document":{"type":"document_url","document_url":`)...)
+	prefix = append(prefix, dataPrefixJSON[:len(dataPrefixJSON)-1]...)
+
+	tail := struct {
+		IncludeImageBase64 bool   `json:"include_image_base64"`
+		IncludeBlocks      bool   `json:"include_blocks"`
+		ExtractHeader      bool   `json:"extract_header"`
+		ExtractFooter      bool   `json:"extract_footer"`
+		Pages              string `json:"pages,omitempty"`
+	}{
+		ExtractHeader: options.ExtractHeader,
+		ExtractFooter: options.ExtractFooter,
+		Pages:         options.Pages,
+	}
+	tailJSON, err := json.Marshal(tail)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("encode Mistral OCR options: %w", err)
+	}
+	suffix := append([]byte(`"},`), tailJSON[1:]...)
+	base64Length := ((size + 2) / 3) * 4
+	if base64Length > math.MaxInt64-int64(len(prefix))-int64(len(suffix)) {
+		return nil, nil, 0, errors.New("mistral OCR request length overflow")
+	}
+	return prefix, suffix, int64(len(prefix)) + base64Length + int64(len(suffix)), nil
+}
+
+func validateResult(result Result, expectedModel string, expectedBytes int64, maxUnits int) error {
+	if result.Model == "" {
+		return errors.New("mistral OCR response omitted model")
+	}
+	if result.Model != expectedModel {
+		return fmt.Errorf("mistral OCR response model %q does not match requested model", result.Model)
+	}
+	if result.Pages == nil {
+		return errors.New("mistral OCR response omitted pages")
+	}
+	if len(result.Pages) > maxUnits {
+		return fmt.Errorf("mistral OCR response has %d units, limit %d", len(result.Pages), maxUnits)
+	}
+	for i, page := range result.Pages {
+		if !page.indexPresent || page.Index != i {
+			return fmt.Errorf("mistral OCR response unit %d has invalid index %d", i, page.Index)
+		}
+	}
+	if result.UsageInfo == nil || !result.UsageInfo.pagesProcessedPresent {
+		return errors.New("mistral OCR response omitted usage")
+	}
+	if result.UsageInfo.PagesProcessed < 0 ||
+		(result.UsageInfo.DocSizeBytes != nil && *result.UsageInfo.DocSizeBytes < 0) {
+		return errors.New("mistral OCR response has invalid usage")
+	}
+	if result.UsageInfo.PagesProcessed != len(result.Pages) {
+		return fmt.Errorf("mistral OCR response processed %d units but returned %d",
+			result.UsageInfo.PagesProcessed, len(result.Pages))
+	}
+	if result.UsageInfo.DocSizeBytes != nil && *result.UsageInfo.DocSizeBytes != expectedBytes {
+		return fmt.Errorf("mistral OCR response accounted for %d document bytes, expected %d",
+			*result.UsageInfo.DocSizeBytes, expectedBytes)
+	}
+	return nil
+}
+
+// UnmarshalJSON records whether index was present so a missing first index is
+// not silently accepted as index zero.
+func (p *Page) UnmarshalJSON(data []byte) error {
+	type pageJSON struct {
+		Index      *int       `json:"index"`
+		Markdown   string     `json:"markdown"`
+		Header     string     `json:"header"`
+		Footer     string     `json:"footer"`
+		Dimensions Dimensions `json:"dimensions"`
+	}
+	var decoded pageJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	p.Markdown = decoded.Markdown
+	p.Header = decoded.Header
+	p.Footer = decoded.Footer
+	p.Dimensions = decoded.Dimensions
+	if decoded.Index != nil {
+		p.Index = *decoded.Index
+		p.indexPresent = true
+	}
+	return nil
+}
+
+// UnmarshalJSON records whether pages_processed was present while preserving
+// the provider's nullable doc_size_bytes field.
+func (u *Usage) UnmarshalJSON(data []byte) error {
+	type usageJSON struct {
+		PagesProcessed *int   `json:"pages_processed"`
+		DocSizeBytes   *int64 `json:"doc_size_bytes"`
+	}
+	var decoded usageJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	u.DocSizeBytes = decoded.DocSizeBytes
+	if decoded.PagesProcessed != nil {
+		u.PagesProcessed = *decoded.PagesProcessed
+		u.pagesProcessedPresent = true
+	}
+	return nil
+}

--- a/internal/documentindex/mistral/client_test.go
+++ b/internal/documentindex/mistral/client_test.go
@@ -1,0 +1,343 @@
+package mistral
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientProcessStreamsGenericDocumentWithExactLength(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	payload := []byte("synthetic docx bytes")
+	document := writeDocument(t, payload, "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+
+	var gotLength int64
+	var gotBody []byte
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/v1/ocr", r.URL.Path)
+		assert.Equal("Bearer synthetic-key", r.Header.Get("Authorization"))
+		gotLength = r.ContentLength
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		assert.NoError(err)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, err = io.WriteString(w, `{"model":"mistral-ocr-4-0","pages":[{"index":0,"markdown":"# Synthetic"}],"usage_info":{"pages_processed":1,"doc_size_bytes":20}}`)
+		assert.NoError(err)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server, Config{APIKey: "synthetic-key"})
+	result, err := client.Process(t.Context(), document, Options{ExtractHeader: true, ExtractFooter: true})
+	require.NoError(err)
+	assert.Equal(int64(len(gotBody)), gotLength)
+	assert.Equal("mistral-ocr-4-0", result.Model)
+	require.Len(result.Pages, 1)
+	assert.Equal("# Synthetic", result.Pages[0].Markdown)
+	require.NotNil(result.UsageInfo)
+	require.NotNil(result.UsageInfo.DocSizeBytes)
+	assert.Equal(int64(20), *result.UsageInfo.DocSizeBytes)
+
+	var request struct {
+		Model    string `json:"model"`
+		Document struct {
+			Type string `json:"type"`
+			URL  string `json:"document_url"`
+		} `json:"document"`
+		IncludeImageBase64 bool   `json:"include_image_base64"`
+		IncludeBlocks      bool   `json:"include_blocks"`
+		ExtractHeader      bool   `json:"extract_header"`
+		ExtractFooter      bool   `json:"extract_footer"`
+		Pages              string `json:"pages"`
+	}
+	require.NoError(json.Unmarshal(gotBody, &request))
+	assert.Equal("mistral-ocr-4-0", request.Model)
+	assert.Equal("document_url", request.Document.Type)
+	assert.True(request.ExtractHeader)
+	assert.True(request.ExtractFooter)
+	assert.False(request.IncludeImageBase64)
+	assert.False(request.IncludeBlocks)
+	assert.Empty(request.Pages)
+	encoded := strings.TrimPrefix(request.Document.URL, "data:"+document.MediaType+";base64,")
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(err)
+	assert.Equal(payload, decoded)
+	assert.NotContains(string(gotBody), "table_format")
+}
+
+func TestClientProcessRejectsChangedOrPublicSpool(t *testing.T) {
+	require := require.New(t)
+	document := writeDocument(t, []byte("first"), "application/pdf")
+	require.NoError(os.WriteFile(document.Path, []byte("other"), 0o600))
+	client := clientWithoutRequests(t)
+	_, err := client.Process(t.Context(), document, Options{})
+	require.ErrorContains(err, "hash mismatch")
+
+	if runtime.GOOS != "windows" {
+		document = writeDocument(t, []byte("private"), "application/pdf")
+		require.NoError(os.Chmod(document.Path, 0o644))
+		_, err = client.Process(t.Context(), document, Options{})
+		require.ErrorContains(err, "permissions must be private")
+	}
+}
+
+func TestClientProcessRejectsOversizedAndInvalidResponses(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		maxBytes  int64
+		wantError string
+	}{
+		{name: "too large", response: strings.Repeat("x", 65), maxBytes: 64, wantError: ErrResponseTooLarge.Error()},
+		{name: "duplicate unit", response: `{"model":"mistral-ocr-4-0","pages":[{"index":0},{"index":0}],"usage_info":{"pages_processed":2}}`, maxBytes: 1024, wantError: "invalid index"},
+		{name: "missing middle unit", response: `{"model":"mistral-ocr-4-0","pages":[{"index":0},{"index":2}],"usage_info":{"pages_processed":2}}`, maxBytes: 1024, wantError: "invalid index"},
+		{name: "missing model", response: `{"pages":[],"usage_info":{}}`, maxBytes: 1024, wantError: "omitted model"},
+		{name: "mismatched model", response: `{"model":"other","pages":[],"usage_info":{"pages_processed":0}}`, maxBytes: 1024, wantError: "does not match requested model"},
+		{name: "missing index", response: `{"model":"mistral-ocr-4-0","pages":[{}],"usage_info":{"pages_processed":1}}`, maxBytes: 1024, wantError: "invalid index"},
+		{name: "missing usage", response: `{"model":"mistral-ocr-4-0","pages":[]}`, maxBytes: 1024, wantError: "omitted usage"},
+		{name: "unit count mismatch", response: `{"model":"mistral-ocr-4-0","pages":[{"index":0}],"usage_info":{"pages_processed":0}}`, maxBytes: 1024, wantError: "processed 0 units but returned 1"},
+		{name: "byte count mismatch", response: `{"model":"mistral-ocr-4-0","pages":[],"usage_info":{"pages_processed":0,"doc_size_bytes":2}}`, maxBytes: 1024, wantError: "accounted for 2 document bytes, expected 1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := io.WriteString(w, tt.response)
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+			client := newTestClient(t, server, Config{MaxResponseBytes: tt.maxBytes})
+			_, err := client.Process(t.Context(), writeDocument(t, []byte("x"), "application/pdf"), Options{})
+			require.ErrorContains(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestClientDoesNotFollowRedirectsOrExposeErrorBody(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	redirectTargetCalled := false
+	target := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectTargetCalled = true
+	}))
+	defer target.Close()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server, Config{})
+	_, err := client.Process(t.Context(), writeDocument(t, []byte("x"), "application/pdf"), Options{})
+	require.ErrorContains(err, "unexpected HTTP 307")
+	assert.False(redirectTargetCalled)
+
+	secret := "synthetic-provider-body-that-must-not-escape"
+	errorServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, writeErr := io.WriteString(w, secret)
+		assert.NoError(writeErr)
+	}))
+	defer errorServer.Close()
+	client = newTestClient(t, errorServer, Config{})
+	_, err = client.Process(t.Context(), writeDocument(t, []byte("x"), "application/pdf"), Options{})
+	require.ErrorIs(err, ErrPermanentResponse)
+	assert.NotContains(err.Error(), secret)
+}
+
+func TestClientRetriesTransientResponsesAndReverifiesSpool(t *testing.T) {
+	assert := assert.New(t)
+	document := writeDocument(t, []byte("original"), "application/pdf")
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, err := io.Copy(io.Discard, r.Body)
+		assert.NoError(err)
+		if requests == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, err = io.WriteString(w, `{"model":"mistral-ocr-4-0","pages":[],"usage_info":{"pages_processed":0,"doc_size_bytes":null}}`)
+		assert.NoError(err)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server, Config{MaxRetryDelay: 200 * time.Millisecond})
+	started := time.Now()
+	result, err := client.Process(t.Context(), document, Options{})
+	elapsed := time.Since(started)
+	require.NoError(t, err)
+	assert.Equal("mistral-ocr-4-0", result.Model)
+	require.NotNil(t, result.UsageInfo)
+	assert.Nil(result.UsageInfo.DocSizeBytes)
+	assert.Equal(2, requests)
+	assert.Equal(2, result.Metrics.Requests)
+	assert.Equal(1, result.Metrics.Retries)
+	assert.Positive(result.Metrics.Latency)
+	assert.GreaterOrEqual(elapsed-result.Metrics.Latency, 150*time.Millisecond,
+		"provider latency must exclude Retry-After backoff")
+
+	requests = 0
+	document = writeDocument(t, []byte("first"), "application/pdf")
+	mutatingServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, copyErr := io.Copy(io.Discard, r.Body)
+		assert.NoError(copyErr)
+		assert.NoError(os.WriteFile(document.Path, []byte("other"), 0o600))
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mutatingServer.Close()
+
+	client = newTestClient(t, mutatingServer, Config{})
+	_, err = client.Process(t.Context(), document, Options{})
+	require.ErrorContains(t, err, "hash mismatch")
+	assert.Equal(1, requests)
+}
+
+func TestClientReturnsTypedErrorAfterBoundedTransientRetries(t *testing.T) {
+	assert := assert.New(t)
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, err := io.Copy(io.Discard, r.Body)
+		assert.NoError(err)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server, Config{})
+	_, err := client.Process(t.Context(), writeDocument(t, []byte("x"), "application/pdf"), Options{})
+	require.ErrorIs(t, err, ErrTransientResponse)
+	assert.Equal(defaultMaxRetries+1, requests)
+	metrics := MetricsFromError(err)
+	assert.Equal(defaultMaxRetries+1, metrics.Requests)
+	assert.Equal(defaultMaxRetries, metrics.Retries)
+	assert.Positive(metrics.Latency)
+}
+
+func TestClientRetriesTruncatedResponseBody(t *testing.T) {
+	assert := assert.New(t)
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, err := io.Copy(io.Discard, r.Body)
+		assert.NoError(err)
+		w.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			w.Header().Set("Content-Length", "100")
+			_, err = io.WriteString(w, "{")
+			assert.NoError(err)
+			return
+		}
+		_, err = io.WriteString(w, `{"model":"mistral-ocr-4-0","pages":[],"usage_info":{"pages_processed":0}}`)
+		assert.NoError(err)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server, Config{MaxRetryDelay: time.Millisecond})
+	result, err := client.Process(t.Context(), writeDocument(t, []byte("x"), "application/pdf"), Options{})
+	require.NoError(t, err)
+	assert.Equal("mistral-ocr-4-0", result.Model)
+	assert.Equal(2, requests)
+}
+
+func TestClientRejectsUnprovenMediaTypeAndOversizedDocument(t *testing.T) {
+	client := clientWithoutRequests(t)
+	document := writeDocument(t, []byte("x"), "application/octet-stream")
+	_, err := client.Process(t.Context(), document, Options{})
+	require.ErrorContains(t, err, "not allowlisted")
+
+	document = writeDocument(t, []byte("large"), "application/pdf")
+	client.maxDocumentBytes = 4
+	_, err = client.Process(t.Context(), document, Options{})
+	require.ErrorContains(t, err, "limit 4")
+}
+
+func TestNewClientRequiresAllowlistedExactEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "http", endpoint: "http://api.mistral.ai/v1/ocr"},
+		{name: "wrong host", endpoint: "https://example.com/v1/ocr"},
+		{name: "wrong path", endpoint: "https://api.mistral.ai/v1/files"},
+		{name: "query", endpoint: "https://api.mistral.ai/v1/ocr?x=1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(Config{Endpoint: tt.endpoint})
+			require.Error(t, err)
+			assert.Nil(t, client)
+		})
+	}
+}
+
+func newTestClient(t *testing.T, server *httptest.Server, overrides Config) *Client {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	overrides.Endpoint = server.URL + "/v1/ocr"
+	overrides.AllowedHosts = []string{parsed.Hostname()}
+	if len(overrides.AllowedMediaTypes) == 0 {
+		overrides.AllowedMediaTypes = []string{
+			"application/pdf",
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		}
+	}
+	overrides.HTTPClient = server.Client()
+	client, err := NewClient(overrides)
+	require.NoError(t, err)
+	return client
+}
+
+func clientWithoutRequests(t *testing.T) *Client {
+	t.Helper()
+	client, err := NewClient(Config{
+		AllowedMediaTypes: []string{"application/pdf"},
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("unexpected request")
+		})},
+	})
+	require.NoError(t, err)
+	return client
+}
+
+func writeDocument(t *testing.T, content []byte, mediaType string) Document {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spool")
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+	hash := sha256.Sum256(content)
+	return Document{
+		Path:      path,
+		MediaType: mediaType,
+		Size:      int64(len(content)),
+		SHA256:    hex.EncodeToString(hash[:]),
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/internal/documentindex/mistral/diskspace_unix.go
+++ b/internal/documentindex/mistral/diskspace_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package mistral
+
+import (
+	"fmt"
+	"math"
+
+	"golang.org/x/sys/unix"
+)
+
+func availableDiskBytes(path string) (int64, error) {
+	var status unix.Statfs_t
+	if err := unix.Statfs(path, &status); err != nil {
+		return 0, fmt.Errorf("stat filesystem: %w", err)
+	}
+	if status.Bavail <= 0 || status.Bsize <= 0 {
+		return 0, nil
+	}
+	blocks := status.Bavail
+	blockSize := uint64(status.Bsize)
+	if blockSize != 0 && blocks > math.MaxUint64/blockSize {
+		return math.MaxInt64, nil
+	}
+	available := blocks * blockSize
+	if available > math.MaxInt64 {
+		return math.MaxInt64, nil
+	}
+	return int64(available), nil
+}

--- a/internal/documentindex/mistral/diskspace_windows.go
+++ b/internal/documentindex/mistral/diskspace_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package mistral
+
+import "golang.org/x/sys/windows"
+
+func availableDiskBytes(path string) (int64, error) {
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	var available uint64
+	if err := windows.GetDiskFreeSpaceEx(pathUTF16, &available, nil, nil); err != nil {
+		return 0, err
+	}
+	const maxInt64 = uint64(^uint64(0) >> 1)
+	if available > maxInt64 {
+		return int64(maxInt64), nil
+	}
+	return int64(available), nil
+}

--- a/internal/documentindex/mistral/fixtures.go
+++ b/internal/documentindex/mistral/fixtures.go
@@ -1,0 +1,159 @@
+package mistral
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+// LoadProbeFixtures validates and privately spools the complete capability
+// matrix. Fixture files are named by candidate ID without an extension (for
+// example, "pdf", "docx", and "xlsx"). Paths never enter the returned
+// documents or capability manifest.
+func LoadProbeFixtures(
+	ctx context.Context,
+	fixtureDirectory string,
+	maxBytes int64,
+) (documents map[string]Document, cleanup func() error, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	if fixtureDirectory == "" || maxBytes <= 0 {
+		return nil, nil, errors.New("mistral capability fixtures require a directory and positive byte limit")
+	}
+	if maxBytes > math.MaxInt64/int64(len(candidateFormats)) {
+		return nil, nil, errors.New("mistral capability fixture spool quota would overflow")
+	}
+	maxSpoolBytes := maxBytes * int64(len(candidateFormats))
+	directoryInfo, err := os.Lstat(fixtureDirectory)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inspect mistral capability fixture directory: %w", err)
+	}
+	if !directoryInfo.IsDir() || directoryInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, nil, errors.New("mistral capability fixture path must be a real directory")
+	}
+
+	spoolDirectory, err := os.MkdirTemp("", "msgvault-mistral-probe-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create mistral capability spool directory: %w", err)
+	}
+	if err := os.Chmod(spoolDirectory, 0o700); err != nil { // #nosec G302 -- this is a private directory, not a file.
+		_ = os.Remove(spoolDirectory)
+		return nil, nil, fmt.Errorf("secure mistral capability spool directory: %w", err)
+	}
+
+	cleanups := make([]func() error, 0, len(candidateFormats))
+	cleanup = func() error {
+		var cleanupErrors []error
+		for _, cleanupFixture := range slices.Backward(cleanups) {
+			if cleanupErr := cleanupFixture(); cleanupErr != nil {
+				cleanupErrors = append(cleanupErrors, cleanupErr)
+			}
+		}
+		if removeErr := os.Remove(spoolDirectory); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove mistral capability spool directory: %w", removeErr))
+		}
+		return errors.Join(cleanupErrors...)
+	}
+	fail := func(loadErr error) error {
+		return errors.Join(loadErr, cleanup())
+	}
+
+	documents = make(map[string]Document, len(candidateFormats))
+	for _, candidate := range candidateFormats {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, fail(err)
+		}
+		fixturePath := filepath.Join(fixtureDirectory, candidate.ID)
+		document, documentCleanup, loadErr := loadProbeFixture(
+			ctx, fixturePath, spoolDirectory, candidate, maxBytes, maxSpoolBytes,
+		)
+		if loadErr != nil {
+			return nil, nil, fail(fmt.Errorf("load mistral capability fixture %q: %w", candidate.ID, loadErr))
+		}
+		cleanups = append(cleanups, documentCleanup)
+		documents[candidate.ID] = document
+	}
+	return documents, cleanup, nil
+}
+
+func loadProbeFixture(
+	ctx context.Context,
+	fixturePath string,
+	spoolDirectory string,
+	candidate CandidateFormat,
+	maxBytes int64,
+	maxSpoolBytes int64,
+) (Document, func() error, error) {
+	pathInfo, err := os.Lstat(fixturePath)
+	if err != nil {
+		return Document{}, nil, fmt.Errorf("inspect fixture: %w", err)
+	}
+	if !pathInfo.Mode().IsRegular() || pathInfo.Mode()&os.ModeSymlink != 0 {
+		return Document{}, nil, errors.New("fixture must be a regular non-symlink file")
+	}
+	if pathInfo.Size() <= 0 || pathInfo.Size() > maxBytes {
+		return Document{}, nil, errors.New("fixture size is outside configured bounds")
+	}
+
+	file, err := os.Open(fixturePath)
+	if err != nil {
+		return Document{}, nil, fmt.Errorf("open fixture: %w", err)
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return Document{}, nil, fmt.Errorf("inspect opened fixture: %w", err)
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(pathInfo, openedInfo) {
+		_ = file.Close()
+		return Document{}, nil, errors.New("fixture changed while opening")
+	}
+
+	hash := sha256.New()
+	written, err := io.Copy(hash, io.LimitReader(&contextReader{ctx: ctx, reader: file}, maxBytes+1))
+	if err != nil {
+		_ = file.Close()
+		return Document{}, nil, fmt.Errorf("hash fixture: %w", err)
+	}
+	if written != openedInfo.Size() || written > maxBytes {
+		_ = file.Close()
+		return Document{}, nil, errors.New("fixture changed or exceeded bounds while hashing")
+	}
+	detected, err := DetectFormat(file, written, candidate.MediaType)
+	if err != nil {
+		_ = file.Close()
+		return Document{}, nil, fmt.Errorf("validate fixture container: %w", err)
+	}
+	if detected.ID != candidate.ID {
+		_ = file.Close()
+		return Document{}, nil, fmt.Errorf(
+			"validate fixture container: detected %q, want %q", detected.ID, candidate.ID,
+		)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		return Document{}, nil, fmt.Errorf("rewind fixture: %w", err)
+	}
+
+	document, cleanup, err := SpoolVerifiedSource(ctx, file, SpoolOptions{
+		Directory:      spoolDirectory,
+		MediaType:      candidate.MediaType,
+		ExpectedSize:   written,
+		ExpectedSHA256: hex.EncodeToString(hash.Sum(nil)),
+		MaxBytes:       maxBytes,
+		MaxSpoolBytes:  maxSpoolBytes,
+		MinFreeBytes:   maxBytes,
+	})
+	if err != nil {
+		return Document{}, nil, err
+	}
+	return document, cleanup, nil
+}

--- a/internal/documentindex/mistral/fixtures_test.go
+++ b/internal/documentindex/mistral/fixtures_test.go
@@ -1,0 +1,155 @@
+package mistral
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadProbeFixturesSpoolsCompletePrivateMatrix(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixtureDirectory := t.TempDir()
+	for _, candidate := range CandidateFormats() {
+		require.NoError(os.WriteFile(
+			filepath.Join(fixtureDirectory, candidate.ID),
+			probeFixtureContent(t, candidate.ID),
+			0o600,
+		))
+	}
+
+	documents, cleanup, err := LoadProbeFixtures(t.Context(), fixtureDirectory, 1<<20)
+	require.NoError(err)
+	require.Len(documents, len(CandidateFormats()))
+	spoolDirectory := ""
+	for _, candidate := range CandidateFormats() {
+		document, ok := documents[candidate.ID]
+		require.True(ok)
+		assert.Equal(candidate.MediaType, document.MediaType)
+		info, statErr := os.Lstat(document.Path)
+		require.NoError(statErr)
+		assert.True(info.Mode().IsRegular())
+		if runtime.GOOS != "windows" {
+			assert.Equal(os.FileMode(0o600), info.Mode().Perm())
+		}
+		if spoolDirectory == "" {
+			spoolDirectory = filepath.Dir(document.Path)
+		}
+		assert.Equal(spoolDirectory, filepath.Dir(document.Path))
+	}
+
+	require.NoError(cleanup())
+	assert.NoDirExists(spoolDirectory)
+	require.NoError(cleanup())
+}
+
+func TestLoadProbeFixturesFailsClosedOnMissingOrSymlinkFixture(t *testing.T) {
+	require := require.New(t)
+	fixtureDirectory := t.TempDir()
+	_, _, err := LoadProbeFixtures(t.Context(), fixtureDirectory, 1<<20)
+	require.ErrorContains(err, `fixture "pdf"`)
+
+	if runtime.GOOS == "windows" {
+		return
+	}
+	target := filepath.Join(fixtureDirectory, "target")
+	require.NoError(os.WriteFile(target, []byte("%PDF-1.7\nsynthetic"), 0o600))
+	require.NoError(os.Symlink(target, filepath.Join(fixtureDirectory, "pdf")))
+	_, _, err = LoadProbeFixtures(t.Context(), fixtureDirectory, 1<<20)
+	require.ErrorContains(err, "regular non-symlink")
+}
+
+func TestLoadProbeFixturesRejectsMislabeledContainer(t *testing.T) {
+	require := require.New(t)
+	fixtureDirectory := t.TempDir()
+	for _, candidate := range CandidateFormats() {
+		require.NoError(os.WriteFile(
+			filepath.Join(fixtureDirectory, candidate.ID),
+			probeFixtureContent(t, candidate.ID),
+			0o600,
+		))
+	}
+	require.NoError(os.WriteFile(
+		filepath.Join(fixtureDirectory, "docx"), probeFixtureContent(t, "pdf"), 0o600,
+	))
+
+	documents, cleanup, err := LoadProbeFixtures(t.Context(), fixtureDirectory, 1<<20)
+	require.ErrorContains(err, `fixture "docx"`)
+	require.ErrorContains(err, "not declared")
+	assert.Nil(t, documents)
+	assert.Nil(t, cleanup)
+}
+
+func probeFixtureContent(t *testing.T, id string) []byte {
+	t.Helper()
+	switch id {
+	case "pdf":
+		return []byte("%PDF-1.7\nsynthetic")
+	case "docx":
+		return documentZIP(t, map[string]string{
+			ooxmlContentTypesName: docxContentTypes("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"),
+			"word/document.xml":   "<document/>",
+		})
+	case "doc":
+		return compoundDocument(t, "WordDocument")
+	case "odt":
+		return documentZIP(t, map[string]string{"mimetype": "application/vnd.oasis.opendocument.text", "META-INF/manifest.xml": "<manifest/>"})
+	case "rtf":
+		return []byte(`{\rtf1 synthetic}`)
+	case "pptx":
+		return documentZIP(t, map[string]string{
+			ooxmlContentTypesName:  `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/></Types>`,
+			"ppt/presentation.xml": "<presentation/>",
+		})
+	case "ppt":
+		return compoundDocument(t, "PowerPoint Document")
+	case "xlsx":
+		return documentZIP(t, map[string]string{
+			ooxmlContentTypesName: `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/></Types>`,
+			"xl/workbook.xml":     "<workbook/>",
+		})
+	case "xls":
+		return compoundDocument(t, "Workbook")
+	case "ods":
+		return documentZIP(t, map[string]string{"mimetype": "application/vnd.oasis.opendocument.spreadsheet", "META-INF/manifest.xml": "<manifest/>"})
+	case "numbers":
+		return documentZIP(t, map[string]string{"Index/Tables/Table.iwa": "synthetic"})
+	case "csv":
+		return []byte("name,value\nsynthetic,42\n")
+	case "epub":
+		return documentZIP(t, map[string]string{"mimetype": "application/epub+zip", "META-INF/container.xml": "<container/>"})
+	case "txt":
+		return []byte("synthetic text")
+	case "markdown":
+		return []byte("# Synthetic\n")
+	case "rst":
+		return []byte("Synthetic\n=========\n")
+	case "latex":
+		return []byte(`\documentclass{article}\begin{document}synthetic\end{document}`)
+	case "json":
+		return []byte(`{"synthetic":true}`)
+	case "jsonl":
+		return []byte("{\"synthetic\":1}\n{\"synthetic\":2}\n")
+	case "xml":
+		return []byte("<synthetic>42</synthetic>")
+	case "yaml":
+		return []byte("---\nsynthetic: true\n")
+	case "go":
+		return []byte("package synthetic\n")
+	case "python":
+		return []byte("synthetic = True\n")
+	case "javascript":
+		return []byte("const synthetic = true;\n")
+	case "eml":
+		return []byte("From: sender@example.test\r\nDate: Thu, 13 Aug 2026 00:00:00 +0000\r\nSubject: Synthetic\r\n\r\nBody")
+	case "msg":
+		return compoundDocument(t, "__properties_version1.0")
+	default:
+		require.FailNow(t, "missing probe fixture builder", id)
+		return nil
+	}
+}

--- a/internal/documentindex/mistral/probe.go
+++ b/internal/documentindex/mistral/probe.go
@@ -1,0 +1,218 @@
+package mistral
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const maxManifestBytes = int64(1 << 20)
+
+type Processor interface {
+	Process(ctx context.Context, document Document, options Options) (Result, error)
+	Target() ProcessorTarget
+}
+
+type ProbeConfig struct {
+	ObservedAt time.Time
+	MaxPages   int
+}
+
+// RunCapabilityProbe executes the full candidate matrix serially. It returns
+// only sanitized shape/accounting evidence; provider text and error bodies
+// never enter the manifest.
+func RunCapabilityProbe(
+	ctx context.Context,
+	processor Processor,
+	documents map[string]Document,
+	config ProbeConfig,
+) (CapabilityManifest, error) {
+	if processor == nil {
+		return CapabilityManifest{}, errors.New("mistral capability probe requires a processor")
+	}
+	if config.ObservedAt.IsZero() {
+		config.ObservedAt = time.Now().UTC()
+	}
+	if config.MaxPages <= 0 || config.MaxPages > 5_000 {
+		return CapabilityManifest{}, errors.New("mistral capability probe requires a page limit between 1 and 5000")
+	}
+	observedOn := config.ObservedAt.UTC().Format(time.DateOnly)
+	observed, observedErr := time.Parse(time.DateOnly, observedOn)
+	if observedErr != nil || observed.After(time.Now().UTC().Add(24*time.Hour)) {
+		return CapabilityManifest{}, errors.New("mistral capability probe has invalid observation date")
+	}
+	target := processor.Target()
+	if target.Endpoint != defaultEndpoint || target.Region != "eu" || target.Model != defaultModel {
+		return CapabilityManifest{}, errors.New("mistral capability probe processor target is not pinned")
+	}
+	if len(documents) != len(candidateFormats) {
+		return CapabilityManifest{}, fmt.Errorf("mistral capability probe has %d fixtures, want %d", len(documents), len(candidateFormats))
+	}
+	for _, candidate := range candidateFormats {
+		document, ok := documents[candidate.ID]
+		if !ok {
+			return CapabilityManifest{}, fmt.Errorf("mistral capability probe is missing fixture %q", candidate.ID)
+		}
+		if document.MediaType != candidate.MediaType {
+			return CapabilityManifest{}, fmt.Errorf("mistral capability probe fixture %q media type mismatch", candidate.ID)
+		}
+		if _, err := shortFixtureDigest(document.SHA256); err != nil {
+			return CapabilityManifest{}, fmt.Errorf("mistral capability probe fixture %q: %w", candidate.ID, err)
+		}
+	}
+
+	manifest := CapabilityManifest{
+		SchemaVersion: CapabilitySchemaVersion, ProbeFixtureContract: probeFixtureContract, ObservedOn: observedOn,
+		Endpoint: target.Endpoint, Region: target.Region, RequestedModel: target.Model, MaxPages: config.MaxPages,
+		Results: make([]CapabilityResult, 0, len(candidateFormats)),
+	}
+	for _, candidate := range candidateFormats {
+		if err := ctx.Err(); err != nil {
+			return CapabilityManifest{}, err
+		}
+		document := documents[candidate.ID]
+		fixtureDigest, err := shortFixtureDigest(document.SHA256)
+		if err != nil {
+			return CapabilityManifest{}, fmt.Errorf("mistral capability probe fixture %q: %w", candidate.ID, err)
+		}
+		options := DefaultOptions()
+		if candidate.Family == "pdf" {
+			options.Pages = "0-" + strconv.Itoa(config.MaxPages-1)
+		}
+		result := CapabilityResult{
+			FormatID: candidate.ID, Family: candidate.Family, MediaType: candidate.MediaType,
+			UnitKind: candidate.UnitKind, FixtureDigest: fixtureDigest,
+			RequestFingerprint: requestFingerprint(candidate, options),
+		}
+		response, processErr := processor.Process(ctx, document, options)
+		if processErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return CapabilityManifest{}, ctxErr
+			}
+			result.Status, result.ReasonCode = classifyProbeError(processErr)
+			manifest.Results = append(manifest.Results, result)
+			continue
+		}
+		if response.UsageInfo == nil || len(response.Pages) == 0 || !hasExtractedText(response.Pages) {
+			result.Status = ProbeStatusFailed
+			result.ReasonCode = "empty_output"
+			manifest.Results = append(manifest.Results, result)
+			continue
+		}
+		sentinel, sentinelErr := ProbeFixtureSentinel(candidate.ID)
+		if sentinelErr != nil {
+			return CapabilityManifest{}, sentinelErr
+		}
+		if !probeResponseContains(response.Pages, sentinel) {
+			result.Status = ProbeStatusFailed
+			result.ReasonCode = "sentinel_missing"
+			manifest.Results = append(manifest.Results, result)
+			continue
+		}
+		result.Status = ProbeStatusPassed
+		result.ReturnedModel = response.Model
+		result.UnitCount = len(response.Pages)
+		result.UnitsProcessed = response.UsageInfo.PagesProcessed
+		result.ProviderBytes = response.UsageInfo.DocSizeBytes
+		manifest.Results = append(manifest.Results, result)
+	}
+	if err := manifest.ValidateComplete(); err != nil {
+		return CapabilityManifest{}, err
+	}
+	return manifest, nil
+}
+
+func classifyProbeError(err error) (string, string) {
+	switch {
+	case errors.Is(err, ErrPermanentResponse):
+		return ProbeStatusRejected, "provider_4xx"
+	case errors.Is(err, ErrTransientResponse):
+		return ProbeStatusFailed, "transient_exhausted"
+	case errors.Is(err, ErrResponseTooLarge):
+		return ProbeStatusFailed, "response_too_large"
+	default:
+		return ProbeStatusFailed, "invalid_or_local_failure"
+	}
+}
+
+func hasExtractedText(pages []Page) bool {
+	for _, page := range pages {
+		if page.Markdown != "" || page.Header != "" || page.Footer != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func probeResponseContains(pages []Page, sentinel string) bool {
+	var text strings.Builder
+	for _, page := range pages {
+		text.WriteString(page.Header)
+		text.WriteByte(' ')
+		text.WriteString(page.Markdown)
+		text.WriteByte(' ')
+		text.WriteString(page.Footer)
+		text.WriteByte(' ')
+	}
+	return strings.Contains(normalizeProbeText(text.String()), normalizeProbeText(sentinel))
+}
+
+func normalizeProbeText(value string) string {
+	var normalized strings.Builder
+	space := true
+	for _, char := range strings.ToLower(value) {
+		if unicode.IsLetter(char) || unicode.IsNumber(char) {
+			normalized.WriteRune(char)
+			space = false
+			continue
+		}
+		if !space {
+			normalized.WriteByte(' ')
+			space = true
+		}
+	}
+	return strings.TrimSpace(normalized.String())
+}
+
+func EncodeCapabilityManifest(writer io.Writer, manifest CapabilityManifest) error {
+	if err := manifest.ValidateComplete(); err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(true)
+	if err := encoder.Encode(manifest); err != nil {
+		return fmt.Errorf("encode Mistral capability manifest: %w", err)
+	}
+	return nil
+}
+
+func DecodeCapabilityManifest(reader io.Reader) (CapabilityManifest, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxManifestBytes+1))
+	if err != nil {
+		return CapabilityManifest{}, fmt.Errorf("read Mistral capability manifest: %w", err)
+	}
+	if int64(len(data)) > maxManifestBytes {
+		return CapabilityManifest{}, errors.New("mistral capability manifest is too large")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest CapabilityManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return CapabilityManifest{}, fmt.Errorf("decode Mistral capability manifest: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return CapabilityManifest{}, errors.New("mistral capability manifest has trailing JSON")
+	}
+	if err := manifest.ValidateComplete(); err != nil {
+		return CapabilityManifest{}, err
+	}
+	return manifest, nil
+}

--- a/internal/documentindex/mistral/probe_test.go
+++ b/internal/documentindex/mistral/probe_test.go
@@ -1,0 +1,278 @@
+package mistral
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCandidateFormatsAreUniqueAndNonVisual(t *testing.T) {
+	assert := assert.New(t)
+	formats := CandidateFormats()
+	ids := map[string]bool{}
+	mediaTypes := map[string]bool{}
+	for _, format := range formats {
+		assert.NotEmpty(format.ID)
+		assert.NotEmpty(format.Family)
+		assert.NotEmpty(format.MediaType)
+		assert.NotEmpty(format.UnitKind)
+		assert.False(ids[format.ID], "duplicate format ID %s", format.ID)
+		assert.False(mediaTypes[format.MediaType], "duplicate media type %s", format.MediaType)
+		assert.NotEqual("image", format.Family)
+		assert.NotEqual("audio", format.Family)
+		assert.NotEqual("video", format.Family)
+		ids[format.ID] = true
+		mediaTypes[format.MediaType] = true
+	}
+	assert.Contains(ids, "pdf")
+	assert.Contains(ids, "docx")
+	assert.Contains(ids, "xlsx")
+	assert.Contains(ids, "epub")
+	assert.Contains(ids, "eml")
+}
+
+func TestRunCapabilityProbeKeepsCompleteSanitizedMatrix(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	documents := candidateDocuments()
+	processor := &fakeProbeProcessor{errors: map[string]error{
+		"application/msword":       fmtPermanent(),
+		"application/vnd.ms-excel": ErrTransientResponse,
+	}}
+	manifest, err := RunCapabilityProbe(t.Context(), processor, documents, ProbeConfig{
+		ObservedAt: time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		MaxPages:   500,
+	})
+	require.NoError(err)
+	require.NoError(manifest.ValidateComplete())
+	assert.Len(manifest.Results, len(CandidateFormats()))
+	assert.Equal("0-499", processor.optionsByMediaType["application/pdf"].Pages)
+	assert.Empty(processor.optionsByMediaType["application/vnd.openxmlformats-officedocument.wordprocessingml.document"].Pages)
+	for mediaType, options := range processor.optionsByMediaType {
+		assert.True(options.ExtractHeader, mediaType)
+		assert.True(options.ExtractFooter, mediaType)
+	}
+
+	docResult := manifestResult(t, manifest, "doc")
+	assert.Equal(ProbeStatusRejected, docResult.Status)
+	assert.Equal("provider_4xx", docResult.ReasonCode)
+	assert.Empty(docResult.ReturnedModel)
+	xlsResult := manifestResult(t, manifest, "xls")
+	assert.Equal(ProbeStatusFailed, xlsResult.Status)
+	assert.Equal("transient_exhausted", xlsResult.ReasonCode)
+
+	allowed, err := manifest.AllowedMediaTypes()
+	require.NoError(err)
+	assert.NotContains(allowed, "application/msword")
+	assert.NotContains(allowed, "application/vnd.ms-excel")
+	assert.Contains(allowed, "application/pdf")
+
+	var encoded bytes.Buffer
+	require.NoError(EncodeCapabilityManifest(&encoded, manifest))
+	for _, document := range documents {
+		assert.NotContains(encoded.String(), document.Path)
+		assert.NotContains(encoded.String(), document.SHA256)
+	}
+	for _, candidate := range CandidateFormats() {
+		sentinel, sentinelErr := ProbeFixtureSentinel(candidate.ID)
+		require.NoError(sentinelErr)
+		assert.NotContains(encoded.String(), sentinel, "extracted probe text must remain transient")
+	}
+	decoded, err := DecodeCapabilityManifest(bytes.NewReader(encoded.Bytes()))
+	require.NoError(err)
+	assert.Equal(manifest, decoded)
+}
+
+func TestCapabilityManifestRejectsPartialUnknownOrTamperedAuthority(t *testing.T) {
+	require := require.New(t)
+	manifest, err := RunCapabilityProbe(t.Context(), &fakeProbeProcessor{}, candidateDocuments(), ProbeConfig{
+		ObservedAt: time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC), MaxPages: 10,
+	})
+	require.NoError(err)
+
+	partial := manifest
+	partial.Results = partial.Results[:len(partial.Results)-1]
+	require.ErrorContains(partial.ValidateComplete(), "want")
+	legacy := manifest
+	legacy.SchemaVersion = 1
+	legacy.ProbeFixtureContract = 0
+	require.ErrorContains(legacy.ValidateComplete(), "schema must be 2")
+
+	tampered := manifest
+	tampered.Results = append([]CapabilityResult(nil), manifest.Results...)
+	tampered.Results[0].Status = ProbeStatusPassed
+	tampered.Results[0].RequestFingerprint = strings.Repeat("0", 64)
+	require.ErrorContains(tampered.ValidateComplete(), "mismatched request fingerprint")
+
+	invalidPass := manifest
+	invalidPass.Results = append([]CapabilityResult(nil), manifest.Results...)
+	invalidPass.Results[0].ReturnedModel = "unexpected-model"
+	require.ErrorContains(invalidPass.ValidateComplete(), "incomplete")
+
+	invalidFailure := manifest
+	invalidFailure.Results = append([]CapabilityResult(nil), manifest.Results...)
+	invalidFailure.Results[0].Status = ProbeStatusFailed
+	invalidFailure.Results[0].ReasonCode = "synthetic_failure"
+	invalidFailure.Results[0].ReturnedModel = ""
+	invalidFailure.Results[0].UnitCount = 0
+	invalidFailure.Results[0].UnitsProcessed = 1
+	invalidFailure.Results[0].ProviderBytes = nil
+	require.ErrorContains(invalidFailure.ValidateComplete(), "not scrubbed")
+
+	var encoded bytes.Buffer
+	require.NoError(EncodeCapabilityManifest(&encoded, manifest))
+	withUnknown := bytes.Replace(encoded.Bytes(), []byte(`"schema_version": 2`), []byte(`"schema_version": 2, "secret": "x"`), 1)
+	_, err = DecodeCapabilityManifest(bytes.NewReader(withUnknown))
+	require.ErrorContains(err, "unknown field")
+}
+
+func TestRunCapabilityProbeRejectsFixtureMismatchBeforeProviderCall(t *testing.T) {
+	documents := candidateDocuments()
+	documents["docx"] = documents["pdf"]
+	processor := &fakeProbeProcessor{}
+	_, err := RunCapabilityProbe(t.Context(), processor, documents, ProbeConfig{MaxPages: 10})
+	require.ErrorContains(t, err, "media type mismatch")
+	assert.Zero(t, processor.calls)
+}
+
+func TestRunCapabilityProbeRequiresFormatSpecificSentinel(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	docx, ok := CandidateFormatByID("docx")
+	require.True(ok)
+	processor := &fakeProbeProcessor{markdownByMediaType: map[string]string{
+		docx.MediaType: "msgvault probe pdf cedar 7319",
+	}}
+	manifest, err := RunCapabilityProbe(t.Context(), processor, candidateDocuments(), ProbeConfig{
+		ObservedAt: time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC), MaxPages: 10,
+	})
+	require.NoError(err)
+	result := manifestResult(t, manifest, "docx")
+	assert.Equal(ProbeStatusFailed, result.Status)
+	assert.Equal("sentinel_missing", result.ReasonCode)
+	allowed, err := manifest.AllowedMediaTypes()
+	require.NoError(err)
+	assert.NotContains(allowed, docx.MediaType)
+
+	sentinel, err := ProbeFixtureSentinel("pdf")
+	require.NoError(err)
+	assert.True(probeResponseContains([]Page{{Header: "**MSGVAULT**\nprobe PDF", Footer: "cedar-7319"}}, sentinel))
+	_, err = ProbeFixtureSentinel("unknown")
+	require.ErrorContains(err, "unknown")
+}
+
+func TestRunCapabilityProbeRejectsInvalidAuthorityBeforeProviderCalls(t *testing.T) {
+	documents := candidateDocuments()
+	tests := []struct {
+		name      string
+		processor *fakeProbeProcessor
+		config    ProbeConfig
+		want      string
+	}{
+		{name: "page limit", processor: &fakeProbeProcessor{}, config: ProbeConfig{MaxPages: 5_001}, want: "between 1 and 5000"},
+		{name: "future date", processor: &fakeProbeProcessor{}, config: ProbeConfig{MaxPages: 10, ObservedAt: time.Now().UTC().Add(72 * time.Hour)}, want: "observation date"},
+		{name: "target", processor: &fakeProbeProcessor{target: ProcessorTarget{Endpoint: "https://example.test/v1/ocr", Region: "eu", Model: defaultModel}}, config: ProbeConfig{MaxPages: 10}, want: "not pinned"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := RunCapabilityProbe(t.Context(), test.processor, documents, test.config)
+			require.ErrorContains(t, err, test.want)
+			assert.Zero(t, test.processor.calls)
+		})
+	}
+}
+
+func TestRunCapabilityProbePropagatesCancellationFromProcessor(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	processor := &cancelingProbeProcessor{cancel: cancel}
+	_, err := RunCapabilityProbe(ctx, processor, candidateDocuments(), ProbeConfig{MaxPages: 10})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func candidateDocuments() map[string]Document {
+	documents := make(map[string]Document, len(candidateFormats))
+	for _, candidate := range candidateFormats {
+		digest := sha256.Sum256([]byte("synthetic-" + candidate.ID))
+		documents[candidate.ID] = Document{
+			Path:      "/private/synthetic/" + candidate.ID,
+			MediaType: candidate.MediaType,
+			Size:      int64(len(candidate.ID)), SHA256: hex.EncodeToString(digest[:]),
+		}
+	}
+	return documents
+}
+
+type fakeProbeProcessor struct {
+	errors              map[string]error
+	markdownByMediaType map[string]string
+	optionsByMediaType  map[string]Options
+	calls               int
+	target              ProcessorTarget
+}
+
+type cancelingProbeProcessor struct {
+	cancel context.CancelFunc
+}
+
+func (p *cancelingProbeProcessor) Target() ProcessorTarget {
+	return ProcessorTarget{Endpoint: defaultEndpoint, Region: "eu", Model: defaultModel}
+}
+
+func (p *cancelingProbeProcessor) Process(context.Context, Document, Options) (Result, error) {
+	p.cancel()
+	return Result{}, context.Canceled
+}
+
+func (f *fakeProbeProcessor) Target() ProcessorTarget {
+	if f.target.Endpoint == "" {
+		return ProcessorTarget{Endpoint: defaultEndpoint, Region: "eu", Model: defaultModel}
+	}
+	return f.target
+}
+
+func (f *fakeProbeProcessor) Process(_ context.Context, document Document, options Options) (Result, error) {
+	f.calls++
+	if f.optionsByMediaType == nil {
+		f.optionsByMediaType = map[string]Options{}
+	}
+	f.optionsByMediaType[document.MediaType] = options
+	if err := f.errors[document.MediaType]; err != nil {
+		return Result{}, err
+	}
+	providerBytes := document.Size
+	candidate, ok := CandidateFormatByMediaType(document.MediaType)
+	if !ok {
+		return Result{}, errors.New("synthetic processor received unknown media type")
+	}
+	markdown, ok := f.markdownByMediaType[document.MediaType]
+	if !ok {
+		markdown, _ = ProbeFixtureSentinel(candidate.ID)
+	}
+	return Result{
+		Model: defaultModel, Pages: []Page{{Index: 0, Markdown: markdown, indexPresent: true}},
+		UsageInfo: &Usage{PagesProcessed: 1, DocSizeBytes: &providerBytes, pagesProcessedPresent: true},
+	}, nil
+}
+
+func fmtPermanent() error {
+	return errors.Join(errors.New("synthetic permanent rejection"), ErrPermanentResponse)
+}
+
+func manifestResult(t *testing.T, manifest CapabilityManifest, formatID string) CapabilityResult {
+	t.Helper()
+	for _, result := range manifest.Results {
+		if result.FormatID == formatID {
+			return result
+		}
+	}
+	require.FailNow(t, "manifest result not found", formatID)
+	return CapabilityResult{}
+}

--- a/internal/documentindex/mistral/sniff.go
+++ b/internal/documentindex/mistral/sniff.go
@@ -1,0 +1,618 @@
+package mistral
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/binary"
+	"encoding/csv"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/mail"
+	"os"
+	"path"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	maxSniffBytes            = int64(8 << 20)
+	maxTextSniffBytes        = int64(50 << 20)
+	maxZIPEntries            = 10_000
+	maxZIPCentralDirectory   = uint32(16 << 20)
+	maxZIPExpandedBytes      = uint64(500 << 20)
+	maxZIPSingleExpandedByte = uint64(100 << 20)
+	ooxmlContentTypesName    = "[Content_Types].xml"
+)
+
+var (
+	compoundFileMagic = []byte{0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1}
+)
+
+const compoundNoStream = uint32(0xffffffff)
+
+type compoundDirectoryEntry struct {
+	name               string
+	entryType          byte
+	left, right, child uint32
+}
+
+// DetectFormat validates a provider candidate from bounded bytes. Declared
+// type is a hint only: container families must prove internal markers, while
+// inherently ambiguous text formats also require syntactically safe UTF-8.
+func DetectFormat(reader io.ReaderAt, size int64, declaredMediaType string) (CandidateFormat, error) {
+	if reader == nil || size <= 0 {
+		return CandidateFormat{}, errors.New("document format detection requires nonempty bytes")
+	}
+	mediaType, parameters, err := mime.ParseMediaType(declaredMediaType)
+	if err != nil || len(parameters) != 0 || mediaType != strings.ToLower(mediaType) {
+		return CandidateFormat{}, errors.New("document format detection requires a canonical media type")
+	}
+	prefix, err := readPrefix(reader, size, maxSniffBytes)
+	if err != nil {
+		return CandidateFormat{}, err
+	}
+
+	var detected CandidateFormat
+	switch {
+	case bytes.HasPrefix(prefix, []byte("%PDF-")):
+		detected, _ = CandidateFormatByID("pdf")
+	case bytes.HasPrefix(prefix, []byte(`{\rtf`)):
+		detected, _ = CandidateFormatByID("rtf")
+	case bytes.HasPrefix(prefix, compoundFileMagic):
+		detected, err = detectCompoundFormat(reader, size)
+	case bytes.HasPrefix(prefix, []byte("PK\x03\x04")) || bytes.HasPrefix(prefix, []byte("PK\x05\x06")):
+		detected, err = detectZIPFormat(reader, size)
+	default:
+		if size > maxTextSniffBytes {
+			return CandidateFormat{}, errors.New("document text exceeds type-detection limit")
+		}
+		content, readErr := readPrefix(reader, size, maxTextSniffBytes)
+		if readErr != nil {
+			return CandidateFormat{}, readErr
+		}
+		detected, err = detectTextFormat(content, mediaType)
+	}
+	if err != nil {
+		return CandidateFormat{}, err
+	}
+	if detected.MediaType != mediaType {
+		return CandidateFormat{}, fmt.Errorf("document bytes are %s, not declared %s", detected.MediaType, mediaType)
+	}
+	return detected, nil
+}
+
+func detectCompoundFormat(reader io.ReaderAt, size int64) (CandidateFormat, error) {
+	names, err := compoundDirectoryNames(reader, size)
+	if err != nil {
+		return CandidateFormat{}, err
+	}
+	ids := make([]string, 0, 2)
+	if names["WordDocument"] {
+		ids = append(ids, "doc")
+	}
+	if names["Workbook"] || names["Book"] {
+		ids = append(ids, "xls")
+	}
+	if names["PowerPoint Document"] {
+		ids = append(ids, "ppt")
+	}
+	if names["__properties_version1.0"] {
+		ids = append(ids, "msg")
+	}
+	if len(ids) != 1 {
+		return CandidateFormat{}, errors.New("compound document has missing or ambiguous family markers")
+	}
+	format, _ := CandidateFormatByID(ids[0])
+	return format, nil
+}
+
+func compoundDirectoryNames(reader io.ReaderAt, size int64) (map[string]bool, error) {
+	const (
+		freeSector        = uint32(0xffffffff)
+		endOfChain        = uint32(0xfffffffe)
+		fatSector         = uint32(0xfffffffd)
+		difatSector       = uint32(0xfffffffc)
+		maxDIFATSectors   = 1_024
+		maxDirectoryBytes = int64(8 << 20)
+	)
+	if size < 512 {
+		return nil, errors.New("compound document header is truncated")
+	}
+	header := make([]byte, 512)
+	if _, err := reader.ReadAt(header, 0); err != nil {
+		return nil, fmt.Errorf("read compound document header: %w", err)
+	}
+	if !bytes.Equal(header[:8], compoundFileMagic) || binary.LittleEndian.Uint16(header[28:30]) != 0xfffe {
+		return nil, errors.New("compound document header is invalid")
+	}
+	sectorShift := binary.LittleEndian.Uint16(header[30:32])
+	majorVersion := binary.LittleEndian.Uint16(header[26:28])
+	if (majorVersion != 3 || sectorShift != 9) && (majorVersion != 4 || sectorShift != 12) {
+		return nil, errors.New("compound document sector size is unsupported")
+	}
+	sectorSize := int64(1 << sectorShift)
+	sectorCount := size/sectorSize - 1
+	if sectorCount <= 0 || size%sectorSize != 0 {
+		return nil, errors.New("compound document size is invalid")
+	}
+	numFAT := int(binary.LittleEndian.Uint32(header[44:48]))
+	firstDirectory := binary.LittleEndian.Uint32(header[48:52])
+	firstDIFAT := binary.LittleEndian.Uint32(header[68:72])
+	numDIFAT := int(binary.LittleEndian.Uint32(header[72:76]))
+	if numFAT <= 0 || numFAT > int(sectorCount) || numDIFAT > maxDIFATSectors {
+		return nil, errors.New("compound document allocation table exceeds limits")
+	}
+	fatSectors := make([]uint32, 0, numFAT)
+	for offset := 76; offset < 512 && len(fatSectors) < numFAT; offset += 4 {
+		sector := binary.LittleEndian.Uint32(header[offset : offset+4])
+		if sector != freeSector {
+			fatSectors = append(fatSectors, sector)
+		}
+	}
+	seenDIFAT := map[uint32]bool{}
+	for i, sector := 0, firstDIFAT; i < numDIFAT; i++ {
+		if int64(sector) >= sectorCount || seenDIFAT[sector] {
+			return nil, errors.New("compound document DIFAT chain is invalid")
+		}
+		seenDIFAT[sector] = true
+		data, readErr := readCompoundSector(reader, sector, sectorSize, size)
+		if readErr != nil {
+			return nil, readErr
+		}
+		for offset := 0; offset < len(data)-4 && len(fatSectors) < numFAT; offset += 4 {
+			fatID := binary.LittleEndian.Uint32(data[offset : offset+4])
+			if fatID != freeSector {
+				fatSectors = append(fatSectors, fatID)
+			}
+		}
+		sector = binary.LittleEndian.Uint32(data[len(data)-4:])
+		if i == numDIFAT-1 && sector != endOfChain {
+			return nil, errors.New("compound document DIFAT chain does not terminate")
+		}
+	}
+	if len(fatSectors) != numFAT {
+		return nil, errors.New("compound document FAT sector count is invalid")
+	}
+	fat := make([]uint32, 0, int(sectorCount))
+	seenFAT := map[uint32]bool{}
+	for _, sector := range fatSectors {
+		if int64(sector) >= sectorCount || seenFAT[sector] {
+			return nil, errors.New("compound document FAT sector list is invalid")
+		}
+		seenFAT[sector] = true
+		data, readErr := readCompoundSector(reader, sector, sectorSize, size)
+		if readErr != nil {
+			return nil, readErr
+		}
+		for offset := 0; offset < len(data); offset += 4 {
+			fat = append(fat, binary.LittleEndian.Uint32(data[offset:offset+4]))
+		}
+	}
+	if len(fat) < int(sectorCount) {
+		return nil, errors.New("compound document FAT is truncated")
+	}
+	for _, sector := range fatSectors {
+		if fat[sector] != fatSector {
+			return nil, errors.New("compound document FAT sector is not self-marked")
+		}
+	}
+	for sector := range seenDIFAT {
+		if fat[sector] != difatSector {
+			return nil, errors.New("compound document DIFAT sector is not self-marked")
+		}
+	}
+
+	var directory bytes.Buffer
+	seenDirectory := map[uint32]bool{}
+	for sector := firstDirectory; sector != endOfChain; {
+		if int64(sector) >= sectorCount || seenDirectory[sector] || int64(directory.Len())+sectorSize > maxDirectoryBytes {
+			return nil, errors.New("compound document directory chain exceeds limits")
+		}
+		seenDirectory[sector] = true
+		data, readErr := readCompoundSector(reader, sector, sectorSize, size)
+		if readErr != nil {
+			return nil, readErr
+		}
+		_, _ = directory.Write(data)
+		next := fat[sector]
+		if next == freeSector || next == fatSector || next == difatSector {
+			return nil, errors.New("compound document directory chain is invalid")
+		}
+		sector = next
+	}
+	entries := make([]compoundDirectoryEntry, 0, directory.Len()/128)
+	rootIndex := -1
+	data := directory.Bytes()
+	for offset := 0; offset+128 <= len(data); offset += 128 {
+		entry := data[offset : offset+128]
+		entryType := entry[66]
+		if entryType == 0 {
+			entries = append(entries, compoundDirectoryEntry{})
+			continue
+		}
+		if entryType != 1 && entryType != 2 && entryType != 5 {
+			return nil, errors.New("compound document directory entry type is invalid")
+		}
+		nameLength := int(binary.LittleEndian.Uint16(entry[64:66]))
+		if nameLength < 2 || nameLength > 64 || nameLength%2 != 0 {
+			return nil, errors.New("compound document directory name is invalid")
+		}
+		name, decodeErr := decodeUTF16LE(entry[:nameLength-2])
+		if decodeErr != nil || name == "" {
+			return nil, errors.New("compound document directory name is invalid")
+		}
+		entries = append(entries, compoundDirectoryEntry{
+			name: name, entryType: entryType,
+			left: binary.LittleEndian.Uint32(entry[68:72]), right: binary.LittleEndian.Uint32(entry[72:76]),
+			child: binary.LittleEndian.Uint32(entry[76:80]),
+		})
+		if entryType == 5 {
+			if rootIndex != -1 {
+				return nil, errors.New("compound document has multiple root entries")
+			}
+			rootIndex = len(entries) - 1
+		}
+	}
+	if rootIndex < 0 {
+		return nil, errors.New("compound document has no root entry")
+	}
+	names := map[string]bool{}
+	seen := map[uint32]bool{}
+	stack := []uint32{entries[rootIndex].child}
+	for len(stack) > 0 {
+		index := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if index == compoundNoStream {
+			continue
+		}
+		if uint64(index) >= uint64(len(entries)) || seen[index] || entries[index].entryType == 0 || entries[index].entryType == 5 {
+			return nil, errors.New("compound document root directory tree is invalid")
+		}
+		seen[index] = true
+		entry := entries[index]
+		if entry.entryType == 2 {
+			names[entry.name] = true
+		}
+		stack = append(stack, entry.left, entry.right)
+	}
+	return names, nil
+}
+
+func readCompoundSector(reader io.ReaderAt, sector uint32, sectorSize, size int64) ([]byte, error) {
+	offset := (int64(sector) + 1) * sectorSize
+	if offset < sectorSize || offset > size-sectorSize {
+		return nil, errors.New("compound document sector is out of range")
+	}
+	data := make([]byte, sectorSize)
+	if _, err := reader.ReadAt(data, offset); err != nil {
+		return nil, fmt.Errorf("read compound document sector: %w", err)
+	}
+	return data, nil
+}
+
+func decodeUTF16LE(data []byte) (string, error) {
+	if len(data)%2 != 0 {
+		return "", errors.New("odd UTF-16 length")
+	}
+	runes := make([]rune, 0, len(data)/2)
+	for i := 0; i < len(data); i += 2 {
+		value := binary.LittleEndian.Uint16(data[i : i+2])
+		if value == 0 || value >= 0xd800 && value <= 0xdfff {
+			return "", errors.New("unsupported UTF-16 directory name")
+		}
+		runes = append(runes, rune(value))
+	}
+	return string(runes), nil
+}
+
+func detectZIPFormat(reader io.ReaderAt, size int64) (CandidateFormat, error) {
+	if err := validateZIPEndRecord(reader, size); err != nil {
+		return CandidateFormat{}, err
+	}
+	archive, err := zip.NewReader(reader, size)
+	if err != nil {
+		return CandidateFormat{}, fmt.Errorf("open document ZIP container: %w", err)
+	}
+	if len(archive.File) > maxZIPEntries {
+		return CandidateFormat{}, errors.New("document ZIP container has too many entries")
+	}
+	names := make(map[string]bool, len(archive.File))
+	var expanded uint64
+	var mimeValue string
+	var contentTypes []byte
+	for _, entry := range archive.File {
+		if err := validateZIPName(entry.Name); err != nil {
+			return CandidateFormat{}, err
+		}
+		if entry.Mode()&os.ModeSymlink != 0 {
+			return CandidateFormat{}, errors.New("document ZIP container contains a symlink")
+		}
+		if entry.Flags&1 != 0 || (entry.Method != zip.Store && entry.Method != zip.Deflate) {
+			return CandidateFormat{}, errors.New("document ZIP container uses unsupported encryption or compression")
+		}
+		if entry.UncompressedSize64 > maxZIPSingleExpandedByte || expanded > maxZIPExpandedBytes-entry.UncompressedSize64 {
+			return CandidateFormat{}, errors.New("document ZIP container exceeds expanded-byte limits")
+		}
+		expanded += entry.UncompressedSize64
+		if names[entry.Name] {
+			return CandidateFormat{}, errors.New("document ZIP container has duplicate entry names")
+		}
+		names[entry.Name] = true
+		if err := verifyZIPEntry(entry); err != nil {
+			return CandidateFormat{}, err
+		}
+		if entry.Name == "mimetype" {
+			value, readErr := readZIPEntry(entry, 256)
+			if readErr != nil {
+				return CandidateFormat{}, readErr
+			}
+			mimeValue = string(value)
+		}
+		if entry.Name == ooxmlContentTypesName {
+			value, readErr := readZIPEntry(entry, 2<<20)
+			if readErr != nil {
+				return CandidateFormat{}, readErr
+			}
+			contentTypes = value
+		}
+	}
+
+	var id string
+	switch {
+	case names["word/document.xml"] && hasOOXMLMainType(contentTypes, "/word/document.xml",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"):
+		id = "docx"
+	case names["ppt/presentation.xml"] && hasOOXMLMainType(contentTypes, "/ppt/presentation.xml",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"):
+		id = "pptx"
+	case names["xl/workbook.xml"] && hasOOXMLMainType(contentTypes, "/xl/workbook.xml",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"):
+		id = "xlsx"
+	case mimeValue == "application/vnd.oasis.opendocument.text" && names["META-INF/manifest.xml"]:
+		id = "odt"
+	case mimeValue == "application/vnd.oasis.opendocument.spreadsheet" && names["META-INF/manifest.xml"]:
+		id = "ods"
+	case mimeValue == "application/epub+zip" && names["META-INF/container.xml"]:
+		id = "epub"
+	case hasNumbersMarker(names):
+		id = "numbers"
+	default:
+		return CandidateFormat{}, errors.New("zip container is not a supported document format")
+	}
+	format, _ := CandidateFormatByID(id)
+	return format, nil
+}
+
+func hasOOXMLMainType(content []byte, partName, contentType string) bool {
+	if len(content) == 0 || !validXMLDocument(content) {
+		return false
+	}
+	var document struct {
+		XMLName   xml.Name `xml:"Types"`
+		Overrides []struct {
+			PartName    string `xml:"PartName,attr"`
+			ContentType string `xml:"ContentType,attr"`
+		} `xml:"Override"`
+	}
+	if err := xml.Unmarshal(content, &document); err != nil ||
+		document.XMLName.Space != "http://schemas.openxmlformats.org/package/2006/content-types" {
+		return false
+	}
+	found := false
+	for _, override := range document.Overrides {
+		if override.PartName != partName {
+			continue
+		}
+		if found || override.ContentType != contentType {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+func validateZIPEndRecord(reader io.ReaderAt, size int64) error {
+	const maxTail = int64(65_557)
+	tailSize := min(size, maxTail)
+	tail := make([]byte, tailSize)
+	if _, err := reader.ReadAt(tail, size-tailSize); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("read document ZIP end record: %w", err)
+	}
+	signature := []byte{'P', 'K', 0x05, 0x06}
+	offset := bytes.LastIndex(tail, signature)
+	if offset < 0 || len(tail)-offset < 22 {
+		return errors.New("document ZIP container has no bounded end record")
+	}
+	record := tail[offset:]
+	entries := binary.LittleEndian.Uint16(record[10:12])
+	entriesOnDisk := binary.LittleEndian.Uint16(record[8:10])
+	centralSize := binary.LittleEndian.Uint32(record[12:16])
+	centralOffset := binary.LittleEndian.Uint32(record[16:20])
+	commentSize := int(binary.LittleEndian.Uint16(record[20:22]))
+	if binary.LittleEndian.Uint16(record[4:6]) != 0 || binary.LittleEndian.Uint16(record[6:8]) != 0 || entriesOnDisk != entries {
+		return errors.New("multi-disk document ZIP containers are unsupported")
+	}
+	if entries == 0xffff || centralSize == 0xffffffff || centralOffset == 0xffffffff ||
+		int(entries) > maxZIPEntries || centralSize > maxZIPCentralDirectory {
+		return errors.New("document ZIP central directory exceeds limits")
+	}
+	if int64(centralOffset)+int64(centralSize) > size {
+		return errors.New("document ZIP central directory is out of range")
+	}
+	if len(record) != 22+commentSize {
+		return errors.New("document ZIP end record has invalid comment length")
+	}
+	return nil
+}
+
+func validateZIPName(name string) error {
+	if name == "" || strings.ContainsRune(name, 0) || strings.ContainsAny(name, "\\:") || strings.HasPrefix(name, "/") {
+		return errors.New("document ZIP container has an unsafe entry name")
+	}
+	clean := path.Clean(name)
+	if clean == ".." || strings.HasPrefix(clean, "../") || clean != strings.TrimSuffix(name, "/") {
+		return errors.New("document ZIP container has a traversing entry name")
+	}
+	return nil
+}
+
+func readZIPEntry(entry *zip.File, limit int64) ([]byte, error) {
+	if limit < 0 || entry.UncompressedSize64 > maxZIPSingleExpandedByte || int64(entry.UncompressedSize64) > limit {
+		return nil, errors.New("document ZIP marker entry exceeds limit")
+	}
+	reader, err := entry.Open()
+	if err != nil {
+		return nil, fmt.Errorf("open document ZIP marker: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	value, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read document ZIP marker: %w", err)
+	}
+	if int64(len(value)) > limit {
+		return nil, errors.New("document ZIP marker entry exceeds limit")
+	}
+	return value, nil
+}
+
+func verifyZIPEntry(entry *zip.File) error {
+	if entry.UncompressedSize64 > maxZIPSingleExpandedByte {
+		return errors.New("document ZIP entry exceeds verification limit")
+	}
+	reader, err := entry.Open()
+	if err != nil {
+		return fmt.Errorf("open document ZIP entry: %w", err)
+	}
+	expectedSize := int64(entry.UncompressedSize64)
+	written, readErr := io.Copy(io.Discard, io.LimitReader(reader, expectedSize+1))
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil || written != expectedSize {
+		return errors.New("document ZIP entry failed bounded verification")
+	}
+	return nil
+}
+
+func hasNumbersMarker(names map[string]bool) bool {
+	for name := range names {
+		if strings.HasPrefix(name, "Index/Tables/") && strings.HasSuffix(name, ".iwa") {
+			return true
+		}
+	}
+	return false
+}
+
+func detectTextFormat(content []byte, mediaType string) (CandidateFormat, error) {
+	if !utf8.Valid(content) || bytes.IndexByte(content, 0) >= 0 {
+		return CandidateFormat{}, errors.New("document text is not safe UTF-8")
+	}
+	candidate, ok := candidateByMediaType(mediaType)
+	if !ok || !isTextCandidate(candidate) {
+		return CandidateFormat{}, errors.New("document bytes have no supported signature")
+	}
+	trimmed := bytes.TrimSpace(content)
+	switch candidate.ID {
+	case "json":
+		if len(trimmed) == 0 || !json.Valid(trimmed) {
+			return CandidateFormat{}, errors.New("declared JSON document is invalid")
+		}
+	case "jsonl":
+		for line := range bytes.SplitSeq(trimmed, []byte{'\n'}) {
+			if len(bytes.TrimSpace(line)) > 0 && !json.Valid(bytes.TrimSpace(line)) {
+				return CandidateFormat{}, errors.New("declared JSONL document is invalid")
+			}
+		}
+	case "xml":
+		if !validXMLDocument(content) {
+			return CandidateFormat{}, errors.New("declared XML document is invalid")
+		}
+	case "csv":
+		csvReader := csv.NewReader(bytes.NewReader(content))
+		csvReader.FieldsPerRecord = -1
+		if records, err := csvReader.ReadAll(); err != nil || len(records) == 0 {
+			return CandidateFormat{}, errors.New("declared CSV document is invalid")
+		}
+	case "latex":
+		if !bytes.Contains(content, []byte(`\documentclass`)) && !bytes.Contains(content, []byte(`\begin{document}`)) {
+			return CandidateFormat{}, errors.New("declared LaTeX document has no document marker")
+		}
+	case "eml":
+		message, err := mail.ReadMessage(bytes.NewReader(content))
+		if err != nil || message.Header.Get("From") == "" || message.Header.Get("Date") == "" {
+			return CandidateFormat{}, errors.New("declared EML document lacks required message headers")
+		}
+	case "yaml":
+		if len(trimmed) == 0 || (!bytes.HasPrefix(trimmed, []byte("---")) && !bytes.Contains(trimmed, []byte(": "))) {
+			return CandidateFormat{}, errors.New("declared YAML document has no structural marker")
+		}
+	}
+	return candidate, nil
+}
+
+func validXMLDocument(content []byte) bool {
+	decoder := xml.NewDecoder(bytes.NewReader(content))
+	depth := 0
+	roots := 0
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return roots == 1 && depth == 0
+		}
+		if err != nil {
+			return false
+		}
+		switch value := token.(type) {
+		case xml.StartElement:
+			if depth == 0 {
+				roots++
+				if roots > 1 {
+					return false
+				}
+			}
+			depth++
+		case xml.EndElement:
+			depth--
+			if depth < 0 {
+				return false
+			}
+		case xml.CharData:
+			if depth == 0 && len(bytes.TrimSpace(value)) != 0 {
+				return false
+			}
+		}
+	}
+}
+
+func isTextCandidate(candidate CandidateFormat) bool {
+	switch candidate.Family {
+	case "text", "structured", "source", "mail", "spreadsheet":
+		return candidate.ID != "msg" && candidate.ID != "xls" && candidate.ID != "xlsx" && candidate.ID != "ods" && candidate.ID != "numbers"
+	default:
+		return false
+	}
+}
+
+func candidateByMediaType(mediaType string) (CandidateFormat, bool) {
+	for _, candidate := range candidateFormats {
+		if candidate.MediaType == mediaType {
+			return candidate, true
+		}
+	}
+	return CandidateFormat{}, false
+}
+
+func readPrefix(reader io.ReaderAt, size, limit int64) ([]byte, error) {
+	length := min(size, limit)
+	buffer := make([]byte, length)
+	read, err := reader.ReadAt(buffer, 0)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("read document signature: %w", err)
+	}
+	if int64(read) != length {
+		return nil, errors.New("document bytes changed during signature read")
+	}
+	return buffer, nil
+}

--- a/internal/documentindex/mistral/sniff_test.go
+++ b/internal/documentindex/mistral/sniff_test.go
@@ -1,0 +1,412 @@
+package mistral
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectFormatRecognizesBoundedDocumentFamilies(t *testing.T) {
+	docx := documentZIP(t, map[string]string{
+		ooxmlContentTypesName: docxContentTypes("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"), "word/document.xml": "<document/>",
+	})
+	epub := documentZIP(t, map[string]string{
+		"mimetype": "application/epub+zip", "META-INF/container.xml": "<container/>",
+	})
+	compound := compoundDocument(t, "WordDocument")
+
+	tests := []struct {
+		name      string
+		content   []byte
+		mediaType string
+		wantID    string
+	}{
+		{name: "PDF", content: []byte("%PDF-1.7\nsynthetic"), mediaType: "application/pdf", wantID: "pdf"},
+		{name: "DOCX", content: docx, mediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", wantID: "docx"},
+		{name: "EPUB", content: epub, mediaType: "application/epub+zip", wantID: "epub"},
+		{name: "legacy DOC", content: compound, mediaType: "application/msword", wantID: "doc"},
+		{name: "CSV", content: []byte("name,value\nalpha,42\n"), mediaType: "text/csv", wantID: "csv"},
+		{name: "JSON", content: []byte(`{"alpha":42}`), mediaType: "application/json", wantID: "json"},
+		{name: "JSONL", content: []byte("{\"alpha\":1}\n{\"alpha\":2}\n"), mediaType: "application/x-ndjson", wantID: "jsonl"},
+		{name: "XML", content: []byte(`<root><value>42</value></root>`), mediaType: "application/xml", wantID: "xml"},
+		{name: "YAML", content: []byte("---\nalpha: 42\n"), mediaType: "application/yaml", wantID: "yaml"},
+		{name: "LaTeX", content: []byte(`\documentclass{article}\begin{document}x\end{document}`), mediaType: "application/x-tex", wantID: "latex"},
+		{name: "EML", content: []byte("From: sender@example.test\r\nDate: Thu, 13 Aug 2026 00:00:00 +0000\r\nSubject: Synthetic\r\n\r\nBody"), mediaType: "message/rfc822", wantID: "eml"},
+		{name: "Go", content: []byte("package synthetic\n"), mediaType: "text/x-go", wantID: "go"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			format, err := DetectFormat(bytes.NewReader(test.content), int64(len(test.content)), test.mediaType)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantID, format.ID)
+		})
+	}
+}
+
+func TestDetectFormatRejectsMismatchUnsafeZIPAndAmbiguousCompound(t *testing.T) {
+	require := require.New(t)
+	pdf := []byte("%PDF-1.7\nsynthetic")
+	_, err := DetectFormat(bytes.NewReader(pdf), int64(len(pdf)), "text/plain")
+	require.ErrorContains(err, "not declared")
+
+	unsafe := documentZIP(t, map[string]string{
+		ooxmlContentTypesName: docxContentTypes("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"), "word/document.xml": "<document/>", "../escape": "x",
+	})
+	_, err = DetectFormat(bytes.NewReader(unsafe), int64(len(unsafe)), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	require.ErrorContains(err, "traversing")
+
+	compound := compoundDocument(t, "WordDocument", "Workbook")
+	_, err = DetectFormat(bytes.NewReader(compound), int64(len(compound)), "application/msword")
+	require.ErrorContains(err, "ambiguous")
+
+	embedded := compoundDocumentWithEmbeddedWorkbook(t)
+	format, err := DetectFormat(bytes.NewReader(embedded), int64(len(embedded)), "application/msword")
+	require.NoError(err)
+	assert.Equal(t, "doc", format.ID)
+
+	rootStorage := compoundDocument(t, "WordDocument", "Workbook")
+	rootStorage[1024+256+66] = 1
+	format, err = DetectFormat(bytes.NewReader(rootStorage), int64(len(rootStorage)), "application/msword")
+	require.NoError(err)
+	assert.Equal(t, "doc", format.ID)
+
+	invalidJSON := []byte(`{"unterminated":`)
+	_, err = DetectFormat(bytes.NewReader(invalidJSON), int64(len(invalidJSON)), "application/json")
+	require.ErrorContains(err, "invalid")
+
+	macroEnabled := documentZIP(t, map[string]string{
+		ooxmlContentTypesName: docxContentTypes("application/vnd.ms-word.document.macroEnabled.main+xml"),
+		"word/document.xml":   "<document/>",
+	})
+	_, err = DetectFormat(bytes.NewReader(macroEnabled), int64(len(macroEnabled)), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	require.ErrorContains(err, "not a supported document format")
+
+	wrongNamespace := documentZIP(t, map[string]string{
+		ooxmlContentTypesName: `<Types xmlns="urn:unrelated"><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`,
+		"word/document.xml":   "<document/>",
+	})
+	_, err = DetectFormat(bytes.NewReader(wrongNamespace), int64(len(wrongNamespace)), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	require.ErrorContains(err, "not a supported document format")
+
+	trailingMalformed := documentZIP(t, map[string]string{
+		ooxmlContentTypesName: docxContentTypes("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml") + "<broken>",
+		"word/document.xml":   "<document/>",
+	})
+	_, err = DetectFormat(bytes.NewReader(trailingMalformed), int64(len(trailingMalformed)), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	require.ErrorContains(err, "not a supported document format")
+
+	for _, invalidXML := range []string{"", "<first/><second/>", "outside<root/>"} {
+		_, err = DetectFormat(bytes.NewReader([]byte(invalidXML)), int64(len(invalidXML)), "application/xml")
+		require.Error(err)
+	}
+}
+
+func TestValidateZIPEndRecordRejectsUnboundedDirectory(t *testing.T) {
+	archive := documentZIP(t, map[string]string{
+		ooxmlContentTypesName: docxContentTypes("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"), "word/document.xml": "<document/>",
+	})
+	offset := bytes.LastIndex(archive, []byte{'P', 'K', 0x05, 0x06})
+	require.GreaterOrEqual(t, offset, 0)
+	binary.LittleEndian.PutUint16(archive[offset+8:offset+10], maxZIPEntries+1)
+	binary.LittleEndian.PutUint16(archive[offset+10:offset+12], maxZIPEntries+1)
+	_, err := DetectFormat(bytes.NewReader(archive), int64(len(archive)), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	require.ErrorContains(t, err, "central directory")
+}
+
+func TestSpoolVerifiedSourceCreatesPrivateDetectedFileAndCleansIt(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	content := []byte("%PDF-1.7\nsynthetic")
+	digest := sha256.Sum256(content)
+	dir := filepath.Join(t.TempDir(), "private")
+	require.NoError(os.Mkdir(dir, 0o700))
+	source := &observedReadCloser{Reader: bytes.NewReader(content)}
+	document, cleanup, err := SpoolVerifiedSource(t.Context(), source, SpoolOptions{
+		Directory: dir, MediaType: "application/pdf", ExpectedSize: int64(len(content)),
+		ExpectedSHA256: hex.EncodeToString(digest[:]), MaxBytes: 1024,
+		MaxSpoolBytes: 2048, MinFreeBytes: 1,
+	})
+	require.NoError(err)
+	assert.True(source.closed)
+	assert.Equal("application/pdf", document.MediaType)
+	info, err := os.Lstat(document.Path)
+	require.NoError(err)
+	assert.True(info.Mode().IsRegular())
+	if runtime.GOOS != "windows" {
+		assert.Equal(os.FileMode(0o600), info.Mode().Perm())
+	}
+	require.NoError(cleanup())
+	assert.NoFileExists(document.Path)
+	require.NoError(cleanup())
+}
+
+func TestSpoolVerifiedSourceFailsClosedAndRemovesPartialFiles(t *testing.T) {
+	content := []byte("%PDF-1.7\nsynthetic")
+	digest := sha256.Sum256(content)
+	dir := filepath.Join(t.TempDir(), "private")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+
+	tests := []struct {
+		name      string
+		source    *observedReadCloser
+		size      int64
+		hash      string
+		maxBytes  int64
+		mediaType string
+		wantError string
+	}{
+		{name: "hash", source: &observedReadCloser{Reader: bytes.NewReader(content)}, size: int64(len(content)), hash: stringsOfZero(64), maxBytes: 1024, mediaType: "application/pdf", wantError: "hash mismatch"},
+		{name: "size", source: &observedReadCloser{Reader: bytes.NewReader(content)}, size: int64(len(content) + 1), hash: hex.EncodeToString(digest[:]), maxBytes: 1024, mediaType: "application/pdf", wantError: "size mismatch"},
+		{name: "limit", source: &observedReadCloser{Reader: bytes.NewReader(content)}, size: int64(len(content)), hash: hex.EncodeToString(digest[:]), maxBytes: 4, mediaType: "application/pdf", wantError: "invalid bounds"},
+		{name: "close", source: &observedReadCloser{Reader: bytes.NewReader(content), closeErr: errors.New("synthetic close")}, size: int64(len(content)), hash: hex.EncodeToString(digest[:]), maxBytes: 1024, mediaType: "application/pdf", wantError: "close verified"},
+		{name: "type", source: &observedReadCloser{Reader: bytes.NewReader(content)}, size: int64(len(content)), hash: hex.EncodeToString(digest[:]), maxBytes: 1024, mediaType: "text/plain", wantError: "not declared"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			_, _, err := SpoolVerifiedSource(t.Context(), test.source, SpoolOptions{
+				Directory: dir, MediaType: test.mediaType, ExpectedSize: test.size,
+				ExpectedSHA256: test.hash, MaxBytes: test.maxBytes,
+				MaxSpoolBytes: 2048, MinFreeBytes: 1,
+			})
+			require.ErrorContains(err, test.wantError)
+			assert.True(test.source.closed)
+			entries, readErr := os.ReadDir(dir)
+			require.NoError(readErr)
+			assert.Empty(entries)
+		})
+	}
+}
+
+func TestSpoolVerifiedSourceSerializesQuotaReservations(t *testing.T) {
+	content := []byte("%PDF-1.7\nserialized")
+	digest := sha256.Sum256(content)
+	dir := filepath.Join(t.TempDir(), "private")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	options := SpoolOptions{
+		Directory: dir, MediaType: "application/pdf", ExpectedSize: int64(len(content)),
+		ExpectedSHA256: hex.EncodeToString(digest[:]), MaxBytes: int64(len(content)),
+		MaxSpoolBytes: int64(len(content)), MinFreeBytes: 1,
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	firstResult := make(chan spoolCallResult, 1)
+	go func() {
+		document, cleanup, err := SpoolVerifiedSource(t.Context(), &gatedReadCloser{
+			Reader: bytes.NewReader(content), entered: entered, release: release,
+		}, options)
+		firstResult <- spoolCallResult{document: document, cleanup: cleanup, err: err}
+	}()
+	<-entered
+	secondResult := make(chan spoolCallResult, 1)
+	go func() {
+		document, cleanup, err := SpoolVerifiedSource(
+			t.Context(), io.NopCloser(bytes.NewReader(content)), options,
+		)
+		secondResult <- spoolCallResult{document: document, cleanup: cleanup, err: err}
+	}()
+	select {
+	case result := <-secondResult:
+		require.Failf(t, "reservation was not serialized", "second spool returned early: %v", result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	first := <-firstResult
+	require.NoError(t, first.err)
+	require.NotNil(t, first.cleanup)
+	second := <-secondResult
+	require.ErrorIs(t, second.err, ErrSpoolCapacity)
+	require.NoError(t, first.cleanup())
+}
+
+type spoolCallResult struct {
+	document Document
+	cleanup  func() error
+	err      error
+}
+
+type gatedReadCloser struct {
+	*bytes.Reader
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *gatedReadCloser) Read(buffer []byte) (int, error) {
+	r.once.Do(func() { close(r.entered) })
+	<-r.release
+	n, err := r.Reader.Read(buffer)
+	if errors.Is(err, io.EOF) {
+		return n, io.EOF
+	}
+	if err != nil {
+		return n, fmt.Errorf("read gated spool source: %w", err)
+	}
+	return n, nil
+}
+
+func (*gatedReadCloser) Close() error { return nil }
+
+func TestSpoolQuotaFreeSpaceAndStaleScavenging(t *testing.T) {
+	require := require.New(t)
+	dir := filepath.Join(t.TempDir(), "private")
+	require.NoError(os.Mkdir(dir, 0o700))
+	stale := filepath.Join(dir, spoolFilenamePrefix+"stale")
+	require.NoError(os.WriteFile(stale, []byte("stale"), 0o600))
+	old := time.Now().UTC().Add(-3 * time.Hour)
+	require.NoError(os.Chtimes(stale, old, old))
+	live := filepath.Join(dir, spoolFilenamePrefix+"live")
+	require.NoError(os.WriteFile(live, []byte("live"), 0o600))
+	removed, err := ScavengeSpoolDirectory(dir, time.Now().UTC().Add(-2*time.Hour))
+	require.NoError(err)
+	assert.Equal(t, 1, removed)
+	assert.NoFileExists(t, stale)
+	assert.FileExists(t, live)
+
+	content := []byte("%PDF-1.7\nsynthetic")
+	digest := sha256.Sum256(content)
+	options := SpoolOptions{
+		Directory: dir, MediaType: "application/pdf", ExpectedSize: int64(len(content)),
+		ExpectedSHA256: hex.EncodeToString(digest[:]), MaxBytes: int64(len(content)),
+		MaxSpoolBytes: int64(len(content) + len("live") - 1), MinFreeBytes: 1,
+	}
+	_, _, err = SpoolVerifiedSource(
+		t.Context(), &observedReadCloser{Reader: bytes.NewReader(content)}, options,
+	)
+	require.ErrorContains(err, "quota")
+	options.MaxSpoolBytes = 2048
+	options.MinFreeBytes = math.MaxInt64
+	_, _, err = SpoolVerifiedSource(
+		t.Context(), &observedReadCloser{Reader: bytes.NewReader(content)}, options,
+	)
+	require.ErrorContains(err, "free-space reserve")
+}
+
+func documentZIP(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	writer := zip.NewWriter(&output)
+	for name, value := range entries {
+		entry, err := writer.Create(name)
+		require.NoError(t, err)
+		_, err = io.WriteString(entry, value)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+	return output.Bytes()
+}
+
+func docxContentTypes(mainContentType string) string {
+	return `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+		`<Override PartName="/word/document.xml" ContentType="` + mainContentType + `"/>` +
+		`</Types>`
+}
+
+func compoundDocument(t *testing.T, streamNames ...string) []byte {
+	t.Helper()
+	const (
+		freeSector = uint32(0xffffffff)
+		endOfChain = uint32(0xfffffffe)
+		fatSector  = uint32(0xfffffffd)
+	)
+	content := make([]byte, 3*512)
+	header := content[:512]
+	copy(header, compoundFileMagic)
+	binary.LittleEndian.PutUint16(header[26:28], 3)
+	binary.LittleEndian.PutUint16(header[28:30], 0xfffe)
+	binary.LittleEndian.PutUint16(header[30:32], 9)
+	binary.LittleEndian.PutUint16(header[32:34], 6)
+	binary.LittleEndian.PutUint32(header[44:48], 1)
+	binary.LittleEndian.PutUint32(header[48:52], 1)
+	binary.LittleEndian.PutUint32(header[56:60], 4096)
+	binary.LittleEndian.PutUint32(header[60:64], endOfChain)
+	binary.LittleEndian.PutUint32(header[68:72], endOfChain)
+	for offset := 76; offset < 512; offset += 4 {
+		binary.LittleEndian.PutUint32(header[offset:offset+4], freeSector)
+	}
+	binary.LittleEndian.PutUint32(header[76:80], 0)
+
+	fat := content[512:1024]
+	for offset := 0; offset < len(fat); offset += 4 {
+		binary.LittleEndian.PutUint32(fat[offset:offset+4], freeSector)
+	}
+	binary.LittleEndian.PutUint32(fat[0:4], fatSector)
+	binary.LittleEndian.PutUint32(fat[4:8], endOfChain)
+
+	directory := content[1024:]
+	writeCompoundDirectoryEntry(t, directory[:128], "Root Entry", 5)
+	if len(streamNames) > 0 {
+		binary.LittleEndian.PutUint32(directory[76:80], 1)
+	}
+	for i, name := range streamNames {
+		offset := (i + 1) * 128
+		require.LessOrEqual(t, offset+128, len(directory))
+		writeCompoundDirectoryEntry(t, directory[offset:offset+128], name, 2)
+		if i+1 < len(streamNames) {
+			binary.LittleEndian.PutUint32(directory[offset+72:offset+76], uint32(i+2))
+		}
+	}
+	return content
+}
+
+func compoundDocumentWithEmbeddedWorkbook(t *testing.T) []byte {
+	t.Helper()
+	content := compoundDocument(t, "WordDocument", "ObjectPool", "Workbook")
+	directory := content[1024:]
+	// Root tree contains WordDocument and ObjectPool only.
+	binary.LittleEndian.PutUint32(directory[128+72:128+76], 2)
+	binary.LittleEndian.PutUint32(directory[256+72:256+76], compoundNoStream)
+	// Workbook is a child of ObjectPool, not a root-level stream.
+	directory[256+66] = 1
+	binary.LittleEndian.PutUint32(directory[256+76:256+80], 3)
+	return content
+}
+
+func writeCompoundDirectoryEntry(t *testing.T, entry []byte, name string, entryType byte) {
+	t.Helper()
+	encoded := make([]byte, 0, (len(name)+1)*2)
+	for _, character := range name {
+		require.Less(t, character, rune(0x10000))
+		encoded = binary.LittleEndian.AppendUint16(encoded, uint16(character))
+	}
+	encoded = binary.LittleEndian.AppendUint16(encoded, 0)
+	require.LessOrEqual(t, len(encoded), 64)
+	copy(entry, encoded)
+	binary.LittleEndian.PutUint16(entry[64:66], uint16(len(encoded)))
+	entry[66] = entryType
+	binary.LittleEndian.PutUint32(entry[68:72], compoundNoStream)
+	binary.LittleEndian.PutUint32(entry[72:76], compoundNoStream)
+	binary.LittleEndian.PutUint32(entry[76:80], compoundNoStream)
+}
+
+type observedReadCloser struct {
+	io.Reader
+
+	closed   bool
+	closeErr error
+}
+
+func (r *observedReadCloser) Close() error {
+	r.closed = true
+	return r.closeErr
+}
+
+func stringsOfZero(length int) string {
+	return string(bytes.Repeat([]byte{'0'}, length))
+}

--- a/internal/documentindex/mistral/spool.go
+++ b/internal/documentindex/mistral/spool.go
@@ -1,0 +1,241 @@
+package mistral
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+const (
+	spoolFilenamePrefix    = ".mistral-ocr-"
+	spoolReservationSuffix = ".mistral-ocr-reservations.lock"
+	spoolLockRetryInterval = 50 * time.Millisecond
+)
+
+// ErrSpoolCapacity marks a retryable quota or free-space reservation failure.
+var ErrSpoolCapacity = errors.New("mistral OCR spool capacity unavailable")
+
+type SpoolOptions struct {
+	Directory      string
+	MediaType      string
+	ExpectedSize   int64
+	ExpectedSHA256 string
+	MaxBytes       int64
+	MaxSpoolBytes  int64
+	MinFreeBytes   int64
+}
+
+// ScavengeSpoolDirectory removes only stale regular files created by this
+// package. Unexpected file types fail closed; unrelated regular files remain
+// untouched and still count against the aggregate quota.
+func ScavengeSpoolDirectory(directory string, staleBefore time.Time) (int, error) {
+	if directory == "" || staleBefore.IsZero() {
+		return 0, errors.New("mistral OCR spool scavenging requires a directory and cutoff")
+	}
+	release, err := acquireSpoolReservationLock(context.Background(), directory)
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return 0, fmt.Errorf("read Mistral OCR spool directory: %w", err)
+	}
+	removed := 0
+	for _, entry := range entries {
+		path := filepath.Join(directory, entry.Name())
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return removed, fmt.Errorf("inspect Mistral OCR spool entry: %w", statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return removed, errors.New("mistral OCR spool directory contains an unsafe entry")
+		}
+		if !strings.HasPrefix(entry.Name(), spoolFilenamePrefix) || !info.ModTime().Before(staleBefore) {
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			return removed, fmt.Errorf("remove stale Mistral OCR spool %s: %w", filepath.Base(path), err)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// SpoolVerifiedSource copies one authoritative CAS stream into a private
+// request spool, consumes and closes the source, validates bytes/hash/type,
+// and returns a cleanup function that removes only the created file.
+func SpoolVerifiedSource(
+	ctx context.Context,
+	source io.ReadCloser,
+	options SpoolOptions,
+) (document Document, cleanup func() error, err error) {
+	if source == nil {
+		return Document{}, nil, errors.New("mistral OCR spool requires a source")
+	}
+	if options.Directory == "" || options.ExpectedSize < 0 || options.MaxBytes <= 0 ||
+		options.ExpectedSize > options.MaxBytes || options.MaxSpoolBytes < options.MaxBytes || options.MinFreeBytes <= 0 {
+		_ = source.Close()
+		return Document{}, nil, errors.New("mistral OCR spool has invalid bounds")
+	}
+	if len(options.ExpectedSHA256) != sha256.Size*2 || options.ExpectedSHA256 != strings.ToLower(options.ExpectedSHA256) {
+		_ = source.Close()
+		return Document{}, nil, errors.New("mistral OCR spool requires a lowercase SHA-256")
+	}
+	if _, decodeErr := hex.DecodeString(options.ExpectedSHA256); decodeErr != nil {
+		_ = source.Close()
+		return Document{}, nil, errors.New("mistral OCR spool requires a lowercase SHA-256")
+	}
+	info, statErr := os.Lstat(options.Directory)
+	if statErr != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		_ = source.Close()
+		return Document{}, nil, errors.New("mistral OCR spool directory must already exist")
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		_ = source.Close()
+		return Document{}, nil, errors.New("mistral OCR spool directory permissions must be private")
+	}
+	release, lockErr := acquireSpoolReservationLock(ctx, options.Directory)
+	if lockErr != nil {
+		_ = source.Close()
+		return Document{}, nil, lockErr
+	}
+	defer release()
+	if capacityErr := checkSpoolCapacity(options); capacityErr != nil {
+		_ = source.Close()
+		return Document{}, nil, fmt.Errorf("%w: %w", ErrSpoolCapacity, capacityErr)
+	}
+
+	file, createErr := os.CreateTemp(options.Directory, spoolFilenamePrefix+"*")
+	if createErr != nil {
+		_ = source.Close()
+		return Document{}, nil, fmt.Errorf("create Mistral OCR spool: %w", createErr)
+	}
+	path := file.Name()
+	success := false
+	defer func() {
+		if !success {
+			_ = file.Close()
+			_ = os.Remove(path)
+		}
+	}()
+	if chmodErr := file.Chmod(0o600); chmodErr != nil {
+		_ = source.Close()
+		return Document{}, nil, fmt.Errorf("secure Mistral OCR spool: %w", chmodErr)
+	}
+
+	hash := sha256.New()
+	limited := io.LimitReader(&contextReader{ctx: ctx, reader: source}, options.MaxBytes+1)
+	written, copyErr := io.Copy(io.MultiWriter(file, hash), limited)
+	closeSourceErr := source.Close()
+	if copyErr != nil {
+		return Document{}, nil, fmt.Errorf("copy Mistral OCR spool: %w", copyErr)
+	}
+	if closeSourceErr != nil {
+		return Document{}, nil, fmt.Errorf("close verified attachment source: %w", closeSourceErr)
+	}
+	if written > options.MaxBytes {
+		return Document{}, nil, errors.New("mistral OCR spool exceeds byte limit")
+	}
+	if written != options.ExpectedSize {
+		return Document{}, nil, errors.New("mistral OCR source size mismatch")
+	}
+	actualHash := hex.EncodeToString(hash.Sum(nil))
+	if actualHash != options.ExpectedSHA256 {
+		return Document{}, nil, errors.New("mistral OCR source hash mismatch")
+	}
+	if syncErr := file.Sync(); syncErr != nil {
+		return Document{}, nil, fmt.Errorf("sync Mistral OCR spool: %w", syncErr)
+	}
+	if _, seekErr := file.Seek(0, io.SeekStart); seekErr != nil {
+		return Document{}, nil, fmt.Errorf("rewind Mistral OCR spool: %w", seekErr)
+	}
+	format, detectErr := DetectFormat(file, written, options.MediaType)
+	if detectErr != nil {
+		return Document{}, nil, detectErr
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		return Document{}, nil, fmt.Errorf("close Mistral OCR spool: %w", closeErr)
+	}
+
+	success = true
+	document = Document{Path: path, MediaType: format.MediaType, Size: written, SHA256: actualHash}
+	cleanup = func() error {
+		err := os.Remove(path)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("remove Mistral OCR spool %s: %w", filepath.Base(path), err)
+		}
+		return nil
+	}
+	return document, cleanup, nil
+}
+
+func checkSpoolCapacity(options SpoolOptions) error {
+	entries, err := os.ReadDir(options.Directory)
+	if err != nil {
+		return fmt.Errorf("read Mistral OCR spool usage: %w", err)
+	}
+	var used int64
+	for _, entry := range entries {
+		info, statErr := os.Lstat(filepath.Join(options.Directory, entry.Name()))
+		if statErr != nil {
+			return fmt.Errorf("inspect Mistral OCR spool usage: %w", statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() < 0 {
+			return errors.New("mistral OCR spool directory contains an unsafe entry")
+		}
+		if used > options.MaxSpoolBytes-info.Size() {
+			return errors.New("mistral OCR spool quota is exhausted")
+		}
+		used += info.Size()
+	}
+	if used > options.MaxSpoolBytes-options.ExpectedSize {
+		return errors.New("mistral OCR spool quota is exhausted")
+	}
+	available, err := availableDiskBytes(options.Directory)
+	if err != nil {
+		return fmt.Errorf("inspect Mistral OCR spool free space: %w", err)
+	}
+	if available < options.ExpectedSize || available-options.ExpectedSize < options.MinFreeBytes {
+		return errors.New("mistral OCR spool free-space reserve would be crossed")
+	}
+	return nil
+}
+
+func acquireSpoolReservationLock(ctx context.Context, directory string) (func(), error) {
+	lockPath := filepath.Join(filepath.Dir(directory), "."+filepath.Base(directory)+spoolReservationSuffix)
+	lock := flock.New(lockPath, flock.SetPermissions(0o600))
+	locked, err := lock.TryLockContext(ctx, spoolLockRetryInterval)
+	if err != nil {
+		return nil, fmt.Errorf("acquire Mistral OCR spool reservation lock: %w", err)
+	}
+	if !locked {
+		return nil, errors.New("mistral OCR spool reservation lock was not acquired")
+	}
+	return func() { _ = lock.Unlock() }, nil
+}
+
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *contextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(buffer)
+}

--- a/internal/documentindex/normalize.go
+++ b/internal/documentindex/normalize.go
@@ -1,0 +1,667 @@
+package documentindex
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"golang.org/x/net/html"
+)
+
+const (
+	normalizationPolicyVersion = 2
+	headingSentinelStart       = '\ue000'
+	headingSentinelEnd         = '\ue001'
+)
+
+type SourceDocument struct {
+	Family   string
+	UnitKind string
+	Units    []SourceUnit
+}
+
+type SourceUnit struct {
+	Index      int
+	Markdown   string
+	Header     string
+	Footer     string
+	Dimensions UnitDimensions
+}
+
+type UnitDimensions struct {
+	DPI    int
+	Height int
+	Width  int
+}
+
+type NormalizePolicy struct {
+	MaxUnitChars           int
+	MaxDocumentChars       int
+	MaxSourceUnitBytes     int
+	MaxMetadataSourceBytes int
+	MaxLinkChars           int
+	MaxChunkRunes          int
+	ChunkOverlap           int
+	MaxChunks              int
+}
+
+func DefaultNormalizePolicy(maxDocumentChars int) NormalizePolicy {
+	return NormalizePolicy{
+		MaxUnitChars: 1_000_000, MaxDocumentChars: maxDocumentChars,
+		MaxSourceUnitBytes: 4_000_000, MaxMetadataSourceBytes: 65_536, MaxLinkChars: 2_048,
+		MaxChunkRunes: 4_000, ChunkOverlap: 200, MaxChunks: 20_000,
+	}
+}
+
+type NormalizedDocument struct {
+	PolicyVersion int
+	Family        string
+	UnitKind      string
+	Units         []NormalizedUnit
+	Chunks        []DocumentChunk
+	Checksum      string
+	Truncated     bool
+}
+
+type NormalizedUnit struct {
+	Index        int
+	SourceKey    string
+	Kind         string
+	Text         string
+	Header       string
+	Footer       string
+	Dimensions   UnitDimensions
+	CharCount    int
+	Checksum     string
+	Truncated    bool
+	HeadingMarks []HeadingMark
+}
+
+type HeadingMark struct {
+	CharOffset int
+	Path       []string
+}
+
+type DocumentChunk struct {
+	Key         string
+	Ordinal     int
+	Text        string
+	HeadingPath []string
+	CharCount   int
+	Checksum    string
+	Truncated   bool
+	Spans       []DocumentChunkSpan
+}
+
+type DocumentChunkSpan struct {
+	UnitIndex int
+	CharStart int
+	CharEnd   int
+}
+
+// NormalizeDocument converts transient provider Markdown into deterministic,
+// inert canonical text plus exact unit spans. It never retains raw responses.
+func NormalizeDocument(source SourceDocument, policy NormalizePolicy) (NormalizedDocument, error) {
+	if source.Family == "" || source.UnitKind == "" || len(source.Units) == 0 {
+		return NormalizedDocument{}, errors.New("document normalization requires family, unit kind, and units")
+	}
+	if err := validateNormalizePolicy(policy); err != nil {
+		return NormalizedDocument{}, err
+	}
+
+	result := NormalizedDocument{
+		PolicyVersion: normalizationPolicyVersion, Family: source.Family, UnitKind: source.UnitKind,
+		Units: make([]NormalizedUnit, 0, len(source.Units)),
+	}
+	remaining := policy.MaxDocumentChars
+	for i, unit := range source.Units {
+		if unit.Index != i {
+			return NormalizedDocument{}, fmt.Errorf("document source unit %d has noncontiguous index %d", i, unit.Index)
+		}
+		if unit.Dimensions.DPI < 0 || unit.Dimensions.Height < 0 || unit.Dimensions.Width < 0 ||
+			unit.Dimensions.DPI > 100_000 || unit.Dimensions.Height > 10_000_000 || unit.Dimensions.Width > 10_000_000 {
+			return NormalizedDocument{}, fmt.Errorf("document source unit %d has invalid dimensions", i)
+		}
+		text, headings, sourceTruncated, err := canonicalMarkdown(
+			unit.Markdown, policy.MaxLinkChars, policy.MaxSourceUnitBytes,
+		)
+		if err != nil {
+			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d: %w", i, err)
+		}
+		header, _, headerSourceTruncated, err := canonicalMarkdown(
+			unit.Header, policy.MaxLinkChars, policy.MaxMetadataSourceBytes,
+		)
+		if err != nil {
+			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d header: %w", i, err)
+		}
+		footer, _, footerSourceTruncated, err := canonicalMarkdown(
+			unit.Footer, policy.MaxLinkChars, policy.MaxMetadataSourceBytes,
+		)
+		if err != nil {
+			return NormalizedDocument{}, fmt.Errorf("normalize document source unit %d footer: %w", i, err)
+		}
+		unitTruncated := sourceTruncated || headerSourceTruncated || footerSourceTruncated
+		header, truncated := truncateRunes(header, min(policy.MaxUnitChars, 16_384))
+		unitTruncated = unitTruncated || truncated
+		footer, truncated = truncateRunes(footer, min(policy.MaxUnitChars, 16_384))
+		unitTruncated = unitTruncated || truncated
+		text, bodyOffset := joinDocumentUnitEvidence(header, text, footer)
+		for headingIndex := range headings {
+			headings[headingIndex].CharOffset += bodyOffset
+		}
+		text, truncated = truncateRunes(text, min(policy.MaxUnitChars, remaining))
+		unitTruncated = unitTruncated || truncated
+		if truncated {
+			result.Truncated = true
+		}
+		combinedChars := utf8.RuneCountInString(text)
+		if combinedChars == 0 && remaining == 0 {
+			result.Truncated = true
+			break
+		}
+		remaining -= combinedChars
+		headings = boundHeadingMarks(text, headings)
+		normalized := NormalizedUnit{
+			Index: unit.Index, SourceKey: fmt.Sprintf("%s:%06d", source.UnitKind, unit.Index), Kind: source.UnitKind,
+			Text: text, Header: header, Footer: footer, Dimensions: unit.Dimensions,
+			CharCount: utf8.RuneCountInString(text), Truncated: unitTruncated, HeadingMarks: headings,
+		}
+		normalized.Checksum = checksumStrings(normalized.SourceKey, normalized.Text, normalized.Header, normalized.Footer)
+		result.Units = append(result.Units, normalized)
+		result.Truncated = result.Truncated || unitTruncated
+	}
+	if len(result.Units) == 0 {
+		return NormalizedDocument{}, errors.New("document normalization produced no units")
+	}
+
+	chunks, chunksTruncated := chunkNormalizedUnits(result.Units, policy)
+	result.Chunks = chunks
+	result.Truncated = result.Truncated || chunksTruncated
+	checksumParts := []string{fmt.Sprintf("v%d", result.PolicyVersion), result.Family, result.UnitKind}
+	for _, unit := range result.Units {
+		checksumParts = append(checksumParts, unit.Checksum)
+	}
+	for _, chunk := range result.Chunks {
+		checksumParts = append(checksumParts, chunk.Checksum)
+	}
+	result.Checksum = checksumStrings(checksumParts...)
+	return result, nil
+}
+
+func joinDocumentUnitEvidence(header, body, footer string) (string, int) {
+	parts := make([]string, 0, 3)
+	bodyOffset := 0
+	if header != "" {
+		parts = append(parts, header)
+		bodyOffset = utf8.RuneCountInString(header)
+		if body != "" || footer != "" {
+			bodyOffset += 2
+		}
+	}
+	if body != "" {
+		parts = append(parts, body)
+	}
+	if footer != "" {
+		parts = append(parts, footer)
+	}
+	return strings.Join(parts, "\n\n"), bodyOffset
+}
+
+func validateNormalizePolicy(policy NormalizePolicy) error {
+	if policy.MaxUnitChars <= 0 || policy.MaxDocumentChars <= 0 || policy.MaxSourceUnitBytes <= 0 ||
+		policy.MaxMetadataSourceBytes <= 0 || policy.MaxLinkChars <= 0 ||
+		policy.MaxChunkRunes <= 0 || policy.MaxChunks <= 0 {
+		return errors.New("document normalization limits must be positive")
+	}
+	if policy.ChunkOverlap < 0 || policy.ChunkOverlap >= policy.MaxChunkRunes {
+		return errors.New("document normalization limits are inconsistent")
+	}
+	return nil
+}
+
+func canonicalMarkdown(markdown string, maxLinkChars, maxSourceBytes int) (string, []HeadingMark, bool, error) {
+	if markdown == "" {
+		return "", nil, false, nil
+	}
+	if !utf8.ValidString(markdown) {
+		return "", nil, false, errors.New("provider Markdown is invalid UTF-8")
+	}
+	markdown, sourceTruncated := truncateUTF8Bytes(markdown, maxSourceBytes)
+	parser := goldmark.New(goldmark.WithExtensions(extension.GFM))
+	var rendered bytes.Buffer
+	if err := parser.Convert([]byte(markdown), &rendered); err != nil {
+		return "", nil, false, fmt.Errorf("parse provider Markdown: %w", err)
+	}
+	writer := canonicalHTMLWriter{maxLinkChars: maxLinkChars}
+	if err := writer.consume(bytes.NewReader(rendered.Bytes())); err != nil {
+		return "", nil, false, err
+	}
+	text, headings := canonicalWhitespace(writer.output.String())
+	return text, headings, sourceTruncated, nil
+}
+
+type canonicalHTMLWriter struct {
+	output       strings.Builder
+	maxLinkChars int
+	inPre        bool
+	skipDepth    int
+	cellIndex    int
+	links        []string
+	preFenceOpen bool
+	pendingSpace bool
+}
+
+func (w *canonicalHTMLWriter) consume(reader io.Reader) error {
+	tokenizer := html.NewTokenizer(reader)
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			if errors.Is(tokenizer.Err(), io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("tokenize normalized document HTML: %w", tokenizer.Err())
+		case html.TextToken:
+			if w.skipDepth == 0 {
+				w.writeText(string(tokenizer.Text()))
+			}
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			w.startTag(token)
+		case html.EndTagToken:
+			w.endTag(tokenizer.Token().Data)
+		case html.CommentToken, html.DoctypeToken:
+			// Comments and document declarations are not searchable evidence.
+		}
+	}
+}
+
+func (w *canonicalHTMLWriter) startTag(token html.Token) {
+	tag := token.Data
+	if w.skipDepth > 0 {
+		w.skipDepth++
+		return
+	}
+	if tag == "script" || tag == "style" || tag == "svg" {
+		w.skipDepth = 1
+		return
+	}
+	switch tag {
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		w.block()
+		level := int(tag[1] - '0')
+		_, _ = fmt.Fprintf(&w.output, "%cH%d%c", headingSentinelStart, level, headingSentinelEnd)
+		w.output.WriteString(strings.Repeat("#", level) + " ")
+	case "p", "div", "section", "blockquote", "ul", "ol", "table":
+		w.block()
+	case "li":
+		w.line()
+		w.output.WriteString("- ")
+	case "br":
+		w.line()
+	case "tr":
+		w.line()
+		w.cellIndex = 0
+	case "td", "th":
+		if w.cellIndex > 0 {
+			w.output.WriteString(" | ")
+		}
+		w.cellIndex++
+	case "pre":
+		w.block()
+		w.output.WriteString("```")
+		w.inPre = true
+		w.preFenceOpen = true
+	case "code":
+		if w.inPre && w.preFenceOpen {
+			for _, attribute := range token.Attr {
+				if attribute.Key == "class" && strings.HasPrefix(attribute.Val, "language-") {
+					language := strings.TrimPrefix(attribute.Val, "language-")
+					if language != "" && len(language) <= 64 {
+						w.output.WriteString(language)
+					}
+				}
+			}
+			w.output.WriteByte('\n')
+			w.preFenceOpen = false
+		} else if !w.inPre {
+			w.output.WriteByte('`')
+		}
+	case "img":
+		for _, attribute := range token.Attr {
+			if attribute.Key == "alt" {
+				w.writeText(attribute.Val)
+				break
+			}
+		}
+	case "input":
+		isCheckbox := false
+		checked := false
+		for _, attribute := range token.Attr {
+			if attribute.Key == "type" && attribute.Val == "checkbox" {
+				isCheckbox = true
+			}
+			if attribute.Key == "checked" {
+				checked = true
+			}
+		}
+		if isCheckbox {
+			if checked {
+				w.output.WriteString("[x] ")
+			} else {
+				w.output.WriteString("[ ] ")
+			}
+		}
+	case "a":
+		link := ""
+		for _, attribute := range token.Attr {
+			if attribute.Key == "href" {
+				link = safeStoredLink(attribute.Val, w.maxLinkChars)
+				break
+			}
+		}
+		w.links = append(w.links, link)
+	}
+}
+
+func (w *canonicalHTMLWriter) endTag(tag string) {
+	if w.skipDepth > 0 {
+		w.skipDepth--
+		return
+	}
+	switch tag {
+	case "h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "section", "blockquote", "ul", "ol", "table":
+		w.block()
+	case "li", "tr":
+		w.line()
+	case "pre":
+		if w.preFenceOpen {
+			w.output.WriteByte('\n')
+		}
+		w.inPre = false
+		w.preFenceOpen = false
+		w.line()
+		w.output.WriteString("```")
+		w.block()
+	case "code":
+		if !w.inPre {
+			w.output.WriteByte('`')
+		}
+	case "a":
+		if len(w.links) == 0 {
+			return
+		}
+		link := w.links[len(w.links)-1]
+		w.links = w.links[:len(w.links)-1]
+		if link != "" {
+			w.output.WriteString(" (" + link + ")")
+		}
+	}
+}
+
+func (w *canonicalHTMLWriter) writeText(value string) {
+	if w.inPre {
+		if w.preFenceOpen {
+			w.output.WriteByte('\n')
+			w.preFenceOpen = false
+		}
+		w.output.WriteString(stripUnsafeControls(value, true))
+		return
+	}
+	value = stripUnsafeControls(value, false)
+	for _, character := range value {
+		if unicode.IsSpace(character) {
+			w.pendingSpace = true
+			continue
+		}
+		if w.pendingSpace && w.output.Len() > 0 &&
+			!strings.HasSuffix(w.output.String(), "\n") && !strings.HasSuffix(w.output.String(), " ") {
+			w.output.WriteByte(' ')
+		}
+		w.pendingSpace = false
+		w.output.WriteRune(character)
+	}
+}
+
+func (w *canonicalHTMLWriter) line() {
+	w.pendingSpace = false
+	if w.output.Len() > 0 && !strings.HasSuffix(w.output.String(), "\n") {
+		w.output.WriteByte('\n')
+	}
+}
+
+func (w *canonicalHTMLWriter) block() {
+	w.line()
+	if w.output.Len() > 0 && !strings.HasSuffix(w.output.String(), "\n\n") {
+		w.output.WriteByte('\n')
+	}
+}
+
+func stripUnsafeControls(value string, preserveNewlines bool) string {
+	return strings.Map(func(character rune) rune {
+		if character == '\n' && preserveNewlines || character == '\t' {
+			return character
+		}
+		if unicode.IsControl(character) || character == '\u2028' || character == '\u2029' ||
+			character == headingSentinelStart || character == headingSentinelEnd {
+			return -1
+		}
+		return character
+	}, strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\r", "\n"))
+}
+
+func safeStoredLink(value string, maxChars int) string {
+	if utf8.RuneCountInString(value) > maxChars {
+		return ""
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.User != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
+		return ""
+	}
+	return parsed.String()
+}
+
+func canonicalWhitespace(value string) (string, []HeadingMark) {
+	lines := strings.Split(strings.ReplaceAll(value, "\r\n", "\n"), "\n")
+	var output strings.Builder
+	headings := make([]HeadingMark, 0)
+	headingPath := make([]string, 0, 6)
+	blank := false
+	endsWithNewline := false
+	runeOffset := 0
+	writeNewline := func() {
+		output.WriteByte('\n')
+		endsWithNewline = true
+		runeOffset++
+	}
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			if output.Len() == 0 || blank {
+				continue
+			}
+			blank = true
+			writeNewline()
+			continue
+		}
+		level := 0
+		prefix := string(headingSentinelStart) + "H"
+		if strings.HasPrefix(line, prefix) {
+			end := strings.IndexRune(line, headingSentinelEnd)
+			if end == len(prefix)+1 && line[len(prefix)] >= '1' && line[len(prefix)] <= '6' {
+				level = int(line[len(prefix)] - '0')
+				line = line[end+utf8.RuneLen(headingSentinelEnd):]
+			}
+		}
+		blank = false
+		if output.Len() > 0 && !endsWithNewline {
+			writeNewline()
+		}
+		offset := runeOffset
+		output.WriteString(line)
+		runeOffset += utf8.RuneCountInString(line)
+		endsWithNewline = false
+		if level > 0 {
+			for len(headingPath) < level {
+				headingPath = append(headingPath, "")
+			}
+			headingPath = headingPath[:level]
+			headingPath[level-1] = strings.TrimSpace(strings.TrimLeft(line, "#"))
+			headings = append(headings, HeadingMark{
+				CharOffset: offset,
+				Path:       append([]string(nil), compactHeadingPath(headingPath)...),
+			})
+		}
+	}
+	return strings.TrimRight(output.String(), "\n"), headings
+}
+
+func boundHeadingMarks(text string, headings []HeadingMark) []HeadingMark {
+	textRunes := []rune(text)
+	bounded := make([]HeadingMark, 0, len(headings))
+	for _, heading := range headings {
+		if heading.CharOffset < 0 || heading.CharOffset >= len(textRunes) || len(heading.Path) == 0 {
+			continue
+		}
+		end := heading.CharOffset
+		for end < len(textRunes) && textRunes[end] != '\n' {
+			end++
+		}
+		title := strings.TrimSpace(strings.TrimLeft(string(textRunes[heading.CharOffset:end]), "#"))
+		path := append([]string(nil), heading.Path...)
+		path[len(path)-1] = title
+		bounded = append(bounded, HeadingMark{CharOffset: heading.CharOffset, Path: path})
+	}
+	return bounded
+}
+
+func truncateUTF8Bytes(value string, limit int) (string, bool) {
+	if len(value) <= limit {
+		return value, false
+	}
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return value[:cut], true
+}
+
+func truncateRunes(value string, limit int) (string, bool) {
+	if limit < 0 {
+		limit = 0
+	}
+	if utf8.RuneCountInString(value) <= limit {
+		return value, false
+	}
+	for byteOffset := range value {
+		if limit == 0 {
+			return value[:byteOffset], true
+		}
+		limit--
+	}
+	return value, false
+}
+
+func chunkNormalizedUnits(units []NormalizedUnit, policy NormalizePolicy) ([]DocumentChunk, bool) {
+	chunks := make([]DocumentChunk, 0)
+	truncated := false
+	for _, unit := range units {
+		spans := chunkUnitText(unit.Text, policy.MaxChunkRunes, policy.ChunkOverlap)
+		for _, span := range spans {
+			if len(chunks) >= policy.MaxChunks {
+				return chunks, true
+			}
+			chunk := DocumentChunk{
+				Key:     fmt.Sprintf("%s:%06d-%06d", unit.SourceKey, span.CharStart, span.CharEnd),
+				Ordinal: len(chunks), Text: span.Text, HeadingPath: headingPathAt(unit.HeadingMarks, span.CharStart),
+				CharCount: utf8.RuneCountInString(span.Text), Truncated: unit.Truncated,
+				Spans: []DocumentChunkSpan{{UnitIndex: unit.Index, CharStart: span.CharStart, CharEnd: span.CharEnd}},
+			}
+			chunk.Checksum = checksumStrings(chunk.Key, chunk.Text, strings.Join(chunk.HeadingPath, "\x00"))
+			chunks = append(chunks, chunk)
+		}
+	}
+	return chunks, truncated
+}
+
+type unitChunkSpan struct {
+	Text      string
+	CharStart int
+	CharEnd   int
+}
+
+func chunkUnitText(text string, maxRunes, overlapRunes int) []unitChunkSpan {
+	if text == "" {
+		return nil
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return []unitChunkSpan{{Text: text, CharEnd: len(runes)}}
+	}
+	spans := make([]unitChunkSpan, 0, len(runes)/maxRunes+1)
+	for cursor := 0; cursor < len(runes); {
+		end := min(cursor+maxRunes, len(runes))
+		cut := end
+		if end < len(runes) {
+			floor := max(cursor+(maxRunes*3/4), cursor+1)
+			for i := end - 1; i >= floor; i-- {
+				if runes[i] == '\n' {
+					cut = i + 1
+					break
+				}
+			}
+			if cut == end {
+				for i := end - 1; i >= floor; i-- {
+					if unicode.IsSpace(runes[i]) {
+						cut = i + 1
+						break
+					}
+				}
+			}
+		}
+		spans = append(spans, unitChunkSpan{Text: string(runes[cursor:cut]), CharStart: cursor, CharEnd: cut})
+		if cut == len(runes) {
+			break
+		}
+		cursor += max((cut-cursor)-overlapRunes, 1)
+	}
+	return spans
+}
+
+func compactHeadingPath(path []string) []string {
+	result := make([]string, 0, len(path))
+	for _, part := range path {
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
+func headingPathAt(marks []HeadingMark, offset int) []string {
+	var result []string
+	for _, mark := range marks {
+		if mark.CharOffset > offset {
+			break
+		}
+		result = mark.Path
+	}
+	return append([]string(nil), result...)
+}
+
+func checksumStrings(values ...string) string {
+	hash := sha256.New()
+	for _, value := range values {
+		_, _ = io.WriteString(hash, fmt.Sprintf("%d:", len(value)))
+		_, _ = io.WriteString(hash, value)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/internal/documentindex/normalize_test.go
+++ b/internal/documentindex/normalize_test.go
@@ -1,0 +1,216 @@
+package documentindex
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeDocumentPreservesEvidenceAndRemovesActiveContent(t *testing.T) {
+	assert := assert.New(t)
+	markdown := `# Damage report
+
+The carton was **crushed**. [Safe](https://example.test/report?id=42)
+and [unsafe](javascript:alert(1)).
+
+![Photo evidence](data:image/png;base64,AAAA)
+
+| Item | Count |
+| --- | ---: |
+| Carton | 3 |
+| Pallet | 1 |
+
+<script>private_executable_marker()</script>
+<style>.hidden { display: none }</style>
+
+## Inspection
+
+- First edge
+- Second edge
+
+~~~go
+package synthetic
+~~~
+`
+	source := SourceDocument{Family: "pdf", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Markdown: markdown, Header: "Warehouse **A**", Footer: "Page 1",
+		Dimensions: UnitDimensions{DPI: 200, Height: 2200, Width: 1700},
+	}}}
+	policy := DefaultNormalizePolicy(100_000)
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	unit := normalized.Units[0]
+	assert.Contains(unit.Text, "# Damage report")
+	assert.Contains(unit.Text, "carton was crushed")
+	assert.Contains(unit.Text, "Safe (https://example.test/report?id=42)")
+	assert.Contains(unit.Text, "unsafe")
+	assert.NotContains(unit.Text, "javascript:")
+	assert.Contains(unit.Text, "Photo evidence")
+	assert.NotContains(unit.Text, "data:image")
+	assert.Contains(unit.Text, "Item | Count")
+	assert.Contains(unit.Text, "Carton | 3")
+	assert.Contains(unit.Text, "Pallet | 1")
+	assert.NotContains(unit.Text, "private_executable_marker")
+	assert.NotContains(unit.Text, "display: none")
+	assert.Contains(unit.Text, "```go\npackage synthetic\n```")
+	assert.Contains(unit.Text, "Warehouse A")
+	assert.Contains(unit.Text, "Page 1")
+	assert.Equal("Warehouse A", unit.Header)
+	assert.Equal("Page 1", unit.Footer)
+	assert.Regexp(`^[0-9a-f]{64}$`, unit.Checksum)
+	assert.Regexp(`^[0-9a-f]{64}$`, normalized.Checksum)
+}
+
+func TestNormalizeDocumentPublishesHeaderAndFooterOnlyEvidence(t *testing.T) {
+	source := SourceDocument{Family: "pdf", UnitKind: "page", Units: []SourceUnit{{
+		Index: 0, Header: "Confidential **shipment**", Footer: "Dock 7",
+	}}}
+
+	normalized, err := NormalizeDocument(source, DefaultNormalizePolicy(100_000))
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	assert.Equal(t, "Confidential shipment\n\nDock 7", normalized.Units[0].Text)
+	assert.Equal(t, "Confidential shipment", normalized.Units[0].Header)
+	assert.Equal(t, "Dock 7", normalized.Units[0].Footer)
+	require.Len(t, normalized.Chunks, 1)
+	assert.Equal(t, normalized.Units[0].Text, normalized.Chunks[0].Text)
+	assert.Equal(t, 0, normalized.Chunks[0].Spans[0].CharStart)
+	assert.Equal(t, normalized.Units[0].CharCount, normalized.Chunks[0].Spans[0].CharEnd)
+}
+
+func TestNormalizeDocumentChunksHaveExactUnitSpansAndHeadingPaths(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	markdown := "# Alpha\n\n" + strings.Repeat("alpha evidence sentence. ", 8) +
+		"\n\n## Beta\n\n" + strings.Repeat("beta evidence sentence. ", 8)
+	policy := DefaultNormalizePolicy(10_000)
+	policy.MaxChunkRunes = 100
+	policy.ChunkOverlap = 10
+	source := SourceDocument{Family: "word", UnitKind: "page", Units: []SourceUnit{{Index: 0, Markdown: markdown}}}
+
+	first, err := NormalizeDocument(source, policy)
+	require.NoError(err)
+	second, err := NormalizeDocument(source, policy)
+	require.NoError(err)
+	assert.Equal(first, second)
+	require.Greater(len(first.Chunks), 1)
+
+	runes := []rune(first.Units[0].Text)
+	for ordinal, chunk := range first.Chunks {
+		assert.Equal(ordinal, chunk.Ordinal)
+		require.Len(chunk.Spans, 1)
+		span := chunk.Spans[0]
+		assert.Equal(chunk.Text, string(runes[span.CharStart:span.CharEnd]))
+		assert.Equal(utf8.RuneCountInString(chunk.Text), chunk.CharCount)
+		assert.Regexp(`^[0-9a-f]{64}$`, chunk.Checksum)
+	}
+	assert.Equal([]string{"Alpha"}, first.Chunks[0].HeadingPath)
+	assert.Contains(first.Chunks[len(first.Chunks)-1].HeadingPath, "Beta")
+}
+
+func TestNormalizeDocumentBoundsUnicodeAndRejectsImpossibleUnits(t *testing.T) {
+	assert := assert.New(t)
+	policy := DefaultNormalizePolicy(6)
+	policy.MaxUnitChars = 6
+	policy.MaxChunkRunes = 3
+	policy.ChunkOverlap = 1
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{Index: 0, Markdown: "é日🙂abcdef"}}}
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Equal("é日🙂abc", normalized.Units[0].Text)
+	assert.True(normalized.Units[0].Truncated)
+	assert.True(normalized.Truncated)
+	assert.True(utf8.ValidString(normalized.Units[0].Text))
+
+	source.Units = append(source.Units, SourceUnit{Index: 3, Markdown: "later"})
+	_, err = NormalizeDocument(source, policy)
+	require.ErrorContains(t, err, "noncontiguous index")
+
+	source.Units = []SourceUnit{{Index: 0, Markdown: "x", Dimensions: UnitDimensions{Width: -1}}}
+	_, err = NormalizeDocument(source, policy)
+	require.ErrorContains(t, err, "invalid dimensions")
+}
+
+func TestNormalizeDocumentCapsChunksWithoutInventingSpans(t *testing.T) {
+	assert := assert.New(t)
+	policy := DefaultNormalizePolicy(100_000)
+	policy.MaxChunkRunes = 20
+	policy.ChunkOverlap = 2
+	policy.MaxChunks = 2
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{
+		Index: 0, Markdown: strings.Repeat("bounded evidence ", 20),
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	assert.Len(normalized.Chunks, 2)
+	assert.True(normalized.Truncated)
+	for _, chunk := range normalized.Chunks {
+		assert.NotEmpty(chunk.Text)
+		assert.Len(chunk.Spans, 1)
+	}
+}
+
+func TestNormalizeDocumentBoundsHeadingProvenanceToRetainedText(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	policy := DefaultNormalizePolicy(12)
+	policy.MaxUnitChars = 12
+	policy.MaxChunkRunes = 12
+	policy.ChunkOverlap = 2
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{
+		Index: 0, Markdown: "# retained-heading-content-that-is-cut\n\nbody",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(err)
+	require.Len(normalized.Units, 1)
+	unit := normalized.Units[0]
+	require.Len(unit.HeadingMarks, 1)
+	assert.Equal("# retained-h", unit.Text)
+	assert.Equal([]string{"retained-h"}, unit.HeadingMarks[0].Path)
+	assert.NotContains(unit.HeadingMarks[0].Path[0], "content")
+}
+
+func TestNormalizeDocumentPreservesInlineAdjacencyAndTaskState(t *testing.T) {
+	assert := assert.New(t)
+	policy := DefaultNormalizePolicy(10_000)
+	source := SourceDocument{Family: "text", UnitKind: "section", Units: []SourceUnit{{
+		Index:    0,
+		Markdown: "pre**condition**ed and `identifier`\n\n- [x] shipped\n- [ ] pending",
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	text := normalized.Units[0].Text
+	assert.Contains(text, "preconditioned")
+	assert.NotContains(text, "pre condition ed")
+	assert.Contains(text, "- [x] shipped")
+	assert.Contains(text, "- [ ] pending")
+}
+
+func TestNormalizeDocumentHeadingMetadataIgnoresCodeAndBoundsSource(t *testing.T) {
+	assert := assert.New(t)
+	policy := DefaultNormalizePolicy(10_000)
+	policy.MaxSourceUnitBytes = 120
+	source := SourceDocument{Family: "source", UnitKind: "section", Units: []SourceUnit{{
+		Index:    0,
+		Markdown: "# Real\n\n```sh\n# not a heading\necho safe\n```\n\n" + strings.Repeat("bounded tail ", 20),
+	}}}
+
+	normalized, err := NormalizeDocument(source, policy)
+	require.NoError(t, err)
+	require.Len(t, normalized.Units, 1)
+	unit := normalized.Units[0]
+	assert.True(unit.Truncated)
+	assert.True(normalized.Truncated)
+	require.Len(t, unit.HeadingMarks, 1)
+	assert.Equal([]string{"Real"}, unit.HeadingMarks[0].Path)
+	for _, chunk := range normalized.Chunks {
+		assert.NotContains(chunk.HeadingPath, "not a heading")
+	}
+}

--- a/internal/documentindex/reconcile.go
+++ b/internal/documentindex/reconcile.go
@@ -1,0 +1,183 @@
+package documentindex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const DocumentAttachmentConsumerKey = "document-index/v1"
+
+type DocumentOccurrenceCatalog interface {
+	RegisterAttachmentChangeConsumer(ctx context.Context, consumerKey string) (store.AttachmentChangeConsumer, bool, error)
+	CompleteAttachmentChangeReconciliation(ctx context.Context, consumerKey string, baselineSequence int64) error
+	ListDocumentAttachmentIDsAfter(ctx context.Context, afterID int64, limit int) ([]int64, error)
+	ReconcileDocumentOccurrence(ctx context.Context, attachmentID int64, sourceSequence int64) (store.DocumentOccurrence, bool, error)
+	ReconcileMissingDocumentOccurrences(ctx context.Context, limit int) (int, error)
+	ListAttachmentChanges(ctx context.Context, consumerKey string, limit int) ([]store.AttachmentChange, error)
+	AdvanceAttachmentChangeConsumer(ctx context.Context, consumerKey string, sequence int64) error
+}
+
+type ReconcilerConfig struct {
+	AttachmentPageSize int
+	ChangePageSize     int
+}
+
+type ReconcileResult struct {
+	ConsumerCreated     bool
+	FullScanCompleted   bool
+	AttachmentsExamined int
+	EligibleOccurrences int
+	MissingRemoved      int
+	ChangesConsumed     int
+}
+
+type Reconciler struct {
+	catalog DocumentOccurrenceCatalog
+	config  ReconcilerConfig
+}
+
+func NewReconciler(catalog DocumentOccurrenceCatalog, config ReconcilerConfig) (*Reconciler, error) {
+	if catalog == nil || config.AttachmentPageSize <= 0 || config.AttachmentPageSize > 10_000 ||
+		config.ChangePageSize <= 0 || config.ChangePageSize > 10_000 {
+		return nil, errors.New("document reconciler configuration is invalid")
+	}
+	return &Reconciler{catalog: catalog, config: config}, nil
+}
+
+// Reconcile performs the full registration protocol on first enablement and
+// then drains the durable journal. Full-scan source sequences use the captured
+// baseline, so replayed later events always supersede bootstrap observations.
+func (r *Reconciler) Reconcile(ctx context.Context) (ReconcileResult, error) {
+	return r.reconcile(ctx, false)
+}
+
+// FullReconcile is the periodic correctness backstop. Normal cycles consume
+// only the journal plus a bounded orphan check; callers schedule this explicit
+// O(all attachments) scan at a lower cadence.
+func (r *Reconciler) FullReconcile(ctx context.Context) (ReconcileResult, error) {
+	return r.reconcile(ctx, true)
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, forceFull bool) (ReconcileResult, error) {
+	consumer, created, err := r.catalog.RegisterAttachmentChangeConsumer(ctx, DocumentAttachmentConsumerKey)
+	if err != nil {
+		return ReconcileResult{}, err
+	}
+	result := ReconcileResult{ConsumerCreated: created}
+	scanSequence := consumer.LastSequence
+	if !consumer.ReconciliationComplete {
+		scanSequence = consumer.BaselineSequence
+	}
+	if !consumer.ReconciliationComplete || forceFull {
+		if err := r.fullScan(ctx, scanSequence, &result); err != nil {
+			return result, err
+		}
+		result.FullScanCompleted = true
+	}
+	if !consumer.ReconciliationComplete {
+		if err := r.catalog.CompleteAttachmentChangeReconciliation(
+			ctx, consumer.ConsumerKey, consumer.BaselineSequence,
+		); err != nil {
+			return result, err
+		}
+	}
+	if err := r.removeMissing(ctx, &result); err != nil {
+		return result, err
+	}
+	if err := r.replay(ctx, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (r *Reconciler) fullScan(
+	ctx context.Context,
+	baseline int64,
+	result *ReconcileResult,
+) error {
+	var afterID int64
+	for {
+		ids, err := r.catalog.ListDocumentAttachmentIDsAfter(ctx, afterID, r.config.AttachmentPageSize)
+		if err != nil {
+			return err
+		}
+		for _, attachmentID := range ids {
+			_, eligible, err := r.catalog.ReconcileDocumentOccurrence(ctx, attachmentID, baseline)
+			if err != nil {
+				return fmt.Errorf("reconcile document attachment %d: %w", attachmentID, err)
+			}
+			result.AttachmentsExamined++
+			if eligible {
+				result.EligibleOccurrences++
+			}
+			afterID = attachmentID
+		}
+		if len(ids) < r.config.AttachmentPageSize {
+			break
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) removeMissing(ctx context.Context, result *ReconcileResult) error {
+	for {
+		removed, err := r.catalog.ReconcileMissingDocumentOccurrences(ctx, r.config.AttachmentPageSize)
+		if err != nil {
+			return err
+		}
+		result.MissingRemoved += removed
+		if removed < r.config.AttachmentPageSize {
+			break
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) replay(ctx context.Context, result *ReconcileResult) error {
+	for {
+		changes, err := r.catalog.ListAttachmentChanges(
+			ctx, DocumentAttachmentConsumerKey, r.config.ChangePageSize,
+		)
+		if err != nil {
+			return err
+		}
+		if len(changes) == 0 {
+			return nil
+		}
+		for _, change := range changes {
+			if err := r.applyChange(ctx, change); err != nil {
+				return err
+			}
+			if err := r.catalog.AdvanceAttachmentChangeConsumer(
+				ctx, DocumentAttachmentConsumerKey, change.Sequence,
+			); err != nil {
+				return fmt.Errorf("advance document attachment change %d: %w", change.Sequence, err)
+			}
+			result.ChangesConsumed++
+		}
+	}
+}
+
+func (r *Reconciler) applyChange(ctx context.Context, change store.AttachmentChange) error {
+	ids := make([]int64, 0, 2)
+	if change.OldAttachmentID != nil {
+		ids = append(ids, *change.OldAttachmentID)
+	}
+	if change.NewAttachmentID != nil &&
+		(change.OldAttachmentID == nil || *change.NewAttachmentID != *change.OldAttachmentID) {
+		ids = append(ids, *change.NewAttachmentID)
+	}
+	for _, attachmentID := range ids {
+		if attachmentID <= 0 {
+			return fmt.Errorf("attachment change %d has invalid attachment coordinates", change.Sequence)
+		}
+		if _, _, err := r.catalog.ReconcileDocumentOccurrence(ctx, attachmentID, change.Sequence); err != nil {
+			return fmt.Errorf("replay attachment change %d for attachment %d: %w",
+				change.Sequence, attachmentID, err)
+		}
+	}
+	return nil
+}

--- a/internal/documentindex/reconcile_integration_test.go
+++ b/internal/documentindex/reconcile_integration_test.go
@@ -1,0 +1,168 @@
+package documentindex
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestReconcilerBootstrapAndReplayConvergeOnCurrentOccurrences(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	firstMessage := f.CreateMessage("document-reconcile-first")
+	firstID := createReconcileAttachment(t, f, firstMessage, "a")
+	unknownMessage := f.CreateMessage("document-reconcile-unknown")
+	unknownHash := strings.Repeat("b", 64)
+	require.NoError(f.Store.UpsertAttachment(
+		unknownMessage, "unknown.pdf", "application/pdf",
+		unknownHash[:2]+"/"+unknownHash, unknownHash, 64,
+	))
+
+	reconciler, err := NewReconciler(f.Store, ReconcilerConfig{
+		AttachmentPageSize: 1, ChangePageSize: 1,
+	})
+	require.NoError(err)
+	result, err := reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	assert.True(result.ConsumerCreated)
+	assert.True(result.FullScanCompleted)
+	assert.Equal(2, result.AttachmentsExamined)
+	assert.Equal(1, result.EligibleOccurrences)
+	assert.Equal(0, result.ChangesConsumed)
+	assert.Equal([]int64{firstID}, documentOccurrenceAttachmentIDs(t, f))
+
+	secondMessage := f.CreateMessage("document-reconcile-second")
+	secondID := createReconcileAttachment(t, f, secondMessage, "c")
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE attachments SET attachment_role = ?, role_source = ? WHERE id = ?`),
+		store.AttachmentRoleInline, store.AttachmentRoleSourceMIMEDisposition, firstID)
+	require.NoError(err)
+
+	result, err = reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	assert.False(result.ConsumerCreated)
+	assert.False(result.FullScanCompleted)
+	assert.Zero(result.AttachmentsExamined)
+	assert.Equal(2, result.ChangesConsumed)
+	assert.Equal([]int64{secondID}, documentOccurrenceAttachmentIDs(t, f))
+}
+
+func TestConcurrentReconciliationTreatsAlreadyAdvancedCursorAsSuccess(t *testing.T) {
+	f := storetest.New(t)
+	reconciler, err := NewReconciler(f.Store, ReconcilerConfig{
+		AttachmentPageSize: 10, ChangePageSize: 10,
+	})
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(t.Context())
+	require.NoError(t, err)
+	messageID := f.CreateMessage("document-reconcile-concurrent")
+	attachmentID := createReconcileAttachment(t, f, messageID, "f")
+
+	start := make(chan struct{})
+	errorsFound := make(chan error, 2)
+	var workers sync.WaitGroup
+	for range 2 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			_, reconcileErr := reconciler.Reconcile(t.Context())
+			errorsFound <- reconcileErr
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(errorsFound)
+	for reconcileErr := range errorsFound {
+		require.NoError(t, reconcileErr)
+	}
+	assert.Equal(t, []int64{attachmentID}, documentOccurrenceAttachmentIDs(t, f))
+}
+
+func TestReconcilerRemovesCascadedOccurrenceFromJournalReplay(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("document-reconcile-delete")
+	attachmentID := createReconcileAttachment(t, f, messageID, "d")
+	reconciler, err := NewReconciler(f.Store, ReconcilerConfig{
+		AttachmentPageSize: 10, ChangePageSize: 10,
+	})
+	require.NoError(err)
+	_, err = reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	assert.Equal(t, []int64{attachmentID}, documentOccurrenceAttachmentIDs(t, f))
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`DELETE FROM messages WHERE id = ?`), messageID)
+	require.NoError(err)
+	result, err := reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	assert.Equal(t, 1, result.ChangesConsumed)
+	assert.Empty(t, documentOccurrenceAttachmentIDs(t, f))
+}
+
+func TestReconcilerPeriodicBackstopRemovesOccurrenceAfterMissedEvent(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("document-reconcile-missed")
+	createReconcileAttachment(t, f, messageID, "e")
+	reconciler, err := NewReconciler(f.Store, ReconcilerConfig{
+		AttachmentPageSize: 10, ChangePageSize: 10,
+	})
+	require.NoError(err)
+	_, err = reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	require.Len(documentOccurrenceAttachmentIDs(t, f), 1)
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP WHERE id = ?`), messageID)
+	require.NoError(err)
+	_, err = f.Store.DB().Exec(`DELETE FROM attachment_change_log`)
+	require.NoError(err, "simulate a legacy or externally lost journal event")
+	result, err := reconciler.FullReconcile(t.Context())
+	require.NoError(err)
+	assert.True(t, result.FullScanCompleted)
+	assert.Equal(t, 1, result.AttachmentsExamined)
+	assert.Empty(t, documentOccurrenceAttachmentIDs(t, f))
+}
+
+func createReconcileAttachment(
+	t *testing.T,
+	f *storetest.Fixture,
+	messageID int64,
+	hashCharacter string,
+) int64 {
+	t.Helper()
+	hash := strings.Repeat(hashCharacter, 64)
+	require.NoError(t, f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: 64,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: "part:1",
+	}))
+	var id int64
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT id FROM attachments WHERE message_id = ? AND source_part_key = ?`), messageID, "part:1").Scan(&id))
+	return id
+}
+
+func documentOccurrenceAttachmentIDs(t *testing.T, f *storetest.Fixture) []int64 {
+	t.Helper()
+	require := require.New(t)
+	rows, err := f.Store.DB().Query(`SELECT attachment_id FROM document_occurrences ORDER BY attachment_id`)
+	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		require.NoError(rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(rows.Err())
+	return ids
+}

--- a/internal/documentindex/worker.go
+++ b/internal/documentindex/worker.go
@@ -1,0 +1,438 @@
+package documentindex
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	"go.kenn.io/msgvault/internal/documentindex/mistral"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const originalDocumentInputKey = "original"
+
+const documentFailureCleanupTimeout = 5 * time.Second
+
+var (
+	errDocumentPreparation  = errors.New("document extraction preparation failed")
+	errDocumentLeaseRenewal = errors.New("document extraction lease renewal failed")
+	errDocumentPublication  = errors.New("document extraction publication failed")
+)
+
+type DocumentExtractionCatalog interface {
+	ClaimDocumentExtraction(ctx context.Context, input store.DocumentExtractionClaimInput) (store.DocumentExtractionClaim, error)
+	RenewDocumentExtractionClaim(ctx context.Context, claim store.DocumentExtractionClaim, leaseUntil time.Time) error
+	PublishDocumentExtraction(ctx context.Context, publication store.DocumentExtractionPublication) error
+	FailDocumentExtraction(ctx context.Context, failure store.DocumentExtractionFailure) error
+}
+
+type DocumentAttachmentOpener interface {
+	OpenStream(ctx context.Context, hash string) (io.ReadCloser, int64, error)
+}
+
+type MistralWorkerConfig struct {
+	ProfileID        string
+	RebuildID        string
+	LeaseOwner       string
+	LeaseDuration    time.Duration
+	RetryDelay       time.Duration
+	SpoolDirectory   string
+	MaxFileBytes     int64
+	MaxSpoolBytes    int64
+	MinFreeBytes     int64
+	MaxPages         int
+	MessageTypes     []string
+	ReplaceCurrent   bool
+	NormalizePolicy  NormalizePolicy
+	CapabilityPolicy mistral.CapabilityManifest
+}
+
+type MistralWorker struct {
+	catalog      DocumentExtractionCatalog
+	opener       DocumentAttachmentOpener
+	processor    mistral.Processor
+	config       MistralWorkerConfig
+	formats      map[string]mistral.CandidateFormat
+	messageTypes map[string]struct{}
+}
+
+type DocumentExtractionResult struct {
+	ExtractionID      string
+	CanonicalBlobHash string
+	Units             int
+	Chunks            int
+	Truncated         bool
+}
+
+// NewMistralWorker binds runtime upload authority to the exact complete probe
+// manifest. A documented format is not eligible unless that manifest recorded
+// a passing authenticated probe for the pinned processor target.
+func NewMistralWorker(
+	catalog DocumentExtractionCatalog,
+	opener DocumentAttachmentOpener,
+	processor mistral.Processor,
+	config MistralWorkerConfig,
+) (*MistralWorker, error) {
+	if catalog == nil || opener == nil || processor == nil {
+		return nil, errors.New("mistral document worker requires catalog, attachment opener, and processor")
+	}
+	if config.ProfileID == "" || config.LeaseOwner == "" || config.SpoolDirectory == "" ||
+		config.MaxFileBytes <= 0 || config.MaxPages <= 0 || config.LeaseDuration <= 0 ||
+		config.MaxSpoolBytes < config.MaxFileBytes || config.MinFreeBytes <= 0 ||
+		config.LeaseDuration > time.Hour || config.RetryDelay <= 0 || config.RetryDelay > 7*24*time.Hour {
+		return nil, errors.New("mistral document worker configuration is incomplete")
+	}
+	if config.ReplaceCurrent != (config.RebuildID != "") {
+		return nil, errors.New("mistral document worker replacement requires an exact rebuild")
+	}
+	if err := config.CapabilityPolicy.ValidateComplete(); err != nil {
+		return nil, err
+	}
+	target := processor.Target()
+	if target.Endpoint != config.CapabilityPolicy.Endpoint || target.Region != config.CapabilityPolicy.Region ||
+		target.Model != config.CapabilityPolicy.RequestedModel {
+		return nil, errors.New("mistral document worker target does not match capability manifest")
+	}
+	if config.MaxPages > config.CapabilityPolicy.MaxPages {
+		return nil, errors.New("mistral document worker page limit exceeds probed policy")
+	}
+	if err := validateNormalizePolicy(config.NormalizePolicy); err != nil {
+		return nil, err
+	}
+	formats := make(map[string]mistral.CandidateFormat)
+	for _, result := range config.CapabilityPolicy.Results {
+		if result.Status != mistral.ProbeStatusPassed {
+			continue
+		}
+		format, ok := mistral.CandidateFormatByID(result.FormatID)
+		if !ok {
+			return nil, fmt.Errorf("mistral capability manifest contains unknown format %q", result.FormatID)
+		}
+		formats[format.MediaType] = format
+	}
+	messageTypes := make(map[string]struct{}, len(config.MessageTypes))
+	for _, messageType := range config.MessageTypes {
+		if messageType == "" {
+			return nil, errors.New("mistral document worker message scope contains an empty type")
+		}
+		messageTypes[messageType] = struct{}{}
+	}
+	config.MessageTypes = slices.Clone(config.MessageTypes)
+	return &MistralWorker{
+		catalog: catalog, opener: opener, processor: processor, config: config,
+		formats: formats, messageTypes: messageTypes,
+	}, nil
+}
+
+// ProcessCandidate uploads one verified private spool, normalizes the returned
+// Markdown entirely in memory, and atomically publishes only canonical local
+// derivatives. The raw provider response and Markdown are never persisted.
+func (w *MistralWorker) ProcessCandidate(
+	ctx context.Context,
+	candidate store.DocumentExtractionCandidate,
+) (result DocumentExtractionResult, runErr error) {
+	format, allowed := w.formats[candidate.MIMEType]
+	if !allowed {
+		return result, fmt.Errorf("document media type %q lacks passing capability authority", candidate.MIMEType)
+	}
+	if len(w.messageTypes) > 0 {
+		if _, allowed = w.messageTypes[candidate.MessageType]; !allowed {
+			return result, fmt.Errorf("document message type %q is outside configured scope", candidate.MessageType)
+		}
+	}
+	if candidate.Size <= 0 || candidate.Size > w.config.MaxFileBytes {
+		return result, errors.New("document candidate size is outside configured bounds")
+	}
+
+	source, authoritativeSize, err := w.opener.OpenStream(ctx, candidate.CanonicalBlobHash)
+	if err != nil {
+		return result, fmt.Errorf("open document attachment: %w", err)
+	}
+	if authoritativeSize != candidate.Size {
+		_ = source.Close()
+		return result, errors.New("document attachment size no longer matches reconciled metadata")
+	}
+	extractionID, err := newDocumentExtractionID()
+	if err != nil {
+		_ = source.Close()
+		return result, err
+	}
+	claim, err := w.catalog.ClaimDocumentExtraction(ctx, store.DocumentExtractionClaimInput{
+		ExtractionID: extractionID, ProfileID: w.config.ProfileID,
+		RebuildID:         w.config.RebuildID,
+		CanonicalBlobHash: candidate.CanonicalBlobHash, ExtractionInputKey: originalDocumentInputKey,
+		OccurrenceAttachmentID: candidate.AttachmentID,
+		OccurrenceMIMEType:     candidate.MIMEType,
+		OccurrenceMessageType:  candidate.MessageType,
+		LeaseOwner:             w.config.LeaseOwner, LeaseUntil: time.Now().UTC().Add(w.config.LeaseDuration),
+		LocalBytes: authoritativeSize, SourceSequence: candidate.SourceSequence,
+		RequireNoHead: !w.config.ReplaceCurrent,
+	})
+	if err != nil {
+		_ = source.Close()
+		return result, err
+	}
+	workCtx, cancelWork, renewalDone, renewalErr := w.keepClaimAlive(ctx, claim)
+	defer func() {
+		cancelWork()
+		<-renewalDone
+	}()
+	document, cleanup, err := mistral.SpoolVerifiedSource(workCtx, source, mistral.SpoolOptions{
+		Directory: w.config.SpoolDirectory, MediaType: candidate.MIMEType,
+		ExpectedSize: authoritativeSize, ExpectedSHA256: candidate.CanonicalBlobHash,
+		MaxBytes: w.config.MaxFileBytes, MaxSpoolBytes: w.config.MaxSpoolBytes,
+		MinFreeBytes: w.config.MinFreeBytes,
+	})
+	if err != nil {
+		err = fmt.Errorf("%w: %w", errDocumentPreparation, err)
+		if renewErr := readRenewalError(renewalErr); renewErr != nil {
+			err = errors.Join(err, renewErr)
+		}
+		err = errors.Join(err, w.recordFailureAfterError(ctx, claim, err, mistral.RequestMetrics{}))
+		return result, err
+	}
+	defer func() { runErr = errors.Join(runErr, cleanup()) }()
+
+	options := mistral.DefaultOptions()
+	if format.Family == "pdf" {
+		options.Pages = fmt.Sprintf("0-%d", w.config.MaxPages-1)
+	}
+	providerStarted := time.Now()
+	providerResult, err := w.processor.Process(workCtx, document, options)
+	providerMetrics := providerResult.Metrics
+	if err != nil {
+		providerMetrics = mistral.MetricsFromError(err)
+		if renewErr := readRenewalError(renewalErr); renewErr != nil {
+			err = errors.Join(err, renewErr)
+		}
+		err = errors.Join(err, w.recordFailureAfterError(ctx, claim, err, providerMetrics))
+		return result, err
+	}
+	if renewErr := readRenewalError(renewalErr); renewErr != nil {
+		err = errors.Join(renewErr, w.recordFailureAfterError(ctx, claim, renewErr, providerMetrics))
+		return result, err
+	}
+	if providerMetrics.Requests == 0 {
+		providerMetrics.Requests = 1
+	}
+	if providerMetrics.Latency <= 0 {
+		providerMetrics.Latency = time.Since(providerStarted)
+	}
+	providerResult.Metrics = providerMetrics
+	if len(providerResult.Pages) > w.config.MaxPages {
+		err = fmt.Errorf("document provider returned %d units, limit %d", len(providerResult.Pages), w.config.MaxPages)
+		err = errors.Join(err, w.recordFailureAfterError(ctx, claim, err, providerMetrics))
+		return result, err
+	}
+	sourceDocument := SourceDocument{
+		Family: format.Family, UnitKind: format.UnitKind,
+		Units: make([]SourceUnit, len(providerResult.Pages)),
+	}
+	for i, page := range providerResult.Pages {
+		sourceDocument.Units[i] = SourceUnit{
+			Index: i, Markdown: page.Markdown, Header: page.Header, Footer: page.Footer,
+			Dimensions: UnitDimensions{
+				DPI: page.Dimensions.DPI, Height: page.Dimensions.Height, Width: page.Dimensions.Width,
+			},
+		}
+	}
+	normalized, err := NormalizeDocument(sourceDocument, w.config.NormalizePolicy)
+	if err != nil {
+		err = errors.Join(err, w.recordFailureAfterError(ctx, claim, err, providerMetrics))
+		return result, err
+	}
+	publication, err := publicationFromNormalized(claim, providerResult, normalized)
+	if err != nil {
+		err = errors.Join(err, w.recordFailureAfterError(ctx, claim, err, providerMetrics))
+		return result, err
+	}
+	if err := w.catalog.PublishDocumentExtraction(workCtx, publication); err != nil {
+		if renewErr := readRenewalError(renewalErr); renewErr != nil {
+			err = errors.Join(err, renewErr)
+		} else {
+			err = fmt.Errorf("%w: %w", errDocumentPublication, err)
+		}
+		err = errors.Join(err, w.recordFailureAfterError(ctx, claim, err, providerMetrics))
+		return result, err
+	}
+	return DocumentExtractionResult{
+		ExtractionID: extractionID, CanonicalBlobHash: candidate.CanonicalBlobHash,
+		Units: len(normalized.Units), Chunks: len(normalized.Chunks), Truncated: normalized.Truncated,
+	}, nil
+}
+
+func (w *MistralWorker) keepClaimAlive(
+	ctx context.Context,
+	claim store.DocumentExtractionClaim,
+) (context.Context, context.CancelFunc, <-chan struct{}, <-chan error) {
+	workCtx, cancelWork := context.WithCancel(ctx)
+	done := make(chan struct{})
+	errCh := make(chan error, 1)
+	interval := w.config.LeaseDuration / 3
+	if interval < time.Millisecond {
+		interval = time.Millisecond
+	}
+	if interval > time.Minute {
+		interval = time.Minute
+	}
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-workCtx.Done():
+				return
+			case <-ticker.C:
+				renewCtx, cancelRenew := context.WithTimeout(
+					context.WithoutCancel(workCtx), documentFailureCleanupTimeout,
+				)
+				err := w.catalog.RenewDocumentExtractionClaim(
+					renewCtx, claim, time.Now().UTC().Add(w.config.LeaseDuration),
+				)
+				cancelRenew()
+				if err != nil {
+					errCh <- fmt.Errorf("%w: %w", errDocumentLeaseRenewal, err)
+					cancelWork()
+					return
+				}
+			}
+		}
+	}()
+	return workCtx, cancelWork, done, errCh
+}
+
+func readRenewalError(errCh <-chan error) error {
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
+	}
+}
+
+func (w *MistralWorker) recordFailureAfterError(
+	ctx context.Context,
+	claim store.DocumentExtractionClaim,
+	cause error,
+	metrics mistral.RequestMetrics,
+) error {
+	failureCtx := ctx
+	cancel := func() {}
+	if ctx.Err() != nil {
+		failureCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), documentFailureCleanupTimeout)
+	}
+	defer cancel()
+	return w.recordFailure(failureCtx, claim, cause, metrics)
+}
+
+func (w *MistralWorker) recordFailure(
+	ctx context.Context,
+	claim store.DocumentExtractionClaim,
+	cause error,
+	metrics mistral.RequestMetrics,
+) error {
+	terminal, reason := classifyDocumentExtractionFailure(cause)
+	failure := store.DocumentExtractionFailure{
+		Claim: claim, ReasonCode: reason, Terminal: terminal,
+		RequestCount: metrics.Requests, RetryCount: metrics.Retries,
+		ProviderLatencyMS: requestLatencyMillis(metrics.Latency),
+	}
+	if !terminal {
+		failure.RetryAt = time.Now().UTC().Add(w.config.RetryDelay)
+	}
+	return w.catalog.FailDocumentExtraction(ctx, failure)
+}
+
+func classifyDocumentExtractionFailure(err error) (bool, string) {
+	switch {
+	case errors.Is(err, mistral.ErrSpoolCapacity):
+		return false, "spool_capacity_unavailable"
+	case errors.Is(err, errDocumentLeaseRenewal):
+		return false, "lease_renewal_failed"
+	case errors.Is(err, errDocumentPublication):
+		return false, "publication_failed"
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return false, "provider_interrupted"
+	case errors.Is(err, errDocumentPreparation):
+		return true, "invalid_local_source"
+	case errors.Is(err, mistral.ErrTransientResponse):
+		return false, "provider_transient"
+	case errors.Is(err, mistral.ErrPermanentResponse):
+		return true, "provider_rejected"
+	case errors.Is(err, mistral.ErrResponseTooLarge):
+		return true, "response_too_large"
+	default:
+		return true, "invalid_provider_output"
+	}
+}
+
+func publicationFromNormalized(
+	claim store.DocumentExtractionClaim,
+	providerResult mistral.Result,
+	normalized NormalizedDocument,
+) (store.DocumentExtractionPublication, error) {
+	if providerResult.UsageInfo == nil || providerResult.UsageInfo.PagesProcessed <= 0 || len(normalized.Chunks) == 0 {
+		return store.DocumentExtractionPublication{}, errors.New("document extraction produced no publishable evidence")
+	}
+	publication := store.DocumentExtractionPublication{
+		ExtractionID: claim.ExtractionID, ProfileID: claim.ProfileID,
+		CanonicalBlobHash: claim.CanonicalBlobHash, ExtractionInputKey: claim.ExtractionInputKey,
+		OccurrenceAttachmentID: claim.OccurrenceAttachmentID,
+		OccurrenceMIMEType:     claim.OccurrenceMIMEType,
+		OccurrenceMessageType:  claim.OccurrenceMessageType,
+		LeaseOwner:             claim.LeaseOwner, LeaseFence: claim.LeaseFence,
+		ReturnedModel: providerResult.Model, ProviderBytes: providerResult.UsageInfo.DocSizeBytes,
+		UnitsProcessed: providerResult.UsageInfo.PagesProcessed, ManifestChecksum: normalized.Checksum,
+		RequestCount: providerResult.Metrics.Requests, RetryCount: providerResult.Metrics.Retries,
+		ProviderLatencyMS: requestLatencyMillis(providerResult.Metrics.Latency),
+		Units:             make([]store.DocumentPublishedUnit, len(normalized.Units)),
+		Chunks:            make([]store.DocumentPublishedChunk, len(normalized.Chunks)),
+	}
+	for i, unit := range normalized.Units {
+		publication.Units[i] = store.DocumentPublishedUnit{
+			Index: unit.Index, Kind: unit.Kind, Text: unit.Text, Header: unit.Header, Footer: unit.Footer,
+			Width: unit.Dimensions.Width, Height: unit.Dimensions.Height, DPI: unit.Dimensions.DPI,
+			Checksum: unit.Checksum, CharCount: unit.CharCount, Truncated: unit.Truncated,
+		}
+	}
+	for i, chunk := range normalized.Chunks {
+		published := store.DocumentPublishedChunk{
+			Key: chunk.Key, Ordinal: chunk.Ordinal, Text: chunk.Text, HeadingPath: chunk.HeadingPath,
+			FirstUnitIndex: chunk.Spans[0].UnitIndex, LastUnitIndex: chunk.Spans[len(chunk.Spans)-1].UnitIndex,
+			Checksum: chunk.Checksum, CharCount: chunk.CharCount, Truncated: chunk.Truncated,
+			Spans: make([]store.DocumentPublishedSpan, len(chunk.Spans)),
+		}
+		for spanIndex, span := range chunk.Spans {
+			published.Spans[spanIndex] = store.DocumentPublishedSpan{
+				UnitIndex: span.UnitIndex, CharStart: span.CharStart, CharEnd: span.CharEnd,
+			}
+		}
+		publication.Chunks[i] = published
+	}
+	return publication, nil
+}
+
+func requestLatencyMillis(latency time.Duration) int64 {
+	if latency <= 0 {
+		return 0
+	}
+	milliseconds := latency.Milliseconds()
+	if milliseconds == 0 {
+		return 1
+	}
+	return milliseconds
+}
+
+func newDocumentExtractionID() (string, error) {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", fmt.Errorf("generate document extraction ID: %w", err)
+	}
+	return "docex_" + hex.EncodeToString(bytes[:]), nil
+}

--- a/internal/documentindex/worker_test.go
+++ b/internal/documentindex/worker_test.go
@@ -1,0 +1,380 @@
+package documentindex
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/documentindex/mistral"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type workerCatalog struct {
+	claimInput        store.DocumentExtractionClaimInput
+	publication       *store.DocumentExtractionPublication
+	failure           *store.DocumentExtractionFailure
+	failureContextErr error
+	claimErr          error
+	publishErr        error
+	renewErr          error
+	renewals          atomic.Int32
+}
+
+func (c *workerCatalog) ClaimDocumentExtraction(
+	_ context.Context,
+	input store.DocumentExtractionClaimInput,
+) (store.DocumentExtractionClaim, error) {
+	c.claimInput = input
+	if c.claimErr != nil {
+		return store.DocumentExtractionClaim{}, c.claimErr
+	}
+	return store.DocumentExtractionClaim{DocumentExtractionClaimInput: input, LeaseFence: 1}, nil
+}
+
+func (c *workerCatalog) PublishDocumentExtraction(
+	_ context.Context,
+	publication store.DocumentExtractionPublication,
+) error {
+	c.publication = &publication
+	return c.publishErr
+}
+
+func (c *workerCatalog) RenewDocumentExtractionClaim(
+	_ context.Context,
+	_ store.DocumentExtractionClaim,
+	_ time.Time,
+) error {
+	c.renewals.Add(1)
+	return c.renewErr
+}
+
+func (c *workerCatalog) FailDocumentExtraction(
+	ctx context.Context,
+	failure store.DocumentExtractionFailure,
+) error {
+	c.failure = &failure
+	c.failureContextErr = ctx.Err()
+	return nil
+}
+
+type workerOpener struct {
+	content []byte
+	opened  int
+}
+
+func (o *workerOpener) OpenStream(context.Context, string) (io.ReadCloser, int64, error) {
+	o.opened++
+	return io.NopCloser(bytes.NewReader(o.content)), int64(len(o.content)), nil
+}
+
+type workerProcessor struct {
+	result  mistral.Result
+	err     error
+	calls   int
+	options mistral.Options
+	cancel  context.CancelFunc
+	block   <-chan struct{}
+}
+
+func (p *workerProcessor) Process(
+	ctx context.Context,
+	_ mistral.Document,
+	options mistral.Options,
+) (mistral.Result, error) {
+	p.calls++
+	p.options = options
+	if p.cancel != nil {
+		p.cancel()
+	}
+	if p.block != nil {
+		select {
+		case <-p.block:
+		case <-ctx.Done():
+			return mistral.Result{}, ctx.Err()
+		}
+	}
+	return p.result, p.err
+}
+
+func (p *workerProcessor) Target() mistral.ProcessorTarget {
+	return mistral.ProcessorTarget{
+		Endpoint: "https://api.mistral.ai/v1/ocr", Region: "eu", Model: "mistral-ocr-4-0",
+	}
+}
+
+func TestMistralWorkerPublishesOnlyNormalizedDerivatives(t *testing.T) {
+	assert := assert.New(t)
+	content := []byte("%PDF-1.7\nsynthetic")
+	hash := sha256.Sum256(content)
+	digest := hex.EncodeToString(hash[:])
+	catalog := &workerCatalog{}
+	opener := &workerOpener{content: content}
+	processor := &workerProcessor{result: mistral.Result{
+		Model: "mistral-ocr-4-0",
+		Pages: []mistral.Page{{
+			Index: 0, Markdown: "# Invoice\n<script>private()</script>\nAmount **42**",
+		}},
+		UsageInfo: &mistral.Usage{PagesProcessed: 1},
+	}}
+	worker := newTestMistralWorker(t, catalog, opener, processor, allPassingCapabilityManifest(t))
+
+	result, err := worker.ProcessCandidate(t.Context(), store.DocumentExtractionCandidate{
+		AttachmentID: 7, CanonicalBlobHash: digest, MIMEType: "application/pdf",
+		Size: int64(len(content)), MessageType: "email", SourceSequence: 11,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, catalog.publication)
+	assert.True(processor.options.ExtractHeader)
+	assert.True(processor.options.ExtractFooter)
+	assert.Equal("0-99", processor.options.Pages)
+	assert.True(catalog.claimInput.RequireNoHead)
+	assert.Equal(int64(11), catalog.claimInput.SourceSequence)
+	assert.Equal("# Invoice\nAmount 42", catalog.publication.Units[0].Text)
+	assert.NotContains(catalog.publication.Units[0].Text, "private")
+	assert.Equal([]string{"Invoice"}, catalog.publication.Chunks[0].HeadingPath)
+	assert.Equal(1, catalog.publication.RequestCount)
+	assert.Zero(catalog.publication.RetryCount)
+	assert.Positive(catalog.publication.ProviderLatencyMS)
+	assert.Equal(1, result.Units)
+	assert.Equal(1, result.Chunks)
+	assert.Nil(catalog.failure)
+
+	entries, err := os.ReadDir(worker.config.SpoolDirectory)
+	require.NoError(t, err)
+	assert.Empty(entries, "verified request spool must be removed after publication")
+}
+
+func TestMistralWorkerRecordsSanitizedRetryWithoutPublishing(t *testing.T) {
+	assert := assert.New(t)
+	content := []byte("%PDF-1.7\nretry")
+	hash := sha256.Sum256(content)
+	catalog := &workerCatalog{}
+	processor := &workerProcessor{err: mistral.ErrTransientResponse}
+	worker := newTestMistralWorker(
+		t, catalog, &workerOpener{content: content}, processor, allPassingCapabilityManifest(t),
+	)
+
+	_, err := worker.ProcessCandidate(t.Context(), store.DocumentExtractionCandidate{
+		AttachmentID: 1, CanonicalBlobHash: hex.EncodeToString(hash[:]), MIMEType: "application/pdf",
+		Size: int64(len(content)), MessageType: "email", SourceSequence: 1,
+	})
+	require.ErrorIs(t, err, mistral.ErrTransientResponse)
+	require.NotNil(t, catalog.failure)
+	assert.False(catalog.failure.Terminal)
+	assert.Equal("provider_transient", catalog.failure.ReasonCode)
+	assert.True(catalog.failure.RetryAt.After(time.Now().UTC()))
+	assert.Nil(catalog.publication)
+}
+
+func TestMistralWorkerReleasesClaimAfterRequestCancellation(t *testing.T) {
+	content := []byte("%PDF-1.7\ncanceled")
+	hash := sha256.Sum256(content)
+	catalog := &workerCatalog{}
+	ctx, cancel := context.WithCancel(t.Context())
+	processor := &workerProcessor{err: context.Canceled, cancel: cancel}
+	worker := newTestMistralWorker(
+		t, catalog, &workerOpener{content: content}, processor, allPassingCapabilityManifest(t),
+	)
+
+	_, err := worker.ProcessCandidate(ctx, store.DocumentExtractionCandidate{
+		AttachmentID: 1, CanonicalBlobHash: hex.EncodeToString(hash[:]), MIMEType: "application/pdf",
+		Size: int64(len(content)), MessageType: "email", SourceSequence: 1,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, catalog.failure)
+	require.NoError(t, catalog.failureContextErr, "claim cleanup must outlive the canceled request context")
+	assert.False(t, catalog.failure.Terminal)
+	assert.Equal(t, "provider_interrupted", catalog.failure.ReasonCode)
+}
+
+func TestMistralWorkerReleasesClaimAfterPublicationFailure(t *testing.T) {
+	content := []byte("%PDF-1.7\npublication failure")
+	hash := sha256.Sum256(content)
+	catalog := &workerCatalog{publishErr: errors.New("synthetic publication failure")}
+	processor := &workerProcessor{result: mistral.Result{
+		Model:     "mistral-ocr-4-0",
+		Pages:     []mistral.Page{{Index: 0, Markdown: "searchable evidence"}},
+		UsageInfo: &mistral.Usage{PagesProcessed: 1},
+	}}
+	worker := newTestMistralWorker(
+		t, catalog, &workerOpener{content: content}, processor, allPassingCapabilityManifest(t),
+	)
+
+	_, err := worker.ProcessCandidate(t.Context(), store.DocumentExtractionCandidate{
+		AttachmentID: 1, CanonicalBlobHash: hex.EncodeToString(hash[:]), MIMEType: "application/pdf",
+		Size: int64(len(content)), MessageType: "email", SourceSequence: 1,
+	})
+	require.ErrorIs(t, err, errDocumentPublication)
+	require.NotNil(t, catalog.failure)
+	assert.False(t, catalog.failure.Terminal)
+	assert.Equal(t, "publication_failed", catalog.failure.ReasonCode)
+}
+
+func TestMistralWorkerCancelsProcessingWhenLeaseRenewalFails(t *testing.T) {
+	content := []byte("%PDF-1.7\nrenewal failure")
+	hash := sha256.Sum256(content)
+	catalog := &workerCatalog{renewErr: errors.New("synthetic renewal failure")}
+	processor := &workerProcessor{block: make(chan struct{})}
+	worker := newTestMistralWorker(
+		t, catalog, &workerOpener{content: content}, processor, allPassingCapabilityManifest(t),
+	)
+	worker.config.LeaseDuration = 15 * time.Millisecond
+
+	_, err := worker.ProcessCandidate(t.Context(), store.DocumentExtractionCandidate{
+		AttachmentID: 1, CanonicalBlobHash: hex.EncodeToString(hash[:]), MIMEType: "application/pdf",
+		Size: int64(len(content)), MessageType: "email", SourceSequence: 1,
+	})
+	require.ErrorIs(t, err, errDocumentLeaseRenewal)
+	assert.Positive(t, catalog.renewals.Load())
+	require.NotNil(t, catalog.failure)
+	assert.False(t, catalog.failure.Terminal)
+	assert.Equal(t, "lease_renewal_failed", catalog.failure.ReasonCode)
+}
+
+func TestMistralWorkerRejectsFormatWithoutPassingProbeBeforeReadingBytes(t *testing.T) {
+	manifest := capabilityManifestWithFailure(t, "docx")
+	opener := &workerOpener{content: []byte("unused")}
+	worker := newTestMistralWorker(t, &workerCatalog{}, opener, &workerProcessor{}, manifest)
+
+	_, err := worker.ProcessCandidate(t.Context(), store.DocumentExtractionCandidate{
+		AttachmentID:      1,
+		CanonicalBlobHash: strings.Repeat("a", 64),
+		MIMEType:          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		Size:              10, MessageType: "email",
+	})
+	require.ErrorContains(t, err, "lacks passing capability authority")
+	assert.Zero(t, opener.opened)
+}
+
+func TestMistralWorkerClaimsBeforeWritingPrivateSpool(t *testing.T) {
+	content := []byte("%PDF-1.7\nduplicate")
+	hash := sha256.Sum256(content)
+	catalog := &workerCatalog{claimErr: store.ErrDocumentExtractionClaimed}
+	opener := &workerOpener{content: content}
+	worker := newTestMistralWorker(t, catalog, opener, &workerProcessor{}, allPassingCapabilityManifest(t))
+
+	_, err := worker.ProcessCandidate(t.Context(), store.DocumentExtractionCandidate{
+		AttachmentID: 1, CanonicalBlobHash: hex.EncodeToString(hash[:]), MIMEType: "application/pdf",
+		Size: int64(len(content)), MessageType: "email", SourceSequence: 1,
+	})
+	require.ErrorIs(t, err, store.ErrDocumentExtractionClaimed)
+	entries, readErr := os.ReadDir(worker.config.SpoolDirectory)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "a rejected claim must not reserve or write private spool bytes")
+}
+
+func TestMistralWorkerRejectsProviderOutputBeyondPageLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	content := []byte("%PDF-1.7\noversized output")
+	hash := sha256.Sum256(content)
+	catalog := &workerCatalog{}
+	processor := &workerProcessor{result: mistral.Result{
+		Model: "mistral-ocr-4-0", Pages: make([]mistral.Page, 101),
+		UsageInfo: &mistral.Usage{PagesProcessed: 101},
+	}}
+	worker := newTestMistralWorker(
+		t, catalog, &workerOpener{content: content}, processor, allPassingCapabilityManifest(t),
+	)
+
+	_, err := worker.ProcessCandidate(t.Context(), store.DocumentExtractionCandidate{
+		AttachmentID: 1, CanonicalBlobHash: hex.EncodeToString(hash[:]), MIMEType: "application/pdf",
+		Size: int64(len(content)), MessageType: "email", SourceSequence: 1,
+	})
+	require.ErrorContains(err, "returned 101 units, limit 100")
+	require.NotNil(catalog.failure)
+	assert.True(catalog.failure.Terminal)
+	assert.Equal("invalid_provider_output", catalog.failure.ReasonCode)
+	assert.Nil(catalog.publication)
+}
+
+func newTestMistralWorker(
+	t *testing.T,
+	catalog DocumentExtractionCatalog,
+	opener DocumentAttachmentOpener,
+	processor mistral.Processor,
+	manifest mistral.CapabilityManifest,
+) *MistralWorker {
+	t.Helper()
+	spoolDirectory := t.TempDir()
+	require.NoError(t, os.Chmod(spoolDirectory, 0o700))
+	worker, err := NewMistralWorker(catalog, opener, processor, MistralWorkerConfig{
+		ProfileID: "profile-test", LeaseOwner: "worker-test", LeaseDuration: 30 * time.Minute,
+		RetryDelay: 5 * time.Minute, SpoolDirectory: spoolDirectory,
+		MaxFileBytes: 1 << 20, MaxSpoolBytes: 2 << 20, MinFreeBytes: 1, MaxPages: 100,
+		NormalizePolicy: DefaultNormalizePolicy(1_000_000), CapabilityPolicy: manifest,
+	})
+	require.NoError(t, err)
+	return worker
+}
+
+func allPassingCapabilityManifest(t *testing.T) mistral.CapabilityManifest {
+	t.Helper()
+	return runCapabilityManifest(t, "")
+}
+
+func capabilityManifestWithFailure(t *testing.T, failedID string) mistral.CapabilityManifest {
+	t.Helper()
+	return runCapabilityManifest(t, failedID)
+}
+
+func runCapabilityManifest(t *testing.T, failedID string) mistral.CapabilityManifest {
+	t.Helper()
+	processor := &capabilityProcessor{failedID: failedID}
+	documents := make(map[string]mistral.Document)
+	for _, format := range mistral.CandidateFormats() {
+		documents[format.ID] = mistral.Document{
+			MediaType: format.MediaType, Size: 1, SHA256: strings.Repeat("a", 64),
+		}
+	}
+	manifest, err := mistral.RunCapabilityProbe(t.Context(), processor, documents, mistral.ProbeConfig{
+		ObservedAt: time.Now().UTC(), MaxPages: 100,
+	})
+	require.NoError(t, err)
+	return manifest
+}
+
+type capabilityProcessor struct {
+	failedID string
+	calls    int
+}
+
+func (p *capabilityProcessor) Process(
+	_ context.Context,
+	document mistral.Document,
+	_ mistral.Options,
+) (mistral.Result, error) {
+	format, ok := mistral.CandidateFormatByMediaType(document.MediaType)
+	if !ok {
+		return mistral.Result{}, errors.New("unexpected media type")
+	}
+	if format.ID == p.failedID {
+		return mistral.Result{}, mistral.ErrPermanentResponse
+	}
+	p.calls++
+	bytes := document.Size
+	sentinel, err := mistral.ProbeFixtureSentinel(format.ID)
+	if err != nil {
+		return mistral.Result{}, err
+	}
+	return mistral.Result{
+		Model: "mistral-ocr-4-0", Pages: []mistral.Page{{Index: 0, Markdown: sentinel}},
+		UsageInfo: &mistral.Usage{PagesProcessed: 1, DocSizeBytes: &bytes},
+	}, nil
+}
+
+func (p *capabilityProcessor) Target() mistral.ProcessorTarget {
+	return mistral.ProcessorTarget{
+		Endpoint: "https://api.mistral.ai/v1/ocr", Region: "eu", Model: "mistral-ocr-4-0",
+	}
+}

--- a/internal/fbmessenger/importer.go
+++ b/internal/fbmessenger/importer.go
@@ -724,7 +724,18 @@ func writeThreadToStore(
 			} else if err := deleteFailedStoredAttachment(st, messageID, contentHash); err != nil {
 				logger.Warn("fbmessenger: delete failed stored attachment", "err", err)
 			}
-			if err := st.UpsertAttachment(messageID, att.Filename, att.MimeType, storagePath, hash, size); err != nil {
+			role := store.AttachmentRoleStandalone
+			roleSource := store.AttachmentRoleSourceImporterSemantics
+			if att.Kind == "sticker" {
+				role = store.AttachmentRoleSticker
+				roleSource = store.AttachmentRoleSourceProviderExplicit
+			}
+			if err := st.UpsertAttachmentRecord(ctx, messageID, store.AttachmentWrite{
+				Filename: att.Filename, MIMEType: att.MimeType, StoragePath: storagePath,
+				ContentHash: hash, Size: int64(size), SourceAttachmentID: att.URI,
+				MediaType: att.Kind, Role: role, RoleSource: roleSource,
+				SourcePartKey: syntheticHash,
+			}); err != nil {
 				logger.Warn("fbmessenger: upsert attachment", "err", err)
 				continue
 			}

--- a/internal/fbmessenger/importer_test.go
+++ b/internal/fbmessenger/importer_test.go
@@ -249,14 +249,19 @@ func TestImportDYI_AttachmentStorage(t *testing.T) {
 	require.NoError(err)
 	wantHash := fmt.Sprintf("%x", sha256.Sum256(png))
 
-	var contentHash, storagePath string
+	var contentHash, storagePath, role, roleSource, sourcePartKey string
 	var size int64
 	err = st.DB().QueryRow(
-		"SELECT content_hash, storage_path, size FROM attachments LIMIT 1",
-	).Scan(&contentHash, &storagePath, &size)
+		`SELECT content_hash, storage_path, size, attachment_role,
+		        role_source, COALESCE(source_part_key, '')
+		 FROM attachments LIMIT 1`,
+	).Scan(&contentHash, &storagePath, &size, &role, &roleSource, &sourcePartKey)
 	require.NoError(err)
 	assert.Equal(wantHash, contentHash, "content_hash")
 	assert.NotEmpty(storagePath, "storage_path")
+	assert.Equal(string(store.AttachmentRoleStandalone), role, "attachment_role")
+	assert.Equal(string(store.AttachmentRoleSourceImporterSemantics), roleSource, "role_source")
+	assert.NotEmpty(sourcePartKey, "source_part_key")
 	absStorage := filepath.Join(attachDir, storagePath)
 	got, err := os.ReadFile(absStorage)
 	require.NoError(err, "stored file")

--- a/internal/importer/ingest.go
+++ b/internal/importer/ingest.go
@@ -321,8 +321,18 @@ func storeAttachment(
 	if err != nil || storagePath == "" {
 		return err
 	}
-	return st.UpsertAttachment(
-		messageID, att.Filename, att.ContentType,
-		storagePath, att.ContentHash, len(att.Content),
+	role, roleSource := store.AttachmentRoleFromMIME(
+		att.Disposition, att.IsInline, att.ContentID,
 	)
+	return st.UpsertAttachmentRecord(context.Background(), messageID, store.AttachmentWrite{
+		Filename:      att.Filename,
+		MIMEType:      att.ContentType,
+		StoragePath:   storagePath,
+		ContentHash:   att.ContentHash,
+		Size:          int64(len(att.Content)),
+		Role:          role,
+		RoleSource:    roleSource,
+		SourcePartKey: att.PartKey,
+		ContentID:     att.ContentID,
+	})
 }

--- a/internal/importer/mbox_import_security_test.go
+++ b/internal/importer/mbox_import_security_test.go
@@ -90,6 +90,59 @@ func TestStoreAttachment_ComputesContentHashWhenMissing(t *testing.T) {
 	assert.Equal(1, count)
 }
 
+func TestStoreAttachmentPreservesMIMEOccurrenceEvidence(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmp := t.TempDir()
+	st, err := store.Open(filepath.Join(tmp, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchema())
+
+	src, err := st.GetOrCreateSource("mbox", "me@example.com")
+	require.NoError(err)
+	convID, err := st.EnsureConversation(src.ID, "thread-role", "Thread")
+	require.NoError(err)
+	msgID, err := st.UpsertMessage(&store.Message{
+		ConversationID: convID, SourceID: src.ID,
+		SourceMessageID: "msg-role", MessageType: "email",
+	})
+	require.NoError(err)
+
+	attachmentsDir := filepath.Join(tmp, "attachments")
+	for _, att := range []*mime.Attachment{
+		{
+			Filename: "report.pdf", ContentType: "application/pdf",
+			Content: []byte("standalone"), Disposition: "attachment", PartKey: "mime:1",
+		},
+		{
+			Filename: "signature.png", ContentType: "image/png",
+			Content: []byte("inline"), Disposition: "inline", IsInline: true,
+			ContentID: "signature-1", PartKey: "mime:2",
+		},
+	} {
+		require.NoError(storeAttachment(st, attachmentsDir, msgID, att))
+	}
+
+	rows, err := st.DB().Query(`
+		SELECT attachment_role, role_source, source_part_key, COALESCE(content_id, '')
+		FROM attachments WHERE message_id = ? ORDER BY source_part_key`, msgID)
+	require.NoError(err)
+	defer func() { _ = rows.Close() }()
+	type evidence struct{ role, source, partKey, contentID string }
+	var got []evidence
+	for rows.Next() {
+		var item evidence
+		require.NoError(rows.Scan(&item.role, &item.source, &item.partKey, &item.contentID))
+		got = append(got, item)
+	}
+	require.NoError(rows.Err())
+	assert.Equal([]evidence{
+		{role: "standalone", source: "mime_disposition", partKey: "mime:1"},
+		{role: "inline", source: "mime_disposition", partKey: "mime:2", contentID: "signature-1"},
+	}, got)
+}
+
 func TestStoreAttachment_StatError_DoesNotUpsertRow(t *testing.T) {
 	require := require.New(t)
 	if runtime.GOOS == "windows" {

--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 const (
@@ -28,6 +29,7 @@ type catalogCapabilities struct {
 	semanticSearch  bool
 	vectorInMessage bool
 	similarMessages bool
+	documentSearch  bool
 }
 
 type catalogToolHandler func(*handlers, context.Context, toolRequest) (*toolResult, error)
@@ -64,23 +66,25 @@ func capabilitiesFor(opts ServeOptions) catalogCapabilities {
 		semanticSearch:  opts.HybridEngine != nil || opts.HybridSearcher != nil,
 		vectorInMessage: opts.HybridEngine != nil && opts.Backend != nil,
 		similarMessages: opts.Backend != nil || opts.SimilarSearcher != nil,
+		documentSearch:  opts.DocumentSearcher != nil,
 	}
 }
 
 // stableOperationCatalogs owns the immutable schemas registered with the SDK.
 // The SDK v1.7 schema cache keys explicit schemas by pointer identity, so a
 // stateless server must reuse these roots instead of rebuilding them per HTTP
-// request. There are only eight possible capability keys, which also keeps the
+// request. There are only sixteen possible capability keys, which also keeps the
 // shared SDK cache boundary fixed.
 var stableOperationCatalogs = buildOperationCatalogs()
 
 func buildOperationCatalogs() map[catalogCapabilities][]toolDefinition {
-	catalogs := make(map[catalogCapabilities][]toolDefinition, 8)
-	for mask := range 8 {
+	catalogs := make(map[catalogCapabilities][]toolDefinition, 16)
+	for mask := range 16 {
 		capabilities := catalogCapabilities{
-			semanticSearch:  mask&0b100 != 0,
-			vectorInMessage: mask&0b010 != 0,
-			similarMessages: mask&0b001 != 0,
+			semanticSearch:  mask&0b1000 != 0,
+			vectorInMessage: mask&0b0100 != 0,
+			similarMessages: mask&0b0010 != 0,
+			documentSearch:  mask&0b0001 != 0,
 		}
 		catalogs[capabilities] = buildOperationCatalog(capabilities)
 	}
@@ -101,6 +105,7 @@ func buildOperationCatalog(capabilities catalogCapabilities) []toolDefinition {
 		getStatsDefinition(nil),
 		listMessagesDefinition(nil),
 		searchByDomainsDefinition(nil),
+		searchDocumentsDefinition(nil),
 		searchInMessageDefinition(nil, capabilities.vectorInMessage),
 		searchMessageBodiesDefinition(nil),
 		searchMessagesDefinition(nil, capabilities.semanticSearch),
@@ -158,6 +163,8 @@ func writeDefinition(
 func alwaysAvailable(catalogCapabilities) bool { return true }
 
 func similarMessagesAvailable(c catalogCapabilities) bool { return c.similarMessages }
+
+func documentSearchAvailable(c catalogCapabilities) bool { return c.documentSearch }
 
 func toolAnnotations(readOnly bool) *sdkmcp.ToolAnnotations {
 	falseValue := false
@@ -599,6 +606,34 @@ func findSimilarMessagesDefinition(_ *handlers) toolDefinition {
 		(*handlers).findSimilarMessages,
 	)
 	definition.availability = similarMessagesAvailable
+	return definition
+}
+
+func searchDocumentsDefinition(_ *handlers) toolDefinition {
+	limit := boundedIntegerSchema("Maximum results to return (default 20, max 100)", 1, 100)
+	limit.Default = json.RawMessage("20")
+	definition := readDefinition(
+		ToolSearchDocuments,
+		"Search locally indexed content and filenames from standalone document attachments extracted by the configured document provider. Results preserve the exact attachment occurrence, containing message, unit range, excerpt, and provider/model provenance. Paginate with the opaque cursor; restart when the index revision changes.",
+		closedObject(map[string]*jsonschema.Schema{
+			"query": stringSchema("Document content or filename query; terms are ANDed"),
+			"source_ids": {
+				Type: "array", Description: "Optional source ID scope",
+				Items: safeIDSchema("Source ID"),
+			},
+			"message_types": {
+				Type: "array", Description: "Optional containing message type scope",
+				Items: stringSchema("Containing message type"),
+			},
+			"attachment_id": safeIDSchema("Optional exact attachment occurrence ID"),
+			"message_id":    safeIDSchema("Optional exact containing message ID"),
+			"limit":         limit,
+			"cursor":        stringSchema("Opaque cursor from the previous page"),
+		}, "query"),
+		outputSchemaFor[store.DocumentSearchResponse](),
+		(*handlers).searchDocuments,
+	)
+	definition.availability = documentSearchAvailable
 	return definition
 }
 

--- a/internal/mcp/catalog_test.go
+++ b/internal/mcp/catalog_test.go
@@ -178,16 +178,19 @@ func TestCatalogSchemaPointersStableAcrossServerConstruction(t *testing.T) {
 	remoteSimilar := similarSearcherFunc(func(context.Context, SimilarSearchRequest) (*SimilarSearchResult, error) {
 		return &SimilarSearchResult{}, nil
 	})
+	documents := &recordingDocumentSearcher{}
 
 	shapes := []struct {
 		name string
 		opts ServeOptions
 	}{
-		{name: "000", opts: ServeOptions{Engine: &querytest.MockEngine{}}},
-		{name: "100", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid}},
-		{name: "001", opts: ServeOptions{Engine: &querytest.MockEngine{}, SimilarSearcher: remoteSimilar}},
-		{name: "101", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid, SimilarSearcher: remoteSimilar}},
-		{name: "111", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridEngine: localHybrid, Backend: backend}},
+		{name: "0000", opts: ServeOptions{Engine: &querytest.MockEngine{}}},
+		{name: "1000", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid}},
+		{name: "0010", opts: ServeOptions{Engine: &querytest.MockEngine{}, SimilarSearcher: remoteSimilar}},
+		{name: "1010", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid, SimilarSearcher: remoteSimilar}},
+		{name: "1110", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridEngine: localHybrid, Backend: backend}},
+		{name: "0001", opts: ServeOptions{Engine: &querytest.MockEngine{}, DocumentSearcher: documents}},
+		{name: "1111", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridEngine: localHybrid, Backend: backend, DocumentSearcher: documents}},
 	}
 
 	for _, shape := range shapes {
@@ -223,6 +226,7 @@ func TestCatalogSchemas(t *testing.T) {
 	remoteSimilar := similarSearcherFunc(func(context.Context, SimilarSearchRequest) (*SimilarSearchResult, error) {
 		return &SimilarSearchResult{}, nil
 	})
+	documents := &recordingDocumentSearcher{}
 
 	shapes := []struct {
 		name            string
@@ -230,12 +234,15 @@ func TestCatalogSchemas(t *testing.T) {
 		semantic        bool
 		vectorInMessage bool
 		similar         bool
+		document        bool
 	}{
-		{name: "000", opts: ServeOptions{Engine: &querytest.MockEngine{}}},
-		{name: "100", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid}, semantic: true},
-		{name: "001", opts: ServeOptions{Engine: &querytest.MockEngine{}, SimilarSearcher: remoteSimilar}, similar: true},
-		{name: "101", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid, SimilarSearcher: remoteSimilar}, semantic: true, similar: true},
-		{name: "111", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridEngine: localHybrid, Backend: backend}, semantic: true, vectorInMessage: true, similar: true},
+		{name: "0000", opts: ServeOptions{Engine: &querytest.MockEngine{}}},
+		{name: "1000", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid}, semantic: true},
+		{name: "0010", opts: ServeOptions{Engine: &querytest.MockEngine{}, SimilarSearcher: remoteSimilar}, similar: true},
+		{name: "1010", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridSearcher: remoteHybrid, SimilarSearcher: remoteSimilar}, semantic: true, similar: true},
+		{name: "1110", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridEngine: localHybrid, Backend: backend}, semantic: true, vectorInMessage: true, similar: true},
+		{name: "0001", opts: ServeOptions{Engine: &querytest.MockEngine{}, DocumentSearcher: documents}, document: true},
+		{name: "1111", opts: ServeOptions{Engine: &querytest.MockEngine{}, HybridEngine: localHybrid, Backend: backend, DocumentSearcher: documents}, semantic: true, vectorInMessage: true, similar: true, document: true},
 	}
 
 	for _, shape := range shapes {
@@ -268,6 +275,9 @@ func TestCatalogSchemas(t *testing.T) {
 				if shape.similar {
 					expectedNames = append(expectedNames, "find_similar_messages")
 				}
+				if shape.document {
+					expectedNames = append(expectedNames, ToolSearchDocuments)
+				}
 				if allowWrites {
 					expectedNames = append(expectedNames, "export_attachment", "stage_deletion")
 				}
@@ -295,6 +305,12 @@ func TestCatalogSchemas(t *testing.T) {
 					checks.Equal(
 						[]string{"account", "after", "before", "has_attachment", "limit", "message_id", "message_type"},
 						toolPropertyNames(t, byName[ToolFindSimilarMessages]),
+					)
+				}
+				if shape.document {
+					checks.Equal(
+						[]string{"attachment_id", "cursor", "limit", "message_id", "message_types", "query", "source_ids"},
+						toolPropertyNames(t, byName[ToolSearchDocuments]),
 					)
 				}
 
@@ -330,6 +346,8 @@ func TestCatalogSchemas(t *testing.T) {
 		{ToolGetAttachment, "attachment_id"},
 		{ToolExportAttachment, "attachment_id"},
 		{ToolFindSimilarMessages, "message_id"},
+		{ToolSearchDocuments, "attachment_id"},
+		{ToolSearchDocuments, "message_id"},
 		{ToolListMessages, "conversation_id"},
 		{ToolSearchInMessage, "id"},
 	} {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/chunkmatch"
 	"go.kenn.io/msgvault/internal/vector/embed"
@@ -106,6 +107,7 @@ type handlers struct {
 	hybridSearcher   HybridSearcher
 	similarSearcher  SimilarSearcher
 	dataDir          string
+	documentSearcher DocumentSearcher
 
 	// Optional vector-search wiring. When hybridEngine is nil, the
 	// search_message_bodies handler rejects mode=vector and mode=hybrid with
@@ -115,6 +117,13 @@ type handlers struct {
 	hybridEngine *hybrid.Engine
 	vectorCfg    vector.Config
 	backend      vector.Backend
+}
+
+// DocumentSearcher runs the dedicated extracted-document retrieval contract.
+// Daemon-backed MCP supplies an HTTP client implementation, keeping this MCP
+// process out of the archive database.
+type DocumentSearcher interface {
+	SearchDocuments(ctx context.Context, request store.DocumentSearchRequest) (store.DocumentSearchResponse, error)
 }
 
 // AttachmentReader fetches content-addressed attachment bytes. It is optional:
@@ -425,6 +434,53 @@ func (h *handlers) searchMetadata(ctx context.Context, req toolRequest) (*toolRe
 	}
 
 	return jsonResult(searchMetadataResponse(newPaginatedResponse(results, totalMatched, offset)))
+}
+
+func (h *handlers) searchDocuments(ctx context.Context, req toolRequest) (*toolResult, error) {
+	args := req.GetArguments()
+	queryText, _ := args["query"].(string)
+	if strings.TrimSpace(queryText) == "" {
+		return toolErrorResult("query parameter is required"), nil
+	}
+	if h.documentSearcher == nil {
+		return toolErrorResult("document_search_unavailable: document attachment search is not configured"), nil
+	}
+	sourceIDs, err := positiveInt64ArrayArg(args, "source_ids")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	messageTypes, err := stringArrayArg(args, "message_types")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	attachmentID, err := positiveInt64Arg(args, "attachment_id")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	messageID, err := positiveInt64Arg(args, "message_id")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	limit := 20
+	if _, found := args["limit"]; found {
+		parsedLimit, parseErr := positiveInt64Arg(args, "limit")
+		if parseErr != nil {
+			return toolErrorResult(parseErr.Error()), nil
+		}
+		if parsedLimit > 100 {
+			return toolErrorResult("limit must be an integer between 1 and 100"), nil
+		}
+		limit = int(parsedLimit)
+	}
+	cursor, _ := args["cursor"].(string)
+	response, err := h.documentSearcher.SearchDocuments(ctx, store.DocumentSearchRequest{
+		Query: queryText, SourceIDs: sourceIDs, MessageTypes: messageTypes,
+		AttachmentID: attachmentID, MessageID: messageID, PageSize: limit, Cursor: cursor,
+	})
+	if err != nil {
+		return toolErrorResult(fmt.Sprintf("document search failed: %v", err)), nil
+	}
+	return jsonResult(response)
 }
 
 func unsupportedSearchOperatorMessage(q *search.Query) string {
@@ -1731,6 +1787,59 @@ func similarLimitArg(args map[string]any) int {
 		return defaultSearchLimit
 	}
 	return limit
+}
+
+func positiveInt64Arg(args map[string]any, key string) (int64, error) {
+	raw, found := args[key]
+	if !found {
+		return 0, nil
+	}
+	value, ok := raw.(float64)
+	if !ok || math.IsNaN(value) || math.IsInf(value, 0) || value <= 0 ||
+		value >= float64(math.MaxInt64) || math.Trunc(value) != value {
+		return 0, fmt.Errorf("%s must be a positive integer", key)
+	}
+	return int64(value), nil
+}
+
+func positiveInt64ArrayArg(args map[string]any, key string) ([]int64, error) {
+	raw, found := args[key]
+	if !found {
+		return nil, nil
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array of positive integers", key)
+	}
+	result := make([]int64, 0, len(values))
+	for _, value := range values {
+		parsed, err := positiveInt64Arg(map[string]any{key: value}, key)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, parsed)
+	}
+	return result, nil
+}
+
+func stringArrayArg(args map[string]any, key string) ([]string, error) {
+	raw, found := args[key]
+	if !found {
+		return nil, nil
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array of nonempty strings", key)
+	}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		text, ok := value.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return nil, fmt.Errorf("%s must be an array of nonempty strings", key)
+		}
+		result = append(result, text)
+	}
+	return result, nil
 }
 
 // maxStageDeletionResults limits how many messages can be staged in one call.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -36,6 +36,7 @@ const (
 	ToolSearchByDomains        = "search_by_domains"
 	ToolFindSimilarMessages    = "find_similar_messages"
 	ToolSearchInMessage        = "search_in_message"
+	ToolSearchDocuments        = "search_document_attachments"
 )
 
 // search_message_bodies/search_in_message mode values (wire format).
@@ -57,6 +58,7 @@ type ServeOptions struct {
 	HybridSearcher   HybridSearcher
 	SimilarSearcher  SimilarSearcher
 	DataDir          string
+	DocumentSearcher DocumentSearcher
 
 	// HybridEngine is optional. When nil, semantic_search_messages rejects
 	// vector/hybrid searches with a vector_not_enabled error.
@@ -182,6 +184,7 @@ func newMCPServerWithPolicy(
 		hybridSearcher:   opts.HybridSearcher,
 		similarSearcher:  opts.SimilarSearcher,
 		dataDir:          opts.DataDir,
+		documentSearcher: opts.DocumentSearcher,
 		hybridEngine:     opts.HybridEngine,
 		vectorCfg:        opts.VectorCfg,
 		backend:          opts.Backend,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -28,6 +28,7 @@ import (
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/query/querytest"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 	"go.kenn.io/msgvault/internal/vector"
@@ -295,6 +296,57 @@ func TestSearchMetadata(t *testing.T) {
 	})
 }
 
+type recordingDocumentSearcher struct {
+	request store.DocumentSearchRequest
+}
+
+func (s *recordingDocumentSearcher) SearchDocuments(
+	_ context.Context,
+	request store.DocumentSearchRequest,
+) (store.DocumentSearchResponse, error) {
+	s.request = request
+	return store.DocumentSearchResponse{
+		Revision: 4,
+		Results: []store.DocumentSearchResult{{
+			AttachmentID: 17, MessageID: 18, Filename: "inspection.xlsx",
+			OccurrenceKey: "occurrence", CanonicalBlobHash: "hash", ChunkKey: "chunk",
+			Excerpt: "carton damage", ProfileID: "profile", ExtractionID: "extraction",
+			Provider: "mistral", Model: "ocr", MatchedSignals: []string{"content"}, Rank: 1,
+		}},
+	}, nil
+}
+
+func TestSearchDocumentAttachmentsPreservesScopeAndProvenance(t *testing.T) {
+	assert := assert.New(t)
+	searcher := &recordingDocumentSearcher{}
+	h := &handlers{documentSearcher: searcher}
+	response := runTool[store.DocumentSearchResponse](t, ToolSearchDocuments, h.searchDocuments, map[string]any{
+		"query": "carton damage", "source_ids": []any{float64(3), float64(7)},
+		"message_types": []any{"email", "mms"}, "attachment_id": float64(17),
+		"message_id": float64(18), "limit": float64(5), "cursor": "opaque",
+	})
+	assert.Equal("carton damage", searcher.request.Query)
+	assert.Equal([]int64{3, 7}, searcher.request.SourceIDs)
+	assert.Equal([]string{"email", "mms"}, searcher.request.MessageTypes)
+	assert.Equal(int64(17), searcher.request.AttachmentID)
+	assert.Equal(int64(18), searcher.request.MessageID)
+	assert.Equal(5, searcher.request.PageSize)
+	assert.Equal("opaque", searcher.request.Cursor)
+	require.Len(t, response.Results, 1)
+	assert.Equal("inspection.xlsx", response.Results[0].Filename)
+	assert.Equal("mistral", response.Results[0].Provider)
+}
+
+func TestSearchDocumentAttachmentsRejectsOutOfRangeExactID(t *testing.T) {
+	searcher := &recordingDocumentSearcher{}
+	h := &handlers{documentSearcher: searcher}
+	result := runToolExpectError(t, ToolSearchDocuments, h.searchDocuments, map[string]any{
+		"query": "carton damage", "attachment_id": math.Exp2(63),
+	})
+	assert.Contains(t, resultText(t, result), "attachment_id must be a positive integer")
+	assert.Empty(t, searcher.request.Query, "an invalid exact filter must never be silently dropped")
+}
+
 func TestSearchRejectsInvalidQueryBeforeDispatch(t *testing.T) {
 	queries := []struct {
 		name string
@@ -533,6 +585,7 @@ func TestSearchMessageBodies(t *testing.T) {
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
+				assert := assert.New(t)
 				var searchRan bool
 				invalid := &listAccountsTrackingEngine{
 					MockEngine: &querytest.MockEngine{
@@ -547,10 +600,10 @@ func TestSearchMessageBodies(t *testing.T) {
 					newTestHandlers(invalid).searchMessageBodies,
 					map[string]any{"query": tc.query, "account": "alice@example.com"})
 				txt := resultText(t, r)
-				assert.Contains(t, txt, "invalid value")
-				assert.Contains(t, txt, tc.op)
-				assert.False(t, invalid.listAccountsCalled, "invalid query must not resolve account filters")
-				assert.False(t, searchRan, "invalid query must not reach body search")
+				assert.Contains(txt, "invalid value")
+				assert.Contains(txt, tc.op)
+				assert.False(invalid.listAccountsCalled, "invalid query must not resolve account filters")
+				assert.False(searchRan, "invalid query must not reach body search")
 			})
 		}
 	})

--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -49,6 +49,8 @@ type Attachment struct {
 	Filename    string
 	ContentType string
 	ContentID   string
+	Disposition string
+	PartKey     string
 	Size        int
 	ContentHash string // SHA-256 of content
 	Content     []byte
@@ -307,11 +309,18 @@ func processParts(parts []*enmime.Part, isInline bool) []Attachment {
 func makeAttachment(part *enmime.Part, isInline bool) Attachment {
 	content := part.Content
 	hash := sha256.Sum256(content)
+	disposition := strings.ToLower(strings.TrimSpace(part.Disposition))
+	partKey := ""
+	if part.PartID != "" {
+		partKey = "mime:" + part.PartID
+	}
 
 	return Attachment{
 		Filename:    part.FileName,
 		ContentType: part.ContentType,
 		ContentID:   part.ContentID,
+		Disposition: disposition,
+		PartKey:     partKey,
 		Size:        len(content),
 		ContentHash: hex.EncodeToString(hash[:]),
 		Content:     content,

--- a/internal/mime/parse_test.go
+++ b/internal/mime/parse_test.go
@@ -32,6 +32,40 @@ func parseEmail(t *testing.T, opts emailOptions) *Message {
 	return mustParse(t, makeRawEmail(opts))
 }
 
+func TestParsePreservesAuthoritativeAttachmentEvidence(t *testing.T) {
+	assert := assert.New(t)
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Subject: attachment evidence\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: multipart/mixed; boundary=outer\r\n\r\n" +
+		"--outer\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+		"--outer\r\nContent-Type: application/pdf\r\n" +
+		"Content-Disposition: attachment; filename=report.pdf\r\n\r\npdf\r\n" +
+		"--outer\r\nContent-Type: image/png; name=inline.png\r\n" +
+		"Content-Disposition: inline; filename=inline.png\r\n" +
+		"Content-ID: <inline-1>\r\n\r\npng\r\n" +
+		"--outer--\r\n")
+
+	msg := mustParse(t, raw)
+	require.Len(t, msg.Attachments, 2)
+	assert.Equal("attachment", msg.Attachments[0].Disposition)
+	assert.False(msg.Attachments[0].IsInline)
+	assert.NotEmpty(msg.Attachments[0].PartKey)
+	assert.Equal("inline", msg.Attachments[1].Disposition)
+	assert.True(msg.Attachments[1].IsInline)
+	assert.Equal("inline-1", msg.Attachments[1].ContentID)
+	assert.NotEmpty(msg.Attachments[1].PartKey)
+	assert.NotEqual(msg.Attachments[0].PartKey, msg.Attachments[1].PartKey)
+
+	ambiguous := makeAttachment(&enmime.Part{
+		PartID: "4", ContentType: "image/jpeg", FileName: "ambiguous.jpg", Content: []byte("jpeg"),
+	}, false)
+	assert.Empty(ambiguous.Disposition)
+	assert.False(ambiguous.IsInline)
+	assert.Equal("mime:4", ambiguous.PartKey)
+}
+
 // assertAddress checks that got has exactly wantLen elements and got[idx] has the expected email and (optionally) domain.
 func assertAddress(t *testing.T, got []Address, wantLen, idx int, wantEmail, wantDomain string) {
 	t.Helper()

--- a/internal/slack/importer_test.go
+++ b/internal/slack/importer_test.go
@@ -1644,10 +1644,14 @@ func TestAttachmentRowFailureFailsRun(t *testing.T) {
 	_, err = imp.Import(context.Background(), opts)
 	require.Error(err, "a failed attachment row write must fail the run — the marker was never durable")
 
-	// Heal: the dropped table also lost its migration-created unique index,
-	// so clear that marker before the idempotent re-init (a test-only
+	// Heal: the dropped table also lost its migration-created unique indexes,
+	// so clear those markers before the idempotent re-init (a test-only
 	// artifact of injecting failure via DROP TABLE).
-	_, err = st.DB().Exec(st.Rebind(`DELETE FROM applied_migrations WHERE name = ?`), "attachments_content_hash_unique_index")
+	_, err = st.DB().Exec(st.Rebind(`
+		DELETE FROM applied_migrations WHERE name IN (?, ?)`),
+		"attachments_content_hash_unique_index",
+		"attachment_occurrence_unique_indexes_v1",
+	)
 	require.NoError(err)
 	require.NoError(st.InitSchema())
 	_, err = imp.Import(context.Background(), opts)

--- a/internal/slack/media.go
+++ b/internal/slack/media.go
@@ -170,6 +170,8 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 		sourceAttID := slackAttachmentID(f.ID)
 		seen[sourceAttID] = true
 		if prev, ok := existing[sourceAttID]; ok && prev.ContentHash != "" {
+			prev.Role = store.AttachmentRoleStandalone
+			prev.RoleSource = store.AttachmentRoleSourceProviderExplicit
 			refs = append(refs, prev)
 			continue
 		}
@@ -268,6 +270,8 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 			Size:               len(data),
 			SourceAttachmentID: sourceAttID,
 			MediaType:          mediaTypeOf(f),
+			Role:               store.AttachmentRoleStandalone,
+			RoleSource:         store.AttachmentRoleSourceProviderExplicit,
 		}
 		refs = append(refs, stored)
 		sum.AttachmentsDownloaded++

--- a/internal/slack/media_test.go
+++ b/internal/slack/media_test.go
@@ -146,26 +146,31 @@ func TestPersistFilesLinkRowsAndPendingMarkers(t *testing.T) {
 	require.NoError(err)
 
 	rows, err := st.DB().Query(st.Rebind(`
-		SELECT a.source_attachment_id, COALESCE(a.content_hash, ''), COALESCE(a.media_type, '')
+		SELECT a.source_attachment_id, COALESCE(a.content_hash, ''), COALESCE(a.media_type, ''),
+		       a.attachment_role, a.role_source
 		FROM attachments a JOIN messages m ON m.id = a.message_id
 		WHERE m.source_message_id = ?`), "C01:"+ts(6))
 	require.NoError(err)
 	defer func() { _ = rows.Close() }()
-	got := map[string][2]string{}
+	got := map[string][4]string{}
 	for rows.Next() {
-		var id, hash, mediaType string
-		require.NoError(rows.Scan(&id, &hash, &mediaType))
-		got[id] = [2]string{hash, mediaType}
+		var id, hash, mediaType, role, roleSource string
+		require.NoError(rows.Scan(&id, &hash, &mediaType, &role, &roleSource))
+		got[id] = [4]string{hash, mediaType, role, roleSource}
 	}
 	require.NoError(rows.Err())
 
 	require.Len(got, 3)
 	assert.NotEmpty(got["slack:F_OK"][0], "on-host file downloads into content-addressed storage")
 	assert.Equal("image", got["slack:F_OK"][1])
+	assert.Equal("standalone", got["slack:F_OK"][2])
+	assert.Equal("provider_explicit", got["slack:F_OK"][3])
 	assert.Empty(got["slack:F_EXT"][0])
 	assert.Equal("link", got["slack:F_EXT"][1], "external file records metadata only")
+	assert.Equal("unknown", got["slack:F_EXT"][2])
 	assert.Empty(got["slack:F_BIG"][0])
 	assert.Empty(got["slack:F_BIG"][1], "over-cap file leaves a retryable pending marker")
+	assert.Equal("unknown", got["slack:F_BIG"][2])
 
 	// The pending list sees the over-cap marker but not the link row.
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
@@ -244,6 +249,9 @@ func TestPersistFilesTreatsGoneDownloadsAsTerminalLinks(t *testing.T) {
 				Size:               123,
 				SourceAttachmentID: "slack:F_GONE",
 				MediaType:          "link",
+				Role:               store.AttachmentRoleUnknown,
+				RoleSource:         store.AttachmentRoleSourceUnknown,
+				SourcePartKey:      "slack:F_GONE",
 			}, refs["slack:F_GONE"])
 		})
 	}

--- a/internal/store/attachment_changes.go
+++ b/internal/store/attachment_changes.go
@@ -1,0 +1,352 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+)
+
+type AttachmentChangeConsumer struct {
+	ConsumerKey            string
+	BaselineSequence       int64
+	LastSequence           int64
+	ReconciliationComplete bool
+}
+
+type AttachmentChange struct {
+	Sequence         int64
+	EventKind        string
+	OldMessageID     *int64
+	NewMessageID     *int64
+	OldAttachmentID  *int64
+	NewAttachmentID  *int64
+	OldContentHash   *string
+	NewContentHash   *string
+	OldSourcePartKey *string
+	NewSourcePartKey *string
+	OldRole          *string
+	NewRole          *string
+	CreatedAt        time.Time
+}
+
+var ErrAttachmentChangeConsumerMissing = errors.New("attachment change consumer is not registered")
+
+// RegisterAttachmentChangeConsumer establishes a race-free journal boundary.
+// PostgreSQL explicitly waits out and blocks attachment/message writers;
+// SQLite's first INSERT takes its one database writer lock. Changes committed
+// before that boundary are covered by the required full reconciliation, while
+// every later relevant change is journaled.
+func (s *Store) RegisterAttachmentChangeConsumer(
+	ctx context.Context,
+	consumerKey string,
+) (AttachmentChangeConsumer, bool, error) {
+	if err := validateAttachmentConsumerKey(consumerKey); err != nil {
+		return AttachmentChangeConsumer{}, false, err
+	}
+	var consumer AttachmentChangeConsumer
+	var created bool
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		if s.IsPostgreSQL() {
+			if _, err := q.Exec(`LOCK TABLE attachments, messages IN SHARE MODE`); err != nil {
+				return fmt.Errorf("lock attachment change registration boundary: %w", err)
+			}
+		}
+		result, err := q.Exec(`
+			INSERT INTO attachment_change_consumers
+				(consumer_key, baseline_sequence, last_sequence, reconciliation_complete)
+			VALUES (?, 0, 0, FALSE)
+			ON CONFLICT (consumer_key) DO NOTHING`, consumerKey)
+		if err != nil {
+			return fmt.Errorf("register attachment change consumer: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read attachment consumer registration result: %w", err)
+		}
+		created = rows == 1
+		if created {
+			var baseline int64
+			if err := q.QueryRow(`SELECT COALESCE(MAX(sequence), 0) FROM attachment_change_log`).Scan(&baseline); err != nil {
+				return fmt.Errorf("capture attachment consumer baseline: %w", err)
+			}
+			if _, err := q.Exec(`
+				UPDATE attachment_change_consumers
+				SET baseline_sequence = ?, last_sequence = ?, updated_at = `+s.dialect.Now()+`
+				WHERE consumer_key = ?`, baseline, baseline, consumerKey); err != nil {
+				return fmt.Errorf("record attachment consumer baseline: %w", err)
+			}
+		}
+		return scanAttachmentChangeConsumer(q, consumerKey, &consumer)
+	})
+	return consumer, created, err
+}
+
+func (s *Store) CompleteAttachmentChangeReconciliation(
+	ctx context.Context,
+	consumerKey string,
+	baselineSequence int64,
+) error {
+	if err := validateAttachmentConsumerKey(consumerKey); err != nil || baselineSequence < 0 {
+		if err != nil {
+			return err
+		}
+		return errors.New("attachment reconciliation baseline cannot be negative")
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		result, err := q.Exec(`
+			UPDATE attachment_change_consumers
+			SET reconciliation_complete = TRUE, updated_at = `+s.dialect.Now()+`
+			WHERE consumer_key = ? AND baseline_sequence = ?
+			  AND reconciliation_complete = FALSE`, consumerKey, baselineSequence)
+		if err != nil {
+			return fmt.Errorf("complete attachment change reconciliation: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read attachment reconciliation result: %w", err)
+		}
+		if rows != 1 {
+			var storedBaseline int64
+			var complete bool
+			if err := q.QueryRow(`
+				SELECT baseline_sequence, reconciliation_complete
+				FROM attachment_change_consumers WHERE consumer_key = ?`, consumerKey).
+				Scan(&storedBaseline, &complete); err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return ErrAttachmentChangeConsumerMissing
+				}
+				return fmt.Errorf("recheck attachment reconciliation completion: %w", err)
+			}
+			if storedBaseline == baselineSequence && complete {
+				return nil
+			}
+			return errors.New("attachment change consumer baseline changed concurrently")
+		}
+		return nil
+	})
+}
+
+func (s *Store) GetAttachmentChangeConsumer(
+	ctx context.Context,
+	consumerKey string,
+) (AttachmentChangeConsumer, error) {
+	if err := validateAttachmentConsumerKey(consumerKey); err != nil {
+		return AttachmentChangeConsumer{}, err
+	}
+	q := boundQuerier{ctx: ctx, q: s.db}
+	var consumer AttachmentChangeConsumer
+	if err := scanAttachmentChangeConsumer(q, consumerKey, &consumer); err != nil {
+		return AttachmentChangeConsumer{}, err
+	}
+	return consumer, nil
+}
+
+func (s *Store) ListAttachmentChanges(
+	ctx context.Context,
+	consumerKey string,
+	limit int,
+) ([]AttachmentChange, error) {
+	if err := validateAttachmentConsumerKey(consumerKey); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > 10_000 {
+		return nil, errors.New("attachment change page limit must be between 1 and 10000")
+	}
+	consumer, err := s.GetAttachmentChangeConsumer(ctx, consumerKey)
+	if err != nil {
+		return nil, err
+	}
+	if !consumer.ReconciliationComplete {
+		return nil, errors.New("attachment change consumer requires full reconciliation before replay")
+	}
+	rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(`
+		SELECT sequence, event_kind, old_message_id, new_message_id,
+		       old_attachment_id, new_attachment_id,
+		       old_content_hash, new_content_hash,
+		       old_source_part_key, new_source_part_key,
+		       old_role, new_role, created_at
+		FROM attachment_change_log
+		WHERE sequence > ? ORDER BY sequence LIMIT ?`), consumer.LastSequence, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list attachment changes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	changes := make([]AttachmentChange, 0, limit)
+	for rows.Next() {
+		var change AttachmentChange
+		var oldMessageID, newMessageID, oldAttachmentID, newAttachmentID sql.NullInt64
+		var oldHash, newHash, oldPart, newPart, oldRole, newRole sql.NullString
+		if err := rows.Scan(
+			&change.Sequence, &change.EventKind, &oldMessageID, &newMessageID,
+			&oldAttachmentID, &newAttachmentID, &oldHash, &newHash,
+			&oldPart, &newPart, &oldRole, &newRole, &change.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan attachment change: %w", err)
+		}
+		change.OldMessageID = nullInt64Pointer(oldMessageID)
+		change.NewMessageID = nullInt64Pointer(newMessageID)
+		change.OldAttachmentID = nullInt64Pointer(oldAttachmentID)
+		change.NewAttachmentID = nullInt64Pointer(newAttachmentID)
+		change.OldContentHash = nullStringPointer(oldHash)
+		change.NewContentHash = nullStringPointer(newHash)
+		change.OldSourcePartKey = nullStringPointer(oldPart)
+		change.NewSourcePartKey = nullStringPointer(newPart)
+		change.OldRole = nullStringPointer(oldRole)
+		change.NewRole = nullStringPointer(newRole)
+		changes = append(changes, change)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate attachment changes: %w", err)
+	}
+	return changes, nil
+}
+
+// AdvanceAttachmentChangeConsumer acknowledges an inclusive, previously
+// journaled sequence and prunes only the prefix consumed by every registered
+// feature. Advancing one consumer can never discard another's unread events.
+func (s *Store) AdvanceAttachmentChangeConsumer(
+	ctx context.Context,
+	consumerKey string,
+	sequence int64,
+) error {
+	if err := validateAttachmentConsumerKey(consumerKey); err != nil {
+		return err
+	}
+	if sequence < 0 {
+		return errors.New("attachment change sequence cannot be negative")
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		var current int64
+		var complete bool
+		if err := q.QueryRow(`
+			SELECT last_sequence, reconciliation_complete
+			FROM attachment_change_consumers WHERE consumer_key = ?`, consumerKey).Scan(&current, &complete); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrAttachmentChangeConsumerMissing
+			}
+			return fmt.Errorf("read attachment consumer cursor: %w", err)
+		}
+		if !complete {
+			return errors.New("attachment change consumer reconciliation is incomplete")
+		}
+		if sequence <= current {
+			return pruneAttachmentChanges(q)
+		}
+		if sequence > current {
+			var exists bool
+			if err := q.QueryRow(`SELECT EXISTS (
+				SELECT 1 FROM attachment_change_log WHERE sequence = ?
+			)`, sequence).Scan(&exists); err != nil {
+				return fmt.Errorf("verify attachment change acknowledgement: %w", err)
+			}
+			if !exists {
+				return errors.New("attachment change acknowledgement is not a retained event")
+			}
+			result, err := q.Exec(`
+				UPDATE attachment_change_consumers
+				SET last_sequence = ?, updated_at = `+s.dialect.Now()+`
+				WHERE consumer_key = ? AND last_sequence = ?`, sequence, consumerKey, current)
+			if err != nil {
+				return fmt.Errorf("advance attachment change consumer: %w", err)
+			}
+			updated, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("read attachment consumer advance result: %w", err)
+			}
+			if updated != 1 {
+				var advanced int64
+				if err := q.QueryRow(`
+					SELECT last_sequence FROM attachment_change_consumers
+					WHERE consumer_key = ?`, consumerKey).Scan(&advanced); err != nil {
+					return fmt.Errorf("recheck attachment consumer cursor: %w", err)
+				}
+				if advanced >= sequence {
+					return pruneAttachmentChanges(q)
+				}
+				return errors.New("attachment change consumer cursor changed concurrently")
+			}
+		}
+		return pruneAttachmentChanges(q)
+	})
+}
+
+func (s *Store) UnregisterAttachmentChangeConsumer(ctx context.Context, consumerKey string) error {
+	if err := validateAttachmentConsumerKey(consumerKey); err != nil {
+		return err
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		if s.IsPostgreSQL() {
+			if _, err := q.Exec(`LOCK TABLE attachments, messages IN SHARE MODE`); err != nil {
+				return fmt.Errorf("lock attachment change unregistration boundary: %w", err)
+			}
+		}
+		if _, err := q.Exec(`DELETE FROM attachment_change_consumers WHERE consumer_key = ?`, consumerKey); err != nil {
+			return fmt.Errorf("unregister attachment change consumer: %w", err)
+		}
+		return pruneAttachmentChanges(q)
+	})
+}
+
+func scanAttachmentChangeConsumer(q querier, key string, consumer *AttachmentChangeConsumer) error {
+	err := q.QueryRow(`
+		SELECT consumer_key, baseline_sequence, last_sequence, reconciliation_complete
+		FROM attachment_change_consumers WHERE consumer_key = ?`, key).Scan(
+		&consumer.ConsumerKey, &consumer.BaselineSequence,
+		&consumer.LastSequence, &consumer.ReconciliationComplete,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrAttachmentChangeConsumerMissing
+	}
+	if err != nil {
+		return fmt.Errorf("read attachment change consumer: %w", err)
+	}
+	return nil
+}
+
+func pruneAttachmentChanges(q querier) error {
+	if _, err := q.Exec(`
+		DELETE FROM attachment_change_log
+		WHERE sequence <= COALESCE(
+			(SELECT MIN(last_sequence) FROM attachment_change_consumers),
+			(SELECT COALESCE(MAX(sequence), 0) FROM attachment_change_log)
+		)`); err != nil {
+		return fmt.Errorf("prune consumed attachment changes: %w", err)
+	}
+	return nil
+}
+
+func validateAttachmentConsumerKey(key string) error {
+	if key == "" || len(key) > 200 || strings.TrimSpace(key) != key {
+		return errors.New("attachment change consumer key is invalid")
+	}
+	for _, character := range key {
+		if unicode.IsControl(character) {
+			return errors.New("attachment change consumer key is invalid")
+		}
+	}
+	return nil
+}
+
+func nullInt64Pointer(value sql.NullInt64) *int64 {
+	if !value.Valid {
+		return nil
+	}
+	result := value.Int64
+	return &result
+}
+
+func nullStringPointer(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+	result := value.String
+	return &result
+}

--- a/internal/store/attachment_changes_test.go
+++ b/internal/store/attachment_changes_test.go
@@ -1,0 +1,174 @@
+package store_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestAttachmentChangeJournalCapturesOnlyRelevantCommittedMutations(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("attachment-journal")
+	firstID := createJournalAttachment(t, f, messageID, "part:1", "a")
+	assert.Zero(attachmentChangeCount(t, f), "journal stays empty with no registered feature")
+
+	consumer, created, err := f.Store.RegisterAttachmentChangeConsumer(t.Context(), "document-index/v1")
+	require.NoError(err)
+	assert.True(created)
+	assert.Zero(consumer.BaselineSequence)
+	_, created, err = f.Store.RegisterAttachmentChangeConsumer(t.Context(), "document-index/v1")
+	require.NoError(err)
+	assert.False(created)
+	require.ErrorContains(
+		func() error {
+			_, listErr := f.Store.ListAttachmentChanges(t.Context(), "document-index/v1", 10)
+			return listErr
+		}(),
+		"requires full reconciliation",
+	)
+	require.NoError(f.Store.CompleteAttachmentChangeReconciliation(
+		t.Context(), consumer.ConsumerKey, consumer.BaselineSequence,
+	))
+	require.NoError(f.Store.CompleteAttachmentChangeReconciliation(
+		t.Context(), consumer.ConsumerKey, consumer.BaselineSequence,
+	), "concurrent completion of the same baseline must be idempotent")
+
+	transaction, err := f.Store.DB().BeginTx(t.Context(), nil)
+	require.NoError(err)
+	_, err = transaction.Exec(f.Store.Rebind(
+		`UPDATE attachments SET filename = ? WHERE id = ?`), "rolled-back.pdf", firstID)
+	require.NoError(err)
+	require.NoError(transaction.Rollback())
+	assert.Zero(attachmentChangeCount(t, f), "rolled-back trigger writes must roll back")
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET is_read = NOT is_read WHERE id = ?`), messageID)
+	require.NoError(err)
+	assert.Zero(attachmentChangeCount(t, f), "read state is not attachment lifecycle")
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE attachments SET filename = ? WHERE id = ?`), "changed.pdf", firstID)
+	require.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP WHERE id = ?`), messageID)
+	require.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`DELETE FROM attachments WHERE id = ?`), firstID)
+	require.NoError(err)
+
+	changes, err := f.Store.ListAttachmentChanges(t.Context(), consumer.ConsumerKey, 10)
+	require.NoError(err)
+	require.Len(changes, 3)
+	assert.Equal("attachment_update", changes[0].EventKind)
+	assert.Equal(firstID, requireInt64Pointer(t, changes[0].OldAttachmentID))
+	assert.Equal(firstID, requireInt64Pointer(t, changes[0].NewAttachmentID))
+	assert.Equal("message_live_exit", changes[1].EventKind)
+	assert.Equal(messageID, requireInt64Pointer(t, changes[1].OldMessageID))
+	assert.Nil(changes[1].NewMessageID)
+	assert.Equal("attachment_delete", changes[2].EventKind)
+	assert.Equal(firstID, requireInt64Pointer(t, changes[2].OldAttachmentID))
+	assert.Nil(changes[2].NewAttachmentID)
+}
+
+func TestAttachmentChangeConsumersPruneOnlySharedConsumedPrefix(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("attachment-consumers")
+	for _, key := range []string{"document-index/v1", "visual-index/v1"} {
+		consumer, created, err := f.Store.RegisterAttachmentChangeConsumer(t.Context(), key)
+		require.NoError(err)
+		require.True(created)
+		require.NoError(f.Store.CompleteAttachmentChangeReconciliation(
+			t.Context(), key, consumer.BaselineSequence,
+		))
+	}
+	attachmentID := createJournalAttachment(t, f, messageID, "part:1", "b")
+	secondAttachmentID := createJournalAttachment(t, f, messageID, "part:2", "c")
+
+	documentChanges, err := f.Store.ListAttachmentChanges(t.Context(), "document-index/v1", 10)
+	require.NoError(err)
+	require.Len(documentChanges, 2)
+	visualChanges, err := f.Store.ListAttachmentChanges(t.Context(), "visual-index/v1", 10)
+	require.NoError(err)
+	require.Len(visualChanges, 2)
+	assert.Equal(documentChanges[0].Sequence, visualChanges[0].Sequence)
+	assert.Equal(attachmentID, requireInt64Pointer(t, documentChanges[0].NewAttachmentID))
+	assert.Equal(secondAttachmentID, requireInt64Pointer(t, documentChanges[1].NewAttachmentID))
+
+	require.NoError(f.Store.AdvanceAttachmentChangeConsumer(
+		t.Context(), "document-index/v1", documentChanges[1].Sequence,
+	))
+	require.NoError(f.Store.AdvanceAttachmentChangeConsumer(
+		t.Context(), "document-index/v1", documentChanges[0].Sequence,
+	), "a slower concurrent caller may acknowledge an older sequence after a newer one")
+	assert.Equal(2, attachmentChangeCount(t, f), "slower consumer retains its events")
+	require.NoError(f.Store.AdvanceAttachmentChangeConsumer(
+		t.Context(), "visual-index/v1", visualChanges[1].Sequence,
+	))
+	assert.Zero(attachmentChangeCount(t, f))
+
+	require.NoError(f.Store.UnregisterAttachmentChangeConsumer(t.Context(), "document-index/v1"))
+	require.NoError(f.Store.UnregisterAttachmentChangeConsumer(t.Context(), "visual-index/v1"))
+	createJournalAttachment(t, f, messageID, "part:3", "d")
+	assert.Zero(attachmentChangeCount(t, f), "capture stops after the final consumer unregisters")
+}
+
+func TestAttachmentChangeJournalCapturesCascadeDeletion(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("attachment-cascade")
+	attachmentID := createJournalAttachment(t, f, messageID, "part:1", "d")
+	consumer, _, err := f.Store.RegisterAttachmentChangeConsumer(t.Context(), "document-index/v1")
+	require.NoError(err)
+	require.NoError(f.Store.CompleteAttachmentChangeReconciliation(
+		t.Context(), consumer.ConsumerKey, consumer.BaselineSequence,
+	))
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`DELETE FROM messages WHERE id = ?`), messageID)
+	require.NoError(err)
+	changes, err := f.Store.ListAttachmentChanges(t.Context(), consumer.ConsumerKey, 10)
+	require.NoError(err)
+	require.Len(changes, 1)
+	assert.Equal(t, "attachment_delete", changes[0].EventKind)
+	assert.Equal(t, attachmentID, requireInt64Pointer(t, changes[0].OldAttachmentID))
+}
+
+func createJournalAttachment(
+	t *testing.T,
+	f *storetest.Fixture,
+	messageID int64,
+	partKey string,
+	hashCharacter string,
+) int64 {
+	t.Helper()
+	hash := strings.Repeat(hashCharacter, 64)
+	require.NoError(t, f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: 64,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: partKey,
+	}))
+	var id int64
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT id FROM attachments WHERE message_id = ? AND source_part_key = ?`), messageID, partKey).Scan(&id))
+	return id
+}
+
+func attachmentChangeCount(t *testing.T, f *storetest.Fixture) int {
+	t.Helper()
+	var count int
+	require.NoError(t, f.Store.DB().QueryRow(`SELECT COUNT(*) FROM attachment_change_log`).Scan(&count))
+	return count
+}
+
+func requireInt64Pointer(t *testing.T, value *int64) int64 {
+	t.Helper()
+	require.NotNil(t, value)
+	return *value
+}

--- a/internal/store/attachment_role_migration_test.go
+++ b/internal/store/attachment_role_migration_test.go
@@ -1,0 +1,81 @@
+package store
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitSchemaMigratesLegacyAttachmentOccurrenceIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbPath := filepath.Join(t.TempDir(), "legacy-attachments.db")
+	st, err := Open(dbPath)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(st.Close()) })
+
+	_, err = st.db.Exec(`
+		CREATE TABLE attachments (
+			id INTEGER PRIMARY KEY,
+			message_id INTEGER NOT NULL,
+			filename TEXT,
+			mime_type TEXT,
+			size INTEGER,
+			content_hash TEXT,
+			storage_path TEXT NOT NULL,
+			media_type TEXT,
+			width INTEGER,
+			height INTEGER,
+			duration_ms INTEGER,
+			thumbnail_hash TEXT,
+			thumbnail_path TEXT,
+			source_attachment_id TEXT,
+			attachment_metadata JSON,
+			encryption_version INTEGER DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		INSERT INTO attachments
+			(message_id, filename, mime_type, size, content_hash, storage_path)
+		VALUES (99, 'legacy.png', 'image/png', 10, 'legacy-hash', 'legacy/path');
+	`)
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+
+	var role, roleSource string
+	var sourcePartKey, contentID *string
+	require.NoError(st.db.QueryRow(`
+		SELECT attachment_role, role_source, source_part_key, content_id
+		FROM attachments WHERE id = 1
+	`).Scan(&role, &roleSource, &sourcePartKey, &contentID))
+	assert.Equal(string(AttachmentRoleUnknown), role)
+	assert.Equal(string(AttachmentRoleSourceUnknown), roleSource)
+	assert.Nil(sourcePartKey)
+	assert.Nil(contentID)
+
+	indexes := make(map[string]string)
+	rows, err := st.db.Query(`
+		SELECT name, sql FROM sqlite_master
+		WHERE type = 'index'
+		  AND name IN ('idx_attachments_msg_source_part', 'idx_attachments_msg_content_hash')
+	`)
+	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
+	for rows.Next() {
+		var name, sqlText string
+		require.NoError(rows.Scan(&name, &sqlText))
+		indexes[name] = strings.ToLower(sqlText)
+	}
+	require.NoError(rows.Err())
+	require.Len(indexes, 2)
+	assert.Contains(indexes["idx_attachments_msg_source_part"],
+		"where source_part_key is not null")
+	assert.Contains(indexes["idx_attachments_msg_content_hash"],
+		"where source_part_key is null")
+
+	applied, err := st.IsMigrationApplied(migrationAttachmentOccurrenceUnique)
+	require.NoError(err)
+	assert.True(applied)
+}

--- a/internal/store/attachment_role_repair.go
+++ b/internal/store/attachment_role_repair.go
@@ -1,0 +1,348 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	internalmime "go.kenn.io/msgvault/internal/mime"
+)
+
+// AttachmentRoleRepairProgress describes one committed repair batch. Counts
+// cover this call; LastMessageID and Completed are the durable cursor state.
+type AttachmentRoleRepairProgress struct {
+	LastMessageID      int64
+	MessagesScanned    int
+	AttachmentsUpdated int
+	Completed          bool
+}
+
+type attachmentRoleRepairUpdate struct {
+	attachmentID int64
+	messageID    int64
+	contentHash  string
+	role         AttachmentRole
+	partKey      string
+	contentID    string
+}
+
+type attachmentRoleRepairMessage struct {
+	id  int64
+	raw []byte
+}
+
+// RepairHistoricalAttachmentRolesBatch repairs at most batchSize historical
+// email messages. Only a unique raw-MIME part/hash match can update a row;
+// malformed, missing, or ambiguous evidence remains unknown. The updates and
+// cursor advance commit atomically, so cancellation is safely resumable.
+func (s *Store) RepairHistoricalAttachmentRolesBatch(
+	ctx context.Context,
+	batchSize int,
+) (AttachmentRoleRepairProgress, error) {
+	if err := ctx.Err(); err != nil {
+		return AttachmentRoleRepairProgress{}, err
+	}
+	if batchSize <= 0 {
+		return AttachmentRoleRepairProgress{}, errors.New("attachment role repair batch size must be positive")
+	}
+
+	progress, err := s.attachmentRoleRepairCursor(ctx)
+	if err != nil {
+		return AttachmentRoleRepairProgress{}, err
+	}
+	messages, hasMore, err := s.nextAttachmentRoleRepairMessages(
+		ctx, progress.LastMessageID, batchSize)
+	if err != nil {
+		return AttachmentRoleRepairProgress{}, err
+	}
+	updates := make([]attachmentRoleRepairUpdate, 0)
+	for _, message := range messages {
+		if err := ctx.Err(); err != nil {
+			return AttachmentRoleRepairProgress{}, err
+		}
+		messageUpdates, err := s.prepareAttachmentRoleRepair(message.id, message.raw)
+		if err != nil {
+			return AttachmentRoleRepairProgress{}, err
+		}
+		updates = append(updates, messageUpdates...)
+	}
+	if s.attachmentRoleRepairPreparedHook != nil {
+		s.attachmentRoleRepairPreparedHook()
+	}
+
+	lastMessageID := progress.LastMessageID
+	if len(messages) > 0 {
+		lastMessageID = messages[len(messages)-1].id
+	}
+	completed := !hasMore
+	updated := 0
+	err = s.runMaintenance(ctx, func(ctx context.Context, tx *loggedTx) error {
+		for _, update := range updates {
+			merged, mergeErr := mergeDuplicateAttachmentRoleRepair(ctx, tx, update)
+			if mergeErr != nil {
+				return fmt.Errorf("merge attachment %d role repair duplicate: %w", update.attachmentID, mergeErr)
+			}
+			if merged {
+				updated++
+				if _, err := tx.ExecContext(ctx, `
+				UPDATE messages
+				SET has_attachments = (SELECT COUNT(*) FROM attachments WHERE message_id = ?) > 0,
+				    attachment_count = (SELECT COUNT(*) FROM attachments WHERE message_id = ?)
+				WHERE id = ?
+			`, update.messageID, update.messageID, update.messageID); err != nil {
+					return fmt.Errorf("refresh message %d attachment stats: %w", update.messageID, err)
+				}
+				continue
+			}
+			result, err := tx.ExecContext(ctx, `
+				UPDATE attachments
+				SET attachment_role = ?, role_source = ?, source_part_key = ?, content_id = ?
+				WHERE id = ?
+				  AND attachment_role = 'unknown'
+				  AND source_part_key IS NULL
+				  AND content_hash = ?
+				  AND NOT EXISTS (
+					SELECT 1 FROM attachments keyed
+					WHERE keyed.message_id = ? AND keyed.source_part_key = ?
+				  )
+			`, string(update.role), string(AttachmentRoleSourceRawMIMERepair),
+				update.partKey, nullIfEmpty(update.contentID), update.attachmentID,
+				update.contentHash, update.messageID, update.partKey)
+			if err != nil {
+				return fmt.Errorf("repair attachment %d role: %w", update.attachmentID, err)
+			}
+			if count, err := result.RowsAffected(); err == nil {
+				updated += int(count)
+			}
+		}
+		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO attachment_role_repair_progress
+				(singleton, last_message_id, completed, updated_at)
+			VALUES (1, ?, ?, %s)
+			ON CONFLICT(singleton) DO UPDATE SET
+				last_message_id = excluded.last_message_id,
+				completed = excluded.completed,
+				updated_at = excluded.updated_at
+		`, s.dialect.Now()), lastMessageID, boolInt(completed))
+		return err
+	})
+	if err != nil {
+		return AttachmentRoleRepairProgress{}, err
+	}
+	return AttachmentRoleRepairProgress{
+		LastMessageID:      lastMessageID,
+		MessagesScanned:    len(messages),
+		AttachmentsUpdated: updated,
+		Completed:          completed,
+	}, nil
+}
+
+// mergeDuplicateAttachmentRoleRepair removes a legacy hash-identified row
+// when a resync has already created the same source occurrence. The keyed row
+// is authoritative and already carries the current storage/reference data;
+// only an exact content-hash match is safe to collapse.
+func mergeDuplicateAttachmentRoleRepair(
+	ctx context.Context,
+	tx *loggedTx,
+	update attachmentRoleRepairUpdate,
+) (bool, error) {
+	var keyedID int64
+	var keyedHash string
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, COALESCE(content_hash, '')
+		FROM attachments
+		WHERE message_id = ? AND source_part_key = ?
+	`, update.messageID, update.partKey).Scan(&keyedID, &keyedHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if keyedHash == "" || keyedHash != update.contentHash {
+		return false, nil
+	}
+	result, err := tx.ExecContext(ctx, `
+		DELETE FROM attachments
+		WHERE id = ?
+		  AND message_id = ?
+		  AND attachment_role = 'unknown'
+		  AND source_part_key IS NULL
+		  AND content_hash = ?
+	`, update.attachmentID, update.messageID, update.contentHash)
+	if err != nil {
+		return false, err
+	}
+	count, err := result.RowsAffected()
+	return count > 0, err
+}
+
+func (s *Store) attachmentRoleRepairCursor(ctx context.Context) (AttachmentRoleRepairProgress, error) {
+	var progress AttachmentRoleRepairProgress
+	var completed int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT last_message_id, completed
+		FROM attachment_role_repair_progress WHERE singleton = 1
+	`).Scan(&progress.LastMessageID, &completed)
+	if errors.Is(err, sql.ErrNoRows) {
+		return progress, nil
+	}
+	if err != nil {
+		return AttachmentRoleRepairProgress{}, fmt.Errorf("read attachment role repair cursor: %w", err)
+	}
+	progress.Completed = completed != 0
+	return progress, nil
+}
+
+func (s *Store) nextAttachmentRoleRepairMessages(
+	ctx context.Context,
+	afterMessageID int64,
+	batchSize int,
+) ([]attachmentRoleRepairMessage, bool, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT m.id, mr.raw_data, mr.compression
+		FROM messages m
+		JOIN message_raw mr ON mr.message_id = m.id AND mr.raw_format = 'mime'
+		WHERE m.id > ?
+		  AND EXISTS (
+			SELECT 1 FROM attachments a
+			WHERE a.message_id = m.id AND a.attachment_role = 'unknown'
+		  )
+		ORDER BY m.id
+		LIMIT ?
+	`, afterMessageID, batchSize+1)
+	if err != nil {
+		return nil, false, fmt.Errorf("list attachment role repair messages: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	messages := make([]attachmentRoleRepairMessage, 0, batchSize+1)
+	for rows.Next() {
+		var message attachmentRoleRepairMessage
+		var compressed []byte
+		var compression sql.NullString
+		if err := rows.Scan(&message.id, &compressed, &compression); err != nil {
+			return nil, false, err
+		}
+		// Corrupt archived MIME is not authoritative evidence. Keep it in the
+		// scanned batch with nil raw data so the durable cursor advances rather
+		// than wedging every future repair batch behind it.
+		message.raw, _ = decodeMessageRaw(compressed, compression)
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	hasMore := len(messages) > batchSize
+	if hasMore {
+		messages = messages[:batchSize]
+	}
+	return messages, hasMore, nil
+}
+
+func (s *Store) prepareAttachmentRoleRepair(messageID int64, raw []byte) ([]attachmentRoleRepairUpdate, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	parsed, err := internalmime.Parse(raw)
+	if err != nil {
+		return nil, nil //nolint:nilerr // corrupt MIME is ineligible evidence, not a repair failure.
+	}
+
+	type historicalAttachment struct {
+		id          int64
+		contentHash string
+	}
+	rows, err := s.db.Query(`
+		SELECT id, COALESCE(content_hash, '')
+		FROM attachments
+		WHERE message_id = ? AND attachment_role = 'unknown'
+	`, messageID)
+	if err != nil {
+		return nil, err
+	}
+	var historical []historicalAttachment
+	for rows.Next() {
+		var attachment historicalAttachment
+		if err := rows.Scan(&attachment.id, &attachment.contentHash); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		historical = append(historical, attachment)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Enmime can expose the same physical part through both Attachments and
+	// Inlines. PartKey is the source identity, so collapse that duplicate while
+	// preserving the stricter inline evidence. A key with conflicting bytes is
+	// corrupt/ambiguous and is excluded entirely.
+	partsByKey := make(map[string]internalmime.Attachment, len(parsed.Attachments))
+	conflictedKeys := make(map[string]struct{})
+	for _, part := range parsed.Attachments {
+		if part.PartKey == "" {
+			continue
+		}
+		previous, exists := partsByKey[part.PartKey]
+		if !exists {
+			partsByKey[part.PartKey] = part
+			continue
+		}
+		if previous.ContentHash != part.ContentHash {
+			conflictedKeys[part.PartKey] = struct{}{}
+			continue
+		}
+		if part.IsInline || part.Disposition == "inline" || part.ContentID != "" {
+			previous.IsInline = true
+			previous.Disposition = "inline"
+			if previous.ContentID == "" {
+				previous.ContentID = part.ContentID
+			}
+			partsByKey[part.PartKey] = previous
+		}
+	}
+	partsByHash := make(map[string][]internalmime.Attachment, len(partsByKey))
+	for partKey, part := range partsByKey {
+		if _, conflicted := conflictedKeys[partKey]; conflicted {
+			continue
+		}
+		partsByHash[part.ContentHash] = append(partsByHash[part.ContentHash], part)
+	}
+	rowsByHash := make(map[string]int, len(historical))
+	for _, attachment := range historical {
+		rowsByHash[attachment.contentHash]++
+	}
+
+	updates := make([]attachmentRoleRepairUpdate, 0, len(historical))
+	for _, attachment := range historical {
+		parts := partsByHash[attachment.contentHash]
+		if attachment.contentHash == "" || rowsByHash[attachment.contentHash] != 1 || len(parts) != 1 {
+			continue
+		}
+		part := parts[0]
+		role, _ := AttachmentRoleFromMIME(part.Disposition, part.IsInline, part.ContentID)
+		if role == AttachmentRoleUnknown || part.PartKey == "" {
+			continue
+		}
+		updates = append(updates, attachmentRoleRepairUpdate{
+			attachmentID: attachment.id,
+			messageID:    messageID,
+			contentHash:  attachment.contentHash,
+			role:         role,
+			partKey:      part.PartKey,
+			contentID:    part.ContentID,
+		})
+	}
+	return updates, nil
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/internal/store/attachment_role_repair_test.go
+++ b/internal/store/attachment_role_repair_test.go
@@ -1,0 +1,303 @@
+package store_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	internalmime "go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestRepairHistoricalAttachmentRolesUsesUnambiguousRawMIME(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := seedHistoricalMIMEAttachment(t, f, "repair-explicit", "attachment", "asset-1", "unique-bytes")
+
+	progress, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(t, err)
+	assert.True(progress.Completed)
+	assert.Equal(1, progress.MessagesScanned)
+	assert.Equal(1, progress.AttachmentsUpdated)
+	assert.Equal(messageID, progress.LastMessageID)
+
+	var role, roleSource, sourcePartKey, contentID string
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT attachment_role, role_source, source_part_key, content_id
+		FROM attachments WHERE message_id = ?`), messageID).
+		Scan(&role, &roleSource, &sourcePartKey, &contentID))
+	assert.Equal("inline", role, "a Content-ID is inline evidence even with attachment disposition")
+	assert.Equal("raw_mime_repair", roleSource)
+	assert.NotEmpty(sourcePartKey)
+	assert.Equal("asset-1", contentID)
+}
+
+func TestRepairHistoricalAttachmentRolesLeavesAmbiguousBytesUnknown(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("repair-ambiguous")
+	raw := historicalMIME(t, "attachment", "first", "same-bytes", "attachment", "second", "same-bytes")
+	require.NoError(t, f.Store.UpsertMessageRaw(messageID, raw))
+	insertHistoricalAttachment(t, f, messageID, "same-bytes")
+
+	progress, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(t, err)
+	assert.True(progress.Completed)
+	assert.Zero(progress.AttachmentsUpdated)
+
+	var role, roleSource string
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT attachment_role, role_source FROM attachments WHERE message_id = ?`), messageID).
+		Scan(&role, &roleSource))
+	assert.Equal("unknown", role)
+	assert.Equal("unknown", roleSource)
+}
+
+func TestRepairHistoricalAttachmentRolesResumesFromDurableCursor(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	firstID := seedHistoricalMIMEAttachment(t, f, "repair-first", "attachment", "first", "first-bytes")
+	secondID := seedHistoricalMIMEAttachment(t, f, "repair-second", "inline", "second", "second-bytes")
+	require.Less(firstID, secondID)
+	raw, err := f.Store.GetMessageRaw(secondID)
+	require.NoError(err)
+	parsed, err := internalmime.Parse(raw)
+	require.NoError(err)
+	require.NotEmpty(parsed.Attachments)
+	for _, part := range parsed.Attachments {
+		assert.Equal(digestString("second-bytes"), part.ContentHash)
+		assert.NotEmpty(part.PartKey)
+	}
+
+	first, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 1)
+	require.NoError(err)
+	assert.False(first.Completed)
+	assert.Equal(firstID, first.LastMessageID)
+	assert.Equal(1, first.AttachmentsUpdated)
+
+	second, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 1)
+	require.NoError(err)
+	assert.True(second.Completed)
+	assert.Equal(secondID, second.LastMessageID)
+	assert.Equal(1, second.AttachmentsUpdated)
+
+	var role, roleSource string
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT attachment_role, role_source FROM attachments WHERE message_id = ?`), secondID).
+		Scan(&role, &roleSource))
+	assert.Equal("inline", role)
+	assert.Equal("raw_mime_repair", roleSource)
+}
+
+func TestRepairHistoricalAttachmentRolesCancellationLeavesCursorResumable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := seedHistoricalMIMEAttachment(t, f, "repair-cancel", "attachment", "asset", "bytes")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := f.Store.RepairHistoricalAttachmentRolesBatch(ctx, 10)
+	require.ErrorIs(err, context.Canceled)
+
+	progress, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(err)
+	assert.True(progress.Completed)
+	assert.Equal(messageID, progress.LastMessageID)
+	assert.Equal(1, progress.AttachmentsUpdated)
+}
+
+func TestRepairHistoricalAttachmentRolesSkipsCorruptRawWithoutWedging(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := seedHistoricalMIMEAttachment(t, f, "repair-corrupt", "attachment", "", "bytes")
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`
+		UPDATE message_raw SET raw_data = ?, compression = 'zlib' WHERE message_id = ?`),
+		[]byte("not-zlib"), messageID)
+	require.NoError(t, err)
+
+	progress, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(t, err)
+	assert.True(progress.Completed)
+	assert.Equal(messageID, progress.LastMessageID)
+	assert.Zero(progress.AttachmentsUpdated)
+
+	var role string
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT attachment_role FROM attachments WHERE message_id = ?`), messageID).Scan(&role))
+	assert.Equal("unknown", role)
+}
+
+func TestRepairHistoricalAttachmentRolesFindsMessagesAddedAfterCompletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	firstID := seedHistoricalMIMEAttachment(t, f, "repair-complete-first", "attachment", "", "first")
+
+	first, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(err)
+	assert.True(first.Completed)
+	assert.Equal(firstID, first.LastMessageID)
+
+	secondID := seedHistoricalMIMEAttachment(t, f, "repair-complete-second", "attachment", "", "second")
+	require.Greater(secondID, firstID)
+	second, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(err)
+	assert.True(second.Completed)
+	assert.Equal(secondID, second.LastMessageID)
+	assert.Equal(1, second.AttachmentsUpdated)
+}
+
+func TestRepairHistoricalAttachmentRolesCollapsesResyncDuplicate(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("repair-resync-duplicate")
+	raw := historicalMIME(t, "attachment", "", "same-bytes")
+	require.NoError(f.Store.UpsertMessageRaw(messageID, raw))
+	parsed, err := internalmime.Parse(raw)
+	require.NoError(err)
+	require.Len(parsed.Attachments, 1)
+	part := parsed.Attachments[0]
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`
+		INSERT INTO attachments
+			(message_id, filename, mime_type, storage_path, content_hash, size,
+			 attachment_role, role_source, created_at)
+		VALUES (?, 'legacy.pdf', 'application/pdf', 'legacy/path', ?, 10,
+		        'unknown', 'legacy_api', CURRENT_TIMESTAMP)`), messageID, part.ContentHash)
+	require.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`
+		INSERT INTO attachments
+			(message_id, filename, mime_type, storage_path, content_hash, size,
+			 attachment_role, role_source, source_part_key, created_at)
+		VALUES (?, 'current.pdf', 'application/pdf', 'current/path', ?, 10,
+		        'standalone', 'mime_disposition', ?, CURRENT_TIMESTAMP)`),
+		messageID, part.ContentHash, part.PartKey)
+	require.NoError(err)
+	var keyedID int64
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT id FROM attachments WHERE message_id = ? AND source_part_key = ?`),
+		messageID, part.PartKey).Scan(&keyedID))
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`
+		UPDATE messages SET has_attachments = TRUE, attachment_count = 2 WHERE id = ?`), messageID)
+	require.NoError(err)
+
+	progress, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(err)
+	assert.True(progress.Completed)
+	assert.Equal(1, progress.AttachmentsUpdated)
+
+	var id int64
+	var count int
+	var filename, storagePath, role, roleSource, partKey string
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT MIN(id), COUNT(*), MIN(filename), MIN(storage_path),
+		       MIN(attachment_role), MIN(role_source), MIN(source_part_key)
+		FROM attachments WHERE message_id = ?`), messageID).
+		Scan(&id, &count, &filename, &storagePath, &role, &roleSource, &partKey))
+	assert.Equal(keyedID, id)
+	assert.Equal(1, count)
+	assert.Equal("current.pdf", filename)
+	assert.Equal("current/path", storagePath)
+	assert.Equal("standalone", role)
+	assert.Equal("mime_disposition", roleSource)
+	assert.Equal(part.PartKey, partKey)
+	var attachmentCount int
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT attachment_count FROM messages WHERE id = ?`), messageID).Scan(&attachmentCount))
+	assert.Equal(1, attachmentCount)
+}
+
+func TestRepairHistoricalAttachmentRolesDoesNotApplyStaleMIMEEvidence(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := seedHistoricalMIMEAttachment(
+		t, f, "repair-concurrent-resync", "attachment", "old-content", "old-bytes",
+	)
+	newHash := digestString("new-bytes")
+	restore := f.Store.SetAttachmentRoleRepairPreparedHookForTest(func() {
+		_, err := f.Store.DB().Exec(f.Store.Rebind(`
+			UPDATE attachments
+			SET content_hash = ?, storage_path = ?, size = ?
+			WHERE message_id = ?`),
+			newHash, newHash[:2]+"/"+newHash, len("new-bytes"), messageID)
+		require.NoError(err)
+	})
+	defer restore()
+
+	progress, err := f.Store.RepairHistoricalAttachmentRolesBatch(t.Context(), 10)
+	require.NoError(err)
+	assert.True(progress.Completed)
+	assert.Zero(progress.AttachmentsUpdated)
+
+	var hash, role, roleSource string
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT content_hash, attachment_role, role_source
+		FROM attachments WHERE message_id = ?`), messageID).
+		Scan(&hash, &role, &roleSource))
+	assert.Equal(newHash, hash)
+	assert.Equal("unknown", role)
+	assert.Equal("unknown", roleSource)
+}
+
+func seedHistoricalMIMEAttachment(
+	t *testing.T,
+	f *storetest.Fixture,
+	sourceMessageID, disposition, contentID, content string,
+) int64 {
+	t.Helper()
+	messageID := f.CreateMessage(sourceMessageID)
+	require.NoError(t, f.Store.UpsertMessageRaw(messageID,
+		historicalMIME(t, disposition, contentID, content)))
+	insertHistoricalAttachment(t, f, messageID, content)
+	return messageID
+}
+
+func insertHistoricalAttachment(t *testing.T, f *storetest.Fixture, messageID int64, content string) {
+	t.Helper()
+	hash := digestString(content)
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`
+		INSERT INTO attachments
+			(message_id, filename, mime_type, storage_path, content_hash, size, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`),
+		messageID, "asset.bin", "application/octet-stream", hash[:2]+"/"+hash, hash, len(content),
+	)
+	require.NoError(t, err)
+}
+
+func digestString(content string) string {
+	digest := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(digest[:])
+}
+
+func historicalMIME(t *testing.T, parts ...string) []byte {
+	t.Helper()
+	require.Zero(t, len(parts)%3)
+	var body strings.Builder
+	body.WriteString("From: sender@example.com\r\nTo: recipient@example.com\r\n" +
+		"MIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=repair\r\n\r\n" +
+		"--repair\r\nContent-Type: text/plain\r\n\r\nbody\r\n")
+	var disposition, contentID string
+	for index, part := range parts {
+		switch index % 3 {
+		case 0:
+			disposition = part
+		case 1:
+			contentID = part
+		case 2:
+			_, _ = fmt.Fprintf(&body, "--repair\r\nContent-Type: application/octet-stream\r\n"+
+				"Content-Disposition: %s; filename=asset.bin\r\nContent-ID: <%s>\r\n\r\n%s\r\n",
+				disposition, contentID, part)
+		}
+	}
+	body.WriteString("--repair--\r\n")
+	return []byte(body.String())
+}

--- a/internal/store/attachment_roles.go
+++ b/internal/store/attachment_roles.go
@@ -1,0 +1,255 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// AttachmentRole is the source-authoritative role of one attachment
+// occurrence. Unknown fails closed for hosted processing.
+type AttachmentRole string
+
+const (
+	AttachmentRoleStandalone AttachmentRole = "standalone"
+	AttachmentRoleInline     AttachmentRole = "inline"
+	AttachmentRoleAvatar     AttachmentRole = "avatar"
+	AttachmentRoleThumbnail  AttachmentRole = "thumbnail"
+	AttachmentRolePreview    AttachmentRole = "preview"
+	AttachmentRoleSticker    AttachmentRole = "sticker"
+	AttachmentRoleUIAsset    AttachmentRole = "ui_asset"
+	AttachmentRoleUnknown    AttachmentRole = "unknown"
+)
+
+// AttachmentRoleSource records why an attachment role is trusted. It is
+// evidence provenance, not an eligibility decision by itself.
+type AttachmentRoleSource string
+
+const (
+	AttachmentRoleSourceMIMEDisposition   AttachmentRoleSource = "mime_disposition"
+	AttachmentRoleSourceProviderExplicit  AttachmentRoleSource = "provider_explicit"
+	AttachmentRoleSourceImporterSemantics AttachmentRoleSource = "importer_semantics"
+	AttachmentRoleSourceLegacyAPI         AttachmentRoleSource = "legacy_api"
+	AttachmentRoleSourceRawMIMERepair     AttachmentRoleSource = "raw_mime_repair"
+	AttachmentRoleSourceUnknown           AttachmentRoleSource = "unknown"
+)
+
+// AttachmentWrite is the complete typed write contract for one attachment
+// occurrence. SourcePartKey is stable within the owning source message; when
+// unavailable it stays empty and the row retains legacy best-effort hash
+// identity.
+type AttachmentWrite struct {
+	Filename           string
+	MIMEType           string
+	StoragePath        string
+	ContentHash        string
+	Size               int64
+	SourceAttachmentID string
+	MediaType          string
+	Width              int64
+	Height             int64
+	DurationMS         int64
+	Metadata           string
+	Role               AttachmentRole
+	RoleSource         AttachmentRoleSource
+	SourcePartKey      string
+	ContentID          string
+}
+
+func (r AttachmentRole) valid() bool {
+	switch r {
+	case AttachmentRoleStandalone, AttachmentRoleInline, AttachmentRoleAvatar,
+		AttachmentRoleThumbnail, AttachmentRolePreview, AttachmentRoleSticker,
+		AttachmentRoleUIAsset, AttachmentRoleUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s AttachmentRoleSource) valid() bool {
+	switch s {
+	case AttachmentRoleSourceMIMEDisposition,
+		AttachmentRoleSourceProviderExplicit,
+		AttachmentRoleSourceImporterSemantics,
+		AttachmentRoleSourceLegacyAPI,
+		AttachmentRoleSourceRawMIMERepair,
+		AttachmentRoleSourceUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// AttachmentRoleFromMIME maps only explicit MIME occurrence evidence. A
+// filename or media type is never enough to promote an ambiguous part.
+func AttachmentRoleFromMIME(
+	disposition string,
+	isInline bool,
+	contentID string,
+) (AttachmentRole, AttachmentRoleSource) {
+	switch {
+	case isInline || contentID != "" || disposition == "inline":
+		return AttachmentRoleInline, AttachmentRoleSourceMIMEDisposition
+	case disposition == "attachment":
+		return AttachmentRoleStandalone, AttachmentRoleSourceMIMEDisposition
+	default:
+		return AttachmentRoleUnknown, AttachmentRoleSourceUnknown
+	}
+}
+
+func (w AttachmentWrite) normalized() AttachmentWrite {
+	if w.Role == "" {
+		w.Role = AttachmentRoleUnknown
+	}
+	if w.RoleSource == "" {
+		w.RoleSource = AttachmentRoleSourceUnknown
+	}
+	return w
+}
+
+func (w AttachmentWrite) validate() error {
+	if !w.Role.valid() {
+		return fmt.Errorf("invalid attachment role %q", w.Role)
+	}
+	if !w.RoleSource.valid() {
+		return fmt.Errorf("invalid attachment role source %q", w.RoleSource)
+	}
+	if w.Size < 0 {
+		return errors.New("attachment size must not be negative")
+	}
+	return nil
+}
+
+// UpsertAttachmentRecord stores one attachment occurrence through the typed
+// role/provenance contract. A stable source-part key updates the same logical
+// occurrence on resync, even when its bytes change. Rows without such a key
+// retain the legacy content-hash behavior.
+func (s *Store) UpsertAttachmentRecord(
+	ctx context.Context,
+	messageID int64,
+	write AttachmentWrite,
+) error {
+	write = write.normalized()
+	if err := write.validate(); err != nil {
+		return err
+	}
+	return s.upsertAttachmentRecord(boundQuerier{ctx: ctx, q: s.db}, messageID, write)
+}
+
+func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write AttachmentWrite) error {
+	if write.SourcePartKey != "" && write.ContentHash != "" {
+		// Upgrade the pre-provenance row in place when a resync supplies a
+		// stable source occurrence for the same bytes. This preserves its row
+		// identity and prevents a later raw-MIME repair from colliding with a
+		// separately inserted keyed row.
+		result, err := q.Exec(fmt.Sprintf(`
+			UPDATE attachments SET
+				filename = ?, mime_type = ?, storage_path = ?, content_hash = ?, size = ?,
+				source_attachment_id = ?, media_type = ?, width = ?, height = ?, duration_ms = ?,
+				attachment_metadata = %s, attachment_role = ?, role_source = ?,
+				source_part_key = ?, content_id = ?
+			WHERE message_id = ?
+			  AND source_part_key IS NULL
+			  AND content_hash = ?
+			  AND attachment_role = 'unknown'
+			  AND NOT EXISTS (
+				SELECT 1 FROM attachments keyed
+				WHERE keyed.message_id = ? AND keyed.source_part_key = ?
+			  )
+		`, s.dialect.JSONBindExpr()),
+			write.Filename, write.MIMEType, write.StoragePath, write.ContentHash, write.Size,
+			nullIfEmpty(write.SourceAttachmentID), nullIfEmpty(write.MediaType),
+			nullIfZero(write.Width), nullIfZero(write.Height), nullIfZero(write.DurationMS),
+			nullIfEmpty(write.Metadata), string(write.Role), string(write.RoleSource),
+			write.SourcePartKey, nullIfEmpty(write.ContentID),
+			messageID, write.ContentHash, messageID, write.SourcePartKey,
+		)
+		if err != nil {
+			return err
+		}
+		if count, countErr := result.RowsAffected(); countErr == nil && count > 0 {
+			return nil
+		}
+	}
+
+	args := []any{
+		messageID,
+		write.Filename,
+		write.MIMEType,
+		write.StoragePath,
+		write.ContentHash,
+		write.Size,
+		nullIfEmpty(write.SourceAttachmentID),
+		nullIfEmpty(write.MediaType),
+		nullIfZero(write.Width),
+		nullIfZero(write.Height),
+		nullIfZero(write.DurationMS),
+		nullIfEmpty(write.Metadata),
+		string(write.Role),
+		string(write.RoleSource),
+		nullIfEmpty(write.SourcePartKey),
+		nullIfEmpty(write.ContentID),
+	}
+	const columns = `(message_id, filename, mime_type, storage_path, content_hash,
+		size, source_attachment_id, media_type, width, height, duration_ms,
+		attachment_metadata, attachment_role, role_source, source_part_key,
+		content_id, created_at)`
+	values := fmt.Sprintf(`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?, %s)`,
+		s.dialect.JSONBindExpr(), s.dialect.Now())
+
+	if write.SourcePartKey != "" {
+		_, err := q.Exec(`
+			INSERT INTO attachments `+columns+`
+			`+values+`
+			ON CONFLICT (message_id, source_part_key) WHERE source_part_key IS NOT NULL
+			DO UPDATE SET
+				filename = EXCLUDED.filename,
+				mime_type = EXCLUDED.mime_type,
+				storage_path = EXCLUDED.storage_path,
+				content_hash = EXCLUDED.content_hash,
+				size = EXCLUDED.size,
+				source_attachment_id = EXCLUDED.source_attachment_id,
+				media_type = EXCLUDED.media_type,
+				width = EXCLUDED.width,
+				height = EXCLUDED.height,
+				duration_ms = EXCLUDED.duration_ms,
+				attachment_metadata = EXCLUDED.attachment_metadata,
+				attachment_role = EXCLUDED.attachment_role,
+				role_source = EXCLUDED.role_source,
+				content_id = EXCLUDED.content_id`, args...)
+		return err
+	}
+
+	if write.ContentHash != "" {
+		_, err := q.Exec(`
+			INSERT INTO attachments `+columns+`
+			`+values+`
+			ON CONFLICT (message_id, content_hash)
+				WHERE source_part_key IS NULL
+				  AND content_hash IS NOT NULL
+				  AND content_hash != ''
+			DO NOTHING`, args...)
+		return err
+	}
+
+	var existingID int64
+	err := q.QueryRow(`
+		SELECT id FROM attachments
+		WHERE message_id = ?
+		  AND source_part_key IS NULL
+		  AND (content_hash IS NULL OR content_hash = '')
+	`, messageID).Scan(&existingID)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	_, err = q.Exec(`INSERT INTO attachments `+columns+` `+values, args...)
+	return err
+}

--- a/internal/store/attachment_roles_test.go
+++ b/internal/store/attachment_roles_test.go
@@ -1,0 +1,195 @@
+package store_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestAttachmentRoleSchemaDefaultsHistoricalRowsUnknown(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("legacy-role-default")
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`
+		INSERT INTO attachments
+			(message_id, filename, mime_type, storage_path, content_hash, size, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`),
+		messageID, "legacy.png", "image/png", "legacy/attachment", "legacy-hash", 42,
+	)
+	require.NoError(t, err)
+
+	fileID := singleAttachmentID(t, f, messageID)
+	file, err := f.Store.GetFileMetadata(t.Context(), fileID)
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(store.AttachmentRoleUnknown, file.AttachmentRole)
+	assert.Equal(store.AttachmentRoleSourceUnknown, file.RoleSource)
+	assert.Empty(file.SourcePartKey)
+	assert.Empty(file.ContentID)
+}
+
+func TestUpsertAttachmentRecordPersistsRoleProvenanceAndSourcePartKey(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("typed-attachment-write")
+	hash := strings.Repeat("ab", 32)
+
+	err := f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename:           "photo.png",
+		MIMEType:           "image/png",
+		StoragePath:        hash[:2] + "/" + hash,
+		ContentHash:        hash,
+		Size:               2048,
+		SourceAttachmentID: "provider:file-1",
+		MediaType:          "image",
+		Width:              640,
+		Height:             480,
+		Role:               store.AttachmentRoleStandalone,
+		RoleSource:         store.AttachmentRoleSourceProviderExplicit,
+		SourcePartKey:      "provider:file-1",
+		ContentID:          "asset-1@example.invalid",
+	})
+	require.NoError(t, err)
+
+	fileID := singleAttachmentID(t, f, messageID)
+	file, err := f.Store.GetFileMetadata(t.Context(), fileID)
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(store.AttachmentRoleStandalone, file.AttachmentRole)
+	assert.Equal(store.AttachmentRoleSourceProviderExplicit, file.RoleSource)
+	assert.Equal("provider:file-1", file.SourcePartKey)
+	assert.Equal("asset-1@example.invalid", file.ContentID)
+}
+
+func TestLegacyUpsertAttachmentFailsClosed(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("legacy-attachment-api")
+	require.NoError(f.Store.UpsertAttachment(
+		messageID, "legacy.png", "image/png", "legacy/path", "legacy-content", 12,
+	))
+
+	file, err := f.Store.GetFileMetadata(t.Context(), singleAttachmentID(t, f, messageID))
+	require.NoError(err)
+	require.NotNil(file)
+	assert.Equal(store.AttachmentRoleUnknown, file.AttachmentRole)
+	assert.Equal(store.AttachmentRoleSourceLegacyAPI, file.RoleSource)
+}
+
+func TestSourceAwareUpsertPromotesMatchingLegacyOccurrence(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("promote-legacy-occurrence")
+	hash := strings.Repeat("bc", 32)
+	require.NoError(f.Store.UpsertAttachment(
+		messageID, "legacy.pdf", "application/pdf", "legacy/path", hash, 12,
+	))
+	legacyID := singleAttachmentID(t, f, messageID)
+
+	require.NoError(f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "current.pdf", MIMEType: "application/pdf", StoragePath: hash[:2] + "/" + hash,
+		ContentHash: hash, Size: 12, Role: store.AttachmentRoleStandalone,
+		RoleSource: store.AttachmentRoleSourceMIMEDisposition, SourcePartKey: "mime:2",
+	}))
+
+	var id int64
+	var count int
+	var role, roleSource, partKey, filename, storagePath string
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT MIN(id), COUNT(*), MIN(attachment_role), MIN(role_source),
+		       MIN(source_part_key), MIN(filename), MIN(storage_path)
+		FROM attachments WHERE message_id = ?`), messageID).
+		Scan(&id, &count, &role, &roleSource, &partKey, &filename, &storagePath))
+	assert.Equal(legacyID, id)
+	assert.Equal(1, count)
+	assert.Equal("standalone", role)
+	assert.Equal("mime_disposition", roleSource)
+	assert.Equal("mime:2", partKey)
+	assert.Equal("current.pdf", filename)
+	assert.Equal(hash[:2]+"/"+hash, storagePath)
+}
+
+func TestAttachmentSourcePartKeyPreservesDistinctDuplicateBytes(t *testing.T) {
+	f := storetest.New(t)
+	messageID := f.CreateMessage("duplicate-byte-parts")
+	hash := strings.Repeat("cd", 32)
+	for _, partKey := range []string{"mime:1.2", "mime:1.3"} {
+		require.NoError(t, f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+			Filename:      "same.png",
+			MIMEType:      "image/png",
+			StoragePath:   hash[:2] + "/" + hash,
+			ContentHash:   hash,
+			Size:          100,
+			Role:          store.AttachmentRoleStandalone,
+			RoleSource:    store.AttachmentRoleSourceMIMEDisposition,
+			SourcePartKey: partKey,
+		}))
+	}
+
+	var count int
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COUNT(*) FROM attachments WHERE message_id = ?`), messageID).Scan(&count))
+	assert.Equal(t, 2, count)
+}
+
+func TestAttachmentSourcePartKeyResyncUpdatesOneOccurrence(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("source-part-resync")
+	firstHash := strings.Repeat("de", 32)
+	secondHash := strings.Repeat("ef", 32)
+	write := store.AttachmentWrite{
+		Filename:      "before.png",
+		MIMEType:      "image/png",
+		StoragePath:   firstHash[:2] + "/" + firstHash,
+		ContentHash:   firstHash,
+		Size:          100,
+		Role:          store.AttachmentRoleStandalone,
+		RoleSource:    store.AttachmentRoleSourceMIMEDisposition,
+		SourcePartKey: "mime:2.1",
+	}
+	require.NoError(t, f.Store.UpsertAttachmentRecord(t.Context(), messageID, write))
+
+	write.Filename = "after.png"
+	write.StoragePath = secondHash[:2] + "/" + secondHash
+	write.ContentHash = secondHash
+	write.Size = 200
+	require.NoError(t, f.Store.UpsertAttachmentRecord(t.Context(), messageID, write))
+
+	var (
+		count       int
+		filename    string
+		contentHash string
+		size        int64
+	)
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COUNT(*), MIN(filename), MIN(content_hash), MIN(size)
+		FROM attachments WHERE message_id = ?`), messageID).
+		Scan(&count, &filename, &contentHash, &size))
+	assert.Equal(1, count)
+	assert.Equal("after.png", filename)
+	assert.Equal(secondHash, contentHash)
+	assert.Equal(int64(200), size)
+}
+
+func TestUpsertAttachmentRecordRejectsInvalidRoleEvidence(t *testing.T) {
+	f := storetest.New(t)
+	messageID := f.CreateMessage("invalid-role")
+	err := f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		StoragePath: "provider:pending",
+		Role:        store.AttachmentRole("photo"),
+		RoleSource:  store.AttachmentRoleSourceProviderExplicit,
+	})
+	require.ErrorContains(t, err, "attachment role")
+
+	var count int
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COUNT(*) FROM attachments WHERE message_id = ?`), messageID).Scan(&count))
+	assert.Zero(t, count)
+}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -33,7 +33,8 @@ func (s *Store) messageProviderAttachments(messageID int64, providerPrefix strin
 	rows, err := s.db.Query(`
 		SELECT COALESCE(filename, ''), COALESCE(mime_type, ''), storage_path, COALESCE(content_hash, ''), size, source_attachment_id,
 		       COALESCE(media_type, ''), COALESCE(width, 0), COALESCE(height, 0), COALESCE(duration_ms, 0),
-		       COALESCE(CAST(attachment_metadata AS TEXT), '')
+		       COALESCE(CAST(attachment_metadata AS TEXT), ''), attachment_role, role_source,
+		       COALESCE(source_part_key, ''), COALESCE(content_id, '')
 		FROM attachments
 		WHERE message_id = ? AND source_attachment_id LIKE ?
 	`, messageID, providerPrefix+"%")
@@ -49,7 +50,8 @@ func (s *Store) messageProviderAttachments(messageID int64, providerPrefix strin
 		if err := rows.Scan(
 			&ref.Filename, &ref.MimeType, &ref.StoragePath, &ref.ContentHash,
 			&size, &ref.SourceAttachmentID, &ref.MediaType, &ref.Width,
-			&ref.Height, &ref.DurationMS, &ref.Metadata,
+			&ref.Height, &ref.DurationMS, &ref.Metadata, &ref.Role, &ref.RoleSource,
+			&ref.SourcePartKey, &ref.ContentID,
 		); err != nil {
 			return nil, err
 		}
@@ -97,34 +99,24 @@ func (s *Store) ReplaceMessageDiscordAttachments(messageID int64, refs []Attachm
 	return s.replaceMessageProviderAttachments(messageID, "discord:", refs)
 }
 
-// normalizeDiscordAttachmentRefs preserves one row per stable Discord
-// attachment ID when several attachments on a message share one CAS blob. The
-// schema's (message_id, content_hash) uniqueness keeps the real hash on the
-// first row; later aliases retain the same trusted local path with an empty
-// hash. Empty source URLs become provider sentinels so generic replacement
-// never drops their metadata.
+// normalizeDiscordAttachmentRefs fills deterministic pending markers and
+// recovers hashes from trusted CAS paths. Stable Discord attachment IDs become
+// source-part keys in the generic replacement path, so duplicate bytes no
+// longer need hashless alias rows.
 func normalizeDiscordAttachmentRefs(refs []AttachmentRef) []AttachmentRef {
 	normalized := append([]AttachmentRef(nil), refs...)
-	seen := make(map[string]struct{}, len(normalized))
 	for i := range normalized {
 		if normalized[i].StoragePath == "" {
 			attachmentID := strings.TrimPrefix(normalized[i].SourceAttachmentID, "discord:")
 			normalized[i].StoragePath = "discord:pending:" + attachmentID
 		}
-		contentHash := strings.ToLower(normalized[i].ContentHash)
-		if contentHash == "" {
+		if normalized[i].ContentHash == "" {
 			pathHash, ok := casPathHash(normalized[i].StoragePath)
 			if !ok {
 				continue
 			}
-			contentHash = pathHash
 			normalized[i].ContentHash = pathHash
 		}
-		if _, ok := seen[contentHash]; ok {
-			normalized[i].ContentHash = ""
-			continue
-		}
-		seen[contentHash] = struct{}{}
 	}
 	return normalized
 }

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -23,6 +23,19 @@ func captureAttachmentQueryLogs(t *testing.T) *bytes.Buffer {
 	return &logs
 }
 
+func persistedProviderRef(ref store.AttachmentRef) store.AttachmentRef {
+	if ref.Role == "" {
+		ref.Role = store.AttachmentRoleUnknown
+	}
+	if ref.RoleSource == "" {
+		ref.RoleSource = store.AttachmentRoleSourceUnknown
+	}
+	if ref.SourcePartKey == "" {
+		ref.SourcePartKey = ref.SourceAttachmentID
+	}
+	return ref
+}
+
 func TestListDiscordPendingAttachmentMessagesManyDownloadedUsesSingleQuery(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -176,8 +189,7 @@ func TestReplaceMessageDiscordAttachmentsPreservesDuplicateContentSourceIDs(t *t
 	assert.Equal(storagePath, got["discord:attachment-1"].StoragePath)
 	assert.Equal(storagePath, got["discord:attachment-2"].StoragePath)
 	assert.Equal(contentHash, got["discord:attachment-1"].ContentHash)
-	assert.Equal(contentHash, got["discord:attachment-2"].ContentHash,
-		"store reads must recover a duplicate alias hash from its trusted CAS path")
+	assert.Equal(contentHash, got["discord:attachment-2"].ContentHash)
 
 	message, err := st.GetMessage(messageID)
 	require.NoError(err)
@@ -195,13 +207,13 @@ func TestReplaceMessageDiscordAttachmentsPreservesDuplicateContentSourceIDs(t *t
 		SELECT COALESCE(content_hash, '') FROM attachments
 		WHERE message_id = ? AND source_attachment_id = ?
 	`), messageID, "discord:attachment-2").Scan(&storedHash))
-	require.Empty(storedHash, "schema-level duplicate alias must retain an empty hash")
+	assert.Equal(contentHash, storedHash,
+		"source-part identity permits duplicate occurrences to retain their canonical hash")
 	require.NoError(st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{remaining}))
 	got, err = st.MessageDiscordAttachments(messageID)
 	require.NoError(err)
 	require.Len(got, 1)
-	assert.Equal(contentHash, got["discord:attachment-2"].ContentHash,
-		"a surviving local alias must be promoted to own the CAS hash")
+	assert.Equal(contentHash, got["discord:attachment-2"].ContentHash)
 }
 
 func TestReplaceMessageDiscordAttachmentsPersistsEmptyURLMarker(t *testing.T) {
@@ -224,10 +236,10 @@ func TestReplaceMessageDiscordAttachmentsPersistsEmptyURLMarker(t *testing.T) {
 	got, err := st.MessageDiscordAttachments(messageID)
 	require.NoError(err)
 	assert.Equal(map[string]store.AttachmentRef{
-		"discord:attachment-empty": {
+		"discord:attachment-empty": persistedProviderRef(store.AttachmentRef{
 			Filename: "unavailable.bin", MimeType: "application/octet-stream", Size: 42,
 			StoragePath: "discord:pending:attachment-empty", SourceAttachmentID: "discord:attachment-empty",
-		},
+		}),
 	}, got)
 	pending, err := st.ListDiscordPendingAttachmentMessages(source.ID)
 	require.NoError(err)
@@ -297,8 +309,7 @@ func TestSlackAliasRowsServeHashesThroughMessageAPI(t *testing.T) {
 	require.NoError(err)
 	messageID := insertStoreTestMessage(t, st, source.ID, conversationID, "C01:1.000100")
 
-	// Two Slack files sharing one CAS blob: normalization keeps the hash on
-	// the first row and writes the duplicate as a hashless alias.
+	// Two Slack source parts may retain the same canonical content hash.
 	contentHash := strings.Repeat("ab", 32)
 	casPath := contentHash[:2] + "/" + contentHash
 	require.NoError(st.ReplaceMessageSlackAttachments(messageID, []store.AttachmentRef{
@@ -306,14 +317,13 @@ func TestSlackAliasRowsServeHashesThroughMessageAPI(t *testing.T) {
 		{Filename: "copy.png", StoragePath: casPath, ContentHash: contentHash, SourceAttachmentID: "slack:F2", MediaType: "image"},
 	}))
 
-	// The message-detail API must serve BOTH attachments as accessible:
-	// the alias row's hash re-derives from its trusted CAS path.
+	// The message-detail API must serve both occurrences as accessible.
 	message, err := st.GetMessage(messageID)
 	require.NoError(err)
 	require.Len(message.Attachments, 2)
 	for _, att := range message.Attachments {
 		assert.Equal(contentHash, att.ContentHash,
-			"a Slack duplicate-content alias must stay accessible through the API (%s)", att.Filename)
+			"a duplicate-byte Slack occurrence must stay accessible through the API (%s)", att.Filename)
 		assert.Empty(att.URL)
 	}
 }
@@ -361,6 +371,9 @@ func TestReplaceAndListMessageDiscordAttachments(t *testing.T) {
 			SourceAttachmentID: "discord:attachment-2",
 		},
 	}
+	for key, ref := range want {
+		want[key] = persistedProviderRef(ref)
+	}
 	require.NoError(st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{
 		want["discord:attachment-1"],
 		want["discord:attachment-2"],
@@ -383,7 +396,9 @@ func TestReplaceAndListMessageDiscordAttachments(t *testing.T) {
 
 	beeperGot, err := st.MessageBeeperAttachments(messageID)
 	require.NoError(err)
-	assert.Equal(map[string]store.AttachmentRef{beeperRef.SourceAttachmentID: beeperRef}, beeperGot)
+	assert.Equal(map[string]store.AttachmentRef{
+		beeperRef.SourceAttachmentID: persistedProviderRef(beeperRef),
+	}, beeperGot)
 }
 
 func TestListDiscordPendingAttachmentMessages(t *testing.T) {

--- a/internal/store/content_changed_at_test.go
+++ b/internal/store/content_changed_at_test.go
@@ -474,7 +474,7 @@ func dropContentChangedAtColumn(t *testing.T, st *store.Store) {
 // contentChangedBackfillMigration is the ledger name InitSchema records once the
 // content_changed_at backfill has run.
 const contentChangedBackfillMigration = "messages_content_changed_at_backfill"
-const messageWatermarkTriggersMigration = "message_watermark_triggers_v1"
+const messageWatermarkTriggersMigration = "message_and_attachment_triggers_v2"
 
 // clearContentChangedBackfillLedger deletes that row from applied_migrations so
 // InitSchema treats the migration as never having run -- the ledger state of

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -638,6 +638,15 @@ func (d *PostgreSQLDialect) LegacyColumnMigrations() []ColumnMigration {
 		// Legacy rows stay NULL (unfillable without re-parsing raw MIME) and
 		// discovery falls back to the participant's email for them.
 		{`ALTER TABLE message_recipients ADD COLUMN IF NOT EXISTS email_address TEXT`, "message_recipients.email_address"},
+		{`ALTER TABLE attachments ADD COLUMN IF NOT EXISTS attachment_role TEXT NOT NULL DEFAULT 'unknown' CHECK (attachment_role IN ('standalone', 'inline', 'avatar', 'thumbnail', 'preview', 'sticker', 'ui_asset', 'unknown'))`, "attachments.attachment_role"},
+		{`ALTER TABLE attachments ADD COLUMN IF NOT EXISTS role_source TEXT NOT NULL DEFAULT 'unknown' CHECK (role_source IN ('mime_disposition', 'provider_explicit', 'importer_semantics', 'legacy_api', 'raw_mime_repair', 'unknown'))`, "attachments.role_source"},
+		{`ALTER TABLE attachments ADD COLUMN IF NOT EXISTS source_part_key TEXT CHECK (source_part_key IS NULL OR source_part_key != '')`, "attachments.source_part_key"},
+		{`ALTER TABLE attachments ADD COLUMN IF NOT EXISTS content_id TEXT`, "attachments.content_id"},
+		{`ALTER TABLE document_extractions ADD COLUMN IF NOT EXISTS rebuild_id TEXT REFERENCES document_extraction_rebuilds(id) ON DELETE SET NULL`, "document_extractions.rebuild_id"},
+		{`ALTER TABLE document_extractions ADD COLUMN IF NOT EXISTS request_count INTEGER NOT NULL DEFAULT 0 CHECK (request_count >= 0)`, "document_extractions.request_count"},
+		{`ALTER TABLE document_extractions ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0 AND retry_count <= request_count)`, "document_extractions.retry_count"},
+		{`ALTER TABLE document_extractions ADD COLUMN IF NOT EXISTS provider_latency_ms BIGINT NOT NULL DEFAULT 0 CHECK (provider_latency_ms >= 0)`, "document_extractions.provider_latency_ms"},
+		{`ALTER TABLE document_index_state ADD COLUMN IF NOT EXISTS target_profile_id TEXT`, "document_index_state.target_profile_id"},
 	}
 }
 
@@ -1116,6 +1125,118 @@ func (d *PostgreSQLDialect) EnsureTriggers(q querier) error {
 		`CREATE TRIGGER trg_embedding_changes_participant_display_name
 		     AFTER UPDATE OF display_name, email_address, phone_number ON participants FOR EACH ROW
 		     EXECUTE FUNCTION journal_beeper_participant_display_name()`,
+		`CREATE OR REPLACE FUNCTION capture_attachment_change() RETURNS trigger AS $$
+		 BEGIN
+		     IF NOT EXISTS (SELECT 1 FROM attachment_change_consumers) THEN
+		         IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+		     END IF;
+		     IF TG_OP = 'INSERT' THEN
+		         INSERT INTO attachment_change_log
+		             (event_kind, new_message_id, new_attachment_id,
+		              new_content_hash, new_source_part_key, new_role)
+		         VALUES ('attachment_insert', NEW.message_id, NEW.id,
+		                 NEW.content_hash, NEW.source_part_key, NEW.attachment_role);
+		         RETURN NEW;
+		     ELSIF TG_OP = 'UPDATE' THEN
+		         INSERT INTO attachment_change_log
+		             (event_kind, old_message_id, new_message_id,
+		              old_attachment_id, new_attachment_id,
+		              old_content_hash, new_content_hash,
+		              old_source_part_key, new_source_part_key,
+		              old_role, new_role)
+		         VALUES ('attachment_update', OLD.message_id, NEW.message_id,
+		                 OLD.id, NEW.id, OLD.content_hash, NEW.content_hash,
+		                 OLD.source_part_key, NEW.source_part_key,
+		                 OLD.attachment_role, NEW.attachment_role);
+		         RETURN NEW;
+		     ELSE
+		         INSERT INTO attachment_change_log
+		             (event_kind, old_message_id, old_attachment_id,
+		              old_content_hash, old_source_part_key, old_role)
+		         VALUES ('attachment_delete', OLD.message_id, OLD.id,
+		                 OLD.content_hash, OLD.source_part_key, OLD.attachment_role);
+		         RETURN OLD;
+		     END IF;
+		 END;
+		 $$ LANGUAGE plpgsql`,
+		`DROP TRIGGER IF EXISTS trg_attachment_change_insert ON attachments`,
+		`CREATE TRIGGER trg_attachment_change_insert
+		     AFTER INSERT ON attachments FOR EACH ROW
+		     EXECUTE FUNCTION capture_attachment_change()`,
+		`DROP TRIGGER IF EXISTS trg_attachment_change_update ON attachments`,
+		`CREATE TRIGGER trg_attachment_change_update
+		     AFTER UPDATE OF message_id, filename, mime_type, size, content_hash,
+		         storage_path, media_type, width, height, duration_ms,
+		         source_attachment_id, attachment_metadata, attachment_role,
+		         role_source, source_part_key, content_id, encryption_version
+		     ON attachments FOR EACH ROW
+		     WHEN (OLD.message_id IS DISTINCT FROM NEW.message_id
+		        OR OLD.filename IS DISTINCT FROM NEW.filename
+		        OR OLD.mime_type IS DISTINCT FROM NEW.mime_type
+		        OR OLD.size IS DISTINCT FROM NEW.size
+		        OR OLD.content_hash IS DISTINCT FROM NEW.content_hash
+		        OR OLD.storage_path IS DISTINCT FROM NEW.storage_path
+		        OR OLD.media_type IS DISTINCT FROM NEW.media_type
+		        OR OLD.width IS DISTINCT FROM NEW.width
+		        OR OLD.height IS DISTINCT FROM NEW.height
+		        OR OLD.duration_ms IS DISTINCT FROM NEW.duration_ms
+		        OR OLD.source_attachment_id IS DISTINCT FROM NEW.source_attachment_id
+		        OR OLD.attachment_metadata IS DISTINCT FROM NEW.attachment_metadata
+		        OR OLD.attachment_role IS DISTINCT FROM NEW.attachment_role
+		        OR OLD.role_source IS DISTINCT FROM NEW.role_source
+		        OR OLD.source_part_key IS DISTINCT FROM NEW.source_part_key
+		        OR OLD.content_id IS DISTINCT FROM NEW.content_id
+		        OR OLD.encryption_version IS DISTINCT FROM NEW.encryption_version)
+		     EXECUTE FUNCTION capture_attachment_change()`,
+		`DROP TRIGGER IF EXISTS trg_attachment_change_delete ON attachments`,
+		`CREATE TRIGGER trg_attachment_change_delete
+		     AFTER DELETE ON attachments FOR EACH ROW
+		     EXECUTE FUNCTION capture_attachment_change()`,
+		`CREATE OR REPLACE FUNCTION capture_attachment_message_live_change() RETURNS trigger AS $$
+		 BEGIN
+		     IF NOT EXISTS (SELECT 1 FROM attachment_change_consumers) THEN
+		         RETURN NEW;
+		     END IF;
+		     INSERT INTO attachment_change_log
+		         (event_kind, old_message_id, new_message_id,
+		          old_attachment_id, new_attachment_id,
+		          old_content_hash, new_content_hash,
+		          old_source_part_key, new_source_part_key,
+		          old_role, new_role)
+		     SELECT
+		         CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		              THEN 'message_live_enter' ELSE 'message_live_exit' END,
+		         CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		              THEN OLD.id END,
+		         CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		              THEN NEW.id END,
+		         CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		              THEN a.id END,
+		         CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		              THEN a.id END,
+		         CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		              THEN a.content_hash END,
+		         CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		              THEN a.content_hash END,
+		         CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		              THEN a.source_part_key END,
+		         CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		              THEN a.source_part_key END,
+		         CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		              THEN a.attachment_role END,
+		         CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		              THEN a.attachment_role END
+		     FROM attachments a WHERE a.message_id = NEW.id;
+		     RETURN NEW;
+		 END;
+		 $$ LANGUAGE plpgsql`,
+		`DROP TRIGGER IF EXISTS trg_attachment_message_live_change ON messages`,
+		`CREATE TRIGGER trg_attachment_message_live_change
+		     AFTER UPDATE OF deleted_at, deleted_from_source_at ON messages FOR EACH ROW
+		     WHEN ((OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL)
+		           IS DISTINCT FROM
+		           (NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL))
+		     EXECUTE FUNCTION capture_attachment_message_live_change()`,
 	}
 	for _, stmt := range stmts {
 		if _, err := q.Exec(stmt); err != nil {
@@ -1235,7 +1356,7 @@ func (d *PostgreSQLDialect) IsFTSValueTooLargeError(err error) bool {
 var exclusiveLockTables = []string{
 	"sync_runs", "sources", "conversations", "conversation_participants",
 	"messages", "message_recipients", "message_labels", "message_bodies", "message_raw",
-	"attachments", "labels", "participants", "participant_identifiers", "reactions",
+	"attachments", "document_occurrences", "labels", "participants", "participant_identifiers", "reactions",
 	"participant_contact_observations", "identity_match_candidates", "identity_match_evidence",
 	// persons and person_participants: MergeParticipants (reached from the
 	// Beeper import path) repoints bindings and bumps person revisions, so

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -960,6 +960,104 @@ func (d *SQLiteDialect) EnsureTriggers(q querier) error {
 		               NULL, NULL, NULL, NULL, NEW.id
 		          FROM embedding_change_clock WHERE singleton = 1 AND enabled = TRUE;
 		    END`,
+		`DROP TRIGGER IF EXISTS trg_attachment_change_insert`,
+		`CREATE TRIGGER trg_attachment_change_insert
+		    AFTER INSERT ON attachments FOR EACH ROW
+		    WHEN EXISTS (SELECT 1 FROM attachment_change_consumers)
+		    BEGIN
+		        INSERT INTO attachment_change_log
+		            (event_kind, new_message_id, new_attachment_id,
+		             new_content_hash, new_source_part_key, new_role)
+		        VALUES ('attachment_insert', NEW.message_id, NEW.id,
+		                NEW.content_hash, NEW.source_part_key, NEW.attachment_role);
+		    END`,
+		`DROP TRIGGER IF EXISTS trg_attachment_change_update`,
+		`CREATE TRIGGER trg_attachment_change_update
+		    AFTER UPDATE OF message_id, filename, mime_type, size, content_hash,
+		        storage_path, media_type, width, height, duration_ms,
+		        source_attachment_id, attachment_metadata, attachment_role,
+		        role_source, source_part_key, content_id, encryption_version
+		    ON attachments FOR EACH ROW
+		    WHEN EXISTS (SELECT 1 FROM attachment_change_consumers)
+		      AND (OLD.message_id IS NOT NEW.message_id
+		        OR OLD.filename IS NOT NEW.filename
+		        OR OLD.mime_type IS NOT NEW.mime_type
+		        OR OLD.size IS NOT NEW.size
+		        OR OLD.content_hash IS NOT NEW.content_hash
+		        OR OLD.storage_path IS NOT NEW.storage_path
+		        OR OLD.media_type IS NOT NEW.media_type
+		        OR OLD.width IS NOT NEW.width
+		        OR OLD.height IS NOT NEW.height
+		        OR OLD.duration_ms IS NOT NEW.duration_ms
+		        OR OLD.source_attachment_id IS NOT NEW.source_attachment_id
+		        OR OLD.attachment_metadata IS NOT NEW.attachment_metadata
+		        OR OLD.attachment_role IS NOT NEW.attachment_role
+		        OR OLD.role_source IS NOT NEW.role_source
+		        OR OLD.source_part_key IS NOT NEW.source_part_key
+		        OR OLD.content_id IS NOT NEW.content_id
+		        OR OLD.encryption_version IS NOT NEW.encryption_version)
+		    BEGIN
+		        INSERT INTO attachment_change_log
+		            (event_kind, old_message_id, new_message_id,
+		             old_attachment_id, new_attachment_id,
+		             old_content_hash, new_content_hash,
+		             old_source_part_key, new_source_part_key,
+		             old_role, new_role)
+		        VALUES ('attachment_update', OLD.message_id, NEW.message_id,
+		                OLD.id, NEW.id, OLD.content_hash, NEW.content_hash,
+		                OLD.source_part_key, NEW.source_part_key,
+		                OLD.attachment_role, NEW.attachment_role);
+		    END`,
+		`DROP TRIGGER IF EXISTS trg_attachment_change_delete`,
+		`CREATE TRIGGER trg_attachment_change_delete
+		    AFTER DELETE ON attachments FOR EACH ROW
+		    WHEN EXISTS (SELECT 1 FROM attachment_change_consumers)
+		    BEGIN
+		        INSERT INTO attachment_change_log
+		            (event_kind, old_message_id, old_attachment_id,
+		             old_content_hash, old_source_part_key, old_role)
+		        VALUES ('attachment_delete', OLD.message_id, OLD.id,
+		                OLD.content_hash, OLD.source_part_key, OLD.attachment_role);
+		    END`,
+		`DROP TRIGGER IF EXISTS trg_attachment_message_live_change`,
+		`CREATE TRIGGER trg_attachment_message_live_change
+		    AFTER UPDATE OF deleted_at, deleted_from_source_at ON messages FOR EACH ROW
+		    WHEN EXISTS (SELECT 1 FROM attachment_change_consumers)
+		      AND ((OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL)
+		           IS NOT
+		           (NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL))
+		    BEGIN
+		        INSERT INTO attachment_change_log
+		            (event_kind, old_message_id, new_message_id,
+		             old_attachment_id, new_attachment_id,
+		             old_content_hash, new_content_hash,
+		             old_source_part_key, new_source_part_key,
+		             old_role, new_role)
+		        SELECT
+		            CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		                 THEN 'message_live_enter' ELSE 'message_live_exit' END,
+		            CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		                 THEN OLD.id END,
+		            CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		                 THEN NEW.id END,
+		            CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		                 THEN a.id END,
+		            CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		                 THEN a.id END,
+		            CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		                 THEN a.content_hash END,
+		            CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		                 THEN a.content_hash END,
+		            CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		                 THEN a.source_part_key END,
+		            CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		                 THEN a.source_part_key END,
+		            CASE WHEN OLD.deleted_at IS NULL AND OLD.deleted_from_source_at IS NULL
+		                 THEN a.attachment_role END,
+		            CASE WHEN NEW.deleted_at IS NULL AND NEW.deleted_from_source_at IS NULL
+		                 THEN a.attachment_role END
+		        FROM attachments a WHERE a.message_id = NEW.id;
+		    END`,
 	)
 	for _, stmt := range stmts {
 		if _, err := q.Exec(stmt); err != nil {
@@ -1136,6 +1234,15 @@ func (d *SQLiteDialect) LegacyColumnMigrations() []ColumnMigration {
 		// Legacy rows stay NULL (unfillable without re-parsing raw MIME) and
 		// discovery falls back to the participant's email for them.
 		{`ALTER TABLE message_recipients ADD COLUMN email_address TEXT`, "message_recipients.email_address"},
+		{`ALTER TABLE attachments ADD COLUMN attachment_role TEXT NOT NULL DEFAULT 'unknown' CHECK (attachment_role IN ('standalone', 'inline', 'avatar', 'thumbnail', 'preview', 'sticker', 'ui_asset', 'unknown'))`, "attachments.attachment_role"},
+		{`ALTER TABLE attachments ADD COLUMN role_source TEXT NOT NULL DEFAULT 'unknown' CHECK (role_source IN ('mime_disposition', 'provider_explicit', 'importer_semantics', 'legacy_api', 'raw_mime_repair', 'unknown'))`, "attachments.role_source"},
+		{`ALTER TABLE attachments ADD COLUMN source_part_key TEXT CHECK (source_part_key IS NULL OR source_part_key != '')`, "attachments.source_part_key"},
+		{`ALTER TABLE attachments ADD COLUMN content_id TEXT`, "attachments.content_id"},
+		{`ALTER TABLE document_extractions ADD COLUMN rebuild_id TEXT REFERENCES document_extraction_rebuilds(id) ON DELETE SET NULL`, "document_extractions.rebuild_id"},
+		{`ALTER TABLE document_extractions ADD COLUMN request_count INTEGER NOT NULL DEFAULT 0 CHECK (request_count >= 0)`, "document_extractions.request_count"},
+		{`ALTER TABLE document_extractions ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0 AND retry_count <= request_count)`, "document_extractions.retry_count"},
+		{`ALTER TABLE document_extractions ADD COLUMN provider_latency_ms INTEGER NOT NULL DEFAULT 0 CHECK (provider_latency_ms >= 0)`, "document_extractions.provider_latency_ms"},
+		{`ALTER TABLE document_index_state ADD COLUMN target_profile_id TEXT`, "document_index_state.target_profile_id"},
 	}
 }
 

--- a/internal/store/document_index.go
+++ b/internal/store/document_index.go
@@ -1,0 +1,1351 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+)
+
+var (
+	ErrDocumentExtractionRebuildActive  = errors.New("document extraction rebuild is already active")
+	ErrDocumentExtractionRebuildMissing = errors.New("document extraction rebuild is not active")
+)
+
+// DocumentExtractionProfile is an immutable hosted-extraction policy. The
+// caller supplies its full policy fingerprint as both durable identity and
+// rebuild boundary; provider consent is recorded separately.
+type DocumentExtractionProfile struct {
+	ID                string
+	Fingerprint       string
+	Provider          string
+	Endpoint          string
+	Region            string
+	Model             string
+	RetentionPosture  string
+	TrainingPosture   string
+	AllowedMediaTypes []string
+	PolicyJSON        json.RawMessage
+}
+
+type DocumentProviderConsent struct {
+	ProfileID          string
+	ProfileFingerprint string
+	RetentionPosture   string
+	TrainingPosture    string
+}
+
+type DocumentOccurrence struct {
+	OccurrenceKey     string
+	AttachmentID      int64
+	MessageID         int64
+	SourceID          int64
+	SourcePartKey     string
+	StableSourcePart  bool
+	CanonicalBlobHash string
+	Filename          string
+	MIMEType          string
+	AttachmentRole    AttachmentRole
+	RoleSource        AttachmentRoleSource
+	SourceSequence    int64
+}
+
+// DocumentExtractionCandidate is one canonical blob owner that has at least
+// one current eligible occurrence but no published extraction for the exact
+// profile and input key.
+type DocumentExtractionCandidate struct {
+	AttachmentID      int64
+	CanonicalBlobHash string
+	MIMEType          string
+	Size              int64
+	MessageType       string
+	SourceSequence    int64
+}
+
+type DocumentExtractionRebuild struct {
+	ID                      string
+	ProfileID               string
+	ExtractionInputKey      string
+	State                   string
+	CreatedAt               time.Time
+	CompletedAt             *time.Time
+	SnapshotOwners          int64
+	IncompleteCurrentOwners int64
+}
+
+type DocumentIndexStatus struct {
+	ProfileExists              bool    `json:"profile_exists"`
+	ProfileEnabled             bool    `json:"profile_enabled"`
+	ExactConsent               bool    `json:"exact_consent"`
+	ExtractionAttempts         int64   `json:"extraction_attempts"`
+	SuccessfulAttempts         int64   `json:"successful_attempts"`
+	FailedAttempts             int64   `json:"failed_attempts"`
+	ProviderRequests           int64   `json:"provider_requests"`
+	ProviderRetries            int64   `json:"provider_retries"`
+	ProviderLatencyMillis      int64   `json:"provider_latency_millis"`
+	AverageProviderLatencyMS   float64 `json:"average_provider_latency_millis"`
+	VerifiedUploadBytes        int64   `json:"verified_upload_bytes"`
+	ProcessedProviderUnits     int64   `json:"processed_provider_units"`
+	ReportedProviderBytes      int64   `json:"reported_provider_bytes"`
+	MissingProviderByteReports int64   `json:"missing_provider_byte_reports"`
+	EligibleOccurrences        int64   `json:"eligible_occurrences"`
+	EligibleOwners             int64   `json:"eligible_owners"`
+	EligibleBytes              int64   `json:"eligible_bytes"`
+	UnknownRoleOccurrences     int64   `json:"unknown_role_occurrences"`
+	IneligibleRoleOccurrences  int64   `json:"ineligible_role_occurrences"`
+	ReadyOwners                int64   `json:"ready_owners"`
+	StagingOwners              int64   `json:"staging_owners"`
+	RetryOwners                int64   `json:"retry_owners"`
+	TerminalOwners             int64   `json:"terminal_owners"`
+	MissingOwners              int64   `json:"missing_owners"`
+	StoredPlaintextChunks      int64   `json:"stored_plaintext_chunks"`
+}
+
+// DocumentIndexStatusRequest identifies one exact profile and configured scope.
+type DocumentIndexStatusRequest struct {
+	ProfileID           string
+	ExtractionInputKey  string
+	AllowedMediaTypes   []string
+	AllowedMessageTypes []string
+}
+
+// DocumentIndexRebuildStatus reports progress for the exact active rebuild.
+type DocumentIndexRebuildStatus struct {
+	SnapshotOwners  int64 `json:"snapshot_owners"`
+	RemainingOwners int64 `json:"remaining_owners"`
+}
+
+// DocumentIndexStatusResponse combines scoped coverage and rebuild progress.
+type DocumentIndexStatusResponse struct {
+	Status        DocumentIndexStatus         `json:"status"`
+	ActiveRebuild *DocumentIndexRebuildStatus `json:"active_rebuild,omitempty"`
+}
+
+type DocumentDerivativeGCResult struct {
+	ExtractionsRemoved  int `json:"extractions_removed"`
+	CurrentHeadsRemoved int `json:"current_heads_removed"`
+}
+
+type DocumentDerivedPurgeResult struct {
+	ExtractionsRemoved int `json:"extractions_removed"`
+	HeadsRemoved       int `json:"heads_removed"`
+}
+
+// EnsureDocumentExtractionProfile inserts one immutable profile or verifies
+// that an existing row has exactly the same policy. It never records consent
+// and never enables hosted processing.
+func (s *Store) EnsureDocumentExtractionProfile(
+	ctx context.Context,
+	profile DocumentExtractionProfile,
+) (bool, error) {
+	allowedJSON, policyJSON, err := validateDocumentProfile(profile)
+	if err != nil {
+		return false, err
+	}
+	var created bool
+	err = s.withTxContext(ctx, func(tx *loggedTx) error {
+		result, execErr := tx.Exec(`
+			INSERT INTO document_extraction_profiles
+				(id, fingerprint, provider, endpoint, region, model,
+				 retention_posture, training_posture, allowed_media_types,
+				 policy_json, enabled)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, FALSE)
+			ON CONFLICT (id) DO NOTHING`,
+			profile.ID, profile.Fingerprint, profile.Provider, profile.Endpoint,
+			profile.Region, profile.Model, profile.RetentionPosture,
+			profile.TrainingPosture, string(allowedJSON), string(policyJSON),
+		)
+		if execErr != nil {
+			return fmt.Errorf("insert document extraction profile: %w", execErr)
+		}
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return fmt.Errorf("read document extraction profile insert result: %w", rowsErr)
+		}
+		created = rows == 1
+
+		var stored DocumentExtractionProfile
+		var storedAllowed, storedPolicy string
+		if scanErr := tx.QueryRow(`
+			SELECT id, fingerprint, provider, endpoint, region, model,
+			       retention_posture, training_posture,
+			       CAST(allowed_media_types AS TEXT), CAST(policy_json AS TEXT)
+			FROM document_extraction_profiles WHERE id = ?`, profile.ID).Scan(
+			&stored.ID, &stored.Fingerprint, &stored.Provider, &stored.Endpoint,
+			&stored.Region, &stored.Model, &stored.RetentionPosture,
+			&stored.TrainingPosture, &storedAllowed, &storedPolicy,
+		); scanErr != nil {
+			return fmt.Errorf("read document extraction profile: %w", scanErr)
+		}
+		if stored.ID != profile.ID || stored.Fingerprint != profile.Fingerprint ||
+			stored.Provider != profile.Provider || stored.Endpoint != profile.Endpoint ||
+			stored.Region != profile.Region || stored.Model != profile.Model ||
+			stored.RetentionPosture != profile.RetentionPosture ||
+			stored.TrainingPosture != profile.TrainingPosture ||
+			!equalJSON([]byte(storedAllowed), allowedJSON) ||
+			!equalJSON([]byte(storedPolicy), policyJSON) {
+			return errors.New("document extraction profile ID already has different immutable policy")
+		}
+		return nil
+	})
+	return created, err
+}
+
+// RecordDocumentProviderConsent enables one exact immutable profile. A change
+// to any privacy assertion or fingerprint requires a different profile and a
+// new explicit consent record.
+func (s *Store) RecordDocumentProviderConsent(
+	ctx context.Context,
+	consent DocumentProviderConsent,
+) error {
+	if consent.ProfileID == "" || !validLowerSHA256(consent.ProfileFingerprint) ||
+		consent.RetentionPosture == "" || consent.TrainingPosture == "" ||
+		consent.RetentionPosture == "unknown" || consent.TrainingPosture == "unknown" {
+		return errors.New("document provider consent requires an exact profile and explicit privacy postures")
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		var fingerprint, retention, training string
+		var retired bool
+		if err := tx.QueryRow(`
+			SELECT fingerprint, retention_posture, training_posture,
+			       retired_at IS NOT NULL
+			FROM document_extraction_profiles WHERE id = ?`, consent.ProfileID).Scan(
+			&fingerprint, &retention, &training, &retired,
+		); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.New("document provider consent profile does not exist")
+			}
+			return fmt.Errorf("read document provider consent profile: %w", err)
+		}
+		if fingerprint != consent.ProfileFingerprint || retention != consent.RetentionPosture || training != consent.TrainingPosture {
+			return errors.New("document provider consent does not match immutable profile")
+		}
+		if retired {
+			return errors.New("document provider consent profile is retired")
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO document_provider_consents
+				(profile_id, profile_fingerprint, retention_posture, training_posture)
+			VALUES (?, ?, ?, ?)
+			ON CONFLICT (profile_id) DO NOTHING`,
+			consent.ProfileID, consent.ProfileFingerprint,
+			consent.RetentionPosture, consent.TrainingPosture,
+		); err != nil {
+			return fmt.Errorf("record document provider consent: %w", err)
+		}
+		var storedFingerprint, storedRetention, storedTraining string
+		if err := tx.QueryRow(`
+			SELECT profile_fingerprint, retention_posture, training_posture
+			FROM document_provider_consents WHERE profile_id = ?`, consent.ProfileID).Scan(
+			&storedFingerprint, &storedRetention, &storedTraining,
+		); err != nil {
+			return fmt.Errorf("read document provider consent: %w", err)
+		}
+		if storedFingerprint != consent.ProfileFingerprint ||
+			storedRetention != consent.RetentionPosture || storedTraining != consent.TrainingPosture {
+			return errors.New("document provider consent already records different assertions")
+		}
+		if _, err := tx.Exec(`
+			UPDATE document_extraction_profiles SET enabled = TRUE
+			WHERE id = ? AND retired_at IS NULL`, consent.ProfileID); err != nil {
+			return fmt.Errorf("enable consented document extraction profile: %w", err)
+		}
+		var currentTarget sql.NullString
+		if err := tx.QueryRow(`
+			SELECT target_profile_id FROM document_index_state WHERE singleton = 1`,
+		).Scan(&currentTarget); err != nil {
+			return fmt.Errorf("read target document extraction profile: %w", err)
+		}
+		if currentTarget.Valid && currentTarget.String == consent.ProfileID {
+			return nil
+		}
+		var hasHeads bool
+		if err := tx.QueryRow(`SELECT EXISTS (SELECT 1 FROM document_extraction_heads)`).Scan(&hasHeads); err != nil {
+			return fmt.Errorf("check document heads before selecting target profile: %w", err)
+		}
+		if _, err := tx.Exec(`
+			UPDATE document_index_state
+			SET target_profile_id = ?, updated_at = CURRENT_TIMESTAMP
+			WHERE singleton = 1`, consent.ProfileID); err != nil {
+			return fmt.Errorf("select target document extraction profile: %w", err)
+		}
+		if hasHeads {
+			return bumpDocumentIndexRevision(tx)
+		}
+		return nil
+	})
+}
+
+// ReconcileDocumentOccurrence resolves current metadata through the same
+// trusted-CAS authority as file downloads. Only live, standalone occurrences
+// with authoritative role provenance and locally available canonical bytes
+// are retained. It returns false for an ineligible or missing attachment.
+func (s *Store) ReconcileDocumentOccurrence(
+	ctx context.Context,
+	attachmentID int64,
+	sourceSequence int64,
+) (DocumentOccurrence, bool, error) {
+	if attachmentID <= 0 || sourceSequence < 0 {
+		return DocumentOccurrence{}, false, errors.New("document occurrence reconciliation has invalid coordinates")
+	}
+	file, err := s.GetFileMetadata(ctx, attachmentID)
+	if err != nil {
+		return DocumentOccurrence{}, false, err
+	}
+	live := false
+	if file != nil {
+		live, err = s.documentAttachmentIsLive(ctx, attachmentID)
+		if err != nil {
+			return DocumentOccurrence{}, false, err
+		}
+	}
+	if file == nil || !live || !eligibleDocumentFile(*file) {
+		if err := s.removeDocumentOccurrence(ctx, attachmentID); err != nil {
+			return DocumentOccurrence{}, false, err
+		}
+		return DocumentOccurrence{}, false, nil
+	}
+	stable := file.SourcePartKey != ""
+	occurrence := DocumentOccurrence{
+		OccurrenceKey:     documentOccurrenceKey(file.MessageID, file.SourcePartKey, file.ID),
+		AttachmentID:      file.ID,
+		MessageID:         file.MessageID,
+		SourceID:          file.SourceID,
+		SourcePartKey:     file.SourcePartKey,
+		StableSourcePart:  stable,
+		CanonicalBlobHash: file.ContentHash,
+		Filename:          file.Filename,
+		MIMEType:          file.MimeType,
+		AttachmentRole:    file.AttachmentRole,
+		RoleSource:        file.RoleSource,
+		SourceSequence:    sourceSequence,
+	}
+	if err := s.upsertDocumentOccurrence(ctx, occurrence); err != nil {
+		return DocumentOccurrence{}, false, err
+	}
+	return occurrence, true, nil
+}
+
+func (s *Store) documentAttachmentIsLive(ctx context.Context, attachmentID int64) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, s.dialect.Rebind(`
+		SELECT EXISTS (
+			SELECT 1 FROM attachments a
+			JOIN messages m ON m.id = a.message_id
+			WHERE a.id = ? AND `+LiveMessagesWhere("m", true)+`
+		)`), attachmentID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check document attachment live state: %w", err)
+	}
+	return exists, nil
+}
+
+func (s *Store) GetDocumentIndexRevision(ctx context.Context) (int64, error) {
+	var revision int64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT revision FROM document_index_state WHERE singleton = 1`).Scan(&revision); err != nil {
+		return 0, fmt.Errorf("read document index revision: %w", err)
+	}
+	return revision, nil
+}
+
+// HasActiveDocumentProviderConsent reports whether any enabled, unretired
+// extraction profile has the exact recorded provider posture it requires.
+// It is the activation gate for bootstrapping the attachment journal consumer.
+func (s *Store) HasActiveDocumentProviderConsent(ctx context.Context) (bool, error) {
+	var consented bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM document_extraction_profiles p
+			JOIN document_provider_consents c ON c.profile_id = p.id
+			WHERE p.enabled = TRUE
+			  AND p.retired_at IS NULL
+			  AND c.profile_fingerprint = p.fingerprint
+			  AND c.retention_posture = p.retention_posture
+			  AND c.training_posture = p.training_posture
+		)`).Scan(&consented)
+	if err != nil {
+		return false, fmt.Errorf("read active document provider consent: %w", err)
+	}
+	return consented, nil
+}
+
+func (s *Store) GetDocumentIndexStatus(ctx context.Context, profileID string) (DocumentIndexStatus, error) {
+	if profileID == "" {
+		return DocumentIndexStatus{}, errors.New("document index status requires a profile ID")
+	}
+	var status DocumentIndexStatus
+	err := s.db.QueryRowContext(ctx, s.dialect.Rebind(`
+		SELECT EXISTS (SELECT 1 FROM document_extraction_profiles WHERE id = ?),
+		       EXISTS (
+		           SELECT 1 FROM document_extraction_profiles
+		           WHERE id = ? AND enabled = TRUE AND retired_at IS NULL
+		       ),
+		       EXISTS (
+		           SELECT 1 FROM document_extraction_profiles p
+		           JOIN document_provider_consents c ON c.profile_id = p.id
+		           WHERE p.id = ?
+		             AND c.profile_fingerprint = p.fingerprint
+		             AND c.retention_posture = p.retention_posture
+		             AND c.training_posture = p.training_posture
+		       ),
+		       (SELECT COUNT(*) FROM document_occurrences WHERE attachment_role = 'standalone'),
+		       (SELECT COUNT(*) FROM document_extraction_heads WHERE profile_id = ?),
+		       (SELECT COUNT(*) FROM document_extractions WHERE profile_id = ? AND state = 'staging'),
+		       (SELECT COUNT(*) FROM document_extractions
+		        WHERE profile_id = ? AND state = 'tombstoned' AND next_retry_at IS NOT NULL),
+		       (SELECT COUNT(*) FROM document_extractions WHERE profile_id = ? AND state = 'terminal'),
+		       (SELECT COALESCE(SUM(CASE WHEN state = 'ready' THEN 1 ELSE 0 END), 0) +
+		               COALESCE(SUM(attempt_count), 0)
+		        FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COUNT(*) FROM document_extractions WHERE profile_id = ? AND state = 'ready'),
+		       (SELECT COALESCE(SUM(attempt_count), 0) FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COALESCE(SUM(request_count), 0) FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COALESCE(SUM(retry_count), 0) FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COALESCE(SUM(provider_latency_ms), 0) FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COALESCE(SUM(local_bytes), 0) FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COALESCE(SUM(units_processed), 0) FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COALESCE(SUM(provider_bytes), 0) FROM document_extractions WHERE profile_id = ?),
+		       (SELECT COUNT(*) FROM document_extractions
+		        WHERE profile_id = ? AND state = 'ready' AND provider_bytes IS NULL)`),
+		profileID, profileID, profileID, profileID, profileID, profileID, profileID,
+		profileID, profileID, profileID, profileID, profileID, profileID, profileID,
+		profileID, profileID, profileID,
+	).Scan(
+		&status.ProfileExists, &status.ProfileEnabled, &status.ExactConsent,
+		&status.EligibleOccurrences, &status.ReadyOwners, &status.StagingOwners,
+		&status.RetryOwners, &status.TerminalOwners,
+		&status.ExtractionAttempts, &status.SuccessfulAttempts, &status.FailedAttempts,
+		&status.ProviderRequests, &status.ProviderRetries, &status.ProviderLatencyMillis,
+		&status.VerifiedUploadBytes, &status.ProcessedProviderUnits,
+		&status.ReportedProviderBytes, &status.MissingProviderByteReports,
+	)
+	if err != nil {
+		return DocumentIndexStatus{}, fmt.Errorf("read document index status: %w", err)
+	}
+	if status.ProviderRequests > 0 {
+		status.AverageProviderLatencyMS = float64(status.ProviderLatencyMillis) / float64(status.ProviderRequests)
+	}
+	return status, nil
+}
+
+// GetDocumentIndexStatusForScope classifies each currently eligible canonical
+// owner once. Ready, staging, retry, terminal, and missing are mutually
+// exclusive in that priority order, so repeated immutable attempts do not
+// inflate operator-facing coverage.
+func (s *Store) GetDocumentIndexStatusForScope(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (DocumentIndexStatus, error) {
+	status, err := s.GetDocumentIndexStatus(ctx, profileID)
+	if err != nil {
+		return DocumentIndexStatus{}, err
+	}
+	scopeSQL, scopeArgs, err := documentOccurrenceScopeSQL(
+		"o", "m", allowedMediaTypes, allowedMessageTypes,
+	)
+	if err != nil {
+		return DocumentIndexStatus{}, err
+	}
+	args := slices.Clone(scopeArgs)
+	for range 4 {
+		args = append(args, profileID, extractionInputKey)
+	}
+	err = s.db.QueryRowContext(ctx, s.dialect.Rebind(`
+		WITH eligible_occurrences AS (
+			SELECT o.canonical_blob_hash, COALESCE(a.size, 0) AS owner_size
+			FROM document_occurrences o
+			JOIN attachments a ON a.id = o.attachment_id
+			JOIN messages m ON m.id = o.message_id
+			WHERE `+scopeSQL+`
+		), eligible AS (
+			SELECT canonical_blob_hash, MAX(owner_size) AS owner_size
+			FROM eligible_occurrences
+			GROUP BY canonical_blob_hash
+		), classified AS (
+			SELECT e.canonical_blob_hash, e.owner_size,
+			       CASE
+			         WHEN EXISTS (
+			             SELECT 1 FROM document_extraction_heads h
+			             WHERE h.profile_id = ? AND h.extraction_input_key = ?
+			               AND h.canonical_blob_hash = e.canonical_blob_hash
+			         ) THEN 'ready'
+			         WHEN EXISTS (
+			             SELECT 1 FROM document_extractions x
+			             WHERE x.profile_id = ? AND x.extraction_input_key = ?
+			               AND x.canonical_blob_hash = e.canonical_blob_hash AND x.state = 'staging'
+			         ) THEN 'staging'
+			         WHEN EXISTS (
+			             SELECT 1 FROM document_extractions x
+			             WHERE x.profile_id = ? AND x.extraction_input_key = ?
+			               AND x.canonical_blob_hash = e.canonical_blob_hash
+			               AND x.state = 'tombstoned' AND x.next_retry_at IS NOT NULL
+			         ) THEN 'retry'
+			         WHEN EXISTS (
+			             SELECT 1 FROM document_extractions x
+			             WHERE x.profile_id = ? AND x.extraction_input_key = ?
+			               AND x.canonical_blob_hash = e.canonical_blob_hash AND x.state = 'terminal'
+			         ) THEN 'terminal'
+			         ELSE 'missing'
+			       END AS coverage_state
+			FROM eligible e
+		)
+		SELECT (SELECT COUNT(*) FROM eligible_occurrences),
+		       COUNT(*), COALESCE(SUM(owner_size), 0),
+		       COALESCE(SUM(CASE WHEN coverage_state = 'ready' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN coverage_state = 'staging' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN coverage_state = 'retry' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN coverage_state = 'terminal' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN coverage_state = 'missing' THEN 1 ELSE 0 END), 0)
+		FROM classified`), args...).Scan(
+		&status.EligibleOccurrences, &status.EligibleOwners, &status.EligibleBytes,
+		&status.ReadyOwners, &status.StagingOwners, &status.RetryOwners,
+		&status.TerminalOwners, &status.MissingOwners,
+	)
+	if err != nil {
+		return DocumentIndexStatus{}, fmt.Errorf("read scoped document index coverage: %w", err)
+	}
+	mediaScopeSQL, mediaScopeArgs, err := documentOccurrenceMediaScopeSQL(
+		"a", "m", allowedMediaTypes, allowedMessageTypes,
+	)
+	if err != nil {
+		return DocumentIndexStatus{}, err
+	}
+	err = s.db.QueryRowContext(ctx, s.dialect.Rebind(`
+		SELECT COALESCE(SUM(CASE WHEN a.attachment_role = 'unknown' THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN a.attachment_role NOT IN ('standalone', 'unknown') THEN 1 ELSE 0 END), 0)
+		FROM attachments a
+		JOIN messages m ON m.id = a.message_id
+		WHERE `+mediaScopeSQL), mediaScopeArgs...).Scan(
+		&status.UnknownRoleOccurrences, &status.IneligibleRoleOccurrences,
+	)
+	if err != nil {
+		return DocumentIndexStatus{}, fmt.Errorf("read document index role exclusions: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM document_chunks`).Scan(
+		&status.StoredPlaintextChunks,
+	); err != nil {
+		return DocumentIndexStatus{}, fmt.Errorf("count stored document plaintext chunks: %w", err)
+	}
+	return status, nil
+}
+
+func (s *Store) StartDocumentExtractionRebuild(
+	ctx context.Context,
+	rebuildID string,
+	profileID string,
+	extractionInputKey string,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (DocumentExtractionRebuild, error) {
+	if rebuildID == "" || profileID == "" || extractionInputKey == "" {
+		return DocumentExtractionRebuild{}, errors.New("document extraction rebuild identity is incomplete")
+	}
+	scopeSQL, scopeArgs, err := documentOccurrenceScopeSQL(
+		"o", "m", allowedMediaTypes, allowedMessageTypes,
+	)
+	if err != nil {
+		return DocumentExtractionRebuild{}, err
+	}
+	rebuild := DocumentExtractionRebuild{
+		ID: rebuildID, ProfileID: profileID, ExtractionInputKey: extractionInputKey, State: "building",
+	}
+	err = s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		var active bool
+		if err := q.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM document_extraction_rebuilds
+				WHERE profile_id = ? AND extraction_input_key = ? AND state = 'building'
+			)`, profileID, extractionInputKey).Scan(&active); err != nil {
+			return fmt.Errorf("check active document extraction rebuild: %w", err)
+		}
+		if active {
+			return ErrDocumentExtractionRebuildActive
+		}
+		var authorized bool
+		if err := q.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM document_extraction_profiles p
+				JOIN document_provider_consents c ON c.profile_id = p.id
+				WHERE p.id = ? AND p.enabled = TRUE AND p.retired_at IS NULL
+				  AND c.profile_fingerprint = p.fingerprint
+				  AND c.retention_posture = p.retention_posture
+				  AND c.training_posture = p.training_posture
+			)`, profileID).Scan(&authorized); err != nil {
+			return fmt.Errorf("check document extraction rebuild authority: %w", err)
+		}
+		if !authorized {
+			return errors.New("document extraction rebuild profile is not enabled with exact consent")
+		}
+		if _, err := q.Exec(`
+			INSERT INTO document_extraction_rebuilds
+				(id, profile_id, extraction_input_key, state)
+			VALUES (?, ?, ?, 'building')`, rebuildID, profileID, extractionInputKey); err != nil {
+			return fmt.Errorf("start document extraction rebuild: %w", err)
+		}
+		args := make([]any, 0, len(scopeArgs)+1)
+		args = append(args, rebuildID)
+		args = append(args, scopeArgs...)
+		result, err := q.Exec(`
+			INSERT INTO document_extraction_rebuild_targets (rebuild_id, canonical_blob_hash)
+			SELECT ?, o.canonical_blob_hash
+			FROM document_occurrences o
+			JOIN messages m ON m.id = o.message_id
+			WHERE `+scopeSQL+`
+			GROUP BY o.canonical_blob_hash`, args...)
+		if err != nil {
+			return fmt.Errorf("snapshot document extraction rebuild targets: %w", err)
+		}
+		rebuild.SnapshotOwners, err = result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read document extraction rebuild target count: %w", err)
+		}
+		return q.QueryRow(`
+			SELECT created_at FROM document_extraction_rebuilds WHERE id = ?`, rebuildID,
+		).Scan(&rebuild.CreatedAt)
+	})
+	if err != nil {
+		return DocumentExtractionRebuild{}, err
+	}
+	rebuild.IncompleteCurrentOwners = rebuild.SnapshotOwners
+	return rebuild, nil
+}
+
+func (s *Store) GetActiveDocumentExtractionRebuild(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+) (DocumentExtractionRebuild, error) {
+	if profileID == "" || extractionInputKey == "" {
+		return DocumentExtractionRebuild{}, errors.New("document extraction rebuild lookup is incomplete")
+	}
+	var rebuild DocumentExtractionRebuild
+	err := s.db.QueryRowContext(ctx, s.dialect.Rebind(`
+		SELECT r.id, r.profile_id, r.extraction_input_key, r.state, r.created_at,
+		       (SELECT COUNT(*) FROM document_extraction_rebuild_targets t WHERE t.rebuild_id = r.id)
+		FROM document_extraction_rebuilds r
+		WHERE r.profile_id = ? AND r.extraction_input_key = ? AND r.state = 'building'`),
+		profileID, extractionInputKey,
+	).Scan(&rebuild.ID, &rebuild.ProfileID, &rebuild.ExtractionInputKey,
+		&rebuild.State, &rebuild.CreatedAt, &rebuild.SnapshotOwners)
+	if errors.Is(err, sql.ErrNoRows) {
+		return DocumentExtractionRebuild{}, ErrDocumentExtractionRebuildMissing
+	}
+	if err != nil {
+		return DocumentExtractionRebuild{}, fmt.Errorf("read active document extraction rebuild: %w", err)
+	}
+	return rebuild, nil
+}
+
+func (s *Store) CountIncompleteDocumentExtractionRebuild(
+	ctx context.Context,
+	rebuild DocumentExtractionRebuild,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (int64, error) {
+	if rebuild.ID == "" || rebuild.ProfileID == "" || rebuild.ExtractionInputKey == "" || rebuild.State != "building" {
+		return 0, errors.New("document extraction rebuild is invalid")
+	}
+	scopeSQL, scopeArgs, err := documentOccurrenceScopeSQL(
+		"o", "m", allowedMediaTypes, allowedMessageTypes,
+	)
+	if err != nil {
+		return 0, err
+	}
+	args := make([]any, 0, len(scopeArgs)+2)
+	args = append(args, rebuild.ID)
+	args = append(args, scopeArgs...)
+	args = append(args, rebuild.ID)
+	var incomplete int64
+	err = s.db.QueryRowContext(ctx, s.dialect.Rebind(`
+		SELECT COUNT(*)
+		FROM document_extraction_rebuild_targets t
+		WHERE t.rebuild_id = ?
+		  AND EXISTS (
+		      SELECT 1 FROM document_occurrences o
+		      JOIN messages m ON m.id = o.message_id
+		      WHERE o.canonical_blob_hash = t.canonical_blob_hash AND `+scopeSQL+`
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM document_extractions e
+		      WHERE e.rebuild_id = ? AND e.canonical_blob_hash = t.canonical_blob_hash
+		        AND e.state = 'ready'
+		  )`), args...).Scan(&incomplete)
+	if err != nil {
+		return 0, fmt.Errorf("count incomplete document extraction rebuild owners: %w", err)
+	}
+	return incomplete, nil
+}
+
+func (s *Store) CompleteDocumentExtractionRebuild(ctx context.Context, rebuildID string) error {
+	if rebuildID == "" {
+		return errors.New("document extraction rebuild completion requires an ID")
+	}
+	result, err := s.db.ExecContext(ctx, s.dialect.Rebind(`
+		UPDATE document_extraction_rebuilds
+		SET state = 'completed', completed_at = `+s.dialect.Now()+`
+		WHERE id = ? AND state = 'building'`), rebuildID)
+	if err != nil {
+		return fmt.Errorf("complete document extraction rebuild: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read document extraction rebuild completion: %w", err)
+	}
+	if updated != 1 {
+		return ErrDocumentExtractionRebuildMissing
+	}
+	return nil
+}
+
+// GarbageCollectDocumentDerivatives removes bounded stale extraction
+// revisions. Superseded revisions are eligible after the recovery cutoff;
+// current owners are eligible only after their final live occurrence is gone.
+// Active staging leases are never collected.
+func (s *Store) GarbageCollectDocumentDerivatives(
+	ctx context.Context,
+	before time.Time,
+	limit int,
+) (DocumentDerivativeGCResult, error) {
+	if before.IsZero() || limit <= 0 || limit > 10_000 {
+		return DocumentDerivativeGCResult{}, errors.New("document derivative GC has invalid bounds")
+	}
+	result := DocumentDerivativeGCResult{}
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		rows, err := tx.Query(`
+			SELECT e.id, e.state,
+			       CASE WHEN h.extraction_id IS NULL THEN FALSE ELSE TRUE END
+			FROM document_extractions e
+			LEFT JOIN document_extraction_heads h ON h.extraction_id = e.id
+			WHERE e.updated_at < ?
+			  AND (e.state != 'staging' OR e.lease_until IS NULL OR e.lease_until < `+s.dialect.Now()+`)
+			  AND (h.extraction_id IS NULL OR NOT EXISTS (
+			      SELECT 1 FROM document_occurrences o
+			      JOIN messages m ON m.id = o.message_id
+			      WHERE o.canonical_blob_hash = e.canonical_blob_hash
+			        AND o.attachment_role = 'standalone'
+			        AND `+LiveMessagesWhere("m", true)+`
+			  ))
+			ORDER BY e.updated_at, e.id
+			LIMIT ?`, before.UTC(), limit)
+		if err != nil {
+			return fmt.Errorf("list stale document derivatives: %w", err)
+		}
+		var extractionIDs []string
+		var terminalRemoved bool
+		for rows.Next() {
+			var extractionID string
+			var state string
+			var current bool
+			if err := rows.Scan(&extractionID, &state, &current); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan stale document derivative: %w", err)
+			}
+			extractionIDs = append(extractionIDs, extractionID)
+			terminalRemoved = terminalRemoved || state == "terminal"
+			if current {
+				result.CurrentHeadsRemoved++
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("iterate stale document derivatives: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close stale document derivative rows: %w", err)
+		}
+		if len(extractionIDs) == 0 {
+			return nil
+		}
+		args := make([]any, len(extractionIDs))
+		for index := range extractionIDs {
+			args[index] = extractionIDs[index]
+		}
+		deleted, err := tx.Exec(`DELETE FROM document_extractions WHERE id IN (`+
+			documentPlaceholders(len(extractionIDs))+`)`, args...)
+		if err != nil {
+			return fmt.Errorf("delete stale document derivatives: %w", err)
+		}
+		count, err := deleted.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read stale document derivative delete count: %w", err)
+		}
+		result.ExtractionsRemoved = int(count)
+		if result.CurrentHeadsRemoved > 0 || terminalRemoved {
+			return bumpDocumentIndexRevision(tx)
+		}
+		return nil
+	})
+	return result, err
+}
+
+func (s *Store) RetryDocumentExtraction(
+	ctx context.Context,
+	profileID string,
+	canonicalBlobHash string,
+) (bool, error) {
+	if profileID == "" || !validLowerSHA256(canonicalBlobHash) {
+		return false, errors.New("document extraction retry requires an exact profile and SHA-256")
+	}
+	var changed bool
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		var hasHead bool
+		if err := tx.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM document_extraction_heads
+				WHERE profile_id = ? AND canonical_blob_hash = ?
+			)`, profileID, canonicalBlobHash).Scan(&hasHead); err != nil {
+			return fmt.Errorf("check current document extraction before retry: %w", err)
+		}
+		retryScope := ""
+		if hasHead {
+			var activeRebuildFailure bool
+			if err := tx.QueryRow(`
+				SELECT EXISTS (
+					SELECT 1 FROM document_extractions e
+					JOIN document_extraction_rebuilds r ON r.id = e.rebuild_id
+					WHERE e.profile_id = ? AND e.canonical_blob_hash = ?
+					  AND e.state IN ('terminal', 'tombstoned') AND r.state = 'building'
+				)`, profileID, canonicalBlobHash).Scan(&activeRebuildFailure); err != nil {
+				return fmt.Errorf("check active rebuild failure before retry: %w", err)
+			}
+			if !activeRebuildFailure {
+				return errors.New("document extraction is already current for this profile")
+			}
+			retryScope = `
+			  AND EXISTS (
+			      SELECT 1 FROM document_extraction_rebuilds r
+			      WHERE r.id = document_extractions.rebuild_id AND r.state = 'building'
+			  )`
+		}
+		var terminalRows int
+		if err := tx.QueryRow(`
+			SELECT COUNT(*)
+			FROM document_extractions
+			WHERE profile_id = ? AND canonical_blob_hash = ?
+			  AND state = 'terminal'`+retryScope, profileID, canonicalBlobHash).Scan(&terminalRows); err != nil {
+			return fmt.Errorf("count terminal document extractions before retry: %w", err)
+		}
+		result, err := tx.Exec(`
+			UPDATE document_extractions
+			SET state = 'tombstoned', next_retry_at = `+s.dialect.Now()+`,
+			    terminal_reason = NULL, updated_at = CURRENT_TIMESTAMP
+			WHERE profile_id = ? AND canonical_blob_hash = ?
+			  AND state IN ('terminal', 'tombstoned')`+retryScope, profileID, canonicalBlobHash)
+		if err != nil {
+			return fmt.Errorf("schedule document extraction retry: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read document extraction retry result: %w", err)
+		}
+		changed = rows > 0
+		if changed && terminalRows > 0 {
+			return bumpDocumentIndexRevision(tx)
+		}
+		return nil
+	})
+	return changed, err
+}
+
+func (s *Store) RetireDocumentExtractionProfile(ctx context.Context, profileID string) (bool, error) {
+	if profileID == "" || len(profileID) > 200 {
+		return false, errors.New("document profile retirement requires an exact profile ID")
+	}
+	var changed bool
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		var headCount int
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM document_extraction_heads WHERE profile_id = ?`,
+			profileID).Scan(&headCount); err != nil {
+			return fmt.Errorf("count document profile heads before retirement: %w", err)
+		}
+		result, err := tx.Exec(`
+			UPDATE document_extraction_profiles
+			SET enabled = FALSE, retired_at = CURRENT_TIMESTAMP
+			WHERE id = ? AND retired_at IS NULL`, profileID)
+		if err != nil {
+			return fmt.Errorf("retire document extraction profile: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read document profile retirement result: %w", err)
+		}
+		changed = rows > 0
+		if !changed {
+			return nil
+		}
+		result, err = tx.Exec(`
+			UPDATE document_index_state
+			SET target_profile_id = NULL
+			WHERE singleton = 1 AND target_profile_id = ?`, profileID)
+		if err != nil {
+			return fmt.Errorf("clear retired target document extraction profile: %w", err)
+		}
+		targetRows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read cleared document target result: %w", err)
+		}
+		if headCount > 0 || targetRows > 0 {
+			return bumpDocumentIndexRevision(tx)
+		}
+		return nil
+	})
+	return changed, err
+}
+
+func (s *Store) PurgeDocumentDerivedByHash(
+	ctx context.Context,
+	canonicalBlobHash string,
+) (DocumentDerivedPurgeResult, error) {
+	if !validLowerSHA256(canonicalBlobHash) {
+		return DocumentDerivedPurgeResult{}, errors.New("document derivative purge requires an exact lowercase SHA-256")
+	}
+	result := DocumentDerivedPurgeResult{}
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		if err := tx.QueryRow(`
+			SELECT COUNT(*) FROM document_extraction_heads WHERE canonical_blob_hash = ?`,
+			canonicalBlobHash).Scan(&result.HeadsRemoved); err != nil {
+			return fmt.Errorf("count document heads before purge: %w", err)
+		}
+		deleted, err := tx.Exec(`DELETE FROM document_extractions WHERE canonical_blob_hash = ?`,
+			canonicalBlobHash)
+		if err != nil {
+			return fmt.Errorf("purge document derivatives: %w", err)
+		}
+		rows, err := deleted.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read document derivative purge result: %w", err)
+		}
+		result.ExtractionsRemoved = int(rows)
+		if result.HeadsRemoved > 0 {
+			return bumpDocumentIndexRevision(tx)
+		}
+		return nil
+	})
+	return result, err
+}
+
+// ListDocumentAttachmentIDsAfter supplies the bounded bootstrap scan used to
+// reconcile archives created before document indexing was enabled. Callers
+// advance by the last returned ID and may safely repeat a page.
+func (s *Store) ListDocumentAttachmentIDsAfter(
+	ctx context.Context,
+	afterID int64,
+	limit int,
+) ([]int64, error) {
+	if afterID < 0 || limit <= 0 || limit > 10_000 {
+		return nil, errors.New("document attachment scan has invalid bounds")
+	}
+	rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(`
+		SELECT id FROM attachments WHERE id > ? ORDER BY id LIMIT ?`), afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list document attachment scan page: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	ids := make([]int64, 0, limit)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan document attachment ID: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate document attachment IDs: %w", err)
+	}
+	return ids, nil
+}
+
+// ReconcileMissingDocumentOccurrences removes catalog rows whose attachment
+// disappeared through direct SQL or cascade deletion. Event replay usually
+// removes them by old attachment ID; this bounded anti-join is the periodic
+// correctness backstop for missed events and legacy catalog state.
+func (s *Store) ReconcileMissingDocumentOccurrences(ctx context.Context, limit int) (int, error) {
+	if limit <= 0 || limit > 10_000 {
+		return 0, errors.New("missing document occurrence scan has invalid bounds")
+	}
+	removed := 0
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		result, err := q.Exec(`
+			DELETE FROM document_occurrences
+			WHERE occurrence_key IN (
+				SELECT o.occurrence_key
+				FROM document_occurrences o
+				LEFT JOIN attachments a ON a.id = o.attachment_id
+				WHERE a.id IS NULL
+				ORDER BY o.occurrence_key
+				LIMIT ?
+			)`, limit)
+		if err != nil {
+			return fmt.Errorf("remove missing document occurrences: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read missing document occurrence count: %w", err)
+		}
+		removed = int(rows)
+		if removed == 0 {
+			return nil
+		}
+		return bumpDocumentIndexRevision(q)
+	})
+	return removed, err
+}
+
+// ListPendingDocumentExtractions returns one representative occurrence per
+// canonical blob. It serves only an enabled profile with exact recorded
+// consent and excludes owners with a ready head, terminal decision, or active
+// retry delay. Every returned row is rechecked again by Claim and Publish.
+func (s *Store) ListPendingDocumentExtractions(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+	allowedMediaTypes []string,
+	limit int,
+) ([]DocumentExtractionCandidate, error) {
+	return s.ListDocumentExtractionCandidates(
+		ctx, profileID, extractionInputKey, allowedMediaTypes, nil, nil, limit,
+	)
+}
+
+// ListDocumentExtractionCandidates returns one representative occurrence per
+// canonical blob. A rebuild scan is restricted to its durable target snapshot
+// and includes current heads until this exact rebuild has resolved each owner.
+func (s *Store) ListDocumentExtractionCandidates(
+	ctx context.Context,
+	profileID string,
+	extractionInputKey string,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+	rebuild *DocumentExtractionRebuild,
+	limit int,
+) ([]DocumentExtractionCandidate, error) {
+	if profileID == "" || extractionInputKey == "" || limit <= 0 || limit > 10_000 {
+		return nil, errors.New("pending document extraction scan has invalid bounds")
+	}
+	outerScopeSQL, outerScopeArgs, err := documentOccurrenceScopeSQL(
+		"o", "m", allowedMediaTypes, allowedMessageTypes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	innerScopeSQL, innerScopeArgs, err := documentOccurrenceScopeSQL(
+		"o2", "m2", allowedMediaTypes, allowedMessageTypes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	args := make([]any, 0, len(outerScopeArgs)+len(innerScopeArgs)+5)
+	args = append(args, profileID)
+	args = append(args, outerScopeArgs...)
+	args = append(args, innerScopeArgs...)
+	var ownerStateFilter string
+	if rebuild == nil {
+		ownerStateFilter = `
+		  AND NOT EXISTS (
+		      SELECT 1 FROM document_extraction_heads h
+		      WHERE h.profile_id = p.id
+		        AND h.canonical_blob_hash = o.canonical_blob_hash
+		        AND h.extraction_input_key = ?
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM document_extractions e
+		      WHERE e.profile_id = p.id
+		        AND e.canonical_blob_hash = o.canonical_blob_hash
+		        AND e.extraction_input_key = ?
+		        AND (e.state = 'terminal' OR
+		             (e.state = 'tombstoned' AND e.next_retry_at > ` + s.dialect.Now() + `))
+		  )`
+		args = append(args, extractionInputKey, extractionInputKey)
+	} else {
+		if rebuild.ID == "" || rebuild.ProfileID != profileID ||
+			rebuild.ExtractionInputKey != extractionInputKey || rebuild.State != "building" {
+			return nil, errors.New("pending document extraction scan has an invalid rebuild")
+		}
+		ownerStateFilter = `
+		  AND EXISTS (
+		      SELECT 1 FROM document_extraction_rebuild_targets t
+		      WHERE t.rebuild_id = ? AND t.canonical_blob_hash = o.canonical_blob_hash
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM document_extractions e
+		      WHERE e.rebuild_id = ? AND e.canonical_blob_hash = o.canonical_blob_hash
+		        AND (e.state IN ('ready', 'terminal') OR
+		             (e.state = 'tombstoned' AND e.next_retry_at > ` + s.dialect.Now() + `))
+		  )`
+		args = append(args, rebuild.ID, rebuild.ID)
+	}
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(`
+		SELECT o.attachment_id, o.canonical_blob_hash, COALESCE(o.mime_type, ''),
+		       COALESCE(a.size, 0), COALESCE(m.message_type, ''), o.source_sequence
+		FROM document_occurrences o
+		JOIN attachments a ON a.id = o.attachment_id
+		JOIN messages m ON m.id = o.message_id
+		JOIN document_extraction_profiles p ON p.id = ?
+		JOIN document_provider_consents c ON c.profile_id = p.id
+		WHERE p.enabled = TRUE AND p.retired_at IS NULL
+		  AND c.profile_fingerprint = p.fingerprint
+		  AND c.retention_posture = p.retention_posture
+		  AND c.training_posture = p.training_posture
+		  AND `+outerScopeSQL+`
+		  AND o.occurrence_key = (
+		      SELECT MIN(o2.occurrence_key) FROM document_occurrences o2
+		      JOIN messages m2 ON m2.id = o2.message_id
+		      WHERE o2.canonical_blob_hash = o.canonical_blob_hash
+		        AND `+innerScopeSQL+`
+		  )
+		`+ownerStateFilter+`
+		ORDER BY o.occurrence_key
+		LIMIT ?`), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list pending document extractions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	candidates := make([]DocumentExtractionCandidate, 0, limit)
+	for rows.Next() {
+		var candidate DocumentExtractionCandidate
+		if err := rows.Scan(&candidate.AttachmentID, &candidate.CanonicalBlobHash,
+			&candidate.MIMEType, &candidate.Size, &candidate.MessageType,
+			&candidate.SourceSequence); err != nil {
+			return nil, fmt.Errorf("scan pending document extraction: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending document extractions: %w", err)
+	}
+	return candidates, nil
+}
+
+func documentOccurrenceScopeSQL(
+	occurrenceAlias string,
+	messageAlias string,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (string, []any, error) {
+	mediaScopeSQL, args, err := documentOccurrenceMediaScopeSQL(
+		occurrenceAlias, messageAlias, allowedMediaTypes, allowedMessageTypes,
+	)
+	if err != nil {
+		return "", nil, err
+	}
+	return occurrenceAlias + ".attachment_role = 'standalone' AND " + mediaScopeSQL, args, nil
+}
+
+func documentOccurrenceMediaScopeSQL(
+	occurrenceAlias string,
+	messageAlias string,
+	allowedMediaTypes []string,
+	allowedMessageTypes []string,
+) (string, []any, error) {
+	if len(allowedMediaTypes) == 0 {
+		return "", nil, errors.New("document occurrence scope requires media types")
+	}
+	mediaPlaceholders := make([]string, len(allowedMediaTypes))
+	args := make([]any, 0, len(allowedMediaTypes)+len(allowedMessageTypes))
+	for index, mediaType := range allowedMediaTypes {
+		if mediaType == "" {
+			return "", nil, errors.New("document occurrence scope has an empty media type")
+		}
+		mediaPlaceholders[index] = "?"
+		args = append(args, mediaType)
+	}
+	conditions := []string{
+		occurrenceAlias + ".mime_type IN (" + strings.Join(mediaPlaceholders, ",") + ")",
+		LiveMessagesWhere(messageAlias, true),
+	}
+	if len(allowedMessageTypes) > 0 {
+		messagePlaceholders := make([]string, len(allowedMessageTypes))
+		for index, messageType := range allowedMessageTypes {
+			if messageType == "" {
+				return "", nil, errors.New("document occurrence scope has an empty message type")
+			}
+			messagePlaceholders[index] = "?"
+			args = append(args, messageType)
+		}
+		conditions = append(conditions,
+			messageAlias+".message_type IN ("+strings.Join(messagePlaceholders, ",")+")")
+	}
+	return strings.Join(conditions, " AND "), args, nil
+}
+
+func (s *Store) upsertDocumentOccurrence(ctx context.Context, occurrence DocumentOccurrence) error {
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		var existing DocumentOccurrence
+		err := tx.QueryRow(`
+			SELECT occurrence_key, attachment_id, message_id, source_id,
+			       COALESCE(source_part_key, ''), stable_source_part,
+			       canonical_blob_hash, COALESCE(filename, ''), COALESCE(mime_type, ''),
+			       attachment_role, role_source, source_sequence
+			FROM document_occurrences WHERE occurrence_key = ?`, occurrence.OccurrenceKey).Scan(
+			&existing.OccurrenceKey, &existing.AttachmentID, &existing.MessageID,
+			&existing.SourceID, &existing.SourcePartKey, &existing.StableSourcePart,
+			&existing.CanonicalBlobHash, &existing.Filename, &existing.MIMEType,
+			&existing.AttachmentRole, &existing.RoleSource, &existing.SourceSequence,
+		)
+		if err == nil && existing == occurrence {
+			return nil
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("read document occurrence: %w", err)
+		}
+		if _, err := tx.Exec(`
+			DELETE FROM document_occurrences
+			WHERE attachment_id = ? AND occurrence_key != ?`,
+			occurrence.AttachmentID, occurrence.OccurrenceKey,
+		); err != nil {
+			return fmt.Errorf("remove replaced document occurrence: %w", err)
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO document_occurrences
+				(occurrence_key, attachment_id, message_id, source_id,
+				 source_part_key, stable_source_part, canonical_blob_hash,
+				 filename, mime_type, attachment_role, role_source, source_sequence)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT (occurrence_key) DO UPDATE SET
+				attachment_id = EXCLUDED.attachment_id,
+				message_id = EXCLUDED.message_id,
+				source_id = EXCLUDED.source_id,
+				source_part_key = EXCLUDED.source_part_key,
+				stable_source_part = EXCLUDED.stable_source_part,
+				canonical_blob_hash = EXCLUDED.canonical_blob_hash,
+				filename = EXCLUDED.filename,
+				mime_type = EXCLUDED.mime_type,
+				attachment_role = EXCLUDED.attachment_role,
+				role_source = EXCLUDED.role_source,
+				source_sequence = EXCLUDED.source_sequence,
+				reconciled_at = CURRENT_TIMESTAMP`,
+			occurrence.OccurrenceKey, occurrence.AttachmentID, occurrence.MessageID,
+			occurrence.SourceID, nullIfEmpty(occurrence.SourcePartKey),
+			occurrence.StableSourcePart, occurrence.CanonicalBlobHash,
+			nullIfEmpty(occurrence.Filename), nullIfEmpty(occurrence.MIMEType),
+			occurrence.AttachmentRole, occurrence.RoleSource, occurrence.SourceSequence,
+		); err != nil {
+			return fmt.Errorf("upsert document occurrence: %w", err)
+		}
+		return bumpDocumentIndexRevision(tx)
+	})
+}
+
+func (s *Store) removeDocumentOccurrence(ctx context.Context, attachmentID int64) error {
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		result, err := tx.Exec(`DELETE FROM document_occurrences WHERE attachment_id = ?`, attachmentID)
+		if err != nil {
+			return fmt.Errorf("remove document occurrence: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read removed document occurrence count: %w", err)
+		}
+		if rows == 0 {
+			return nil
+		}
+		return bumpDocumentIndexRevision(tx)
+	})
+}
+
+func bumpDocumentIndexRevision(q querier) error {
+	if _, err := q.Exec(`
+		UPDATE document_index_state
+		SET revision = revision + 1, updated_at = CURRENT_TIMESTAMP
+		WHERE singleton = 1`); err != nil {
+		return fmt.Errorf("advance document index revision: %w", err)
+	}
+	return nil
+}
+
+func eligibleDocumentFile(file FileMetadata) bool {
+	if file.AttachmentRole != AttachmentRoleStandalone || file.StoragePath == "" ||
+		file.Size <= 0 || !validLowerSHA256(file.ContentHash) {
+		return false
+	}
+	switch file.RoleSource {
+	case AttachmentRoleSourceMIMEDisposition, AttachmentRoleSourceProviderExplicit,
+		AttachmentRoleSourceImporterSemantics, AttachmentRoleSourceRawMIMERepair:
+		return true
+	default:
+		return false
+	}
+}
+
+func documentOccurrenceKey(messageID int64, sourcePartKey string, attachmentID int64) string {
+	identity := fmt.Sprintf("unstable\x00%d\x00%d", messageID, attachmentID)
+	if sourcePartKey != "" {
+		identity = fmt.Sprintf("stable\x00%d\x00%s", messageID, sourcePartKey)
+	}
+	digest := sha256.Sum256([]byte(identity))
+	return "dococc_" + hex.EncodeToString(digest[:])
+}
+
+func validateDocumentProfile(profile DocumentExtractionProfile) ([]byte, []byte, error) {
+	if profile.ID == "" || len(profile.ID) > 200 || !validLowerSHA256(profile.Fingerprint) ||
+		profile.Provider == "" || profile.Endpoint == "" || profile.Region == "" || profile.Model == "" ||
+		profile.RetentionPosture == "" || profile.TrainingPosture == "" ||
+		profile.RetentionPosture == "unknown" || profile.TrainingPosture == "unknown" {
+		return nil, nil, errors.New("document extraction profile is incomplete")
+	}
+	allowed := slices.Clone(profile.AllowedMediaTypes)
+	slices.Sort(allowed)
+	allowed = slices.Compact(allowed)
+	if len(allowed) == 0 || slices.Contains(allowed, "") {
+		return nil, nil, errors.New("document extraction profile requires a media allowlist")
+	}
+	allowedJSON, err := json.Marshal(allowed)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode document extraction profile allowlist: %w", err)
+	}
+	policyJSON, err := compactJSON(profile.PolicyJSON)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate document extraction profile policy: %w", err)
+	}
+	return allowedJSON, policyJSON, nil
+}
+
+func compactJSON(value []byte) ([]byte, error) {
+	if len(value) == 0 || !json.Valid(value) {
+		return nil, errors.New("value is not valid JSON")
+	}
+	var output bytes.Buffer
+	if err := json.Compact(&output, value); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func equalJSON(first, second []byte) bool {
+	decode := func(value []byte) (any, error) {
+		decoder := json.NewDecoder(bytes.NewReader(value))
+		decoder.UseNumber()
+		var decoded any
+		if err := decoder.Decode(&decoded); err != nil {
+			return nil, err
+		}
+		return decoded, nil
+	}
+	firstValue, firstErr := decode(first)
+	secondValue, secondErr := decode(second)
+	return firstErr == nil && secondErr == nil && reflect.DeepEqual(firstValue, secondValue)
+}
+
+func validLowerSHA256(value string) bool {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/internal/store/document_index_schema_test.go
+++ b/internal/store/document_index_schema_test.go
@@ -1,0 +1,151 @@
+package store_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestDocumentIndexSchemaStoresCanonicalTextAndRebuildableFTS(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	profileID := "profile-" + strings.Repeat("a", 64)
+	extractionID := "extraction-synthetic"
+	hash := strings.Repeat("b", 64)
+
+	_, err := st.DB().Exec(st.Rebind(`
+		INSERT INTO document_extraction_profiles
+			(id, fingerprint, provider, endpoint, region, model,
+			 retention_posture, training_posture, allowed_media_types,
+			 policy_json, enabled)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		profileID, strings.Repeat("a", 64), "mistral",
+		"https://api.mistral.ai/v1/ocr", "eu", "mistral-ocr-4-0",
+		"standard", "opted-out", `["application/pdf"]`, `{}`, true,
+	)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO document_extractions
+			(id, profile_id, canonical_blob_hash, extraction_input_key,
+			 state, local_bytes)
+		VALUES (?, ?, ?, 'original', 'ready', ?)`),
+		extractionID, profileID, hash, 128,
+	)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO document_units
+			(extraction_id, unit_index, unit_kind, text, checksum,
+			 char_count, truncated)
+		VALUES (?, 0, 'page', ?, ?, ?, ?)`),
+		extractionID, "canonical unit text", strings.Repeat("c", 64), 19, false,
+	)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO document_chunks
+			(extraction_id, chunk_key, ordinal, text, heading_path,
+			 first_unit_index, last_unit_index, checksum, char_count)
+		VALUES (?, 'chunk-0', 0, ?, ?, 0, 0, ?, ?)`),
+		extractionID, "quasar invoice total", `[]`, strings.Repeat("d", 64), 20,
+	)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO document_chunk_spans
+			(extraction_id, chunk_key, span_ordinal, unit_index,
+			 start_char, end_char, synthetic)
+		VALUES (?, 'chunk-0', 0, 0, 0, 19, ?)`),
+		extractionID, false,
+	)
+	require.NoError(err)
+
+	assert.Equal(t, 1, documentFTSMatchCount(t, st, "quasar"))
+	var revision int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT revision FROM document_index_state WHERE singleton = ?`), 1).Scan(&revision))
+	assert.Zero(t, revision)
+
+	_, err = st.DB().Exec(st.Rebind(`DELETE FROM document_extractions WHERE id = ?`), extractionID)
+	require.NoError(err)
+	assert.Zero(t, documentFTSMatchCount(t, st, "quasar"))
+}
+
+func TestInitSchemaAddsDocumentRebuildIDToLegacyExtractionTable(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	drop := `ALTER TABLE document_extractions DROP COLUMN rebuild_id`
+	if st.IsPostgreSQL() {
+		drop += ` CASCADE`
+	}
+	_, err := st.DB().Exec(drop)
+	require.NoError(err)
+
+	require.NoError(st.InitSchema())
+	var columnCount int
+	query := `SELECT COUNT(*) FROM pragma_table_info('document_extractions') WHERE name = 'rebuild_id'`
+	if st.IsPostgreSQL() {
+		query = `SELECT COUNT(*) FROM information_schema.columns
+		         WHERE table_schema = current_schema()
+		           AND table_name = 'document_extractions' AND column_name = 'rebuild_id'`
+	}
+	require.NoError(st.DB().QueryRow(query).Scan(&columnCount))
+	assert.Equal(t, 1, columnCount)
+}
+
+func TestInitSchemaAddsDocumentTargetProfileToLegacyIndexState(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	_, err := st.DB().Exec(`ALTER TABLE document_index_state DROP COLUMN target_profile_id`)
+	require.NoError(err)
+
+	require.NoError(st.InitSchema())
+	var columnCount int
+	query := `SELECT COUNT(*) FROM pragma_table_info('document_index_state') WHERE name = 'target_profile_id'`
+	if st.IsPostgreSQL() {
+		query = `SELECT COUNT(*) FROM information_schema.columns
+		         WHERE table_schema = current_schema()
+		           AND table_name = 'document_index_state' AND column_name = 'target_profile_id'`
+	}
+	require.NoError(st.DB().QueryRow(query).Scan(&columnCount))
+	assert.Equal(t, 1, columnCount)
+}
+
+func TestInitSchemaAddsDocumentProviderAccountingToLegacyExtractions(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	for _, column := range []string{"retry_count", "request_count", "provider_latency_ms"} {
+		_, err := st.DB().Exec(`ALTER TABLE document_extractions DROP COLUMN ` + column)
+		require.NoError(err)
+	}
+
+	require.NoError(st.InitSchema())
+	for _, column := range []string{"request_count", "retry_count", "provider_latency_ms"} {
+		var columnCount int
+		query := `SELECT COUNT(*) FROM pragma_table_info('document_extractions') WHERE name = ?`
+		if st.IsPostgreSQL() {
+			query = `SELECT COUNT(*) FROM information_schema.columns
+			         WHERE table_schema = current_schema()
+			           AND table_name = 'document_extractions' AND column_name = ?`
+		}
+		require.NoError(st.DB().QueryRow(st.Rebind(query), column).Scan(&columnCount))
+		assert.Equal(t, 1, columnCount, column)
+	}
+}
+
+func documentFTSMatchCount(t *testing.T, st *store.Store, term string) int {
+	t.Helper()
+	var count int
+	if store.IsPostgresURL(os.Getenv("MSGVAULT_TEST_DB")) {
+		require.NoError(t, st.DB().QueryRow(st.Rebind(`
+			SELECT COUNT(*) FROM document_chunks
+			WHERE search_fts @@ plainto_tsquery('simple', ?)`), term).Scan(&count))
+		return count
+	}
+	require.NoError(t, st.DB().QueryRow(`
+		SELECT COUNT(*) FROM document_chunks_fts
+		WHERE document_chunks_fts MATCH ?`, term).Scan(&count))
+	return count
+}

--- a/internal/store/document_index_test.go
+++ b/internal/store/document_index_test.go
@@ -1,0 +1,388 @@
+package store_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestDocumentExtractionProfileRequiresExactConsent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	fingerprint := strings.Repeat("a", 64)
+	profile := store.DocumentExtractionProfile{
+		ID: "profile-" + fingerprint, Fingerprint: fingerprint,
+		Provider: "mistral", Endpoint: "https://api.mistral.ai/v1/ocr",
+		Region: "eu", Model: "mistral-ocr-4-0",
+		RetentionPosture: "standard", TrainingPosture: "opted-out",
+		AllowedMediaTypes: []string{"text/csv", "application/pdf", "text/csv"},
+		PolicyJSON:        []byte(`{"normalization":1,"chunking":1}`),
+	}
+
+	created, err := f.Store.EnsureDocumentExtractionProfile(t.Context(), profile)
+	require.NoError(err)
+	assert.True(created)
+	created, err = f.Store.EnsureDocumentExtractionProfile(t.Context(), profile)
+	require.NoError(err)
+	assert.False(created)
+
+	changed := profile
+	changed.Model = "different-model"
+	_, err = f.Store.EnsureDocumentExtractionProfile(t.Context(), changed)
+	require.ErrorContains(err, "different immutable policy")
+
+	err = f.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+	})
+	require.NoError(err)
+	var enabled bool
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT enabled FROM document_extraction_profiles WHERE id = ?`), profile.ID).Scan(&enabled))
+	assert.True(enabled)
+	revision, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Zero(revision, "consent cannot invalidate an empty document index")
+
+	err = f.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: "zdr", TrainingPosture: profile.TrainingPosture,
+	})
+	require.ErrorContains(err, "does not match immutable profile")
+}
+
+func TestReconcileDocumentOccurrenceUsesTrustedCASAndLiveRole(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("document-occurrence")
+	hash := strings.Repeat("b", 64)
+	require.NoError(f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: 128,
+		StoragePath:   hash[:2] + "/" + hash,
+		Role:          store.AttachmentRoleStandalone,
+		RoleSource:    store.AttachmentRoleSourceMIMEDisposition,
+		SourcePartKey: "mime:1.2",
+	}))
+	attachmentID := singleAttachmentID(t, f, messageID)
+
+	occurrence, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), attachmentID, 10)
+	require.NoError(err)
+	assert.True(eligible)
+	assert.Equal(hash, occurrence.CanonicalBlobHash)
+	assert.True(occurrence.StableSourcePart)
+	assert.NotContains(occurrence.OccurrenceKey, "mime:1.2")
+	revision, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(int64(1), revision)
+
+	_, eligible, err = f.Store.ReconcileDocumentOccurrence(t.Context(), attachmentID, 10)
+	require.NoError(err)
+	assert.True(eligible)
+	revision, err = f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(int64(1), revision, "idempotent reconciliation must not invalidate search cursors")
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP WHERE id = ?`), messageID)
+	require.NoError(err)
+	_, eligible, err = f.Store.ReconcileDocumentOccurrence(t.Context(), attachmentID, 11)
+	require.NoError(err)
+	assert.False(eligible)
+	revision, err = f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(int64(2), revision)
+	var occurrences int
+	require.NoError(f.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM document_occurrences`).Scan(&occurrences))
+	assert.Zero(occurrences)
+}
+
+func TestReconcileDocumentOccurrenceFailsClosedForUnknownRole(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("document-unknown-role")
+	hash := strings.Repeat("c", 64)
+	require.NoError(f.Store.UpsertAttachment(
+		messageID, "synthetic.pdf", "application/pdf", hash[:2]+"/"+hash, hash, 64,
+	))
+	attachmentID := singleAttachmentID(t, f, messageID)
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), attachmentID, 1)
+	require.NoError(err)
+	assert.False(eligible)
+	revision, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Zero(revision)
+}
+
+func TestListPendingDocumentExtractionsRespectsAuthorityAndRetryState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+
+	candidates, err := f.Store.ListPendingDocumentExtractions(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, 10,
+	)
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(hash, candidates[0].CanonicalBlobHash)
+	assert.Equal("application/pdf", candidates[0].MIMEType)
+
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-retry", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-retry", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1, RequireNoHead: true,
+	}))
+	require.NoError(err)
+	require.NoError(f.Store.FailDocumentExtraction(t.Context(), store.DocumentExtractionFailure{
+		Claim: claim, ReasonCode: "provider_transient", RetryAt: time.Now().UTC().Add(time.Hour),
+	}))
+	candidates, err = f.Store.ListPendingDocumentExtractions(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, 10,
+	)
+	require.NoError(err)
+	assert.Empty(candidates)
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE document_extractions SET next_retry_at = ? WHERE id = ?`),
+		time.Now().UTC().Add(-time.Minute), claim.ExtractionID)
+	require.NoError(err)
+	candidates, err = f.Store.ListPendingDocumentExtractions(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, 10,
+	)
+	require.NoError(err)
+	assert.Len(candidates, 1)
+}
+
+func TestListDocumentExtractionCandidatesIncludesCurrentOnlyForFullRebuild(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "current document evidence", "current-for-rebuild")
+
+	pending, err := f.Store.ListDocumentExtractionCandidates(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, nil, nil, 10,
+	)
+	require.NoError(err)
+	assert.Empty(t, pending)
+
+	rebuild, err := f.Store.StartDocumentExtractionRebuild(
+		t.Context(), "rebuild-current", profile.ID, "original", []string{"application/pdf"}, nil,
+	)
+	require.NoError(err)
+	rebuildCandidates, err := f.Store.ListDocumentExtractionCandidates(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, nil, &rebuild, 10,
+	)
+	require.NoError(err)
+	require.Len(rebuildCandidates, 1)
+	assert.Equal(t, hash, rebuildCandidates[0].CanonicalBlobHash)
+}
+
+func TestDocumentExtractionRebuildKeepsTerminalTargetsIncompleteUntilRetry(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "current document evidence", "current-before-terminal-rebuild")
+	rebuild, err := f.Store.StartDocumentExtractionRebuild(
+		t.Context(), "rebuild-terminal", profile.ID, "original", []string{"application/pdf"}, nil,
+	)
+	require.NoError(err)
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "terminal-rebuild-attempt", ProfileID: profile.ID, RebuildID: rebuild.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-terminal-rebuild", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(err)
+	require.NoError(f.Store.FailDocumentExtraction(t.Context(), store.DocumentExtractionFailure{
+		Claim: claim, ReasonCode: "unsupported_provider_response", Terminal: true,
+	}))
+	response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "current",
+	})
+	require.NoError(err)
+	require.Len(response.Results, 1,
+		"a failed replacement must preserve the previously published current head")
+	assert.Equal("current document evidence", response.Results[0].Excerpt)
+
+	remaining, err := f.Store.CountIncompleteDocumentExtractionRebuild(
+		t.Context(), rebuild, []string{"application/pdf"}, nil,
+	)
+	require.NoError(err)
+	assert.Equal(int64(1), remaining)
+	candidates, err := f.Store.ListDocumentExtractionCandidates(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, nil, &rebuild, 10,
+	)
+	require.NoError(err)
+	assert.Empty(candidates, "terminal targets require an explicit retry")
+
+	changed, err := f.Store.RetryDocumentExtraction(t.Context(), profile.ID, hash)
+	require.NoError(err)
+	assert.True(changed)
+	candidates, err = f.Store.ListDocumentExtractionCandidates(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, nil, &rebuild, 10,
+	)
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(hash, candidates[0].CanonicalBlobHash)
+}
+
+func TestDocumentIndexScopedStatusClassifiesOwnersAndRoleExclusions(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "status evidence", "status-current")
+	messageID := f.CreateMessage("document-status-exclusions")
+	unknownHash := strings.Repeat("c", 64)
+	require.NoError(t, f.Store.UpsertAttachment(
+		messageID, "unknown.pdf", "application/pdf", unknownHash[:2]+"/"+unknownHash,
+		unknownHash, 64,
+	))
+	inlineHash := strings.Repeat("d", 64)
+	require.NoError(t, f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "inline.pdf", MIMEType: "application/pdf", Size: 32,
+		StoragePath: inlineHash[:2] + "/" + inlineHash, ContentHash: inlineHash,
+		Role: store.AttachmentRoleInline, RoleSource: store.AttachmentRoleSourceMIMEDisposition,
+		SourcePartKey: "mime:inline",
+	}))
+
+	status, err := f.Store.GetDocumentIndexStatusForScope(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(int64(1), status.EligibleOccurrences)
+	assert.Equal(int64(1), status.EligibleOwners)
+	assert.Equal(int64(128), status.EligibleBytes)
+	assert.Equal(int64(1), status.ReadyOwners)
+	assert.Zero(status.MissingOwners)
+	assert.Equal(int64(1), status.UnknownRoleOccurrences)
+	assert.Equal(int64(1), status.IneligibleRoleOccurrences)
+	assert.Equal(int64(1), status.StoredPlaintextChunks)
+	assert.Equal(int64(1), status.ExtractionAttempts)
+	assert.Equal(int64(1), status.SuccessfulAttempts)
+	assert.Zero(status.FailedAttempts)
+	assert.Equal(int64(1), status.ProviderRequests)
+	assert.Zero(status.ProviderRetries)
+	assert.Equal(int64(25), status.ProviderLatencyMillis)
+	assert.InDelta(25, status.AverageProviderLatencyMS, 0.001)
+	assert.Equal(int64(128), status.VerifiedUploadBytes)
+	assert.Equal(int64(1), status.ProcessedProviderUnits)
+	assert.Zero(status.ReportedProviderBytes)
+	assert.Equal(int64(1), status.MissingProviderByteReports)
+}
+
+func TestDocumentIndexStatusCountsCompletedAttemptOutcomes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	failedClaim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "status-failed-attempt", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "status-failed-worker", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1, RequireNoHead: true,
+	}))
+	require.NoError(err)
+	require.NoError(f.Store.FailDocumentExtraction(t.Context(), store.DocumentExtractionFailure{
+		Claim: failedClaim, ReasonCode: "provider_transient",
+		RetryAt:      time.Now().UTC().Add(time.Minute),
+		RequestCount: 2, RetryCount: 1, ProviderLatencyMS: 50,
+	}))
+	publishSearchDocument(t, f, profile, hash, "successful retry", "status-successful-retry")
+
+	status, err := f.Store.GetDocumentIndexStatus(t.Context(), profile.ID)
+	require.NoError(err)
+	assert.Equal(int64(2), status.ExtractionAttempts)
+	assert.Equal(int64(1), status.SuccessfulAttempts)
+	assert.Equal(int64(1), status.FailedAttempts)
+	assert.Equal(int64(3), status.ProviderRequests)
+	assert.Equal(int64(1), status.ProviderRetries)
+	assert.Equal(int64(75), status.ProviderLatencyMillis)
+	assert.InDelta(25, status.AverageProviderLatencyMS, 0.001)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`
+		UPDATE document_extractions SET attempt_count = 1 WHERE id = ?`),
+		"status-successful-retry")
+	require.NoError(err)
+	status, err = f.Store.GetDocumentIndexStatus(t.Context(), profile.ID)
+	require.NoError(err)
+	assert.Equal(int64(3), status.ExtractionAttempts,
+		"a successful row retains any failed attempts recorded before publication")
+	assert.Equal(int64(1), status.SuccessfulAttempts)
+	assert.Equal(int64(2), status.FailedAttempts)
+
+	staging, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "status-in-flight-attempt", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "replacement",
+		LeaseOwner: "status-in-flight-worker", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(err)
+	assert.NotEmpty(staging.ExtractionID)
+	status, err = f.Store.GetDocumentIndexStatus(t.Context(), profile.ID)
+	require.NoError(err)
+	assert.Equal(int64(3), status.ExtractionAttempts,
+		"in-flight work is reported separately from completed outcomes")
+	assert.Equal(int64(1), status.StagingOwners)
+}
+
+func TestRetryDocumentExtractionReschedulesOnlyTerminalOwner(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-terminal", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-terminal", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1, RequireNoHead: true,
+	}))
+	require.NoError(err)
+	require.NoError(f.Store.FailDocumentExtraction(t.Context(), store.DocumentExtractionFailure{
+		Claim: claim, ReasonCode: "unsupported_provider_response", Terminal: true,
+	}))
+
+	changed, err := f.Store.RetryDocumentExtraction(t.Context(), profile.ID, hash)
+	require.NoError(err)
+	assert.True(t, changed)
+	candidates, err := f.Store.ListPendingDocumentExtractions(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, 10,
+	)
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(t, hash, candidates[0].CanonicalBlobHash)
+
+	publishSearchDocument(t, f, profile, hash, "current evidence", "retry-current")
+	_, err = f.Store.RetryDocumentExtraction(t.Context(), profile.ID, hash)
+	require.ErrorContains(err, "already current")
+}
+
+func TestListDocumentAttachmentIDsAfterIsBoundedAndResumable(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	messageID := f.CreateMessage("document-bootstrap")
+	for i := range 3 {
+		hash := strings.Repeat(string(rune('d'+i)), 64)
+		require.NoError(f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+			Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: 10,
+			StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+			Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+			SourcePartKey: "part:" + string(rune('1'+i)),
+		}))
+	}
+	first, err := f.Store.ListDocumentAttachmentIDsAfter(t.Context(), 0, 2)
+	require.NoError(err)
+	require.Len(first, 2)
+	second, err := f.Store.ListDocumentAttachmentIDsAfter(t.Context(), first[1], 2)
+	require.NoError(err)
+	require.Len(second, 1)
+	assert.Greater(t, second[0], first[1])
+}

--- a/internal/store/document_publication.go
+++ b/internal/store/document_publication.go
@@ -1,0 +1,616 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+	"unicode/utf8"
+)
+
+var (
+	ErrDocumentExtractionClaimed   = errors.New("document extraction owner is already claimed")
+	ErrDocumentExtractionCurrent   = errors.New("document extraction owner already has a current head")
+	ErrDocumentExtractionFenceLost = errors.New("document extraction claim fence is no longer current")
+)
+
+type DocumentExtractionClaimInput struct {
+	ExtractionID           string
+	ProfileID              string
+	RebuildID              string
+	CanonicalBlobHash      string
+	ExtractionInputKey     string
+	OccurrenceAttachmentID int64
+	OccurrenceMIMEType     string
+	OccurrenceMessageType  string
+	LeaseOwner             string
+	LeaseUntil             time.Time
+	LocalBytes             int64
+	SourceSequence         int64
+	RequireNoHead          bool
+}
+
+type DocumentExtractionClaim struct {
+	DocumentExtractionClaimInput
+
+	LeaseFence int64
+}
+
+type DocumentPublishedUnit struct {
+	Index     int
+	Kind      string
+	Text      string
+	Header    string
+	Footer    string
+	Width     int
+	Height    int
+	DPI       int
+	Checksum  string
+	CharCount int
+	Truncated bool
+}
+
+type DocumentPublishedSpan struct {
+	UnitIndex int
+	CharStart int
+	CharEnd   int
+	Synthetic bool
+}
+
+type DocumentPublishedChunk struct {
+	Key                string
+	Ordinal            int
+	Text               string
+	HeadingPath        []string
+	FirstUnitIndex     int
+	LastUnitIndex      int
+	SyntheticPrefixLen int
+	Checksum           string
+	CharCount          int
+	TableChunk         bool
+	CodeChunk          bool
+	Truncated          bool
+	Spans              []DocumentPublishedSpan
+}
+
+type DocumentExtractionPublication struct {
+	ExtractionID           string
+	ProfileID              string
+	CanonicalBlobHash      string
+	ExtractionInputKey     string
+	LeaseOwner             string
+	LeaseFence             int64
+	OccurrenceAttachmentID int64
+	OccurrenceMIMEType     string
+	OccurrenceMessageType  string
+	ReturnedModel          string
+	ProviderBytes          *int64
+	UnitsProcessed         int
+	RequestCount           int
+	RetryCount             int
+	ProviderLatencyMS      int64
+	ManifestChecksum       string
+	Units                  []DocumentPublishedUnit
+	Chunks                 []DocumentPublishedChunk
+}
+
+// ClaimDocumentExtraction creates an immutable staging revision and acquires
+// the one owner-level lease. A later claimant can replace only an expired
+// lease and receives a larger monotonic fence.
+func (s *Store) ClaimDocumentExtraction(
+	ctx context.Context,
+	input DocumentExtractionClaimInput,
+) (DocumentExtractionClaim, error) {
+	if err := validateDocumentClaimInput(input); err != nil {
+		return DocumentExtractionClaim{}, err
+	}
+	claim := DocumentExtractionClaim{DocumentExtractionClaimInput: input}
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		var eligible bool
+		if err := q.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM document_extraction_profiles p
+				JOIN document_provider_consents c ON c.profile_id = p.id
+				WHERE p.id = ? AND p.enabled = TRUE AND p.retired_at IS NULL
+				  AND c.profile_fingerprint = p.fingerprint
+				  AND c.retention_posture = p.retention_posture
+				  AND c.training_posture = p.training_posture
+			)`, input.ProfileID).Scan(&eligible); err != nil {
+			return fmt.Errorf("check document extraction profile authority: %w", err)
+		}
+		if !eligible {
+			return errors.New("document extraction profile is not enabled with exact consent")
+		}
+		if err := q.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM document_occurrences o
+				JOIN attachments a ON a.id = o.attachment_id
+				JOIN messages m ON m.id = o.message_id
+				WHERE o.attachment_id = ? AND o.canonical_blob_hash = ?
+				  AND o.attachment_role = 'standalone'
+				  AND a.attachment_role = 'standalone'
+				  AND (COALESCE(a.content_hash, '') = ? OR
+				       (COALESCE(a.content_hash, '') = '' AND a.storage_path = ?))
+				  AND COALESCE(o.mime_type, '') = ?
+				  AND COALESCE(a.mime_type, '') = ?
+				  AND COALESCE(m.message_type, '') = ?
+				  AND `+LiveMessagesWhere("m", true)+`
+			)`, input.OccurrenceAttachmentID, input.CanonicalBlobHash,
+			input.CanonicalBlobHash, canonicalCASPath(input.CanonicalBlobHash), input.OccurrenceMIMEType,
+			input.OccurrenceMIMEType, input.OccurrenceMessageType).Scan(&eligible); err != nil {
+			return fmt.Errorf("check document extraction occurrence: %w", err)
+		}
+		if !eligible {
+			return errors.New("document extraction owner has no eligible occurrence")
+		}
+		if input.RebuildID != "" {
+			if err := q.QueryRow(`
+				SELECT EXISTS (
+					SELECT 1 FROM document_extraction_rebuilds r
+					JOIN document_extraction_rebuild_targets t ON t.rebuild_id = r.id
+					WHERE r.id = ? AND r.profile_id = ? AND r.extraction_input_key = ?
+					  AND r.state = 'building' AND t.canonical_blob_hash = ?
+				)`, input.RebuildID, input.ProfileID, input.ExtractionInputKey,
+				input.CanonicalBlobHash).Scan(&eligible); err != nil {
+				return fmt.Errorf("check document extraction rebuild target: %w", err)
+			}
+			if !eligible {
+				return errors.New("document extraction owner is not in the active rebuild")
+			}
+		}
+		if input.RequireNoHead {
+			if err := q.QueryRow(`
+				SELECT NOT EXISTS (
+					SELECT 1 FROM document_extraction_heads
+					WHERE profile_id = ? AND canonical_blob_hash = ?
+					  AND extraction_input_key = ?
+				)`, input.ProfileID, input.CanonicalBlobHash, input.ExtractionInputKey).Scan(&eligible); err != nil {
+				return fmt.Errorf("check current document extraction head: %w", err)
+			}
+			if !eligible {
+				return ErrDocumentExtractionCurrent
+			}
+		}
+		if _, err := q.Exec(`
+			INSERT INTO document_extractions
+				(id, profile_id, rebuild_id, canonical_blob_hash, extraction_input_key,
+				 state, lease_owner, lease_until, local_bytes, source_sequence)
+			VALUES (?, ?, ?, ?, ?, 'staging', ?, ?, ?, ?)`,
+			input.ExtractionID, input.ProfileID, nullIfEmpty(input.RebuildID), input.CanonicalBlobHash,
+			input.ExtractionInputKey, input.LeaseOwner, input.LeaseUntil,
+			input.LocalBytes, input.SourceSequence,
+		); err != nil {
+			return fmt.Errorf("create staging document extraction: %w", err)
+		}
+		claimSQL := `
+			INSERT INTO document_extraction_claims
+				(profile_id, canonical_blob_hash, extraction_input_key,
+				 extraction_id, lease_owner, lease_fence, lease_until)
+			VALUES (?, ?, ?, ?, ?, 1, ?)
+			ON CONFLICT (profile_id, canonical_blob_hash, extraction_input_key)
+			DO UPDATE SET
+				extraction_id = EXCLUDED.extraction_id,
+				lease_owner = EXCLUDED.lease_owner,
+				lease_fence = document_extraction_claims.lease_fence + 1,
+				lease_until = EXCLUDED.lease_until,
+				updated_at = ` + s.dialect.Now() + `
+			WHERE document_extraction_claims.lease_until <= ` + s.dialect.Now() + `
+			RETURNING lease_fence`
+		if err := q.QueryRow(claimSQL,
+			input.ProfileID, input.CanonicalBlobHash, input.ExtractionInputKey,
+			input.ExtractionID, input.LeaseOwner, input.LeaseUntil,
+		).Scan(&claim.LeaseFence); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrDocumentExtractionClaimed
+			}
+			return fmt.Errorf("claim document extraction owner: %w", err)
+		}
+		if _, err := q.Exec(`
+			UPDATE document_extractions
+			SET state = 'tombstoned', updated_at = `+s.dialect.Now()+`
+			WHERE profile_id = ? AND canonical_blob_hash = ?
+			  AND extraction_input_key = ? AND state = 'staging' AND id != ?`,
+			input.ProfileID, input.CanonicalBlobHash, input.ExtractionInputKey,
+			input.ExtractionID,
+		); err != nil {
+			return fmt.Errorf("tombstone superseded document extraction: %w", err)
+		}
+		if _, err := q.Exec(`
+			UPDATE document_extractions SET lease_fence = ? WHERE id = ?`,
+			claim.LeaseFence, input.ExtractionID,
+		); err != nil {
+			return fmt.Errorf("record document extraction fence: %w", err)
+		}
+		return nil
+	})
+	return claim, err
+}
+
+type DocumentExtractionFailure struct {
+	Claim             DocumentExtractionClaim
+	ReasonCode        string
+	Terminal          bool
+	RetryAt           time.Time
+	RequestCount      int
+	RetryCount        int
+	ProviderLatencyMS int64
+}
+
+// FailDocumentExtraction records only a bounded reason code, releases the
+// exact fenced claim, and either suppresses the owner for this immutable
+// profile or schedules a later retry. Provider bodies and extracted content
+// are never stored on failure.
+func (s *Store) FailDocumentExtraction(ctx context.Context, failure DocumentExtractionFailure) error {
+	if err := validateDocumentFailure(failure); err != nil {
+		return err
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		state := "tombstoned"
+		var terminalReason any
+		var nextRetry any = failure.RetryAt
+		var hadServingHead bool
+		if failure.Terminal {
+			state = "terminal"
+			terminalReason = failure.ReasonCode
+			nextRetry = nil
+			if err := q.QueryRow(`
+				SELECT EXISTS (
+					SELECT 1 FROM document_extraction_heads
+					WHERE canonical_blob_hash = ? AND extraction_input_key = ?
+				)`, failure.Claim.CanonicalBlobHash, failure.Claim.ExtractionInputKey,
+			).Scan(&hadServingHead); err != nil {
+				return fmt.Errorf("check document heads before terminal suppression: %w", err)
+			}
+		}
+		result, err := q.Exec(`
+			UPDATE document_extractions
+			SET state = ?, attempt_count = attempt_count + 1,
+			    request_count = ?, retry_count = ?, provider_latency_ms = ?,
+			    next_retry_at = ?, terminal_reason = ?, lease_owner = NULL,
+			    lease_until = NULL, updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND profile_id = ? AND canonical_blob_hash = ?
+			  AND extraction_input_key = ? AND state = 'staging'
+			  AND lease_owner = ? AND lease_fence = ?`,
+			state, failure.RequestCount, failure.RetryCount, failure.ProviderLatencyMS,
+			nextRetry, terminalReason, failure.Claim.ExtractionID,
+			failure.Claim.ProfileID, failure.Claim.CanonicalBlobHash,
+			failure.Claim.ExtractionInputKey, failure.Claim.LeaseOwner,
+			failure.Claim.LeaseFence,
+		)
+		if err != nil {
+			return fmt.Errorf("record document extraction failure: %w", err)
+		}
+		updated, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read document extraction failure result: %w", err)
+		}
+		if updated != 1 {
+			return ErrDocumentExtractionFenceLost
+		}
+		result, err = q.Exec(`
+			DELETE FROM document_extraction_claims
+			WHERE profile_id = ? AND canonical_blob_hash = ?
+			  AND extraction_input_key = ? AND extraction_id = ?
+			  AND lease_owner = ? AND lease_fence = ?`,
+			failure.Claim.ProfileID, failure.Claim.CanonicalBlobHash,
+			failure.Claim.ExtractionInputKey, failure.Claim.ExtractionID,
+			failure.Claim.LeaseOwner, failure.Claim.LeaseFence,
+		)
+		if err != nil {
+			return fmt.Errorf("release failed document extraction claim: %w", err)
+		}
+		deleted, err := result.RowsAffected()
+		if err != nil || deleted != 1 {
+			return ErrDocumentExtractionFenceLost
+		}
+		if failure.Terminal {
+			result, err = q.Exec(`
+				DELETE FROM document_extraction_heads
+				WHERE profile_id = ? AND canonical_blob_hash = ?
+				  AND extraction_input_key = ? AND extraction_id = ?`,
+				failure.Claim.ProfileID, failure.Claim.CanonicalBlobHash,
+				failure.Claim.ExtractionInputKey, failure.Claim.ExtractionID,
+			)
+			if err != nil {
+				return fmt.Errorf("suppress terminal document extraction head: %w", err)
+			}
+			if _, rowsErr := result.RowsAffected(); rowsErr != nil {
+				return fmt.Errorf("read terminal document head suppression result: %w", rowsErr)
+			}
+			if hadServingHead {
+				return bumpDocumentIndexRevision(q)
+			}
+		}
+		return nil
+	})
+}
+
+func (s *Store) RenewDocumentExtractionClaim(
+	ctx context.Context,
+	claim DocumentExtractionClaim,
+	leaseUntil time.Time,
+) error {
+	if leaseUntil.IsZero() || !leaseUntil.After(time.Now().UTC()) ||
+		leaseUntil.After(time.Now().UTC().Add(time.Hour)) {
+		return errors.New("document extraction renewal has invalid lease deadline")
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		query := `
+			UPDATE document_extraction_claims
+			SET lease_until = ?, updated_at = ` + s.dialect.Now() + `
+			WHERE profile_id = ? AND canonical_blob_hash = ?
+			  AND extraction_input_key = ? AND extraction_id = ?
+			  AND lease_owner = ? AND lease_fence = ?
+			  AND lease_until > ` + s.dialect.Now() + `
+			RETURNING lease_fence`
+		var fence int64
+		if err := q.QueryRow(query, leaseUntil, claim.ProfileID, claim.CanonicalBlobHash,
+			claim.ExtractionInputKey, claim.ExtractionID, claim.LeaseOwner,
+			claim.LeaseFence).Scan(&fence); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrDocumentExtractionFenceLost
+			}
+			return fmt.Errorf("renew document extraction claim: %w", err)
+		}
+		if _, err := q.Exec(`UPDATE document_extractions SET lease_until = ? WHERE id = ?`,
+			leaseUntil, claim.ExtractionID); err != nil {
+			return fmt.Errorf("record renewed document extraction lease: %w", err)
+		}
+		return nil
+	})
+}
+
+// PublishDocumentExtraction atomically writes canonical derivatives, marks
+// the staging revision ready, switches the owner head, and advances the search
+// revision. Provider work must already be complete before this call.
+func (s *Store) PublishDocumentExtraction(
+	ctx context.Context,
+	publication DocumentExtractionPublication,
+) error {
+	if err := validateDocumentPublication(publication); err != nil {
+		return err
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		q := boundQuerier{ctx: ctx, q: tx}
+		claimQuery := `
+			SELECT EXISTS (
+				SELECT 1 FROM document_extraction_claims
+				WHERE profile_id = ? AND canonical_blob_hash = ?
+				  AND extraction_input_key = ? AND extraction_id = ?
+				  AND lease_owner = ? AND lease_fence = ?
+				  AND lease_until > ` + s.dialect.Now() + `
+			)`
+		var current bool
+		if err := q.QueryRow(claimQuery,
+			publication.ProfileID, publication.CanonicalBlobHash,
+			publication.ExtractionInputKey, publication.ExtractionID,
+			publication.LeaseOwner, publication.LeaseFence,
+		).Scan(&current); err != nil {
+			return fmt.Errorf("check document extraction publication fence: %w", err)
+		}
+		if !current {
+			return ErrDocumentExtractionFenceLost
+		}
+		var sourceSequence int64
+		if err := q.QueryRow(`
+			SELECT COALESCE(MAX(o.source_sequence), -1)
+			FROM document_occurrences o
+			JOIN attachments a ON a.id = o.attachment_id
+			JOIN messages m ON m.id = o.message_id
+			WHERE o.attachment_id = ? AND o.canonical_blob_hash = ?
+			  AND o.attachment_role = 'standalone'
+			  AND a.attachment_role = 'standalone'
+			  AND (COALESCE(a.content_hash, '') = ? OR
+			       (COALESCE(a.content_hash, '') = '' AND a.storage_path = ?))
+			  AND COALESCE(o.mime_type, '') = ?
+			  AND COALESCE(a.mime_type, '') = ?
+			  AND COALESCE(m.message_type, '') = ?
+			  AND `+LiveMessagesWhere("m", true),
+			publication.OccurrenceAttachmentID, publication.CanonicalBlobHash,
+			publication.CanonicalBlobHash, canonicalCASPath(publication.CanonicalBlobHash), publication.OccurrenceMIMEType,
+			publication.OccurrenceMIMEType, publication.OccurrenceMessageType,
+		).Scan(&sourceSequence); err != nil {
+			return fmt.Errorf("recheck document extraction occurrences: %w", err)
+		}
+		if sourceSequence < 0 {
+			return errors.New("document extraction claimed occurrence is no longer eligible")
+		}
+		if _, err := q.Exec(`DELETE FROM document_units WHERE extraction_id = ?`, publication.ExtractionID); err != nil {
+			return fmt.Errorf("clear staged document units: %w", err)
+		}
+		for _, unit := range publication.Units {
+			if _, err := q.Exec(`
+				INSERT INTO document_units
+					(extraction_id, unit_index, unit_kind, text, header_text,
+					 footer_text, width, height, dpi, checksum, char_count, truncated)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				publication.ExtractionID, unit.Index, unit.Kind, unit.Text,
+				nullIfEmpty(unit.Header), nullIfEmpty(unit.Footer), nullIfZero(int64(unit.Width)),
+				nullIfZero(int64(unit.Height)), nullIfZero(int64(unit.DPI)), unit.Checksum,
+				unit.CharCount, unit.Truncated,
+			); err != nil {
+				return fmt.Errorf("publish document unit %d: %w", unit.Index, err)
+			}
+		}
+		for _, chunk := range publication.Chunks {
+			headingPath, err := json.Marshal(chunk.HeadingPath)
+			if err != nil {
+				return fmt.Errorf("encode document chunk heading path: %w", err)
+			}
+			if _, err := q.Exec(`
+				INSERT INTO document_chunks
+					(extraction_id, chunk_key, ordinal, text, heading_path,
+					 first_unit_index, last_unit_index, synthetic_prefix_len,
+					 checksum, char_count, table_chunk, code_chunk, truncated)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				publication.ExtractionID, chunk.Key, chunk.Ordinal, chunk.Text,
+				string(headingPath), chunk.FirstUnitIndex, chunk.LastUnitIndex,
+				chunk.SyntheticPrefixLen, chunk.Checksum, chunk.CharCount,
+				chunk.TableChunk, chunk.CodeChunk, chunk.Truncated,
+			); err != nil {
+				return fmt.Errorf("publish document chunk %d: %w", chunk.Ordinal, err)
+			}
+			for spanOrdinal, span := range chunk.Spans {
+				if _, err := q.Exec(`
+					INSERT INTO document_chunk_spans
+						(extraction_id, chunk_key, span_ordinal, unit_index,
+						 start_char, end_char, synthetic)
+					VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					publication.ExtractionID, chunk.Key, spanOrdinal, span.UnitIndex,
+					span.CharStart, span.CharEnd, span.Synthetic,
+				); err != nil {
+					return fmt.Errorf("publish document chunk %d span %d: %w", chunk.Ordinal, spanOrdinal, err)
+				}
+			}
+		}
+		providerBytes := any(nil)
+		if publication.ProviderBytes != nil {
+			providerBytes = *publication.ProviderBytes
+		}
+		result, err := q.Exec(`
+			UPDATE document_extractions
+			SET state = 'ready', lease_owner = NULL, lease_until = NULL,
+				provider_bytes = ?, units_processed = ?, returned_model = ?,
+				request_count = ?, retry_count = ?, provider_latency_ms = ?,
+				manifest_checksum = ?, source_sequence = ?,
+				updated_at = `+s.dialect.Now()+`, published_at = `+s.dialect.Now()+`
+			WHERE id = ? AND profile_id = ? AND canonical_blob_hash = ?
+			  AND extraction_input_key = ? AND state = 'staging'`,
+			providerBytes, publication.UnitsProcessed, publication.ReturnedModel,
+			publication.RequestCount, publication.RetryCount, publication.ProviderLatencyMS,
+			publication.ManifestChecksum, sourceSequence, publication.ExtractionID,
+			publication.ProfileID, publication.CanonicalBlobHash,
+			publication.ExtractionInputKey,
+		)
+		if err != nil {
+			return fmt.Errorf("mark document extraction ready: %w", err)
+		}
+		updated, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read document extraction publication result: %w", err)
+		}
+		if updated != 1 {
+			return errors.New("document extraction staging revision is no longer publishable")
+		}
+		if _, err := q.Exec(`
+			INSERT INTO document_extraction_heads
+				(profile_id, canonical_blob_hash, extraction_input_key,
+				 extraction_id, source_sequence)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT (profile_id, canonical_blob_hash, extraction_input_key)
+			DO UPDATE SET extraction_id = EXCLUDED.extraction_id,
+				source_sequence = EXCLUDED.source_sequence,
+				switched_at = `+s.dialect.Now(),
+			publication.ProfileID, publication.CanonicalBlobHash,
+			publication.ExtractionInputKey, publication.ExtractionID, sourceSequence,
+		); err != nil {
+			return fmt.Errorf("switch document extraction head: %w", err)
+		}
+		result, err = q.Exec(`
+			DELETE FROM document_extraction_claims
+			WHERE profile_id = ? AND canonical_blob_hash = ?
+			  AND extraction_input_key = ? AND extraction_id = ?
+			  AND lease_owner = ? AND lease_fence = ?`,
+			publication.ProfileID, publication.CanonicalBlobHash,
+			publication.ExtractionInputKey, publication.ExtractionID,
+			publication.LeaseOwner, publication.LeaseFence,
+		)
+		if err != nil {
+			return fmt.Errorf("release document extraction claim: %w", err)
+		}
+		deleted, err := result.RowsAffected()
+		if err != nil || deleted != 1 {
+			return ErrDocumentExtractionFenceLost
+		}
+		return bumpDocumentIndexRevision(q)
+	})
+}
+
+func canonicalCASPath(contentHash string) string {
+	return contentHash[:2] + "/" + contentHash
+}
+
+func validateDocumentClaimInput(input DocumentExtractionClaimInput) error {
+	now := time.Now().UTC()
+	if input.ExtractionID == "" || input.ProfileID == "" ||
+		!validLowerSHA256(input.CanonicalBlobHash) || input.ExtractionInputKey == "" ||
+		input.OccurrenceAttachmentID <= 0 || input.OccurrenceMIMEType == "" ||
+		input.LeaseOwner == "" || input.LocalBytes <= 0 || input.SourceSequence < 0 ||
+		!input.LeaseUntil.After(now) || input.LeaseUntil.After(now.Add(time.Hour)) {
+		return errors.New("document extraction claim is incomplete or outside safety bounds")
+	}
+	return nil
+}
+
+func validateDocumentPublication(publication DocumentExtractionPublication) error {
+	if publication.ExtractionID == "" || publication.ProfileID == "" ||
+		!validLowerSHA256(publication.CanonicalBlobHash) || publication.ExtractionInputKey == "" ||
+		publication.OccurrenceAttachmentID <= 0 || publication.OccurrenceMIMEType == "" ||
+		publication.LeaseOwner == "" || publication.LeaseFence <= 0 ||
+		publication.ReturnedModel == "" || publication.UnitsProcessed <= 0 ||
+		!validLowerSHA256(publication.ManifestChecksum) || len(publication.Units) == 0 || len(publication.Chunks) == 0 {
+		return errors.New("document extraction publication is incomplete")
+	}
+	if publication.ProviderBytes != nil && *publication.ProviderBytes < 0 {
+		return errors.New("document extraction publication has invalid provider bytes")
+	}
+	if publication.RequestCount < 0 || publication.RetryCount < 0 ||
+		publication.RetryCount > publication.RequestCount || publication.ProviderLatencyMS < 0 {
+		return errors.New("document extraction publication has invalid provider request accounting")
+	}
+	for index, unit := range publication.Units {
+		if unit.Index != index || unit.Kind == "" || !utf8.ValidString(unit.Text) ||
+			unit.CharCount != utf8.RuneCountInString(unit.Text) || !validLowerSHA256(unit.Checksum) ||
+			unit.Width < 0 || unit.Height < 0 || unit.DPI < 0 {
+			return fmt.Errorf("document extraction publication unit %d is invalid", index)
+		}
+	}
+	for ordinal, chunk := range publication.Chunks {
+		if chunk.Ordinal != ordinal || chunk.Key == "" || !utf8.ValidString(chunk.Text) ||
+			chunk.CharCount != utf8.RuneCountInString(chunk.Text) || !validLowerSHA256(chunk.Checksum) ||
+			chunk.FirstUnitIndex < 0 || chunk.LastUnitIndex < chunk.FirstUnitIndex ||
+			chunk.LastUnitIndex >= len(publication.Units) || chunk.SyntheticPrefixLen < 0 ||
+			chunk.SyntheticPrefixLen > chunk.CharCount || len(chunk.Spans) == 0 {
+			return fmt.Errorf("document extraction publication chunk %d is invalid", ordinal)
+		}
+		for spanOrdinal, span := range chunk.Spans {
+			if span.UnitIndex < chunk.FirstUnitIndex || span.UnitIndex > chunk.LastUnitIndex ||
+				span.CharStart < 0 || span.CharEnd < span.CharStart ||
+				span.CharEnd > publication.Units[span.UnitIndex].CharCount {
+				return fmt.Errorf("document extraction publication chunk %d span %d is invalid", ordinal, spanOrdinal)
+			}
+		}
+	}
+	return nil
+}
+
+func validateDocumentFailure(failure DocumentExtractionFailure) error {
+	claim := failure.Claim
+	if claim.ExtractionID == "" || claim.ProfileID == "" ||
+		!validLowerSHA256(claim.CanonicalBlobHash) || claim.ExtractionInputKey == "" ||
+		claim.LeaseOwner == "" || claim.LeaseFence <= 0 ||
+		failure.ReasonCode == "" || len(failure.ReasonCode) > 64 ||
+		failure.RequestCount < 0 || failure.RetryCount < 0 ||
+		failure.RetryCount > failure.RequestCount || failure.ProviderLatencyMS < 0 {
+		return errors.New("document extraction failure is incomplete")
+	}
+	for _, character := range failure.ReasonCode {
+		if character != '_' && character != '-' && (character < 'a' || character > 'z') &&
+			(character < '0' || character > '9') {
+			return errors.New("document extraction failure reason code is invalid")
+		}
+	}
+	if failure.Terminal {
+		if !failure.RetryAt.IsZero() {
+			return errors.New("terminal document extraction failure cannot retry")
+		}
+	} else if !failure.RetryAt.After(time.Now().UTC()) || failure.RetryAt.After(time.Now().UTC().Add(7*24*time.Hour)) {
+		return errors.New("retryable document extraction failure has invalid retry deadline")
+	}
+	return nil
+}

--- a/internal/store/document_publication_test.go
+++ b/internal/store/document_publication_test.go
@@ -1,0 +1,378 @@
+package store_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestDocumentExtractionPublicationKeepsOldHeadUntilAtomicSwitch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+
+	firstClaim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-first", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-first", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(err)
+	assert.Equal(int64(1), firstClaim.LeaseFence)
+
+	_, err = f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-concurrent", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-concurrent", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.ErrorIs(err, store.ErrDocumentExtractionClaimed)
+	var concurrentRows int
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT COUNT(*) FROM document_extractions WHERE id = ?`), "extraction-concurrent").Scan(&concurrentRows))
+	assert.Zero(concurrentRows, "failed owner claims must roll back their staging revision")
+
+	wrongFence := firstClaim
+	wrongFence.LeaseFence++
+	err = f.Store.RenewDocumentExtractionClaim(t.Context(), wrongFence, time.Now().UTC().Add(15*time.Minute))
+	require.ErrorIs(err, store.ErrDocumentExtractionFenceLost)
+	require.NoError(f.Store.PublishDocumentExtraction(t.Context(), publicationFor(
+		firstClaim, "old searchable quasar evidence", strings.Repeat("d", 64),
+	)))
+	assert.Equal(1, documentFTSMatchCount(t, f.Store, "quasar"))
+	assert.Equal([]string{"old searchable quasar evidence"}, currentDocumentTexts(t, f, profile.ID, hash))
+
+	secondClaim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-second", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-second", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(err)
+	assert.Equal([]string{"old searchable quasar evidence"}, currentDocumentTexts(t, f, profile.ID, hash),
+		"a staging replacement must not hide the ready head")
+
+	require.NoError(f.Store.PublishDocumentExtraction(t.Context(), publicationFor(
+		secondClaim, "new searchable nebula evidence", strings.Repeat("e", 64),
+	)))
+	assert.Equal([]string{"new searchable nebula evidence"}, currentDocumentTexts(t, f, profile.ID, hash))
+	assert.Equal(1, documentFTSMatchCount(t, f.Store, "quasar"),
+		"old immutable derivatives may remain until GC but are unreachable through the head")
+	assert.Equal(1, documentFTSMatchCount(t, f.Store, "nebula"))
+
+	revision, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(int64(3), revision, "one occurrence and two head publications")
+}
+
+func TestDocumentExtractionPublicationRejectsInvalidSpanBeforeMutation(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-invalid", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-invalid", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(err)
+	publication := publicationFor(claim, "short text", strings.Repeat("f", 64))
+	publication.Chunks[0].Spans[0].CharEnd = 100
+	require.ErrorContains(f.Store.PublishDocumentExtraction(t.Context(), publication), "span 0 is invalid")
+
+	var units int
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT COUNT(*) FROM document_units WHERE extraction_id = ?`), claim.ExtractionID).Scan(&units))
+	assert.Zero(t, units)
+	var state string
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT state FROM document_extractions WHERE id = ?`), claim.ExtractionID).Scan(&state))
+	assert.Equal(t, "staging", state)
+}
+
+func TestDocumentExtractionPublicationRechecksClaimedOccurrenceScope(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-scope-change", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-scope-change", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(err)
+
+	otherMessageID := f.CreateMessage("document-publication-other-scope")
+	require.NoError(f.Store.UpsertAttachmentRecord(t.Context(), otherMessageID, store.AttachmentWrite{
+		Filename: "other.pdf", MIMEType: "application/pdf", Size: 128,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceMIMEDisposition,
+		SourcePartKey: "mime:other",
+	}))
+	otherAttachmentID := singleAttachmentID(t, f, otherMessageID)
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), otherAttachmentID, 2)
+	require.NoError(err)
+	require.True(eligible)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`
+		UPDATE attachments SET attachment_role = 'inline' WHERE id = ?`),
+		claim.OccurrenceAttachmentID,
+	)
+	require.NoError(err)
+
+	err = f.Store.PublishDocumentExtraction(t.Context(), publicationFor(
+		claim, "must not publish", strings.Repeat("f", 64),
+	))
+	require.ErrorContains(err, "claimed occurrence is no longer eligible")
+}
+
+func TestDocumentExtractionPublicationAcceptsTrustedHashlessCASAlias(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	input := documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "extraction-hashless-alias", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "worker-hashless-alias", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	})
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`
+		UPDATE attachments SET content_hash = '' WHERE id = ?`), input.OccurrenceAttachmentID)
+	require.NoError(err)
+
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), input)
+	require.NoError(err)
+	require.NoError(f.Store.PublishDocumentExtraction(t.Context(), publicationFor(
+		claim, "hashless alias evidence", strings.Repeat("a", 64),
+	)))
+}
+
+func TestGarbageCollectDocumentDerivativesKeepsCurrentUntilFinalOccurrenceIsGone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "old quasar evidence", "gc-old")
+	publishSearchDocument(t, f, profile, hash, "current nebula evidence", "gc-current")
+	_, err := f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE document_extractions SET updated_at = ? WHERE id = ?`),
+		time.Now().UTC().Add(-48*time.Hour), "gc-old")
+	require.NoError(err)
+
+	result, err := f.Store.GarbageCollectDocumentDerivatives(
+		t.Context(), time.Now().UTC().Add(-24*time.Hour), 10,
+	)
+	require.NoError(err)
+	assert.Equal(store.DocumentDerivativeGCResult{ExtractionsRemoved: 1}, result)
+	assert.Equal([]string{"current nebula evidence"}, currentDocumentTexts(t, f, profile.ID, hash))
+	var oldExtractions int
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT COUNT(*) FROM document_extractions WHERE id = ?`), "gc-old").Scan(&oldExtractions))
+	assert.Zero(oldExtractions)
+
+	var attachmentID, messageID int64
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT attachment_id, message_id FROM document_occurrences
+		WHERE canonical_blob_hash = ?`), hash).Scan(&attachmentID, &messageID))
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP WHERE id = ?`), messageID)
+	require.NoError(err)
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), attachmentID, 2)
+	require.NoError(err)
+	assert.False(eligible)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE document_extractions SET updated_at = ? WHERE id = ?`),
+		time.Now().UTC().Add(-48*time.Hour), "gc-current")
+	require.NoError(err)
+
+	revisionBefore, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	result, err = f.Store.GarbageCollectDocumentDerivatives(
+		t.Context(), time.Now().UTC().Add(-24*time.Hour), 10,
+	)
+	require.NoError(err)
+	assert.Equal(store.DocumentDerivativeGCResult{
+		ExtractionsRemoved: 1, CurrentHeadsRemoved: 1,
+	}, result)
+	var heads, chunks int
+	require.NoError(f.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM document_extraction_heads`).Scan(&heads))
+	require.NoError(f.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM document_chunks`).Scan(&chunks))
+	assert.Zero(heads)
+	assert.Zero(chunks)
+	revisionAfter, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(revisionBefore+1, revisionAfter)
+}
+
+func TestGarbageCollectDocumentDerivativesInvalidatesTerminalSuppression(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "gc-terminal", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "gc-terminal-worker", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1, RequireNoHead: true,
+	}))
+	require.NoError(err)
+	require.NoError(f.Store.FailDocumentExtraction(t.Context(), store.DocumentExtractionFailure{
+		Claim: claim, ReasonCode: "provider_rejected", Terminal: true,
+	}))
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE document_extractions SET updated_at = ? WHERE id = ?`),
+		time.Now().UTC().Add(-48*time.Hour), claim.ExtractionID)
+	require.NoError(err)
+	revisionBefore, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+
+	result, err := f.Store.GarbageCollectDocumentDerivatives(
+		t.Context(), time.Now().UTC().Add(-24*time.Hour), 10,
+	)
+	require.NoError(err)
+	assert.Equal(t, store.DocumentDerivativeGCResult{ExtractionsRemoved: 1}, result)
+	revisionAfter, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(t, revisionBefore+1, revisionAfter,
+		"removing a terminal marker may restore older-profile fallback evidence")
+}
+
+func TestPurgeDocumentDerivedByHashKeepsOccurrenceReadyForRebuild(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "purge nebula evidence", "purge-current")
+	revisionBefore, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+
+	result, err := f.Store.PurgeDocumentDerivedByHash(t.Context(), hash)
+	require.NoError(err)
+	assert.Equal(store.DocumentDerivedPurgeResult{ExtractionsRemoved: 1, HeadsRemoved: 1}, result)
+	var occurrences, heads, chunks int
+	require.NoError(f.Store.DB().QueryRow(`SELECT COUNT(*) FROM document_occurrences`).Scan(&occurrences))
+	require.NoError(f.Store.DB().QueryRow(`SELECT COUNT(*) FROM document_extraction_heads`).Scan(&heads))
+	require.NoError(f.Store.DB().QueryRow(`SELECT COUNT(*) FROM document_chunks`).Scan(&chunks))
+	assert.Equal(1, occurrences)
+	assert.Zero(heads)
+	assert.Zero(chunks)
+	revisionAfter, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(revisionBefore+1, revisionAfter)
+
+	candidates, err := f.Store.ListPendingDocumentExtractions(
+		t.Context(), profile.ID, "original", []string{"application/pdf"}, 10,
+	)
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(hash, candidates[0].CanonicalBlobHash)
+}
+
+func seedDocumentPublicationAuthority(
+	t *testing.T,
+	f *storetest.Fixture,
+) (store.DocumentExtractionProfile, string) {
+	t.Helper()
+	require := require.New(t)
+	fingerprint := strings.Repeat("a", 64)
+	profile := store.DocumentExtractionProfile{
+		ID: "profile-" + fingerprint, Fingerprint: fingerprint,
+		Provider: "mistral", Endpoint: "https://api.mistral.ai/v1/ocr",
+		Region: "eu", Model: "mistral-ocr-4-0",
+		RetentionPosture: "standard", TrainingPosture: "opted-out",
+		AllowedMediaTypes: []string{"application/pdf"}, PolicyJSON: []byte(`{"policy":1}`),
+	}
+	_, err := f.Store.EnsureDocumentExtractionProfile(t.Context(), profile)
+	require.NoError(err)
+	require.NoError(f.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: profile.ID, ProfileFingerprint: profile.Fingerprint,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+	}))
+	messageID := f.CreateMessage("document-publication")
+	hash := strings.Repeat("b", 64)
+	require.NoError(f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "synthetic.pdf", MIMEType: "application/pdf", Size: 128,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceMIMEDisposition,
+		SourcePartKey: "mime:1.2",
+	}))
+	attachmentID := singleAttachmentID(t, f, messageID)
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), attachmentID, 1)
+	require.NoError(err)
+	require.True(eligible)
+	return profile, hash
+}
+
+func publicationFor(
+	claim store.DocumentExtractionClaim,
+	text string,
+	checksum string,
+) store.DocumentExtractionPublication {
+	return store.DocumentExtractionPublication{
+		ExtractionID: claim.ExtractionID, ProfileID: claim.ProfileID,
+		CanonicalBlobHash: claim.CanonicalBlobHash, ExtractionInputKey: claim.ExtractionInputKey,
+		OccurrenceAttachmentID: claim.OccurrenceAttachmentID,
+		OccurrenceMIMEType:     claim.OccurrenceMIMEType,
+		OccurrenceMessageType:  claim.OccurrenceMessageType,
+		LeaseOwner:             claim.LeaseOwner, LeaseFence: claim.LeaseFence,
+		ReturnedModel: "mistral-ocr-4-0", UnitsProcessed: 1,
+		RequestCount: 1, ProviderLatencyMS: 25,
+		ManifestChecksum: strings.Repeat("c", 64),
+		Units: []store.DocumentPublishedUnit{{
+			Index: 0, Kind: "page", Text: text, Checksum: checksum, CharCount: len([]rune(text)),
+		}},
+		Chunks: []store.DocumentPublishedChunk{{
+			Key: "chunk-0", Ordinal: 0, Text: text, FirstUnitIndex: 0, LastUnitIndex: 0,
+			Checksum: checksum, CharCount: len([]rune(text)),
+			Spans: []store.DocumentPublishedSpan{{UnitIndex: 0, CharStart: 0, CharEnd: len([]rune(text))}},
+		}},
+	}
+}
+
+func documentClaimInputForHash(
+	t *testing.T,
+	f *storetest.Fixture,
+	input store.DocumentExtractionClaimInput,
+) store.DocumentExtractionClaimInput {
+	t.Helper()
+	require.NoError(t, f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT o.attachment_id, COALESCE(o.mime_type, ''), COALESCE(m.message_type, '')
+		FROM document_occurrences o
+		JOIN messages m ON m.id = o.message_id
+		WHERE o.canonical_blob_hash = ? AND o.attachment_role = 'standalone'
+		ORDER BY o.occurrence_key
+		LIMIT 1`), input.CanonicalBlobHash).Scan(
+		&input.OccurrenceAttachmentID, &input.OccurrenceMIMEType, &input.OccurrenceMessageType,
+	))
+	return input
+}
+
+func currentDocumentTexts(t *testing.T, f *storetest.Fixture, profileID, hash string) []string {
+	t.Helper()
+	require := require.New(t)
+	rows, err := f.Store.DB().Query(f.Store.Rebind(`
+		SELECT c.text
+		FROM document_extraction_heads h
+		JOIN document_chunks c ON c.extraction_id = h.extraction_id
+		JOIN document_occurrences o ON o.canonical_blob_hash = h.canonical_blob_hash
+		JOIN messages m ON m.id = o.message_id
+		WHERE h.profile_id = ? AND h.canonical_blob_hash = ?
+		  AND m.deleted_at IS NULL AND m.deleted_from_source_at IS NULL
+		ORDER BY c.ordinal`), profileID, hash)
+	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
+	var texts []string
+	for rows.Next() {
+		var text string
+		require.NoError(rows.Scan(&text))
+		texts = append(texts, text)
+	}
+	require.NoError(rows.Err())
+	return texts
+}

--- a/internal/store/document_search.go
+++ b/internal/store/document_search.go
@@ -1,0 +1,738 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	documentSearchCursorVersion = 2
+	documentSearchRRFConstant   = 60.0
+	maxDocumentSearchQueryBytes = 1_024
+	maxDocumentSearchTerms      = 20
+	maxDocumentSearchPageSize   = 100
+	maxDocumentSearchOffset     = 200_000
+	maxDocumentSearchCandidates = 100_000
+	maxDocumentSearchExcerpt    = 320
+)
+
+var (
+	ErrDocumentSearchInvalidCursor  = errors.New("invalid document search cursor")
+	ErrDocumentSearchCursorStale    = errors.New("document search cursor is stale")
+	ErrDocumentSearchInvalidRequest = errors.New("invalid document search request")
+	ErrDocumentSearchUnavailable    = errors.New("document search requires full-text search support")
+)
+
+type DocumentSearchRequest struct {
+	Query        string
+	SourceIDs    []int64
+	MessageTypes []string
+	AttachmentID int64
+	MessageID    int64
+	PageSize     int
+	Cursor       string
+}
+
+type DocumentSearchResponse struct {
+	Results    []DocumentSearchResult `json:"results"`
+	NextCursor string                 `json:"next_cursor,omitempty"`
+	Revision   int64                  `json:"revision"`
+	Truncated  bool                   `json:"truncated,omitempty"`
+}
+
+type DocumentSearchResult struct {
+	AttachmentID      int64    `json:"attachment_id"`
+	MessageID         int64    `json:"message_id"`
+	SourceID          int64    `json:"source_id"`
+	OccurrenceKey     string   `json:"occurrence_key"`
+	SourcePartKey     string   `json:"source_part_key,omitempty"`
+	Filename          string   `json:"filename,omitempty"`
+	ContainingTitle   string   `json:"containing_title,omitempty"`
+	MIMEType          string   `json:"mime_type,omitempty"`
+	CanonicalBlobHash string   `json:"canonical_blob_hash"`
+	OtherLiveCopies   int      `json:"other_live_copies"`
+	ChunkKey          string   `json:"chunk_key"`
+	ChunkOrdinal      int      `json:"chunk_ordinal"`
+	HeadingPath       []string `json:"heading_path,omitempty"`
+	FirstUnitIndex    int      `json:"first_unit_index"`
+	LastUnitIndex     int      `json:"last_unit_index"`
+	Excerpt           string   `json:"excerpt"`
+	HighlightStart    int      `json:"highlight_start"`
+	HighlightEnd      int      `json:"highlight_end"`
+	ProfileID         string   `json:"profile_id"`
+	ExtractionID      string   `json:"extraction_id"`
+	Provider          string   `json:"provider"`
+	Model             string   `json:"model"`
+	MatchedSignals    []string `json:"matched_signals"`
+	Truncated         bool     `json:"truncated"`
+	Rank              int      `json:"rank"`
+}
+
+type documentSearchCursor struct {
+	Version        int    `json:"version"`
+	Revision       int64  `json:"revision"`
+	RequestHash    string `json:"request_hash"`
+	Offset         int    `json:"offset"`
+	CandidateLimit int    `json:"candidate_limit"`
+}
+
+type documentSearchRow struct {
+	DocumentSearchResult
+
+	Text         string
+	ContentRank  int
+	FilenameRank int
+	Score        float64
+}
+
+func (s *Store) SearchDocuments(
+	ctx context.Context,
+	request DocumentSearchRequest,
+) (DocumentSearchResponse, error) {
+	prepared, terms, requestHash, offset, candidateLimit, revision, err := s.prepareDocumentSearch(ctx, request)
+	if err != nil {
+		return DocumentSearchResponse{}, err
+	}
+	if !s.fts5Available {
+		return DocumentSearchResponse{}, ErrDocumentSearchUnavailable
+	}
+	contentRows, contentMore, err := s.searchDocumentContent(ctx, prepared, terms, candidateLimit)
+	if err != nil {
+		return DocumentSearchResponse{}, err
+	}
+	filenameRows, filenameMore, err := s.searchDocumentFilenames(ctx, prepared, terms, candidateLimit)
+	if err != nil {
+		return DocumentSearchResponse{}, err
+	}
+	rows := fuseDocumentSearchRows(contentRows, filenameRows, terms)
+	moreCandidates := contentMore || filenameMore
+	response := DocumentSearchResponse{
+		Revision:  revision,
+		Truncated: moreCandidates && candidateLimit == maxDocumentSearchCandidates,
+	}
+	if offset >= len(rows) {
+		if moreCandidates && candidateLimit < maxDocumentSearchCandidates {
+			response.NextCursor, err = encodeDocumentSearchCursor(documentSearchCursor{
+				Version: documentSearchCursorVersion, Revision: revision,
+				RequestHash: requestHash, Offset: offset,
+				CandidateLimit: nextDocumentSearchCandidateLimit(candidateLimit, offset, prepared.PageSize),
+			})
+			if err != nil {
+				return DocumentSearchResponse{}, err
+			}
+		}
+		return response, nil
+	}
+	end := min(offset+prepared.PageSize, len(rows))
+	response.Results = make([]DocumentSearchResult, 0, end-offset)
+	for index := offset; index < end; index++ {
+		result := rows[index].DocumentSearchResult
+		result.Rank = index + 1
+		response.Results = append(response.Results, result)
+	}
+	if err := s.populateDocumentLiveCopyCounts(ctx, response.Results); err != nil {
+		return DocumentSearchResponse{}, err
+	}
+	if end < len(rows) || (moreCandidates && candidateLimit < maxDocumentSearchCandidates) {
+		nextCandidateLimit := candidateLimit
+		if end == len(rows) {
+			nextCandidateLimit = nextDocumentSearchCandidateLimit(candidateLimit, end, prepared.PageSize)
+		}
+		response.NextCursor, err = encodeDocumentSearchCursor(documentSearchCursor{
+			Version: documentSearchCursorVersion, Revision: revision,
+			RequestHash: requestHash, Offset: end, CandidateLimit: nextCandidateLimit,
+		})
+		if err != nil {
+			return DocumentSearchResponse{}, err
+		}
+	}
+	return response, nil
+}
+
+func (s *Store) prepareDocumentSearch(
+	ctx context.Context,
+	request DocumentSearchRequest,
+) (DocumentSearchRequest, []string, string, int, int, int64, error) {
+	request.Query = strings.TrimSpace(request.Query)
+	if request.Query == "" || len(request.Query) > maxDocumentSearchQueryBytes || !utf8.ValidString(request.Query) {
+		return request, nil, "", 0, 0, 0, fmt.Errorf("%w: requires a bounded UTF-8 query", ErrDocumentSearchInvalidRequest)
+	}
+	terms := strings.Fields(request.Query)
+	if len(terms) == 0 || len(terms) > maxDocumentSearchTerms {
+		return request, nil, "", 0, 0, 0, fmt.Errorf("%w: query has invalid term count", ErrDocumentSearchInvalidRequest)
+	}
+	if s.dialect.BuildFTSArg(terms) == "" {
+		return request, nil, "", 0, 0, 0, fmt.Errorf("%w: query contains no searchable terms", ErrDocumentSearchInvalidRequest)
+	}
+	if request.PageSize == 0 {
+		request.PageSize = 20
+	}
+	if request.PageSize < 1 || request.PageSize > maxDocumentSearchPageSize ||
+		request.AttachmentID < 0 || request.MessageID < 0 {
+		return request, nil, "", 0, 0, 0, fmt.Errorf("%w: request has invalid bounds", ErrDocumentSearchInvalidRequest)
+	}
+	var err error
+	request.Query = strings.ToLower(strings.Join(terms, " "))
+	request.SourceIDs, err = sortedUniquePositive(request.SourceIDs)
+	if err != nil {
+		return request, nil, "", 0, 0, 0, err
+	}
+	request.MessageTypes, err = sortedUniqueNonempty(request.MessageTypes)
+	if err != nil {
+		return request, nil, "", 0, 0, 0, err
+	}
+	requestHash, err := hashDocumentSearchRequest(request)
+	if err != nil {
+		return request, nil, "", 0, 0, 0, err
+	}
+	revision, err := s.GetDocumentIndexRevision(ctx)
+	if err != nil {
+		return request, nil, "", 0, 0, 0, err
+	}
+	offset := 0
+	candidateLimit := min(max(request.PageSize*20, 200), maxDocumentSearchCandidates)
+	if request.Cursor != "" {
+		cursor, decodeErr := decodeDocumentSearchCursor(request.Cursor)
+		if decodeErr != nil {
+			return request, nil, "", 0, 0, 0, decodeErr
+		}
+		if cursor.RequestHash != requestHash {
+			return request, nil, "", 0, 0, 0, ErrDocumentSearchInvalidCursor
+		}
+		if cursor.Revision != revision {
+			return request, nil, "", 0, 0, 0, ErrDocumentSearchCursorStale
+		}
+		offset = cursor.Offset
+		candidateLimit = cursor.CandidateLimit
+	}
+	return request, terms, requestHash, offset, candidateLimit, revision, nil
+}
+
+func (s *Store) searchDocumentContent(
+	ctx context.Context,
+	request DocumentSearchRequest,
+	terms []string,
+	limit int,
+) ([]documentSearchRow, bool, error) {
+	ftsArg := s.dialect.BuildFTSArg(terms)
+	conditions, scopeArgs := documentSearchScope(request, "m", "a")
+	validity := documentSearchValidity("p", "c", "h", "o", "a", "m", "ds")
+	var query string
+	args := make([]any, 0, len(scopeArgs)+2)
+	if s.IsPostgreSQL() {
+		query = `
+			WITH search_query AS (
+				SELECT to_tsquery('simple', ?) AS value
+			), ranked AS (
+				SELECT ` + documentSearchRankedSelectColumns + `,
+				       ROW_NUMBER() OVER (
+				           PARTITION BY o.occurrence_key
+				           ORDER BY ts_rank(dc.search_fts, sq.value) DESC, dc.id
+				       ) AS occurrence_rank,
+				       ts_rank(dc.search_fts, sq.value) AS search_rank
+				FROM document_chunks dc
+				JOIN document_extraction_heads h ON h.extraction_id = dc.extraction_id
+				JOIN document_extraction_profiles p ON p.id = h.profile_id
+				JOIN document_provider_consents c ON c.profile_id = p.id
+				JOIN document_occurrences o ON o.canonical_blob_hash = h.canonical_blob_hash
+				JOIN attachments a ON a.id = o.attachment_id
+				JOIN messages m ON m.id = o.message_id
+				JOIN conversations cv ON cv.id = m.conversation_id
+				CROSS JOIN document_index_state ds
+				CROSS JOIN search_query sq
+				WHERE dc.search_fts @@ sq.value
+				  AND ` + validity + conditions + `
+			)
+			SELECT ` + documentSearchOuterColumns + `
+			FROM ranked
+			WHERE occurrence_rank = 1
+			ORDER BY search_rank DESC, occurrence_key
+			LIMIT ?`
+		args = append(args, ftsArg)
+		args = append(args, scopeArgs...)
+		args = append(args, limit+1)
+	} else {
+		query = `
+			WITH matched AS MATERIALIZED (
+				SELECT ` + documentSearchRankedSelectColumns + `,
+				       bm25(document_chunks_fts) AS search_rank
+				FROM document_chunks_fts
+				JOIN document_chunks dc ON dc.id = document_chunks_fts.rowid
+				JOIN document_extraction_heads h ON h.extraction_id = dc.extraction_id
+				JOIN document_extraction_profiles p ON p.id = h.profile_id
+				JOIN document_provider_consents c ON c.profile_id = p.id
+				JOIN document_occurrences o ON o.canonical_blob_hash = h.canonical_blob_hash
+				JOIN attachments a ON a.id = o.attachment_id
+				JOIN messages m ON m.id = o.message_id
+				JOIN conversations cv ON cv.id = m.conversation_id
+				CROSS JOIN document_index_state ds
+				WHERE document_chunks_fts MATCH ?
+				  AND ` + validity + conditions + `
+			), ranked AS (
+				SELECT matched.*,
+				       ROW_NUMBER() OVER (
+				           PARTITION BY occurrence_key
+				           ORDER BY search_rank, chunk_ordinal, chunk_key
+				       ) AS occurrence_rank
+				FROM matched
+			)
+			SELECT ` + documentSearchOuterColumns + `
+			FROM ranked
+			WHERE occurrence_rank = 1
+			ORDER BY search_rank, occurrence_key
+			LIMIT ?`
+		args = append(args, ftsArg)
+		args = append(args, scopeArgs...)
+		args = append(args, limit+1)
+		return s.scanDocumentSearchRows(ctx, query, args, true, limit)
+	}
+	return s.scanDocumentSearchRows(ctx, query, args, true, limit)
+}
+
+func (s *Store) searchDocumentFilenames(
+	ctx context.Context,
+	request DocumentSearchRequest,
+	terms []string,
+	limit int,
+) ([]documentSearchRow, bool, error) {
+	conditions, args := documentSearchScope(request, "m", "a")
+	var filenameConditions strings.Builder
+	for _, term := range terms {
+		filenameConditions.WriteString(` AND LOWER(COALESCE(o.filename, '')) LIKE ? ESCAPE '!'`)
+		args = append(args, "%"+escapeDocumentLike(strings.ToLower(term))+"%")
+	}
+	conditions += filenameConditions.String()
+	query := `
+		SELECT ` + documentSearchSelectColumns + `
+		FROM document_extraction_heads h
+		JOIN document_extraction_profiles p ON p.id = h.profile_id
+		JOIN document_provider_consents c ON c.profile_id = p.id
+		JOIN document_chunks dc ON dc.extraction_id = h.extraction_id AND dc.ordinal = 0
+		JOIN document_occurrences o ON o.canonical_blob_hash = h.canonical_blob_hash
+		JOIN attachments a ON a.id = o.attachment_id
+		JOIN messages m ON m.id = o.message_id
+		JOIN conversations cv ON cv.id = m.conversation_id
+		CROSS JOIN document_index_state ds
+		WHERE ` + documentSearchValidity("p", "c", "h", "o", "a", "m", "ds") + conditions + `
+		ORDER BY LOWER(COALESCE(o.filename, '')), o.occurrence_key
+		LIMIT ?`
+	args = append(args, limit+1)
+	return s.scanDocumentSearchRows(ctx, query, args, false, limit)
+}
+
+const documentSearchSelectColumns = `
+		a.id, m.id, m.source_id, o.occurrence_key,
+		COALESCE(o.source_part_key, ''), COALESCE(o.filename, ''),
+		COALESCE(NULLIF(m.subject, ''), NULLIF(cv.title, ''), ''),
+		COALESCE(o.mime_type, ''), h.canonical_blob_hash,
+		dc.chunk_key, dc.ordinal, CAST(dc.heading_path AS TEXT),
+		dc.first_unit_index, dc.last_unit_index, dc.text,
+		h.profile_id, h.extraction_id, p.provider, p.model,
+		dc.truncated`
+
+const documentSearchRankedSelectColumns = `
+		a.id AS attachment_id, m.id AS message_id, m.source_id AS source_id,
+		o.occurrence_key AS occurrence_key,
+		COALESCE(o.source_part_key, '') AS source_part_key,
+		COALESCE(o.filename, '') AS filename,
+		COALESCE(NULLIF(m.subject, ''), NULLIF(cv.title, ''), '') AS containing_title,
+		COALESCE(o.mime_type, '') AS mime_type,
+		h.canonical_blob_hash AS canonical_blob_hash,
+		dc.chunk_key AS chunk_key, dc.ordinal AS chunk_ordinal,
+		CAST(dc.heading_path AS TEXT) AS heading_path,
+		dc.first_unit_index AS first_unit_index,
+		dc.last_unit_index AS last_unit_index, dc.text AS chunk_text,
+		h.profile_id AS profile_id, h.extraction_id AS extraction_id,
+		p.provider AS provider, p.model AS model, dc.truncated AS truncated`
+
+const documentSearchOuterColumns = `
+		attachment_id, message_id, source_id, occurrence_key,
+		source_part_key, filename, containing_title, mime_type,
+		canonical_blob_hash, chunk_key, chunk_ordinal, heading_path,
+		first_unit_index, last_unit_index, chunk_text,
+		profile_id, extraction_id, provider, model, truncated`
+
+func documentSearchValidity(profile, consent, head, occurrence, attachment, message, state string) string {
+	return profile + `.enabled = TRUE
+		AND ` + profile + `.retired_at IS NULL
+		AND ` + consent + `.profile_fingerprint = ` + profile + `.fingerprint
+		AND ` + consent + `.retention_posture = ` + profile + `.retention_posture
+		AND ` + consent + `.training_posture = ` + profile + `.training_posture
+		AND ` + occurrence + `.attachment_role = 'standalone'
+		AND ` + attachment + `.attachment_role = 'standalone'
+		AND ` + occurrence + `.role_source IN ('mime_disposition', 'provider_explicit', 'importer_semantics', 'raw_mime_repair')
+		AND ` + attachment + `.role_source IN ('mime_disposition', 'provider_explicit', 'importer_semantics', 'raw_mime_repair')
+		AND ` + LiveMessagesWhere(message, true) + `
+		AND (` + attachment + `.content_hash = ` + head + `.canonical_blob_hash
+		     OR (COALESCE(` + attachment + `.content_hash, '') = ''
+		         AND ` + attachment + `.storage_path =
+		             SUBSTR(` + head + `.canonical_blob_hash, 1, 2) || '/' || ` + head + `.canonical_blob_hash))
+		AND (
+		    ` + head + `.profile_id = ` + state + `.target_profile_id
+		    OR (
+		        NOT EXISTS (
+		            SELECT 1
+		            FROM document_extraction_heads target_head
+		            JOIN document_extraction_profiles target_profile
+		              ON target_profile.id = target_head.profile_id
+		            JOIN document_provider_consents target_consent
+		              ON target_consent.profile_id = target_profile.id
+		            WHERE target_head.canonical_blob_hash = ` + head + `.canonical_blob_hash
+		              AND target_head.profile_id = ` + state + `.target_profile_id
+		              AND target_profile.enabled = TRUE
+		              AND target_profile.retired_at IS NULL
+		              AND target_consent.profile_fingerprint = target_profile.fingerprint
+		              AND target_consent.retention_posture = target_profile.retention_posture
+		              AND target_consent.training_posture = target_profile.training_posture
+		        )
+		        AND NOT EXISTS (
+		            SELECT 1
+		            FROM document_extractions target_terminal
+		            WHERE target_terminal.profile_id = ` + state + `.target_profile_id
+		              AND target_terminal.canonical_blob_hash = ` + head + `.canonical_blob_hash
+		              AND target_terminal.extraction_input_key = ` + head + `.extraction_input_key
+		              AND target_terminal.state = 'terminal'
+		        )
+		        AND NOT EXISTS (
+		            SELECT 1
+		            FROM document_extraction_heads fallback_head
+		            JOIN document_extraction_profiles fallback_profile
+		              ON fallback_profile.id = fallback_head.profile_id
+		            JOIN document_provider_consents fallback_consent
+		              ON fallback_consent.profile_id = fallback_profile.id
+		            WHERE fallback_head.canonical_blob_hash = ` + head + `.canonical_blob_hash
+		              AND fallback_profile.enabled = TRUE
+		              AND fallback_profile.retired_at IS NULL
+		              AND fallback_consent.profile_fingerprint = fallback_profile.fingerprint
+		              AND fallback_consent.retention_posture = fallback_profile.retention_posture
+		              AND fallback_consent.training_posture = fallback_profile.training_posture
+		              AND (
+		                  fallback_consent.consented_at > ` + consent + `.consented_at
+		                  OR (fallback_consent.consented_at = ` + consent + `.consented_at
+		                      AND fallback_profile.id > ` + profile + `.id)
+		              )
+		        )
+		    )
+	)`
+}
+
+func documentSearchScope(request DocumentSearchRequest, message, attachment string) (string, []any) {
+	var conditions strings.Builder
+	var args []any
+	if len(request.SourceIDs) > 0 {
+		conditions.WriteString(` AND ` + message + `.source_id IN (`)
+		conditions.WriteString(documentPlaceholders(len(request.SourceIDs)))
+		conditions.WriteByte(')')
+		for _, id := range request.SourceIDs {
+			args = append(args, id)
+		}
+	}
+	if len(request.MessageTypes) > 0 {
+		conditions.WriteString(` AND ` + message + `.message_type IN (`)
+		conditions.WriteString(documentPlaceholders(len(request.MessageTypes)))
+		conditions.WriteByte(')')
+		for _, messageType := range request.MessageTypes {
+			args = append(args, messageType)
+		}
+	}
+	if request.AttachmentID > 0 {
+		conditions.WriteString(` AND ` + attachment + `.id = ?`)
+		args = append(args, request.AttachmentID)
+	}
+	if request.MessageID > 0 {
+		conditions.WriteString(` AND ` + message + `.id = ?`)
+		args = append(args, request.MessageID)
+	}
+	return conditions.String(), args
+}
+
+func (s *Store) scanDocumentSearchRows(
+	ctx context.Context,
+	query string,
+	args []any,
+	contentSignal bool,
+	uniqueOccurrenceLimit int,
+) ([]documentSearchRow, bool, error) {
+	rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(query), args...)
+	if err != nil {
+		return nil, false, fmt.Errorf("search document index: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	results := make([]documentSearchRow, 0)
+	seenOccurrences := make(map[string]struct{})
+	for rows.Next() {
+		var row documentSearchRow
+		var headingJSON string
+		if err := rows.Scan(
+			&row.AttachmentID, &row.MessageID, &row.SourceID, &row.OccurrenceKey,
+			&row.SourcePartKey, &row.Filename, &row.ContainingTitle, &row.MIMEType,
+			&row.CanonicalBlobHash, &row.ChunkKey, &row.ChunkOrdinal, &headingJSON,
+			&row.FirstUnitIndex, &row.LastUnitIndex, &row.Text,
+			&row.ProfileID, &row.ExtractionID, &row.Provider, &row.Model,
+			&row.Truncated,
+		); err != nil {
+			return nil, false, fmt.Errorf("scan document search result: %w", err)
+		}
+		if err := json.Unmarshal([]byte(headingJSON), &row.HeadingPath); err != nil {
+			return nil, false, fmt.Errorf("decode document search heading path: %w", err)
+		}
+		if contentSignal {
+			if _, found := seenOccurrences[row.OccurrenceKey]; found {
+				continue
+			}
+			seenOccurrences[row.OccurrenceKey] = struct{}{}
+			row.ContentRank = len(results) + 1
+		} else {
+			row.FilenameRank = len(results) + 1
+		}
+		results = append(results, row)
+		if uniqueOccurrenceLimit > 0 && len(results) > uniqueOccurrenceLimit {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, fmt.Errorf("iterate document search results: %w", err)
+	}
+	hasMore := uniqueOccurrenceLimit > 0 && len(results) > uniqueOccurrenceLimit
+	if hasMore {
+		results = results[:uniqueOccurrenceLimit]
+	}
+	return results, hasMore, nil
+}
+
+func nextDocumentSearchCandidateLimit(current, offset, pageSize int) int {
+	required := min(offset+pageSize, maxDocumentSearchCandidates)
+	return min(max(current*2, required), maxDocumentSearchCandidates)
+}
+
+func (s *Store) populateDocumentLiveCopyCounts(
+	ctx context.Context,
+	results []DocumentSearchResult,
+) error {
+	if len(results) == 0 {
+		return nil
+	}
+	hashes := make([]string, 0, len(results))
+	seen := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		if _, found := seen[result.CanonicalBlobHash]; found {
+			continue
+		}
+		seen[result.CanonicalBlobHash] = struct{}{}
+		hashes = append(hashes, result.CanonicalBlobHash)
+	}
+	query := `
+		SELECT h.canonical_blob_hash, COUNT(DISTINCT o.occurrence_key)
+		FROM document_extraction_heads h
+		JOIN document_extraction_profiles p ON p.id = h.profile_id
+		JOIN document_provider_consents c ON c.profile_id = p.id
+		JOIN document_occurrences o ON o.canonical_blob_hash = h.canonical_blob_hash
+		JOIN attachments a ON a.id = o.attachment_id
+		JOIN messages m ON m.id = o.message_id
+		CROSS JOIN document_index_state ds
+		WHERE h.canonical_blob_hash IN (` + documentPlaceholders(len(hashes)) + `)
+		  AND ` + documentSearchValidity("p", "c", "h", "o", "a", "m", "ds") + `
+		GROUP BY h.canonical_blob_hash`
+	args := make([]any, len(hashes))
+	for index := range hashes {
+		args[index] = hashes[index]
+	}
+	rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(query), args...)
+	if err != nil {
+		return fmt.Errorf("count live document copies: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	counts := make(map[string]int, len(hashes))
+	for rows.Next() {
+		var hash string
+		var count int
+		if err := rows.Scan(&hash, &count); err != nil {
+			return fmt.Errorf("scan live document copy count: %w", err)
+		}
+		counts[hash] = count
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate live document copy counts: %w", err)
+	}
+	for index := range results {
+		results[index].OtherLiveCopies = max(counts[results[index].CanonicalBlobHash]-1, 0)
+	}
+	return nil
+}
+
+func fuseDocumentSearchRows(
+	contentRows []documentSearchRow,
+	filenameRows []documentSearchRow,
+	terms []string,
+) []documentSearchRow {
+	byOccurrence := make(map[string]documentSearchRow, len(contentRows)+len(filenameRows))
+	for _, row := range contentRows {
+		existing, found := byOccurrence[row.OccurrenceKey]
+		if !found || row.ContentRank < existing.ContentRank {
+			row.Score = 1 / (documentSearchRRFConstant + float64(row.ContentRank))
+			row.MatchedSignals = []string{"content"}
+			byOccurrence[row.OccurrenceKey] = row
+		}
+	}
+	for _, filenameRow := range filenameRows {
+		existing, found := byOccurrence[filenameRow.OccurrenceKey]
+		if found {
+			existing.FilenameRank = filenameRow.FilenameRank
+			existing.Score += 1 / (documentSearchRRFConstant + float64(filenameRow.FilenameRank))
+			existing.MatchedSignals = []string{"content", "filename"}
+			byOccurrence[filenameRow.OccurrenceKey] = existing
+			continue
+		}
+		filenameRow.Score = 1 / (documentSearchRRFConstant + float64(filenameRow.FilenameRank))
+		filenameRow.MatchedSignals = []string{"filename"}
+		byOccurrence[filenameRow.OccurrenceKey] = filenameRow
+	}
+	results := make([]documentSearchRow, 0, len(byOccurrence))
+	for _, row := range byOccurrence {
+		row.Excerpt, row.HighlightStart, row.HighlightEnd = documentSearchExcerpt(row.Text, terms)
+		row.Text = ""
+		results = append(results, row)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if math.Abs(results[i].Score-results[j].Score) > 1e-12 {
+			return results[i].Score > results[j].Score
+		}
+		if results[i].MessageID != results[j].MessageID {
+			return results[i].MessageID < results[j].MessageID
+		}
+		return results[i].AttachmentID < results[j].AttachmentID
+	})
+	return results
+}
+
+func documentSearchExcerpt(text string, terms []string) (string, int, int) {
+	runes := []rune(text)
+	matchStart, matchEnd := 0, 0
+	lower := []rune(strings.ToLower(text))
+	for _, term := range terms {
+		termRunes := []rune(strings.ToLower(term))
+		if len(termRunes) == 0 {
+			continue
+		}
+		for index := 0; index+len(termRunes) <= len(lower); index++ {
+			if slices.Equal(lower[index:index+len(termRunes)], termRunes) {
+				matchStart, matchEnd = index, index+len(termRunes)
+				break
+			}
+		}
+		if matchEnd > matchStart {
+			break
+		}
+	}
+	start := max(matchStart-maxDocumentSearchExcerpt/3, 0)
+	end := min(start+maxDocumentSearchExcerpt, len(runes))
+	if end-start < maxDocumentSearchExcerpt {
+		start = max(end-maxDocumentSearchExcerpt, 0)
+	}
+	excerpt := strings.TrimSpace(string(runes[start:end]))
+	trimmedPrefix := utf8.RuneCountInString(string(runes[start:end])) - utf8.RuneCountInString(strings.TrimLeftFunc(string(runes[start:end]), unicode.IsSpace))
+	highlightStart := max(matchStart-start-trimmedPrefix, 0)
+	highlightEnd := max(matchEnd-start-trimmedPrefix, highlightStart)
+	if matchEnd == matchStart || highlightStart > utf8.RuneCountInString(excerpt) {
+		highlightStart, highlightEnd = 0, 0
+	} else {
+		highlightEnd = min(highlightEnd, utf8.RuneCountInString(excerpt))
+	}
+	return excerpt, highlightStart, highlightEnd
+}
+
+func hashDocumentSearchRequest(request DocumentSearchRequest) (string, error) {
+	payload := struct {
+		Query        string   `json:"query"`
+		SourceIDs    []int64  `json:"source_ids"`
+		MessageTypes []string `json:"message_types"`
+		AttachmentID int64    `json:"attachment_id"`
+		MessageID    int64    `json:"message_id"`
+		PageSize     int      `json:"page_size"`
+	}{
+		Query: request.Query, SourceIDs: request.SourceIDs, MessageTypes: request.MessageTypes,
+		AttachmentID: request.AttachmentID, MessageID: request.MessageID, PageSize: request.PageSize,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode document search request: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func encodeDocumentSearchCursor(cursor documentSearchCursor) (string, error) {
+	encoded, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("encode document search cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func decodeDocumentSearchCursor(value string) (documentSearchCursor, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil || len(decoded) > 1_024 {
+		return documentSearchCursor{}, ErrDocumentSearchInvalidCursor
+	}
+	var cursor documentSearchCursor
+	decoder := json.NewDecoder(strings.NewReader(string(decoded)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cursor); err != nil || cursor.Version != documentSearchCursorVersion ||
+		!validLowerSHA256(cursor.RequestHash) || cursor.Revision < 0 ||
+		cursor.Offset <= 0 || cursor.Offset > maxDocumentSearchOffset ||
+		cursor.CandidateLimit < 1 || cursor.CandidateLimit > maxDocumentSearchCandidates {
+		return documentSearchCursor{}, ErrDocumentSearchInvalidCursor
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return documentSearchCursor{}, ErrDocumentSearchInvalidCursor
+	}
+	return cursor, nil
+}
+
+func sortedUniquePositive(values []int64) ([]int64, error) {
+	result := slices.Clone(values)
+	slices.Sort(result)
+	result = slices.Compact(result)
+	for _, value := range result {
+		if value <= 0 {
+			return nil, fmt.Errorf("%w: source IDs must be positive", ErrDocumentSearchInvalidRequest)
+		}
+	}
+	return result, nil
+}
+
+func sortedUniqueNonempty(values []string) ([]string, error) {
+	result := slices.Clone(values)
+	for index := range result {
+		result[index] = strings.ToLower(strings.TrimSpace(result[index]))
+		if result[index] == "" {
+			return nil, fmt.Errorf("%w: message types must be nonempty", ErrDocumentSearchInvalidRequest)
+		}
+	}
+	slices.Sort(result)
+	return slices.Compact(result), nil
+}
+
+func escapeDocumentLike(value string) string {
+	replacer := strings.NewReplacer(`!`, `!!`, `%`, `!%`, `_`, `!_`)
+	return replacer.Replace(value)
+}
+
+func documentPlaceholders(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
+}

--- a/internal/store/document_search_test.go
+++ b/internal/store/document_search_test.go
@@ -1,0 +1,423 @@
+package store_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestSearchDocumentsReturnsCurrentExactOccurrences(t *testing.T) {
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "old quasar evidence", "search-old")
+	publishSearchDocument(t, f, profile, hash, "new nebula evidence", "search-new")
+
+	response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar"})
+	require.NoError(t, err)
+	assert.Empty(response.Results, "an immutable superseded chunk must not remain searchable")
+
+	response, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula"})
+	require.NoError(t, err)
+	require.Len(t, response.Results, 1)
+	result := response.Results[0]
+	assert.Equal("synthetic.pdf", result.Filename)
+	assert.Equal(hash, result.CanonicalBlobHash)
+	assert.Equal(profile.ID, result.ProfileID)
+	assert.Equal("mistral", result.Provider)
+	assert.Equal("mistral-ocr-4-0", result.Model)
+	assert.Equal([]string{"content"}, result.MatchedSignals)
+	assert.Equal("new nebula evidence", result.Excerpt)
+	assert.Equal(4, result.HighlightStart)
+	assert.Equal(10, result.HighlightEnd)
+	assert.Zero(result.OtherLiveCopies)
+	assert.Equal(1, result.Rank)
+}
+
+func TestSearchDocumentsFailsCleanlyWithoutFTS(t *testing.T) {
+	f := storetest.New(t)
+	store.SetFTS5AvailableForTest(f.Store, false)
+
+	_, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "evidence"})
+	require.ErrorIs(t, err, store.ErrDocumentSearchUnavailable)
+}
+
+func TestSearchDocumentsPreservesWinningOccurrenceAndFilenameSignal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "shared nebula evidence", "search-shared")
+
+	secondMessageID := f.CreateMessage("document-search-copy")
+	secondAttachmentID := addSearchAttachment(t, f, secondMessageID, hash, "invoice-nebula.xlsx", "provider:copy")
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), secondAttachmentID, 2)
+	require.NoError(err)
+	require.True(eligible)
+
+	response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "invoice", AttachmentID: secondAttachmentID,
+	})
+	require.NoError(err)
+	require.Len(response.Results, 1)
+	assert.Equal(secondAttachmentID, response.Results[0].AttachmentID)
+	assert.Equal(secondMessageID, response.Results[0].MessageID)
+	assert.Equal([]string{"filename"}, response.Results[0].MatchedSignals)
+	assert.Equal(1, response.Results[0].OtherLiveCopies,
+		"copy count is global even when the request is scoped to one occurrence")
+
+	response, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula"})
+	require.NoError(err)
+	require.Len(response.Results, 2)
+	assert.Contains([]int64{response.Results[0].AttachmentID, response.Results[1].AttachmentID}, secondAttachmentID)
+	for _, result := range response.Results {
+		var expectedAttachmentID int64
+		require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+			`SELECT id FROM attachments WHERE message_id = ?`), result.MessageID).Scan(&expectedAttachmentID))
+		assert.Equal(expectedAttachmentID, result.AttachmentID,
+			"a hash-level hit must not be broadcast onto a different occurrence")
+		assert.Equal(1, result.OtherLiveCopies)
+		assert.NotZero(result.AttachmentID)
+		assert.NotZero(result.MessageID)
+	}
+}
+
+func TestSearchDocumentsRejectsStaleOrMismatchedCursor(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "cursor nebula evidence", "search-cursor")
+
+	secondMessageID := f.CreateMessage("document-search-page-two")
+	secondAttachmentID := addSearchAttachment(t, f, secondMessageID, hash, "second.pdf", "provider:second")
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), secondAttachmentID, 2)
+	require.NoError(err)
+	require.True(eligible)
+
+	first, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula", PageSize: 1})
+	require.NoError(err)
+	require.Len(first.Results, 1)
+	require.NotEmpty(first.NextCursor)
+
+	_, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "different", PageSize: 1, Cursor: first.NextCursor,
+	})
+	require.ErrorIs(err, store.ErrDocumentSearchInvalidCursor)
+
+	thirdMessageID := f.CreateMessage("document-search-page-three")
+	thirdAttachmentID := addSearchAttachment(t, f, thirdMessageID, hash, "third.pdf", "provider:third")
+	_, eligible, err = f.Store.ReconcileDocumentOccurrence(t.Context(), thirdAttachmentID, 3)
+	require.NoError(err)
+	require.True(eligible)
+	_, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "nebula", PageSize: 1, Cursor: first.NextCursor,
+	})
+	require.ErrorIs(err, store.ErrDocumentSearchCursorStale)
+}
+
+func TestRetireDocumentExtractionProfileHidesResultsAndInvalidatesCursor(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "retirement nebula evidence", "search-retirement")
+
+	secondMessageID := f.CreateMessage("document-retirement-page-two")
+	secondAttachmentID := addSearchAttachment(t, f, secondMessageID, hash, "second.pdf", "provider:retirement")
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), secondAttachmentID, 2)
+	require.NoError(err)
+	require.True(eligible)
+	first, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula", PageSize: 1})
+	require.NoError(err)
+	require.NotEmpty(first.NextCursor)
+
+	changed, err := f.Store.RetireDocumentExtractionProfile(t.Context(), profile.ID)
+	require.NoError(err)
+	assert.True(t, changed)
+	response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula"})
+	require.NoError(err)
+	assert.Empty(t, response.Results)
+	_, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "nebula", PageSize: 1, Cursor: first.NextCursor,
+	})
+	require.ErrorIs(err, store.ErrDocumentSearchCursorStale)
+}
+
+func TestSearchDocumentsRotatesProfilesAfterEachReplacementIsReady(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	oldProfile, firstHash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, oldProfile, firstHash, "old quasar first", "search-old-first")
+
+	secondHash := strings.Repeat("c", 64)
+	secondMessageID := f.CreateMessage("document-profile-rotation-second")
+	secondAttachmentID := addSearchAttachment(
+		t, f, secondMessageID, secondHash, "second.pdf", "provider:rotation-second",
+	)
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), secondAttachmentID, 2)
+	require.NoError(err)
+	require.True(eligible)
+	publishSearchDocument(t, f, oldProfile, secondHash, "old quasar second", "search-old-second")
+
+	before, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar", PageSize: 1})
+	require.NoError(err)
+	require.Len(before.Results, 1)
+	require.NotEmpty(before.NextCursor)
+
+	newProfile := oldProfile
+	newProfile.Fingerprint = strings.Repeat("e", 64)
+	newProfile.ID = "profile-" + newProfile.Fingerprint
+	newProfile.Model = "mistral-ocr-latest"
+	newProfile.PolicyJSON = []byte(`{"policy":2}`)
+	_, err = f.Store.EnsureDocumentExtractionProfile(t.Context(), newProfile)
+	require.NoError(err)
+	require.NoError(f.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: newProfile.ID, ProfileFingerprint: newProfile.Fingerprint,
+		RetentionPosture: newProfile.RetentionPosture, TrainingPosture: newProfile.TrainingPosture,
+	}))
+
+	_, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "quasar", PageSize: 1, Cursor: before.NextCursor,
+	})
+	require.ErrorIs(err, store.ErrDocumentSearchCursorStale)
+	whilePending, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar"})
+	require.NoError(err)
+	require.Len(whilePending.Results, 2, "old heads remain visible until each target replacement is ready")
+
+	publishSearchDocument(t, f, newProfile, firstHash, "new nebula first", "search-new-first")
+	oldResults, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar"})
+	require.NoError(err)
+	require.Len(oldResults.Results, 1)
+	assert.Equal(secondHash, oldResults.Results[0].CanonicalBlobHash)
+	assert.Equal(oldProfile.ID, oldResults.Results[0].ProfileID)
+
+	newResults, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula"})
+	require.NoError(err)
+	require.Len(newResults.Results, 1)
+	assert.Equal(firstHash, newResults.Results[0].CanonicalBlobHash)
+	assert.Equal(newProfile.ID, newResults.Results[0].ProfileID)
+	assert.Equal("mistral-ocr-latest", newResults.Results[0].Model)
+
+	changed, err := f.Store.RetireDocumentExtractionProfile(t.Context(), newProfile.ID)
+	require.NoError(err)
+	require.True(changed)
+	fallback, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar"})
+	require.NoError(err)
+	assert.Len(fallback.Results, 2, "retiring the target restores the newest eligible fallback heads")
+
+	err = f.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: newProfile.ID, ProfileFingerprint: newProfile.Fingerprint,
+		RetentionPosture: newProfile.RetentionPosture, TrainingPosture: newProfile.TrainingPosture,
+	})
+	require.ErrorContains(err, "retired")
+}
+
+func TestSearchDocumentsSuppressesFallbackAfterTargetProfileTerminalFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	oldProfile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, oldProfile, hash, "old quasar evidence", "search-terminal-old")
+
+	newProfile := oldProfile
+	newProfile.Fingerprint = strings.Repeat("e", 64)
+	newProfile.ID = "profile-" + newProfile.Fingerprint
+	newProfile.PolicyJSON = []byte(`{"policy":2}`)
+	_, err := f.Store.EnsureDocumentExtractionProfile(t.Context(), newProfile)
+	require.NoError(err)
+	require.NoError(f.Store.RecordDocumentProviderConsent(t.Context(), store.DocumentProviderConsent{
+		ProfileID: newProfile.ID, ProfileFingerprint: newProfile.Fingerprint,
+		RetentionPosture: newProfile.RetentionPosture, TrainingPosture: newProfile.TrainingPosture,
+	}))
+	before, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar"})
+	require.NoError(err)
+	require.Len(before.Results, 1, "the old profile remains a fallback while the target is pending")
+	revisionBefore, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "search-terminal-target", ProfileID: newProfile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "search-terminal-worker", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1, RequireNoHead: true,
+	}))
+	require.NoError(err)
+	require.NoError(f.Store.FailDocumentExtraction(t.Context(), store.DocumentExtractionFailure{
+		Claim: claim, ReasonCode: "provider_rejected", Terminal: true,
+	}))
+
+	after, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar"})
+	require.NoError(err)
+	assert.Empty(after.Results, "a terminal decision for the desired policy suppresses older profile fallback")
+	revisionAfter, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(revisionBefore+1, revisionAfter, "terminal suppression must invalidate search cursors")
+
+	changed, err := f.Store.RetryDocumentExtraction(t.Context(), newProfile.ID, hash)
+	require.NoError(err)
+	require.True(changed)
+	retried, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "quasar"})
+	require.NoError(err)
+	require.Len(retried.Results, 1, "retrying the desired policy restores eligible fallback evidence")
+	assert.Equal(oldProfile.ID, retried.Results[0].ProfileID)
+	revisionRetried, err := f.Store.GetDocumentIndexRevision(t.Context())
+	require.NoError(err)
+	assert.Equal(revisionAfter+1, revisionRetried, "restoring fallback must invalidate search cursors")
+}
+
+func TestSearchDocumentsFailsClosedOnLiveAuthorityAndInvalidScopes(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "authority nebula evidence", "search-authority")
+
+	response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula"})
+	require.NoError(err)
+	require.Len(response.Results, 1)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP WHERE id = ?`),
+		response.Results[0].MessageID)
+	require.NoError(err)
+	response, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula"})
+	require.NoError(err)
+	assert.Empty(t, response.Results, "serving must recheck live authority before reconciliation catches up")
+
+	_, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula", SourceIDs: []int64{0}})
+	require.ErrorContains(err, "source IDs must be positive")
+	_, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula", MessageTypes: []string{""}})
+	require.ErrorContains(err, "message types must be nonempty")
+}
+
+func TestSearchDocumentsAppliesCandidateLimitAfterOccurrenceDeduplication(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, crowdedHash := seedDocumentPublicationAuthority(t, f)
+	publishManySearchChunks(t, f, profile, crowdedHash, 201)
+
+	secondHash := strings.Repeat("c", 64)
+	secondMessageID := f.CreateMessage("document-search-not-crowded-out")
+	secondAttachmentID := addSearchAttachment(
+		t, f, secondMessageID, secondHash, "second.docx", "provider:second-owner",
+	)
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), secondAttachmentID, 2)
+	require.NoError(err)
+	require.True(eligible)
+	publishSearchDocument(t, f, profile, secondHash, "second nebula evidence", "search-second-owner")
+
+	response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{Query: "nebula"})
+	require.NoError(err)
+	require.Len(response.Results, 2,
+		"many matching chunks from one occurrence must not crowd out another attachment")
+	assert.Contains(t, []int64{response.Results[0].AttachmentID, response.Results[1].AttachmentID}, secondAttachmentID)
+}
+
+func TestSearchDocumentsExpandsCandidateWindowAcrossPagination(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "window nebula evidence", "search-window")
+
+	const copies = 201
+	for index := 1; index < copies; index++ {
+		messageID := f.CreateMessage("document-search-window-" + strconv.Itoa(index))
+		attachmentID := addSearchAttachment(
+			t, f, messageID, hash, "copy-"+strconv.Itoa(index)+".pdf",
+			"provider:window:"+strconv.Itoa(index),
+		)
+		_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), attachmentID, int64(index+1))
+		require.NoError(err)
+		require.True(eligible)
+	}
+
+	cursor := ""
+	seen := make(map[int64]struct{}, copies)
+	for {
+		response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+			Query: "nebula", PageSize: 10, Cursor: cursor,
+		})
+		require.NoError(err)
+		for _, result := range response.Results {
+			seen[result.AttachmentID] = struct{}{}
+		}
+		if response.NextCursor == "" {
+			require.False(response.Truncated)
+			break
+		}
+		cursor = response.NextCursor
+	}
+	require.Len(seen, copies, "pagination must expand beyond the initial 200-candidate window")
+}
+
+func publishSearchDocument(
+	t *testing.T,
+	f *storetest.Fixture,
+	profile store.DocumentExtractionProfile,
+	hash string,
+	text string,
+	extractionID string,
+) {
+	t.Helper()
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: extractionID, ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: extractionID + "-worker", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(t, err)
+	require.NoError(t, f.Store.PublishDocumentExtraction(t.Context(), publicationFor(
+		claim, text, strings.Repeat("d", 64),
+	)))
+}
+
+func addSearchAttachment(
+	t *testing.T,
+	f *storetest.Fixture,
+	messageID int64,
+	hash string,
+	filename string,
+	sourcePartKey string,
+) int64 {
+	t.Helper()
+	require.NoError(t, f.Store.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: filename, MIMEType: "application/pdf", Size: 128,
+		StoragePath: hash[:2] + "/" + hash, ContentHash: hash,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		SourcePartKey: sourcePartKey,
+	}))
+	return singleAttachmentID(t, f, messageID)
+}
+
+func publishManySearchChunks(
+	t *testing.T,
+	f *storetest.Fixture,
+	profile store.DocumentExtractionProfile,
+	hash string,
+	count int,
+) {
+	t.Helper()
+	claim, err := f.Store.ClaimDocumentExtraction(t.Context(), documentClaimInputForHash(t, f, store.DocumentExtractionClaimInput{
+		ExtractionID: "search-crowded", ProfileID: profile.ID,
+		CanonicalBlobHash: hash, ExtractionInputKey: "original",
+		LeaseOwner: "search-crowded-worker", LeaseUntil: time.Now().UTC().Add(10 * time.Minute),
+		LocalBytes: 128, SourceSequence: 1,
+	}))
+	require.NoError(t, err)
+	text := "crowded nebula evidence"
+	publication := publicationFor(claim, text, strings.Repeat("d", 64))
+	publication.Chunks = make([]store.DocumentPublishedChunk, count)
+	for index := range count {
+		publication.Chunks[index] = store.DocumentPublishedChunk{
+			Key: "crowded-" + strconv.Itoa(index), Ordinal: index, Text: text,
+			FirstUnitIndex: 0, LastUnitIndex: 0, Checksum: strings.Repeat("d", 64),
+			CharCount: len([]rune(text)),
+			Spans:     []store.DocumentPublishedSpan{{UnitIndex: 0, CharStart: 0, CharEnd: len([]rune(text))}},
+		}
+	}
+	require.NoError(t, f.Store.PublishDocumentExtraction(t.Context(), publication))
+}

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -95,3 +95,11 @@ func (s *Store) SetInitSchemaWindowHookForTest(fn func()) func() {
 	s.initSchemaWindowHook = fn
 	return func() { s.initSchemaWindowHook = nil }
 }
+
+// SetAttachmentRoleRepairPreparedHookForTest installs a hook after historical
+// MIME evidence has been prepared but before the repair transaction begins.
+// Tests use it to reproduce a concurrent resync that changes attachment bytes.
+func (s *Store) SetAttachmentRoleRepairPreparedHookForTest(fn func()) func() {
+	s.attachmentRoleRepairPreparedHook = fn
+	return func() { s.attachmentRoleRepairPreparedHook = nil }
+}

--- a/internal/store/files.go
+++ b/internal/store/files.go
@@ -26,6 +26,10 @@ type FileMetadata struct {
 	ContentHash      string
 	StoragePath      string
 	URL              string
+	AttachmentRole   AttachmentRole
+	RoleSource       AttachmentRoleSource
+	SourcePartKey    string
+	ContentID        string
 }
 
 func (s *Store) GetFileMetadata(ctx context.Context, id int64) (*FileMetadata, error) {
@@ -72,7 +76,9 @@ func (s *Store) GetFileMetadataBatch(ctx context.Context, ids []int64) (map[int6
 			m.source_id, COALESCE(m.source_message_id, ''),
 			COALESCE(m.message_type, ''), COALESCE(c.conversation_type, ''),
 			COALESCE(a.filename, ''), COALESCE(a.mime_type, ''), COALESCE(a.size, 0),
-			COALESCE(a.content_hash, ''), COALESCE(a.storage_path, '')
+			COALESCE(a.content_hash, ''), COALESCE(a.storage_path, ''),
+			a.attachment_role, a.role_source,
+			COALESCE(a.source_part_key, ''), COALESCE(a.content_id, '')
 		FROM attachments a
 		JOIN messages m ON m.id = a.message_id
 		JOIN conversations c ON c.id = m.conversation_id
@@ -87,7 +93,8 @@ func (s *Store) GetFileMetadataBatch(ctx context.Context, ids []int64) (map[int6
 		var file FileMetadata
 		if err := rows.Scan(&file.ID, &file.MessageID, &file.ConversationID,
 			&file.SourceID, &file.SourceMessageID, &file.MessageType, &file.ConversationType,
-			&file.Filename, &file.MimeType, &file.Size, &file.ContentHash, &file.StoragePath); err != nil {
+			&file.Filename, &file.MimeType, &file.Size, &file.ContentHash, &file.StoragePath,
+			&file.AttachmentRole, &file.RoleSource, &file.SourcePartKey, &file.ContentID); err != nil {
 			return nil, fmt.Errorf("scan file metadata: %w", err)
 		}
 		lowerPath := strings.ToLower(file.StoragePath)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -1120,16 +1120,26 @@ func (s *Store) GetMessageRaw(messageID int64) ([]byte, error) {
 		return nil, err
 	}
 
-	if compression.Valid && compression.String == "zlib" {
-		r, err := zlib.NewReader(bytes.NewReader(compressed))
-		if err != nil {
-			return nil, fmt.Errorf("zlib reader: %w", err)
-		}
-		defer func() { _ = r.Close() }()
-		return io.ReadAll(r)
-	}
+	return decodeMessageRaw(compressed, compression)
+}
 
-	return compressed, nil
+func decodeMessageRaw(compressed []byte, compression sql.NullString) ([]byte, error) {
+	if !compression.Valid || compression.String != "zlib" {
+		return compressed, nil
+	}
+	r, err := zlib.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return nil, fmt.Errorf("zlib reader: %w", err)
+	}
+	data, readErr := io.ReadAll(r)
+	closeErr := r.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close zlib reader: %w", closeErr)
+	}
+	return data, nil
 }
 
 // GetMessageIsFromMe returns the baked account-attribution flag for a message.
@@ -4036,13 +4046,12 @@ func (s *Store) IsAttachmentPathReferenced(storagePath string) (bool, error) {
 	return count > 0, nil
 }
 
-// UpsertAttachment stores an attachment record. Idempotency for the
-// common case is enforced by the partial unique index
-// idx_attachments_msg_content_hash on (message_id, content_hash) where
-// content_hash is non-empty; concurrent inserts collapse to one row via
-// ON CONFLICT DO NOTHING. `size` is widened to int64 at the bind
-// boundary so 32-bit builds cannot truncate large attachments before
-// the column (BIGINT on PG, INTEGER on SQLite).
+// UpsertAttachment is the compatibility write path for callers without stable
+// occurrence provenance. It fails closed to role unknown/legacy_api and keeps
+// the legacy best-effort content-hash identity. New and source-aware writers
+// use UpsertAttachmentRecord. `size` is widened to int64 at the bind boundary
+// so 32-bit builds cannot truncate large attachments before the column (BIGINT
+// on PG, INTEGER on SQLite).
 //
 // When contentHash is empty (the rare untyped-blob path used by some
 // importers), the unique index does not cover the row; a best-effort
@@ -4050,30 +4059,15 @@ func (s *Store) IsAttachmentPathReferenced(storagePath string) (bool, error) {
 // but two concurrent empty-hash inserts on the same message may both
 // succeed.
 func (s *Store) UpsertAttachment(messageID int64, filename, mimeType, storagePath, contentHash string, size int) error {
-	if contentHash != "" {
-		_, err := s.db.Exec(fmt.Sprintf(`
-			INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, %s)
-			ON CONFLICT (message_id, content_hash) WHERE content_hash IS NOT NULL AND content_hash != '' DO NOTHING
-		`, s.dialect.Now()), messageID, filename, mimeType, storagePath, contentHash, int64(size))
-		return err
-	}
-
-	var existingID int64
-	err := s.db.QueryRow(`
-		SELECT id FROM attachments WHERE message_id = ? AND (content_hash IS NULL OR content_hash = '')
-	`, messageID).Scan(&existingID)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return err
-	}
-	_, err = s.db.Exec(fmt.Sprintf(`
-		INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, %s)
-	`, s.dialect.Now()), messageID, filename, mimeType, storagePath, contentHash, int64(size))
-	return err
+	return s.UpsertAttachmentRecord(context.Background(), messageID, AttachmentWrite{
+		Filename:    filename,
+		MIMEType:    mimeType,
+		StoragePath: storagePath,
+		ContentHash: contentHash,
+		Size:        int64(size),
+		Role:        AttachmentRoleUnknown,
+		RoleSource:  AttachmentRoleSourceLegacyAPI,
+	})
 }
 
 // RecomputeMessageAttachmentStats refreshes the denormalized attachment flags
@@ -4103,7 +4097,11 @@ type AttachmentRef struct {
 	// Metadata is importer-supplied JSON stored in attachments.attachment_metadata
 	// (e.g. the source URL a link-preview attachment was forwarded from). Empty
 	// stores NULL; callers own the shape and must supply valid JSON.
-	Metadata string
+	Metadata      string
+	Role          AttachmentRole
+	RoleSource    AttachmentRoleSource
+	SourcePartKey string
+	ContentID     string
 }
 
 // replaceMessageAttachmentsWhere atomically deletes a message's attachment
@@ -4121,14 +4119,34 @@ func (s *Store) replaceMessageAttachmentsWhere(
 			if ref.StoragePath == "" || (requireHash && ref.ContentHash == "") {
 				continue
 			}
-			if _, err := tx.Exec(fmt.Sprintf(`
-				INSERT INTO attachments (message_id, filename, mime_type, storage_path, content_hash, size, source_attachment_id,
-					media_type, width, height, duration_ms, attachment_metadata, created_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, %s)
-				ON CONFLICT (message_id, content_hash) WHERE content_hash IS NOT NULL AND content_hash != '' DO NOTHING
-			`, s.dialect.JSONBindExpr(), s.dialect.Now()), messageID, ref.Filename, ref.MimeType, ref.StoragePath, ref.ContentHash, int64(ref.Size), ref.SourceAttachmentID,
-				nullIfEmpty(ref.MediaType), nullIfZero(ref.Width), nullIfZero(ref.Height), nullIfZero(ref.DurationMS),
-				nullIfEmpty(ref.Metadata)); err != nil {
+			write := AttachmentWrite{
+				Filename:           ref.Filename,
+				MIMEType:           ref.MimeType,
+				StoragePath:        ref.StoragePath,
+				ContentHash:        ref.ContentHash,
+				Size:               int64(ref.Size),
+				SourceAttachmentID: ref.SourceAttachmentID,
+				MediaType:          ref.MediaType,
+				Width:              ref.Width,
+				Height:             ref.Height,
+				DurationMS:         ref.DurationMS,
+				Metadata:           ref.Metadata,
+				Role:               ref.Role,
+				RoleSource:         ref.RoleSource,
+				SourcePartKey:      ref.SourcePartKey,
+				ContentID:          ref.ContentID,
+			}.normalized()
+			if write.SourcePartKey == "" && write.SourceAttachmentID != "" {
+				// Provider attachment IDs are already namespaced by every caller of
+				// this replacement path. They are the stable occurrence identity;
+				// unlike a content hash, they preserve two source parts with the
+				// same bytes and keep hashless pending rows distinct.
+				write.SourcePartKey = write.SourceAttachmentID
+			}
+			if err := write.validate(); err != nil {
+				return err
+			}
+			if err := s.upsertAttachmentRecord(tx, messageID, write); err != nil {
 				return err
 			}
 		}
@@ -4233,24 +4251,43 @@ func (s *Store) ScanArchivedRawMessages(sourceID int64, format string, afterID i
 	return out, rows.Err()
 }
 
-// SetBeeperAttachmentMetadata replaces attachment_metadata on a message's
-// Beeper-managed attachment rows, returning how many rows changed. Empty
-// metadata clears the column. Rows already holding the value are left alone so
-// a repeated call reports no change; updating in place (rather than replacing
-// rows) leaves the stored blobs untouched.
-func (s *Store) SetBeeperAttachmentMetadata(messageID int64, metadata string) (int64, error) {
+// SetBeeperAttachmentClassification refreshes link-preview metadata and role
+// on a message's Beeper-managed attachment rows. Sticker is explicit provider
+// evidence and takes precedence over the message-level preview shape.
+func (s *Store) SetBeeperAttachmentClassification(
+	messageID int64,
+	metadata string,
+	isPreview bool,
+) (int64, error) {
+	role := AttachmentRoleStandalone
+	if isPreview {
+		role = AttachmentRolePreview
+	}
 	res, err := s.db.Exec(s.Rebind(fmt.Sprintf(`
-		UPDATE attachments SET attachment_metadata = %s
+		UPDATE attachments
+		SET attachment_metadata = %s,
+		    attachment_role = CASE
+		        WHEN attachment_role = 'sticker' THEN attachment_role
+		        ELSE ?
+		    END,
+		    role_source = CASE
+		        WHEN attachment_role = 'sticker' THEN role_source
+		        ELSE 'importer_semantics'
+		    END
 		WHERE message_id = ? AND source_attachment_id LIKE 'beeper:%%'
-		  AND %s
+		  AND (
+		      %s
+		      OR (attachment_role != 'sticker' AND attachment_role != ?)
+		      OR (attachment_role != 'sticker' AND role_source != 'importer_semantics')
+		  )
 	`, s.dialect.JSONBindExpr(), s.dialect.JSONIsDistinctExpr("attachment_metadata"))),
-		nullIfEmpty(metadata), messageID, nullIfEmpty(metadata))
+		nullIfEmpty(metadata), string(role), messageID, nullIfEmpty(metadata), string(role))
 	if err != nil {
-		return 0, fmt.Errorf("set beeper attachment metadata: %w", err)
+		return 0, fmt.Errorf("set beeper attachment classification: %w", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return 0, fmt.Errorf("set beeper attachment metadata: rows affected: %w", err)
+		return 0, fmt.Errorf("set beeper attachment classification: rows affected: %w", err)
 	}
 	return n, nil
 }
@@ -4443,41 +4480,15 @@ func (s *Store) ListSlackPendingAttachmentMessages(sourceID int64) ([]PendingAtt
 
 // ReplaceMessageSlackAttachments replaces Slack-managed attachment rows for
 // a message (rows whose source_attachment_id carries the "slack:" prefix).
-// Duplicate-content refs are normalized into alias rows first (see
-// normalizeSlackAttachmentRefs) so every Slack file ID keeps a row.
+// Stable Slack file IDs are persisted as source-part keys so every file keeps
+// one row even when several files on a message have identical bytes.
 func (s *Store) ReplaceMessageSlackAttachments(messageID int64, refs []AttachmentRef) error {
-	refs = normalizeSlackAttachmentRefs(refs)
 	return s.replaceMessageProviderAttachments(messageID, "slack:", refs)
-}
-
-// normalizeSlackAttachmentRefs preserves one row per Slack file ID when
-// several files on a message share one CAS blob. The schema's
-// (message_id, content_hash) uniqueness keeps the real hash on the first
-// row; later duplicates retain the same trusted local path with an empty
-// hash (the Discord alias pattern). Pending markers and link rows carry
-// permalink URLs, never CAS paths, so they pass through untouched.
-func normalizeSlackAttachmentRefs(refs []AttachmentRef) []AttachmentRef {
-	normalized := append([]AttachmentRef(nil), refs...)
-	seen := make(map[string]struct{}, len(normalized))
-	for i := range normalized {
-		contentHash := strings.ToLower(normalized[i].ContentHash)
-		if contentHash == "" {
-			continue
-		}
-		if _, ok := seen[contentHash]; ok {
-			normalized[i].ContentHash = ""
-			continue
-		}
-		seen[contentHash] = struct{}{}
-	}
-	return normalized
 }
 
 // MessageSlackAttachments returns the message's existing Slack-managed
 // attachment rows keyed by source_attachment_id, so re-persisting a message
-// can keep already-downloaded media without re-fetching it. Alias rows get
-// their hash re-derived from the CAS path, so callers see them as
-// downloaded.
+// can keep already-downloaded media without re-fetching it.
 func (s *Store) MessageSlackAttachments(messageID int64) (map[string]AttachmentRef, error) {
 	refs, err := s.messageProviderAttachments(messageID, "slack:")
 	if err != nil {

--- a/internal/store/migrate_init_schema_ledger_test.go
+++ b/internal/store/migrate_init_schema_ledger_test.go
@@ -33,6 +33,7 @@ func TestInitSchema_OneShotMigrationsGatedOnLedger(t *testing.T) {
 
 	for _, name := range []string{
 		migrationAttachmentsContentHashUnique,
+		migrationAttachmentOccurrenceUnique,
 		migrationMessageAttributionProvenance,
 		migrationMessagesLastModifiedBackfill,
 		migrationMessagesContentChangedAtBackfill,

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -17,11 +17,12 @@ import (
 // startup on a large archive).
 const (
 	migrationAttachmentsContentHashUnique     = "attachments_content_hash_unique_index"
+	migrationAttachmentOccurrenceUnique       = "attachment_occurrence_unique_indexes_v1"
 	migrationMessagesLastModifiedBackfill     = "messages_last_modified_backfill"
 	migrationMessageAttributionProvenance     = "message_attribution_provenance_v2"
 	migrationArchiveIdentity                  = "archive_identity_v1"
 	migrationMessagesContentChangedAtBackfill = "messages_content_changed_at_backfill"
-	migrationMessageWatermarkTriggers         = "message_watermark_triggers_v1"
+	migrationMessageWatermarkTriggers         = "message_and_attachment_triggers_v2"
 	migrationEmbeddingChangeJournalTriggers   = "embedding_change_journal_triggers_v7"
 )
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -395,6 +395,15 @@ CREATE TABLE IF NOT EXISTS attachments (
     source_attachment_id TEXT,      -- original ID from platform
     attachment_metadata JSON,       -- EXIF, etc.
 
+    -- Source-authoritative occurrence role and provenance. Unknown fails
+    -- closed for any hosted attachment processing.
+    attachment_role TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (attachment_role IN ('standalone', 'inline', 'avatar', 'thumbnail', 'preview', 'sticker', 'ui_asset', 'unknown')),
+    role_source TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (role_source IN ('mime_disposition', 'provider_explicit', 'importer_semantics', 'legacy_api', 'raw_mime_repair', 'unknown')),
+    source_part_key TEXT CHECK (source_part_key IS NULL OR source_part_key != ''),
+    content_id TEXT,
+
     -- Encryption
     encryption_version INTEGER DEFAULT 0,
 
@@ -491,6 +500,48 @@ CREATE TABLE IF NOT EXISTS message_raw (
 
     compression TEXT DEFAULT 'zlib',
     encryption_version INTEGER DEFAULT 0
+);
+
+-- Resumable cursor for the bounded, raw-MIME-only attachment role repair.
+CREATE TABLE IF NOT EXISTS attachment_role_repair_progress (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    last_message_id INTEGER NOT NULL DEFAULT 0,
+    completed INTEGER NOT NULL DEFAULT 0 CHECK (completed IN (0, 1)),
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Shared database-owned attachment lifecycle journal. It deliberately omits
+-- filenames, paths, and content; consumers re-read current attachment
+-- authority before acting. Capture triggers append only while at least one
+-- independently-cursored derived feature is registered.
+CREATE TABLE IF NOT EXISTS attachment_change_log (
+    sequence                INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_kind              TEXT NOT NULL CHECK (event_kind IN (
+                                'attachment_insert', 'attachment_update',
+                                'attachment_delete', 'message_live_enter',
+                                'message_live_exit')),
+    old_message_id          INTEGER,
+    new_message_id          INTEGER,
+    old_attachment_id       INTEGER,
+    new_attachment_id       INTEGER,
+    old_content_hash        TEXT,
+    new_content_hash        TEXT,
+    old_source_part_key     TEXT,
+    new_source_part_key     TEXT,
+    old_role                TEXT,
+    new_role                TEXT,
+    created_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS attachment_change_consumers (
+    consumer_key            TEXT PRIMARY KEY,
+    baseline_sequence       INTEGER NOT NULL,
+    last_sequence           INTEGER NOT NULL,
+    reconciliation_complete BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (baseline_sequence >= 0),
+    CHECK (last_sequence >= baseline_sequence)
 );
 
 -- ============================================================================
@@ -1465,6 +1516,211 @@ CREATE TABLE IF NOT EXISTS attachment_pack_index (
     flags       INTEGER NOT NULL,
     crc32c      BIGINT NOT NULL
 );
+
+-- ==========================================================================
+-- DOCUMENT ATTACHMENT EXTRACTION
+-- ==========================================================================
+
+-- Immutable hosted-extraction policy. A policy change creates a new profile;
+-- mixed profiles may serve while an incremental rebuild is in progress.
+CREATE TABLE IF NOT EXISTS document_extraction_profiles (
+    id                    TEXT PRIMARY KEY,
+    fingerprint           TEXT NOT NULL UNIQUE,
+    provider              TEXT NOT NULL,
+    endpoint              TEXT NOT NULL,
+    region                TEXT NOT NULL,
+    model                 TEXT NOT NULL,
+    retention_posture     TEXT NOT NULL,
+    training_posture      TEXT NOT NULL,
+    allowed_media_types   JSON NOT NULL,
+    policy_json           JSON NOT NULL,
+    enabled               BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    retired_at            DATETIME
+);
+
+-- Recording consent is separate from supplying a key or enabling config.
+CREATE TABLE IF NOT EXISTS document_provider_consents (
+    profile_id            TEXT PRIMARY KEY REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    profile_fingerprint   TEXT NOT NULL,
+    retention_posture     TEXT NOT NULL,
+    training_posture      TEXT NOT NULL,
+    consented_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- A bounded full rebuild snapshots exact canonical owners once. This keeps a
+-- limited/resumed rebuild from selecting its first page forever while normal
+-- attachment reconciliation continues independently.
+CREATE TABLE IF NOT EXISTS document_extraction_rebuilds (
+    id                    TEXT PRIMARY KEY,
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    extraction_input_key  TEXT NOT NULL,
+    state                 TEXT NOT NULL CHECK (state IN ('building', 'completed')),
+    created_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at          DATETIME
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_document_extraction_rebuilds_active
+    ON document_extraction_rebuilds(profile_id, extraction_input_key)
+    WHERE state = 'building';
+
+CREATE TABLE IF NOT EXISTS document_extraction_rebuild_targets (
+    rebuild_id            TEXT NOT NULL REFERENCES document_extraction_rebuilds(id) ON DELETE CASCADE,
+    canonical_blob_hash   TEXT NOT NULL CHECK (length(canonical_blob_hash) = 64),
+    PRIMARY KEY (rebuild_id, canonical_blob_hash)
+);
+
+-- Immutable attempts owned by canonical bytes, not an attachment-row ID.
+CREATE TABLE IF NOT EXISTS document_extractions (
+    id                    TEXT PRIMARY KEY,
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    rebuild_id            TEXT REFERENCES document_extraction_rebuilds(id) ON DELETE SET NULL,
+    canonical_blob_hash   TEXT NOT NULL CHECK (length(canonical_blob_hash) = 64),
+    extraction_input_key  TEXT NOT NULL DEFAULT 'original',
+    state                 TEXT NOT NULL CHECK (state IN ('staging', 'ready', 'terminal', 'tombstoned')),
+    lease_owner           TEXT,
+    lease_fence           INTEGER NOT NULL DEFAULT 0,
+    lease_until           DATETIME,
+    attempt_count         INTEGER NOT NULL DEFAULT 0,
+    request_count         INTEGER NOT NULL DEFAULT 0 CHECK (request_count >= 0),
+    retry_count           INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0 AND retry_count <= request_count),
+    provider_latency_ms   INTEGER NOT NULL DEFAULT 0 CHECK (provider_latency_ms >= 0),
+    next_retry_at         DATETIME,
+    local_bytes           INTEGER NOT NULL,
+    provider_bytes        INTEGER,
+    units_processed       INTEGER,
+    returned_model        TEXT,
+    manifest_checksum     TEXT,
+    terminal_reason       TEXT,
+    source_sequence       INTEGER NOT NULL DEFAULT 0,
+    created_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    published_at          DATETIME,
+    CHECK (local_bytes >= 0),
+    CHECK (provider_bytes IS NULL OR provider_bytes >= 0),
+    CHECK (units_processed IS NULL OR units_processed >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_extractions_owner
+    ON document_extractions(profile_id, canonical_blob_hash, extraction_input_key, state);
+CREATE INDEX IF NOT EXISTS idx_document_extractions_lease
+    ON document_extractions(state, lease_until);
+
+-- One renewable claim per stable content owner. The monotonic fence prevents
+-- an expired worker from publishing after a later worker has taken ownership.
+CREATE TABLE IF NOT EXISTS document_extraction_claims (
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    canonical_blob_hash   TEXT NOT NULL,
+    extraction_input_key  TEXT NOT NULL,
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    lease_owner           TEXT NOT NULL,
+    lease_fence           INTEGER NOT NULL,
+    lease_until           DATETIME NOT NULL,
+    updated_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (profile_id, canonical_blob_hash, extraction_input_key)
+);
+
+-- The only serving pointer. Candidate revisions are unreachable until this
+-- row switches in the same transaction that publishes their derivatives.
+CREATE TABLE IF NOT EXISTS document_extraction_heads (
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    canonical_blob_hash   TEXT NOT NULL,
+    extraction_input_key  TEXT NOT NULL,
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    source_sequence       INTEGER NOT NULL DEFAULT 0,
+    switched_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (profile_id, canonical_blob_hash, extraction_input_key)
+);
+
+CREATE TABLE IF NOT EXISTS document_units (
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    unit_index            INTEGER NOT NULL,
+    unit_kind             TEXT NOT NULL,
+    text                  TEXT NOT NULL,
+    header_text           TEXT,
+    footer_text           TEXT,
+    width                 INTEGER,
+    height                INTEGER,
+    dpi                    INTEGER,
+    checksum              TEXT NOT NULL,
+    char_count            INTEGER NOT NULL,
+    truncated             BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (extraction_id, unit_index),
+    CHECK (unit_index >= 0),
+    CHECK (char_count >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS document_chunks (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    chunk_key             TEXT NOT NULL,
+    ordinal               INTEGER NOT NULL,
+    text                  TEXT NOT NULL,
+    heading_path          JSON NOT NULL,
+    first_unit_index      INTEGER NOT NULL,
+    last_unit_index       INTEGER NOT NULL,
+    synthetic_prefix_len  INTEGER NOT NULL DEFAULT 0,
+    checksum              TEXT NOT NULL,
+    char_count            INTEGER NOT NULL,
+    table_chunk           BOOLEAN NOT NULL DEFAULT FALSE,
+    code_chunk            BOOLEAN NOT NULL DEFAULT FALSE,
+    truncated             BOOLEAN NOT NULL DEFAULT FALSE,
+    UNIQUE (extraction_id, chunk_key),
+    UNIQUE (extraction_id, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (first_unit_index >= 0 AND last_unit_index >= first_unit_index),
+    CHECK (synthetic_prefix_len >= 0 AND char_count >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS document_chunk_spans (
+    extraction_id         TEXT NOT NULL,
+    chunk_key             TEXT NOT NULL,
+    span_ordinal          INTEGER NOT NULL,
+    unit_index            INTEGER NOT NULL,
+    start_char            INTEGER NOT NULL,
+    end_char              INTEGER NOT NULL,
+    synthetic             BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (extraction_id, chunk_key, span_ordinal),
+    FOREIGN KEY (extraction_id, chunk_key)
+        REFERENCES document_chunks(extraction_id, chunk_key) ON DELETE CASCADE,
+    FOREIGN KEY (extraction_id, unit_index)
+        REFERENCES document_units(extraction_id, unit_index) ON DELETE CASCADE,
+    CHECK (span_ordinal >= 0),
+    CHECK (start_char >= 0 AND end_char >= start_char)
+);
+
+-- Occurrence identity is source-part based when authoritative. attachment_id
+-- is only the current representative and may change after provider resync.
+CREATE TABLE IF NOT EXISTS document_occurrences (
+    occurrence_key        TEXT PRIMARY KEY,
+    attachment_id         INTEGER NOT NULL UNIQUE REFERENCES attachments(id) ON DELETE CASCADE,
+    message_id            INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    source_id             INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    source_part_key       TEXT,
+    stable_source_part    BOOLEAN NOT NULL DEFAULT FALSE,
+    canonical_blob_hash   TEXT NOT NULL CHECK (length(canonical_blob_hash) = 64),
+    filename              TEXT,
+    mime_type             TEXT,
+    attachment_role       TEXT NOT NULL,
+    role_source           TEXT NOT NULL,
+    source_sequence       INTEGER NOT NULL DEFAULT 0,
+    reconciled_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_occurrences_hash
+    ON document_occurrences(canonical_blob_hash, message_id, occurrence_key);
+CREATE INDEX IF NOT EXISTS idx_document_occurrences_source
+    ON document_occurrences(source_id, message_id);
+
+-- Monotonic search snapshot fence. Publication and occurrence reconciliation
+-- increment it in their transaction; cursors bind to its observed value.
+CREATE TABLE IF NOT EXISTS document_index_state (
+    singleton             INTEGER PRIMARY KEY CHECK (singleton = 1),
+    revision              INTEGER NOT NULL DEFAULT 0,
+    target_profile_id     TEXT,
+    updated_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT OR IGNORE INTO document_index_state(singleton, revision) VALUES (1, 0);
 CREATE INDEX IF NOT EXISTS idx_attachment_pack_index_pack
     ON attachment_pack_index(pack_id);
 

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -324,6 +324,13 @@ CREATE TABLE IF NOT EXISTS attachments (
     source_attachment_id TEXT,
     attachment_metadata JSONB,
 
+    attachment_role TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (attachment_role IN ('standalone', 'inline', 'avatar', 'thumbnail', 'preview', 'sticker', 'ui_asset', 'unknown')),
+    role_source TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (role_source IN ('mime_disposition', 'provider_explicit', 'importer_semantics', 'legacy_api', 'raw_mime_repair', 'unknown')),
+    source_part_key TEXT CHECK (source_part_key IS NULL OR source_part_key != ''),
+    content_id TEXT,
+
     encryption_version INTEGER DEFAULT 0,
 
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
@@ -371,6 +378,43 @@ CREATE TABLE IF NOT EXISTS message_raw (
 
     compression TEXT DEFAULT 'zlib',
     encryption_version INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS attachment_role_repair_progress (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    last_message_id BIGINT NOT NULL DEFAULT 0,
+    completed INTEGER NOT NULL DEFAULT 0 CHECK (completed IN (0, 1)),
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS attachment_change_log (
+    sequence                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    event_kind              TEXT NOT NULL CHECK (event_kind IN (
+                                'attachment_insert', 'attachment_update',
+                                'attachment_delete', 'message_live_enter',
+                                'message_live_exit')),
+    old_message_id          BIGINT,
+    new_message_id          BIGINT,
+    old_attachment_id       BIGINT,
+    new_attachment_id       BIGINT,
+    old_content_hash        TEXT,
+    new_content_hash        TEXT,
+    old_source_part_key     TEXT,
+    new_source_part_key     TEXT,
+    old_role                TEXT,
+    new_role                TEXT,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS attachment_change_consumers (
+    consumer_key            TEXT PRIMARY KEY,
+    baseline_sequence       BIGINT NOT NULL,
+    last_sequence           BIGINT NOT NULL,
+    reconciliation_complete BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (baseline_sequence >= 0),
+    CHECK (last_sequence >= baseline_sequence)
 );
 
 -- ============================================================================
@@ -1241,6 +1285,201 @@ CREATE TABLE IF NOT EXISTS attachment_pack_index (
     flags       INTEGER NOT NULL,
     crc32c      BIGINT NOT NULL
 );
+
+-- ==========================================================================
+-- DOCUMENT ATTACHMENT EXTRACTION
+-- ==========================================================================
+
+CREATE TABLE IF NOT EXISTS document_extraction_profiles (
+    id                    TEXT PRIMARY KEY,
+    fingerprint           TEXT NOT NULL UNIQUE,
+    provider              TEXT NOT NULL,
+    endpoint              TEXT NOT NULL,
+    region                TEXT NOT NULL,
+    model                 TEXT NOT NULL,
+    retention_posture     TEXT NOT NULL,
+    training_posture      TEXT NOT NULL,
+    allowed_media_types   JSONB NOT NULL,
+    policy_json           JSONB NOT NULL,
+    enabled               BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    retired_at            TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS document_provider_consents (
+    profile_id            TEXT PRIMARY KEY REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    profile_fingerprint   TEXT NOT NULL,
+    retention_posture     TEXT NOT NULL,
+    training_posture      TEXT NOT NULL,
+    consented_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS document_extraction_rebuilds (
+    id                    TEXT PRIMARY KEY,
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    extraction_input_key  TEXT NOT NULL,
+    state                 TEXT NOT NULL CHECK (state IN ('building', 'completed')),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at          TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_document_extraction_rebuilds_active
+    ON document_extraction_rebuilds(profile_id, extraction_input_key)
+    WHERE state = 'building';
+
+CREATE TABLE IF NOT EXISTS document_extraction_rebuild_targets (
+    rebuild_id            TEXT NOT NULL REFERENCES document_extraction_rebuilds(id) ON DELETE CASCADE,
+    canonical_blob_hash   TEXT NOT NULL CHECK (length(canonical_blob_hash) = 64),
+    PRIMARY KEY (rebuild_id, canonical_blob_hash)
+);
+
+CREATE TABLE IF NOT EXISTS document_extractions (
+    id                    TEXT PRIMARY KEY,
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    rebuild_id            TEXT REFERENCES document_extraction_rebuilds(id) ON DELETE SET NULL,
+    canonical_blob_hash   TEXT NOT NULL CHECK (length(canonical_blob_hash) = 64),
+    extraction_input_key  TEXT NOT NULL DEFAULT 'original',
+    state                 TEXT NOT NULL CHECK (state IN ('staging', 'ready', 'terminal', 'tombstoned')),
+    lease_owner           TEXT,
+    lease_fence           BIGINT NOT NULL DEFAULT 0,
+    lease_until           TIMESTAMPTZ,
+    attempt_count         INTEGER NOT NULL DEFAULT 0,
+    request_count         INTEGER NOT NULL DEFAULT 0 CHECK (request_count >= 0),
+    retry_count           INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0 AND retry_count <= request_count),
+    provider_latency_ms   BIGINT NOT NULL DEFAULT 0 CHECK (provider_latency_ms >= 0),
+    next_retry_at         TIMESTAMPTZ,
+    local_bytes           BIGINT NOT NULL,
+    provider_bytes        BIGINT,
+    units_processed       INTEGER,
+    returned_model        TEXT,
+    manifest_checksum     TEXT,
+    terminal_reason       TEXT,
+    source_sequence       BIGINT NOT NULL DEFAULT 0,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    published_at          TIMESTAMPTZ,
+    CHECK (local_bytes >= 0),
+    CHECK (provider_bytes IS NULL OR provider_bytes >= 0),
+    CHECK (units_processed IS NULL OR units_processed >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_extractions_owner
+    ON document_extractions(profile_id, canonical_blob_hash, extraction_input_key, state);
+CREATE INDEX IF NOT EXISTS idx_document_extractions_lease
+    ON document_extractions(state, lease_until);
+
+CREATE TABLE IF NOT EXISTS document_extraction_claims (
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    canonical_blob_hash   TEXT NOT NULL,
+    extraction_input_key  TEXT NOT NULL,
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    lease_owner           TEXT NOT NULL,
+    lease_fence           BIGINT NOT NULL,
+    lease_until           TIMESTAMPTZ NOT NULL,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (profile_id, canonical_blob_hash, extraction_input_key)
+);
+
+CREATE TABLE IF NOT EXISTS document_extraction_heads (
+    profile_id            TEXT NOT NULL REFERENCES document_extraction_profiles(id) ON DELETE CASCADE,
+    canonical_blob_hash   TEXT NOT NULL,
+    extraction_input_key  TEXT NOT NULL,
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    source_sequence       BIGINT NOT NULL DEFAULT 0,
+    switched_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (profile_id, canonical_blob_hash, extraction_input_key)
+);
+
+CREATE TABLE IF NOT EXISTS document_units (
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    unit_index            INTEGER NOT NULL,
+    unit_kind             TEXT NOT NULL,
+    text                  TEXT NOT NULL,
+    header_text           TEXT,
+    footer_text           TEXT,
+    width                 INTEGER,
+    height                INTEGER,
+    dpi                    INTEGER,
+    checksum              TEXT NOT NULL,
+    char_count            INTEGER NOT NULL,
+    truncated             BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (extraction_id, unit_index),
+    CHECK (unit_index >= 0),
+    CHECK (char_count >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS document_chunks (
+    id                    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    extraction_id         TEXT NOT NULL REFERENCES document_extractions(id) ON DELETE CASCADE,
+    chunk_key             TEXT NOT NULL,
+    ordinal               INTEGER NOT NULL,
+    text                  TEXT NOT NULL,
+    heading_path          JSONB NOT NULL,
+    first_unit_index      INTEGER NOT NULL,
+    last_unit_index       INTEGER NOT NULL,
+    synthetic_prefix_len  INTEGER NOT NULL DEFAULT 0,
+    checksum              TEXT NOT NULL,
+    char_count            INTEGER NOT NULL,
+    table_chunk           BOOLEAN NOT NULL DEFAULT FALSE,
+    code_chunk            BOOLEAN NOT NULL DEFAULT FALSE,
+    truncated             BOOLEAN NOT NULL DEFAULT FALSE,
+    search_fts            TSVECTOR GENERATED ALWAYS AS (to_tsvector('simple', COALESCE(text, ''))) STORED,
+    UNIQUE (extraction_id, chunk_key),
+    UNIQUE (extraction_id, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (first_unit_index >= 0 AND last_unit_index >= first_unit_index),
+    CHECK (synthetic_prefix_len >= 0 AND char_count >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_chunks_search_fts
+    ON document_chunks USING GIN(search_fts);
+
+CREATE TABLE IF NOT EXISTS document_chunk_spans (
+    extraction_id         TEXT NOT NULL,
+    chunk_key             TEXT NOT NULL,
+    span_ordinal          INTEGER NOT NULL,
+    unit_index            INTEGER NOT NULL,
+    start_char            INTEGER NOT NULL,
+    end_char              INTEGER NOT NULL,
+    synthetic             BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (extraction_id, chunk_key, span_ordinal),
+    FOREIGN KEY (extraction_id, chunk_key)
+        REFERENCES document_chunks(extraction_id, chunk_key) ON DELETE CASCADE,
+    FOREIGN KEY (extraction_id, unit_index)
+        REFERENCES document_units(extraction_id, unit_index) ON DELETE CASCADE,
+    CHECK (span_ordinal >= 0),
+    CHECK (start_char >= 0 AND end_char >= start_char)
+);
+
+CREATE TABLE IF NOT EXISTS document_occurrences (
+    occurrence_key        TEXT PRIMARY KEY,
+    attachment_id         BIGINT NOT NULL UNIQUE REFERENCES attachments(id) ON DELETE CASCADE,
+    message_id            BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    source_id             BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    source_part_key       TEXT,
+    stable_source_part    BOOLEAN NOT NULL DEFAULT FALSE,
+    canonical_blob_hash   TEXT NOT NULL CHECK (length(canonical_blob_hash) = 64),
+    filename              TEXT,
+    mime_type             TEXT,
+    attachment_role       TEXT NOT NULL,
+    role_source           TEXT NOT NULL,
+    source_sequence       BIGINT NOT NULL DEFAULT 0,
+    reconciled_at         TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_occurrences_hash
+    ON document_occurrences(canonical_blob_hash, message_id, occurrence_key);
+CREATE INDEX IF NOT EXISTS idx_document_occurrences_source
+    ON document_occurrences(source_id, message_id);
+
+CREATE TABLE IF NOT EXISTS document_index_state (
+    singleton             SMALLINT PRIMARY KEY CHECK (singleton = 1),
+    revision              BIGINT NOT NULL DEFAULT 0,
+    target_profile_id     TEXT,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO document_index_state(singleton, revision) VALUES (1, 0)
+ON CONFLICT (singleton) DO NOTHING;
 CREATE INDEX IF NOT EXISTS idx_attachment_pack_index_pack
     ON attachment_pack_index(pack_id);
 

--- a/internal/store/schema_sqlite.sql
+++ b/internal/store/schema_sqlite.sql
@@ -17,3 +17,30 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     cc_addr,
     tokenize='unicode61 remove_diacritics 1'
 );
+
+-- Document chunks keep canonical text in document_chunks. This external-
+-- content index is a rebuildable derivative and never owns excerpts.
+CREATE VIRTUAL TABLE IF NOT EXISTS document_chunks_fts USING fts5(
+    text,
+    content='document_chunks',
+    content_rowid='id',
+    tokenize='unicode61 remove_diacritics 1'
+);
+
+CREATE TRIGGER IF NOT EXISTS trg_document_chunks_fts_insert
+AFTER INSERT ON document_chunks BEGIN
+    INSERT INTO document_chunks_fts(rowid, text) VALUES (new.id, new.text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_document_chunks_fts_delete
+AFTER DELETE ON document_chunks BEGIN
+    INSERT INTO document_chunks_fts(document_chunks_fts, rowid, text)
+    VALUES ('delete', old.id, old.text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_document_chunks_fts_update
+AFTER UPDATE OF text ON document_chunks BEGIN
+    INSERT INTO document_chunks_fts(document_chunks_fts, rowid, text)
+    VALUES ('delete', old.id, old.text);
+    INSERT INTO document_chunks_fts(rowid, text) VALUES (new.id, new.text);
+END;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -58,9 +58,10 @@ type Store struct {
 	// never fire on another Store's migration. As package-level variables
 	// they were also a data race between a test that installs one and any
 	// concurrent migration that reads it.
-	initSchemaWindowHook            func()
-	contentChangedBackfillBatchHook func(fromID, toID int64) error
-	backfillFTSBatchErrHook         func(fromID, toID int64) error
+	initSchemaWindowHook             func()
+	contentChangedBackfillBatchHook  func(fromID, toID int64) error
+	backfillFTSBatchErrHook          func(fromID, toID int64) error
+	attachmentRoleRepairPreparedHook func()
 
 	// Zero means "use the production batch size"; see
 	// contentChangedBackfillBatch. Per-Store for the same reason.
@@ -1132,9 +1133,17 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 		return fmt.Errorf("classify participant identifier service scope: %w", err)
 	}
 
-	// Create the message watermark and contextual embedding journal triggers.
-	// This must run after the migration loop above, which adds last_modified and
-	// content_changed_at on legacy DBs — the triggers reference both columns.
+	// Stable source-part identity supersedes content hash for attachment rows
+	// that have it. The legacy hash index remains only for rows whose source
+	// cannot provide an occurrence key. This runs after the column migrations
+	// because upgraded archives do not have source_part_key before this point.
+	if err := s.ensureAttachmentOccurrenceUniqueIndexes(ctx); err != nil {
+		return err
+	}
+
+	// Create the message watermark, contextual embedding journal, and attachment
+	// change journal triggers. This must run after the migration loop above,
+	// which adds the legacy columns referenced by those triggers.
 	//
 	// It runs HERE, immediately after the columns exist, rather than at the end
 	// of the upgrade: everything below is index builds and whole-table backfills
@@ -1881,6 +1890,39 @@ func (s *Store) dedupeAttachmentsBeforeUniqueIndex(ctx context.Context, tx *logg
 		  )
 	`)
 	return err
+}
+
+func (s *Store) ensureAttachmentOccurrenceUniqueIndexes(ctx context.Context) error {
+	return s.runOnceMigration(
+		ctx,
+		migrationAttachmentOccurrenceUnique,
+		false,
+		func(ctx context.Context) error {
+			return s.runMaintenance(ctx, func(ctx context.Context, tx *loggedTx) error {
+				if _, err := tx.ExecContext(ctx,
+					`DROP INDEX IF EXISTS idx_attachments_msg_content_hash`); err != nil {
+					return fmt.Errorf("drop legacy attachment hash identity index: %w", err)
+				}
+				if _, err := tx.ExecContext(ctx, `
+					CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_msg_source_part
+					    ON attachments(message_id, source_part_key)
+					    WHERE source_part_key IS NOT NULL
+				`); err != nil {
+					return fmt.Errorf("create attachment source-part identity index: %w", err)
+				}
+				if _, err := tx.ExecContext(ctx, `
+					CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_msg_content_hash
+					    ON attachments(message_id, content_hash)
+					    WHERE source_part_key IS NULL
+					      AND content_hash IS NOT NULL
+					      AND content_hash != ''
+				`); err != nil {
+					return fmt.Errorf("create legacy attachment hash identity index: %w", err)
+				}
+				return nil
+			})
+		},
+	)
 }
 
 // NeedsFTSBackfill reports whether the FTS index needs to be populated.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1134,15 +1134,18 @@ func TestStore_GetStats_ClosedDB(t *testing.T) {
 }
 
 func TestStore_GetStats_MissingTable(t *testing.T) {
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 
 	// Drop a table to simulate missing table scenario
-	_, err := st.DB().Exec("DROP TABLE IF EXISTS attachments")
-	require.NoError(t, err, "DROP TABLE attachments")
+	_, err := st.DB().Exec("DROP TABLE IF EXISTS document_occurrences")
+	require.NoError(err, "DROP TABLE document_occurrences")
+	_, err = st.DB().Exec("DROP TABLE IF EXISTS attachments")
+	require.NoError(err, "DROP TABLE attachments")
 
 	// GetStats should ignore missing tables and return partial stats
 	stats, err := st.GetStats()
-	require.NoError(t, err, "GetStats() with missing table")
+	require.NoError(err, "GetStats() with missing table")
 
 	// AttachmentCount should be 0 (table missing, ignored)
 	assert.Equal(t, int64(0), stats.AttachmentCount, "AttachmentCount (missing table)")

--- a/internal/store/subset_test.go
+++ b/internal/store/subset_test.go
@@ -37,21 +37,22 @@ func subsetPersonDefinition(slug string) AttributeDefinitionInput {
 // data. Returns the path to the database.
 func createTestSourceDB(t *testing.T, dir string, msgCount int) string {
 	t.Helper()
+	require := require.New(t)
 
 	dbPath := filepath.Join(dir, "msgvault.db")
 
 	st, err := Open(dbPath)
-	require.NoError(t, err, "Open")
-	require.NoError(t, st.InitSchema(), "InitSchema")
+	require.NoError(err, "Open")
+	require.NoError(st.InitSchema(), "InitSchema")
 	_ = st.Close()
 
 	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=OFF")
-	require.NoError(t, err, "open db")
+	require.NoError(err, "open db")
 	defer func() { _ = db.Close() }()
 
 	_, err = db.Exec(`INSERT INTO sources (id, source_type, identifier)
 		VALUES (1, 'gmail', 'test@example.com')`)
-	require.NoError(t, err, "insert source")
+	require.NoError(err, "insert source")
 
 	_, err = db.Exec(`
 		INSERT INTO participants
@@ -60,7 +61,7 @@ func createTestSourceDB(t *testing.T, dir string, msgCount int) string {
 			(1, 'alice@example.com', 'Alice', 'example.com'),
 			(2, 'bob@example.com', 'Bob', 'example.com'),
 			(3, 'charlie@example.com', 'Charlie', 'example.com')`)
-	require.NoError(t, err, "insert participants")
+	require.NoError(err, "insert participants")
 
 	_, err = db.Exec(`
 		INSERT INTO participant_identifiers
@@ -69,7 +70,7 @@ func createTestSourceDB(t *testing.T, dir string, msgCount int) string {
 			(1, 1, 'email', 'alice@example.com'),
 			(2, 2, 'email', 'bob@example.com'),
 			(3, 3, 'email', 'charlie@example.com')`)
-	require.NoError(t, err, "insert participant_identifiers")
+	require.NoError(err, "insert participant_identifiers")
 
 	_, err = db.Exec(`
 		INSERT INTO conversations
@@ -78,13 +79,13 @@ func createTestSourceDB(t *testing.T, dir string, msgCount int) string {
 		VALUES
 			(1, 1, 'email_thread', 'Thread 1', 5, 2),
 			(2, 1, 'email_thread', 'Thread 2', 5, 2)`)
-	require.NoError(t, err, "insert conversations")
+	require.NoError(err, "insert conversations")
 
 	_, err = db.Exec(`
 		INSERT INTO conversation_participants
 			(conversation_id, participant_id)
 		VALUES (1, 1), (1, 2), (2, 2), (2, 3)`)
-	require.NoError(t, err, "insert conversation_participants")
+	require.NoError(err, "insert conversation_participants")
 
 	_, err = db.Exec(`
 		INSERT INTO labels (id, source_id, name, label_type)
@@ -92,7 +93,7 @@ func createTestSourceDB(t *testing.T, dir string, msgCount int) string {
 			(1, 1, 'INBOX', 'system'),
 			(2, 1, 'SENT', 'system'),
 			(3, 1, 'Work', 'user')`)
-	require.NoError(t, err, "insert labels")
+	require.NoError(err, "insert labels")
 
 	for i := 1; i <= msgCount; i++ {
 		convID := 1
@@ -112,20 +113,20 @@ func createTestSourceDB(t *testing.T, dir string, msgCount int) string {
 				?, ?)`,
 			i, convID, fmt.Sprintf("msg_%d", i),
 			i, senderID, "Subject "+string(rune('A'+i%26)))
-		require.NoError(t, err, "insert message %d", i)
+		require.NoError(err, "insert message %d", i)
 
 		_, err = db.Exec(
 			`INSERT INTO message_bodies (message_id, body_text)
 			 VALUES (?, ?)`,
 			i, "Body of message "+string(rune('A'+i%26)))
-		require.NoError(t, err, "insert message_body %d", i)
+		require.NoError(err, "insert message_body %d", i)
 
 		_, err = db.Exec(
 			`INSERT INTO message_recipients
 				(message_id, participant_id, recipient_type)
 			 VALUES (?, ?, 'from')`,
 			i, senderID)
-		require.NoError(t, err, "insert message_recipient from %d", i)
+		require.NoError(err, "insert message_recipient from %d", i)
 
 		toID := 2
 		if senderID == 2 {
@@ -136,14 +137,14 @@ func createTestSourceDB(t *testing.T, dir string, msgCount int) string {
 				(message_id, participant_id, recipient_type)
 			 VALUES (?, ?, 'to')`,
 			i, toID)
-		require.NoError(t, err, "insert message_recipient to %d", i)
+		require.NoError(err, "insert message_recipient to %d", i)
 
 		labelID := (i % 3) + 1
 		_, err = db.Exec(
 			`INSERT INTO message_labels (message_id, label_id)
 			 VALUES (?, ?)`,
 			i, labelID)
-		require.NoError(t, err, "insert message_label %d", i)
+		require.NoError(err, "insert message_label %d", i)
 	}
 
 	return dbPath
@@ -204,6 +205,53 @@ func TestCopySubset_Basic(t *testing.T) {
 	hasViolation := fkRows.Next()
 	require.NoError(fkRows.Err(), "foreign_key_check rows")
 	assert.False(hasViolation, "foreign key violations found in destination database")
+}
+
+func TestCopySubsetExcludesDocumentDerivativesAndHostedConsent(t *testing.T) {
+	require := require.New(t)
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "dst")
+	srcDB := createTestSourceDB(t, srcDir, 1)
+	db, err := sql.Open("sqlite3", srcDB+"?_foreign_keys=ON")
+	require.NoError(err)
+	fingerprint := strings.Repeat("a", 64)
+	_, err = db.Exec(`
+		INSERT INTO document_extraction_profiles
+			(id, fingerprint, provider, endpoint, region, model,
+			 retention_posture, training_posture, allowed_media_types, policy_json, enabled)
+		VALUES ('profile-subset', ?, 'mistral', 'https://api.mistral.ai/v1/ocr', 'eu',
+		        'mistral-ocr-4-0', 'standard', 'opted-out', '["application/pdf"]', '{}', TRUE);
+		INSERT INTO document_provider_consents
+			(profile_id, profile_fingerprint, retention_posture, training_posture)
+		VALUES ('profile-subset', ?, 'standard', 'opted-out');
+		INSERT INTO document_extractions
+			(id, profile_id, canonical_blob_hash, state, local_bytes,
+			 returned_model, manifest_checksum, units_processed)
+		VALUES ('subset-extraction', 'profile-subset', ?, 'ready', 10,
+		        'mistral-ocr-4-0', ?, 1);
+		INSERT INTO document_units
+			(extraction_id, unit_index, unit_kind, text, checksum, char_count)
+		VALUES ('subset-extraction', 0, 'page', 'private extracted evidence', ?, 26)`,
+		fingerprint, fingerprint, strings.Repeat("b", 64), strings.Repeat("c", 64), strings.Repeat("d", 64),
+	)
+	require.NoError(err)
+	require.NoError(db.Close())
+
+	_, err = CopySubset(srcDB, dstDir, 1, false)
+	require.NoError(err)
+	destination, err := sql.Open("sqlite3", filepath.Join(dstDir, "msgvault.db"))
+	require.NoError(err)
+	defer func() { _ = destination.Close() }()
+	for _, table := range []string{
+		"document_extraction_profiles", "document_provider_consents", "document_extractions",
+		"document_extraction_rebuilds", "document_extraction_rebuild_targets",
+		"document_extraction_heads", "document_units", "document_chunks", "document_chunk_spans",
+		"document_occurrences", "document_extraction_claims",
+	} {
+		var count int
+		require.NoError(destination.QueryRow(`SELECT COUNT(*) FROM `+table).Scan(&count), table)
+		assert.Zero(t, count, table+" must require a target-side rebuild")
+	}
 }
 
 func TestCopySubset_UpgradedMessageColumnOrder(t *testing.T) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1494,8 +1494,19 @@ func (s *Syncer) storeAttachment(messageID int64, att *mime.Attachment) error {
 		return err
 	}
 
-	// Record in database
-	return s.store.UpsertAttachment(messageID, att.Filename, att.ContentType, storagePath, att.ContentHash, len(att.Content))
+	role, roleSource := store.AttachmentRoleFromMIME(
+		att.Disposition, att.IsInline, att.ContentID)
+	return s.store.UpsertAttachmentRecord(context.Background(), messageID, store.AttachmentWrite{
+		Filename:      att.Filename,
+		MIMEType:      att.ContentType,
+		StoragePath:   storagePath,
+		ContentHash:   att.ContentHash,
+		Size:          int64(len(att.Content)),
+		Role:          role,
+		RoleSource:    roleSource,
+		SourcePartKey: att.PartKey,
+		ContentID:     att.ContentID,
+	})
 }
 
 // joinEmails concatenates email addresses from a slice of mime.Address with spaces.

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1056,6 +1056,8 @@ func TestStoreAttachment_ComputesHashWhenMissing(t *testing.T) {
 	att := mime.Attachment{
 		Filename:    "a.txt",
 		ContentType: "text/plain",
+		Disposition: "attachment",
+		PartKey:     "mime:2",
 		Size:        len(content),
 		ContentHash: "",
 		Content:     content,
@@ -1063,14 +1065,49 @@ func TestStoreAttachment_ComputesHashWhenMissing(t *testing.T) {
 	require.NoError(env.Syncer.storeAttachment(messageID, &att), "storeAttachment")
 	require.Equal(wantHash, att.ContentHash, "ContentHash")
 
-	var gotHash, storagePath string
-	require.NoError(env.Store.DB().QueryRow(`SELECT content_hash, storage_path FROM attachments WHERE message_id = ?`, messageID).Scan(&gotHash, &storagePath), "select attachment")
+	var gotHash, storagePath, role, roleSource, sourcePartKey string
+	require.NoError(env.Store.DB().QueryRow(`
+		SELECT content_hash, storage_path, attachment_role, role_source, source_part_key
+		FROM attachments WHERE message_id = ?`, messageID).
+		Scan(&gotHash, &storagePath, &role, &roleSource, &sourcePartKey), "select attachment")
 	require.Equal(wantHash, gotHash, "db content_hash")
+	require.Equal("standalone", role)
+	require.Equal("mime_disposition", roleSource)
+	require.Equal("mime:2", sourcePartKey)
 
 	fullPath := filepath.Join(attachmentsDir, filepath.FromSlash(storagePath))
 	b, err := os.ReadFile(fullPath)
 	require.NoError(err, "read attachment file")
 	require.Equal(string(content), string(b), "attachment file contents")
+}
+
+func TestStoreAttachmentPersistsInlineMIMEEvidence(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	env.SetOptions(t, func(o *Options) { o.AttachmentsDir = filepath.Join(env.TmpDir, "attachments") })
+	src := env.CreateSource(t)
+	convID, err := env.Store.EnsureConversation(src.ID, "inline-thread", "Thread")
+	require.NoError(err)
+	messageID, err := env.Store.UpsertMessage(&store.Message{
+		ConversationID: convID, SourceID: src.ID, SourceMessageID: "inline-message", MessageType: "email",
+	})
+	require.NoError(err)
+
+	att := mime.Attachment{
+		Filename: "inline.png", ContentType: "image/png", Content: []byte("png"),
+		Disposition: "inline", PartKey: "mime:3", ContentID: "inline-1", IsInline: true,
+	}
+	require.NoError(env.Syncer.storeAttachment(messageID, &att))
+
+	var role, roleSource, sourcePartKey, contentID string
+	require.NoError(env.Store.DB().QueryRow(`
+		SELECT attachment_role, role_source, source_part_key, content_id
+		FROM attachments WHERE message_id = ?`, messageID).
+		Scan(&role, &roleSource, &sourcePartKey, &contentID))
+	require.Equal("inline", role)
+	require.Equal("mime_disposition", roleSource)
+	require.Equal("mime:3", sourcePartKey)
+	require.Equal("inline-1", contentID)
 }
 
 func TestStoreAttachment_InvalidContentHash_ReturnsError(t *testing.T) {

--- a/internal/synctechsms/importer.go
+++ b/internal/synctechsms/importer.go
@@ -1,6 +1,7 @@
 package synctechsms
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -463,7 +464,16 @@ func (i *Importer) importMMSAttachments(sourceID int64, sourceMessageID string, 
 		if err != nil {
 			return count, fmt.Errorf("store MMS attachment: %w", err)
 		}
-		if err := i.store.UpsertAttachment(messageID, filename, part.ContentType, storagePath, att.ContentHash, len(part.Data)); err != nil {
+		if err := i.store.UpsertAttachmentRecord(context.Background(), messageID, store.AttachmentWrite{
+			Filename:      filename,
+			MIMEType:      part.ContentType,
+			StoragePath:   storagePath,
+			ContentHash:   att.ContentHash,
+			Size:          int64(len(part.Data)),
+			Role:          store.AttachmentRoleStandalone,
+			RoleSource:    store.AttachmentRoleSourceImporterSemantics,
+			SourcePartKey: fmt.Sprintf("synctech:mms:%d", idx),
+		}); err != nil {
 			return count, fmt.Errorf("upsert attachment: %w", err)
 		}
 		count++

--- a/internal/synctechsms/importer_test.go
+++ b/internal/synctechsms/importer_test.go
@@ -220,14 +220,20 @@ func assertConversationCount(t *testing.T, st *store.Store, want int) {
 // synctech-sms/ namespace) and that the file exists on disk at that path.
 func assertAttachmentAtCanonicalPath(t *testing.T, st *store.Store, attachmentsDir string) {
 	t.Helper()
-	var storagePath, contentHash string
-	err := st.DB().QueryRow(`SELECT storage_path, content_hash FROM attachments ORDER BY id LIMIT 1`).Scan(&storagePath, &contentHash)
+	var storagePath, contentHash, role, roleSource, sourcePartKey string
+	err := st.DB().QueryRow(`
+		SELECT storage_path, content_hash, attachment_role, role_source, source_part_key
+		FROM attachments ORDER BY id LIMIT 1`).
+		Scan(&storagePath, &contentHash, &role, &roleSource, &sourcePartKey)
 	require.NoError(t, err, "read attachment row")
 	require.NotEmpty(t, contentHash, "content_hash")
 	// storage_path is stored slash-separated on every platform.
 	wantPath := contentHash[:2] + "/" + contentHash
 	assert.Equal(t, wantPath, storagePath, "storage_path")
 	assert.NotContains(t, storagePath, "synctech-sms", "storage_path must not use legacy namespace")
+	assert.Equal(t, "standalone", role)
+	assert.Equal(t, "importer_semantics", roleSource)
+	assert.NotEmpty(t, sourcePartKey)
 	_, err = os.Stat(filepath.Join(attachmentsDir, contentHash[:2], contentHash))
 	assert.NoError(t, err, "attachment file at canonical path")
 }

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -766,6 +766,8 @@ func (imp *Importer) downloadInlineImages(ctx context.Context, messageID int64, 
 			ContentHash:        att.ContentHash,
 			Size:               len(data),
 			SourceAttachmentID: "teams:inline:" + fetchPath,
+			Role:               store.AttachmentRoleInline,
+			RoleSource:         store.AttachmentRoleSourceImporterSemantics,
 		})
 	}
 	if err := imp.store.ReplaceMessageInlineAttachments(messageID, refs); err != nil {

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -147,6 +147,7 @@ func fakeChannelGraph(t *testing.T) *httptest.Server {
 }
 
 func TestInlineImageDownloaded(t *testing.T) {
+	assert := assert.New(t)
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -175,8 +176,13 @@ func TestInlineImageDownloaded(t *testing.T) {
 	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
 	sum, err := imp.Import(context.Background(), ImportOptions{Email: "me@example.com", AttachmentsDir: dir})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, sum.InlineImagesCopied)
-	assert.EqualValues(t, 0, sum.Errors)
+	assert.EqualValues(1, sum.InlineImagesCopied)
+	assert.EqualValues(0, sum.Errors)
+	var role, roleSource string
+	require.NoError(t, st.DB().QueryRow(`
+		SELECT attachment_role, role_source FROM attachments LIMIT 1`).Scan(&role, &roleSource))
+	assert.Equal("inline", role)
+	assert.Equal("importer_semantics", roleSource)
 }
 
 func TestContentlessGraphAttachmentDoesNotSetMessageAttachmentStats(t *testing.T) {

--- a/internal/whatsapp/importer.go
+++ b/internal/whatsapp/importer.go
@@ -386,7 +386,17 @@ func (imp *Importer) Import(ctx context.Context, waDBPath string, opts ImportOpt
 					// Without --media-dir, storagePath and contentHash are both
 					// empty; inserting would create broken records.
 					if storagePath != "" || contentHash != "" {
-						err := imp.store.UpsertAttachment(messageID, filename, mimeType, storagePath, contentHash, size)
+						role := store.AttachmentRoleStandalone
+						roleSource := store.AttachmentRoleSourceImporterSemantics
+						if mediaType == "sticker" {
+							role = store.AttachmentRoleSticker
+							roleSource = store.AttachmentRoleSourceProviderExplicit
+						}
+						err := imp.store.UpsertAttachmentRecord(ctx, messageID, store.AttachmentWrite{
+							Filename: filename, MIMEType: mimeType, StoragePath: storagePath,
+							ContentHash: contentHash, Size: int64(size), MediaType: mediaType,
+							Role: role, RoleSource: roleSource, SourcePartKey: "whatsapp:media",
+						})
 						if err != nil {
 							summary.Errors++
 							imp.progress.OnError(fmt.Errorf("upsert attachment for message %s: %w", waMsg.KeyID, err))
@@ -413,7 +423,7 @@ func (imp *Importer) Import(ctx context.Context, waDBPath string, opts ImportOpt
 
 					// Store media metadata in the attachments table is done above.
 					// For extra metadata (width, height, duration, media_type),
-					// update via a direct SQL call since UpsertAttachment doesn't have those fields.
+					// update via a direct SQL call for provider dimensions and duration.
 					if mediaType != "" || (media.Width.Valid && media.Width.Int64 > 0) {
 						imp.updateAttachmentMetadata(messageID, contentHash, mediaType, media)
 					}

--- a/internal/whatsapp/importer_media_test.go
+++ b/internal/whatsapp/importer_media_test.go
@@ -1,6 +1,7 @@
 package whatsapp
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -8,8 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
 )
 
 func TestHandleMediaFile(t *testing.T) {
@@ -56,4 +60,87 @@ func TestHandleMediaFile(t *testing.T) {
 		assert.Empty(t, rel)
 		assert.Empty(t, hash)
 	})
+}
+
+func TestImportClassifiesStoredMediaAttachments(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	mediaDir := t.TempDir()
+	attachmentsDir := t.TempDir()
+	require.NoError(os.WriteFile(filepath.Join(mediaDir, "report.pdf"), []byte("document bytes"), 0o600))
+	require.NoError(os.WriteFile(filepath.Join(mediaDir, "sticker.webp"), []byte("sticker bytes"), 0o600))
+
+	waDBPath := filepath.Join(t.TempDir(), "msgstore.db")
+	waDB, err := sql.Open("sqlite3", waDBPath)
+	require.NoError(err)
+	_, err = waDB.Exec(`
+		PRAGMA journal_mode=WAL;
+		CREATE TABLE jid (
+			_id INTEGER PRIMARY KEY, user TEXT, server TEXT, raw_string TEXT
+		);
+		CREATE TABLE chat (
+			_id INTEGER PRIMARY KEY, jid_row_id INTEGER UNIQUE, hidden INTEGER,
+			subject TEXT, sort_timestamp INTEGER
+		);
+		CREATE TABLE message (
+			_id INTEGER PRIMARY KEY, chat_row_id INTEGER, from_me INTEGER,
+			key_id TEXT, sender_jid_row_id INTEGER, timestamp INTEGER,
+			message_type INTEGER, text_data TEXT, status INTEGER, starred INTEGER
+		);
+		CREATE TABLE message_media (
+			message_row_id INTEGER PRIMARY KEY, mime_type TEXT, file_size INTEGER,
+			file_path TEXT, width INTEGER, height INTEGER, media_duration INTEGER
+		);
+		INSERT INTO jid VALUES
+			(1, '15555550101', 's.whatsapp.net', '15555550101@s.whatsapp.net');
+		INSERT INTO chat VALUES (10, 1, 0, NULL, 2000);
+		INSERT INTO message VALUES
+			(100, 10, 1, 'document-message', NULL, 1000, 13, NULL, 0, 0),
+			(101, 10, 1, 'sticker-message', NULL, 2000, 90, NULL, 0, 0);
+		INSERT INTO message_media VALUES
+			(100, 'application/pdf', 14, 'report.pdf', NULL, NULL, NULL),
+			(101, 'image/webp', 13, 'sticker.webp', NULL, NULL, NULL);
+	`)
+	require.NoError(err)
+	require.NoError(waDB.Close())
+
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, nil)
+	summary, err := imp.Import(context.Background(), waDBPath, ImportOptions{
+		Phone: "+15555550100", MediaDir: mediaDir, AttachmentsDir: attachmentsDir,
+	})
+	require.NoError(err)
+	assert.Equal(int64(2), summary.AttachmentsFound)
+	assert.Equal(int64(2), summary.MediaCopied)
+
+	rows, err := st.DB().Query(`
+		SELECT a.filename, a.attachment_role, a.role_source,
+		       COALESCE(a.source_part_key, '')
+		FROM attachments a
+		ORDER BY a.filename`)
+	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
+
+	type attachmentRole struct {
+		filename, role, roleSource, sourcePartKey string
+	}
+	var got []attachmentRole
+	for rows.Next() {
+		var item attachmentRole
+		require.NoError(rows.Scan(&item.filename, &item.role, &item.roleSource, &item.sourcePartKey))
+		got = append(got, item)
+	}
+	require.NoError(rows.Err())
+	require.Len(got, 2)
+	assert.Equal(attachmentRole{
+		filename: "report.pdf", role: string(store.AttachmentRoleStandalone),
+		roleSource:    string(store.AttachmentRoleSourceImporterSemantics),
+		sourcePartKey: "whatsapp:media",
+	}, got[0])
+	assert.Equal(attachmentRole{
+		filename: "sticker.webp", role: string(store.AttachmentRoleSticker),
+		roleSource:    string(store.AttachmentRoleSourceProviderExplicit),
+		sourcePartKey: "whatsapp:media",
+	}, got[1])
 }

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -271,6 +271,14 @@ type ClientInterface interface {
 	GetDeletion(ctx context.Context, options *GetDeletionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetDeletionResponse, error)
 	GetDeletionWithResponse(ctx context.Context, options *GetDeletionRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetDeletionResp, error)
 
+	// SearchDocuments Search extracted document attachments
+	SearchDocuments(ctx context.Context, options *SearchDocumentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchDocumentsResponse, error)
+	SearchDocumentsWithResponse(ctx context.Context, options *SearchDocumentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchDocumentsResp, error)
+
+	// GetDocumentIndexStatus Get extracted document index status
+	GetDocumentIndexStatus(ctx context.Context, options *GetDocumentIndexStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetDocumentIndexStatusResponse, error)
+	GetDocumentIndexStatusWithResponse(ctx context.Context, options *GetDocumentIndexStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetDocumentIndexStatusResp, error)
+
 	// SearchDomains Search analytical domains
 	SearchDomains(ctx context.Context, options *SearchDomainsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchDomainsResponse, error)
 	SearchDomainsWithResponse(ctx context.Context, options *SearchDomainsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchDomainsResp, error)
@@ -4232,6 +4240,132 @@ func (c *Client) GetDeletion(ctx context.Context, options *GetDeletionRequestOpt
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/deletions/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// SearchDocuments Search extracted document attachments
+func (c *Client) SearchDocuments(ctx context.Context, options *SearchDocumentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchDocumentsResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/documents/search",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*SearchDocumentsResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(SearchDocumentsErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "SearchDocumentsErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(SearchDocumentsResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "SearchDocumentsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/documents/search")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// GetDocumentIndexStatus Get extracted document index status
+func (c *Client) GetDocumentIndexStatus(ctx context.Context, options *GetDocumentIndexStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetDocumentIndexStatusResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/documents/status",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetDocumentIndexStatusResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetDocumentIndexStatusErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetDocumentIndexStatusErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetDocumentIndexStatusResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetDocumentIndexStatusResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/documents/status")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -2225,6 +2225,94 @@ func (o *GetDeletionRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// SearchDocumentsRequestOptions is the options needed to make a request to SearchDocuments.
+type SearchDocumentsRequestOptions struct {
+	Query *SearchDocumentsQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *SearchDocumentsRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *SearchDocumentsRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *SearchDocumentsRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *SearchDocumentsRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *SearchDocumentsRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// GetDocumentIndexStatusRequestOptions is the options needed to make a request to GetDocumentIndexStatus.
+type GetDocumentIndexStatusRequestOptions struct {
+	Query *GetDocumentIndexStatusQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetDocumentIndexStatusRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetDocumentIndexStatusRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetDocumentIndexStatusRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetDocumentIndexStatusRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetDocumentIndexStatusRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // SearchDomainsRequestOptions is the options needed to make a request to SearchDomains.
 type SearchDomainsRequestOptions struct {
 	Body *SearchDomainsBody

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -4297,6 +4297,180 @@ func (c *Client) GetDeletionWithResponse(ctx context.Context, options *GetDeleti
 	}
 }
 
+// SearchDocuments Search extracted document attachments
+func (c *Client) SearchDocumentsWithResponse(ctx context.Context, options *SearchDocumentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchDocumentsResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/documents/search",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/documents/search")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &SearchDocumentsResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(SearchDocumentsResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchDocumentsResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(SearchDocumentsErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchDocumentsErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(SearchDocumentsErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchDocumentsErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(SearchDocumentsErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchDocumentsErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// GetDocumentIndexStatus Get extracted document index status
+func (c *Client) GetDocumentIndexStatusWithResponse(ctx context.Context, options *GetDocumentIndexStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetDocumentIndexStatusResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/documents/status",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/documents/status")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetDocumentIndexStatusResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetDocumentIndexStatusResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetDocumentIndexStatusResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(GetDocumentIndexStatusErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetDocumentIndexStatusErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(GetDocumentIndexStatusErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetDocumentIndexStatusErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // SearchDomains Search analytical domains
 func (c *Client) SearchDomainsWithResponse(ctx context.Context, options *SearchDomainsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchDomainsResp, error) {
 	var err error

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -290,6 +290,51 @@ type ListDeletionsQuery struct {
 	Status *string `json:"status,omitempty"`
 }
 
+type SearchDocumentsQuery struct {
+	// Q Extracted document content or filename query
+	Q string `json:"q" validate:"required"`
+
+	// SourceID Source IDs to include; repeat or comma-separate values
+	SourceID []int64 `json:"source_id,omitempty"`
+
+	// MessageType Message types to include; repeat or comma-separate values
+	MessageType []string `json:"message_type,omitempty"`
+
+	// AttachmentID Exact attachment occurrence ID
+	AttachmentID *int64 `json:"attachment_id,omitempty"`
+
+	// MessageID Exact containing message ID
+	MessageID *int64 `json:"message_id,omitempty"`
+
+	// Limit Maximum results to return (default 20, max 100)
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Cursor Opaque cursor from the previous document search page
+	Cursor *string `json:"cursor,omitempty"`
+}
+
+func (s SearchDocumentsQuery) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(s))
+}
+
+type GetDocumentIndexStatusQuery struct {
+	// ProfileID Exact document extraction profile ID
+	ProfileID string `json:"profile_id" validate:"required"`
+
+	// InputKey Exact extraction input key
+	InputKey string `json:"input_key" validate:"required"`
+
+	// MediaType Allowed document media types
+	MediaType []string `json:"media_type" validate:"required"`
+
+	// MessageType Allowed message types
+	MessageType []string `json:"message_type,omitempty"`
+}
+
+func (g GetDocumentIndexStatusQuery) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
 type SearchIntegrationTasksQuery struct {
 	// Q Task title search within the configured project
 	Q string `json:"q" validate:"required"`

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -395,6 +395,20 @@ type GetDeletionResponse = DeletionManifestDetail
 
 type GetDeletionErrorResponse = ErrorResponse
 
+type SearchDocumentsResponse = DocumentSearchResponse
+
+type SearchDocumentsErrorResponse = ErrorResponse
+
+type SearchDocumentsErrorResponseJSON = ErrorResponse
+
+type SearchDocumentsErrorResponseJSON503 = ErrorResponse
+
+type GetDocumentIndexStatusResponse = DocumentIndexStatusResponse
+
+type GetDocumentIndexStatusErrorResponse = ErrorResponse
+
+type GetDocumentIndexStatusErrorResponseJSON = ErrorResponse
+
 type SearchDomainsResponse = DomainSearchHTTPResponse
 
 type SearchDomainsErrorResponse = ErrorResponse
@@ -2144,6 +2158,25 @@ type GetDeletionResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *GetDeletionResponse
+}
+
+type SearchDocumentsResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *SearchDocumentsResponse
+	JSON400      *SearchDocumentsErrorResponse
+	JSON409      *SearchDocumentsErrorResponseJSON
+	JSON503      *SearchDocumentsErrorResponseJSON503
+}
+
+type GetDocumentIndexStatusResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetDocumentIndexStatusResponse
+	JSON400      *GetDocumentIndexStatusErrorResponse
+	JSON503      *GetDocumentIndexStatusErrorResponseJSON
 }
 
 type SearchDomainsResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1592,6 +1592,118 @@ func (d DiscoverResult) Validate() error {
 	return errors
 }
 
+type DocumentIndexRebuildStatus struct {
+	RemainingOwners int64 `json:"remaining_owners"`
+	SnapshotOwners  int64 `json:"snapshot_owners"`
+}
+
+type DocumentIndexStatus struct {
+	AverageProviderLatencyMillis float64 `json:"average_provider_latency_millis"`
+	EligibleBytes                int64   `json:"eligible_bytes"`
+	EligibleOccurrences          int64   `json:"eligible_occurrences"`
+	EligibleOwners               int64   `json:"eligible_owners"`
+	ExactConsent                 bool    `json:"exact_consent"`
+	ExtractionAttempts           int64   `json:"extraction_attempts"`
+	FailedAttempts               int64   `json:"failed_attempts"`
+	IneligibleRoleOccurrences    int64   `json:"ineligible_role_occurrences"`
+	MissingOwners                int64   `json:"missing_owners"`
+	MissingProviderByteReports   int64   `json:"missing_provider_byte_reports"`
+	ProcessedProviderUnits       int64   `json:"processed_provider_units"`
+	ProfileEnabled               bool    `json:"profile_enabled"`
+	ProfileExists                bool    `json:"profile_exists"`
+	ProviderLatencyMillis        int64   `json:"provider_latency_millis"`
+	ProviderRequests             int64   `json:"provider_requests"`
+	ProviderRetries              int64   `json:"provider_retries"`
+	ReadyOwners                  int64   `json:"ready_owners"`
+	ReportedProviderBytes        int64   `json:"reported_provider_bytes"`
+	RetryOwners                  int64   `json:"retry_owners"`
+	StagingOwners                int64   `json:"staging_owners"`
+	StoredPlaintextChunks        int64   `json:"stored_plaintext_chunks"`
+	SuccessfulAttempts           int64   `json:"successful_attempts"`
+	TerminalOwners               int64   `json:"terminal_owners"`
+	UnknownRoleOccurrences       int64   `json:"unknown_role_occurrences"`
+	VerifiedUploadBytes          int64   `json:"verified_upload_bytes"`
+}
+
+type DocumentIndexStatusResponse struct {
+	ActiveRebuild *DocumentIndexRebuildStatus `json:"active_rebuild,omitempty"`
+	Status        DocumentIndexStatus         `json:"status"`
+}
+
+func (d DocumentIndexStatusResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if d.ActiveRebuild != nil {
+		if v, ok := any(d.ActiveRebuild).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("ActiveRebuild", err)
+			}
+		}
+	}
+	if v, ok := any(d.Status).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Status", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type DocumentSearchResponse struct {
+	NextCursor *string                `json:"next_cursor,omitempty"`
+	Results    []DocumentSearchResult `json:"results,omitempty" validate:"required"`
+	Revision   int64                  `json:"revision"`
+	Truncated  *bool                  `json:"truncated,omitempty"`
+}
+
+func (d DocumentSearchResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range d.Results {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Results[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type DocumentSearchResult struct {
+	AttachmentID      int64    `json:"attachment_id"`
+	CanonicalBlobHash string   `json:"canonical_blob_hash" validate:"required"`
+	ChunkKey          string   `json:"chunk_key" validate:"required"`
+	ChunkOrdinal      int64    `json:"chunk_ordinal"`
+	ContainingTitle   *string  `json:"containing_title,omitempty"`
+	Excerpt           string   `json:"excerpt" validate:"required"`
+	ExtractionID      string   `json:"extraction_id" validate:"required"`
+	Filename          *string  `json:"filename,omitempty"`
+	FirstUnitIndex    int64    `json:"first_unit_index"`
+	HeadingPath       []string `json:"heading_path,omitempty"`
+	HighlightEnd      int64    `json:"highlight_end"`
+	HighlightStart    int64    `json:"highlight_start"`
+	LastUnitIndex     int64    `json:"last_unit_index"`
+	MatchedSignals    []string `json:"matched_signals,omitempty" validate:"required"`
+	MessageID         int64    `json:"message_id"`
+	MimeType          *string  `json:"mime_type,omitempty"`
+	Model             string   `json:"model" validate:"required"`
+	OccurrenceKey     string   `json:"occurrence_key" validate:"required"`
+	OtherLiveCopies   int64    `json:"other_live_copies"`
+	ProfileID         string   `json:"profile_id" validate:"required"`
+	Provider          string   `json:"provider" validate:"required"`
+	Rank              int64    `json:"rank"`
+	SourceID          int64    `json:"source_id"`
+	SourcePartKey     *string  `json:"source_part_key,omitempty"`
+	Truncated         bool     `json:"truncated"`
+}
+
+func (d DocumentSearchResult) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(d))
+}
+
 type DomainContextSummaryHTTPResponse struct {
 	CacheRevision       string           `json:"cache_revision" validate:"required"`
 	CandidateSnapshotID *string          `json:"candidate_snapshot_id,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1778,6 +1778,236 @@ components:
         - rejected
         - applied
       type: object
+    DocumentIndexRebuildStatus:
+      properties:
+        remaining_owners:
+          format: int64
+          type: integer
+        snapshot_owners:
+          format: int64
+          type: integer
+      required:
+        - snapshot_owners
+        - remaining_owners
+      type: object
+    DocumentIndexStatus:
+      properties:
+        average_provider_latency_millis:
+          format: double
+          type: number
+        eligible_bytes:
+          format: int64
+          type: integer
+        eligible_occurrences:
+          format: int64
+          type: integer
+        eligible_owners:
+          format: int64
+          type: integer
+        exact_consent:
+          type: boolean
+        extraction_attempts:
+          format: int64
+          type: integer
+        failed_attempts:
+          format: int64
+          type: integer
+        ineligible_role_occurrences:
+          format: int64
+          type: integer
+        missing_owners:
+          format: int64
+          type: integer
+        missing_provider_byte_reports:
+          format: int64
+          type: integer
+        processed_provider_units:
+          format: int64
+          type: integer
+        profile_enabled:
+          type: boolean
+        profile_exists:
+          type: boolean
+        provider_latency_millis:
+          format: int64
+          type: integer
+        provider_requests:
+          format: int64
+          type: integer
+        provider_retries:
+          format: int64
+          type: integer
+        ready_owners:
+          format: int64
+          type: integer
+        reported_provider_bytes:
+          format: int64
+          type: integer
+        retry_owners:
+          format: int64
+          type: integer
+        staging_owners:
+          format: int64
+          type: integer
+        stored_plaintext_chunks:
+          format: int64
+          type: integer
+        successful_attempts:
+          format: int64
+          type: integer
+        terminal_owners:
+          format: int64
+          type: integer
+        unknown_role_occurrences:
+          format: int64
+          type: integer
+        verified_upload_bytes:
+          format: int64
+          type: integer
+      required:
+        - profile_exists
+        - profile_enabled
+        - exact_consent
+        - extraction_attempts
+        - successful_attempts
+        - failed_attempts
+        - provider_requests
+        - provider_retries
+        - provider_latency_millis
+        - average_provider_latency_millis
+        - verified_upload_bytes
+        - processed_provider_units
+        - reported_provider_bytes
+        - missing_provider_byte_reports
+        - eligible_occurrences
+        - eligible_owners
+        - eligible_bytes
+        - unknown_role_occurrences
+        - ineligible_role_occurrences
+        - ready_owners
+        - staging_owners
+        - retry_owners
+        - terminal_owners
+        - missing_owners
+        - stored_plaintext_chunks
+      type: object
+    DocumentIndexStatusResponse:
+      properties:
+        active_rebuild:
+          $ref: "#/components/schemas/DocumentIndexRebuildStatus"
+        status:
+          $ref: "#/components/schemas/DocumentIndexStatus"
+      required:
+        - status
+      type: object
+    DocumentSearchResponse:
+      properties:
+        next_cursor:
+          type: string
+        results:
+          items:
+            $ref: "#/components/schemas/DocumentSearchResult"
+          nullable: true
+          type: array
+        revision:
+          format: int64
+          type: integer
+        truncated:
+          type: boolean
+      required:
+        - results
+        - revision
+      type: object
+    DocumentSearchResult:
+      properties:
+        attachment_id:
+          format: int64
+          type: integer
+        canonical_blob_hash:
+          type: string
+        chunk_key:
+          type: string
+        chunk_ordinal:
+          format: int64
+          type: integer
+        containing_title:
+          type: string
+        excerpt:
+          type: string
+        extraction_id:
+          type: string
+        filename:
+          type: string
+        first_unit_index:
+          format: int64
+          type: integer
+        heading_path:
+          items:
+            type: string
+          nullable: true
+          type: array
+        highlight_end:
+          format: int64
+          type: integer
+        highlight_start:
+          format: int64
+          type: integer
+        last_unit_index:
+          format: int64
+          type: integer
+        matched_signals:
+          items:
+            type: string
+          nullable: true
+          type: array
+        message_id:
+          format: int64
+          type: integer
+        mime_type:
+          type: string
+        model:
+          type: string
+        occurrence_key:
+          type: string
+        other_live_copies:
+          format: int64
+          type: integer
+        profile_id:
+          type: string
+        provider:
+          type: string
+        rank:
+          format: int64
+          type: integer
+        source_id:
+          format: int64
+          type: integer
+        source_part_key:
+          type: string
+        truncated:
+          type: boolean
+      required:
+        - attachment_id
+        - message_id
+        - source_id
+        - occurrence_key
+        - canonical_blob_hash
+        - other_live_copies
+        - chunk_key
+        - chunk_ordinal
+        - first_unit_index
+        - last_unit_index
+        - excerpt
+        - highlight_start
+        - highlight_end
+        - profile_id
+        - extraction_id
+        - provider
+        - model
+        - matched_signals
+        - truncated
+        - rank
+      type: object
     DomainContextSummaryHTTPResponse:
       properties:
         cache_revision:
@@ -6299,7 +6529,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.39.0
+  version: 1.40.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -8752,6 +8982,151 @@ paths:
       security:
         - apiKey: []
       summary: Inspect a staged deletion manifest
+      tags:
+        - API
+  /api/v1/documents/search:
+    get:
+      operationId: searchDocuments
+      parameters:
+        - description: Extracted document content or filename query
+          in: query
+          name: q
+          required: true
+          schema:
+            type: string
+        - description: Source IDs to include; repeat or comma-separate values
+          in: query
+          name: source_id
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
+        - description: Message types to include; repeat or comma-separate values
+          in: query
+          name: message_type
+          schema:
+            items:
+              type: string
+            type: array
+        - description: Exact attachment occurrence ID
+          in: query
+          name: attachment_id
+          schema:
+            format: int64
+            type: integer
+        - description: Exact containing message ID
+          in: query
+          name: message_id
+          schema:
+            format: int64
+            type: integer
+        - description: Maximum results to return (default 20, max 100)
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+        - description: Opaque cursor from the previous document search page
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentSearchResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Search extracted document attachments
+      tags:
+        - API
+  /api/v1/documents/status:
+    get:
+      operationId: getDocumentIndexStatus
+      parameters:
+        - description: Exact document extraction profile ID
+          in: query
+          name: profile_id
+          required: true
+          schema:
+            type: string
+        - description: Exact extraction input key
+          in: query
+          name: input_key
+          required: true
+          schema:
+            type: string
+        - description: Allowed document media types
+          in: query
+          name: media_type
+          required: true
+          schema:
+            items:
+              type: string
+            type: array
+        - description: Allowed message types
+          in: query
+          name: message_type
+          schema:
+            items:
+              type: string
+            type: array
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentIndexStatusResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get extracted document index status
       tags:
         - API
   /api/v1/domains/search:

--- a/scripts/mistral-probe-fixtures/main.go
+++ b/scripts/mistral-probe-fixtures/main.go
@@ -1,0 +1,379 @@
+// Command mistral-probe-fixtures builds the private synthetic corpus consumed
+// by `msgvault documents probe-mistral`. It uses only the Go standard library
+// for open formats. Native binary formats must be supplied as synthetic seeds.
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/documentindex/mistral"
+)
+
+const maxSeedBytes = int64(50 << 20)
+
+// ZIP timestamps are encoded directly so fixtures remain byte-for-byte
+// reproducible without adding extended timestamp fields. 33 is 1980-01-01 in
+// the MS-DOS date representation used by ZIP.
+const zipEpochDate = uint16(33)
+
+const openDocumentStyles = `<office:document-styles xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" office:version="1.3"><office:styles/></office:document-styles>`
+
+var nativeSeedFormats = []string{"doc", "ppt", "xls", "numbers", "msg"}
+
+type zipEntry struct {
+	name   string
+	value  string
+	stored bool
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	flags := flag.NewFlagSet("mistral-probe-fixtures", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	var outputDirectory string
+	var seedDirectory string
+	flags.StringVar(&outputDirectory, "output", "", "private output directory")
+	flags.StringVar(&seedDirectory, "seed-dir", "", "private directory containing native-format seeds")
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("parse fixture builder flags: %w", err)
+	}
+	if flags.NArg() != 0 || outputDirectory == "" {
+		return errors.New("usage: mistral-probe-fixtures --output <private-dir> [--seed-dir <private-dir>]")
+	}
+	created, missing, err := buildFixtureDirectory(outputDirectory, seedDirectory)
+	if err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"fixture matrix remains incomplete: supply synthetic native seeds named %s through --seed-dir",
+			strings.Join(missing, ", "),
+		)
+	}
+	_, _ = fmt.Fprintf(stdout,
+		"Validated %d Mistral probe fixtures in a private directory (%d created, no provider requests).\n",
+		len(mistral.CandidateFormats()), created)
+	return nil
+}
+
+func buildFixtureDirectory(outputDirectory, seedDirectory string) (int, []string, error) {
+	if err := ensurePrivateDirectory(outputDirectory); err != nil {
+		return 0, nil, fmt.Errorf("prepare fixture output: %w", err)
+	}
+	if seedDirectory != "" {
+		info, err := os.Lstat(seedDirectory)
+		if err != nil {
+			return 0, nil, fmt.Errorf("inspect fixture seed directory: %w", err)
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return 0, nil, errors.New("fixture seed path must be a real directory")
+		}
+	}
+
+	created := 0
+	missing := make([]string, 0, len(nativeSeedFormats))
+	for _, candidate := range mistral.CandidateFormats() {
+		target := filepath.Join(outputDirectory, candidate.ID)
+		if _, err := os.Lstat(target); err == nil {
+			if err := validateFixture(target, candidate); err != nil {
+				return created, missing, fmt.Errorf("validate existing fixture %q: %w", candidate.ID, err)
+			}
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return created, missing, fmt.Errorf("inspect fixture %q: %w", candidate.ID, err)
+		}
+
+		if seedDirectory != "" {
+			seed := filepath.Join(seedDirectory, candidate.ID)
+			if _, err := os.Lstat(seed); err == nil {
+				if err := copyFixture(seed, target); err != nil {
+					return created, missing, fmt.Errorf("copy fixture seed %q: %w", candidate.ID, err)
+				}
+				if err := validateFixture(target, candidate); err != nil {
+					_ = os.Remove(target)
+					return created, missing, fmt.Errorf("validate fixture seed %q: %w", candidate.ID, err)
+				}
+				created++
+				continue
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return created, missing, fmt.Errorf("inspect fixture seed %q: %w", candidate.ID, err)
+			}
+		}
+
+		content, generated, err := generatedFixture(candidate.ID)
+		if err != nil {
+			return created, missing, fmt.Errorf("generate fixture %q: %w", candidate.ID, err)
+		}
+		if !generated {
+			missing = append(missing, candidate.ID)
+			continue
+		}
+		if err := writeNewPrivateFile(target, bytes.NewReader(content), int64(len(content))); err != nil {
+			return created, missing, fmt.Errorf("write fixture %q: %w", candidate.ID, err)
+		}
+		if err := validateFixture(target, candidate); err != nil {
+			_ = os.Remove(target)
+			return created, missing, fmt.Errorf("validate generated fixture %q: %w", candidate.ID, err)
+		}
+		created++
+	}
+	slices.Sort(missing)
+	return created, missing, nil
+}
+
+func ensurePrivateDirectory(directory string) error {
+	info, err := os.Lstat(directory)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(directory, 0o700); err != nil { // #nosec G301 -- private fixture directory.
+			return err
+		}
+		return os.Chmod(directory, 0o700) // #nosec G302 -- private fixture directory.
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("fixture output path must be a real directory")
+	}
+	return os.Chmod(directory, 0o700) // #nosec G302 -- private fixture directory.
+}
+
+func copyFixture(source, target string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maxSeedBytes {
+		return errors.New("fixture seed must be a bounded regular non-symlink file")
+	}
+	file, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	return writeNewPrivateFile(target, io.LimitReader(file, maxSeedBytes+1), info.Size())
+}
+
+func writeNewPrivateFile(target string, reader io.Reader, expectedSize int64) error {
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- target is a fixed candidate ID under an operator-selected directory.
+	if err != nil {
+		return err
+	}
+	written, copyErr := io.Copy(file, reader)
+	closeErr := file.Close()
+	if copyErr != nil || closeErr != nil || written != expectedSize {
+		_ = os.Remove(target)
+		var sizeErr error
+		if written != expectedSize {
+			sizeErr = fmt.Errorf("fixture write size %d, want %d", written, expectedSize)
+		}
+		return errors.Join(copyErr, closeErr, sizeErr)
+	}
+	return nil
+}
+
+func validateFixture(path string, candidate mistral.CandidateFormat) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maxSeedBytes {
+		return errors.New("fixture must be a bounded regular non-symlink file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	detected, err := mistral.DetectFormat(file, info.Size(), candidate.MediaType)
+	if err != nil {
+		return err
+	}
+	if detected.ID != candidate.ID {
+		return fmt.Errorf("detected %q, want %q", detected.ID, candidate.ID)
+	}
+	return nil
+}
+
+func generatedFixture(id string) ([]byte, bool, error) {
+	sentinel, err := mistral.ProbeFixtureSentinel(id)
+	if err != nil {
+		return nil, false, err
+	}
+	xmlSentinel := escapeXML(sentinel)
+	switch id {
+	case "pdf":
+		return pdfFixture(sentinel), true, nil
+	case "docx":
+		return zipFixture([]zipEntry{
+			{name: "[Content_Types].xml", value: `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`},
+			{name: "_rels/.rels", value: `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>`},
+			{name: "word/document.xml", value: `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>` + xmlSentinel + `</w:t></w:r></w:p><w:sectPr/></w:body></w:document>`},
+		})
+	case "odt":
+		return zipFixture([]zipEntry{
+			{name: "mimetype", value: "application/vnd.oasis.opendocument.text", stored: true},
+			{name: "META-INF/manifest.xml", value: `<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.3"><manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.text"/><manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/><manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/></manifest:manifest>`},
+			{name: "content.xml", value: `<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3"><office:body><office:text><text:p>` + xmlSentinel + `</text:p></office:text></office:body></office:document-content>`},
+			{name: "styles.xml", value: openDocumentStyles},
+		})
+	case "rtf":
+		return []byte(`{\rtf1\ansi ` + sentinel + `}`), true, nil
+	case "pptx":
+		return zipFixture([]zipEntry{
+			{name: "[Content_Types].xml", value: `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/></Types>`},
+			{name: "_rels/.rels", value: `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/></Relationships>`},
+			{name: "ppt/presentation.xml", value: `<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst><p:sldSz cx="9144000" cy="6858000"/></p:presentation>`},
+			{name: "ppt/_rels/presentation.xml.rels", value: `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>`},
+			{name: "ppt/slides/slide1.xml", value: `<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/><p:sp><p:nvSpPr><p:cNvPr id="2" name="Probe"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US"/><a:t>` + xmlSentinel + `</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>`},
+		})
+	case "xlsx":
+		return zipFixture([]zipEntry{
+			{name: "[Content_Types].xml", value: `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>`},
+			{name: "_rels/.rels", value: `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>`},
+			{name: "xl/workbook.xml", value: `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Probe" sheetId="1" r:id="rId1"/></sheets></workbook>`},
+			{name: "xl/_rels/workbook.xml.rels", value: `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`},
+			{name: "xl/worksheets/sheet1.xml", value: `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>` + xmlSentinel + `</t></is></c></row></sheetData></worksheet>`},
+		})
+	case "ods":
+		return zipFixture([]zipEntry{
+			{name: "mimetype", value: "application/vnd.oasis.opendocument.spreadsheet", stored: true},
+			{name: "META-INF/manifest.xml", value: `<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.3"><manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.spreadsheet"/><manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/><manifest:file-entry manifest:full-path="styles.xml" manifest:media-type="text/xml"/></manifest:manifest>`},
+			{name: "content.xml", value: `<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3"><office:body><office:spreadsheet><table:table table:name="Probe"><table:table-row><table:table-cell office:value-type="string"><text:p>` + xmlSentinel + `</text:p></table:table-cell></table:table-row></table:table></office:spreadsheet></office:body></office:document-content>`},
+			{name: "styles.xml", value: openDocumentStyles},
+		})
+	case "csv":
+		return []byte("kind,value\nprobe,\"" + sentinel + "\"\n"), true, nil
+	case "epub":
+		return zipFixture([]zipEntry{
+			{name: "mimetype", value: "application/epub+zip", stored: true},
+			{name: "META-INF/container.xml", value: `<?xml version="1.0"?><container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles></container>`},
+			{name: "OEBPS/content.opf", value: `<?xml version="1.0"?><package version="3.0" unique-identifier="id" xmlns="http://www.idpf.org/2007/opf"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="id">urn:uuid:00000000-0000-0000-0000-000000000001</dc:identifier><dc:title>Probe</dc:title><dc:language>en</dc:language></metadata><manifest><item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="chapter"/></spine></package>`},
+			{name: "OEBPS/chapter.xhtml", value: `<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Probe</title></head><body><p>` + xmlSentinel + `</p></body></html>`},
+		})
+	case "txt":
+		return []byte(sentinel + "\n"), true, nil
+	case "markdown":
+		return []byte("# Probe\n\n" + sentinel + "\n"), true, nil
+	case "rst":
+		return []byte("Probe\n=====\n\n" + sentinel + "\n"), true, nil
+	case "latex":
+		return []byte(`\documentclass{article}\begin{document}` + sentinel + `\end{document}`), true, nil
+	case "json":
+		return []byte(`{"probe":"` + sentinel + `"}`), true, nil
+	case "jsonl":
+		return []byte(`{"kind":"probe","value":"` + sentinel + `"}` + "\n"), true, nil
+	case "xml":
+		return []byte(`<probe>` + xmlSentinel + `</probe>`), true, nil
+	case "yaml":
+		return []byte("---\nprobe: \"" + sentinel + "\"\n"), true, nil
+	case "go":
+		return []byte("package probe\n\nconst sentinel = \"" + sentinel + "\"\n"), true, nil
+	case "python":
+		return []byte("sentinel = \"" + sentinel + "\"\n"), true, nil
+	case "javascript":
+		return []byte("const sentinel = \"" + sentinel + "\";\n"), true, nil
+	case "eml":
+		return []byte("From: probe@example.test\r\nTo: archive@example.test\r\nDate: Thu, 13 Aug 2026 00:00:00 +0000\r\nSubject: Synthetic probe\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n" + sentinel + "\r\n"), true, nil
+	case "doc", "ppt", "xls", "numbers", "msg":
+		return nil, false, nil
+	default:
+		return nil, false, fmt.Errorf("no fixture policy for %q", id)
+	}
+}
+
+func zipFixture(entries []zipEntry) ([]byte, bool, error) {
+	var output bytes.Buffer
+	writer := zip.NewWriter(&output)
+	for _, entry := range entries {
+		header := &zip.FileHeader{
+			Name:         entry.name,
+			Method:       zip.Deflate,
+			ModifiedDate: zipEpochDate,
+		}
+		value := []byte(entry.value)
+		if entry.stored {
+			header.Method = zip.Store
+			header.CRC32 = crc32.ChecksumIEEE(value)
+			header.CompressedSize64 = uint64(len(value))
+			header.UncompressedSize64 = uint64(len(value))
+		}
+		var part io.Writer
+		var err error
+		if entry.stored {
+			// CreateRaw avoids a data descriptor and keeps package-mandated
+			// first mimetype entries stored with no extra fields.
+			part, err = writer.CreateRaw(header)
+		} else {
+			part, err = writer.CreateHeader(header)
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("create fixture ZIP entry %q: %w", entry.name, err)
+		}
+		if _, err := part.Write(value); err != nil {
+			return nil, false, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, false, fmt.Errorf("close fixture ZIP: %w", err)
+	}
+	return output.Bytes(), true, nil
+}
+
+func escapeXML(value string) string {
+	var output bytes.Buffer
+	for _, char := range value {
+		switch char {
+		case '&':
+			output.WriteString("&amp;")
+		case '<':
+			output.WriteString("&lt;")
+		case '>':
+			output.WriteString("&gt;")
+		default:
+			output.WriteRune(char)
+		}
+	}
+	return output.String()
+}
+
+func pdfFixture(sentinel string) []byte {
+	stream := "BT /F1 12 Tf 72 720 Td (" + strings.NewReplacer("\\", "\\\\", "(", "\\(", ")", "\\)").Replace(sentinel) + ") Tj ET"
+	objects := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+		"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+		fmt.Sprintf("<< /Length %d >>\nstream\n%s\nendstream", len(stream), stream),
+	}
+	var output bytes.Buffer
+	output.WriteString("%PDF-1.4\n")
+	offsets := make([]int, len(objects))
+	for index, object := range objects {
+		offsets[index] = output.Len()
+		_, _ = fmt.Fprintf(&output, "%d 0 obj\n%s\nendobj\n", index+1, object)
+	}
+	xref := output.Len()
+	_, _ = fmt.Fprintf(&output, "xref\n0 %d\n0000000000 65535 f \n", len(objects)+1)
+	for _, offset := range offsets {
+		_, _ = fmt.Fprintf(&output, "%010d 00000 n \n", offset)
+	}
+	_, _ = fmt.Fprintf(&output, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return output.Bytes()
+}

--- a/scripts/mistral-probe-fixtures/main_test.go
+++ b/scripts/mistral-probe-fixtures/main_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/documentindex/mistral"
+)
+
+func TestGeneratedFixturesContainSentinelAndPassProductionDetection(t *testing.T) {
+	for _, candidate := range mistral.CandidateFormats() {
+		if slices.Contains(nativeSeedFormats, candidate.ID) {
+			continue
+		}
+		t.Run(candidate.ID, func(t *testing.T) {
+			require := require.New(t)
+			content, generated, err := generatedFixture(candidate.ID)
+			require.NoError(err)
+			require.True(generated)
+			require.NotEmpty(content)
+			detected, err := mistral.DetectFormat(bytes.NewReader(content), int64(len(content)), candidate.MediaType)
+			require.NoError(err)
+			assert.Equal(t, candidate.ID, detected.ID)
+			sentinel, err := mistral.ProbeFixtureSentinel(candidate.ID)
+			require.NoError(err)
+			assert.True(t, fixtureContains(t, content, sentinel), "fixture must contain its native sentinel")
+		})
+	}
+}
+
+func TestGeneratedPackageFixturesAreDeterministicAndPortable(t *testing.T) {
+	for _, id := range []string{"odt", "ods", "epub"} {
+		t.Run(id, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			first, generated, err := generatedFixture(id)
+			require.NoError(err)
+			require.True(generated)
+			second, generated, err := generatedFixture(id)
+			require.NoError(err)
+			require.True(generated)
+			assert.Equal(first, second)
+
+			archive, err := zip.NewReader(bytes.NewReader(first), int64(len(first)))
+			require.NoError(err)
+			require.NotEmpty(archive.File)
+			mimetype := archive.File[0]
+			assert.Equal("mimetype", mimetype.Name)
+			assert.Equal(zip.Store, mimetype.Method)
+			assert.Empty(mimetype.Extra)
+			assert.Zero(mimetype.Flags&0x8, "mimetype entry must not use a data descriptor")
+			assert.Equal(zipEpochDate, mimetype.ModifiedDate)
+		})
+	}
+}
+
+func TestBuildFixtureDirectoryResumesWithNativeSeeds(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	outputDirectory := filepath.Join(t.TempDir(), "fixtures")
+	created, missing, err := buildFixtureDirectory(outputDirectory, "")
+	require.NoError(err)
+	assert.Equal(len(mistral.CandidateFormats())-len(nativeSeedFormats), created)
+	assert.Equal([]string{"doc", "msg", "numbers", "ppt", "xls"}, missing)
+
+	seedDirectory := t.TempDir()
+	for _, id := range nativeSeedFormats {
+		candidate, ok := mistral.CandidateFormatByID(id)
+		require.True(ok)
+		sentinel, sentinelErr := mistral.ProbeFixtureSentinel(id)
+		require.NoError(sentinelErr)
+		var content []byte
+		if id == "numbers" {
+			content, _, err = zipFixture([]zipEntry{{name: "Index/Tables/Table.iwa", value: sentinel}})
+			require.NoError(err)
+		} else {
+			markers := map[string]string{
+				"doc": "WordDocument", "ppt": "PowerPoint Document", "xls": "Workbook", "msg": "__properties_version1.0",
+			}
+			content = nativeCompoundFixture(t, markers[id], sentinel)
+		}
+		detected, detectErr := mistral.DetectFormat(bytes.NewReader(content), int64(len(content)), candidate.MediaType)
+		require.NoError(detectErr)
+		assert.Equal(id, detected.ID)
+		require.NoError(os.WriteFile(filepath.Join(seedDirectory, id), content, 0o600))
+	}
+
+	created, missing, err = buildFixtureDirectory(outputDirectory, seedDirectory)
+	require.NoError(err)
+	assert.Equal(len(nativeSeedFormats), created)
+	assert.Empty(missing)
+	entries, err := os.ReadDir(outputDirectory)
+	require.NoError(err)
+	assert.Len(entries, len(mistral.CandidateFormats()))
+	if runtime.GOOS != "windows" {
+		for _, entry := range entries {
+			info, infoErr := entry.Info()
+			require.NoError(infoErr)
+			assert.Equal(os.FileMode(0o600), info.Mode().Perm())
+		}
+	}
+
+	var output bytes.Buffer
+	require.NoError(run([]string{"--output", outputDirectory}, &output))
+	assert.Contains(output.String(), "26 Mistral probe fixtures")
+	assert.Contains(output.String(), "0 created")
+}
+
+func fixtureContains(t *testing.T, content []byte, sentinel string) bool {
+	t.Helper()
+	require := require.New(t)
+	if !bytes.HasPrefix(content, []byte("PK")) {
+		return bytes.Contains(content, []byte(sentinel))
+	}
+	archive, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+	require.NoError(err)
+	for _, entry := range archive.File {
+		reader, openErr := entry.Open()
+		require.NoError(openErr)
+		value, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		require.NoError(readErr)
+		require.NoError(closeErr)
+		if bytes.Contains(value, []byte(sentinel)) {
+			return true
+		}
+	}
+	return false
+}
+
+func nativeCompoundFixture(t *testing.T, streamName, sentinel string) []byte {
+	t.Helper()
+	const (
+		freeSector = uint32(0xffffffff)
+		endOfChain = uint32(0xfffffffe)
+		fatSector  = uint32(0xfffffffd)
+		noStream   = uint32(0xffffffff)
+	)
+	content := make([]byte, 3*512)
+	header := content[:512]
+	copy(header, []byte{0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1})
+	binary.LittleEndian.PutUint16(header[26:28], 3)
+	binary.LittleEndian.PutUint16(header[28:30], 0xfffe)
+	binary.LittleEndian.PutUint16(header[30:32], 9)
+	binary.LittleEndian.PutUint16(header[32:34], 6)
+	binary.LittleEndian.PutUint32(header[44:48], 1)
+	binary.LittleEndian.PutUint32(header[48:52], 1)
+	binary.LittleEndian.PutUint32(header[56:60], 4096)
+	binary.LittleEndian.PutUint32(header[60:64], endOfChain)
+	binary.LittleEndian.PutUint32(header[68:72], endOfChain)
+	for offset := 76; offset < 512; offset += 4 {
+		binary.LittleEndian.PutUint32(header[offset:offset+4], freeSector)
+	}
+	binary.LittleEndian.PutUint32(header[76:80], 0)
+	fat := content[512:1024]
+	for offset := 0; offset < len(fat); offset += 4 {
+		binary.LittleEndian.PutUint32(fat[offset:offset+4], freeSector)
+	}
+	binary.LittleEndian.PutUint32(fat[0:4], fatSector)
+	binary.LittleEndian.PutUint32(fat[4:8], endOfChain)
+	copy(fat[64:], sentinel)
+
+	directory := content[1024:]
+	writeCompoundEntry(t, directory[:128], "Root Entry", 5, noStream)
+	binary.LittleEndian.PutUint32(directory[76:80], 1)
+	writeCompoundEntry(t, directory[128:256], streamName, 2, noStream)
+	return content
+}
+
+func writeCompoundEntry(t *testing.T, entry []byte, name string, entryType byte, noStream uint32) {
+	t.Helper()
+	encoded := make([]byte, 0, (len(name)+1)*2)
+	for _, character := range name {
+		require.Less(t, character, rune(0x10000))
+		encoded = binary.LittleEndian.AppendUint16(encoded, uint16(character))
+	}
+	encoded = binary.LittleEndian.AppendUint16(encoded, 0)
+	require.LessOrEqual(t, len(encoded), 64)
+	copy(entry, encoded)
+	binary.LittleEndian.PutUint16(entry[64:66], uint16(len(encoded)))
+	entry[66] = entryType
+	binary.LittleEndian.PutUint32(entry[68:72], noStream)
+	binary.LittleEndian.PutUint32(entry[72:76], noStream)
+	binary.LittleEndian.PutUint32(entry[76:80], noStream)
+}

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -838,6 +838,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/documents/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Search extracted document attachments */
+        get: operations["searchDocuments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/documents/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get extracted document index status */
+        get: operations["getDocumentIndexStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/domains/search": {
         parameters: {
             query?: never;
@@ -2936,6 +2970,119 @@ export interface components {
             /** Format: int64 */
             source_id: number;
             source_type: string;
+        } & {
+            [key: string]: unknown;
+        };
+        DocumentIndexRebuildStatus: {
+            /** Format: int64 */
+            remaining_owners: number;
+            /** Format: int64 */
+            snapshot_owners: number;
+        } & {
+            [key: string]: unknown;
+        };
+        DocumentIndexStatus: {
+            /** Format: double */
+            average_provider_latency_millis: number;
+            /** Format: int64 */
+            eligible_bytes: number;
+            /** Format: int64 */
+            eligible_occurrences: number;
+            /** Format: int64 */
+            eligible_owners: number;
+            exact_consent: boolean;
+            /** Format: int64 */
+            extraction_attempts: number;
+            /** Format: int64 */
+            failed_attempts: number;
+            /** Format: int64 */
+            ineligible_role_occurrences: number;
+            /** Format: int64 */
+            missing_owners: number;
+            /** Format: int64 */
+            missing_provider_byte_reports: number;
+            /** Format: int64 */
+            processed_provider_units: number;
+            profile_enabled: boolean;
+            profile_exists: boolean;
+            /** Format: int64 */
+            provider_latency_millis: number;
+            /** Format: int64 */
+            provider_requests: number;
+            /** Format: int64 */
+            provider_retries: number;
+            /** Format: int64 */
+            ready_owners: number;
+            /** Format: int64 */
+            reported_provider_bytes: number;
+            /** Format: int64 */
+            retry_owners: number;
+            /** Format: int64 */
+            staging_owners: number;
+            /** Format: int64 */
+            stored_plaintext_chunks: number;
+            /** Format: int64 */
+            successful_attempts: number;
+            /** Format: int64 */
+            terminal_owners: number;
+            /** Format: int64 */
+            unknown_role_occurrences: number;
+            /** Format: int64 */
+            verified_upload_bytes: number;
+        } & {
+            [key: string]: unknown;
+        };
+        DocumentIndexStatusResponse: {
+            active_rebuild?: components["schemas"]["DocumentIndexRebuildStatus"];
+            status: components["schemas"]["DocumentIndexStatus"];
+        } & {
+            [key: string]: unknown;
+        };
+        DocumentSearchResponse: {
+            next_cursor?: string;
+            results: components["schemas"]["DocumentSearchResult"][] | null;
+            /** Format: int64 */
+            revision: number;
+            truncated?: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        DocumentSearchResult: {
+            /** Format: int64 */
+            attachment_id: number;
+            canonical_blob_hash: string;
+            chunk_key: string;
+            /** Format: int64 */
+            chunk_ordinal: number;
+            containing_title?: string;
+            excerpt: string;
+            extraction_id: string;
+            filename?: string;
+            /** Format: int64 */
+            first_unit_index: number;
+            heading_path?: string[] | null;
+            /** Format: int64 */
+            highlight_end: number;
+            /** Format: int64 */
+            highlight_start: number;
+            /** Format: int64 */
+            last_unit_index: number;
+            matched_signals: string[] | null;
+            /** Format: int64 */
+            message_id: number;
+            mime_type?: string;
+            model: string;
+            occurrence_key: string;
+            /** Format: int64 */
+            other_live_copies: number;
+            profile_id: string;
+            provider: string;
+            /** Format: int64 */
+            rank: number;
+            /** Format: int64 */
+            source_id: number;
+            source_part_key?: string;
+            truncated: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -7747,6 +7894,133 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CancelDeletionResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    searchDocuments: {
+        parameters: {
+            query: {
+                /** @description Extracted document content or filename query */
+                q: string;
+                /** @description Source IDs to include; repeat or comma-separate values */
+                source_id?: number[];
+                /** @description Message types to include; repeat or comma-separate values */
+                message_type?: string[];
+                /** @description Exact attachment occurrence ID */
+                attachment_id?: number;
+                /** @description Exact containing message ID */
+                message_id?: number;
+                /** @description Maximum results to return (default 20, max 100) */
+                limit?: number;
+                /** @description Opaque cursor from the previous document search page */
+                cursor?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentSearchResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getDocumentIndexStatus: {
+        parameters: {
+            query: {
+                /** @description Exact document extraction profile ID */
+                profile_id: string;
+                /** @description Exact extraction input key */
+                input_key: string;
+                /** @description Allowed document media types */
+                media_type: string[];
+                /** @description Allowed message types */
+                message_type?: string[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentIndexStatusResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Error */


### PR DESCRIPTION
## What changed

- Add an opt-in Mistral OCR document-indexing lane with authenticated format capabilities, explicit retention/training consent, bounded processing, and private inline uploads.
- Classify attachment occurrences across importers with stable source-part provenance, then reconcile edits, replacements, deletions, retries, and rebuilds for SQLite and PostgreSQL.
- Store normalized source units and chunks locally, expose dedicated lexical document search and status through CLI, HTTP/OpenAPI, and MCP, and return exact attachment, message, and source provenance.
- Keep raw provider JSON and full provider Markdown transient, disclose derived plaintext in full backups, and leave attachment-document embeddings to #617.

## Why

Msgvault stores attachment bytes, but evidence inside documents is not searchable. This adds a consent-gated lexical foundation that can find document content without silently uploading unsupported formats or returning stale results after attachment lifecycle changes.

The authenticated Mistral capability matrix covers all 26 non-visual document formats supported by this lane:

- Documents: PDF, DOCX, DOC, ODT, and RTF
- Presentations: PPTX and PPT
- Spreadsheets: XLSX, XLS, ODS, Apple Numbers, and CSV
- Ebooks: EPUB
- Text and markup: TXT, Markdown, reStructuredText, and LaTeX
- Structured data: JSON, JSONL/NDJSON, XML, and YAML
- Source code: Go, Python, and JavaScript
- Email: EML and Outlook MSG

Each format still has to pass the authenticated private-fixture probe before Msgvault will send that format to Mistral or include it in the recorded consent profile.

## Usage

Set `MISTRAL_API_KEY`, enable `[attachments.documents]`, and choose explicit retention and training postures. Then probe a private synthetic format matrix and record consent for that exact capability manifest:

```sh
msgvault documents probe-mistral --fixtures <fixture-directory> > mistral-capabilities.json
msgvault documents consent-mistral --capabilities mistral-capabilities.json --yes
msgvault documents build --capabilities mistral-capabilities.json --yes
msgvault documents search "shipping damage"
```

Document embeddings remain unavailable in this PR; search is lexical and filename-ranked. The semantic/vector phase is tracked in #617.

Refs #608 and #617
