### PR TITLE
fix: preserve UTF-8 calendar snippets during sync and repair

### DIFF
--- a/cmd/msgvault/cmd/build_cache_calendar_test.go
+++ b/cmd/msgvault/cmd/build_cache_calendar_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +19,7 @@ import (
 	"go.kenn.io/msgvault/internal/calsync"
 	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/store"
+	"golang.org/x/oauth2"
 )
 
 // TestBuildCache_IncludesCalendarEventsInModalityNeutralCache verifies calendar
@@ -158,4 +163,211 @@ func TestBuildCache_AllCalendarEventsWritesAnalyticalCacheState(t *testing.T) {
 	result2, err := buildCache(dbPath, analyticsDir, false)
 	require.NoError(err, "second buildCache should accept stable calendar-only state")
 	assert.True(result2.Skipped, "calendar-only cache should be skipped on the second build")
+}
+
+const (
+	cacheCalendarBoundaryAccount = "alice@example.com"
+	cacheCalendarBoundaryEventID = "utf8-boundary-event"
+)
+
+func TestBuildCache_PreservesCalsyncUTF8ByteBoundary(t *testing.T) {
+	boundarySummary := strings.Repeat("a", 198) + "\u2014after-boundary"
+	boundarySnippet := strings.Repeat("a", 198)
+
+	runInitial := func(t *testing.T, forceCSV bool) {
+		t.Helper()
+		require := require.New(t)
+
+		if forceCSV {
+			t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "1")
+		} else {
+			t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "")
+		}
+
+		tmp := t.TempDir()
+		dbPath := filepath.Join(tmp, "msgvault.db")
+		analyticsDir := filepath.Join(tmp, "analytics")
+
+		_, stored := syncCalendarBoundaryEvent(t, dbPath, boundarySummary, "TOKEN1")
+		require.Equal(boundarySnippet, stored, "exact SQLite snippet")
+
+		_, err := buildCache(dbPath, analyticsDir, false)
+		require.NoError(err, "initial cache publication")
+		assertCalendarBoundarySnippetPublished(t, analyticsDir, boundarySnippet)
+	}
+
+	t.Run("initial default publication", func(t *testing.T) {
+		runInitial(t, false)
+	})
+
+	t.Run("initial forced CSV publication", func(t *testing.T) {
+		runInitial(t, true)
+	})
+
+	t.Run("explicit full publication replaces the same event", func(t *testing.T) {
+		require := require.New(t)
+		t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "")
+
+		tmp := t.TempDir()
+		dbPath := filepath.Join(tmp, "msgvault.db")
+		analyticsDir := filepath.Join(tmp, "analytics")
+		oldSummary := strings.Repeat("b", 200) + "old-tail"
+		oldSnippet := strings.Repeat("b", 200)
+
+		oldID, stored := syncCalendarBoundaryEvent(t, dbPath, oldSummary, "TOKEN1")
+		require.Equal(oldSnippet, stored, "initial SQLite snippet")
+
+		_, err := buildCache(dbPath, analyticsDir, false)
+		require.NoError(err, "initial cache publication")
+		assertCalendarBoundarySnippetPublished(t, analyticsDir, oldSnippet)
+
+		updatedID, stored := syncCalendarBoundaryEvent(t, dbPath, boundarySummary, "TOKEN2")
+		require.Equal(oldID, updatedID, "full sync must update the existing event row")
+		require.Equal(boundarySnippet, stored, "updated SQLite snippet")
+
+		_, err = buildCache(dbPath, analyticsDir, true)
+		require.NoError(err, "explicit full cache publication")
+		assertCalendarBoundarySnippetPublished(t, analyticsDir, boundarySnippet)
+	})
+}
+
+func syncCalendarBoundaryEvent(
+	t *testing.T,
+	dbPath, summary, syncToken string,
+) (int64, string) {
+	t.Helper()
+
+	calendarListJSON, err := json.Marshal(map[string]any{
+		"items": []map[string]any{
+			{
+				"id":         "primary",
+				"accessRole": "owner",
+			},
+		},
+	})
+	require.NoError(t, err, "marshal calendar list response")
+
+	eventsJSON, err := json.Marshal(map[string]any{
+		"items": []map[string]any{
+			{
+				"id":      cacheCalendarBoundaryEventID,
+				"status":  gcal.StatusConfirmed,
+				"summary": summary,
+				"organizer": map[string]any{
+					"email": cacheCalendarBoundaryAccount,
+					"self":  true,
+				},
+				"start": map[string]any{
+					"dateTime": "2024-05-02T09:00:00Z",
+				},
+				"end": map[string]any{
+					"dateTime": "2024-05-02T09:30:00Z",
+				},
+			},
+		},
+		"nextSyncToken": syncToken,
+	})
+	require.NoError(t, err, "marshal events response")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users/me/calendarList":
+			_, _ = w.Write(calendarListJSON)
+		case "/calendars/primary/events":
+			_, _ = w.Write(eventsJSON)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	st, err := store.Open(dbPath)
+	require.NoError(t, err, "open store")
+	defer func() {
+		assert.NoError(t, st.Close(), "close store")
+	}()
+	require.NoError(t, st.InitSchema(), "init schema")
+
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"})
+	client := gcal.NewClient(
+		tokenSource,
+		gcal.WithBaseURL(srv.URL),
+		gcal.WithHTTPClient(srv.Client()),
+	)
+	defer func() {
+		assert.NoError(t, client.Close(), "close calendar client")
+	}()
+
+	_, err = calsync.New(client, st, calsync.Options{
+		AccountEmail: cacheCalendarBoundaryAccount,
+	}).Full(context.Background())
+	require.NoError(t, err, "full calendar sync")
+
+	var messageID int64
+	var stored sql.NullString
+	err = st.DB().QueryRow(`
+		SELECT m.id, m.snippet
+		FROM messages m
+		JOIN sources s ON s.id = m.source_id
+		WHERE s.source_type = ?
+		  AND s.identifier = ?
+		  AND m.source_message_id = ?
+		  AND m.message_type = ?`,
+		gcal.SourceType,
+		cacheCalendarBoundaryAccount+"/primary",
+		cacheCalendarBoundaryEventID,
+		gcal.MessageTypeCalendarEvent,
+	).Scan(&messageID, &stored)
+	require.NoError(t, err, "read stored calendar snippet")
+	require.True(t, stored.Valid, "calendar snippet must be non-NULL")
+	return messageID, stored.String
+}
+
+func assertCalendarBoundarySnippetPublished(
+	t *testing.T,
+	analyticsDir, want string,
+) {
+	t.Helper()
+	assert := assert.New(t)
+	got := readCalendarBoundarySnippet(t, analyticsDir)
+
+	assert.Equal(want, got)
+	assert.LessOrEqual(len(got), 200)
+	assert.True(utf8.ValidString(got))
+}
+
+func readCalendarBoundarySnippet(t *testing.T, analyticsDir string) string {
+	t.Helper()
+	require := require.New(t)
+
+	duckDB, err := sql.Open("duckdb", "")
+	require.NoError(err, "open DuckDB")
+	defer func() {
+		assert.NoError(t, duckDB.Close(), "close DuckDB")
+	}()
+
+	pattern := filepath.Join(analyticsDir, "messages", "**", "*.parquet")
+	var count int
+	require.NoError(duckDB.QueryRow(`
+		SELECT COUNT(*)
+		FROM read_parquet(?, hive_partitioning=true)
+		WHERE source_message_id = ? AND message_type = ?`,
+		pattern,
+		cacheCalendarBoundaryEventID,
+		gcal.MessageTypeCalendarEvent,
+	).Scan(&count), "count boundary event in Parquet")
+	require.Equal(1, count, "boundary event must have exactly one Parquet row")
+
+	var got sql.NullString
+	require.NoError(duckDB.QueryRow(`
+		SELECT snippet
+		FROM read_parquet(?, hive_partitioning=true)
+		WHERE source_message_id = ? AND message_type = ?`,
+		pattern,
+		cacheCalendarBoundaryEventID,
+		gcal.MessageTypeCalendarEvent,
+	).Scan(&got), "read boundary snippet from Parquet")
+	require.True(got.Valid, "Parquet snippet must be non-NULL")
+	return got.String
 }

--- a/cmd/msgvault/cmd/cache_refresh_test.go
+++ b/cmd/msgvault/cmd/cache_refresh_test.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/duckdbutil"
+	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/identityindex"
 	"go.kenn.io/msgvault/internal/oauth"
 	"go.kenn.io/msgvault/internal/query"
@@ -1162,4 +1164,53 @@ func TestIncrementalBuildRepairsParticipantIdentifierDriftWithNewMessages(t *tes
 	repaired := cacheNeedsBuild(dbPath, analyticsDir)
 	assertions.False(repaired.NeedsBuild,
 		"incremental build must clear identifier drift (reason: %q)", repaired.Reason)
+}
+
+func TestRepairEncodingRebuildsCacheWithRegeneratedCalendarSnippet(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmpDir := t.TempDir()
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{HomeDir: tmpDir, Data: config.DataConfig{DataDir: tmpDir}}
+
+	dbPath := cfg.DatabaseDSN()
+	st, err := store.Open(dbPath)
+	require.NoError(err, "open store")
+	require.NoError(st.InitSchema(), "initialize schema")
+	_, err = st.DB().Exec(`INSERT INTO sources
+		(id, source_type, identifier, created_at, updated_at)
+		VALUES (1, ?, 'alice@example.com/primary', datetime('now'), datetime('now'))`, gcal.SourceType)
+	require.NoError(err, "insert calendar source")
+	_, err = st.DB().Exec(`INSERT INTO conversations
+		(id, source_id, source_conversation_id, conversation_type, title, created_at, updated_at)
+		VALUES (1, 1, 'repair-calendar-conversation', ?, 'Calendar', datetime('now'), datetime('now'))`,
+		gcal.ConversationType)
+	require.NoError(err, "insert calendar conversation")
+
+	canonicalBody := strings.Repeat("a", 198) + "\u2014after-boundary"
+	brokenSnippet := strings.Repeat("a", 198) + "\xe2\x80"
+	_, err = st.DB().Exec(`INSERT INTO messages
+		(id, conversation_id, source_id, source_message_id, message_type, snippet, sent_at, size_estimate)
+		VALUES (1, 1, 1, ?, ?, ?, datetime('now'), 1000)`,
+		cacheCalendarBoundaryEventID, gcal.MessageTypeCalendarEvent, brokenSnippet)
+	require.NoError(err, "insert damaged calendar message")
+	_, err = st.DB().Exec(`INSERT INTO message_bodies (message_id, body_text) VALUES (1, ?)`, canonicalBody)
+	require.NoError(err, "insert canonical calendar body")
+	require.NoError(st.Close(), "close fixture store")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	require.NoError(runRepairEncodingLocal(cmd), "run local encoding repair")
+
+	st, err = store.Open(dbPath)
+	require.NoError(err, "reopen repaired store")
+	defer func() { assert.NoError(st.Close()) }()
+	var stored string
+	require.NoError(st.DB().QueryRow(`SELECT snippet FROM messages WHERE id = 1`).Scan(&stored),
+		"read repaired SQLite snippet")
+	want := strings.Repeat("a", 198)
+	assert.Equal(want, stored, "normal repair stores the canonical preview")
+	assert.Equal(want, readCalendarBoundarySnippet(t, cfg.AnalyticsDir()),
+		"normal repair full rebuild republishes the canonical preview")
 }

--- a/cmd/msgvault/cmd/repair_encoding.go
+++ b/cmd/msgvault/cmd/repair_encoding.go
@@ -12,6 +12,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/calsync"
+	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/textutil"
@@ -271,7 +273,7 @@ func repairMessageFields(s *store.Store, stats *repairStats) (reembedNeededIDs [
 
 	// Query all messages with their raw data
 	rows, err := db.Query(`
-		SELECT m.id, m.subject, mb.body_text, mb.body_html, m.snippet,
+		SELECT m.id, m.message_type, m.subject, mb.body_text, mb.body_html, m.snippet,
 		       mr.raw_data, mr.compression
 		FROM messages m
 		LEFT JOIN message_bodies mb ON mb.message_id = m.id
@@ -370,11 +372,12 @@ func repairMessageFields(s *store.Store, stats *repairStats) (reembedNeededIDs [
 
 	for rows.Next() {
 		var id int64
+		var messageType string
 		var subject, bodyText, bodyHTML, snippet sql.NullString
 		var rawData []byte
 		var compression sql.NullString
 
-		if err := rows.Scan(&id, &subject, &bodyText, &bodyHTML, &snippet, &rawData, &compression); err != nil {
+		if err := rows.Scan(&id, &messageType, &subject, &bodyText, &bodyHTML, &snippet, &rawData, &compression); err != nil {
 			logger.Warn("skipping message row with scan error", "error", err)
 			stats.skippedRows++
 			continue
@@ -433,9 +436,17 @@ func repairMessageFields(s *store.Store, stats *repairStats) (reembedNeededIDs [
 			stats.bodyHTMLs++
 		}
 
-		// Snippet (from Gmail API, not in raw MIME)
+		// Only the exact historical body[:200] signature can be reconstructed from
+		// canonical body text. Every other case retains the generic repair.
 		if snippet.Valid && !utf8.ValidString(snippet.String) {
-			repair.newSnippet = sql.NullString{String: textutil.EnsureUTF8(snippet.String), Valid: true}
+			repairedSnippet := textutil.EnsureUTF8(snippet.String)
+			if messageType == gcal.MessageTypeCalendarEvent &&
+				len(snippet.String) == 200 &&
+				bodyText.Valid && utf8.ValidString(bodyText.String) &&
+				strings.HasPrefix(bodyText.String, snippet.String) {
+				repairedSnippet = calsync.Snippet(bodyText.String)
+			}
+			repair.newSnippet = sql.NullString{String: repairedSnippet, Valid: true}
 			needsRepair = true
 			stats.snippets++
 		}

--- a/cmd/msgvault/cmd/repair_encoding.go
+++ b/cmd/msgvault/cmd/repair_encoding.go
@@ -186,6 +186,7 @@ type repairStats struct {
 	filenames     int
 	convTitles    int
 	convSourceIDs int
+	convPreviews  int
 	emailAddrs    int
 	domains       int
 	skippedRows   int
@@ -206,6 +207,13 @@ func repairEncoding(s *store.Store) (reembedNeededIDs []int64, err error) {
 		return nil, err
 	}
 
+	// Repair denormalized conversation previews after all message snippets so
+	// each preview is derived once from the final message state. This also
+	// catches previews stranded by a repair run from an older version.
+	if err := repairConversationPreviews(s, stats); err != nil {
+		return nil, err
+	}
+
 	// Repair display names in participants and message_recipients
 	if err := repairDisplayNames(s, stats); err != nil {
 		return nil, err
@@ -219,7 +227,7 @@ func repairEncoding(s *store.Store) (reembedNeededIDs []int64, err error) {
 	// Summary
 	total := stats.subjects + stats.bodyTexts + stats.bodyHTMLs + stats.snippets +
 		stats.displayNames + stats.labels + stats.filenames + stats.convTitles +
-		stats.convSourceIDs + stats.emailAddrs + stats.domains
+		stats.convSourceIDs + stats.convPreviews + stats.emailAddrs + stats.domains
 	if total == 0 {
 		fmt.Println("No encoding repairs needed.")
 		return nil, nil
@@ -252,6 +260,9 @@ func repairEncoding(s *store.Store) (reembedNeededIDs []int64, err error) {
 	}
 	if stats.convSourceIDs > 0 {
 		fmt.Printf("  Conv src IDs:  %d\n", stats.convSourceIDs)
+	}
+	if stats.convPreviews > 0 {
+		fmt.Printf("  Conv previews: %d\n", stats.convPreviews)
 	}
 	if stats.emailAddrs > 0 {
 		fmt.Printf("  Email addrs:   %d\n", stats.emailAddrs)
@@ -623,6 +634,63 @@ func repairDisplayNameTable(s *store.Store, tableName, query, updateStmt string,
 	}
 
 	return totalRepaired, nil
+}
+
+// repairConversationPreviews recomputes invalid denormalized previews from
+// the final message state. The compare-and-set store update preserves a
+// preview changed after this scan and makes a failed run safe to retry.
+func repairConversationPreviews(s *store.Store, stats *repairStats) error {
+	fmt.Println("Scanning conversations.last_message_preview for invalid UTF-8...")
+
+	type previewRepair struct {
+		id       int64
+		expected string
+	}
+	repairs, err := func() ([]previewRepair, error) {
+		rows, err := s.DB().Query(`SELECT id, last_message_preview
+			FROM conversations WHERE last_message_preview IS NOT NULL`)
+		if err != nil {
+			return nil, fmt.Errorf("query conversation previews: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+
+		var repairs []previewRepair
+		for rows.Next() {
+			var repair previewRepair
+			if err := rows.Scan(&repair.id, &repair.expected); err != nil {
+				logger.Warn("skipping row with scan error", "table", tableConversations,
+					"column", "last_message_preview", "error", err)
+				stats.skippedRows++
+				continue
+			}
+			if !utf8.ValidString(repair.expected) {
+				repairs = append(repairs, repair)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterate conversation previews: %w", err)
+		}
+		return repairs, nil
+	}()
+	if err != nil {
+		return err
+	}
+
+	repaired := 0
+	for _, repair := range repairs {
+		updated, err := s.RecomputeConversationPreviewIfMatches(repair.id, repair.expected)
+		if err != nil {
+			return err
+		}
+		if updated {
+			stats.convPreviews++
+			repaired++
+		}
+	}
+	if repaired > 0 {
+		fmt.Printf("Repaired %d conversations.last_message_preview values\n", repaired)
+	}
+	return nil
 }
 
 // repairOtherStrings repairs other string fields that could have encoding issues.

--- a/cmd/msgvault/cmd/repair_encoding_test.go
+++ b/cmd/msgvault/cmd/repair_encoding_test.go
@@ -243,6 +243,85 @@ func TestRepairOtherStrings_FixesNewColumns(t *testing.T) {
 	assert.Equal(1, stats.domains, "domains")
 }
 
+func TestRepairConversationPreviews_RestoresPreviewStrandedByEarlierRepair(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	testutil.SkipIfPostgres(t, "inserts invalid UTF-8 bytes into TEXT columns; PostgreSQL rejects them")
+	st := testutil.NewTestStore(t)
+	db := st.DB()
+
+	broken := strings.Repeat("a", 198) + "\xe2\x80"
+	want := strings.Repeat("a", 198)
+	_, err := db.Exec(`INSERT INTO sources
+		(id, source_type, identifier, created_at, updated_at)
+		VALUES (1, ?, 'alice@example.com/primary', datetime('now'), datetime('now'))`, gcal.SourceType)
+	require.NoError(err, "insert source")
+	_, err = db.Exec(`INSERT INTO conversations
+		(id, source_id, source_conversation_id, conversation_type, title, last_message_preview, created_at, updated_at)
+		VALUES (1, 1, 'calendar-conversation', ?, 'Calendar', ?, datetime('now'), datetime('now'))`,
+		gcal.ConversationType, broken)
+	require.NoError(err, "insert conversation with stranded preview")
+	_, err = db.Exec(`INSERT INTO messages
+		(id, conversation_id, source_id, source_message_id, message_type, snippet, sent_at, size_estimate)
+		VALUES (10, 1, 1, 'repair-10', ?, ?, datetime('now'), 1000)`,
+		gcal.MessageTypeCalendarEvent, want)
+	require.NoError(err, "insert previously repaired message")
+
+	stats := &repairStats{}
+	require.NoError(repairConversationPreviews(st, stats), "repair stranded conversation preview")
+	var got string
+	require.NoError(db.QueryRow(`SELECT last_message_preview FROM conversations WHERE id = 1`).Scan(&got),
+		"read repaired conversation preview")
+	assert.Equal(want, got, "preview is rederived from the previously repaired latest message")
+	assert.Equal(1, stats.convPreviews, "convPreviews")
+
+	require.NoError(repairConversationPreviews(st, stats), "rerun preview repair")
+	assert.Equal(1, stats.convPreviews, "rerun is idempotent")
+}
+
+func TestRepairConversationPreviews_UsesLatestMessageAfterCollidingRepairs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	testutil.SkipIfPostgres(t, "inserts invalid UTF-8 bytes into TEXT columns; PostgreSQL rejects them")
+	st := testutil.NewTestStore(t)
+	db := st.DB()
+
+	broken := strings.Repeat("c", 198) + "\xe2\x80"
+	calendarBody := strings.Repeat("c", 198) + "\u2014after-boundary"
+	_, err := db.Exec(`INSERT INTO sources
+		(id, source_type, identifier, created_at, updated_at)
+		VALUES (1, ?, 'alice@example.com/primary', datetime('now'), datetime('now'))`, gcal.SourceType)
+	require.NoError(err, "insert source")
+	_, err = db.Exec(`INSERT INTO conversations
+		(id, source_id, source_conversation_id, conversation_type, title, last_message_preview, created_at, updated_at)
+		VALUES (1, 1, 'calendar-conversation', ?, 'Calendar', ?, datetime('now'), datetime('now'))`,
+		gcal.ConversationType, broken)
+	require.NoError(err, "insert conversation")
+	_, err = db.Exec(`INSERT INTO messages
+		(id, conversation_id, source_id, source_message_id, message_type, snippet, sent_at, size_estimate)
+		VALUES (10, 1, 1, 'older-generic', 'email', ?, datetime('now'), 1000),
+		       (20, 1, 1, 'latest-calendar', ?, ?, datetime('now', '+1 minute'), 1000)`,
+		broken, gcal.MessageTypeCalendarEvent, broken)
+	require.NoError(err, "insert colliding damaged snippets")
+	_, err = db.Exec(`INSERT INTO message_bodies (message_id, body_text)
+		VALUES (10, 'generic body'), (20, ?)`, calendarBody)
+	require.NoError(err, "insert message bodies")
+
+	stats := &repairStats{}
+	_, err = repairMessageFields(st, stats)
+	require.NoError(err, "repair colliding message snippets")
+	require.NoError(repairConversationPreviews(st, stats), "repair conversation preview")
+
+	var older, latest, preview string
+	require.NoError(db.QueryRow(`SELECT snippet FROM messages WHERE id = 10`).Scan(&older), "read older snippet")
+	require.NoError(db.QueryRow(`SELECT snippet FROM messages WHERE id = 20`).Scan(&latest), "read latest snippet")
+	require.NoError(db.QueryRow(`SELECT last_message_preview FROM conversations WHERE id = 1`).Scan(&preview),
+		"read conversation preview")
+	assert.Equal(textutil.EnsureUTF8(broken), older, "generic repair keeps its existing behavior")
+	assert.Equal(strings.Repeat("c", 198), latest, "calendar repair uses canonical body")
+	assert.Equal(latest, preview, "conversation preview follows the latest message after all repairs")
+}
+
 func TestRepairMessageFields_RegeneratesOnlyInvalidCalendarSnippetFromCanonicalBody(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -290,10 +369,17 @@ func TestRepairMessageFields_RegeneratesOnlyInvalidCalendarSnippetFromCanonicalB
 			require.NoError(execErr, "insert body %d", row.id)
 		}
 	}
+	_, err = db.Exec(`UPDATE messages SET sent_at = datetime('now', '+1 minute') WHERE id = 10`)
+	require.NoError(err, "make repaired calendar message the conversation's latest")
+	_, err = db.Exec(`UPDATE conversations SET last_message_preview = ? WHERE id = 1`, rows[0].snippet)
+	require.NoError(err, "store copied damaged calendar preview")
+	_, err = db.Exec(`UPDATE conversations SET last_message_preview = 'sibling sentinel' WHERE id = 2`)
+	require.NoError(err, "store unrelated conversation preview")
 
 	stats := &repairStats{}
 	reembedNeededIDs, err := repairMessageFields(st, stats)
 	require.NoError(err, "repair message fields")
+	require.NoError(repairConversationPreviews(st, stats), "repair copied conversation preview")
 
 	got := make(map[int64]string)
 	resultRows, err := db.Query(`SELECT id, snippet FROM messages WHERE id IN (10, 20, 30, 40, 50, 60, 70)`)
@@ -316,10 +402,20 @@ func TestRepairMessageFields_RegeneratesOnlyInvalidCalendarSnippetFromCanonicalB
 		"wrong-length calendar snippet retains generic repair")
 	assert.Equal(textutil.EnsureUTF8(strings.Repeat("b", 198)+"\xe2\x80"), got[70],
 		"200-byte non-prefix calendar snippet retains generic repair")
+	var conversationPreview string
+	require.NoError(db.QueryRow(`SELECT last_message_preview FROM conversations WHERE id = 1`).Scan(&conversationPreview),
+		"read repaired conversation preview")
+	assert.Equal(strings.Repeat("a", 198), conversationPreview,
+		"copied conversation preview follows the repaired latest message")
+	require.NoError(db.QueryRow(`SELECT last_message_preview FROM conversations WHERE id = 2`).Scan(&conversationPreview),
+		"read unrelated conversation preview")
+	assert.Equal("sibling sentinel", conversationPreview,
+		"repair does not overwrite a preview that is not the damaged snippet")
 	for id, snippet := range got {
 		assert.True(utf8.ValidString(snippet), "message %d snippet must be valid UTF-8", id)
 	}
 	assert.Equal(6, stats.snippets, "only invalid snippets count as repaired")
+	assert.Equal(1, stats.convPreviews, "only the copied invalid conversation preview is repaired")
 	assert.Contains(reembedNeededIDs, int64(40), "invalid body repair still requests re-embedding")
 	assert.NotContains(reembedNeededIDs, int64(10), "snippet-only regeneration does not request re-embedding")
 }

--- a/cmd/msgvault/cmd/repair_encoding_test.go
+++ b/cmd/msgvault/cmd/repair_encoding_test.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/textutil"
 )
 
 func TestRepairDisplayNamesBumpsParticipantRevisionWithTheRepair(t *testing.T) {
@@ -238,4 +241,85 @@ func TestRepairOtherStrings_FixesNewColumns(t *testing.T) {
 	assert.Equal(1, stats.convSourceIDs, "convSourceIDs")
 	assert.Equal(1, stats.emailAddrs, "emailAddrs")
 	assert.Equal(1, stats.domains, "domains")
+}
+
+func TestRepairMessageFields_RegeneratesOnlyInvalidCalendarSnippetFromCanonicalBody(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	testutil.SkipIfPostgres(t, "inserts invalid UTF-8 bytes into TEXT columns; PostgreSQL rejects them")
+	st := testutil.NewTestStore(t)
+	db := st.DB()
+
+	_, err := db.Exec(`INSERT INTO sources (id, source_type, identifier, created_at, updated_at)
+		VALUES (1, ?, 'alice@example.com/primary', datetime('now'), datetime('now')),
+		       (2, 'gmail', 'alice@example.com', datetime('now'), datetime('now'))`, gcal.SourceType)
+	require.NoError(err, "insert sources")
+	_, err = db.Exec(`INSERT INTO conversations
+		(id, source_id, source_conversation_id, conversation_type, title, created_at, updated_at)
+		VALUES (1, 1, 'calendar-conversation', ?, 'Calendar', datetime('now'), datetime('now')),
+		       (2, 2, 'email-conversation', 'email_thread', 'Email', datetime('now'), datetime('now'))`,
+		gcal.ConversationType)
+	require.NoError(err, "insert conversations")
+
+	canonicalBody := strings.Repeat("a", 198) + "\u2014after-boundary"
+	bodyPtr := func(value string) *string { return &value }
+	rows := []struct {
+		id           int64
+		conversation int64
+		source       int64
+		messageType  string
+		snippet      string
+		body         *string
+	}{
+		{10, 1, 1, gcal.MessageTypeCalendarEvent, strings.Repeat("a", 198) + "\xe2\x80", &canonicalBody},
+		{20, 2, 2, "email", "mail\xff", bodyPtr("email canonical body")},
+		{30, 1, 1, gcal.MessageTypeCalendarEvent, "missing\xff", nil},
+		{40, 1, 1, gcal.MessageTypeCalendarEvent, "invalid-body\xff", bodyPtr("body\xff")},
+		{50, 1, 1, gcal.MessageTypeCalendarEvent, "keep existing preview", &canonicalBody},
+		{60, 1, 1, gcal.MessageTypeCalendarEvent, strings.Repeat("a", 198) + "\xe2", &canonicalBody},
+		{70, 1, 1, gcal.MessageTypeCalendarEvent, strings.Repeat("b", 198) + "\xe2\x80", &canonicalBody},
+	}
+	for _, row := range rows {
+		_, execErr := db.Exec(`INSERT INTO messages
+			(id, conversation_id, source_id, source_message_id, message_type, snippet, sent_at, size_estimate)
+			VALUES (?, ?, ?, ?, ?, ?, datetime('now'), 1000)`,
+			row.id, row.conversation, row.source, fmt.Sprintf("repair-%d", row.id), row.messageType, row.snippet)
+		require.NoError(execErr, "insert message %d", row.id)
+		if row.body != nil {
+			_, execErr = db.Exec(`INSERT INTO message_bodies (message_id, body_text) VALUES (?, ?)`, row.id, *row.body)
+			require.NoError(execErr, "insert body %d", row.id)
+		}
+	}
+
+	stats := &repairStats{}
+	reembedNeededIDs, err := repairMessageFields(st, stats)
+	require.NoError(err, "repair message fields")
+
+	got := make(map[int64]string)
+	resultRows, err := db.Query(`SELECT id, snippet FROM messages WHERE id IN (10, 20, 30, 40, 50, 60, 70)`)
+	require.NoError(err, "query repaired snippets")
+	defer func() { assert.NoError(resultRows.Close()) }()
+	for resultRows.Next() {
+		var id int64
+		var snippet string
+		require.NoError(resultRows.Scan(&id, &snippet), "scan repaired snippet")
+		got[id] = snippet
+	}
+	require.NoError(resultRows.Err(), "iterate repaired snippets")
+
+	assert.Equal(strings.Repeat("a", 198), got[10], "calendar snippet derives from intact canonical body")
+	assert.Equal(textutil.EnsureUTF8("mail\xff"), got[20], "non-calendar snippet retains generic repair")
+	assert.Equal(textutil.EnsureUTF8("missing\xff"), got[30], "missing calendar body retains generic repair")
+	assert.Equal(textutil.EnsureUTF8("invalid-body\xff"), got[40], "invalid calendar body retains generic repair")
+	assert.Equal("keep existing preview", got[50], "valid calendar snippet is not backfilled")
+	assert.Equal(textutil.EnsureUTF8(strings.Repeat("a", 198)+"\xe2"), got[60],
+		"wrong-length calendar snippet retains generic repair")
+	assert.Equal(textutil.EnsureUTF8(strings.Repeat("b", 198)+"\xe2\x80"), got[70],
+		"200-byte non-prefix calendar snippet retains generic repair")
+	for id, snippet := range got {
+		assert.True(utf8.ValidString(snippet), "message %d snippet must be valid UTF-8", id)
+	}
+	assert.Equal(6, stats.snippets, "only invalid snippets count as repaired")
+	assert.Contains(reembedNeededIDs, int64(40), "invalid body repair still requests re-embedding")
+	assert.NotContains(reembedNeededIDs, int64(10), "snippet-only regeneration does not request re-embedding")
 }

--- a/internal/calsync/calsync_test.go
+++ b/internal/calsync/calsync_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -808,4 +810,61 @@ func TestFull_EnqueuesForEmbedding(t *testing.T) {
 	src := primarySource(t, st)
 	e1, _ := getMsg(t, st, src.ID, "e1")
 	assert.Contains(t, enq.ids, e1.id)
+}
+
+func TestSnippet(t *testing.T) {
+	const maxSnippetBytes = 200
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "trims short input",
+			body: "  Team sync notes  ",
+			want: "Team sync notes",
+		},
+		{
+			name: "trims before checking exact byte limit",
+			body: " \t" + strings.Repeat("\u00e9", 100) + " \n",
+			want: strings.Repeat("\u00e9", 100),
+		},
+		{
+			name: "truncates long ASCII",
+			body: strings.Repeat("a", 201),
+			want: strings.Repeat("a", 200),
+		},
+		{
+			name: "caps multibyte text by bytes",
+			body: strings.Repeat("\u00e9", 101),
+			want: strings.Repeat("\u00e9", 100),
+		},
+		{
+			name: "keeps complete rune ending at byte 200",
+			body: strings.Repeat("a", 197) + "\u2014" + "tail",
+			want: strings.Repeat("a", 197) + "\u2014",
+		},
+		{
+			name: "drops em dash crossing byte 200",
+			body: strings.Repeat("a", 198) + "\u2014" + "tail",
+			want: strings.Repeat("a", 198),
+		},
+		{
+			name: "drops two-byte rune crossing byte 200",
+			body: strings.Repeat("a", 199) + "\u00e9" + "tail",
+			want: strings.Repeat("a", 199),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := snippet(tt.body)
+
+			assert.Equal(tt.want, got)
+			assert.LessOrEqual(len(got), maxSnippetBytes)
+			assert.True(utf8.ValidString(got))
+		})
+	}
 }

--- a/internal/calsync/calsync_test.go
+++ b/internal/calsync/calsync_test.go
@@ -860,7 +860,7 @@ func TestSnippet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
-			got := snippet(tt.body)
+			got := Snippet(tt.body)
 
 			assert.Equal(tt.want, got)
 			assert.LessOrEqual(len(got), maxSnippetBytes)

--- a/internal/calsync/persist.go
+++ b/internal/calsync/persist.go
@@ -124,7 +124,7 @@ func (s *Syncer) ingestEvent(sourceID int64, cal gcal.Calendar, ev gcal.Event) (
 		IsFromMe:                fromMe,
 		IdentityDerivedIsFromMe: identityFromMe,
 		Subject:                 sql.NullString{String: subject, Valid: subject != ""},
-		Snippet:                 sql.NullString{String: snippet(body), Valid: body != ""},
+		Snippet:                 sql.NullString{String: Snippet(body), Valid: body != ""},
 		SizeEstimate:            int64(len(body)),
 	})
 	if err != nil {
@@ -363,8 +363,8 @@ func whenLine(ev gcal.Event) string {
 	return "When: " + start.Format("2006-01-02 15:04")
 }
 
-// snippet returns a trimmed preview of at most 200 bytes without splitting valid UTF-8.
-func snippet(body string) string {
+// Snippet returns a trimmed calendar-event preview of at most 200 bytes without splitting valid UTF-8.
+func Snippet(body string) string {
 	const maxSnippetBytes = 200
 	body = strings.TrimSpace(body)
 	if len(body) <= maxSnippetBytes {

--- a/internal/calsync/persist.go
+++ b/internal/calsync/persist.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/store"
@@ -362,12 +363,17 @@ func whenLine(ev gcal.Event) string {
 	return "When: " + start.Format("2006-01-02 15:04")
 }
 
-// snippet is a short preview derived from the body.
+// snippet returns a trimmed preview of at most 200 bytes without splitting valid UTF-8.
 func snippet(body string) string {
-	const maxSnippetLength = 200
+	const maxSnippetBytes = 200
 	body = strings.TrimSpace(body)
-	if len(body) <= maxSnippetLength {
+	if len(body) <= maxSnippetBytes {
 		return body
 	}
-	return body[:maxSnippetLength]
+
+	end := maxSnippetBytes
+	for end > 0 && !utf8.RuneStart(body[end]) {
+		end--
+	}
+	return body[:end]
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2698,6 +2698,11 @@ func (s *Store) backfillFTSBatchContext(
 	return affected, err
 }
 
+const latestConversationPreviewSubquery = `(SELECT snippet FROM messages
+	WHERE conversation_id = conversations.id
+	ORDER BY COALESCE(sent_at, received_at, internal_date) DESC, id DESC
+	LIMIT 1)`
+
 // RecomputeConversationStats updates the denormalized stats columns on all conversations
 // belonging to the given source. It recomputes message_count, participant_count,
 // last_message_at, and last_message_preview from the current table state.
@@ -2742,18 +2747,31 @@ func (s *Store) recomputeConversationStatsContext(ctx context.Context, whereClau
 				FROM messages
 				WHERE conversation_id = conversations.id
 			),
-			last_message_preview = (
-				SELECT snippet FROM messages
-				WHERE conversation_id = conversations.id
-				ORDER BY COALESCE(sent_at, received_at, internal_date) DESC, id DESC
-				LIMIT 1
-			)
+			last_message_preview = %s
 		WHERE %s
-	`, whereClause), arg)
+	`, latestConversationPreviewSubquery, whereClause), arg)
 	if err != nil {
 		return fmt.Errorf("recompute conversation stats: %w", err)
 	}
 	return nil
+}
+
+// RecomputeConversationPreviewIfMatches refreshes one denormalized preview
+// from current message state only if it still equals expected. It returns
+// whether the guarded row was updated.
+func (s *Store) RecomputeConversationPreviewIfMatches(conversationID int64, expected string) (bool, error) {
+	result, err := s.db.Exec(s.Rebind(fmt.Sprintf(`UPDATE conversations
+		SET last_message_preview = %s
+		WHERE id = ? AND last_message_preview = ?`, latestConversationPreviewSubquery)),
+		conversationID, expected)
+	if err != nil {
+		return false, fmt.Errorf("recompute conversation preview: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read recomputed conversation preview count: %w", err)
+	}
+	return updated > 0, nil
 }
 
 // ForEachTeamsHostedContentBody invokes fn with (messageID, bodyHTML) for every


### PR DESCRIPTION
Calendar sync currently caps previews by slicing the first 200 bytes. When byte 200 falls inside a multi-byte character, the stored snippet is invalid UTF-8 and can make analytics cache reads fail.

This keeps the existing 200-byte calendar preview limit while backing up to a valid character boundary. It also extends the existing repair-encoding path to faithfully regenerate only the exact historical damage signature: an invalid 200-byte calendar snippet that is a byte-for-byte prefix of a present, valid canonical body. Other invalid snippets retain the existing generic encoding repair, and valid snippets are left untouched.

The repair command's existing full cache rebuild republishes corrected previews, so no cache schema or publication changes are needed.