### PR TITLE
feat(media): add scoped attachment policies and excluded-media purge

### DIFF
--- a/cmd/msgvault/cmd/backfill_beeper_media.go
+++ b/cmd/msgvault/cmd/backfill_beeper_media.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/beeper"
 )
 
 var backfillBeeperMediaAccounts []string
@@ -14,13 +16,13 @@ func newBackfillBeeperMediaCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backfill-beeper-media",
 		Short: "Retry pending Beeper attachment downloads",
-		Long: `Retry pending Beeper attachment downloads.
+		Long: `Retry eligible Beeper attachment downloads.
 
-Attachments that failed to download during sync-beeper (Beeper Desktop asset
-temporarily unavailable, over the size cap at the time, transient errors)
-leave a pending marker. This command re-fetches those messages from Beeper
-Desktop and downloads their media into the attachment store. Idempotent:
-already-downloaded attachments are content-addressed and skipped.
+This command retries unfinished downloads and policy exclusions that are now
+allowed, such as media whose configured size cap was raised. It re-fetches
+eligible messages from Beeper Desktop and downloads their media into the
+attachment store. Already-downloaded attachments are content-addressed and
+skipped.
 
 Examples:
   msgvault backfill-beeper-media
@@ -53,10 +55,7 @@ Examples:
 						rebuildCacheAfterWrite(dbPath),
 					)
 				}
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-					"%s: %d messages checked, %d attachments downloaded, %d still pending (%s)\n",
-					accountID, sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending,
-					sum.Duration.Round(time.Second))
+				writeBeeperMediaBackfillSummary(cmd.OutOrStdout(), accountID, sum)
 				if sum.Errors > 0 {
 					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %d errors — see sync run items; re-run to retry\n", sum.Errors)
 				}
@@ -67,6 +66,13 @@ Examples:
 	}
 	cmd.Flags().StringArrayVar(&backfillBeeperMediaAccounts, "account", nil, "Beeper accountID to backfill (repeatable; default: all registered accounts)")
 	return cmd
+}
+
+func writeBeeperMediaBackfillSummary(out io.Writer, accountID string, sum *beeper.ImportSummary) {
+	_, _ = fmt.Fprintf(out,
+		"%s: %d messages checked, %d attachments downloaded, %d still pending, %d skipped by policy (%s)\n",
+		accountID, sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending,
+		sum.AttachmentsSkipped, sum.Duration.Round(time.Second))
 }
 
 func init() {

--- a/cmd/msgvault/cmd/backfill_discord_media.go
+++ b/cmd/msgvault/cmd/backfill_discord_media.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/discord"
 	"go.kenn.io/msgvault/internal/store"
 )
@@ -31,8 +32,12 @@ type discordMediaBackfillSummary struct {
 	MessagesProcessed int64
 	Downloaded        int64
 	Pending           int64
+	Skipped           int64
 	Unrecoverable     int64
-	Warnings          map[discordMediaWarningKind]int64
+	// MembershipUnavailable records that the guild's member count could not be
+	// read, so every participant-limited attachment stayed excluded.
+	MembershipUnavailable bool
+	Warnings              map[discordMediaWarningKind]int64
 }
 
 type discordMediaWarningKind string
@@ -100,7 +105,11 @@ func runBackfillDiscordMedia(
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Messages processed: %d\n", summary.MessagesProcessed)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Downloaded: %d\n", summary.Downloaded)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Pending: %d\n", summary.Pending)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Skipped: %d\n", summary.Skipped)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Unrecoverable: %d\n", summary.Unrecoverable)
+		if summary.MembershipUnavailable {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  Guild membership unavailable: participant-limited media stayed skipped")
+		}
 		writeDiscordMediaWarnings(cmd.OutOrStdout(), summary.Warnings)
 		return backfillErr
 	})
@@ -125,13 +134,32 @@ func backfillDiscordSourceMedia(
 		return summary, err
 	}
 	provider := deps.providerConfig()
-	archiver, err := discord.NewMediaArchiver(st, client, deps.attachmentsDir(), provider.MaxMediaBytes)
+	policy := provider.MediaPolicy(source.Identifier)
+	archiver, err := discord.NewMediaArchiver(st, client, deps.attachmentsDir(), policy.MaxBytes)
 	if err != nil {
 		return summary, fmt.Errorf("configure Discord media archiver: %w", err)
 	}
+	archiver.SetPolicy(policy, attachmentpolicy.Conversation{Type: "channel"})
+	// Archived channel membership undercounts an ordinary Discord channel: only
+	// the message authors seen so far are persisted. Evaluating the guild's own
+	// count alongside it keeps the participant threshold from admitting on
+	// backfill exactly the media sync excluded.
+	guildParticipants, membershipErr := discord.GuildParticipantFloor(ctx, client, source.Identifier, policy)
+	if membershipErr != nil {
+		summary.MembershipUnavailable = true
+	}
+	// Archive the lookup outcome before selecting messages: purge must see an
+	// unreadable roster as unresolved rather than trust a stale count, and a
+	// readable one has to reconcile the archived floor before retry selection
+	// decides which skips the current membership releases.
+	if err := discord.NewImporter(st, client).ArchiveGuildMembership(
+		source.ID, guildParticipants, membershipErr,
+	); err != nil {
+		return summary, fmt.Errorf("archive Discord guild membership: %w", err)
+	}
 	var messages []store.DiscordAttachmentMessage
 	if onlyIncomplete {
-		messages, err = st.ListDiscordPendingAttachmentMessages(source.ID)
+		messages, err = st.ListDiscordRetryableAttachmentMessages(source.ID, policy)
 	} else {
 		messages, err = st.ListDiscordAttachmentMessages(source.ID)
 	}
@@ -146,6 +174,10 @@ func backfillDiscordSourceMedia(
 			contextErrorRecorded = true
 			break
 		}
+		archiver.SetPolicy(policy, attachmentpolicy.Conversation{
+			Type:             message.ConversationType,
+			ParticipantCount: max(message.ParticipantCount, guildParticipants),
+		})
 		result, backfillErr := archiver.BackfillMessage(
 			ctx, message.MessageID, message.ChatID, message.SourceMessageID,
 		)
@@ -160,6 +192,8 @@ func backfillDiscordSourceMedia(
 				summary.Downloaded++
 			case discord.MediaPending:
 				summary.Pending++
+			case discord.MediaSkipped:
+				summary.Skipped++
 			case discord.MediaUnrecoverable:
 				summary.Unrecoverable++
 			}

--- a/cmd/msgvault/cmd/backfill_discord_media_test.go
+++ b/cmd/msgvault/cmd/backfill_discord_media_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/discord"
 	"go.kenn.io/msgvault/internal/store"
@@ -31,7 +32,32 @@ func (c *cancelAfterFirstErrContext) Err() error {
 	return c.Context.Err()
 }
 
-func TestBackfillDiscordMediaReportsPendingWithoutSignedURL(t *testing.T) {
+func newDiscordPendingMediaMessage(t *testing.T, st *store.Store, sourceID int64) int64 {
+	t.Helper()
+	conversationID, err := st.EnsureConversationWithType(sourceID, testDiscordChannel, "channel", "general")
+	require.NoError(t, err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		SourceID: sourceID, ConversationID: conversationID,
+		SourceMessageID: "400000000000000001", MessageType: "discord",
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{{
+		Filename: "file.bin", Size: 5, StoragePath: "discord:pending:500000000000000001",
+		SourceAttachmentID: "discord:500000000000000001", MediaType: "document",
+		State: attachmentpolicy.StatePending,
+	}}))
+	return messageID
+}
+
+func discordAttachmentOutcome(t *testing.T, st *store.Store, messageID int64) (state, reason string) {
+	t.Helper()
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments WHERE message_id = ?
+	`), messageID).Scan(&state, &reason))
+	return state, reason
+}
+
+func TestBackfillDiscordMediaReportsSizePolicySkipWithoutSignedURL(t *testing.T) {
 	req := require.New(t)
 	st := newDiscordCLIStore(t)
 	tokensDir := t.TempDir()
@@ -80,8 +106,8 @@ func TestBackfillDiscordMediaReportsPendingWithoutSignedURL(t *testing.T) {
 		args          []string
 		wantProcessed string
 	}{
-		{name: "all attachment messages", args: []string{"Alpha Guild"}, wantProcessed: "Messages processed: 2"},
 		{name: "only incomplete", args: []string{"Alpha Guild", "--only-incomplete"}, wantProcessed: "Messages processed: 1"},
+		{name: "all attachment messages", args: []string{"Alpha Guild"}, wantProcessed: "Messages processed: 2"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
@@ -93,7 +119,7 @@ func TestBackfillDiscordMediaReportsPendingWithoutSignedURL(t *testing.T) {
 			cmd.SetErr(&output)
 			require.NoError(cmd.Execute())
 			assert.Contains(output.String(), tt.wantProcessed)
-			assert.Contains(output.String(), "Pending: 1")
+			assert.Contains(output.String(), "Skipped: 1")
 			assert.Contains(output.String(), "Attachment warnings: 1")
 			assert.Contains(output.String(), "Size cap exceeded: 1")
 			assert.NotContains(output.String(), "hm=secret-signature")
@@ -156,6 +182,177 @@ func TestBackfillDiscordMediaReportsSanitizedRefreshAndUnrecoverableWarnings(t *
 			assert.NotContains(output.String(), testDiscordBotToken)
 		})
 	}
+}
+
+func TestBackfillDiscordMediaUsesArchivedParticipantCount(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := newDiscordCLIStore(t)
+	tokensDir := t.TempDir()
+	require.NoError(discord.NewTokenManager(tokensDir).Save(discord.NewTokenRecord(testDiscordBotID, "archive-bot", testDiscordBotToken, "")))
+	source, err := st.GetOrCreateSource("discord", testDiscordGuildA)
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(source.ID, testDiscordChannel, "channel", "general")
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE conversations SET participant_count = ? WHERE id = ?`), 20, conversationID)
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		SourceID: source.ID, ConversationID: conversationID,
+		SourceMessageID: "400000000000000001", MessageType: "discord",
+	})
+	require.NoError(err)
+	require.NoError(st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{{
+		Filename: "file.bin", Size: 5, StoragePath: "discord:pending:500000000000000001",
+		SourceAttachmentID: "discord:500000000000000001", MediaType: "document",
+		State: attachmentpolicy.StatePending,
+	}}))
+	api := newDiscordCLIServer(t)
+	api.messages[testDiscordChannel] = []discord.Message{{
+		ID: "400000000000000001", ChannelID: testDiscordChannel,
+		Attachments: []discord.Attachment{{ID: "500000000000000001", Filename: "file.bin", Size: 5}},
+	}}
+	deps := testDiscordCommandDeps(t, st, tokensDir, api.server.URL)
+	deps.providerConfig = func() config.DiscordConfig {
+		return config.DiscordConfig{MediaMaxParticipants: 8}
+	}
+
+	summary, err := backfillDiscordSourceMedia(t.Context(), st, source, deps, false)
+	require.NoError(err)
+	assert.Equal(int64(1), summary.Skipped)
+	var state, reason string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments WHERE message_id = ?
+	`), messageID).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+}
+
+func TestBackfillDiscordMediaUsesGuildMemberCountWhenArchivedCountIsUnderIt(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := newDiscordCLIStore(t)
+	tokensDir := t.TempDir()
+	require.NoError(discord.NewTokenManager(tokensDir).Save(discord.NewTokenRecord(testDiscordBotID, "archive-bot", testDiscordBotToken, "")))
+	source, err := st.GetOrCreateSource("discord", testDiscordGuildA)
+	require.NoError(err)
+	messageID := newDiscordPendingMediaMessage(t, st, source.ID)
+	api := newDiscordCLIServer(t)
+	// An ordinary guild channel archives no membership of its own, so only the
+	// guild's own count can exclude its media.
+	api.guildMemberCount = 12
+	api.messages[testDiscordChannel] = []discord.Message{{
+		ID: "400000000000000001", ChannelID: testDiscordChannel,
+		Attachments: []discord.Attachment{{ID: "500000000000000001", Filename: "file.bin", Size: 5}},
+	}}
+	deps := testDiscordCommandDeps(t, st, tokensDir, api.server.URL)
+	deps.providerConfig = func() config.DiscordConfig {
+		return config.DiscordConfig{MediaMaxParticipants: 8}
+	}
+
+	summary, err := backfillDiscordSourceMedia(t.Context(), st, source, deps, false)
+	require.NoError(err)
+	assert.Equal(int64(1), summary.Skipped)
+	assert.False(summary.MembershipUnavailable)
+	state, reason := discordAttachmentOutcome(t, st, messageID)
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+}
+
+func TestBackfillDiscordMediaFailsClosedWhenGuildMembershipIsUnreadable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := newDiscordCLIStore(t)
+	tokensDir := t.TempDir()
+	require.NoError(discord.NewTokenManager(tokensDir).Save(discord.NewTokenRecord(testDiscordBotID, "archive-bot", testDiscordBotToken, "")))
+	source, err := st.GetOrCreateSource("discord", testDiscordGuildA)
+	require.NoError(err)
+	messageID := newDiscordPendingMediaMessage(t, st, source.ID)
+	api := newDiscordCLIServer(t)
+	api.fail["/guilds/"+testDiscordGuildA] = http.StatusForbidden
+	api.failCode["/guilds/"+testDiscordGuildA] = 50001
+	api.messages[testDiscordChannel] = []discord.Message{{
+		ID: "400000000000000001", ChannelID: testDiscordChannel,
+		Attachments: []discord.Attachment{{ID: "500000000000000001", Filename: "file.bin", Size: 5}},
+	}}
+	deps := testDiscordCommandDeps(t, st, tokensDir, api.server.URL)
+	deps.providerConfig = func() config.DiscordConfig {
+		return config.DiscordConfig{MediaMaxParticipants: 8}
+	}
+	cmd := newBackfillDiscordMediaLocalCmd(deps)
+	var output bytes.Buffer
+	cmd.SetArgs([]string{testDiscordGuildA})
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	require.NoError(cmd.Execute())
+	assert.Contains(output.String(), "Skipped: 1")
+	assert.Contains(output.String(), "Guild membership unavailable")
+	state, reason := discordAttachmentOutcome(t, st, messageID)
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+}
+
+// TestBackfillDiscordMediaArchivesGuildMembershipOutcome pins that the
+// backfill's own guild lookup lands in the archive: an unreadable lookup marks
+// the guild's rosters unresolved so purge retains rather than trusting a stale
+// count, and a readable one clears the marker and reconciles the floor before
+// the retry selection runs, so a guild that shrank releases what it excluded.
+func TestBackfillDiscordMediaArchivesGuildMembershipOutcome(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := newDiscordCLIStore(t)
+	tokensDir := t.TempDir()
+	require.NoError(discord.NewTokenManager(tokensDir).Save(discord.NewTokenRecord(testDiscordBotID, "archive-bot", testDiscordBotToken, "")))
+	source, err := st.GetOrCreateSource("discord", testDiscordGuildA)
+	require.NoError(err)
+	messageID := newDiscordPendingMediaMessage(t, st, source.ID)
+	conversationID, err := st.EnsureConversationWithType(source.ID, testDiscordChannel, "channel", "general")
+	require.NoError(err)
+	// A floor archived while the guild was large.
+	require.NoError(st.SetConversationMetadata(conversationID, sql.NullString{
+		String: `{"guild_id":"` + testDiscordGuildA + `","discord_channel_type":0,"member_count":40}`, Valid: true,
+	}))
+	api := newDiscordCLIServer(t)
+	api.fail["/guilds/"+testDiscordGuildA] = http.StatusForbidden
+	api.failCode["/guilds/"+testDiscordGuildA] = 50001
+	api.messages[testDiscordChannel] = []discord.Message{{
+		ID: "400000000000000001", ChannelID: testDiscordChannel,
+		Attachments: []discord.Attachment{{ID: "500000000000000001", Filename: "file.bin", Size: 5}},
+	}}
+	deps := testDiscordCommandDeps(t, st, tokensDir, api.server.URL)
+	deps.providerConfig = func() config.DiscordConfig {
+		return config.DiscordConfig{MediaMaxParticipants: 8}
+	}
+	metadataOf := func() string {
+		metadata, err := st.GetConversationMetadata(conversationID)
+		require.NoError(err)
+		return metadata.String
+	}
+
+	summary, err := backfillDiscordSourceMedia(t.Context(), st, source, deps, false)
+	require.NoError(err)
+	assert.True(summary.MembershipUnavailable)
+	assert.Equal(int64(1), summary.Skipped)
+	state, reason := discordAttachmentOutcome(t, st, messageID)
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+	assert.JSONEq(`{"guild_id":"`+testDiscordGuildA+`","discord_channel_type":0,"member_count":40,"member_count_unknown":true}`,
+		metadataOf(), "an unreadable lookup marks the roster unresolved and keeps the count for reference")
+	candidates, err := st.ListAttachmentPolicyCandidates(t.Context())
+	require.NoError(err)
+	assert.Empty(candidates, "a skipped marker holds no stored media")
+
+	delete(api.fail, "/guilds/"+testDiscordGuildA)
+	delete(api.failCode, "/guilds/"+testDiscordGuildA)
+	api.guildMemberCount = 5
+	summary, err = backfillDiscordSourceMedia(t.Context(), st, source, deps, true)
+	require.NoError(err)
+	assert.False(summary.MembershipUnavailable)
+	assert.Equal(int64(1), summary.MessagesProcessed,
+		"the readable lookup is archived before retry selection, so the shrunken guild's skip is revisited")
+	assert.Zero(summary.Skipped)
+	assert.JSONEq(`{"guild_id":"`+testDiscordGuildA+`","discord_channel_type":0,"member_count":5}`,
+		metadataOf(), "a readable lookup clears the marker and lowers the archived floor")
 }
 
 func TestBackfillDiscordMediaReturnsCancellationAfterFinalMessage(t *testing.T) {

--- a/cmd/msgvault/cmd/backfill_slack_media.go
+++ b/cmd/msgvault/cmd/backfill_slack_media.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -13,12 +14,12 @@ func newBackfillSlackMediaCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backfill-slack-media [team-id]",
 		Short: "Retry pending Slack file downloads",
-		Long: `Retry pending Slack file downloads.
+		Long: `Retry eligible Slack file downloads.
 
-Files that failed to download during sync (outages, size caps since raised)
-leave pending markers. This command re-reads the archived message JSON and
-retries the downloads. Idempotent: already-downloaded files are never
-re-fetched.
+This command retries unfinished downloads and policy exclusions that are now
+allowed, such as files whose configured size cap was raised. It re-reads the
+archived message JSON and retries eligible downloads. Already-downloaded files
+are never re-fetched.
 
 Examples:
   msgvault backfill-slack-media
@@ -69,8 +70,7 @@ Examples:
 					runErrors = append(runErrors, fmt.Errorf("%s: %w", teamID, berr))
 					continue
 				}
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s done in %s: %d messages, %d downloaded, %d still pending\n",
-					teamID, sum.Duration.Round(time.Second), sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending)
+				writeSlackMediaBackfillSummary(cmd.OutOrStdout(), teamID, sum)
 			}
 			return slackMediaBackfillExit(
 				ctx.Err(),
@@ -80,6 +80,12 @@ Examples:
 		},
 	}
 	return cmd
+}
+
+func writeSlackMediaBackfillSummary(out io.Writer, teamID string, sum *slack.ImportSummary) {
+	_, _ = fmt.Fprintf(out, "%s done in %s: %d messages, %d downloaded, %d still pending, %d skipped by policy\n",
+		teamID, sum.Duration.Round(time.Second), sum.MessagesProcessed, sum.AttachmentsDownloaded,
+		sum.AttachmentsPending, sum.AttachmentsSkipped)
 }
 
 func slackMediaBackfillExit(ctxErr error, runErrors []error, cacheErr error) error {

--- a/cmd/msgvault/cmd/backfill_teams_media.go
+++ b/cmd/msgvault/cmd/backfill_teams_media.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -94,6 +95,7 @@ Examples:
 		sum, err := imp.BackfillInlineMedia(ctx, teams.ImportOptions{
 			Email:          email,
 			AttachmentsDir: cfg.AttachmentsDir(),
+			MediaPolicy:    cfg.Teams.MediaPolicy(email),
 			OnlyIncomplete: backfillTeamsMediaOnlyIncomplete,
 			Progress:       func(s string) { fmt.Println(s) },
 		})
@@ -105,15 +107,20 @@ Examples:
 			return fmt.Errorf("teams inline-media backfill failed: %w", err)
 		}
 
-		_, _ = fmt.Fprintln(cmd.OutOrStdout())
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Teams inline-media backfill complete!")
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Duration:            %s\n", sum.Duration.Round(time.Second))
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Messages processed:  %d\n", sum.MessagesProcessed)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Inline images copied:%d\n", sum.InlineImagesCopied)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Errors:              %d\n", sum.Errors)
+		writeTeamsMediaBackfillSummary(cmd.OutOrStdout(), sum)
 
 		return rebuildCacheAfterWrite(dbPath)
 	},
+}
+
+func writeTeamsMediaBackfillSummary(out io.Writer, sum *teams.ImportSummary) {
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "Teams inline-media backfill complete!")
+	_, _ = fmt.Fprintf(out, "  Duration:             %s\n", sum.Duration.Round(time.Second))
+	_, _ = fmt.Fprintf(out, "  Messages processed:   %d\n", sum.MessagesProcessed)
+	_, _ = fmt.Fprintf(out, "  Inline images copied: %d\n", sum.InlineImagesCopied)
+	_, _ = fmt.Fprintf(out, "  Skipped by policy:    %d\n", sum.InlineImagesSkipped)
+	_, _ = fmt.Fprintf(out, "  Errors:               %d\n", sum.Errors)
 }
 
 func init() {

--- a/cmd/msgvault/cmd/discord_common.go
+++ b/cmd/msgvault/cmd/discord_common.go
@@ -118,11 +118,13 @@ func newDiscordImporterForSource(
 
 func discordImportOptions(source *store.Source, deps discordCommandDeps, full bool, after time.Time, progress func(string)) discord.ImportOptions {
 	provider := deps.providerConfig()
+	policy := provider.MediaPolicy(source.Identifier)
 	return discord.ImportOptions{
 		GuildID:          source.Identifier,
 		GuildConfig:      provider.Guilds[source.Identifier],
 		AttachmentsDir:   deps.attachmentsDir(),
-		MaxMediaBytes:    provider.MaxMediaBytes,
+		MaxMediaBytes:    policy.MaxBytes,
+		MediaPolicy:      policy,
 		EditRescanWindow: provider.EditRescanWindow,
 		After:            after,
 		Full:             full,

--- a/cmd/msgvault/cmd/discord_test_helpers_test.go
+++ b/cmd/msgvault/cmd/discord_test_helpers_test.go
@@ -28,21 +28,25 @@ type discordCLIServer struct {
 	testing *testing.T
 	server  *httptest.Server
 
-	mu       sync.Mutex
-	requests []string
-	guilds   []discord.Guild
-	fail     map[string]int
-	failCode map[string]int
-	messages map[string][]discord.Message
+	mu               sync.Mutex
+	requests         []string
+	guilds           []discord.Guild
+	guildMemberCount int
+	fail             map[string]int
+	failCode         map[string]int
+	messages         map[string][]discord.Message
 }
 
 func newDiscordCLIServer(t *testing.T, guilds ...discord.Guild) *discordCLIServer {
 	t.Helper()
 	fake := &discordCLIServer{
-		testing:  t,
-		guilds:   guilds,
-		fail:     make(map[string]int),
-		failCode: make(map[string]int),
+		testing: t,
+		guilds:  guilds,
+		// A guild holding only the archiving bot keeps the guild-wide floor out
+		// of the way of tests that exercise archived membership.
+		guildMemberCount: 1,
+		fail:             make(map[string]int),
+		failCode:         make(map[string]int),
 		messages: map[string][]discord.Message{
 			testDiscordChannel: {},
 		},
@@ -78,9 +82,9 @@ func (f *discordCLIServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/users/@me/guilds":
 		writeDiscordCLIJSON(f.testing, w, f.guilds)
 	case "/guilds/" + testDiscordGuildA:
-		writeDiscordCLIJSON(f.testing, w, discord.Guild{ID: testDiscordGuildA, Name: "Alpha Guild"})
+		writeDiscordCLIJSON(f.testing, w, f.guildDetail(r, testDiscordGuildA, "Alpha Guild"))
 	case "/guilds/" + testDiscordGuildB:
-		writeDiscordCLIJSON(f.testing, w, discord.Guild{ID: testDiscordGuildB, Name: "Beta Guild"})
+		writeDiscordCLIJSON(f.testing, w, f.guildDetail(r, testDiscordGuildB, "Beta Guild"))
 	case "/guilds/" + testDiscordGuildA + "/channels", "/guilds/" + testDiscordGuildB + "/channels":
 		writeDiscordCLIJSON(f.testing, w, []discord.Channel{{ID: testDiscordChannel, Type: 0, Name: "general"}})
 	case "/guilds/" + testDiscordGuildA + "/threads/active", "/guilds/" + testDiscordGuildB + "/threads/active":
@@ -100,6 +104,18 @@ func (f *discordCLIServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.NotFound(w, r)
 	}
+}
+
+// guildDetail mirrors Discord's guild endpoint, which reports an approximate
+// member count only for requests that ask for counts.
+func (f *discordCLIServer) guildDetail(request *http.Request, guildID, name string) discord.Guild {
+	guild := discord.Guild{ID: guildID, Name: name}
+	if request.URL.Query().Get("with_counts") == "true" {
+		f.mu.Lock()
+		guild.ApproximateMemberCount = f.guildMemberCount
+		f.mu.Unlock()
+	}
+	return guild
 }
 
 func filterDiscordCLIMessages(messages []discord.Message, request *http.Request) []discord.Message {

--- a/cmd/msgvault/cmd/media_summary_test.go
+++ b/cmd/msgvault/cmd/media_summary_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"go.kenn.io/msgvault/internal/beeper"
+	"go.kenn.io/msgvault/internal/discord"
+	"go.kenn.io/msgvault/internal/slack"
+	"go.kenn.io/msgvault/internal/teams"
+)
+
+func TestProviderSyncSummariesReportPolicySkips(t *testing.T) {
+	tests := []struct {
+		name  string
+		print func(*cobra.Command)
+	}{
+		{
+			name: "beeper",
+			print: func(cmd *cobra.Command) {
+				printBeeperSummary(cmd, "account", &beeper.ImportSummary{AttachmentsSkipped: 2})
+			},
+		},
+		{
+			name: "slack",
+			print: func(cmd *cobra.Command) {
+				printSlackSummary(cmd, "workspace", &slack.ImportSummary{AttachmentsSkipped: 2})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&output)
+			tt.print(cmd)
+			assert.Contains(t, output.String(), "2 media skipped by policy")
+		})
+	}
+}
+
+func TestRemainingProviderSummariesReportPolicySkips(t *testing.T) {
+	tests := []struct {
+		name  string
+		print func(*bytes.Buffer)
+	}{
+		{
+			name: "discord sync",
+			print: func(out *bytes.Buffer) {
+				writeDiscordSyncSummary(out, "guild", &discord.ImportSummary{MediaSkipped: 2})
+			},
+		},
+		{
+			name: "teams sync",
+			print: func(out *bytes.Buffer) {
+				writeTeamsSyncSummary(out, &teams.ImportSummary{InlineImagesSkipped: 2})
+			},
+		},
+		{
+			name: "beeper backfill",
+			print: func(out *bytes.Buffer) {
+				writeBeeperMediaBackfillSummary(out, "account", &beeper.ImportSummary{AttachmentsSkipped: 2})
+			},
+		},
+		{
+			name: "slack backfill",
+			print: func(out *bytes.Buffer) {
+				writeSlackMediaBackfillSummary(out, "workspace", &slack.ImportSummary{AttachmentsSkipped: 2})
+			},
+		},
+		{
+			name: "teams backfill",
+			print: func(out *bytes.Buffer) {
+				writeTeamsMediaBackfillSummary(out, &teams.ImportSummary{InlineImagesSkipped: 2})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			tt.print(&output)
+			assert.Contains(t, output.String(), "2")
+			assert.Contains(t, strings.ToLower(output.String()), "skipped by policy")
+		})
+	}
+}

--- a/cmd/msgvault/cmd/purge_excluded_media.go
+++ b/cmd/msgvault/cmd/purge_excluded_media.go
@@ -1,0 +1,354 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	purgeExcludedMediaCommandName   = "purge-excluded-media"
+	purgeExcludedMediaConfirmedFlag = "confirmed"
+	purgeExcludedMediaYesFlag       = "--yes"
+)
+
+type purgeExcludedMediaDeps struct {
+	openStore  func() (*store.Store, func(), error)
+	config     func() *config.Config
+	removeFile func(string) error
+}
+
+func defaultPurgeExcludedMediaDeps() purgeExcludedMediaDeps {
+	return purgeExcludedMediaDeps{
+		openStore:  openWritableStoreAndInitForIngest,
+		config:     func() *config.Config { return cfg },
+		removeFile: os.Remove,
+	}
+}
+
+func newPurgeExcludedMediaCmd() *cobra.Command {
+	cmd := newPurgeExcludedMediaLocalCmd(defaultPurgeExcludedMediaDeps())
+	runLocal := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if isDaemonCLISubprocess() {
+			return runLocal(cmd, args)
+		}
+		dryRun, err := cmd.Flags().GetBool("dry-run")
+		if err != nil {
+			return fmt.Errorf("read --dry-run flag: %w", err)
+		}
+		yes, err := cmd.Flags().GetBool("yes")
+		if err != nil {
+			return fmt.Errorf("read --yes flag: %w", err)
+		}
+		if !dryRun && !yes {
+			confirmed, err := confirmExcludedMediaPurge(cmd.InOrStdin(), cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+			if err := cmd.Flags().Set(purgeExcludedMediaConfirmedFlag, "true"); err != nil {
+				return fmt.Errorf("record purge confirmation: %w", err)
+			}
+		}
+		return runDaemonCLICommandHTTPFromCobra(cmd, args)
+	}
+	return cmd
+}
+
+func newPurgeExcludedMediaLocalCmd(deps purgeExcludedMediaDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   purgeExcludedMediaCommandName,
+		Short: "Reclaim locally stored media excluded by current policy",
+		Long: `Replace locally stored provider attachment occurrences that the current
+media policy excludes with typed skip markers. Shared blobs remain live while
+any retained occurrence references them. Packed dead bytes are reclaimed by
+the daemon's normal attachment repack maintenance.
+
+Run with --dry-run to preview occurrence, blob, and logical byte counts.
+Applying the purge requires an interactive confirmation or --yes. This command
+never deletes media from a provider.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return fmt.Errorf("read --dry-run flag: %w", err)
+			}
+			yes, err := cmd.Flags().GetBool("yes")
+			if err != nil {
+				return fmt.Errorf("read --yes flag: %w", err)
+			}
+			confirmed, err := cmd.Flags().GetBool(purgeExcludedMediaConfirmedFlag)
+			if err != nil {
+				return fmt.Errorf("read --%s flag: %w", purgeExcludedMediaConfirmedFlag, err)
+			}
+			return runPurgeExcludedMedia(cmd, deps, dryRun, yes || confirmed)
+		},
+	}
+	cmd.Flags().Bool("dry-run", false, "preview exclusions without changing the archive")
+	cmd.Flags().BoolP("yes", "y", false, "apply without an interactive confirmation")
+	cmd.Flags().Bool(purgeExcludedMediaConfirmedFlag, false, "Internal: confirmation was accepted by the frontend CLI")
+	if err := cmd.Flags().MarkHidden(purgeExcludedMediaConfirmedFlag); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+func confirmExcludedMediaPurge(in io.Reader, out io.Writer) (bool, error) {
+	_, _ = fmt.Fprint(out, "Purge locally stored media excluded by the current config? [y/N] ")
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("read purge confirmation: %w", err)
+		}
+		return false, errors.New("no confirmation input (stdin closed); use --dry-run or --yes")
+	}
+	if !isYesAnswer(strings.TrimSpace(strings.ToLower(scanner.Text()))) {
+		_, _ = fmt.Fprintln(out, "Aborted.")
+		return false, nil
+	}
+	return true, nil
+}
+
+type excludedMediaPlan struct {
+	Exclusions   []store.AttachmentExclusion
+	Paths        map[string]string
+	LogicalBytes int64
+	BlobCount    int
+	ByReason     map[attachmentpolicy.SkipReason]int
+	// UnresolvedRosters counts occurrences left in place because a participant
+	// limit is configured but no authoritative roster is archived for their
+	// conversation, so the limit could not be evaluated.
+	UnresolvedRosters int
+}
+
+func buildExcludedMediaPlan(candidates []store.AttachmentPolicyCandidate, cfg *config.Config) excludedMediaPlan {
+	plan := excludedMediaPlan{
+		Paths:    make(map[string]string),
+		ByReason: make(map[attachmentpolicy.SkipReason]int),
+	}
+	seenBlobs := make(map[string]struct{})
+	for _, candidate := range candidates {
+		policy, ok := mediaPolicyForSource(cfg, candidate.SourceType, candidate.SourceIdentifier)
+		if !ok {
+			continue
+		}
+		unresolvedLimit := candidate.RosterUnresolved && policy.MaxParticipants > 0
+		if unresolvedLimit {
+			// No authoritative roster is archived, so the accumulated participant
+			// count is not one to delete on. Excluding deletes blobs, so retain
+			// rather than fail closed; scope, account, and size rules still apply.
+			policy.MaxParticipants = 0
+		}
+		reason := policy.Evaluate(attachmentpolicy.Conversation{
+			Type: candidate.ConversationType, ParticipantCount: candidate.ParticipantCount,
+		}, candidate.Size)
+		if reason == "" {
+			if unresolvedLimit {
+				plan.UnresolvedRosters++
+			}
+			continue
+		}
+		plan.Exclusions = append(plan.Exclusions, store.AttachmentExclusion{
+			AttachmentID: candidate.AttachmentID, Reason: reason,
+			SourceAttachmentID: candidate.SourceAttachmentID,
+		})
+		plan.LogicalBytes += candidate.Size
+		plan.ByReason[reason]++
+		addExcludedMediaBlob(&plan, seenBlobs, candidate.StoragePath, candidate.ContentHash)
+		addExcludedMediaBlob(&plan, seenBlobs, candidate.ThumbnailPath, candidate.ThumbnailHash)
+	}
+	plan.BlobCount = len(seenBlobs)
+	return plan
+}
+
+func addExcludedMediaBlob(plan *excludedMediaPlan, seen map[string]struct{}, storagePath, hash string) {
+	if storagePath == "" || hash == "" {
+		return
+	}
+	plan.Paths[storagePath] = hash
+	seen[hash] = struct{}{}
+}
+
+func mediaPolicyForSource(cfg *config.Config, sourceType, identifier string) (attachmentpolicy.Policy, bool) {
+	if cfg == nil {
+		return attachmentpolicy.Policy{}, false
+	}
+	switch sourceType {
+	case sourceTypeBeeper:
+		return cfg.Beeper.MediaPolicy(identifier), true
+	case sourceTypeSlack:
+		teamID, _, ok := splitSlackIdentifier(identifier)
+		if !ok {
+			return attachmentpolicy.Policy{}, false
+		}
+		return cfg.Slack.MediaPolicy(teamID), true
+	case sourceTypeDiscord:
+		return cfg.Discord.MediaPolicy(identifier), true
+	case sourceTypeTeams:
+		return cfg.Teams.MediaPolicy(identifier), true
+	default:
+		return attachmentpolicy.Policy{}, false
+	}
+}
+
+func runPurgeExcludedMedia(cmd *cobra.Command, deps purgeExcludedMediaDeps, dryRun, confirmed bool) error {
+	if deps.openStore == nil || deps.config == nil {
+		return errors.New("purge-excluded-media dependencies are unavailable")
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	candidates, err := st.ListAttachmentPolicyCandidates(cmd.Context())
+	if err != nil {
+		return err
+	}
+	currentConfig := deps.config()
+	plan := buildExcludedMediaPlan(candidates, currentConfig)
+	if dryRun {
+		writeExcludedMediaPlan(cmd.OutOrStdout(), plan, true)
+		return nil
+	}
+	if !confirmed {
+		accepted, err := confirmExcludedMediaPurge(cmd.InOrStdin(), cmd.OutOrStdout())
+		if err != nil {
+			return err
+		}
+		if !accepted {
+			return nil
+		}
+	}
+	if len(plan.Exclusions) > 0 {
+		if err := st.ExcludeAttachmentOccurrences(cmd.Context(), plan.Exclusions); err != nil {
+			return err
+		}
+	}
+	writeExcludedMediaPlan(cmd.OutOrStdout(), plan, false)
+	removeFile := deps.removeFile
+	if removeFile == nil {
+		removeFile = os.Remove
+	}
+	removed, cleanupErr := sweepUnreferencedLooseMedia(
+		cmd.Context(), st, currentConfig.AttachmentsDir(), removeFile,
+	)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"Removed %d unreferenced loose blob file(s); packed dead bytes are eligible for attachment repack.\n", removed)
+	return cleanupErr
+}
+
+func writeExcludedMediaPlan(out io.Writer, plan excludedMediaPlan, dryRun bool) {
+	verb := "Excluded"
+	if dryRun {
+		verb = "Would exclude"
+	}
+	_, _ = fmt.Fprintf(out, "%s %d stored attachment occurrence(s), %s logical bytes across %d unique blob(s).\n",
+		verb, len(plan.Exclusions), formatSize(plan.LogicalBytes), plan.BlobCount)
+	reasons := make([]string, 0, len(plan.ByReason))
+	for reason := range plan.ByReason {
+		reasons = append(reasons, string(reason))
+	}
+	sort.Strings(reasons)
+	for _, reason := range reasons {
+		_, _ = fmt.Fprintf(out, "  %s: %d\n", reason, plan.ByReason[attachmentpolicy.SkipReason(reason)])
+	}
+	if plan.UnresolvedRosters > 0 {
+		_, _ = fmt.Fprintf(out, "%d stored attachment occurrence(s) left in place: conversation membership is not archived, "+
+			"so the participant limit could not be evaluated. Run a sync to record rosters, then purge again.\n",
+			plan.UnresolvedRosters)
+	}
+	if dryRun && len(plan.Exclusions) > 0 {
+		_, _ = fmt.Fprintln(out, "No changes made. Re-run with --yes to apply this local-only purge.")
+	}
+}
+
+func sweepUnreferencedLooseMedia(
+	ctx context.Context, st *store.Store, attachmentsDir string, removeFile func(string) error,
+) (int, error) {
+	topEntries, err := os.ReadDir(attachmentsDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("scan loose attachments: %w", err)
+	}
+	removed := 0
+	var cleanupErrors []error
+	for _, topEntry := range topEntries {
+		if err := ctx.Err(); err != nil {
+			return removed, errors.Join(append(cleanupErrors, err)...)
+		}
+		prefix := topEntry.Name()
+		if !topEntry.IsDir() || !isLowerHex(prefix, 2) {
+			continue
+		}
+		dirPath := filepath.Join(attachmentsDir, prefix)
+		blobEntries, err := os.ReadDir(dirPath)
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("scan attachment directory %s: %w", prefix, err))
+			continue
+		}
+		for _, blobEntry := range blobEntries {
+			if err := ctx.Err(); err != nil {
+				return removed, errors.Join(append(cleanupErrors, err)...)
+			}
+			hash := blobEntry.Name()
+			storagePath := prefix + "/" + hash
+			if !blobEntry.Type().IsRegular() || !isCanonicalAttachmentPath(storagePath, hash) {
+				continue
+			}
+			referenced, err := st.AttachmentBlobReferenced(ctx, hash, storagePath)
+			if err != nil {
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("check attachment %s: %w", storagePath, err))
+				continue
+			}
+			if referenced {
+				continue
+			}
+			err = removeFile(filepath.Join(dirPath, hash))
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("remove unreferenced attachment %s: %w", storagePath, err))
+				continue
+			}
+			if err == nil {
+				removed++
+			}
+		}
+	}
+	return removed, errors.Join(cleanupErrors...)
+}
+
+func isCanonicalAttachmentPath(storagePath, hash string) bool {
+	if !isLowerHex(hash, 64) || storagePath != hash[:2]+"/"+hash {
+		return false
+	}
+	decoded, err := hex.DecodeString(hash)
+	return err == nil && len(decoded) == 32
+}
+
+func isLowerHex(value string, length int) bool {
+	if len(value) != length || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func init() {
+	rootCmd.AddCommand(newPurgeExcludedMediaCmd())
+}

--- a/cmd/msgvault/cmd/purge_excluded_media_test.go
+++ b/cmd/msgvault/cmd/purge_excluded_media_test.go
@@ -1,0 +1,303 @@
+package cmd
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type purgeMediaFixture struct {
+	store       *store.Store
+	config      *config.Config
+	excludedID  int64
+	retainedID  int64
+	contentHash string
+	contentPath string
+	fullPath    string
+}
+
+func newPurgeMediaFixture(t *testing.T) purgeMediaFixture {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	dataDir := t.TempDir()
+	cfg := &config.Config{
+		Data:   config.DataConfig{DataDir: dataDir},
+		Beeper: config.BeeperConfig{MediaScope: string(attachmentpolicy.ScopeDirect)},
+	}
+	source, err := st.GetOrCreateSource(sourceTypeBeeper, "signal")
+	require.NoError(t, err)
+	newMessage := func(sourceMessageID, conversationType string, participants int) int64 {
+		conversationID, err := st.EnsureConversationWithType(
+			source.ID, "conversation-"+sourceMessageID, conversationType, sourceMessageID,
+		)
+		require.NoError(t, err)
+		_, err = st.DB().Exec(st.Rebind(`UPDATE conversations SET participant_count = ? WHERE id = ?`), participants, conversationID)
+		require.NoError(t, err)
+		messageID, err := st.UpsertMessage(&store.Message{
+			SourceID: source.ID, ConversationID: conversationID,
+			SourceMessageID: sourceMessageID, MessageType: sourceTypeBeeper,
+		})
+		require.NoError(t, err)
+		return messageID
+	}
+	excludedMessageID := newMessage("excluded", "channel", 20)
+	retainedMessageID := newMessage("retained", "direct_chat", 2)
+	hash := strings.Repeat("ab", 32)
+	path := hash[:2] + "/" + hash
+	for messageID, sourceAttachmentID := range map[int64]string{
+		excludedMessageID: "beeper:excluded",
+		retainedMessageID: "beeper:retained",
+	} {
+		require.NoError(t, st.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{{
+			SourceAttachmentID: sourceAttachmentID,
+			StoragePath:        path,
+			ContentHash:        hash,
+			Size:               100,
+			State:              attachmentpolicy.StateStored,
+		}}))
+	}
+	fullPath := filepath.Join(cfg.AttachmentsDir(), filepath.FromSlash(path))
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	require.NoError(t, os.WriteFile(fullPath, []byte("shared attachment"), 0o600))
+
+	attachmentID := func(messageID int64) int64 {
+		var id int64
+		require.NoError(t, st.DB().QueryRow(st.Rebind(`SELECT id FROM attachments WHERE message_id = ?`), messageID).Scan(&id))
+		return id
+	}
+	return purgeMediaFixture{
+		store: st, config: cfg,
+		excludedID: attachmentID(excludedMessageID), retainedID: attachmentID(retainedMessageID),
+		contentHash: hash, contentPath: path, fullPath: fullPath,
+	}
+}
+
+func (f purgeMediaFixture) deps() purgeExcludedMediaDeps {
+	return purgeExcludedMediaDeps{
+		openStore:  func() (*store.Store, func(), error) { return f.store, func() {}, nil },
+		config:     func() *config.Config { return f.config },
+		removeFile: os.Remove,
+	}
+}
+
+func (f purgeMediaFixture) state(t *testing.T, attachmentID int64) attachmentpolicy.DownloadState {
+	t.Helper()
+	var state sql.NullString
+	require.NoError(t, f.store.DB().QueryRow(
+		f.store.Rebind(`SELECT attachment_state FROM attachments WHERE id = ?`), attachmentID,
+	).Scan(&state))
+	return attachmentpolicy.DownloadState(state.String)
+}
+
+func TestPurgeExcludedMediaDryRunAndApplyPreservesSharedBlob(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newPurgeMediaFixture(t)
+
+	dryRun := newPurgeExcludedMediaLocalCmd(f.deps())
+	var dryOutput bytes.Buffer
+	dryRun.SetOut(&dryOutput)
+	dryRun.SetErr(&dryOutput)
+	dryRun.SetArgs([]string{"--dry-run"})
+	require.NoError(dryRun.Execute())
+	assert.Contains(dryOutput.String(), "Would exclude 1 stored attachment occurrence(s)")
+	assert.Equal(attachmentpolicy.StateStored, f.state(t, f.excludedID))
+	assert.Equal(attachmentpolicy.StateStored, f.state(t, f.retainedID))
+	assert.FileExists(f.fullPath)
+
+	apply := newPurgeExcludedMediaLocalCmd(f.deps())
+	var applyOutput bytes.Buffer
+	apply.SetOut(&applyOutput)
+	apply.SetErr(&applyOutput)
+	apply.SetArgs([]string{"--yes"})
+	require.NoError(apply.Execute())
+	assert.Contains(applyOutput.String(), "Excluded 1 stored attachment occurrence(s)")
+	assert.Equal(attachmentpolicy.StateSkipped, f.state(t, f.excludedID))
+	assert.Equal(attachmentpolicy.StateStored, f.state(t, f.retainedID))
+	assert.FileExists(f.fullPath, "shared blob must remain while one stored occurrence references it")
+
+	f.config.Beeper.MediaScope = string(attachmentpolicy.ScopeNone)
+	removeLast := newPurgeExcludedMediaLocalCmd(f.deps())
+	removeLast.SetOut(&bytes.Buffer{})
+	removeLast.SetErr(&bytes.Buffer{})
+	removeLast.SetArgs([]string{"--yes"})
+	require.NoError(removeLast.Execute())
+	assert.Equal(attachmentpolicy.StateSkipped, f.state(t, f.retainedID))
+	assert.NoFileExists(f.fullPath)
+}
+
+func TestPurgeExcludedMediaPreservesBlobReferencedByThumbnail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newPurgeMediaFixture(t)
+	require.NoError(f.store.DB().QueryRow(f.store.Rebind(`
+		UPDATE attachments
+		SET content_hash = NULL, storage_path = ?, thumbnail_hash = ?, thumbnail_path = ?
+		WHERE id = ?
+		RETURNING id
+	`), "thumbnail-only", f.contentHash, f.contentPath, f.retainedID).Scan(&f.retainedID))
+
+	command := newPurgeExcludedMediaLocalCmd(f.deps())
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"--yes"})
+	require.NoError(command.Execute())
+
+	assert.Equal(attachmentpolicy.StateSkipped, f.state(t, f.excludedID))
+	assert.FileExists(f.fullPath, "thumbnail references keep the shared loose blob live")
+}
+
+func TestPurgeExcludedMediaRefusalLeavesArchiveUnchanged(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newPurgeMediaFixture(t)
+	command := newPurgeExcludedMediaLocalCmd(f.deps())
+	var output bytes.Buffer
+	command.SetIn(strings.NewReader("n\n"))
+	command.SetOut(&output)
+	command.SetErr(&output)
+	require.NoError(command.Execute())
+
+	assert.Contains(output.String(), "Aborted.")
+	assert.Equal(attachmentpolicy.StateStored, f.state(t, f.excludedID))
+	assert.FileExists(f.fullPath)
+}
+
+func TestPurgeExcludedMediaRetriesAndContinuesLooseBlobCleanup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newPurgeMediaFixture(t)
+	f.config.Beeper.MediaScope = string(attachmentpolicy.ScopeNone)
+	orphanHash := strings.Repeat("cd", 32)
+	orphanPath := orphanHash[:2] + "/" + orphanHash
+	orphanFullPath := filepath.Join(f.config.AttachmentsDir(), filepath.FromSlash(orphanPath))
+	require.NoError(os.MkdirAll(filepath.Dir(orphanFullPath), 0o755))
+	require.NoError(os.WriteFile(orphanFullPath, []byte("unreferenced attachment"), 0o600))
+
+	deps := f.deps()
+	deps.removeFile = func(path string) error {
+		if path == f.fullPath {
+			return errors.New("synthetic removal failure")
+		}
+		return os.Remove(path)
+	}
+	first := newPurgeExcludedMediaLocalCmd(deps)
+	first.SetOut(&bytes.Buffer{})
+	first.SetErr(&bytes.Buffer{})
+	first.SetArgs([]string{"--yes"})
+	require.Error(first.Execute())
+	assert.Equal(attachmentpolicy.StateSkipped, f.state(t, f.excludedID))
+	assert.Equal(attachmentpolicy.StateSkipped, f.state(t, f.retainedID))
+	assert.FileExists(f.fullPath)
+	assert.NoFileExists(orphanFullPath, "cleanup continues after an individual removal failure")
+
+	retry := newPurgeExcludedMediaLocalCmd(f.deps())
+	retry.SetOut(&bytes.Buffer{})
+	retry.SetErr(&bytes.Buffer{})
+	retry.SetArgs([]string{"--yes"})
+	require.NoError(retry.Execute())
+	assert.NoFileExists(f.fullPath, "a later run sweeps dead blobs even with no new exclusions")
+}
+
+// TestPurgeExcludedMediaRetainsUnresolvedRostersUnderParticipantLimit keeps
+// the purge from deleting media on the strength of a roster nobody has
+// archived — one a sync could not read, or one recorded before rosters were —
+// because the accumulated participant rows may exceed the limit even when the
+// current membership does not. Only the scope, account, and size rules apply
+// until a sync records the roster, and the dry run says what was left in place.
+func TestPurgeExcludedMediaRetainsUnresolvedRostersUnderParticipantLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	cfg := &config.Config{
+		Data:  config.DataConfig{DataDir: t.TempDir()},
+		Teams: config.TeamsConfig{MediaMaxParticipants: 4, MaxMediaMB: 1},
+	}
+	source, err := st.GetOrCreateSource(sourceTypeTeams, "me@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(source.ID, "team/channel", "channel", "Releases")
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE conversations SET participant_count = ? WHERE id = ?`), 20, conversationID)
+	require.NoError(err)
+	require.NoError(st.MarkConversationMemberCountUnknown(conversationID))
+	messageID, err := st.UpsertMessage(&store.Message{
+		SourceID: source.ID, ConversationID: conversationID,
+		SourceMessageID: "m1", MessageType: sourceTypeTeams,
+	})
+	require.NoError(err)
+	smallHash := strings.Repeat("ab", 32)
+	largeHash := strings.Repeat("cd", 32)
+	require.NoError(st.ReplaceMessageInlineAttachments(messageID, []store.AttachmentRef{
+		{
+			SourceAttachmentID: "teams:inline:small", StoragePath: smallHash[:2] + "/" + smallHash,
+			ContentHash: smallHash, Size: 100, State: attachmentpolicy.StateStored,
+		},
+		{
+			SourceAttachmentID: "teams:inline:large", StoragePath: largeHash[:2] + "/" + largeHash,
+			ContentHash: largeHash, Size: 2 << 20, State: attachmentpolicy.StateStored,
+		},
+	}, false))
+	// A conversation archived before rosters were recorded: many accumulated
+	// participants, no membership record at all.
+	legacyID, err := st.EnsureConversationWithType(source.ID, "team/legacy", "channel", "Legacy")
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE conversations SET participant_count = ? WHERE id = ?`), 20, legacyID)
+	require.NoError(err)
+	legacyMessageID, err := st.UpsertMessage(&store.Message{
+		SourceID: source.ID, ConversationID: legacyID,
+		SourceMessageID: "m2", MessageType: sourceTypeTeams,
+	})
+	require.NoError(err)
+	legacyHash := strings.Repeat("ef", 32)
+	require.NoError(st.ReplaceMessageInlineAttachments(legacyMessageID, []store.AttachmentRef{{
+		SourceAttachmentID: "teams:inline:legacy", StoragePath: legacyHash[:2] + "/" + legacyHash,
+		ContentHash: legacyHash, Size: 100, State: attachmentpolicy.StateStored,
+	}}, false))
+	deps := purgeExcludedMediaDeps{
+		openStore:  func() (*store.Store, func(), error) { return st, func() {}, nil },
+		config:     func() *config.Config { return cfg },
+		removeFile: os.Remove,
+	}
+	dryRun := func() string {
+		cmd := newPurgeExcludedMediaLocalCmd(deps)
+		var output bytes.Buffer
+		cmd.SetOut(&output)
+		cmd.SetErr(&output)
+		cmd.SetArgs([]string{"--dry-run"})
+		require.NoError(cmd.Execute())
+		return output.String()
+	}
+
+	output := dryRun()
+	assert.Contains(output, "Would exclude 1 stored attachment occurrence(s)")
+	assert.Contains(output, "size_cap: 1")
+	assert.NotContains(output, string(attachmentpolicy.SkipParticipantThreshold))
+	assert.Contains(output, "2 stored attachment occurrence(s) left in place: conversation membership is not archived",
+		"the dry run must say what the participant limit could not evaluate")
+
+	cfg.Teams.MediaScope = string(attachmentpolicy.ScopeDirect)
+	output = dryRun()
+	assert.Contains(output, "Would exclude 3 stored attachment occurrence(s)")
+	assert.Contains(output, "policy_scope: 3")
+	assert.NotContains(output, "left in place")
+	cfg.Teams.MediaScope = ""
+
+	// Rosters the sync has read make the participant limit authoritative.
+	require.NoError(st.SetConversationMemberCount(conversationID, 20))
+	require.NoError(st.SetConversationMemberCount(legacyID, 20))
+	output = dryRun()
+	assert.Contains(output, "Would exclude 3 stored attachment occurrence(s)")
+	assert.Contains(output, "participant_threshold: 3")
+	assert.NotContains(output, "left in place")
+}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1543,7 +1543,7 @@ func (a *storeAPIAdapter) runCLICommandWithRunner(
 		return nil
 	}
 	if !attachmentProducingCommand(req.Args) {
-		if len(req.Args) == 0 || req.Args[0] != removeAccountCommandName {
+		if !attachmentRemovalCommand(req.Args) {
 			return runSubprocess(ctx)
 		}
 		emitWarning := func(message string) error {
@@ -1568,6 +1568,29 @@ func (a *storeAPIAdapter) runCLICommandWithRunner(
 		runSubprocess,
 		emitWarning,
 	)
+}
+
+func attachmentRemovalCommand(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	if args[0] == removeAccountCommandName {
+		return true
+	}
+	if args[0] != purgeExcludedMediaCommandName {
+		return false
+	}
+	confirmed := false
+	for _, arg := range args[1:] {
+		switch arg {
+		case "--dry-run", "--dry-run=true":
+			return false
+		case purgeExcludedMediaYesFlag, "-y", purgeExcludedMediaYesFlag + "=true", "--" + purgeExcludedMediaConfirmedFlag,
+			"--" + purgeExcludedMediaConfirmedFlag + "=true":
+			confirmed = true
+		}
+	}
+	return confirmed
 }
 
 // repackAttachmentsParentArgsAllowed accepts only root logging flags that
@@ -2729,11 +2752,16 @@ func runScheduledTeamsSync(ctx context.Context, src *store.Source, s *store.Stor
 		qps = 5
 	}
 	client := teams.NewClient("https://graph.microsoft.com/v1.0", teams.TokenFunc(tokenFn), qps)
-	opts := teams.ImportOptions{
-		Email:           email,
-		AttachmentsDir:  cfg.AttachmentsDir(),
-		IncludeChannels: true,
-	}
+	opts := scheduledTeamsImportOptions(email)
 	_, err = teams.NewImporter(s, client).Import(ctx, opts)
 	return err
+}
+
+func scheduledTeamsImportOptions(email string) teams.ImportOptions {
+	return teams.ImportOptions{
+		Email:           email,
+		AttachmentsDir:  cfg.AttachmentsDir(),
+		MediaPolicy:     cfg.Teams.MediaPolicy(email),
+		IncludeChannels: true,
+	}
 }

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -1409,11 +1409,16 @@ func TestRepackAttachmentsParentArgsAllowed(t *testing.T) {
 func TestStoreAPIAdapterRepackAfterSuccessfulRemovalOnly(t *testing.T) {
 	tests := []struct {
 		name           string
+		args           []string
 		predecessorErr error
 		wantRemoved    bool
 	}{
-		{name: "successful removal", wantRemoved: true},
-		{name: "failed removal", predecessorErr: errors.New("remove failed")},
+		{name: "successful account removal", args: []string{"remove-account", "alice@example.com", "--yes"}, wantRemoved: true},
+		{name: "failed account removal", args: []string{"remove-account", "alice@example.com", "--yes"}, predecessorErr: errors.New("remove failed")},
+		{name: "successful excluded media purge", args: []string{"purge-excluded-media", "--yes"}, wantRemoved: true},
+		{name: "dry run is not a removal", args: []string{"purge-excluded-media", "--dry-run"}},
+		{name: "unconfirmed purge is not a removal", args: []string{"purge-excluded-media"}},
+		{name: "failed excluded media purge", args: []string{"purge-excluded-media", "--yes"}, predecessorErr: errors.New("purge failed")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1426,7 +1431,7 @@ func TestStoreAPIAdapterRepackAfterSuccessfulRemovalOnly(t *testing.T) {
 
 			err := adapter.runCLICommandWithRunner(
 				context.Background(),
-				api.CLIRunRequest{Args: []string{"remove-account", "alice@example.com", "--yes"}},
+				api.CLIRunRequest{Args: tt.args},
 				nil,
 				func(context.Context, []string, map[string]string, string, func(string, string) error) error {
 					runnerCalls++
@@ -1916,6 +1921,26 @@ func TestFindScheduledSyncSources(t *testing.T) {
 	got, err = findScheduledSyncSources(s, "Shared Guild")
 	require.NoError(err, "do not resolve Discord source by display name")
 	assert.Empty(got, "duplicate guild display names must not select an arbitrary source")
+}
+
+func TestScheduledTeamsImportOptionsApplyMediaPolicy(t *testing.T) {
+	oldConfig := cfg
+	t.Cleanup(func() { cfg = oldConfig })
+	enabled := true
+	cfg = &config.Config{
+		Data: config.DataConfig{DataDir: t.TempDir()},
+		Teams: config.TeamsConfig{
+			MediaScope: "direct",
+			AccountsConfig: map[string]config.MediaAccountConfig{
+				"user@example.com": {Media: &enabled, MaxMediaMB: 7},
+			},
+		},
+	}
+
+	opts := scheduledTeamsImportOptions("user@example.com")
+	assert.Equal(t, cfg.Teams.MediaPolicy("user@example.com"), opts.MediaPolicy)
+	assert.Equal(t, cfg.AttachmentsDir(), opts.AttachmentsDir)
+	assert.True(t, opts.IncludeChannels)
 }
 
 func TestRunScheduledSyncUsesSharedDiscordImporterAndRebuildsOnce(t *testing.T) {

--- a/cmd/msgvault/cmd/sync_beeper.go
+++ b/cmd/msgvault/cmd/sync_beeper.go
@@ -138,6 +138,9 @@ func printBeeperSummary(cmd *cobra.Command, accountID string, sum *beeper.Import
 	if sum.AttachmentsPending > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media pending (see backfill-beeper-media)", sum.AttachmentsPending)
 	}
+	if sum.AttachmentsSkipped > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media skipped by policy", sum.AttachmentsSkipped)
+	}
 	if sum.Errors > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d errors", sum.Errors)
 	}
@@ -186,11 +189,12 @@ func resolveBeeperSyncAccounts(s *store.Store, flagAccounts []string) ([]string,
 // beeperImportOptions builds the config-derived import options shared by the
 // CLI and scheduler paths (flag overlays are applied by the CLI caller).
 func beeperImportOptions(accountID string) beeper.ImportOptions {
+	policy := cfg.Beeper.MediaPolicy(accountID)
 	return beeper.ImportOptions{
 		AccountID:      accountID,
 		AttachmentsDir: cfg.AttachmentsDir(),
-		NoMedia:        !cfg.Beeper.MediaEnabled(),
-		MaxMediaBytes:  cfg.Beeper.MaxMediaBytes(),
+		MaxMediaBytes:  policy.MaxBytes,
+		MediaPolicy:    policy,
 	}
 }
 

--- a/cmd/msgvault/cmd/sync_discord.go
+++ b/cmd/msgvault/cmd/sync_discord.go
@@ -83,12 +83,7 @@ func runSyncDiscord(cmd *cobra.Command, deps discordCommandDeps, selector string
 		if importErr != nil {
 			return importErr
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Discord sync complete: %s\n", label)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Containers processed: %d\n", summary.ContainersProcessed)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Messages added: %d\n", summary.MessagesAdded)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Messages updated: %d\n", summary.MessagesUpdated)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Media downloaded: %d\n", summary.MediaDownloaded)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Media pending: %d\n", summary.MediaPending)
+		writeDiscordSyncSummary(cmd.OutOrStdout(), label, summary)
 		return nil
 	})
 	if anyWrites {
@@ -97,6 +92,16 @@ func runSyncDiscord(cmd *cobra.Command, deps discordCommandDeps, selector string
 		}
 	}
 	return runErr
+}
+
+func writeDiscordSyncSummary(out io.Writer, label string, summary *discord.ImportSummary) {
+	_, _ = fmt.Fprintf(out, "Discord sync complete: %s\n", label)
+	_, _ = fmt.Fprintf(out, "  Containers processed: %d\n", summary.ContainersProcessed)
+	_, _ = fmt.Fprintf(out, "  Messages added: %d\n", summary.MessagesAdded)
+	_, _ = fmt.Fprintf(out, "  Messages updated: %d\n", summary.MessagesUpdated)
+	_, _ = fmt.Fprintf(out, "  Media downloaded: %d\n", summary.MediaDownloaded)
+	_, _ = fmt.Fprintf(out, "  Media pending: %d\n", summary.MediaPending)
+	_, _ = fmt.Fprintf(out, "  Media skipped by policy: %d\n", summary.MediaSkipped)
 }
 
 func writeDiscordSyncIssues(out io.Writer, summary *discord.ImportSummary) {
@@ -108,6 +113,8 @@ func writeDiscordSyncIssues(out io.Writer, summary *discord.ImportSummary) {
 		switch issue.Scope {
 		case discord.CatalogScopeGuildChannels:
 			label = "Guild channel catalog unavailable"
+		case discord.CatalogScopeGuildMembers:
+			label = "Guild membership unavailable"
 		case discord.CatalogScopeActiveThreads:
 			label = "Active thread catalog unavailable"
 		case discord.CatalogScopePublicArchive:

--- a/cmd/msgvault/cmd/sync_discord_test.go
+++ b/cmd/msgvault/cmd/sync_discord_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/discord"
 	"go.kenn.io/msgvault/internal/store"
 )
@@ -104,6 +105,32 @@ func TestSyncDiscordReportsSanitizedCatalogAndContainerAccessIssues(t *testing.T
 	assert.Contains(output.String(), testDiscordChannel)
 	assert.Contains(output.String(), "HTTP 403")
 	assert.NotContains(output.String(), "synthetic failure")
+	assert.NotContains(output.String(), testDiscordBotToken)
+}
+
+func TestSyncDiscordWarnsWhenGuildMembershipIsUnavailable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := newDiscordCLIStore(t)
+	tokensDir := t.TempDir()
+	require.NoError(discord.NewTokenManager(tokensDir).Save(discord.NewTokenRecord(testDiscordBotID, "archive-bot", testDiscordBotToken, "")))
+	_, err := st.GetOrCreateSource("discord", testDiscordGuildA)
+	require.NoError(err)
+	api := newDiscordCLIServer(t)
+	api.guildMemberCount = 0
+	deps := testDiscordCommandDeps(t, st, tokensDir, api.server.URL)
+	deps.providerConfig = func() config.DiscordConfig {
+		return config.DiscordConfig{MediaMaxParticipants: 8}
+	}
+
+	cmd := newSyncDiscordLocalCmd(deps)
+	var output bytes.Buffer
+	cmd.SetArgs([]string{testDiscordGuildA})
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	require.NoError(cmd.Execute(), "unreadable membership restricts media, it does not fail the sync")
+	assert.Contains(output.String(), "Guild membership unavailable")
+	assert.Contains(output.String(), testDiscordGuildA)
 	assert.NotContains(output.String(), testDiscordBotToken)
 }
 

--- a/cmd/msgvault/cmd/sync_slack.go
+++ b/cmd/msgvault/cmd/sync_slack.go
@@ -140,6 +140,9 @@ func printSlackSummary(cmd *cobra.Command, teamID string, sum *slack.ImportSumma
 	if sum.AttachmentsPending > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media pending (see backfill-slack-media)", sum.AttachmentsPending)
 	}
+	if sum.AttachmentsSkipped > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media skipped by policy", sum.AttachmentsSkipped)
+	}
 	if sum.Errors > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d errors", sum.Errors)
 	}
@@ -197,12 +200,13 @@ func slackSyncExit(ctxErr error, syncErrors []string, cacheErr error) error {
 // slackImportOptions builds the config-derived import options shared by the
 // CLI and scheduler paths (flag overlays are applied by the CLI caller).
 func slackImportOptions(teamID, userID string) slack.ImportOptions {
+	policy := cfg.Slack.MediaPolicy(teamID)
 	return slack.ImportOptions{
 		TeamID:          teamID,
 		UserID:          userID,
 		AttachmentsDir:  cfg.AttachmentsDir(),
-		NoMedia:         !cfg.Slack.MediaEnabled(),
-		MaxMediaBytes:   cfg.Slack.MaxMediaBytes(),
+		MaxMediaBytes:   policy.MaxBytes,
+		MediaPolicy:     policy,
 		IncludeChannels: cfg.Slack.Channels,
 		ExcludeChannels: cfg.Slack.ExcludeChannels,
 	}

--- a/cmd/msgvault/cmd/sync_slack_routing_test.go
+++ b/cmd/msgvault/cmd/sync_slack_routing_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/clirun"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/testutil"
@@ -105,7 +106,8 @@ func TestSlackImportOptionsDeriveFromConfig(t *testing.T) {
 	opts := slackImportOptions("T01", "UME")
 	assert.Equal("T01", opts.TeamID)
 	assert.Equal("UME", opts.UserID)
-	assert.True(opts.NoMedia)
+	assert.False(opts.NoMedia, "persistent config is represented by typed policy, not the one-run flag")
+	assert.Equal(attachmentpolicy.SkipPolicyScope, opts.MediaPolicy.DisabledReason)
 	assert.Equal(int64(7)<<20, opts.MaxMediaBytes)
 	assert.Equal([]string{"eng"}, opts.IncludeChannels)
 	assert.Equal([]string{"noise"}, opts.ExcludeChannels)

--- a/cmd/msgvault/cmd/sync_teams.go
+++ b/cmd/msgvault/cmd/sync_teams.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -99,6 +100,7 @@ Examples:
 		opts := teams.ImportOptions{
 			Email:           email,
 			AttachmentsDir:  cfg.AttachmentsDir(),
+			MediaPolicy:     cfg.Teams.MediaPolicy(email),
 			IncludeChannels: !syncTeamsNoChannels,
 			Limit:           syncTeamsLimit,
 			Full:            syncTeamsFull,
@@ -113,21 +115,26 @@ Examples:
 			return fmt.Errorf("teams sync failed: %w", err)
 		}
 
-		_, _ = fmt.Fprintln(cmd.OutOrStdout())
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Teams sync complete!")
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Duration:        %s\n", sum.Duration.Round(time.Second))
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Chats:           %d\n", sum.ChatsProcessed)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Channels:        %d\n", sum.ChannelsProcessed)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Messages added:  %d\n", sum.MessagesAdded)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Reactions:       %d\n", sum.ReactionsAdded)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Attachments:     %d\n", sum.AttachmentsFound)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Inline images:   %d\n", sum.InlineImagesCopied)
-		if sum.Errors > 0 {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Errors:          %d\n", sum.Errors)
-		}
+		writeTeamsSyncSummary(cmd.OutOrStdout(), sum)
 
 		return rebuildCacheAfterWrite(dbPath)
 	},
+}
+
+func writeTeamsSyncSummary(out io.Writer, sum *teams.ImportSummary) {
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "Teams sync complete!")
+	_, _ = fmt.Fprintf(out, "  Duration:        %s\n", sum.Duration.Round(time.Second))
+	_, _ = fmt.Fprintf(out, "  Chats:           %d\n", sum.ChatsProcessed)
+	_, _ = fmt.Fprintf(out, "  Channels:        %d\n", sum.ChannelsProcessed)
+	_, _ = fmt.Fprintf(out, "  Messages added:  %d\n", sum.MessagesAdded)
+	_, _ = fmt.Fprintf(out, "  Reactions:       %d\n", sum.ReactionsAdded)
+	_, _ = fmt.Fprintf(out, "  Attachments:     %d\n", sum.AttachmentsFound)
+	_, _ = fmt.Fprintf(out, "  Inline images:   %d\n", sum.InlineImagesCopied)
+	_, _ = fmt.Fprintf(out, "  Inline skipped by policy: %d\n", sum.InlineImagesSkipped)
+	if sum.Errors > 0 {
+		_, _ = fmt.Fprintf(out, "  Errors:          %d\n", sum.Errors)
+	}
 }
 
 func init() {

--- a/docs/guides/oauth-setup.md
+++ b/docs/guides/oauth-setup.md
@@ -317,6 +317,8 @@ delegated permissions to the app registration:
 - `Channel.ReadBasic.All`
 - `User.Read`
 - `User.ReadBasic.All`
+- `TeamMember.Read.All`
+- `ChannelMember.Read.All`
 
 Then authorize and sync Teams:
 

--- a/docs/usage/teams.md
+++ b/docs/usage/teams.md
@@ -25,7 +25,8 @@ Register a Microsoft Entra app as described in
 - Public client flows enabled
 - Delegated Microsoft Graph permissions:
   `Chat.Read`, `ChannelMessage.Read.All`, `Team.ReadBasic.All`,
-  `Channel.ReadBasic.All`, `User.Read`, and `User.ReadBasic.All`
+  `Channel.ReadBasic.All`, `User.Read`, `User.ReadBasic.All`,
+  `TeamMember.Read.All`, and `ChannelMember.Read.All`
 
 Some tenants require an administrator to grant consent for channel-message
 permissions before users can authorize the app.

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1411,6 +1411,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"list-folders",
 		"logs",
 		"pack-attachments",
+		"purge-excluded-media",
 		"repair-dates",
 		"repack-attachments",
 		"remove-account",

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1548,6 +1548,7 @@ func TestHandleCLIRunBackupSubcommandAdmission(t *testing.T) {
 		{"backup unknown subcommand rejected", []string{"backup", "restore"}, false},
 		{"logs still allowed", []string{"logs"}, true},
 		{"remove-account still allowed", []string{"remove-account", "alice@example.com", "--yes"}, true},
+		{"purge excluded media dry-run allowed", []string{"purge-excluded-media", "--dry-run"}, true},
 		{"pack-attachments allowed", []string{"pack-attachments"}, true},
 		{"repair-dates apply allowed", []string{"repair-dates", "--apply"}, true},
 		{"repack-attachments allowed", []string{"repack-attachments"}, true},

--- a/internal/attachmentpolicy/policy.go
+++ b/internal/attachmentpolicy/policy.go
@@ -1,0 +1,117 @@
+// Package attachmentpolicy evaluates provider-neutral media download policy.
+package attachmentpolicy
+
+import "fmt"
+
+// Scope limits media downloads by conversation kind.
+type Scope string
+
+const (
+	ScopeAll    Scope = "all"
+	ScopeDirect Scope = "direct"
+	ScopeNone   Scope = "none"
+)
+
+// SkipReason explains why an attachment occurrence was not stored.
+type SkipReason string
+
+const (
+	SkipPolicyScope          SkipReason = "policy_scope"
+	SkipParticipantThreshold SkipReason = "participant_threshold"
+	SkipAccountPolicy        SkipReason = "account_policy"
+	SkipSizeCap              SkipReason = "size_cap"
+	SkipFetchFailure         SkipReason = "fetch_failure"
+)
+
+// DownloadState is the durable outcome of provider attachment processing.
+type DownloadState string
+
+const (
+	StatePending DownloadState = "pending"
+	StateStored  DownloadState = "stored"
+	StateSkipped DownloadState = "skipped"
+	StateFailed  DownloadState = "failed"
+)
+
+// Conversation is the provider-neutral context used to evaluate scope.
+type Conversation struct {
+	Type             string
+	ParticipantCount int
+}
+
+// Policy is the resolved provider/account media policy. Its zero value allows
+// all conversations and sizes for backward compatibility.
+type Policy struct {
+	Scope           Scope
+	MaxParticipants int
+	MaxBytes        int64
+	DisabledReason  SkipReason
+}
+
+// Validate rejects values that cannot be evaluated consistently.
+func (p Policy) Validate() error {
+	switch p.Scope {
+	case "", ScopeAll, ScopeDirect, ScopeNone:
+	default:
+		return fmt.Errorf("invalid media_scope %q (want all, direct, or none)", p.Scope)
+	}
+	if p.MaxParticipants < 0 {
+		return fmt.Errorf("invalid media_max_participants %d: must be zero or positive", p.MaxParticipants)
+	}
+	if p.MaxBytes < 0 {
+		return fmt.Errorf("invalid max_media_mb: byte limit %d must be zero or positive", p.MaxBytes)
+	}
+	return nil
+}
+
+// Evaluate returns the first policy reason that excludes an occurrence.
+func (p Policy) Evaluate(conversation Conversation, size int64) SkipReason {
+	if p.DisabledReason != "" {
+		return p.DisabledReason
+	}
+	switch p.Scope {
+	case ScopeAll:
+		// Every conversation type is eligible; only the shared limits below apply.
+	case ScopeNone:
+		return SkipPolicyScope
+	case ScopeDirect:
+		if conversation.Type != "direct_chat" && conversation.Type != "group_chat" {
+			return SkipPolicyScope
+		}
+	}
+	if p.MaxParticipants > 0 && conversation.ParticipantCount > p.MaxParticipants {
+		return SkipParticipantThreshold
+	}
+	if p.MaxBytes > 0 && size > p.MaxBytes {
+		return SkipSizeCap
+	}
+	return ""
+}
+
+// Allows reports whether an occurrence is permitted by the resolved policy.
+func (p Policy) Allows(conversation Conversation, size int64) bool {
+	return p.Evaluate(conversation, size) == ""
+}
+
+// RetryEligible reports whether a stored outcome represents unfinished work.
+// Empty state is eligible for backward compatibility with legacy markers.
+func RetryEligible(state DownloadState) bool {
+	return state == "" || state == StatePending || state == StateFailed
+}
+
+// OversizeMarkerSize returns a safely representable observation that remains
+// above maxBytes. Providers use it when a bounded stream proves the source's
+// declared size was missing or understated.
+func OversizeMarkerSize(maxBytes, observed int64) int {
+	maxInt := int64(^uint(0) >> 1)
+	if observed <= maxBytes && maxBytes < maxInt {
+		observed = maxBytes + 1
+	}
+	if observed > maxInt {
+		observed = maxInt
+	}
+	if observed < 0 {
+		return 0
+	}
+	return int(observed)
+}

--- a/internal/attachmentpolicy/policy_test.go
+++ b/internal/attachmentpolicy/policy_test.go
@@ -1,0 +1,105 @@
+package attachmentpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyEvaluate(t *testing.T) {
+	tests := []struct {
+		name         string
+		policy       Policy
+		conversation Conversation
+		size         int64
+		want         SkipReason
+	}{
+		{
+			name:         "zero value permits a channel",
+			conversation: Conversation{Type: "channel", ParticipantCount: 100},
+		},
+		{
+			name:         "none excludes a direct chat",
+			policy:       Policy{Scope: ScopeNone},
+			conversation: Conversation{Type: "direct_chat", ParticipantCount: 2},
+			want:         SkipPolicyScope,
+		},
+		{
+			name:         "direct excludes a channel",
+			policy:       Policy{Scope: ScopeDirect},
+			conversation: Conversation{Type: "channel", ParticipantCount: 2},
+			want:         SkipPolicyScope,
+		},
+		{
+			name:         "direct permits a group DM",
+			policy:       Policy{Scope: ScopeDirect},
+			conversation: Conversation{Type: "group_chat", ParticipantCount: 4},
+		},
+		{
+			name:         "participant cap excludes a large chat",
+			policy:       Policy{MaxParticipants: 3},
+			conversation: Conversation{Type: "group_chat", ParticipantCount: 4},
+			want:         SkipParticipantThreshold,
+		},
+		{
+			name:         "unknown participant count remains eligible",
+			policy:       Policy{MaxParticipants: 3},
+			conversation: Conversation{Type: "group_chat"},
+		},
+		{
+			name:   "account exclusion wins",
+			policy: Policy{DisabledReason: SkipAccountPolicy},
+			want:   SkipAccountPolicy,
+		},
+		{
+			name:   "known oversize item is excluded",
+			policy: Policy{MaxBytes: 1024},
+			size:   1025,
+			want:   SkipSizeCap,
+		},
+		{
+			name:   "unknown size remains eligible",
+			policy: Policy{MaxBytes: 1024},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.policy.Evaluate(tt.conversation, tt.size))
+			assert.Equal(t, tt.want == "", tt.policy.Allows(tt.conversation, tt.size))
+		})
+	}
+}
+
+func TestPolicyValidate(t *testing.T) {
+	require := require.New(t)
+	require.NoError((Policy{}).Validate())
+	require.NoError((Policy{Scope: ScopeAll}).Validate())
+	require.NoError((Policy{Scope: ScopeDirect}).Validate())
+	require.NoError((Policy{Scope: ScopeNone}).Validate())
+	require.ErrorContains((Policy{Scope: "rooms"}).Validate(), "media_scope")
+	require.ErrorContains((Policy{MaxParticipants: -1}).Validate(), "media_max_participants")
+	require.ErrorContains((Policy{MaxBytes: -1}).Validate(), "max_media_mb")
+}
+
+func TestRetryEligible(t *testing.T) {
+	tests := []struct {
+		state DownloadState
+		want  bool
+	}{
+		{state: "", want: true},
+		{state: StatePending, want: true},
+		{state: StateFailed, want: true},
+		{state: StateSkipped, want: false},
+		{state: StateStored, want: false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, RetryEligible(tt.state), string(tt.state))
+	}
+}
+
+func TestOversizeMarkerSize(t *testing.T) {
+	assert.Equal(t, 11, OversizeMarkerSize(10, 0))
+	assert.Equal(t, 12, OversizeMarkerSize(10, 12))
+}

--- a/internal/beeper/doc.go
+++ b/internal/beeper/doc.go
@@ -12,6 +12,6 @@
 // Beeper message IDs are unique only per installation. Anchor probes
 // (anchors.go) fingerprint the installation and are verified before any
 // stored cursor is trusted: a reinstall or re-index aborts the run instead of
-// silently duplicating the archive. Failed or over-cap media downloads leave
-// pending marker rows that BackfillMedia retries later.
+// silently duplicating the archive. Media outcomes are stored as typed marker
+// rows, and BackfillMedia retries only work eligible under current policy.
 package beeper

--- a/internal/beeper/fake_server_test.go
+++ b/internal/beeper/fake_server_test.go
@@ -55,6 +55,9 @@ type fakeChat struct {
 	// ParticipantListingLimit controls how many participants a truncated search
 	// result exposes. Zero keeps the historical one-participant fixture default.
 	ParticipantListingLimit int
+	// ParticipantsTotalUnknown omits the participants total from every payload,
+	// so a truncated listing carries no authoritative roster size.
+	ParticipantsTotalUnknown bool
 	// StuckHead emulates a misbehaving live API whose direction=after pages
 	// re-serve the head with a non-advancing cursor.
 	StuckHead bool
@@ -386,15 +389,17 @@ func (f *fakeBeeper) chatJSON(ch *fakeChat, listing bool) map[string]any {
 	if parts == nil {
 		parts = []map[string]any{}
 	}
+	participants := map[string]any{"items": parts, "hasMore": hasMore}
+	if !ch.ParticipantsTotalUnknown {
+		participants["total"] = len(ch.Participants)
+	}
 	return map[string]any{
-		"id":        ch.ID,
-		"accountID": ch.AccountID,
-		"network":   ch.Network,
-		"title":     ch.Title,
-		"type":      ch.Type,
-		"participants": map[string]any{
-			"items": parts, "hasMore": hasMore, "total": len(ch.Participants),
-		},
+		"id":           ch.ID,
+		"accountID":    ch.AccountID,
+		"network":      ch.Network,
+		"title":        ch.Title,
+		"type":         ch.Type,
+		"participants": participants,
 		"lastActivity": ch.LastActivity.UTC().Format(time.RFC3339Nano),
 		"unreadCount":  0,
 	}

--- a/internal/beeper/importer.go
+++ b/internal/beeper/importer.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/rederive"
 	"go.kenn.io/msgvault/internal/store"
 )
@@ -369,7 +370,7 @@ func chatActivityCutoff(opts ImportOptions, state *SyncState, reconcileCutoff ti
 // incrementally extends the chat's messages. Returns the number of messages
 // processed for this chat.
 func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *Chat, opts ImportOptions, state *SyncState, reconcileCutoff time.Time, tailScan, tailOnly bool, sum *ImportSummary) (int64, error) {
-	convID, membershipComplete, err := imp.ensureConversation(
+	convID, membershipComplete, membership, err := imp.ensureConversation(
 		ctx, syncID, sourceID, ch, opts.AccountID, sum,
 	)
 	if err != nil {
@@ -381,6 +382,10 @@ func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *C
 		chatID: ch.ID, convID: convID, sourceID: sourceID, syncID: syncID,
 		opts: opts, cs: cs, membershipComplete: membershipComplete,
 		tailScan: tailScan,
+	}
+	cc.opts.MediaConversation = attachmentpolicy.Conversation{
+		Type:             conversationType(ch.Type),
+		ParticipantCount: membership.policyCount(opts.MediaPolicy),
 	}
 	before := sum.MessagesProcessed
 
@@ -424,19 +429,55 @@ func (imp *Importer) syncChat(ctx context.Context, syncID, sourceID int64, ch *C
 	return sum.MessagesProcessed - before, nil
 }
 
+// chatMembership is the roster media policy weighs for one chat: the
+// participant total Beeper reports, or the full participant list when no
+// total is reported. Neither is known when a truncated listing reports no
+// total and the detail fetch failed; that roster stays unresolved.
+type chatMembership struct {
+	count int
+	known bool
+}
+
+// chatMembershipOf resolves the roster from the freshest payload this run has
+// for the chat and whether that payload's participant list is complete.
+func chatMembershipOf(chat *Chat, membershipComplete bool) chatMembership {
+	if chat == nil {
+		return chatMembership{}
+	}
+	if chat.Participants.Total > 0 {
+		return chatMembership{count: chat.Participants.Total, known: true}
+	}
+	return chatMembership{count: len(chat.Participants.Items), known: membershipComplete}
+}
+
+// policyCount is the count media policy evaluates: an unresolved roster must
+// not read as a chat under a configured limit, so it fails closed there. The
+// resulting skips stay retryable, and the archived unknown marker keeps the
+// backfill closed until a run reads the roster.
+func (m chatMembership) policyCount(policy attachmentpolicy.Policy) int {
+	if !m.known && policy.MaxParticipants > 0 {
+		return policy.MaxParticipants + 1
+	}
+	return m.count
+}
+
 // ensureConversation upserts the conversation row and its membership,
 // fetching the full participant list when the search listing truncated it
-// (chat search returns at most 20 participants per chat).
+// (chat search returns at most 20 participants per chat). It archives the
+// roster media policy weighs — the reported total, or the unknown marker
+// when there is none and the list is incomplete — so backfill and purge
+// evaluate the same membership rather than the participant rows, which a
+// truncated listing undercounts.
 func (imp *Importer) ensureConversation(
 	ctx context.Context, syncID, sourceID int64, ch *Chat, accountID string, sum *ImportSummary,
-) (int64, bool, error) {
+) (int64, bool, chatMembership, error) {
 	detail := ch
 	membershipComplete := !ch.Participants.HasMore
 	if ch.Participants.HasMore {
 		d, gerr := imp.client.GetChat(ctx, ch.ID)
 		if gerr != nil {
 			if ctx.Err() != nil {
-				return 0, false, ctx.Err()
+				return 0, false, chatMembership{}, ctx.Err()
 			}
 			imp.recordItem(syncID, ch.ID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
 			sum.FetchErrors++
@@ -446,9 +487,18 @@ func (imp *Importer) ensureConversation(
 			membershipComplete = !d.Participants.HasMore
 		}
 	}
+	membership := chatMembershipOf(detail, membershipComplete)
 	convID, err := imp.store.EnsureConversationWithType(sourceID, ch.ID, conversationType(ch.Type), ch.Title)
 	if err != nil {
-		return 0, false, err
+		return 0, false, chatMembership{}, err
+	}
+	if membership.known {
+		err = imp.store.SetConversationMemberCount(convID, membership.count)
+	} else {
+		err = imp.store.MarkConversationMemberCountUnknown(convID)
+	}
+	if err != nil {
+		return 0, false, chatMembership{}, err
 	}
 	members := make([]store.ConversationParticipantRef, 0, len(detail.Participants.Items))
 	type resolvedMember struct {
@@ -468,7 +518,7 @@ func (imp *Importer) ensureConversation(
 		p := &detail.Participants.Items[i]
 		pid, rerr := imp.res.resolveUser(&p.User)
 		if rerr != nil {
-			return 0, false, rerr
+			return 0, false, chatMembership{}, rerr
 		}
 		if pid == 0 {
 			continue
@@ -482,7 +532,7 @@ func (imp *Importer) ensureConversation(
 	}
 	if membershipComplete {
 		if err := imp.store.ReplaceConversationParticipants(convID, members); err != nil {
-			return 0, false, err
+			return 0, false, chatMembership{}, err
 		}
 	} else {
 		for _, member := range members {
@@ -502,7 +552,7 @@ func (imp *Importer) ensureConversation(
 			sourceID, accountID, bridgePrefix, sum,
 		)
 	}
-	return convID, membershipComplete, nil
+	return convID, membershipComplete, membership, nil
 }
 
 // probeChatTail searches past a completed chat's oldest cursor and clears Done
@@ -975,7 +1025,7 @@ func (imp *Importer) persistMessage(ctx context.Context, cc *chatScope, m *Messa
 		}
 	}
 
-	if !cc.opts.NoMedia && cc.opts.AttachmentsDir != "" {
+	if len(m.Attachments) > 0 || (!cc.opts.NoMedia && cc.opts.AttachmentsDir != "") {
 		imp.persistAttachments(ctx, cc.syncID, messageID, m, cc.opts, sum)
 	}
 

--- a/internal/beeper/mapping.go
+++ b/internal/beeper/mapping.go
@@ -164,11 +164,15 @@ func mapMessage(m *Message, conversationID, sourceID int64) (store.Message, stri
 // chatTypeSingle is the Beeper chat type for direct messages (vs "group").
 const chatTypeSingle = "single"
 
-// conversationType maps a Beeper chat type to the msgvault conversation type:
-// "single" becomes "direct_chat"; everything else becomes "group_chat".
+// conversationType maps Beeper's explicit room-like types to channels while
+// retaining backward-compatible group handling for unknown non-single types.
 func conversationType(chatType string) string {
-	if chatType == chatTypeSingle {
+	switch strings.ToLower(strings.TrimSpace(chatType)) {
+	case chatTypeSingle:
 		return "direct_chat"
+	case "room", "space", "channel":
+		return "channel"
+	default:
+		return "group_chat"
 	}
-	return "group_chat"
 }

--- a/internal/beeper/mapping_test.go
+++ b/internal/beeper/mapping_test.go
@@ -190,5 +190,8 @@ func TestConversationType(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal("direct_chat", conversationType("single"))
 	assert.Equal("group_chat", conversationType("group"))
+	assert.Equal("channel", conversationType("room"))
+	assert.Equal("channel", conversationType("space"))
+	assert.Equal("channel", conversationType("channel"))
 	assert.Equal("group_chat", conversationType("anything-else"))
 }

--- a/internal/beeper/media.go
+++ b/internal/beeper/media.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
@@ -88,9 +89,9 @@ func shareMetadata(m *Message) string {
 // storage and replaces the message's Beeper attachment rows. Media already
 // downloaded for this message (matched by source_attachment_id) is kept
 // as-is, so re-persisting a message never re-fetches its attachments. Failed
-// or over-cap downloads leave a pending marker row (the asset URL in
-// storage_path, no content hash) so BackfillMedia can retry them; the message
-// itself is always archived regardless.
+// downloads and deliberate policy exclusions leave typed metadata markers;
+// BackfillMedia retries only outcomes allowed by the current policy. The
+// message itself is always archived regardless.
 func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID int64, m *Message, opts ImportOptions, sum *ImportSummary) {
 	existing, err := imp.store.MessageBeeperAttachments(messageID)
 	if err != nil {
@@ -104,9 +105,14 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 		return
 	}
 	maxBytes := opts.MaxMediaBytes
+	if opts.MediaPolicy.MaxBytes > 0 {
+		maxBytes = opts.MediaPolicy.MaxBytes
+	}
 	if maxBytes <= 0 {
 		maxBytes = defaultMaxMediaBytes
 	}
+	policy := opts.MediaPolicy
+	policy.MaxBytes = maxBytes
 	shareMeta := shareMetadata(m)
 	isPreview := shareMeta != ""
 	refs := make([]store.AttachmentRef, 0, len(m.Attachments))
@@ -133,16 +139,50 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			Size:               declaredSize(att),
 			SourceAttachmentID: sourceAttID,
 			Metadata:           shareMeta,
+			State:              attachmentpolicy.StatePending,
 		}
-		// Every failure leaves the marker as a pending row (BackfillMedia
-		// retries it); only unexpected failures also count as errors.
+		if previous, ok := existing[sourceAttID]; ok && previous.Size > marker.Size {
+			marker.Size = previous.Size
+		}
+		// Every unsuccessful fetch leaves a typed marker. Transient failures
+		// remain retryable; size exclusions wait until the cap is raised.
 		pend := func(status, kind string, err error) {
 			imp.recordItem(syncID, m.ID, "attachment", status, kind, err)
+			if status == store.SyncRunItemStatusSkipped {
+				marker.State = attachmentpolicy.StateSkipped
+				marker.SkipReason = attachmentpolicy.SkipSizeCap
+			} else {
+				marker.State = attachmentpolicy.StateFailed
+				marker.SkipReason = attachmentpolicy.SkipFetchFailure
+			}
 			refs = append(refs, marker)
-			sum.AttachmentsPending++
+			if marker.State == attachmentpolicy.StateSkipped {
+				sum.AttachmentsSkipped++
+			} else {
+				sum.AttachmentsPending++
+			}
 			if status == store.SyncRunItemStatusError {
 				sum.Errors++
 			}
+		}
+		if opts.NoMedia || opts.AttachmentsDir == "" {
+			refs = append(refs, marker)
+			sum.AttachmentsPending++
+			continue
+		}
+		if reason := policy.Evaluate(opts.MediaConversation, int64(marker.Size)); reason != "" {
+			if reason == attachmentpolicy.SkipSizeCap {
+				marker.SkipReason = reason
+				pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large",
+					fmt.Errorf("attachment %s is %d bytes (cap %d)", ref, marker.Size, maxBytes))
+				continue
+			}
+			marker.State = attachmentpolicy.StateSkipped
+			marker.SkipReason = reason
+			imp.recordItem(syncID, m.ID, "attachment", store.SyncRunItemStatusSkipped, "beeper_media_policy", nil)
+			refs = append(refs, marker)
+			sum.AttachmentsSkipped++
+			continue
 		}
 		if att.FileSize > 0 && int64(att.FileSize) > maxBytes {
 			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large",
@@ -156,6 +196,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 		if errors.Is(err, ErrAssetTooLarge) {
 			// The declared fileSize was absent or wrong; the capped reader
 			// caught it. Same outcome as the declared-size check above.
+			marker.Size = attachmentpolicy.OversizeMarkerSize(maxBytes, int64(marker.Size))
 			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large", err)
 			continue
 		}
@@ -179,6 +220,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			MediaType:          mediaTypeOf(att),
 			DurationMS:         int64(att.Duration * 1000),
 			Metadata:           shareMeta,
+			State:              attachmentpolicy.StateStored,
 		}
 		setBeeperAttachmentRole(&stored, att, isPreview)
 		if att.Size != nil {
@@ -212,6 +254,57 @@ func setBeeperAttachmentRole(ref *store.AttachmentRef, att *Attachment, isPrevie
 	ref.RoleSource = store.AttachmentRoleSourceImporterSemantics
 }
 
+// chatRefresh is one chat's re-read source context: its current conversation
+// type and membership, found=false for a chat the source no longer has, or a
+// non-nil err for one it could not read.
+type chatRefresh struct {
+	conversationType string
+	membership       chatMembership
+	found            bool
+	err              error
+}
+
+// refreshChatContext re-reads one chat from the source and reconciles the
+// archived conversation type and membership record with it, so this backfill
+// and every later policy evaluation weigh the source's current truth rather
+// than a type or roster the archive predates. The returned error is fatal
+// (store failure); a fetch failure is carried in the result instead.
+func (imp *Importer) refreshChatContext(
+	ctx context.Context, syncID, sourceID int64, chatID string, sum *ImportSummary,
+) (*chatRefresh, error) {
+	chat, gerr := imp.client.GetChat(ctx, chatID)
+	if errors.Is(gerr, ErrNotFound) {
+		return &chatRefresh{}, nil
+	}
+	if gerr != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		imp.recordItem(syncID, chatID, "fetch", store.SyncRunItemStatusError, "beeper_fetch_error", gerr)
+		sum.FetchErrors++
+		sum.Errors++
+		return &chatRefresh{err: gerr}, nil
+	}
+	refresh := &chatRefresh{
+		conversationType: conversationType(chat.Type),
+		membership:       chatMembershipOf(chat, !chat.Participants.HasMore),
+		found:            true,
+	}
+	convID, err := imp.store.EnsureConversationWithType(sourceID, chatID, refresh.conversationType, chat.Title)
+	if err != nil {
+		return nil, err
+	}
+	if refresh.membership.known {
+		err = imp.store.SetConversationMemberCount(convID, refresh.membership.count)
+	} else {
+		err = imp.store.MarkConversationMemberCountUnknown(convID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return refresh, nil
+}
+
 // clearPendingMarkers removes a message's pending Beeper markers while
 // preserving its downloaded (content-hashed) attachment rows.
 func (imp *Importer) clearPendingMarkers(messageID int64) error {
@@ -231,10 +324,10 @@ func (imp *Importer) clearPendingMarkers(messageID int64) error {
 	return imp.store.RecomputeMessageAttachmentStats(messageID)
 }
 
-// BackfillMedia retries pending Beeper attachment downloads for one account:
-// every message that still has a pending marker is re-fetched from the API
-// and its attachments re-persisted. Idempotent (content-addressed storage,
-// replace-by-prefix rows).
+// BackfillMedia retries eligible Beeper attachment downloads for one account:
+// messages with unfinished work, plus exclusions now allowed by current
+// policy, are re-fetched and re-persisted. Idempotent (content-addressed
+// storage, replace-by-prefix rows).
 func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
 	start := time.Now()
 	if opts.AttachmentsDir == "" {
@@ -262,29 +355,69 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 	// Preserve the carried-forward state even if this run is interrupted.
 	imp.checkpointNow(syncID, state, sum)
 
-	// This pass trusts stored message IDs, which are only unique per Beeper
-	// installation — the same guard the main sync runs applies here, or a
-	// reinstall could attach some other message's media to archived rows.
-	if err = imp.verifyAnchors(ctx, syncID, src.ID, state); err != nil {
+	policy := opts.MediaPolicy
+	if policy.MaxBytes <= 0 {
+		policy.MaxBytes = opts.MaxMediaBytes
+	}
+	if policy.MaxBytes <= 0 {
+		policy.MaxBytes = defaultMaxMediaBytes
+	}
+	policyResult, skipErr := imp.store.ApplyBeeperRetryableAttachmentPolicy(ctx, src.ID, policy)
+	if skipErr != nil {
+		err = skipErr
 		return sum, err
 	}
-	// This run's state becomes the newest completed baseline: like the main
-	// sync, never persist it with the reinstall guard weakened.
-	imp.rearmAnchors(ctx, nil, state)
+	sum.AttachmentsSkipped += policyResult.NewlySkipped
+	pending, err := imp.store.ListBeeperRetryableAttachmentMessages(src.ID, policy)
+	if err != nil {
+		return sum, err
+	}
+	if len(pending) > 0 || !policyResult.HasExcluded {
+		// Preserve the established guard-refresh behavior for ordinary media
+		// runs. Only a pass whose remaining work was entirely excluded by the
+		// current policy can safely remain local.
+		if err = imp.verifyAnchors(ctx, syncID, src.ID, state); err != nil {
+			return sum, err
+		}
+		// This run's state becomes the newest completed baseline: like the main
+		// sync, never persist it with the reinstall guard weakened.
+		imp.rearmAnchors(ctx, nil, state)
+	}
 	stateBlob, merr := state.Marshal()
 	if merr != nil {
 		err = merr
 		return sum, err
 	}
-
-	var pending []store.BeeperPendingAttachmentMessage
-	pending, err = imp.store.ListBeeperPendingAttachmentMessages(src.ID)
-	if err != nil {
-		return sum, err
-	}
+	// A direct-scope policy decides on the conversation type alone, and the
+	// archived type may predate the mapping of Beeper rooms to channels — a
+	// legacy group_chat row would admit a room the current mapping excludes.
+	// Re-read each chat's type once from the source before evaluating.
+	chatRefreshes := map[string]*chatRefresh{}
 	for _, item := range pending {
 		if err = ctx.Err(); err != nil {
 			return sum, err
+		}
+		if policy.Scope == attachmentpolicy.ScopeDirect {
+			refresh, cached := chatRefreshes[item.ChatID]
+			if !cached {
+				refresh, err = imp.refreshChatContext(ctx, syncID, src.ID, item.ChatID, sum)
+				if err != nil {
+					return sum, err
+				}
+				chatRefreshes[item.ChatID] = refresh
+			}
+			if refresh.err != nil {
+				// The type cannot be resolved, so scope cannot be evaluated.
+				// The marker stays retryable rather than trusting the archive.
+				sum.AttachmentsPending++
+				continue
+			}
+			if refresh.found {
+				item.ConversationType = refresh.conversationType
+				item.ParticipantCount = refresh.membership.policyCount(policy)
+			}
+			// A gone chat falls through: the message fetch below observes it
+			// and clears the markers.
 		}
 		m, gerr := imp.client.GetMessage(ctx, item.ChatID, item.SourceMessageID)
 		if errors.Is(gerr, ErrNotFound) {
@@ -307,7 +440,11 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 			sum.Errors++
 			continue
 		}
-		imp.persistAttachments(ctx, syncID, item.MessageID, m, opts, sum)
+		itemOpts := opts
+		itemOpts.MediaConversation = attachmentpolicy.Conversation{
+			Type: item.ConversationType, ParticipantCount: item.ParticipantCount,
+		}
+		imp.persistAttachments(ctx, syncID, item.MessageID, m, itemOpts, sum)
 		sum.MessagesProcessed++
 		if opts.Progress != nil && sum.MessagesProcessed%100 == 0 {
 			opts.Progress(fmt.Sprintf("media backfill: %d messages, %d downloaded, %d still pending",

--- a/internal/beeper/media_test.go
+++ b/internal/beeper/media_test.go
@@ -2,14 +2,17 @@ package beeper
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -150,6 +153,35 @@ func TestSetBeeperAttachmentRoleUsesSourceSemantics(t *testing.T) {
 	}
 }
 
+func TestImportMediaPolicySkipsWithoutFetching(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	f.setAsset("mxc://beeper.local/photo1", []byte("must not be fetched"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	opts.MediaPolicy = attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeNone, MaxBytes: 100 << 20}
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, sum.AttachmentsSkipped)
+	assert.EqualValues(0, sum.AttachmentsPending)
+	for _, request := range f.requests() {
+		assert.NotContains(request, "/v1/assets/serve")
+	}
+
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments
+		WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipPolicyScope), reason)
+}
+
 func TestImportMediaFailureLeavesMarkerAndBackfillRepairs(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -165,6 +197,7 @@ func TestImportMediaFailureLeavesMarkerAndBackfillRepairs(t *testing.T) {
 	require.NoError(err)
 	assert.EqualValues(0, sum.AttachmentsDownloaded)
 	assert.EqualValues(1, sum.AttachmentsPending)
+	assert.EqualValues(0, sum.AttachmentsSkipped)
 
 	var msgCount int
 	require.NoError(st.DB().QueryRow(st.Rebind(
@@ -248,7 +281,8 @@ func TestImportMediaSizeCap(t *testing.T) {
 	sum, err := imp.Import(context.Background(), opts)
 	require.NoError(err)
 	assert.EqualValues(0, sum.AttachmentsDownloaded)
-	assert.EqualValues(1, sum.AttachmentsPending)
+	assert.EqualValues(0, sum.AttachmentsPending)
+	assert.EqualValues(1, sum.AttachmentsSkipped)
 	assert.EqualValues(0, sum.Errors, "over-cap is a skip, not an error")
 
 	var itemCount int
@@ -276,13 +310,23 @@ func TestImportMediaSizeCapUndeclaredSize(t *testing.T) {
 	sum, err := imp.Import(context.Background(), opts)
 	require.NoError(err)
 	assert.EqualValues(0, sum.AttachmentsDownloaded)
-	assert.EqualValues(1, sum.AttachmentsPending)
+	assert.EqualValues(0, sum.AttachmentsPending)
+	assert.EqualValues(1, sum.AttachmentsSkipped)
 	assert.EqualValues(0, sum.Errors, "over-cap is a skip, not an error")
 
 	var itemCount int
 	require.NoError(st.DB().QueryRow(
 		`SELECT COUNT(*) FROM sync_run_items WHERE error_kind = 'beeper_media_too_large'`).Scan(&itemCount))
 	assert.Equal(1, itemCount)
+	var storedSize int64
+	require.NoError(st.DB().QueryRow(`
+		SELECT size FROM attachments
+		WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+	`).Scan(&storedSize))
+	assert.Greater(storedSize, int64(1<<20))
+	backfill, err := imp.BackfillMedia(context.Background(), opts)
+	require.NoError(err)
+	assert.Zero(backfill.MessagesProcessed, "unchanged cap must not retry streamed oversize media")
 }
 
 func TestImportNoMediaSkipsDownloadsEntirely(t *testing.T) {
@@ -300,11 +344,11 @@ func TestImportNoMediaSkipsDownloadsEntirely(t *testing.T) {
 	sum, err := imp.Import(context.Background(), opts)
 	require.NoError(err)
 	assert.EqualValues(0, sum.AttachmentsDownloaded)
-	assert.EqualValues(0, sum.AttachmentsPending)
+	assert.EqualValues(1, sum.AttachmentsPending)
 
 	var attCount int
 	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM attachments`).Scan(&attCount))
-	assert.Zero(attCount, "no rows, not even markers, when media is disabled")
+	assert.Equal(1, attCount, "one-run no-media deferral leaves a retryable marker")
 
 	// Message metadata still reflects the attachment.
 	var hasAtt bool
@@ -436,6 +480,300 @@ func TestBackfillMediaTransientFetchErrorKeepsMarker(t *testing.T) {
 	require.NoError(err)
 	assert.EqualValues(1, bsum.AttachmentsDownloaded)
 	assert.EqualValues(0, bsum.Errors)
+}
+
+func TestBackfillMediaAppliesTightenedPolicyBeforeFetchingPendingMessage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	chat := mediaChat()
+	chat.Msgs = append(chat.Msgs, fakeMsg{
+		ID: "p1", SortKey: 1, Timestamp: chat.Msgs[0].Timestamp.Add(time.Minute),
+		Text: "newer anchor", SenderID: "@signal_ann:beeper.local", SenderName: "Ann",
+	})
+	chat.LastActivity = chat.Msgs[1].Timestamp
+	f.addChat(chat)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+
+	f.resetRequests()
+	opts.MediaPolicy = attachmentpolicy.Policy{MaxParticipants: 1}
+	summary, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, summary.AttachmentsSkipped)
+	assert.Empty(f.requests(), "a fully policy-excluded backfill must remain local")
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason
+		FROM attachments WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+
+	f.resetRequests()
+	summary, err = imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(summary.AttachmentsSkipped, "unchanged exclusions are not newly processed")
+	assert.Empty(f.requests(), "an unchanged fully policy-excluded backfill must remain local")
+}
+
+// mediaGroupChat is a group chat whose search listing truncates the roster:
+// only two of its members appear there, so the participant rows the archive
+// accumulates undercount the chat until a detail fetch succeeds.
+func mediaGroupChat(members int) *fakeChat {
+	chat := mediaChat()
+	chat.Type = "group"
+	chat.Participants = chat.Participants[:1]
+	for i := range members - 1 {
+		chat.Participants = append(chat.Participants, map[string]any{
+			"id": "@signal_member" + strconv.Itoa(i) + ":beeper.local", "fullName": "Member " + strconv.Itoa(i),
+		})
+	}
+	chat.ParticipantsTruncated = true
+	chat.ParticipantListingLimit = 2
+	return chat
+}
+
+func assetRequests(f *fakeBeeper) []string {
+	var served []string
+	for _, req := range f.requests() {
+		if strings.Contains(req, "/v1/assets/serve") {
+			served = append(served, req)
+		}
+	}
+	return served
+}
+
+// TestMediaPolicyArchivesAuthoritativeParticipantTotal covers a truncated
+// listing whose detail fetch fails: sync weighs the total Beeper reports, so
+// the archive has to carry that total too — otherwise the backfill sees only
+// the few participant rows that were persisted and downloads exactly what the
+// participant limit excluded.
+func TestMediaPolicyArchivesAuthoritativeParticipantTotal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	chat := mediaGroupChat(8)
+	f.addChat(chat)
+	f.setChatGetFailure(chat.ID, true)
+	f.setAsset("mxc://beeper.local/photo1", []byte("group photo"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+	opts := mediaImportOptions(t)
+	opts.MediaPolicy = attachmentpolicy.Policy{MaxParticipants: 5}
+
+	_, err := imp.Import(t.Context(), opts)
+	require.Error(err, "the failed detail fetch leaves the run partial")
+	assert.Empty(assetRequests(f), "the reported total excludes the chat's media")
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason
+		FROM attachments WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+	var messageID int64
+	require.NoError(st.DB().QueryRow(`SELECT message_id FROM attachments`).Scan(&messageID))
+	membership, err := st.AttachmentConversationMembership(messageID)
+	require.NoError(err)
+	assert.Equal(8, membership.Conversation.ParticipantCount,
+		"the archive carries the total sync weighed, not the truncated participant rows")
+	assert.True(membership.RosterArchived)
+
+	f.resetRequests()
+	summary, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(summary.AttachmentsDownloaded)
+	assert.Empty(assetRequests(f), "the backfill must not re-admit on the smaller stored roster")
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state FROM attachments WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+	`).Scan(&state))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+}
+
+// TestMediaPolicyFailsClosedWithoutParticipantTotal covers the same truncated
+// listing when Beeper reports no total either: the roster is unresolved, so
+// sync and backfill fail closed until a detail fetch reads it, and then the
+// real size decides.
+func TestMediaPolicyFailsClosedWithoutParticipantTotal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	chat := mediaGroupChat(4)
+	chat.ParticipantsTotalUnknown = true
+	f.addChat(chat)
+	f.setChatGetFailure(chat.ID, true)
+	f.setAsset("mxc://beeper.local/photo1", []byte("group photo"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+	opts := mediaImportOptions(t)
+	opts.MediaPolicy = attachmentpolicy.Policy{MaxParticipants: 5}
+	attachmentState := func() string {
+		var state string
+		require.NoError(st.DB().QueryRow(`
+			SELECT attachment_state FROM attachments WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+		`).Scan(&state))
+		return state
+	}
+
+	_, err := imp.Import(t.Context(), opts)
+	require.Error(err, "the failed detail fetch leaves the run partial")
+	assert.Empty(assetRequests(f), "an unresolved roster must not read as a chat under the limit")
+	assert.Equal(string(attachmentpolicy.StateSkipped), attachmentState())
+	var messageID int64
+	require.NoError(st.DB().QueryRow(`SELECT message_id FROM attachments`).Scan(&messageID))
+	membership, err := st.AttachmentConversationMembership(messageID)
+	require.NoError(err)
+	assert.False(membership.RosterArchived, "no total and no complete list leaves the roster unresolved")
+
+	f.resetRequests()
+	summary, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(summary.AttachmentsDownloaded)
+	assert.Empty(assetRequests(f), "the backfill stays closed while the roster is unresolved")
+
+	// A detail fetch that succeeds reads the whole roster; the chat is under
+	// the limit, so the run that resolves it releases the deferred download.
+	f.setChatGetFailure(chat.ID, false)
+	f.resetRequests()
+	_, err = imp.Import(t.Context(), ImportOptions{
+		AccountID: opts.AccountID, AttachmentsDir: opts.AttachmentsDir, MediaPolicy: opts.MediaPolicy, Full: true,
+	})
+	require.NoError(err)
+	membership, err = st.AttachmentConversationMembership(messageID)
+	require.NoError(err)
+	assert.True(membership.RosterArchived)
+	assert.Equal(4, membership.Conversation.ParticipantCount)
+	assert.Len(assetRequests(f), 1)
+	assert.Equal(string(attachmentpolicy.StateStored), attachmentState())
+}
+
+// TestBackfillMediaFailsClosedOnConversationWithoutArchivedRoster covers a
+// chat archived before rosters were recorded: its participant rows are all
+// the archive holds, and they may undercount a membership over the limit, so
+// the backfill must not download on them. A sync that visits the chat archives
+// the roster and the next backfill decides on it.
+func TestBackfillMediaFailsClosedOnConversationWithoutArchivedRoster(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+	opts := mediaImportOptions(t)
+	// Asset missing: the sync leaves a pending marker.
+	_, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	var conversationID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM conversations WHERE source_conversation_id = ?`), "!media:beeper.local").Scan(&conversationID))
+	require.NoError(st.SetConversationMetadata(conversationID, sql.NullString{}),
+		"drop the archived roster to model a conversation synced before rosters were recorded")
+	f.setAsset("mxc://beeper.local/photo1", []byte("hello bytes"))
+	attachmentState := func() string {
+		var state string
+		require.NoError(st.DB().QueryRow(`
+			SELECT attachment_state FROM attachments WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+		`).Scan(&state))
+		return state
+	}
+
+	opts.MediaPolicy = attachmentpolicy.Policy{MaxParticipants: 5}
+	f.resetRequests()
+	summary, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(summary.AttachmentsDownloaded)
+	assert.EqualValues(1, summary.AttachmentsSkipped)
+	assert.Empty(assetRequests(f), "two observed participants are not a roster the limit may admit on")
+	assert.Equal(string(attachmentpolicy.StateSkipped), attachmentState())
+
+	// A sync that visits the chat archives its roster; the chat is under the
+	// limit, so the deferred download is released.
+	f.resetRequests()
+	_, err = imp.Import(t.Context(), ImportOptions{
+		AccountID: opts.AccountID, AttachmentsDir: opts.AttachmentsDir, MediaPolicy: opts.MediaPolicy, Full: true,
+	})
+	require.NoError(err)
+	_, err = imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Equal(string(attachmentpolicy.StateStored), attachmentState())
+	assert.NotEmpty(assetRequests(f))
+}
+
+// TestBackfillMediaRefreshesLegacyConversationTypeForDirectScope covers an
+// archive typed before rooms mapped to channels: the stored group_chat would
+// pass a direct-scope policy, so the backfill re-reads each chat's type from
+// the source before evaluating, corrects the archive, and excludes the room's
+// media. A chat it cannot re-read stays pending, and a genuine direct chat
+// still downloads.
+func TestBackfillMediaRefreshesLegacyConversationTypeForDirectScope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	room := mediaChat()
+	room.Type = "room"
+	f.addChat(room)
+	dm := mediaChat()
+	dm.ID = "!dm:beeper.local"
+	dm.Msgs[0].ID = "p1"
+	dm.Msgs[0].Attachments[0]["id"] = "mxc://beeper.local/photo2"
+	f.addChat(dm)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+	opts := mediaImportOptions(t)
+	// Assets missing: the sync leaves pending markers.
+	_, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	// Model an archive written before rooms mapped to channels.
+	_, err = st.DB().Exec(st.Rebind(
+		`UPDATE conversations SET conversation_type = 'group_chat' WHERE source_conversation_id = ?`,
+	), room.ID)
+	require.NoError(err)
+	f.setAsset("mxc://beeper.local/photo1", []byte("room bytes"))
+	f.setAsset("mxc://beeper.local/photo2", []byte("dm bytes"))
+	opts.MediaPolicy = attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeDirect}
+	attachmentOutcome := func(sourceAttachmentID string) (state, reason string) {
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT COALESCE(attachment_state, ''), COALESCE(attachment_skip_reason, '')
+			FROM attachments WHERE source_attachment_id = ?
+		`), sourceAttachmentID).Scan(&state, &reason))
+		return state, reason
+	}
+	conversationTypeOf := func(chatID string) string {
+		var conversationType string
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`SELECT conversation_type FROM conversations WHERE source_conversation_id = ?`,
+		), chatID).Scan(&conversationType))
+		return conversationType
+	}
+
+	// An unreadable chat cannot resolve its type, so its media stays pending.
+	f.setChatGetFailure(room.ID, true)
+	summary, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Positive(summary.Errors)
+	state, _ := attachmentOutcome("beeper:mxc://beeper.local/photo1")
+	assert.True(attachmentpolicy.RetryEligible(attachmentpolicy.DownloadState(state)),
+		"a chat whose type cannot be re-read leaves its media retryable, got %q", state)
+	assert.Equal("group_chat", conversationTypeOf(room.ID))
+	state, _ = attachmentOutcome("beeper:mxc://beeper.local/photo2")
+	assert.Equal(string(attachmentpolicy.StateStored), state, "the direct chat still downloads")
+
+	f.setChatGetFailure(room.ID, false)
+	f.resetRequests()
+	summary, err = imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(summary.AttachmentsDownloaded)
+	assert.Empty(assetRequests(f),
+		"the stored group_chat type must not admit a room a direct-scope policy excludes")
+	state, reason := attachmentOutcome("beeper:mxc://beeper.local/photo1")
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipPolicyScope), reason)
+	assert.Equal("channel", conversationTypeOf(room.ID),
+		"the backfill archives the corrected type so purge and later runs read it")
 }
 
 func TestBackfillMediaVerifiesAnchorFirst(t *testing.T) {

--- a/internal/beeper/types.go
+++ b/internal/beeper/types.go
@@ -3,6 +3,8 @@ package beeper
 import (
 	"encoding/json"
 	"time"
+
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 )
 
 // ---- Beeper Desktop API objects (see /v1/spec, "Beeper Client API") ----
@@ -198,12 +200,16 @@ type ImportOptions struct {
 	// AttachmentsDir is the content-addressed attachment store root. Empty
 	// disables media download (as does NoMedia).
 	AttachmentsDir string
-	// NoMedia skips attachment downloads entirely (no pending markers are
-	// written; a later --full run re-persists messages and downloads then).
+	// NoMedia skips attachment downloads and writes pending markers for a later
+	// backfill or full run.
 	NoMedia bool
 	// MaxMediaBytes caps individual attachment downloads (0 = 100 MB).
-	// Over-cap attachments leave a pending marker.
+	// Over-cap attachments leave a typed size-cap exclusion marker.
 	MaxMediaBytes int64
+	// MediaPolicy is the effective provider/account collection policy.
+	MediaPolicy attachmentpolicy.Policy
+	// MediaConversation is populated per chat or from archived metadata.
+	MediaConversation attachmentpolicy.Conversation
 	// Progress, if non-nil, is called after each chat with a human-readable
 	// status line. Safe to leave nil (silent mode).
 	Progress func(msg string) `json:"-"`
@@ -247,6 +253,7 @@ type ImportSummary struct {
 	// retry marker (see backfill-beeper-media).
 	AttachmentsDownloaded int64
 	AttachmentsPending    int64
+	AttachmentsSkipped    int64
 	// FetchErrors counts Beeper API fetch failures (a subset of Errors). Any
 	// fetch failure keeps the discovery watermark from advancing so the
 	// affected chats are re-visited next run.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/robfig/cron/v3"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/documentindex"
 	"go.kenn.io/msgvault/internal/duckdbutil"
 	"go.kenn.io/msgvault/internal/fileutil"
@@ -324,23 +325,39 @@ type BackupConfig struct {
 }
 
 const (
+	DefaultChatMaxMediaBytes       int64         = 100 << 20
 	DefaultDiscordMaxMediaBytes    int64         = 50 << 20
 	DefaultDiscordEditRescanWindow time.Duration = 7 * 24 * time.Hour
 )
 
+// MediaAccountConfig overrides attachment download settings for one provider
+// account. Pointer booleans distinguish an omitted value from explicit false.
+type MediaAccountConfig struct {
+	Media      *bool `toml:"media"`
+	MaxMediaMB int   `toml:"max_media_mb"`
+}
+
 // DiscordConfig holds provider-wide Discord import settings and optional
 // per-guild message-container filters.
+//
+//nolint:recvcheck // ApplyDefaults mutates; MediaPolicy keeps the value receiver shared by the sibling provider configs
 type DiscordConfig struct {
-	MaxMediaBytes    int64                         `toml:"max_media_bytes"`
-	EditRescanWindow time.Duration                 `toml:"edit_rescan_window"`
-	Guilds           map[string]DiscordGuildConfig `toml:"guilds"`
+	MaxMediaBytes        int64                         `toml:"max_media_bytes"`
+	Media                *bool                         `toml:"media"`
+	MediaScope           string                        `toml:"media_scope"`
+	MediaMaxParticipants int                           `toml:"media_max_participants"`
+	MaxMediaMB           int                           `toml:"max_media_mb"`
+	EditRescanWindow     time.Duration                 `toml:"edit_rescan_window"`
+	Guilds               map[string]DiscordGuildConfig `toml:"guilds"`
 }
 
 // DiscordGuildConfig filters channels, threads, and forum posts for one guild.
 // Empty Include means every accessible message container is eligible.
 type DiscordGuildConfig struct {
-	Include []string `toml:"include"`
-	Exclude []string `toml:"exclude"`
+	Include    []string `toml:"include"`
+	Exclude    []string `toml:"exclude"`
+	Media      *bool    `toml:"media"`
+	MaxMediaMB int      `toml:"max_media_mb"`
 }
 
 // ApplyDefaults restores Discord provider defaults for omitted or zero-valued
@@ -393,6 +410,7 @@ type Config struct {
 	Discord      DiscordConfig                   `toml:"discord"`
 	Attachments  documentindex.AttachmentsConfig `toml:"attachments"`
 	Activity     ActivityConfig                  `toml:"activity"`
+	Teams        TeamsConfig                     `toml:"teams"`
 
 	// Computed paths (not from config file)
 	HomeDir    string `toml:"-"`
@@ -801,6 +819,9 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	if err := cfg.Backup.Validate(); err != nil {
 		return nil, err
 	}
+	if err := cfg.validateMediaPolicies(); err != nil {
+		return nil, err
+	}
 	cfg.applySynctechSMSDefaults()
 	cfg.applyGCalDefaults()
 	cfg.applyMeetingSourceDefaults()
@@ -1168,6 +1189,12 @@ type BeeperConfig struct {
 	Media *bool `toml:"media"`
 	// MaxMediaMB caps individual attachment downloads in MiB (0 = 100).
 	MaxMediaMB int `toml:"max_media_mb"`
+	// MediaScope is all, direct, or none (empty = all).
+	MediaScope string `toml:"media_scope"`
+	// MediaMaxParticipants caps eligible conversation membership (0 = no cap).
+	MediaMaxParticipants int `toml:"media_max_participants"`
+	// AccountsConfig holds per-Beeper-account media overrides.
+	AccountsConfig map[string]MediaAccountConfig `toml:"accounts_config"`
 }
 
 // SlackConfig configures Slack workspace archive sources ([slack] table).
@@ -1187,6 +1214,21 @@ type SlackConfig struct {
 	Media *bool `toml:"media"`
 	// MaxMediaMB caps individual file downloads in MiB (0 = 100).
 	MaxMediaMB int `toml:"max_media_mb"`
+	// MediaScope is all, direct, or none (empty = all).
+	MediaScope string `toml:"media_scope"`
+	// MediaMaxParticipants caps eligible conversation membership (0 = no cap).
+	MediaMaxParticipants int `toml:"media_max_participants"`
+	// AccountsConfig holds per-workspace media overrides keyed by team ID.
+	AccountsConfig map[string]MediaAccountConfig `toml:"accounts_config"`
+}
+
+// TeamsConfig configures provider-wide and per-account Teams media policy.
+type TeamsConfig struct {
+	Media                *bool                         `toml:"media"`
+	MediaScope           string                        `toml:"media_scope"`
+	MediaMaxParticipants int                           `toml:"media_max_participants"`
+	MaxMediaMB           int                           `toml:"max_media_mb"`
+	AccountsConfig       map[string]MediaAccountConfig `toml:"accounts_config"`
 }
 
 // MediaEnabled reports whether file download is on (default true).
@@ -1213,6 +1255,126 @@ func (b BeeperConfig) MaxMediaBytes() int64 {
 		return int64(b.MaxMediaMB) << 20
 	}
 	return 100 << 20
+}
+
+// MediaPolicy resolves Beeper provider settings and an account override.
+func (b BeeperConfig) MediaPolicy(accountID string) attachmentpolicy.Policy {
+	account, ok := b.AccountsConfig[accountID]
+	return resolveMediaPolicy(b.Media, b.MediaScope, b.MediaMaxParticipants,
+		b.MaxMediaMB, DefaultChatMaxMediaBytes, account, ok)
+}
+
+// MediaPolicy resolves Slack provider settings and a workspace override.
+func (s SlackConfig) MediaPolicy(teamID string) attachmentpolicy.Policy {
+	account, ok := s.AccountsConfig[teamID]
+	return resolveMediaPolicy(s.Media, s.MediaScope, s.MediaMaxParticipants,
+		s.MaxMediaMB, DefaultChatMaxMediaBytes, account, ok)
+}
+
+// MediaPolicy resolves Discord provider settings and a guild override.
+func (d DiscordConfig) MediaPolicy(guildID string) attachmentpolicy.Policy {
+	guild, ok := d.Guilds[guildID]
+	account := MediaAccountConfig{Media: guild.Media, MaxMediaMB: guild.MaxMediaMB}
+	defaultBytes := d.MaxMediaBytes
+	if defaultBytes <= 0 {
+		defaultBytes = DefaultDiscordMaxMediaBytes
+	}
+	return resolveMediaPolicy(d.Media, d.MediaScope, d.MediaMaxParticipants,
+		d.MaxMediaMB, defaultBytes, account, ok)
+}
+
+// MediaPolicy resolves Teams provider settings and an email-account override.
+func (t TeamsConfig) MediaPolicy(email string) attachmentpolicy.Policy {
+	account, ok := t.AccountsConfig[email]
+	return resolveMediaPolicy(t.Media, t.MediaScope, t.MediaMaxParticipants,
+		t.MaxMediaMB, DefaultChatMaxMediaBytes, account, ok)
+}
+
+func resolveMediaPolicy(
+	providerMedia *bool,
+	scope string,
+	maxParticipants, providerMaxMB int,
+	defaultMaxBytes int64,
+	account MediaAccountConfig,
+	hasAccount bool,
+) attachmentpolicy.Policy {
+	resolvedScope := attachmentpolicy.Scope(scope)
+	if resolvedScope == "" {
+		resolvedScope = attachmentpolicy.ScopeAll
+	}
+	maxBytes := defaultMaxBytes
+	if providerMaxMB > 0 {
+		maxBytes = int64(providerMaxMB) << 20
+	}
+	disabled := attachmentpolicy.SkipReason("")
+	if providerMedia != nil && !*providerMedia {
+		disabled = attachmentpolicy.SkipPolicyScope
+	}
+	if hasAccount {
+		if account.MaxMediaMB > 0 {
+			maxBytes = int64(account.MaxMediaMB) << 20
+		}
+		if account.Media != nil {
+			if *account.Media {
+				disabled = ""
+			} else {
+				disabled = attachmentpolicy.SkipAccountPolicy
+			}
+		}
+	}
+	return attachmentpolicy.Policy{
+		Scope: resolvedScope, MaxParticipants: maxParticipants,
+		MaxBytes: maxBytes, DisabledReason: disabled,
+	}
+}
+
+func (c *Config) validateMediaPolicies() error {
+	providers := []struct {
+		name            string
+		policy          attachmentpolicy.Policy
+		providerMaxMB   int
+		accountMaxMedia map[string]int
+	}{
+		{name: "beeper", policy: c.Beeper.MediaPolicy(""), providerMaxMB: c.Beeper.MaxMediaMB,
+			accountMaxMedia: mediaAccountMaximums(c.Beeper.AccountsConfig)},
+		{name: "slack", policy: c.Slack.MediaPolicy(""), providerMaxMB: c.Slack.MaxMediaMB,
+			accountMaxMedia: mediaAccountMaximums(c.Slack.AccountsConfig)},
+		{name: "discord", policy: c.Discord.MediaPolicy(""), providerMaxMB: c.Discord.MaxMediaMB,
+			accountMaxMedia: discordGuildMaximums(c.Discord.Guilds)},
+		{name: "teams", policy: c.Teams.MediaPolicy(""), providerMaxMB: c.Teams.MaxMediaMB,
+			accountMaxMedia: mediaAccountMaximums(c.Teams.AccountsConfig)},
+	}
+	for _, provider := range providers {
+		if provider.providerMaxMB < 0 {
+			return fmt.Errorf("invalid [%s] max_media_mb %d: must be zero or positive", provider.name, provider.providerMaxMB)
+		}
+		if err := provider.policy.Validate(); err != nil {
+			return fmt.Errorf("invalid [%s] attachment policy: %w", provider.name, err)
+		}
+		for account, maxMediaMB := range provider.accountMaxMedia {
+			if maxMediaMB < 0 {
+				return fmt.Errorf("invalid [%s] account %q max_media_mb %d: must be zero or positive",
+					provider.name, account, maxMediaMB)
+			}
+		}
+	}
+	return nil
+}
+
+func mediaAccountMaximums(accounts map[string]MediaAccountConfig) map[string]int {
+	maximums := make(map[string]int, len(accounts))
+	for account, cfg := range accounts {
+		maximums[account] = cfg.MaxMediaMB
+	}
+	return maximums
+}
+
+func discordGuildMaximums(guilds map[string]DiscordGuildConfig) map[string]int {
+	maximums := make(map[string]int, len(guilds))
+	for guild, cfg := range guilds {
+		maximums[guild] = cfg.MaxMediaMB
+	}
+	return maximums
 }
 
 // AccountIncluded reports whether a Beeper accountID passes the

--- a/internal/config/config_media_policy_test.go
+++ b/internal/config/config_media_policy_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+)
+
+func TestMediaPolicyDefaultsRemainAllowAll(t *testing.T) {
+	assert := assert.New(t)
+	cfg := NewDefaultConfig()
+	assert.Equal(attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeAll, MaxBytes: 100 << 20}, cfg.Beeper.MediaPolicy("signal"))
+	assert.Equal(attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeAll, MaxBytes: 100 << 20}, cfg.Slack.MediaPolicy("T01"))
+	assert.Equal(attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeAll, MaxBytes: 50 << 20}, cfg.Discord.MediaPolicy("G01"))
+	assert.Equal(attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeAll, MaxBytes: 100 << 20}, cfg.Teams.MediaPolicy("user@example.com"))
+}
+
+func TestLoadMediaPolicyAccountOverrides(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(configPath, []byte(`
+[beeper]
+media = false
+media_scope = "direct"
+media_max_participants = 5
+max_media_mb = 80
+[beeper.accounts_config.signal]
+media = true
+max_media_mb = 20
+
+[slack]
+media = true
+media_scope = "none"
+max_media_mb = 90
+[slack.accounts_config.T01]
+media = false
+
+[discord]
+media_scope = "all"
+media_max_participants = 10
+max_media_mb = 70
+[discord.guilds.G01]
+media = false
+max_media_mb = 30
+
+[teams]
+media = false
+media_scope = "direct"
+max_media_mb = 60
+[teams.accounts_config."user@example.com"]
+media = true
+max_media_mb = 40
+`), 0o644))
+
+	cfg, err := Load(configPath, "")
+	require.NoError(err)
+
+	assert.Equal(attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeDirect, MaxParticipants: 5, MaxBytes: 20 << 20,
+	}, cfg.Beeper.MediaPolicy("signal"))
+	assert.Equal(attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeDirect, MaxParticipants: 5, MaxBytes: 80 << 20,
+		DisabledReason: attachmentpolicy.SkipPolicyScope,
+	}, cfg.Beeper.MediaPolicy("telegram"))
+	assert.Equal(attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeNone, MaxBytes: 90 << 20,
+		DisabledReason: attachmentpolicy.SkipAccountPolicy,
+	}, cfg.Slack.MediaPolicy("T01"))
+	assert.Equal(attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeAll, MaxParticipants: 10, MaxBytes: 30 << 20,
+		DisabledReason: attachmentpolicy.SkipAccountPolicy,
+	}, cfg.Discord.MediaPolicy("G01"))
+	assert.Equal(attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeDirect, MaxBytes: 40 << 20,
+	}, cfg.Teams.MediaPolicy("user@example.com"))
+}
+
+func TestLoadRejectsInvalidMediaPolicies(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "scope", content: "[slack]\nmedia_scope = \"rooms\"\n", want: "media_scope"},
+		{name: "participants", content: "[beeper]\nmedia_max_participants = -1\n", want: "media_max_participants"},
+		{name: "provider size", content: "[teams]\nmax_media_mb = -1\n", want: "max_media_mb"},
+		{name: "account size", content: "[discord.guilds.G01]\nmax_media_mb = -1\n", want: "max_media_mb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.toml")
+			require.NoError(t, os.WriteFile(configPath, []byte(tt.content), 0o644))
+			_, err := Load(configPath, "")
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}

--- a/internal/discord/catalog.go
+++ b/internal/discord/catalog.go
@@ -34,6 +34,7 @@ type CatalogScope string
 
 const (
 	CatalogScopeGuildChannels  CatalogScope = "guild_channels"
+	CatalogScopeGuildMembers   CatalogScope = "guild_members"
 	CatalogScopeActiveThreads  CatalogScope = "active_threads"
 	CatalogScopePublicArchive  CatalogScope = "public_archive"
 	CatalogScopePrivateArchive CatalogScope = "private_archive"

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -159,6 +159,20 @@ func (c *Client) Guild(ctx context.Context, guildID string) (Guild, error) {
 	return out, err
 }
 
+// GuildWithCounts fetches a guild together with Discord's approximate member
+// count. The estimate is served from Discord's own cache and needs none of the
+// privileged gateway intents that enumerating the roster would.
+func (c *Client) GuildWithCounts(ctx context.Context, guildID string) (Guild, error) {
+	var out Guild
+	id, err := snowflakePathValue("guild ID", guildID)
+	if err != nil {
+		return out, err
+	}
+	query := url.Values{"with_counts": {"true"}}
+	err = c.getJSON(ctx, discordRoute{"guild member counts", "/guilds/" + id, "GET /guilds/:guild", guildID}, query, &out)
+	return out, err
+}
+
 func (c *Client) GuildChannels(ctx context.Context, guildID string) ([]Channel, error) {
 	var out []Channel
 	id, err := snowflakePathValue("guild ID", guildID)

--- a/internal/discord/client_test.go
+++ b/internal/discord/client_test.go
@@ -176,6 +176,27 @@ func TestMessageQueryValidation(t *testing.T) {
 	}
 }
 
+func TestClientGuildWithCountsAsksDiscordForApproximateMembership(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	requested := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested <- r.URL.RequestURI()
+		writeDiscordJSON(w, http.StatusOK, map[string]any{
+			"id": "201", "name": "Test Guild", "approximate_member_count": 4200,
+		})
+	}))
+	t.Cleanup(server.Close)
+	client, err := NewClient(server.URL+"/api/v10", "test-bot-token")
+	require.NoError(err)
+
+	guild, err := client.GuildWithCounts(context.Background(), "201")
+
+	require.NoError(err)
+	assert.Equal("/api/v10/guilds/201?with_counts=true", <-requested)
+	assert.Equal(4200, guild.ApproximateMemberCount)
+}
+
 func TestClientDecodesDiscordAPIError(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/discord/importer.go
+++ b/internal/discord/importer.go
@@ -2,11 +2,13 @@ package discord
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/http"
 	"os"
@@ -15,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/store"
 )
@@ -32,6 +35,7 @@ type ImportOptions struct {
 	GuildConfig      config.DiscordGuildConfig
 	AttachmentsDir   string
 	MaxMediaBytes    int64
+	MediaPolicy      attachmentpolicy.Policy
 	EditRescanWindow time.Duration
 	After            time.Time
 	Full             bool
@@ -49,6 +53,7 @@ type ImportSummary struct {
 	MessagesUpdated     int64
 	MediaDownloaded     int64
 	MediaPending        int64
+	MediaSkipped        int64
 	CatalogIssues       []CatalogIssue
 	ContainerIssues     []ContainerIssue
 	processedMessageIDs map[string]struct{}
@@ -192,7 +197,20 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (summary *I
 	if err != nil {
 		return summary, err
 	}
-	if err := imp.stageCatalogContainers(source.ID, containers, state); err != nil {
+	// Resolve the floor before staging: the archived catalog has to record the
+	// membership this run's media policy is about to be evaluated against, so
+	// purge and retry selection later reach the same verdict sync did.
+	floor := guildFloor{}
+	if media != nil {
+		floor = imp.guildParticipantFloor(ctx, opts, summary)
+		// The floor is guild-wide, so its outcome lands on every conversation of
+		// the guild before staging rewrites this run's containers: purge and
+		// backfill then see the same resolved (or unresolved) membership.
+		if err := imp.archiveGuildFloor(source.ID, floor); err != nil {
+			return summary, err
+		}
+	}
+	if err := imp.stageCatalogContainers(source.ID, containers, state, floor); err != nil {
 		return summary, err
 	}
 	state.ThreadCatalog = catalog.ThreadCatalog
@@ -203,9 +221,15 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (summary *I
 		if err := ctx.Err(); err != nil {
 			return summary, err
 		}
+		if media != nil {
+			media.SetPolicy(opts.MediaPolicy, attachmentpolicy.Conversation{
+				Type:             discordConversationType,
+				ParticipantCount: max(container.Channel.MemberCount, floor.count),
+			})
+		}
 		if err := imp.importContainer(
 			ctx, source.ID, syncID, container, lowerBound, state, summary, media,
-			repairLower,
+			repairLower, floor,
 		); err != nil {
 			return summary, fmt.Errorf("import Discord container %s: %w", container.Channel.ID, err)
 		}
@@ -232,11 +256,83 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (summary *I
 	return summary, nil
 }
 
+// guildFloor is the guild-wide membership one run evaluates every container's
+// media against. Known separates a count Discord answered with from the
+// fail-closed substitute an unreadable one produces: the substitute governs
+// this run's downloads but is not membership, so it is never archived as such;
+// unreadable records that the lookup was made and failed, which is archived
+// as an unresolved roster. A known zero means no participant limit is
+// configured and no floor was requested, which is also nothing to archive.
+type guildFloor struct {
+	count      int
+	known      bool
+	unreadable bool
+}
+
+// archivable reports whether the floor carries a lookup outcome worth
+// recording: a count Discord answered with, or the fact that it did not.
+func (f guildFloor) archivable() bool {
+	return f.unreadable || (f.known && f.count > 0)
+}
+
+// guildFloorFromLookup classifies one guild membership lookup outcome.
+func guildFloorFromLookup(count int, lookupErr error) guildFloor {
+	if lookupErr != nil {
+		return guildFloor{count: count, unreadable: true}
+	}
+	return guildFloor{count: count, known: true}
+}
+
+// guildParticipantFloor resolves the guild membership every container in this
+// run evaluates media policy against, once per run rather than once per
+// container. An unreadable count restricts media instead of failing the guild
+// import: the core message archive is durable work that a media lookup must not
+// cost, and the resulting exclusions are retryable by a later run or backfill.
+func (imp *Importer) guildParticipantFloor(
+	ctx context.Context, opts ImportOptions, summary *ImportSummary,
+) guildFloor {
+	count, err := GuildParticipantFloor(ctx, imp.api, opts.GuildID, opts.MediaPolicy)
+	if err != nil {
+		issue := newCatalogIssue(CatalogScopeGuildMembers, opts.GuildID, "", err)
+		issue.Fatal = false
+		summary.CatalogIssues = append(summary.CatalogIssues, issue)
+	}
+	return guildFloorFromLookup(count, err)
+}
+
+// ArchiveGuildMembership records the outcome of one guild membership lookup on
+// every conversation of the source, so purge and later runs evaluate the same
+// membership the caller did. The floor is guild-wide, which is why it lands on
+// every conversation rather than only those the caller touched. A readable
+// count reconciles each conversation's archived floor and clears the unknown
+// marker; an unreadable one (lookupErr != nil) marks every roster unresolved
+// and keeps the last counts for reference. A count of zero without an error
+// means no lookup was made, and nothing is rewritten.
+func (imp *Importer) ArchiveGuildMembership(sourceID int64, count int, lookupErr error) error {
+	return imp.archiveGuildFloor(sourceID, guildFloorFromLookup(count, lookupErr))
+}
+
+func (imp *Importer) archiveGuildFloor(sourceID int64, floor guildFloor) error {
+	if !floor.archivable() {
+		return nil
+	}
+	conversationIDs, err := imp.store.ListConversationIDs(sourceID)
+	if err != nil {
+		return err
+	}
+	for _, conversationID := range conversationIDs {
+		if err := imp.reconcileArchivedParticipantFloor(conversationID, floor); err != nil {
+			return fmt.Errorf("archive guild membership for conversation %d: %w", conversationID, err)
+		}
+	}
+	return nil
+}
+
 // stageCatalogContainers makes every discovered container recoverable before
 // publishing archive watermarks that can page past it. Conversation metadata
 // and an empty per-container state entry together form the durable catalog.
 func (imp *Importer) stageCatalogContainers(
-	sourceID int64, containers []importerContainer, state *SyncState,
+	sourceID int64, containers []importerContainer, state *SyncState, floor guildFloor,
 ) error {
 	for _, container := range containers {
 		if container.Channel.ID == "" {
@@ -248,12 +344,14 @@ func (imp *Importer) stageCatalogContainers(
 		if err != nil {
 			return fmt.Errorf("stage Discord container %s: ensure conversation: %w", container.Channel.ID, err)
 		}
+		// A preserved container keeps its archived metadata; its floor was
+		// already reconciled guild-wide before staging.
 		if !container.preserveMetadata {
 			mapped, err := mapConversation(&container.Channel)
 			if err != nil {
 				return fmt.Errorf("stage Discord container %s: %w", container.Channel.ID, err)
 			}
-			if err := imp.setConversationCatalogMetadata(conversationID, mapped.Metadata); err != nil {
+			if err := imp.setConversationCatalogMetadata(conversationID, mapped.Metadata, floor); err != nil {
 				return fmt.Errorf("stage Discord container %s: %w", container.Channel.ID, err)
 			}
 		}
@@ -366,7 +464,10 @@ func (imp *Importer) importerContainers(
 			continue
 		}
 		containers = append(containers, importerContainer{
-			CatalogContainer: CatalogContainer{Channel: Channel{ID: containerID, GuildID: guildID}},
+			CatalogContainer: CatalogContainer{Channel: Channel{
+				ID: containerID, GuildID: guildID,
+				MemberCount: storedContainerMemberCount(storedMetadata[containerID]),
+			}},
 			preserveMetadata: true,
 		})
 	}
@@ -462,6 +563,7 @@ func (imp *Importer) importContainer(
 	summary *ImportSummary,
 	media *MediaArchiver,
 	repairLower string,
+	floor guildFloor,
 ) error {
 	if container.Channel.ID == "" {
 		return errors.New("catalog container has an empty ID")
@@ -478,7 +580,7 @@ func (imp *Importer) importContainer(
 		if err != nil {
 			return err
 		}
-		if err := imp.setConversationCatalogMetadata(conversationID, mapped.Metadata); err != nil {
+		if err := imp.setConversationCatalogMetadata(conversationID, mapped.Metadata, floor); err != nil {
 			return err
 		}
 	}
@@ -1033,7 +1135,7 @@ func (imp *Importer) setContainerAccessMarker(
 }
 
 func (imp *Importer) setConversationCatalogMetadata(
-	conversationID int64, catalogMetadata json.RawMessage,
+	conversationID int64, catalogMetadata json.RawMessage, floor guildFloor,
 ) error {
 	metadata := make(map[string]json.RawMessage)
 	if len(catalogMetadata) != 0 {
@@ -1045,8 +1147,8 @@ func (imp *Importer) setConversationCatalogMetadata(
 	if err != nil {
 		return err
 	}
+	var existing map[string]json.RawMessage
 	if stored.Valid && json.Valid([]byte(stored.String)) {
-		var existing map[string]json.RawMessage
 		if err := json.Unmarshal([]byte(stored.String), &existing); err != nil {
 			return fmt.Errorf("decode stored Discord conversation metadata: %w", err)
 		}
@@ -1058,7 +1160,129 @@ func (imp *Importer) setConversationCatalogMetadata(
 			}
 		}
 	}
+	applyParticipantFloor(metadata, existing, floor)
 	return imp.writeContainerMetadata(conversationID, metadata)
+}
+
+// applyParticipantFloor records the membership media policy weighed this
+// container against, because Discord reports member_count for threads only:
+// without the guild floor an ordinary channel archives no membership at all and
+// purge and retry selection then re-admit exactly what sync excluded.
+//
+// The container's own count, when the catalog reports one, is archived beside
+// the resolved member_count as container_member_count, so a later run that
+// preserves this metadata rather than re-cataloging it can still reconcile the
+// resolved count with the guild floor it reads then.
+//
+// A floor Discord did not answer with is not membership. Rather than archive
+// the fail-closed substitute, such a run keeps the larger of the catalog's own
+// count and what an earlier run established: a stale count is worth more than
+// the zero an ordinary channel would otherwise write back. A floor Discord did
+// answer with replaces the archived one outright, so a shrinking guild relaxes
+// its exclusions on the next run.
+func applyParticipantFloor(metadata, archived map[string]json.RawMessage, floor guildFloor) {
+	own := metadataCount(metadata, "member_count")
+	if own > 0 {
+		metadata["container_member_count"] = json.RawMessage(strconv.Itoa(own))
+	}
+	count := own
+	if floor.known && floor.count > 0 {
+		count = max(count, floor.count)
+	} else {
+		count = max(count, metadataCount(archived, "member_count"))
+	}
+	applyMembershipMarker(metadata, archived, floor)
+	if count <= 0 {
+		delete(metadata, "member_count")
+		return
+	}
+	metadata["member_count"] = json.RawMessage(strconv.Itoa(count))
+}
+
+// applyMembershipMarker keeps member_count_unknown in step with the lookup
+// this run made: an unreadable lookup archives the roster as unresolved, a
+// readable one resolves it, and a run that made no lookup leaves whatever an
+// earlier run archived. The marker is what keeps purge from trusting a stale
+// count and backfill from admitting on it.
+func applyMembershipMarker(metadata, archived map[string]json.RawMessage, floor guildFloor) {
+	switch {
+	case floor.unreadable:
+		metadata["member_count_unknown"] = json.RawMessage("true")
+	case floor.known && floor.count > 0:
+		delete(metadata, "member_count_unknown")
+	default:
+		if marker, ok := archived["member_count_unknown"]; ok {
+			metadata["member_count_unknown"] = marker
+		}
+	}
+}
+
+// reconcileArchivedParticipantFloor records a guild lookup outcome on a
+// conversation whose archived metadata is otherwise left alone: the larger of
+// the container's own archived membership and the floor Discord answered with,
+// or the unresolved marker when it did not answer. Lowering matters as much as
+// raising — a guild that shrank below the limit must relax the exclusions its
+// earlier size produced, or retry and purge keep weighing a count no run can
+// correct. Every other archived key is left alone.
+func (imp *Importer) reconcileArchivedParticipantFloor(conversationID int64, floor guildFloor) error {
+	if !floor.archivable() {
+		return nil
+	}
+	stored, err := imp.store.GetConversationMetadata(conversationID)
+	if err != nil {
+		return err
+	}
+	metadata := make(map[string]json.RawMessage)
+	if stored.Valid && strings.TrimSpace(stored.String) != "" {
+		// A legacy opaque payload has no mergeable object. Preserving it whole
+		// matters more than a floor the next catalog refresh will record anyway.
+		if !json.Valid([]byte(stored.String)) {
+			return nil
+		}
+		if err := json.Unmarshal([]byte(stored.String), &metadata); err != nil {
+			return fmt.Errorf("decode Discord conversation metadata: %w", err)
+		}
+	}
+	reconciled := make(map[string]json.RawMessage, len(metadata)+2)
+	maps.Copy(reconciled, metadata)
+	if floor.known {
+		count := max(metadataCount(metadata, "container_member_count"), floor.count)
+		reconciled["member_count"] = json.RawMessage(strconv.Itoa(count))
+	}
+	applyMembershipMarker(reconciled, metadata, floor)
+	unchanged := maps.EqualFunc(metadata, reconciled, func(left, right json.RawMessage) bool {
+		return bytes.Equal(left, right)
+	})
+	if unchanged {
+		return nil
+	}
+	return imp.writeContainerMetadata(conversationID, reconciled)
+}
+
+func metadataCount(metadata map[string]json.RawMessage, key string) int {
+	raw, ok := metadata[key]
+	if !ok {
+		return 0
+	}
+	var count int
+	if err := json.Unmarshal(raw, &count); err != nil {
+		return 0
+	}
+	return count
+}
+
+// storedContainerMemberCount reads the container-specific membership an
+// earlier catalog archived, so a preserved container's live media policy
+// weighs the same count its reconciled metadata records.
+func storedContainerMemberCount(metadata sql.NullString) int {
+	if !metadata.Valid || !json.Valid([]byte(metadata.String)) {
+		return 0
+	}
+	var archived map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(metadata.String), &archived); err != nil {
+		return 0
+	}
+	return metadataCount(archived, "container_member_count")
 }
 
 func (imp *Importer) clearContainerAccessMarkers(conversationID int64) error {
@@ -1228,6 +1452,14 @@ func (imp *Importer) persistPage(
 			}
 		}
 		if media != nil {
+			conversation, err := imp.store.AttachmentConversation(messageID)
+			if err != nil {
+				return fmt.Errorf("load Discord message %s media conversation: %w", message.ID, err)
+			}
+			if conversation.ParticipantCount < media.conversation.ParticipantCount {
+				conversation.ParticipantCount = media.conversation.ParticipantCount
+			}
+			media.SetPolicy(media.policy, conversation)
 			result, err := media.persistAttachments(ctx, messageID, message.Attachments, !alreadyProcessed)
 			if err != nil {
 				return fmt.Errorf("persist Discord message %s media metadata: %w", message.ID, err)
@@ -1238,6 +1470,8 @@ func (imp *Importer) persistPage(
 					summary.MediaDownloaded++
 				case MediaPending, MediaUnrecoverable:
 					summary.MediaPending++
+				case MediaSkipped:
+					summary.MediaSkipped++
 				}
 			}
 		} else {

--- a/internal/discord/importer_test.go
+++ b/internal/discord/importer_test.go
@@ -8,12 +8,14 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
@@ -22,7 +24,11 @@ import (
 type importerFakeAPI struct {
 	mu sync.Mutex
 
-	guild       Guild
+	guild         Guild
+	guildMembers  int
+	guildCountErr error
+	guildCounts   int
+
 	channels    []Channel
 	active      []Channel
 	messages    map[string][]Message
@@ -37,12 +43,15 @@ type importerFakeAPI struct {
 
 func newImporterFakeAPI(channels ...Channel) *importerFakeAPI {
 	return &importerFakeAPI{
-		guild:       Guild{ID: "200", Name: "Test Guild"},
-		channels:    channels,
-		messages:    map[string][]Message{},
-		queries:     map[string][]MessageQuery{},
-		failBefore:  map[string]map[string]error{},
-		injectAfter: map[string][]Message{},
+		guild: Guild{ID: "200", Name: "Test Guild"},
+		// A guild holding only the archiving bot keeps the guild-wide floor out
+		// of the way of tests that exercise container or observed membership.
+		guildMembers: 1,
+		channels:     channels,
+		messages:     map[string][]Message{},
+		queries:      map[string][]MessageQuery{},
+		failBefore:   map[string]map[string]error{},
+		injectAfter:  map[string][]Message{},
 	}
 }
 
@@ -56,6 +65,26 @@ func (f *importerFakeAPI) Guild(_ context.Context, _ string) (Guild, error) {
 	}
 	return f.guild, nil
 }
+func (f *importerFakeAPI) GuildWithCounts(_ context.Context, _ string) (Guild, error) {
+	f.mu.Lock()
+	f.guildCounts++
+	countErr := f.guildCountErr
+	members := f.guildMembers
+	f.mu.Unlock()
+	if countErr != nil {
+		return Guild{}, countErr
+	}
+	guild := f.guild
+	guild.ApproximateMemberCount = members
+	return guild, nil
+}
+
+func (f *importerFakeAPI) guildCountRequests() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.guildCounts
+}
+
 func (f *importerFakeAPI) GuildChannels(_ context.Context, _ string) ([]Channel, error) {
 	if f.catalogErr != nil {
 		return nil, f.catalogErr
@@ -266,6 +295,516 @@ func TestImporterPinsBackfillPagesBackwardThenCollectsForwardPerContainer(t *tes
 	assert.Equal(1, mentionCount)
 	assert.Equal(1, attachmentCount)
 	assert.Equal(7, conversationCount)
+}
+
+func TestImporterUsesContainerParticipantCountForMediaPolicy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	channel := importerTestChannel("300", "general")
+	channel.MemberCount = 20
+	api := newImporterFakeAPI(channel)
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 8},
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MediaSkipped)
+	assert.Zero(summary.MediaPending)
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+
+	source, err := st.GetSourceByIdentifier("200")
+	require.NoError(err)
+	retryable, err := st.ListDiscordRetryableAttachmentMessages(source.ID, attachmentpolicy.Policy{MaxParticipants: 8})
+	require.NoError(err)
+	assert.Empty(retryable, "the archived catalog count must keep the unchanged exclusion out of backfill")
+	messageID := messageIDBySource(t, st, source.ID, "101")
+	contentHash := strings.Repeat("ab", 32)
+	require.NoError(st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{{
+		StoragePath: contentHash[:2] + "/" + contentHash, ContentHash: contentHash,
+		SourceAttachmentID: "discord:401", State: attachmentpolicy.StateStored,
+	}}))
+	candidates, err := st.ListAttachmentPolicyCandidates(t.Context())
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(20, candidates[0].ParticipantCount, "purge sees catalog membership")
+	conversation, err := st.AttachmentConversation(messageID)
+	require.NoError(err)
+	assert.Equal(20, conversation.ParticipantCount, "catalog membership survives stat recomputation")
+	metadata, err := st.ConversationMetadataBatch(source.ID, []string{"300"})
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","discord_channel_type":0,"member_count":20,"container_member_count":20}`,
+		metadata["300"].String,
+		"the container's own count is archived beside the resolved one so a later run can reconcile it",
+	)
+}
+
+func TestImporterUsesGuildMemberCountForOrdinaryChannelMediaPolicy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	// Discord reports member_count for threads only, so an ordinary guild
+	// channel arrives with no membership of its own.
+	api := newImporterFakeAPI(importerTestChannel("300", "general"), importerTestChannel("400", "random"))
+	api.guildMembers = 12
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 8},
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MediaSkipped)
+	assert.Zero(summary.MediaPending)
+	assert.Empty(summary.CatalogIssues)
+	assert.Equal(1, api.guildCountRequests(), "guild membership is fetched once per sync, not per container")
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+}
+
+func TestImporterAdmitsMediaWhenGuildMemberCountIsUnderTheLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	api := newImporterFakeAPI(importerTestChannel("300", "general"))
+	api.guildMembers = 3
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 8},
+	})
+	require.NoError(err)
+	assert.Zero(summary.MediaSkipped)
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments
+	`).Scan(&state, &reason))
+	// The download itself cannot succeed against a fixture URL; reaching it at
+	// all proves policy admitted the attachment.
+	assert.Equal(string(attachmentpolicy.StateFailed), state)
+	assert.Equal(string(attachmentpolicy.SkipFetchFailure), reason)
+}
+
+func TestImporterFailsClosedWhenGuildMemberCountIsUnreadable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	api := newImporterFakeAPI(importerTestChannel("300", "general"))
+	api.guildCountErr = &APIError{
+		Operation: "guild member counts", StatusCode: http.StatusForbidden, Code: 50001,
+	}
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 8},
+	})
+	require.NoError(err, "unreadable membership restricts media, it does not fail the guild import")
+	assert.Equal(int64(1), summary.MediaSkipped)
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+	require.Len(summary.CatalogIssues, 1)
+	issue := summary.CatalogIssues[0]
+	assert.Equal(CatalogScopeGuildMembers, issue.Scope)
+	assert.Equal(CatalogIssueForbidden, issue.Kind)
+	assert.Equal("200", issue.GuildID)
+	assert.False(issue.Fatal)
+}
+
+func TestImporterSkipsGuildMemberCountWithoutParticipantLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	api := newImporterFakeAPI(importerTestChannel("300", "general"))
+	api.guildCountErr = errors.New("guild membership must not be requested")
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+	})
+	require.NoError(err)
+	assert.Zero(api.guildCountRequests(), "no participant limit needs no membership lookup")
+	assert.Empty(summary.CatalogIssues)
+}
+
+func TestImporterArchivesGuildParticipantFloorForOrdinaryChannels(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	api := newImporterFakeAPI(importerTestChannel("300", "general"))
+	api.guildMembers = 12
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+	policy := attachmentpolicy.Policy{MaxParticipants: 8}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(), MediaPolicy: policy,
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MediaSkipped)
+
+	source, err := st.GetSourceByIdentifier("200")
+	require.NoError(err)
+	metadata, err := st.ConversationMetadataBatch(source.ID, []string{"300"})
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","discord_channel_type":0,"member_count":12}`, metadata["300"].String,
+		"the membership sync evaluated must outlive the run that read it",
+	)
+	retryable, err := st.ListDiscordRetryableAttachmentMessages(source.ID, policy)
+	require.NoError(err)
+	assert.Empty(retryable, "backfill selection must not re-admit what the guild floor excluded")
+
+	messageID := messageIDBySource(t, st, source.ID, "101")
+	contentHash := strings.Repeat("cd", 32)
+	require.NoError(st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{{
+		StoragePath: contentHash[:2] + "/" + contentHash, ContentHash: contentHash,
+		SourceAttachmentID: "discord:401", State: attachmentpolicy.StateStored,
+	}}))
+	candidates, err := st.ListAttachmentPolicyCandidates(t.Context())
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(12, candidates[0].ParticipantCount, "purge sees the guild floor")
+}
+
+func TestImporterArchivesGuildParticipantFloorWhenMediaIsAdmitted(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	api := newImporterFakeAPI(importerTestChannel("300", "general"))
+	api.guildMembers = 3
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 8},
+	})
+	require.NoError(err)
+	assert.Zero(summary.MediaSkipped)
+	source, err := st.GetSourceByIdentifier("200")
+	require.NoError(err)
+	metadata, err := st.ConversationMetadataBatch(source.ID, []string{"300"})
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","discord_channel_type":0,"member_count":3}`, metadata["300"].String,
+		"an admitting floor is archived too, so a later purge weighs the same membership",
+	)
+}
+
+func TestImporterMarksMembershipUnknownWhenGuildMembershipIsUnreadable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	api := newImporterFakeAPI(importerTestChannel("300", "general"))
+	api.guildMembers = 12
+	message := importerTestMessage("101", "300", "attachment")
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+	opts := ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 8},
+	}
+	importer := newTestImporter(st, api)
+
+	_, err := importer.Import(t.Context(), opts)
+	require.NoError(err)
+	api.guildCountErr = &APIError{
+		Operation: "guild member counts", StatusCode: http.StatusForbidden, Code: 50001,
+	}
+	summary, err := importer.Import(t.Context(), opts)
+	require.NoError(err)
+	require.Len(summary.CatalogIssues, 1)
+
+	source, err := st.GetSourceByIdentifier("200")
+	require.NoError(err)
+	metadata, err := st.ConversationMetadataBatch(source.ID, []string{"300"})
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","discord_channel_type":0,"member_count":12,"member_count_unknown":true}`,
+		metadata["300"].String,
+		"an unreadable count keeps the membership an earlier run established for reference, "+
+			"but archives that the roster is unresolved",
+	)
+	messageID := messageIDBySource(t, st, source.ID, "101")
+	contentHash := strings.Repeat("cd", 32)
+	require.NoError(st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{{
+		StoragePath: contentHash[:2] + "/" + contentHash, ContentHash: contentHash,
+		SourceAttachmentID: "discord:401", State: attachmentpolicy.StateStored,
+	}}))
+	candidates, err := st.ListAttachmentPolicyCandidates(t.Context())
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.True(candidates[0].RosterUnresolved,
+		"purge must see the unresolved roster rather than trust the stale count")
+
+	// A readable count resolves the roster again and replaces the stale floor.
+	api.guildCountErr = nil
+	api.guildMembers = 5
+	_, err = importer.Import(t.Context(), opts)
+	require.NoError(err)
+	metadata, err = st.ConversationMetadataBatch(source.ID, []string{"300"})
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","discord_channel_type":0,"member_count":5}`, metadata["300"].String,
+		"a successful lookup clears the marker and lowers the archived floor",
+	)
+	candidates, err = st.ListAttachmentPolicyCandidates(t.Context())
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.False(candidates[0].RosterUnresolved)
+	assert.Equal(5, candidates[0].ParticipantCount)
+}
+
+// TestImporterArchiveGuildMembershipCoversEveryConversation pins the helper
+// sync and the media backfill share: the guild floor is guild-wide, so a
+// lookup outcome lands on every conversation of the source — including ones
+// this run did not catalog. An unreadable lookup marks each roster unresolved
+// and keeps the counts for reference; a readable one reconciles each floor
+// against the container's own archived count and clears the marker.
+func TestImporterArchiveGuildMembershipCoversEveryConversation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("discord", "200")
+	require.NoError(err)
+	archive := func(containerID, metadata string) int64 {
+		conversationID, err := st.EnsureConversationWithType(source.ID, containerID, discordConversationType, containerID)
+		require.NoError(err)
+		require.NoError(st.SetConversationMetadata(conversationID, sql.NullString{String: metadata, Valid: true}))
+		return conversationID
+	}
+	channelID := archive("300", `{"guild_id":"200","discord_channel_type":0,"member_count":40}`)
+	threadID := archive("301", `{"guild_id":"200","discord_channel_type":11,"member_count":40,"container_member_count":20}`)
+	metadataOf := func(conversationID int64) string {
+		metadata, err := st.GetConversationMetadata(conversationID)
+		require.NoError(err)
+		return metadata.String
+	}
+	importer := newTestImporter(st, newImporterFakeAPI())
+
+	require.NoError(importer.ArchiveGuildMembership(source.ID, 9, errors.New("members unavailable")))
+	assert.JSONEq(`{"guild_id":"200","discord_channel_type":0,"member_count":40,"member_count_unknown":true}`,
+		metadataOf(channelID))
+	assert.JSONEq(`{"guild_id":"200","discord_channel_type":11,"member_count":40,"container_member_count":20,`+
+		`"member_count_unknown":true}`, metadataOf(threadID))
+
+	require.NoError(importer.ArchiveGuildMembership(source.ID, 5, nil))
+	assert.JSONEq(`{"guild_id":"200","discord_channel_type":0,"member_count":5}`, metadataOf(channelID))
+	assert.JSONEq(`{"guild_id":"200","discord_channel_type":11,"member_count":20,"container_member_count":20}`,
+		metadataOf(threadID), "the container's own count outlives a floor that no longer exceeds it")
+
+	// Without a participant limit no lookup is made, and nothing is rewritten.
+	require.NoError(importer.ArchiveGuildMembership(source.ID, 0, nil))
+	assert.JSONEq(`{"guild_id":"200","discord_channel_type":0,"member_count":5}`, metadataOf(channelID))
+}
+
+func TestImporterArchivesGuildParticipantFloorForPreservedContainerMetadata(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("discord", "200")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(
+		source.ID, "300", discordConversationType, "Archived thread",
+	)
+	require.NoError(err)
+	archived := `{"guild_id":"200","parent_channel_id":"250","discord_channel_type":11,"thread":{"archived":true}}`
+	require.NoError(st.SetConversationMetadata(conversationID, sql.NullString{String: archived, Valid: true}))
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	highWater := importerTestSnowflake(t, now.Add(-time.Hour), 1)
+	baseline := NewSyncState()
+	baseline.Containers["300"] = ContainerState{
+		HighWater: highWater, BackfillUpper: highWater, BackfillBefore: "1", BackfillComplete: true,
+	}
+	blob, err := baseline.Marshal()
+	require.NoError(err)
+	runID, err := st.StartSync(source.ID, "discord")
+	require.NoError(err)
+	require.NoError(st.CompleteSync(runID, blob))
+	api := newImporterFakeAPI()
+	api.guildMembers = 12
+
+	importer := newTestImporter(st, api)
+	importer.now = func() time.Time { return now }
+	_, err = importer.Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 8},
+	})
+	require.NoError(err)
+	metadata, err := st.GetConversationMetadata(conversationID)
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","parent_channel_id":"250","discord_channel_type":11,`+
+			`"thread":{"archived":true},"member_count":12}`, metadata.String,
+		"a container whose media the floor governs records it without losing archived keys",
+	)
+}
+
+// TestImporterReconcilesPreservedContainerFloorWhenGuildShrinks pins the
+// preserved-container half of the floor contract: a container this run does
+// not re-catalog still evaluates media against the guild membership Discord
+// answers with today, so a guild that shrank below the limit relaxes its
+// exclusions instead of keeping a count nobody can lower. A container-specific
+// count the catalog once reported outlives the floor that used to exceed it.
+func TestImporterReconcilesPreservedContainerFloorWhenGuildShrinks(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("discord", "200")
+	require.NoError(err)
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	highWater := importerTestSnowflake(t, now.Add(-time.Hour), 1)
+	baseline := NewSyncState()
+	archiveThread := func(containerID, metadata string) int64 {
+		conversationID, err := st.EnsureConversationWithType(
+			source.ID, containerID, discordConversationType, "Archived thread "+containerID,
+		)
+		require.NoError(err)
+		require.NoError(st.SetConversationMetadata(conversationID, sql.NullString{String: metadata, Valid: true}))
+		baseline.Containers[containerID] = ContainerState{
+			HighWater: highWater, BackfillUpper: highWater, BackfillBefore: "1", BackfillComplete: true,
+		}
+		return conversationID
+	}
+	// A floor of 40 was archived while the guild was large; 300 reported no
+	// membership of its own, 301 is a thread the catalog once counted at 20.
+	guildOnlyID := archiveThread("300", `{"guild_id":"200","parent_channel_id":"250",`+
+		`"discord_channel_type":11,"thread":{"archived":true},"member_count":40}`)
+	threadOwnID := archiveThread("301", `{"guild_id":"200","parent_channel_id":"250",`+
+		`"discord_channel_type":11,"thread":{"archived":true},"member_count":40,"container_member_count":20}`)
+	blob, err := baseline.Marshal()
+	require.NoError(err)
+	runID, err := st.StartSync(source.ID, "discord")
+	require.NoError(err)
+	require.NoError(st.CompleteSync(runID, blob))
+	skippedMessage := func(conversationID int64, sourceMessageID, attachmentID string) int64 {
+		messageID, err := st.UpsertMessage(&store.Message{
+			SourceID: source.ID, ConversationID: conversationID,
+			SourceMessageID: sourceMessageID, MessageType: "discord",
+		})
+		require.NoError(err)
+		require.NoError(st.ReplaceMessageDiscordAttachments(messageID, []store.AttachmentRef{{
+			SourceAttachmentID: "discord:" + attachmentID, Size: 5,
+			State: attachmentpolicy.StateSkipped, SkipReason: attachmentpolicy.SkipParticipantThreshold,
+		}}))
+		return messageID
+	}
+	guildOnlyMessageID := skippedMessage(guildOnlyID, "101", "401")
+	skippedMessage(threadOwnID, "102", "402")
+	policy := attachmentpolicy.Policy{MaxParticipants: 8}
+	api := newImporterFakeAPI()
+	api.guildMembers = 5
+	// New media in each container is weighed live against the same membership
+	// the reconciled metadata records.
+	freshMessage := func(containerID, attachmentID string, sequence uint64) Message {
+		message := importerTestMessage(importerTestSnowflake(t, now, sequence), containerID, "attachment")
+		message.Attachments = []Attachment{{ID: attachmentID, Filename: "private.bin", Size: 5}}
+		return message
+	}
+	api.messages["300"] = []Message{freshMessage("300", "403", 2)}
+	api.messages["301"] = []Message{freshMessage("301", "404", 3)}
+
+	importer := newTestImporter(st, api)
+	importer.now = func() time.Time { return now }
+	summary, err := importer.Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(), MediaPolicy: policy,
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MediaSkipped, "only the thread's own count still exceeds the limit")
+	attachmentOutcome := func(sourceAttachmentID string) (string, string) {
+		var state, reason sql.NullString
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT attachment_state, attachment_skip_reason FROM attachments WHERE source_attachment_id = ?
+		`), sourceAttachmentID).Scan(&state, &reason))
+		return state.String, reason.String
+	}
+	state, reason := attachmentOutcome("discord:403")
+	assert.Equal(string(attachmentpolicy.StateFailed), state, "the shrunken guild admits new media")
+	assert.Equal(string(attachmentpolicy.SkipFetchFailure), reason)
+	state, reason = attachmentOutcome("discord:404")
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason,
+		"a preserved container's own archived count governs its live media policy")
+
+	metadata, err := st.GetConversationMetadata(guildOnlyID)
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","parent_channel_id":"250","discord_channel_type":11,`+
+			`"thread":{"archived":true},"member_count":5}`, metadata.String,
+		"a shrinking guild lowers the archived floor of a preserved container",
+	)
+	metadata, err = st.GetConversationMetadata(threadOwnID)
+	require.NoError(err)
+	assert.JSONEq(
+		`{"guild_id":"200","parent_channel_id":"250","discord_channel_type":11,`+
+			`"thread":{"archived":true},"member_count":20,"container_member_count":20}`, metadata.String,
+		"the container's own membership outlives a floor that no longer exceeds it",
+	)
+	retryable, err := st.ListDiscordRetryableAttachmentMessages(source.ID, policy)
+	require.NoError(err)
+	retryableIDs := make([]int64, 0, len(retryable))
+	for _, item := range retryable {
+		retryableIDs = append(retryableIDs, item.MessageID)
+		assert.Equal("300", item.ChatID, "only the container the guild floor alone governed becomes retryable")
+		assert.Equal(5, item.ParticipantCount)
+	}
+	assert.Contains(retryableIDs, guildOnlyMessageID,
+		"the exclusion the earlier floor produced is retryable once the guild shrinks")
+}
+
+func TestImporterUsesObservedParticipantCountForMediaPolicy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	api := newImporterFakeAPI(importerTestChannel("300", "general"))
+	message := importerTestMessage("101", "300", "attachment")
+	message.Mentions = []User{{ID: "mentioned", Username: "Mentioned User"}}
+	message.Attachments = []Attachment{{ID: "401", Filename: "private.bin", Size: 5}}
+	api.messages["300"] = []Message{message}
+
+	summary, err := newTestImporter(st, api).Import(t.Context(), ImportOptions{
+		GuildID: "200", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{MaxParticipants: 1},
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MediaSkipped)
+	assert.Zero(summary.MediaPending)
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
 }
 
 func TestImporterResumesFromNewestCheckpointMergedOverSuccessfulBaseline(t *testing.T) {

--- a/internal/discord/mapping.go
+++ b/internal/discord/mapping.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -31,6 +32,7 @@ type conversationMetadata struct {
 	Topic              string          `json:"topic,omitempty"`
 	NSFW               bool            `json:"nsfw,omitempty"`
 	OwnerID            string          `json:"owner_id,omitempty"`
+	MemberCount        int             `json:"member_count,omitempty"`
 	AppliedTagIDs      []string        `json:"applied_tag_ids,omitempty"`
 	Thread             *ThreadMetadata `json:"thread,omitempty"`
 }
@@ -46,6 +48,7 @@ func mapConversation(channel *Channel) (mappedConversation, error) {
 		Topic:              channel.Topic,
 		NSFW:               channel.NSFW,
 		OwnerID:            channel.OwnerID,
+		MemberCount:        channel.MemberCount,
 		AppliedTagIDs:      channel.AppliedTags,
 		Thread:             channel.ThreadMetadata,
 	})
@@ -444,6 +447,7 @@ func mapAttachments(attachments []Attachment) []store.AttachmentRef {
 			SourceAttachmentID: "discord:" + attachment.ID,
 			MediaType:          attachmentMediaType(attachment.ContentType),
 			DurationMS:         int64(math.Round(attachment.Duration * 1000)),
+			State:              attachmentpolicy.StatePending,
 		}
 		if attachment.Width != nil {
 			ref.Width = int64(*attachment.Width)

--- a/internal/discord/mapping_test.go
+++ b/internal/discord/mapping_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -200,6 +201,7 @@ func TestDecodeAndMapRetainsUnknownAttachmentAndEmbedFields(t *testing.T) {
 		Filename: "diagram.png", MimeType: "image/png", Size: 4096,
 		StoragePath:        "https://cdn.discordapp.com/attachments/800/asset-1/diagram.png",
 		SourceAttachmentID: "discord:asset-1", MediaType: "image", Width: 640, Height: 480,
+		State: attachmentpolicy.StatePending,
 	}}, got.Attachments)
 	assert.Contains(got.BodyText, "release details")
 	assert.Contains(got.BodyText, "Release 2.0")
@@ -302,11 +304,13 @@ func TestMapDiscordAttachments(t *testing.T) {
 			Filename: "image.png", MimeType: "image/png", Size: 4096,
 			StoragePath:        "https://cdn.discordapp.com/attachments/1/a1/image.png",
 			SourceAttachmentID: "discord:a1", MediaType: "image", Width: 640, Height: 480,
+			State: attachmentpolicy.StatePending,
 		},
 		{
 			Filename: "voice.ogg", MimeType: "audio/ogg", Size: 8192,
 			StoragePath:        "https://cdn.discordapp.com/attachments/1/a2/voice.ogg",
 			SourceAttachmentID: "discord:a2", MediaType: "audio", DurationMS: 1250,
+			State: attachmentpolicy.StatePending,
 		},
 	}, got)
 

--- a/internal/discord/media.go
+++ b/internal/discord/media.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/mime"
@@ -36,6 +37,9 @@ var (
 	ErrMediaRefresh = errors.New("discord attachment URL refresh failed")
 	// ErrMediaUnrecoverable means the source message or stable attachment is gone.
 	ErrMediaUnrecoverable = errors.New("discord attachment is no longer recoverable")
+	// ErrGuildMembershipUnknown classifies a guild whose membership Discord
+	// answered without an approximate member count.
+	ErrGuildMembershipUnknown = errors.New("discord guild membership count is unavailable")
 )
 
 const mediaHTTPTimeout = 60 * time.Second
@@ -47,6 +51,7 @@ type MediaOutcome string
 const (
 	MediaDownloaded    MediaOutcome = "downloaded"
 	MediaPending       MediaOutcome = "pending"
+	MediaSkipped       MediaOutcome = "skipped"
 	MediaUnrecoverable MediaOutcome = "unrecoverable"
 )
 
@@ -64,6 +69,37 @@ type MediaResult struct {
 	Items []MediaItemResult
 }
 
+// GuildParticipantFloor resolves the guild-wide membership that media policy
+// must evaluate every conversation in a guild against. Discord populates
+// Channel.MemberCount for threads only — and stops counting those at 50 — so an
+// ordinary guild channel carries no membership of its own and a participant
+// threshold applied to it alone would never exclude anything. The guild's
+// approximate member count is the conservative ceiling for every container
+// inside it, and Discord serves it without the privileged gateway intent that
+// enumerating the roster would need.
+//
+// Membership that cannot be read is not membership under the limit: an
+// unreadable count returns MaxParticipants+1 alongside the error so callers
+// fail closed, which stays retryable because a later run re-evaluates the
+// policy. Callers with no participant limit configured get zero and no request.
+func GuildParticipantFloor(
+	ctx context.Context, api API, guildID string, policy attachmentpolicy.Policy,
+) (int, error) {
+	if policy.MaxParticipants <= 0 {
+		return 0, nil
+	}
+	guild, err := api.GuildWithCounts(ctx, guildID)
+	if err != nil {
+		return policy.MaxParticipants + 1, err
+	}
+	if guild.ApproximateMemberCount <= 0 {
+		// Every guild holds at least the archiving bot, so a zero count is an
+		// absent count rather than an empty guild.
+		return policy.MaxParticipants + 1, fmt.Errorf("discord guild %s: %w", guildID, ErrGuildMembershipUnknown)
+	}
+	return guild.ApproximateMemberCount, nil
+}
+
 // MediaArchiver persists Discord attachment markers and best-effort binary
 // content. Its production URL policy is fixed rather than caller-configurable.
 type MediaArchiver struct {
@@ -74,6 +110,17 @@ type MediaArchiver struct {
 	httpClient          *http.Client
 	allowedOrigins      map[string]struct{}
 	storeAttachmentFile func(string, *mime.Attachment) (string, error)
+	policy              attachmentpolicy.Policy
+	conversation        attachmentpolicy.Conversation
+}
+
+// SetPolicy applies the resolved account policy and normalized conversation.
+func (m *MediaArchiver) SetPolicy(policy attachmentpolicy.Policy, conversation attachmentpolicy.Conversation) {
+	m.policy = policy
+	m.conversation = conversation
+	if policy.MaxBytes > 0 {
+		m.maxBytes = policy.MaxBytes
+	}
 }
 
 // NewMediaArchiver constructs the production attachment boundary. A nonpositive
@@ -195,16 +242,31 @@ func (m *MediaArchiver) persistAttachments(
 		remainingRefs = remainingRefs[1:]
 		item := attachmentWork{attachment: attachment, ref: ref, download: true, report: true}
 		if previous, ok := existing[ref.SourceAttachmentID]; ok {
+			if previous.Size > ref.Size {
+				ref.Size = previous.Size
+			}
 			if store.IsDiscordAttachmentDownloaded(previous) {
 				ref.StoragePath = previous.StoragePath
 				ref.ContentHash = previous.ContentHash
 				ref.Role = store.AttachmentRoleStandalone
 				ref.RoleSource = store.AttachmentRoleSourceProviderExplicit
+				ref.State = attachmentpolicy.StateStored
+				ref.SkipReason = ""
 				item.download = false
 				item.report = retryExisting
 			} else if !retryExisting {
+				ref.State = previous.State
+				ref.SkipReason = previous.SkipReason
 				item.download = false
 				item.report = false
+			}
+		}
+		if item.download {
+			if reason := m.policy.Evaluate(m.conversation, int64(ref.Size)); reason != "" {
+				ref.State = attachmentpolicy.StateSkipped
+				ref.SkipReason = reason
+				item.download = false
+				item.report = true
 			}
 		}
 		work = append(work, item)
@@ -220,13 +282,28 @@ func (m *MediaArchiver) persistAttachments(
 		}
 		item := MediaItemResult{SourceAttachmentID: pending.ref.SourceAttachmentID}
 		if !pending.download {
-			item.Outcome = MediaDownloaded
+			if pending.ref.State == attachmentpolicy.StateSkipped {
+				item.Outcome = MediaSkipped
+			} else {
+				item.Outcome = MediaDownloaded
+			}
 			result.Items = append(result.Items, item)
 			continue
 		}
 		stored, downloadErr := m.downloadAttachment(ctx, pending.attachment, *pending.ref)
 		if downloadErr != nil {
+			*pending.ref = stored
+			pending.ref.State = attachmentpolicy.StateFailed
+			pending.ref.SkipReason = attachmentpolicy.SkipFetchFailure
 			item.Outcome = MediaPending
+			if errors.Is(downloadErr, ErrMediaTooLarge) {
+				pending.ref.State = attachmentpolicy.StateSkipped
+				pending.ref.SkipReason = attachmentpolicy.SkipSizeCap
+				item.Outcome = MediaSkipped
+			}
+			if replaceErr := m.replaceMetadata(messageID, refs); replaceErr != nil {
+				return result, replaceErr
+			}
 			item.Err = downloadErr
 			result.Items = append(result.Items, item)
 			continue
@@ -261,50 +338,107 @@ func (m *MediaArchiver) BackfillMessage(
 	if err != nil {
 		return MediaResult{}, fmt.Errorf("load pending Discord attachment metadata: %w", err)
 	}
-	pendingIDs := make([]string, 0, len(existing))
-	for sourceAttachmentID, ref := range existing {
-		if !store.IsDiscordAttachmentDownloaded(ref) {
-			pendingIDs = append(pendingIDs, sourceAttachmentID)
+	refs := attachmentRefsInOrder(existing)
+	refIndex := make(map[string]int, len(refs))
+	retryIDs := make([]string, 0, len(refs))
+	result := MediaResult{Items: make([]MediaItemResult, 0, len(refs))}
+	metadataChanged := false
+	for i := range refs {
+		refIndex[refs[i].SourceAttachmentID] = i
+		if store.IsDiscordAttachmentDownloaded(refs[i]) {
+			continue
+		}
+		if reason := m.policy.Evaluate(m.conversation, int64(refs[i].Size)); reason != "" {
+			if refs[i].State != attachmentpolicy.StateSkipped || refs[i].SkipReason != reason {
+				refs[i].State = attachmentpolicy.StateSkipped
+				refs[i].SkipReason = reason
+				metadataChanged = true
+			}
+			item := MediaItemResult{
+				SourceAttachmentID: refs[i].SourceAttachmentID, Outcome: MediaSkipped,
+			}
+			if reason == attachmentpolicy.SkipSizeCap {
+				item.Err = ErrMediaTooLarge
+			}
+			result.Items = append(result.Items, item)
+			continue
+		}
+		retryIDs = append(retryIDs, refs[i].SourceAttachmentID)
+	}
+	if metadataChanged {
+		if err := m.replaceMetadata(messageID, refs); err != nil {
+			return MediaResult{}, err
+		}
+		for _, ref := range refs {
+			existing[ref.SourceAttachmentID] = ref
 		}
 	}
-	sort.Strings(pendingIDs)
-	if len(pendingIDs) == 0 {
-		return MediaResult{}, nil
+	if len(retryIDs) == 0 {
+		return result, nil
 	}
 	if m.api == nil {
-		return pendingRefreshResults(pendingIDs, ErrMediaRefresh), nil
+		if err := m.markFailed(messageID, existing, retryIDs); err != nil {
+			return MediaResult{}, err
+		}
+		pending := pendingRefreshResults(retryIDs, ErrMediaRefresh)
+		result.Items = append(result.Items, pending.Items...)
+		return result, nil
 	}
 
 	message, refreshErr := m.api.Message(ctx, channelID, sourceMessageID)
 	if refreshErr != nil {
 		var apiErr *APIError
 		if errors.As(refreshErr, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
-			return unrecoverableResults(pendingIDs), nil
+			unrecoverable := unrecoverableResults(retryIDs)
+			result.Items = append(result.Items, unrecoverable.Items...)
+			return result, nil
 		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return pendingRefreshResults(
-				pendingIDs, fmt.Errorf("%w: %w", ErrMediaRefresh, ctxErr),
-			), nil
+			pending := pendingRefreshResults(
+				retryIDs, fmt.Errorf("%w: %w", ErrMediaRefresh, ctxErr),
+			)
+			result.Items = append(result.Items, pending.Items...)
+			return result, nil
 		}
-		return pendingRefreshResults(pendingIDs, ErrMediaRefresh), nil
+		if err := m.markFailed(messageID, existing, retryIDs); err != nil {
+			return MediaResult{}, err
+		}
+		pending := pendingRefreshResults(retryIDs, ErrMediaRefresh)
+		result.Items = append(result.Items, pending.Items...)
+		return result, nil
 	}
 
 	fresh := make(map[string]Attachment, len(message.Attachments))
 	for _, attachment := range message.Attachments {
 		fresh["discord:"+attachment.ID] = attachment
 	}
-	refs := attachmentRefsInOrder(existing)
-	refIndex := make(map[string]int, len(refs))
-	for i := range refs {
-		refIndex[refs[i].SourceAttachmentID] = i
-	}
 	matched := false
-	for _, sourceAttachmentID := range pendingIDs {
+	downloadIDs := make([]string, 0, len(retryIDs))
+	for _, sourceAttachmentID := range retryIDs {
 		attachment, ok := fresh[sourceAttachmentID]
 		if !ok {
+			result.Items = append(result.Items, MediaItemResult{
+				SourceAttachmentID: sourceAttachmentID,
+				Outcome:            MediaUnrecoverable,
+				Err:                ErrMediaUnrecoverable,
+			})
 			continue
 		}
-		refs[refIndex[sourceAttachmentID]] = mapAttachments([]Attachment{attachment})[0]
+		ref := mapAttachments([]Attachment{attachment})[0]
+		if reason := m.policy.Evaluate(m.conversation, attachment.Size); reason != "" {
+			ref.State = attachmentpolicy.StateSkipped
+			ref.SkipReason = reason
+			item := MediaItemResult{
+				SourceAttachmentID: sourceAttachmentID, Outcome: MediaSkipped,
+			}
+			if reason == attachmentpolicy.SkipSizeCap {
+				item.Err = ErrMediaTooLarge
+			}
+			result.Items = append(result.Items, item)
+		} else {
+			downloadIDs = append(downloadIDs, sourceAttachmentID)
+		}
+		refs[refIndex[sourceAttachmentID]] = ref
 		matched = true
 	}
 	// Persist refreshed provenance before using any new signed URL. Missing
@@ -315,23 +449,26 @@ func (m *MediaArchiver) BackfillMessage(
 		}
 	}
 
-	result := MediaResult{Items: make([]MediaItemResult, 0, len(pendingIDs))}
-	for _, sourceAttachmentID := range pendingIDs {
-		attachment, ok := fresh[sourceAttachmentID]
-		if !ok {
-			result.Items = append(result.Items, MediaItemResult{
-				SourceAttachmentID: sourceAttachmentID,
-				Outcome:            MediaUnrecoverable,
-				Err:                ErrMediaUnrecoverable,
-			})
-			continue
-		}
+	for _, sourceAttachmentID := range downloadIDs {
+		attachment := fresh[sourceAttachmentID]
 		idx := refIndex[sourceAttachmentID]
 		stored, downloadErr := m.downloadAttachment(ctx, attachment, refs[idx])
 		if downloadErr != nil {
+			refs[idx] = stored
+			refs[idx].State = attachmentpolicy.StateFailed
+			refs[idx].SkipReason = attachmentpolicy.SkipFetchFailure
+			outcome := MediaPending
+			if errors.Is(downloadErr, ErrMediaTooLarge) {
+				refs[idx].State = attachmentpolicy.StateSkipped
+				refs[idx].SkipReason = attachmentpolicy.SkipSizeCap
+				outcome = MediaSkipped
+			}
+			if err := m.replaceMetadata(messageID, refs); err != nil {
+				return result, err
+			}
 			result.Items = append(result.Items, MediaItemResult{
 				SourceAttachmentID: sourceAttachmentID,
-				Outcome:            MediaPending,
+				Outcome:            outcome,
 				Err:                downloadErr,
 			})
 			continue
@@ -359,6 +496,24 @@ func (m *MediaArchiver) BackfillMessage(
 		})
 	}
 	return result, nil
+}
+
+func (m *MediaArchiver) markFailed(
+	messageID int64, existing map[string]store.AttachmentRef, sourceAttachmentIDs []string,
+) error {
+	refs := attachmentRefsInOrder(existing)
+	wanted := make(map[string]struct{}, len(sourceAttachmentIDs))
+	for _, sourceAttachmentID := range sourceAttachmentIDs {
+		wanted[sourceAttachmentID] = struct{}{}
+	}
+	for i := range refs {
+		if _, ok := wanted[refs[i].SourceAttachmentID]; !ok || store.IsDiscordAttachmentDownloaded(refs[i]) {
+			continue
+		}
+		refs[i].State = attachmentpolicy.StateFailed
+		refs[i].SkipReason = attachmentpolicy.SkipFetchFailure
+	}
+	return m.replaceMetadata(messageID, refs)
 }
 
 func pendingRefreshResults(sourceAttachmentIDs []string, err error) MediaResult {
@@ -412,6 +567,7 @@ func (m *MediaArchiver) downloadAttachment(
 	ctx context.Context, attachment Attachment, marker store.AttachmentRef,
 ) (store.AttachmentRef, error) {
 	if attachment.Size > m.maxBytes {
+		marker.Size = attachmentpolicy.OversizeMarkerSize(m.maxBytes, attachment.Size)
 		return marker, ErrMediaTooLarge
 	}
 	requestURL, err := m.validateMediaURL(attachment.URL, attachment.ID, attachment.Ephemeral)
@@ -440,6 +596,7 @@ func (m *MediaArchiver) downloadAttachment(
 		return marker, fmt.Errorf("%w: HTTP %d", ErrMediaDownload, response.StatusCode)
 	}
 	if response.ContentLength > m.maxBytes {
+		marker.Size = attachmentpolicy.OversizeMarkerSize(m.maxBytes, response.ContentLength)
 		return marker, ErrMediaTooLarge
 	}
 
@@ -460,6 +617,7 @@ func (m *MediaArchiver) downloadAttachment(
 	}
 	if written > m.maxBytes {
 		_ = temporary.Close()
+		marker.Size = attachmentpolicy.OversizeMarkerSize(m.maxBytes, written)
 		return marker, ErrMediaTooLarge
 	}
 	if err := temporary.Close(); err != nil {
@@ -492,6 +650,8 @@ func (m *MediaArchiver) downloadAttachment(
 	marker.Size = len(content)
 	marker.Role = store.AttachmentRoleStandalone
 	marker.RoleSource = store.AttachmentRoleSourceProviderExplicit
+	marker.State = attachmentpolicy.StateStored
+	marker.SkipReason = ""
 	return marker, nil
 }
 

--- a/internal/discord/media_test.go
+++ b/internal/discord/media_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	internalexport "go.kenn.io/msgvault/internal/export"
 	internalmime "go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
@@ -140,6 +141,71 @@ func TestMediaArchiverStoresAttachmentAfterDurableMarker(t *testing.T) {
 	stored, err := os.ReadFile(filepath.Join(f.dir, filepath.FromSlash(ref.StoragePath)))
 	require.NoError(err)
 	assert.Equal(content, stored)
+}
+
+func TestMediaArchiverPolicySkipsWithoutFetch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newMediaFixture(t)
+	var requests atomic.Int64
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte("must not download"))
+	}))
+	defer cdn.Close()
+
+	archiver := newTestArchiver(t, f, nil, 1<<20, cdn)
+	archiver.SetPolicy(
+		attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeDirect, MaxBytes: 1 << 20},
+		attachmentpolicy.Conversation{Type: "channel", ParticipantCount: 20},
+	)
+	result, err := archiver.PersistAttachments(context.Background(), f.messageID, []Attachment{
+		testDiscordAttachment(cdn.URL+"/attachments/301/401/policy.png", 5),
+	})
+	require.NoError(err)
+	require.Len(result.Items, 1)
+	assert.Equal(MediaSkipped, result.Items[0].Outcome)
+	assert.Zero(requests.Load())
+
+	refs, err := f.store.MessageDiscordAttachments(f.messageID)
+	require.NoError(err)
+	ref := refs["discord:"+mediaTestAttachmentID]
+	assert.Equal(attachmentpolicy.StateSkipped, ref.State)
+	assert.Equal(attachmentpolicy.SkipPolicyScope, ref.SkipReason)
+}
+
+func TestMediaArchiverReuseKeepsStoredState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newMediaFixture(t)
+	content := []byte("stored once")
+	var requests atomic.Int32
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write(content)
+	}))
+	defer cdn.Close()
+	rawURL := cdn.URL + "/attachments/301/401/stored.bin"
+	archiver := newTestArchiver(t, f, nil, 1<<20, cdn)
+
+	_, err := archiver.PersistAttachments(t.Context(), f.messageID, []Attachment{
+		testDiscordAttachment(rawURL, int64(len(content))),
+	})
+	require.NoError(err)
+	_, err = archiver.PersistAttachments(t.Context(), f.messageID, []Attachment{
+		testDiscordAttachment(rawURL, 1),
+	})
+	require.NoError(err)
+	assert.EqualValues(1, requests.Load())
+
+	refs, err := f.store.MessageDiscordAttachments(f.messageID)
+	require.NoError(err)
+	assert.Equal(attachmentpolicy.StateStored, refs["discord:"+mediaTestAttachmentID].State)
+	assert.Equal(len(content), refs["discord:"+mediaTestAttachmentID].Size,
+		"a smaller refreshed declaration must not erase the known stored size")
+	candidates, err := f.store.ListAttachmentPolicyCandidates(t.Context())
+	require.NoError(err)
+	assert.Len(candidates, 1, "reused stored media must remain eligible for policy purge")
 }
 
 func TestMediaArchiverStoresEphemeralAttachment(t *testing.T) {
@@ -285,6 +351,41 @@ func TestMediaArchiverRepeatedPayloadRefreshesSetWithoutRetryingKnownPendingRows
 	assert.Equal("new.bin", refs["discord:402"].Filename)
 }
 
+func TestMediaArchiverRepeatedPayloadPreservesSuppressedOutcome(t *testing.T) {
+	tests := []struct {
+		name       string
+		state      attachmentpolicy.DownloadState
+		skipReason attachmentpolicy.SkipReason
+	}{
+		{name: "skipped", state: attachmentpolicy.StateSkipped, skipReason: attachmentpolicy.SkipSizeCap},
+		{name: "failed", state: attachmentpolicy.StateFailed, skipReason: attachmentpolicy.SkipFetchFailure},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := newMediaFixture(t)
+			ref := pendingDiscordRef("")
+			ref.State = tt.state
+			ref.SkipReason = tt.skipReason
+			require.NoError(f.store.ReplaceMessageDiscordAttachments(f.messageID, []store.AttachmentRef{ref}))
+			cdn := httptest.NewServer(nil)
+			t.Cleanup(cdn.Close)
+			archiver := newTestArchiver(t, f, nil, 1<<20, cdn)
+
+			result, err := archiver.persistAttachments(
+				context.Background(), f.messageID, []Attachment{testDiscordAttachment("", 0)}, false,
+			)
+			require.NoError(err)
+			assert.Empty(result.Items)
+			refs, err := f.store.MessageDiscordAttachments(f.messageID)
+			require.NoError(err)
+			assert.Equal(tt.state, refs["discord:"+mediaTestAttachmentID].State)
+			assert.Equal(tt.skipReason, refs["discord:"+mediaTestAttachmentID].SkipReason)
+		})
+	}
+}
+
 func TestMediaArchiverPersistsPendingMetadataForEmptyURL(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -315,6 +416,8 @@ func TestMediaArchiverPersistsPendingMetadataForEmptyURL(t *testing.T) {
 		Role:          store.AttachmentRoleUnknown,
 		RoleSource:    store.AttachmentRoleSourceUnknown,
 		SourcePartKey: "discord:401",
+		State:         attachmentpolicy.StateFailed,
+		SkipReason:    attachmentpolicy.SkipFetchFailure,
 	}, refs["discord:401"])
 	pending, err := f.store.ListDiscordPendingAttachmentMessages(f.sourceID)
 	require.NoError(err)
@@ -378,12 +481,66 @@ func TestMediaArchiverEnforcesSizeCapBeforeAndDuringStreaming(t *testing.T) {
 			)
 			require.NoError(err)
 			require.Len(result.Items, 1)
-			assert.Equal(MediaPending, result.Items[0].Outcome)
+			assert.Equal(MediaSkipped, result.Items[0].Outcome)
 			require.ErrorIs(result.Items[0].Err, ErrMediaTooLarge)
 			assert.Equal(tt.wantRequests, requests.Load())
 			requirePendingDiscordAttachment(t, f, rawURL)
+			refs, err := f.store.MessageDiscordAttachments(f.messageID)
+			require.NoError(err)
+			assert.Greater(refs["discord:"+mediaTestAttachmentID].Size, 10,
+				"stream-detected oversize must remain excluded under the unchanged cap")
 		})
 	}
+}
+
+func TestMediaBackfillPreservesKnownSizeSkipAndChecksRefreshedSize(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newMediaFixture(t)
+	knownID := "discord:known-large"
+	retryID := "discord:retry"
+	require.NoError(f.store.ReplaceMessageDiscordAttachments(f.messageID, []store.AttachmentRef{
+		{SourceAttachmentID: knownID, StoragePath: "old-known", Size: 11,
+			State: attachmentpolicy.StateSkipped, SkipReason: attachmentpolicy.SkipSizeCap},
+		{SourceAttachmentID: retryID, StoragePath: "old-retry", State: attachmentpolicy.StatePending},
+	}))
+	var cdnRequests atomic.Int32
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		cdnRequests.Add(1)
+		_, _ = w.Write([]byte("must not download"))
+	}))
+	defer cdn.Close()
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeDiscordJSON(w, http.StatusOK, map[string]any{
+			"id": mediaTestMessageID, "channel_id": mediaTestChannelID,
+			"author": map[string]any{"id": "101"}, "timestamp": "2026-07-18T12:00:00Z",
+			"attachments": []map[string]any{
+				{"id": "known-large", "filename": "known.bin", "size": 11,
+					"url": cdn.URL + "/attachments/301/known-large/known.bin"},
+				{"id": "retry", "filename": "retry.bin", "size": 11,
+					"url": cdn.URL + "/attachments/301/retry/retry.bin"},
+			},
+		})
+	}))
+	defer api.Close()
+	client, err := NewClient(api.URL+"/api/v10", "synthetic-token")
+	require.NoError(err)
+	archiver := newTestArchiver(t, f, client, 10, cdn)
+	archiver.SetPolicy(attachmentpolicy.Policy{MaxBytes: 10}, attachmentpolicy.Conversation{Type: "channel"})
+
+	result, err := archiver.BackfillMessage(t.Context(), f.messageID, mediaTestChannelID, mediaTestMessageID)
+	require.NoError(err)
+	assert.Zero(cdnRequests.Load())
+	require.Len(result.Items, 2)
+	for _, item := range result.Items {
+		assert.Equal(MediaSkipped, item.Outcome)
+	}
+	refs, err := f.store.MessageDiscordAttachments(f.messageID)
+	require.NoError(err)
+	assert.Equal(attachmentpolicy.StateSkipped, refs[knownID].State)
+	assert.Equal(attachmentpolicy.SkipSizeCap, refs[knownID].SkipReason)
+	assert.Equal(attachmentpolicy.StateSkipped, refs[retryID].State)
+	assert.Equal(attachmentpolicy.SkipSizeCap, refs[retryID].SkipReason)
 }
 
 func TestMediaArchiverPreservesPendingMarkerOnHTTPAndStorageFailures(t *testing.T) {

--- a/internal/discord/types.go
+++ b/internal/discord/types.go
@@ -11,6 +11,7 @@ type API interface {
 	Me(ctx context.Context) (User, error)
 	Guilds(ctx context.Context) ([]Guild, error)
 	Guild(ctx context.Context, guildID string) (Guild, error)
+	GuildWithCounts(ctx context.Context, guildID string) (Guild, error)
 	GuildChannels(ctx context.Context, guildID string) ([]Channel, error)
 	ActiveThreads(ctx context.Context, guildID string) ([]Channel, error)
 	ArchivedThreads(ctx context.Context, channelID string, private bool, before ArchiveCursor) (ThreadPage, error)
@@ -41,14 +42,17 @@ type User struct {
 }
 
 // Guild contains the metadata needed to bind and display a Discord source.
+// ApproximateMemberCount is Discord's own estimate of guild membership and is
+// populated only for responses requested with counts.
 type Guild struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Icon        string   `json:"icon"`
-	OwnerID     string   `json:"owner_id"`
-	Description string   `json:"description"`
-	Features    []string `json:"features"`
-	Unavailable bool     `json:"unavailable"`
+	ID                     string   `json:"id"`
+	Name                   string   `json:"name"`
+	Icon                   string   `json:"icon"`
+	OwnerID                string   `json:"owner_id"`
+	Description            string   `json:"description"`
+	Features               []string `json:"features"`
+	Unavailable            bool     `json:"unavailable"`
+	ApproximateMemberCount int      `json:"approximate_member_count"`
 }
 
 // Channel contains catalog and conversation metadata for guild channels and

--- a/internal/microsoft/graph_oauth.go
+++ b/internal/microsoft/graph_oauth.go
@@ -23,6 +23,12 @@ const (
 	scopeGraphChannelBasic   = "https://graph.microsoft.com/Channel.ReadBasic.All"
 	scopeGraphUserRead       = "https://graph.microsoft.com/User.Read"
 	scopeGraphUserReadBasic  = "https://graph.microsoft.com/User.ReadBasic.All"
+	// Channel imports read the team roster (GET /teams/{id}/members) to
+	// evaluate the participant threshold; Team.ReadBasic.All does not cover it.
+	scopeGraphTeamMemberRead = "https://graph.microsoft.com/TeamMember.Read.All"
+	// Private and shared channels carry their own membership, read via
+	// GET /teams/{id}/channels/{id}/members.
+	scopeGraphChannelMemberRead = "https://graph.microsoft.com/ChannelMember.Read.All"
 )
 
 // GraphScopes returns the OAuth scopes requested for Microsoft Teams ingestion
@@ -32,6 +38,7 @@ func GraphScopes() []string {
 	return []string{
 		scopeGraphChatRead, scopeGraphChannelMessage, scopeGraphTeamReadBasic,
 		scopeGraphChannelBasic, scopeGraphUserRead, scopeGraphUserReadBasic,
+		scopeGraphTeamMemberRead, scopeGraphChannelMemberRead,
 		scopeOfflineAccess, "openid", scopeEmail,
 	}
 }

--- a/internal/microsoft/graph_oauth_test.go
+++ b/internal/microsoft/graph_oauth_test.go
@@ -27,6 +27,8 @@ func TestGraphScopes(t *testing.T) {
 	assert.Contains(got, "https://graph.microsoft.com/Channel.ReadBasic.All")
 	assert.Contains(got, "https://graph.microsoft.com/User.Read")
 	assert.Contains(got, "https://graph.microsoft.com/User.ReadBasic.All")
+	assert.Contains(got, "https://graph.microsoft.com/TeamMember.Read.All")
+	assert.Contains(got, "https://graph.microsoft.com/ChannelMember.Read.All")
 	assert.Contains(got, scopeOfflineAccess)
 }
 
@@ -143,6 +145,38 @@ func TestGraphManager_TokenSource_StaleGraphScopesReturnsError(t *testing.T) {
 	require.Error(err, "expected stale Graph scope error")
 	require.ErrorContains(err, "missing Microsoft Graph scopes")
 	require.ErrorContains(err, "User.ReadBasic.All")
+	require.ErrorContains(err, "msgvault add-teams user@company.com")
+}
+
+// TestGraphManager_TokenSource_MissingRosterScopesReturnsError covers tokens
+// minted before channel imports read rosters. Without TeamMember.Read.All and
+// ChannelMember.Read.All every roster fetch fails, and channel media then fails
+// closed on every sync, so the account must be prompted to re-authorize rather
+// than sync silently.
+func TestGraphManager_TokenSource_MissingRosterScopesReturnsError(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	m := NewGraphManager("test-client", "common", "", dir, slog.Default())
+
+	token := &oauth2.Token{AccessToken: "graph-access", RefreshToken: "graph-refresh", TokenType: "Bearer"}
+	previouslyShippedScopes := []string{
+		"https://graph.microsoft.com/Chat.Read",
+		"https://graph.microsoft.com/ChannelMessage.Read.All",
+		"https://graph.microsoft.com/Team.ReadBasic.All",
+		"https://graph.microsoft.com/Channel.ReadBasic.All",
+		"https://graph.microsoft.com/User.Read",
+		"https://graph.microsoft.com/User.ReadBasic.All",
+		scopeOfflineAccess,
+		"openid",
+		scopeEmail,
+	}
+	require.NoError(m.saveToken("user@company.com", token, previouslyShippedScopes, "org-tid"))
+
+	_, err := m.TokenSource(t.Context(), "user@company.com")
+	require.Error(err, "expected missing Graph scope error")
+	require.ErrorContains(err, "missing Microsoft Graph scopes")
+	require.ErrorContains(err, "TeamMember.Read.All")
+	require.ErrorContains(err, "ChannelMember.Read.All")
 	require.ErrorContains(err, "msgvault add-teams user@company.com")
 }
 

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -348,7 +349,7 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 	if err != nil {
 		return nil, err
 	}
-	toRecipients, err := imp.ensureMembership(ctx, syncID, convID, c, opts, sum)
+	toRecipients, participantCount, err := imp.ensureMembership(ctx, syncID, convID, c, opts, sum)
 	if err != nil {
 		return nil, err
 	}
@@ -358,6 +359,9 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 		channelID: c.ID, convID: convID, sourceID: sourceID, syncID: syncID,
 		opts: opts, cs: cs, toRecipients: toRecipients,
 		membershipReady: !c.IsMpim || toRecipients != nil,
+	}
+	cc.opts.MediaConversation = attachmentpolicy.Conversation{
+		Type: conversationType(c), ParticipantCount: participantCount,
 	}
 	// MPIM membership defines every message's "to" snapshot. A failed
 	// members call must hold both history and reply debt so the retry can
@@ -413,10 +417,25 @@ func (imp *Importer) syncConversation(ctx context.Context, syncID, sourceID int6
 	return cc, nil
 }
 
-// ensureMembership records the conversation's member list. Channel failures
-// are isolated from message archiving, while MPIM callers hold progress
-// because membership defines their per-message recipient snapshot.
-func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64, c *Conversation, opts ImportOptions, sum *ImportSummary) ([]messageRecipient, error) {
+// unknownMembershipCount is the participant count an unreadable members
+// listing evaluates as. Unknown membership must not pass as a conversation
+// under the threshold, so it fails closed while a limit is configured; the
+// skips that follow are retryable once the listing can be read again.
+func unknownMembershipCount(policy attachmentpolicy.Policy) int {
+	if policy.MaxParticipants > 0 {
+		return policy.MaxParticipants + 1
+	}
+	return 0
+}
+
+// ensureMembership records the conversation's member list and returns the
+// participant count media policy evaluates it against. Channel failures are
+// isolated from message archiving, while MPIM callers hold progress because
+// membership defines their per-message recipient snapshot. The roster size is
+// also archived on the conversation: a media backfill re-reads the archive
+// rather than the workspace, so an unreadable listing has to be
+// distinguishable there from a conversation with few members.
+func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64, c *Conversation, opts ImportOptions, sum *ImportSummary) ([]messageRecipient, int, error) {
 	var members []store.ConversationParticipantRef
 	directRecipients := make([]messageRecipient, 0)
 	add := func(userID string) error {
@@ -434,22 +453,23 @@ func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64,
 	}
 	if c.IsIM {
 		if err := add(c.User); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if err := add(opts.UserID); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	} else {
 		if err := imp.client.AllMembers(ctx, c.ID, add); err != nil {
 			if ctx.Err() != nil {
-				return nil, ctx.Err()
+				return nil, 0, ctx.Err()
 			}
 			if errors.Is(err, ErrNotFound) {
 				imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusSkipped, "slack_channel_gone", err)
 				// Known-gone is distinct from a transient outage. Let the
 				// history path confirm/record the gone conversation rather
-				// than parking it forever as missing membership.
-				return []messageRecipient{}, nil
+				// than parking it forever as missing membership; whatever
+				// roster earlier runs archived is the last one there was.
+				return []messageRecipient{}, 0, nil
 			}
 			// Isolated (message archiving proceeds) but honest: a members
 			// listing outage is a fetch failure and the run must report
@@ -457,13 +477,22 @@ func (imp *Importer) ensureMembership(ctx context.Context, syncID, convID int64,
 			imp.recordItem(syncID, c.ID, "membership", store.SyncRunItemStatusError, "slack_fetch_error", err)
 			sum.FetchErrors++
 			sum.Errors++
-			return nil, nil
+			// Store failures stay fatal here (see processMessage): the archived
+			// roster decides later downloads, so failing to record the outage
+			// would silently restore the fail-open behavior.
+			if merr := imp.store.MarkConversationMemberCountUnknown(convID); merr != nil {
+				return nil, 0, merr
+			}
+			return nil, unknownMembershipCount(opts.MediaPolicy), nil
 		}
 	}
 	if err := imp.store.ReplaceConversationParticipants(convID, members); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return directRecipients, nil
+	if err := imp.store.SetConversationMemberCount(convID, len(members)); err != nil {
+		return nil, 0, err
+	}
+	return directRecipients, len(members), nil
 }
 
 // walkWindow walks one pinned window of the conversation's top-level
@@ -1266,10 +1295,10 @@ func (imp *Importer) recordItem(syncID int64, sourceMessageID, phase, status, ki
 	})
 }
 
-// BackfillMedia retries pending Slack file downloads for one workspace:
-// every message that still has a pending marker is re-read from the archived
-// raw JSON and its files re-persisted. Idempotent (content-addressed
-// storage, replace-by-prefix rows).
+// BackfillMedia retries eligible Slack file downloads for one workspace:
+// messages with unfinished work, plus exclusions now allowed by current
+// policy, are re-read from archived JSON and re-persisted. Idempotent
+// (content-addressed storage, replace-by-prefix rows).
 func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*ImportSummary, error) {
 	// An explicit media backfill IS the download request. NoMedia means
 	// "defer downloads, leave pending markers for backfill-slack-media" —
@@ -1278,6 +1307,13 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 	// configuration ([slack].media = false) whose documented workflow
 	// depends on this command.
 	opts.NoMedia = false
+	// [slack].media = false defers downloads the same way --no-media does; an
+	// explicit backfill is the download request for both. Account-level
+	// opt-outs (SkipAccountPolicy) and scope/participant/size rules still
+	// apply.
+	if opts.MediaPolicy.DisabledReason == attachmentpolicy.SkipPolicyScope {
+		opts.MediaPolicy.DisabledReason = ""
+	}
 	start := imp.now()
 	if opts.AttachmentsDir == "" {
 		return nil, errors.New("attachments dir required")
@@ -1312,7 +1348,14 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 		return sum, err
 	}
 
-	pending, err := imp.store.ListSlackPendingAttachmentMessages(src.ID)
+	policy := opts.MediaPolicy
+	if policy.MaxBytes <= 0 {
+		policy.MaxBytes = opts.MaxMediaBytes
+	}
+	if policy.MaxBytes <= 0 {
+		policy.MaxBytes = defaultMaxMediaBytes
+	}
+	pending, err := imp.store.ListSlackRetryableAttachmentMessages(src.ID, policy)
 	if err != nil {
 		return sum, err
 	}
@@ -1342,7 +1385,11 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 			sum.AttachmentsPending += imp.pendingMarkerCount(item.MessageID)
 			continue
 		}
-		if err = imp.persistFiles(ctx, syncID, item.MessageID, &m, opts, sum); err != nil {
+		itemOpts := opts
+		itemOpts.MediaConversation = attachmentpolicy.Conversation{
+			Type: item.ConversationType, ParticipantCount: item.ParticipantCount,
+		}
+		if err = imp.persistFiles(ctx, syncID, item.MessageID, &m, itemOpts, sum); err != nil {
 			return sum, err
 		}
 		sum.MessagesProcessed++

--- a/internal/slack/media.go
+++ b/internal/slack/media.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
@@ -141,8 +142,8 @@ func (c *Client) DownloadFile(ctx context.Context, rawURL string, maxBytes int64
 // files the source has since tombstoned or dropped from the message
 // (archive semantics: source deletions never propagate). External or
 // off-host files become metadata-only link rows (media_type "link", the
-// permalink as storage path); failed or over-cap downloads leave a pending
-// marker row (no content hash) for BackfillMedia to retry.
+// permalink as storage path). Failed downloads remain retryable, while
+// deliberate exclusions retain typed markers until current policy allows them.
 //
 // DOWNLOAD failures are non-fatal because they leave that durable marker;
 // STORE failures are fatal and hold the cursor — a row write that fails
@@ -157,9 +158,14 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 		return nil
 	}
 	maxBytes := opts.MaxMediaBytes
+	if opts.MediaPolicy.MaxBytes > 0 {
+		maxBytes = opts.MediaPolicy.MaxBytes
+	}
 	if maxBytes <= 0 {
 		maxBytes = defaultMaxMediaBytes
 	}
+	policy := opts.MediaPolicy
+	policy.MaxBytes = maxBytes
 	refs := make([]store.AttachmentRef, 0, len(m.Files))
 	seen := map[string]bool{}
 	for i := range m.Files {
@@ -200,12 +206,27 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 		}
 		pendingRow := linkRow
 		pendingRow.MediaType = ""
+		pendingRow.State = attachmentpolicy.StatePending
+		if previous, ok := existing[sourceAttID]; ok && previous.Size > pendingRow.Size {
+			pendingRow.Size = previous.Size
+		}
 
 		// pend leaves a retryable marker; link records metadata permanently.
 		pend := func(status, kind string, err error) {
 			imp.recordItem(syncID, sourceMessageID("", m.TS), "attachment", status, kind, err)
+			if status == store.SyncRunItemStatusSkipped {
+				pendingRow.State = attachmentpolicy.StateSkipped
+				pendingRow.SkipReason = attachmentpolicy.SkipSizeCap
+			} else {
+				pendingRow.State = attachmentpolicy.StateFailed
+				pendingRow.SkipReason = attachmentpolicy.SkipFetchFailure
+			}
 			refs = append(refs, pendingRow)
-			sum.AttachmentsPending++
+			if pendingRow.State == attachmentpolicy.StateSkipped {
+				sum.AttachmentsSkipped++
+			} else {
+				sum.AttachmentsPending++
+			}
 			if status == store.SyncRunItemStatusError {
 				sum.Errors++
 			}
@@ -225,6 +246,21 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 			sum.AttachmentsPending++
 			continue
 		}
+		if reason := policy.Evaluate(opts.MediaConversation, int64(pendingRow.Size)); reason != "" {
+			if reason == attachmentpolicy.SkipSizeCap {
+				pendingRow.SkipReason = reason
+				pend(store.SyncRunItemStatusSkipped, "slack_media_too_large",
+					fmt.Errorf("file %s is %d bytes (cap %d)", f.ID, f.Size, maxBytes))
+				continue
+			}
+			pendingRow.State = attachmentpolicy.StateSkipped
+			pendingRow.SkipReason = reason
+			imp.recordItem(syncID, sourceMessageID("", m.TS), "attachment",
+				store.SyncRunItemStatusSkipped, "slack_media_policy", nil)
+			refs = append(refs, pendingRow)
+			sum.AttachmentsSkipped++
+			continue
+		}
 		if f.Size > 0 && f.Size > maxBytes {
 			pend(store.SyncRunItemStatusSkipped, "slack_media_too_large",
 				fmt.Errorf("file %s is %d bytes (cap %d)", f.ID, f.Size, maxBytes))
@@ -232,6 +268,7 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 		}
 		data, derr := imp.client.DownloadFile(ctx, fetchRef, maxBytes)
 		if errors.Is(derr, ErrAssetTooLarge) {
+			pendingRow.Size = attachmentpolicy.OversizeMarkerSize(maxBytes, int64(pendingRow.Size))
 			pend(store.SyncRunItemStatusSkipped, "slack_media_too_large", derr)
 			continue
 		}
@@ -272,6 +309,7 @@ func (imp *Importer) persistFiles(ctx context.Context, syncID, messageID int64, 
 			MediaType:          mediaTypeOf(f),
 			Role:               store.AttachmentRoleStandalone,
 			RoleSource:         store.AttachmentRoleSourceProviderExplicit,
+			State:              attachmentpolicy.StateStored,
 		}
 		refs = append(refs, stored)
 		sum.AttachmentsDownloaded++

--- a/internal/slack/media_test.go
+++ b/internal/slack/media_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
@@ -111,6 +113,42 @@ func TestDownloadFileSizeCap(t *testing.T) {
 	assert.ErrorIs(t, err, ErrAssetTooLarge)
 }
 
+func TestPersistFilesRecordsStreamedOversizeForRetryPolicy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{{
+		"id": "F_STREAM_BIG", "name": "large.bin", "mimetype": "application/octet-stream",
+		"url_private": "https://files.slack.com/files-pri/T01-F_STREAM_BIG/large.bin",
+		"permalink":   "https://testers.slack.com/files/F_STREAM_BIG",
+	}}
+	srv := f.serve()
+	defer srv.Close()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	transport := &recordingTransport{body: "12345678901"}
+	client.mediaTransport = transport
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+	opts := ImportOptions{
+		TeamID: "T01", UserID: "UME", AttachmentsDir: t.TempDir(), MaxMediaBytes: 10,
+		MediaPolicy: attachmentpolicy.Policy{MaxBytes: 10},
+	}
+
+	sum, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	assert.Equal(1, sum.AttachmentsSkipped)
+	var size int64
+	require.NoError(st.DB().QueryRow(`
+		SELECT size FROM attachments WHERE source_attachment_id = 'slack:F_STREAM_BIG'
+	`).Scan(&size))
+	assert.Greater(size, int64(10))
+	backfill, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(backfill.MessagesProcessed)
+	assert.Len(transport.requests, 1, "unchanged cap must not retry streamed oversize media")
+}
+
 func TestPersistFilesLinkRowsAndPendingMarkers(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -169,17 +207,17 @@ func TestPersistFilesLinkRowsAndPendingMarkers(t *testing.T) {
 	assert.Equal("link", got["slack:F_EXT"][1], "external file records metadata only")
 	assert.Equal("unknown", got["slack:F_EXT"][2])
 	assert.Empty(got["slack:F_BIG"][0])
-	assert.Empty(got["slack:F_BIG"][1], "over-cap file leaves a retryable pending marker")
+	assert.Empty(got["slack:F_BIG"][1], "over-cap file leaves a policy marker")
 	assert.Equal("unknown", got["slack:F_BIG"][2])
 
-	// The pending list sees the over-cap marker but not the link row.
+	// A policy skip is not ordinary retry debt while the cap is unchanged.
 	src, err := st.GetOrCreateSource("slack", "T01:UME")
 	require.NoError(err)
 	pending, err := st.ListSlackPendingAttachmentMessages(src.ID)
 	require.NoError(err)
-	require.Len(pending, 1)
+	require.Empty(pending)
 
-	// Raising the cap and backfilling repairs the pending download (the
+	// Raising the cap and backfilling re-evaluates and repairs the download (the
 	// declared size in the archived raw JSON no longer exceeds it).
 	opts.MaxMediaBytes = 1 << 50
 	sum, err := imp.BackfillMedia(context.Background(), opts)
@@ -440,6 +478,116 @@ func TestNoMediaDefersFilesAsPendingNotLinks(t *testing.T) {
 	assert.NotEmpty(hash)
 }
 
+func TestMediaPolicySkipsChannelWithoutDownload(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{{
+		"id": "F_POLICY", "name": "policy.png", "mimetype": "image/png", "size": 5,
+		"url_private": "https://files.slack.com/files-pri/T01-F_POLICY/policy.png",
+		"permalink":   "https://testers.slack.com/files/F_POLICY",
+	}}
+	srv := f.serve()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	transport := &recordingTransport{body: "must not download"}
+	client.mediaTransport = transport
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+
+	sum, err := imp.Import(context.Background(), ImportOptions{
+		TeamID: "T01", UserID: "UME", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeDirect, MaxBytes: 100 << 20},
+	})
+	require.NoError(err)
+	assert.Equal(1, sum.AttachmentsSkipped)
+	assert.Empty(transport.requests)
+
+	var state, reason string
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments
+		WHERE source_attachment_id = 'slack:F_POLICY'
+	`).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipPolicyScope), reason)
+}
+
+// TestBackfillMediaOverridesProviderMediaToggle verifies that an explicit
+// backfill downloads media the provider-level [slack].media = false toggle
+// deferred, while an account-level opt-out still holds. The toggle's
+// documented workflow is "sync without media, backfill later", so honoring it
+// inside the backfill would make backfill-slack-media a no-op for exactly the
+// configuration that depends on it.
+func TestBackfillMediaOverridesProviderMediaToggle(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		disabled      attachmentpolicy.SkipReason
+		wantDownloads int
+		wantReason    string
+	}{
+		{
+			name:     "provider toggle defers to the explicit backfill",
+			disabled: attachmentpolicy.SkipPolicyScope, wantDownloads: 1,
+		},
+		{
+			name:       "account opt-out still declines",
+			disabled:   attachmentpolicy.SkipAccountPolicy,
+			wantReason: string(attachmentpolicy.SkipAccountPolicy),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := testWorkspace(t)
+			f.conv("C01").Msgs[6].Files = []map[string]any{{
+				"id": "F_TOGGLE", "name": "toggle.png", "mimetype": "image/png", "size": 5,
+				"url_private": "https://files.slack.com/files-pri/T01-F_TOGGLE/toggle.png",
+				"permalink":   "https://testers.slack.com/files/F_TOGGLE",
+			}}
+
+			prevInterval := checkpointMinInterval
+			checkpointMinInterval = 0
+			t.Cleanup(func() { checkpointMinInterval = prevInterval })
+			srv := f.serve()
+			defer srv.Close()
+			client := NewClient(srv.URL, "xoxp-test")
+			client.disableRateLimits()
+			transport := &recordingTransport{body: "png06"}
+			client.mediaTransport = transport
+			st := testutil.NewTestStore(t)
+			imp := NewImporter(st, client, "T01")
+
+			opts := ImportOptions{
+				TeamID: "T01", UserID: "UME", AttachmentsDir: t.TempDir(),
+				MediaPolicy: attachmentpolicy.Policy{
+					Scope: attachmentpolicy.ScopeAll, MaxBytes: 1 << 20, DisabledReason: tc.disabled,
+				},
+			}
+			sum, err := imp.Import(t.Context(), opts)
+			require.NoError(err)
+			require.Equal(1, sum.AttachmentsSkipped)
+			require.Empty(transport.requests, "a disabled media policy must not download during sync")
+
+			backfill, err := imp.BackfillMedia(t.Context(), opts)
+			require.NoError(err)
+			assert.Equal(tc.wantDownloads, backfill.AttachmentsDownloaded)
+			assert.Len(transport.requests, tc.wantDownloads)
+
+			var contentHash, reason string
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT COALESCE(content_hash, ''), COALESCE(attachment_skip_reason, '')
+				FROM attachments WHERE source_attachment_id = ?
+			`), "slack:F_TOGGLE").Scan(&contentHash, &reason))
+			assert.Equal(tc.wantReason, reason)
+			if tc.wantDownloads > 0 {
+				assert.NotEmpty(contentHash, "the backfill must archive the deferred file")
+			} else {
+				assert.Empty(contentHash)
+			}
+		})
+	}
+}
+
 func TestMediaTimeoutScalesWithCap(t *testing.T) {
 	assert := assert.New(t)
 	// The API client's 60s whole-request deadline starves large downloads
@@ -449,4 +597,180 @@ func TestMediaTimeoutScalesWithCap(t *testing.T) {
 	assert.Equal(800*time.Second, mediaTimeout(100<<20), "default 100 MiB cap ≈ 13m20s")
 	assert.Equal(8192*time.Second, mediaTimeout(1<<30), "bigger caps scale up")
 	assert.Greater(mediaTimeout(1), time.Minute, "never anywhere near the 60s API deadline")
+}
+
+// membershipRecord returns the roster the fixture channel's provider metadata
+// records: the exact member count, and whether the roster is marked unreadable.
+func membershipRecord(t *testing.T, st *store.Store) (count int, unknown bool) {
+	t.Helper()
+
+	var metadata string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(CAST(metadata AS TEXT), '') FROM conversations
+		WHERE source_conversation_id = ?
+	`), "C01").Scan(&metadata))
+	if metadata == "" {
+		return 0, false
+	}
+	var record struct {
+		MemberCount        int  `json:"member_count"`
+		MemberCountUnknown bool `json:"member_count_unknown"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(metadata), &record))
+	return record.MemberCount, record.MemberCountUnknown
+}
+
+// TestMediaPolicyFailsClosedOnLaterMembershipOutage covers a members listing
+// that succeeded once and then fails. The count read earlier is kept for
+// reference, but the roster is unresolved: a backfill must not trust the stale
+// count to release a deferred download until a sync reads the roster again.
+func TestMediaPolicyFailsClosedOnLaterMembershipOutage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	f.conv("C01").Msgs[6].Files = []map[string]any{{
+		"id": "F_LATER", "name": "later.png", "mimetype": "image/png", "size": 5,
+		"url_private": "https://files.slack.com/files-pri/T01-F_LATER/later.png",
+		"permalink":   "https://testers.slack.com/files/F_LATER",
+	}}
+
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	defer srv.Close()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	transport := &recordingTransport{body: "png07", status: http.StatusInternalServerError}
+	client.mediaTransport = transport
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+	opts := ImportOptions{
+		TeamID: "T01", UserID: "UME", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{
+			Scope: attachmentpolicy.ScopeAll, MaxParticipants: 5, MaxBytes: 1 << 20,
+		},
+	}
+	fileOutcome := func() (state, contentHash string) {
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT COALESCE(attachment_state, ''), COALESCE(content_hash, '')
+			FROM attachments WHERE source_attachment_id = ?
+		`), "slack:F_LATER").Scan(&state, &contentHash))
+		return state, contentHash
+	}
+
+	// The roster reads fine; only the download itself fails, leaving a
+	// retryable marker the backfill will decide on later.
+	_, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	count, unknown := membershipRecord(t, st)
+	require.Equal(3, count)
+	require.False(unknown)
+	state, contentHash := fileOutcome()
+	require.Equal(string(attachmentpolicy.StateFailed), state)
+	require.Empty(contentHash)
+	require.NotEmpty(transport.requests)
+	transport.requests = nil
+	transport.status = 0
+
+	f.failMembers["C01"] = true
+	_, err = imp.Import(t.Context(), opts)
+	require.Error(err, "a members-listing outage leaves the run partial")
+	count, unknown = membershipRecord(t, st)
+	assert.Equal(3, count, "the count read earlier stays for reference")
+	assert.True(unknown, "a later failed listing must be archived, not hidden behind the earlier count")
+
+	backfill, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(backfill.AttachmentsDownloaded)
+	assert.Empty(transport.requests, "a stale count must not release a download while the roster is unresolved")
+	state, _ = fileOutcome()
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+
+	f.failMembers["C01"] = false
+	_, err = imp.Import(t.Context(), opts)
+	require.NoError(err)
+	count, unknown = membershipRecord(t, st)
+	assert.Equal(3, count)
+	assert.False(unknown)
+	_, err = imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	state, contentHash = fileOutcome()
+	assert.Equal(string(attachmentpolicy.StateStored), state)
+	assert.NotEmpty(contentHash, "a readable roster releases the deferred download")
+	assert.Len(transport.requests, 1)
+}
+
+// TestMediaPolicyFailsClosedOnUnreadableMembership covers a members-listing
+// outage under a participant threshold. The count is unknown, not zero, so the
+// channel's media must not download as if it were a small conversation — and
+// the outage must be archived, because the backfill evaluates the archive
+// rather than the run that wrote it.
+func TestMediaPolicyFailsClosedOnUnreadableMembership(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := testWorkspace(t)
+	f.failMembers["C01"] = true
+	f.conv("C01").Msgs[6].Files = []map[string]any{{
+		"id": "F_ROSTER", "name": "roster.png", "mimetype": "image/png", "size": 5,
+		"url_private": "https://files.slack.com/files-pri/T01-F_ROSTER/roster.png",
+		"permalink":   "https://testers.slack.com/files/F_ROSTER",
+	}}
+
+	prevInterval := checkpointMinInterval
+	checkpointMinInterval = 0
+	t.Cleanup(func() { checkpointMinInterval = prevInterval })
+	srv := f.serve()
+	defer srv.Close()
+	client := NewClient(srv.URL, "xoxp-test")
+	client.disableRateLimits()
+	transport := &recordingTransport{body: "png07"}
+	client.mediaTransport = transport
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, client, "T01")
+	opts := ImportOptions{
+		TeamID: "T01", UserID: "UME", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{
+			Scope: attachmentpolicy.ScopeAll, MaxParticipants: 5, MaxBytes: 1 << 20,
+		},
+	}
+
+	_, err := imp.Import(t.Context(), opts)
+	require.Error(err, "a members-listing outage leaves the run partial")
+	assert.Empty(transport.requests, "unknown membership must not read as a channel under the limit")
+
+	fileOutcome := func() (reason, contentHash string) {
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT COALESCE(attachment_skip_reason, ''), COALESCE(content_hash, '')
+			FROM attachments WHERE source_attachment_id = ?
+		`), "slack:F_ROSTER").Scan(&reason, &contentHash))
+		return reason, contentHash
+	}
+	reason, contentHash := fileOutcome()
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+	assert.Empty(contentHash)
+	count, unknown := membershipRecord(t, st)
+	assert.True(unknown, "the failed members listing must be archived, not left absent")
+	assert.Zero(count)
+
+	// The backfill reads the same archive, so it stays closed until a sync can
+	// read the roster again.
+	backfill, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(backfill.AttachmentsDownloaded)
+	assert.Empty(transport.requests)
+
+	f.failMembers["C01"] = false
+	_, err = imp.Import(t.Context(), opts)
+	require.NoError(err)
+	count, unknown = membershipRecord(t, st)
+	assert.Equal(3, count)
+	assert.False(unknown)
+
+	_, err = imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	reason, contentHash = fileOutcome()
+	assert.Empty(reason)
+	assert.NotEmpty(contentHash, "a readable roster releases the deferred download")
+	assert.Len(transport.requests, 1)
 }

--- a/internal/slack/types.go
+++ b/internal/slack/types.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 )
 
 // apiResponse is the envelope every Slack Web API method returns.
@@ -295,7 +297,9 @@ type ImportOptions struct {
 	// NoMedia skips file downloads entirely.
 	NoMedia bool
 	// MaxMediaBytes caps individual file downloads (0 = 100 MB).
-	MaxMediaBytes int64
+	MaxMediaBytes     int64
+	MediaPolicy       attachmentpolicy.Policy
+	MediaConversation attachmentpolicy.Conversation
 	// IncludeChannels/ExcludeChannels filter by channel name (no "#").
 	// Include empty = all memberships. DMs/group DMs are never filtered.
 	IncludeChannels []string
@@ -315,6 +319,7 @@ type ImportSummary struct {
 	RepliesFetched         int
 	AttachmentsDownloaded  int
 	AttachmentsPending     int
+	AttachmentsSkipped     int
 	FetchErrors            int
 	Errors                 int
 	Duration               time.Duration

--- a/internal/store/attachment_membership_test.go
+++ b/internal/store/attachment_membership_test.go
@@ -1,0 +1,379 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// decodeJSONObject reads a metadata payload as a plain JSON object.
+func decodeJSONObject(t *testing.T, payload string) map[string]any {
+	t.Helper()
+	var object map[string]any
+	require.NoError(t, json.Unmarshal([]byte(payload), &object))
+	return object
+}
+
+// membershipFixture is one archived message whose conversation carries both an
+// observed participant count and a provider membership record.
+type membershipFixture struct {
+	sourceID       int64
+	conversationID int64
+	messageID      int64
+}
+
+// newMembershipFixture archives a message in a channel conversation under
+// sourceType, reporting observed participants and the given metadata JSON
+// (empty leaves the column NULL).
+func newMembershipFixture(
+	t *testing.T, st *store.Store, sourceType string, observed int, metadata string,
+) membershipFixture {
+	t.Helper()
+	require := require.New(t)
+
+	source, err := st.GetOrCreateSource(sourceType, sourceType+"-account")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(
+		source.ID, sourceType+"-conversation", "channel", "Membership")
+	require.NoError(err)
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE conversations SET participant_count = ? WHERE id = ?`),
+		observed, conversationID)
+	require.NoError(err)
+	if metadata != "" {
+		require.NoError(st.SetConversationMetadata(conversationID,
+			sql.NullString{String: metadata, Valid: true}))
+	}
+	return membershipFixture{
+		sourceID:       source.ID,
+		conversationID: conversationID,
+		messageID: insertStoreTestMessage(
+			t, st, source.ID, conversationID, sourceType+"-message"),
+	}
+}
+
+// TestAttachmentConversationAppliesProviderMembershipRecord pins the two
+// membership semantics media policy evaluates. Discord stages a catalog count
+// that may only raise the observed one. Teams and Slack archive the exact
+// roster they read, which must win in both directions: participant rows only
+// ever accumulate, so a conversation whose membership shrank below the
+// threshold would otherwise stay excluded forever.
+func TestAttachmentConversationAppliesProviderMembershipRecord(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		sourceType string
+		observed   int
+		metadata   string
+		want       int
+	}{
+		{
+			name:       "teams roster shrinks below the observed rows",
+			sourceType: "teams", observed: 9, metadata: `{"member_count":3}`,
+			want: 3,
+		},
+		{
+			name:       "slack roster shrinks below the observed rows",
+			sourceType: "slack", observed: 9, metadata: `{"member_count":3}`,
+			want: 3,
+		},
+		{
+			name:       "teams roster above the observed rows",
+			sourceType: "teams", observed: 2, metadata: `{"member_count":7}`,
+			want: 7,
+		},
+		{
+			name:       "discord catalog count only ever raises",
+			sourceType: "discord", observed: 9, metadata: `{"member_count":3}`,
+			want: 9,
+		},
+		{
+			name:       "no record keeps the observed count",
+			sourceType: "teams", observed: 4,
+			want: 4,
+		},
+		{
+			name:       "unreadable record keeps the observed count",
+			sourceType: "slack", observed: 4, metadata: `{"member_count":"many"}`,
+			want: 4,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := testutil.NewTestStore(t)
+			fixture := newMembershipFixture(t, st, tc.sourceType, tc.observed, tc.metadata)
+
+			conversation, err := st.AttachmentConversation(fixture.messageID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, conversation.ParticipantCount)
+		})
+	}
+}
+
+// TestRetryableAttachmentMessagesFailClosedOnUnknownMembership covers the
+// durable half of a failed roster read. The provider skips the media in memory,
+// but a backfill re-reads the archive: without the unknown marker the missing
+// roster reads as a small conversation and the backfill downloads exactly what
+// the threshold excluded.
+func TestRetryableAttachmentMessagesFailClosedOnUnknownMembership(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fixture := newMembershipFixture(t, st, "slack", 2, `{"member_count_unknown":true}`)
+	require.NoError(st.ReplaceMessageSlackAttachments(fixture.messageID, []store.AttachmentRef{{
+		SourceAttachmentID: "slack:F_PENDING",
+		StoragePath:        "https://files.slack.com/files-pri/T01-F_PENDING/a.png",
+		Size:               5, State: attachmentpolicy.StatePending,
+	}}))
+
+	policy := attachmentpolicy.Policy{MaxParticipants: 4, MaxBytes: 1 << 20}
+	items, err := st.ListSlackRetryableAttachmentMessages(fixture.sourceID, policy)
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(5, items[0].ParticipantCount,
+		"an unreadable roster must not evaluate as a conversation under the limit")
+	assert.False(policy.Allows(attachmentpolicy.Conversation{
+		Type: items[0].ConversationType, ParticipantCount: items[0].ParticipantCount,
+	}, 5))
+
+	// A skip recorded against the unknown roster stays excluded rather than
+	// being re-admitted by the archived zero.
+	require.NoError(st.ReplaceMessageSlackAttachments(fixture.messageID, []store.AttachmentRef{{
+		SourceAttachmentID: "slack:F_PENDING",
+		StoragePath:        "https://files.slack.com/files-pri/T01-F_PENDING/a.png",
+		Size:               5, State: attachmentpolicy.StateSkipped,
+		SkipReason: attachmentpolicy.SkipParticipantThreshold,
+	}}))
+	items, err = st.ListSlackRetryableAttachmentMessages(fixture.sourceID, policy)
+	require.NoError(err)
+	assert.Empty(items)
+
+	// Without a configured limit there is no threshold to fail closed on.
+	items, err = st.ListSlackRetryableAttachmentMessages(fixture.sourceID,
+		attachmentpolicy.Policy{MaxBytes: 1 << 20})
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(2, items[0].ParticipantCount)
+
+	// A count an earlier run read does not resolve a roster whose latest read
+	// failed: the stale count may permit what the current membership excludes.
+	require.NoError(st.ReplaceMessageSlackAttachments(fixture.messageID, []store.AttachmentRef{{
+		SourceAttachmentID: "slack:F_PENDING",
+		StoragePath:        "https://files.slack.com/files-pri/T01-F_PENDING/a.png",
+		Size:               5, State: attachmentpolicy.StatePending,
+	}}))
+	require.NoError(st.SetConversationMemberCount(fixture.conversationID, 2))
+	require.NoError(st.MarkConversationMemberCountUnknown(fixture.conversationID))
+	items, err = st.ListSlackRetryableAttachmentMessages(fixture.sourceID, policy)
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(5, items[0].ParticipantCount,
+		"a stale count beside the unknown marker must not evaluate as a conversation under the limit")
+}
+
+// TestRetryableAttachmentMessagesFailClosedWithoutArchivedRoster covers a
+// conversation archived before rosters were recorded: its participant rows
+// may undercount a membership that exceeds the limit, so retry selection and
+// the Beeper policy pass must not admit on them. A roster the provider reads
+// later resolves it either way.
+func TestRetryableAttachmentMessagesFailClosedWithoutArchivedRoster(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	slack := newMembershipFixture(t, st, "slack", 2, "")
+	require.NoError(st.ReplaceMessageSlackAttachments(slack.messageID, []store.AttachmentRef{{
+		SourceAttachmentID: "slack:F_LEGACY",
+		StoragePath:        "https://files.slack.com/files-pri/T01-F_LEGACY/a.png",
+		Size:               5, State: attachmentpolicy.StatePending,
+	}}))
+	policy := attachmentpolicy.Policy{MaxParticipants: 4, MaxBytes: 1 << 20}
+
+	items, err := st.ListSlackRetryableAttachmentMessages(slack.sourceID, policy)
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(5, items[0].ParticipantCount,
+		"accumulated participant rows must not evaluate as a conversation under the limit")
+
+	// Without a configured limit the observed count is all there is to report.
+	items, err = st.ListSlackRetryableAttachmentMessages(slack.sourceID, attachmentpolicy.Policy{MaxBytes: 1 << 20})
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(2, items[0].ParticipantCount)
+
+	// A roster the provider reads resolves the conversation.
+	require.NoError(st.SetConversationMemberCount(slack.conversationID, 2))
+	items, err = st.ListSlackRetryableAttachmentMessages(slack.sourceID, policy)
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(2, items[0].ParticipantCount)
+
+	beeper := newMembershipFixture(t, st, "beeper", 2, "")
+	require.NoError(st.ReplaceMessageBeeperAttachments(beeper.messageID, []store.AttachmentRef{{
+		SourceAttachmentID: "beeper:mxc://beeper.local/legacy",
+		StoragePath:        "mxc://beeper.local/legacy",
+		Size:               5, State: attachmentpolicy.StatePending,
+	}}))
+	result, err := st.ApplyBeeperRetryableAttachmentPolicy(context.Background(), beeper.sourceID, policy)
+	require.NoError(err)
+	assert.EqualValues(1, result.NewlySkipped, "the policy pass must not admit on an unarchived roster either")
+	items, err = st.ListBeeperRetryableAttachmentMessages(beeper.sourceID, policy)
+	require.NoError(err)
+	assert.Empty(items)
+	require.NoError(st.SetConversationMemberCount(beeper.conversationID, 2))
+	items, err = st.ListBeeperRetryableAttachmentMessages(beeper.sourceID, policy)
+	require.NoError(err)
+	require.Len(items, 1, "the resolved roster releases the skip")
+	assert.Equal(2, items[0].ParticipantCount)
+}
+
+// TestBeeperRetryPolicyWeighsArchivedTotal pins the Beeper half of the
+// contract: the sync weighs the participant total Beeper reports, and the
+// archived participant rows can undercount it when a listing was truncated. The
+// retry policy pass and retry selection must weigh the archived total — and
+// fail closed on an unresolved roster — rather than the smaller stored rows.
+func TestBeeperRetryPolicyWeighsArchivedTotal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fixture := newMembershipFixture(t, st, "beeper", 2, `{"member_count":8}`)
+	pending := func() {
+		require.NoError(st.ReplaceMessageBeeperAttachments(fixture.messageID, []store.AttachmentRef{{
+			SourceAttachmentID: "beeper:mxc://beeper.local/photo1",
+			StoragePath:        "mxc://beeper.local/photo1",
+			Size:               5, State: attachmentpolicy.StatePending,
+		}}))
+	}
+	pending()
+	policy := attachmentpolicy.Policy{MaxParticipants: 5, MaxBytes: 1 << 20}
+
+	result, err := st.ApplyBeeperRetryableAttachmentPolicy(context.Background(), fixture.sourceID, policy)
+	require.NoError(err)
+	assert.EqualValues(1, result.NewlySkipped, "the archived total excludes what the stored rows would admit")
+	assert.True(result.HasExcluded)
+	items, err := st.ListBeeperRetryableAttachmentMessages(fixture.sourceID, policy)
+	require.NoError(err)
+	assert.Empty(items)
+
+	// The roster shrinks below the limit: the archived total is authoritative
+	// in both directions.
+	require.NoError(st.SetConversationMemberCount(fixture.conversationID, 3))
+	items, err = st.ListBeeperRetryableAttachmentMessages(fixture.sourceID, policy)
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(3, items[0].ParticipantCount)
+
+	// An unresolved roster fails closed even though the last total permits.
+	pending()
+	require.NoError(st.MarkConversationMemberCountUnknown(fixture.conversationID))
+	result, err = st.ApplyBeeperRetryableAttachmentPolicy(context.Background(), fixture.sourceID, policy)
+	require.NoError(err)
+	assert.EqualValues(1, result.NewlySkipped)
+	items, err = st.ListBeeperRetryableAttachmentMessages(fixture.sourceID, policy)
+	require.NoError(err)
+	assert.Empty(items)
+}
+
+// TestAttachmentPolicyCandidatesReportUnresolvedRosters keeps purge on the
+// safe side of a roster nobody has archived: excluding media deletes blobs, so
+// a candidate must say when no authoritative roster backs its count — whether
+// a read failed or none was ever recorded — rather than let the accumulated
+// participant rows stand in for one.
+func TestAttachmentPolicyCandidatesReportUnresolvedRosters(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fixture := newMembershipFixture(t, st, "slack", 20, "")
+	contentHash := strings.Repeat("ab", 32)
+	require.NoError(st.ReplaceMessageSlackAttachments(fixture.messageID, []store.AttachmentRef{{
+		SourceAttachmentID: "slack:F_STORED",
+		StoragePath:        contentHash[:2] + "/" + contentHash,
+		ContentHash:        contentHash, Size: 5, State: attachmentpolicy.StateStored,
+	}}))
+	candidate := func() store.AttachmentPolicyCandidate {
+		candidates, err := st.ListAttachmentPolicyCandidates(context.Background())
+		require.NoError(err)
+		require.Len(candidates, 1)
+		return candidates[0]
+	}
+
+	// A conversation archived before rosters were recorded carries only the
+	// accumulated participant rows.
+	assert.Equal(20, candidate().ParticipantCount)
+	assert.True(candidate().RosterUnresolved,
+		"accumulated participant rows are not a roster purge may delete on")
+
+	require.NoError(st.MarkConversationMemberCountUnknown(fixture.conversationID))
+	assert.Equal(20, candidate().ParticipantCount)
+	assert.True(candidate().RosterUnresolved,
+		"an unreadable roster must be visible to purge so it can retain the media")
+
+	// A roster the provider has read replaces the marker and is authoritative.
+	require.NoError(st.SetConversationMemberCount(fixture.conversationID, 3))
+	assert.Equal(3, candidate().ParticipantCount)
+	assert.False(candidate().RosterUnresolved)
+
+	// A later failed read leaves the count for reference but the roster
+	// unresolved, so purge retains rather than trusting the stale count.
+	require.NoError(st.MarkConversationMemberCountUnknown(fixture.conversationID))
+	assert.Equal(3, candidate().ParticipantCount)
+	assert.True(candidate().RosterUnresolved)
+}
+
+// TestMembershipRecordWritesPreserveKnownCounts pins the write side: an exact
+// roster replaces whatever was recorded before, an unreadable roster keeps the
+// count the provider already read but marks the roster unresolved until a read
+// succeeds again, and neither disturbs the other provider metadata sharing the
+// column.
+func TestMembershipRecordWritesPreserveKnownCounts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	fixture := newMembershipFixture(t, st, "teams", 0, `{"topic":"releases"}`)
+
+	memberCount := func() int {
+		conversation, err := st.AttachmentConversation(fixture.messageID)
+		require.NoError(err)
+		return conversation.ParticipantCount
+	}
+	metadataKeys := func() map[string]any {
+		metadata, err := st.GetConversationMetadata(fixture.conversationID)
+		require.NoError(err)
+		require.True(metadata.Valid)
+		return decodeJSONObject(t, metadata.String)
+	}
+
+	require.NoError(st.MarkConversationMemberCountUnknown(fixture.conversationID))
+	assert.Contains(metadataKeys(), "member_count_unknown")
+	assert.Equal("releases", metadataKeys()["topic"], "unrelated metadata survives")
+
+	require.NoError(st.SetConversationMemberCount(fixture.conversationID, 6))
+	assert.Equal(6, memberCount())
+	assert.NotContains(metadataKeys(), "member_count_unknown",
+		"a roster that was read clears the unknown marker")
+	membership, err := st.AttachmentConversationMembership(fixture.messageID)
+	require.NoError(err)
+	assert.True(membership.RosterArchived)
+
+	// A later outage keeps the count for reference but leaves the roster
+	// unresolved: the sync that could not read it failed closed, and a
+	// backfill or purge that trusted the stale count could act against the
+	// membership the conversation has now.
+	require.NoError(st.MarkConversationMemberCountUnknown(fixture.conversationID))
+	assert.Equal(6, memberCount())
+	assert.Equal(true, metadataKeys()["member_count_unknown"])
+	assert.Equal("releases", metadataKeys()["topic"])
+	membership, err = st.AttachmentConversationMembership(fixture.messageID)
+	require.NoError(err)
+	assert.False(membership.RosterArchived,
+		"a roster whose latest read failed must be re-resolved before the threshold is trusted")
+
+	require.NoError(st.SetConversationMemberCount(fixture.conversationID, 4))
+	assert.Equal(4, memberCount())
+	assert.NotContains(metadataKeys(), "member_count_unknown")
+}

--- a/internal/store/attachment_policy.go
+++ b/internal/store/attachment_policy.go
@@ -1,0 +1,194 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+)
+
+// AttachmentPolicyCandidate is one stored provider occurrence that current
+// policy may exclude.
+type AttachmentPolicyCandidate struct {
+	AttachmentID     int64
+	MessageID        int64
+	SourceType       string
+	SourceIdentifier string
+	ConversationType string
+	ParticipantCount int
+	// RosterUnresolved reports that no authoritative roster backs
+	// ParticipantCount: the provider could not read one, or none was ever
+	// archived, so the count is only the accumulated participant rows. Purge
+	// must not exclude on the participant threshold while it is set: excluding
+	// deletes blobs, and the current membership may be under the limit even
+	// when the accumulated count is not.
+	RosterUnresolved   bool
+	Size               int64
+	ContentHash        string
+	StoragePath        string
+	ThumbnailHash      string
+	ThumbnailPath      string
+	SourceAttachmentID string
+}
+
+// AttachmentExclusion selects one occurrence and records its policy reason.
+type AttachmentExclusion struct {
+	AttachmentID       int64
+	Reason             attachmentpolicy.SkipReason
+	SourceAttachmentID string
+}
+
+// ListAttachmentPolicyCandidates returns stored provider media with the
+// source and conversation context needed to apply current configuration.
+func (s *Store) ListAttachmentPolicyCandidates(ctx context.Context) ([]AttachmentPolicyCandidate, error) {
+	rows, err := s.db.QueryContext(ctx, s.Rebind(`
+		SELECT a.id, a.message_id, src.source_type, src.identifier,
+		       c.conversation_type, COALESCE(c.participant_count, 0),
+		       COALESCE(CAST(c.metadata AS TEXT), ''), COALESCE(a.size, 0),
+		       COALESCE(a.content_hash, ''), a.storage_path,
+		       COALESCE(a.thumbnail_hash, ''), COALESCE(a.thumbnail_path, ''),
+		       COALESCE(a.source_attachment_id, ''), COALESCE(a.attachment_state, '')
+		FROM attachments a
+		JOIN messages m ON m.id = a.message_id
+		JOIN conversations c ON c.id = m.conversation_id
+		JOIN sources src ON src.id = m.source_id
+		WHERE src.source_type IN ('beeper', 'slack', 'discord', 'teams')
+		  AND COALESCE(a.attachment_state, '') IN (?, '')
+		  AND (
+		    COALESCE(a.source_attachment_id, '') <> ''
+		    OR (
+		      src.source_type = 'teams'
+		      AND COALESCE(a.filename, '') = '' AND COALESCE(a.mime_type, '') = ''
+		      AND COALESCE(a.content_hash, '') <> ''
+		      AND a.storage_path NOT LIKE 'http://%' AND a.storage_path NOT LIKE 'https://%'
+		    )
+		  )
+		ORDER BY a.id
+	`), attachmentpolicy.StateStored)
+	if err != nil {
+		return nil, fmt.Errorf("list attachment policy candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var candidates []AttachmentPolicyCandidate
+	for rows.Next() {
+		var candidate AttachmentPolicyCandidate
+		var state attachmentpolicy.DownloadState
+		var conversationMetadata string
+		if err := rows.Scan(
+			&candidate.AttachmentID, &candidate.MessageID, &candidate.SourceType,
+			&candidate.SourceIdentifier, &candidate.ConversationType,
+			&candidate.ParticipantCount, &conversationMetadata, &candidate.Size, &candidate.ContentHash,
+			&candidate.StoragePath, &candidate.ThumbnailHash, &candidate.ThumbnailPath,
+			&candidate.SourceAttachmentID, &state,
+		); err != nil {
+			return nil, fmt.Errorf("scan attachment policy candidate: %w", err)
+		}
+		candidate.ParticipantCount = attachmentPolicyParticipantCount(
+			candidate.SourceType, candidate.ParticipantCount, conversationMetadata,
+		)
+		record := decodeMembershipRecord(conversationMetadata)
+		candidate.RosterUnresolved = !record.counted || record.unknown
+		if state == "" && candidate.ContentHash == "" {
+			contentHash, ok := casPathHash(candidate.StoragePath)
+			if !ok {
+				continue
+			}
+			candidate.ContentHash = contentHash
+		}
+		if candidate.SourceAttachmentID == "" {
+			candidate.SourceAttachmentID = fmt.Sprintf("teams:inline:legacy:%d", candidate.AttachmentID)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list attachment policy candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+// ExcludeAttachmentOccurrences atomically detaches selected occurrences from
+// their blobs and leaves typed metadata markers in their place.
+func (s *Store) ExcludeAttachmentOccurrences(ctx context.Context, exclusions []AttachmentExclusion) error {
+	if len(exclusions) == 0 {
+		return nil
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		messageIDs := make(map[int64]struct{})
+		for _, exclusion := range exclusions {
+			if exclusion.AttachmentID <= 0 || exclusion.Reason == "" || exclusion.Reason == attachmentpolicy.SkipFetchFailure {
+				return fmt.Errorf("invalid attachment exclusion: id=%d reason=%q", exclusion.AttachmentID, exclusion.Reason)
+			}
+			var messageID int64
+			var sourceAttachmentID string
+			err := tx.QueryRow(`
+				SELECT message_id, COALESCE(source_attachment_id, '')
+				FROM attachments WHERE id = ?
+			`, exclusion.AttachmentID).Scan(&messageID, &sourceAttachmentID)
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("attachment occurrence %d not found", exclusion.AttachmentID)
+			}
+			if err != nil {
+				return fmt.Errorf("select attachment occurrence %d: %w", exclusion.AttachmentID, err)
+			}
+			if sourceAttachmentID == "" {
+				sourceAttachmentID = exclusion.SourceAttachmentID
+			}
+			if sourceAttachmentID == "" {
+				return fmt.Errorf("attachment occurrence %d has no provider identity", exclusion.AttachmentID)
+			}
+			result, err := tx.Exec(`
+				UPDATE attachments
+				SET storage_path = ?, content_hash = NULL,
+				    thumbnail_hash = NULL, thumbnail_path = NULL,
+				    source_attachment_id = ?, attachment_state = ?, attachment_skip_reason = ?
+				WHERE id = ?
+			`, "excluded:"+sourceAttachmentID, sourceAttachmentID, attachmentpolicy.StateSkipped,
+				exclusion.Reason, exclusion.AttachmentID)
+			if err != nil {
+				return fmt.Errorf("exclude attachment occurrence %d: %w", exclusion.AttachmentID, err)
+			}
+			changed, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("exclude attachment occurrence %d rows affected: %w", exclusion.AttachmentID, err)
+			}
+			if changed != 1 {
+				return fmt.Errorf("exclude attachment occurrence %d: changed %d rows", exclusion.AttachmentID, changed)
+			}
+			messageIDs[messageID] = struct{}{}
+		}
+		for messageID := range messageIDs {
+			if _, err := tx.Exec(`
+				UPDATE messages
+				SET has_attachments = (SELECT COUNT(*) FROM attachments WHERE message_id = ?) > 0,
+				    attachment_count = (SELECT COUNT(*) FROM attachments WHERE message_id = ?)
+				WHERE id = ?
+			`, messageID, messageID, messageID); err != nil {
+				return fmt.Errorf("recompute attachment stats for message %d: %w", messageID, err)
+			}
+		}
+		return nil
+	})
+}
+
+// AttachmentBlobReferenced reports whether any occurrence still owns the
+// given content hash or canonical storage path as full-size or thumbnail media.
+func (s *Store) AttachmentBlobReferenced(ctx context.Context, contentHash, storagePath string) (bool, error) {
+	if contentHash == "" && storagePath == "" {
+		return false, nil
+	}
+	var exists bool
+	err := s.db.QueryRowContext(ctx, s.Rebind(`
+		SELECT EXISTS (
+			SELECT 1 FROM attachments
+			WHERE (? <> '' AND (content_hash = ? OR thumbnail_hash = ?))
+			   OR (? <> '' AND (storage_path = ? OR thumbnail_path = ?))
+		)
+	`), contentHash, contentHash, contentHash,
+		storagePath, storagePath, storagePath).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check attachment blob reference: %w", err)
+	}
+	return exists, nil
+}

--- a/internal/store/attachment_policy_test.go
+++ b/internal/store/attachment_policy_test.go
@@ -1,0 +1,215 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestInitSchemaAddsAttachmentOutcomeColumns(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dbPath := filepath.Join(t.TempDir(), "legacy-attachments.db")
+	st, err := store.Open(dbPath)
+	require.NoError(err)
+	t.Cleanup(func() { _ = st.Close() })
+	_, err = st.DB().Exec(`
+		CREATE TABLE attachments (
+			id INTEGER PRIMARY KEY,
+			message_id INTEGER NOT NULL,
+			content_hash TEXT,
+			storage_path TEXT NOT NULL,
+			thumbnail_hash TEXT,
+			thumbnail_path TEXT
+		)
+	`)
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+
+	var state, reason sql.NullString
+	_, err = st.DB().Exec(`INSERT INTO attachments (message_id, storage_path) VALUES (1, 'legacy:pending')`)
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments WHERE message_id = 1
+	`).Scan(&state, &reason))
+	assert.False(state.Valid)
+	assert.False(reason.Valid)
+}
+
+// newPolicyMessage archives one message in a conversation whose roster the
+// provider has read: participants is both the observed participant count and
+// the archived membership record.
+func newPolicyMessage(t *testing.T, st *store.Store, sourceType, identifier, conversationType, sourceMessageID string, participants int) (int64, int64) {
+	t.Helper()
+	source, err := st.GetOrCreateSource(sourceType, identifier)
+	require.NoError(t, err)
+	conversationID, err := st.EnsureConversationWithType(source.ID, "conversation-"+sourceMessageID, conversationType, sourceMessageID)
+	require.NoError(t, err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE conversations SET participant_count = ? WHERE id = ?`), participants, conversationID)
+	require.NoError(t, err)
+	require.NoError(t, st.SetConversationMemberCount(conversationID, participants))
+	return source.ID, insertStoreTestMessage(t, st, source.ID, conversationID, sourceMessageID)
+}
+
+func TestAttachmentOutcomeRoundTrip(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	_, messageID := newPolicyMessage(t, st, "beeper", "signal", "direct_chat", "round-trip", 2)
+	want := store.AttachmentRef{
+		Filename: "photo.jpg", MimeType: "image/jpeg", Size: 2048,
+		SourceAttachmentID: "beeper:asset-1", StoragePath: "https://example.invalid/asset-1",
+		State: attachmentpolicy.StateSkipped, SkipReason: attachmentpolicy.SkipPolicyScope,
+	}
+	require.NoError(t, st.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{want}))
+
+	refs, err := st.MessageBeeperAttachments(messageID)
+	require.NoError(t, err)
+	// The replacement path normalizes role provenance and keys the occurrence
+	// by its provider attachment ID; the typed outcome rides along unchanged.
+	want.Role, want.RoleSource = store.AttachmentRoleUnknown, store.AttachmentRoleSourceUnknown
+	want.SourcePartKey = want.SourceAttachmentID
+	assert.Equal(t, want, refs[want.SourceAttachmentID])
+}
+
+func TestRetryableAttachmentMessagesReevaluateSkippedUnderCurrentPolicy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	sourceID, pendingID := newPolicyMessage(t, st, "beeper", "signal", "group_chat", "pending", 4)
+	_, failedID := newPolicyMessage(t, st, "beeper", "signal", "group_chat", "failed", 4)
+	_, skippedID := newPolicyMessage(t, st, "beeper", "signal", "group_chat", "skipped", 4)
+	_, storedID := newPolicyMessage(t, st, "beeper", "signal", "group_chat", "stored", 4)
+
+	for _, item := range []struct {
+		messageID int64
+		name      string
+		state     attachmentpolicy.DownloadState
+		hash      string
+		path      string
+	}{
+		{messageID: pendingID, name: "pending", state: attachmentpolicy.StatePending, path: "https://example.invalid/pending"},
+		{messageID: failedID, name: "failed", state: attachmentpolicy.StateFailed, path: "https://example.invalid/failed"},
+		{messageID: skippedID, name: "skipped", state: attachmentpolicy.StateSkipped, path: "https://example.invalid/skipped"},
+		{messageID: storedID, name: "stored", state: attachmentpolicy.StateStored, hash: strings.Repeat("ab", 32), path: "ab/" + strings.Repeat("ab", 32)},
+	} {
+		require.NoError(st.ReplaceMessageBeeperAttachments(item.messageID, []store.AttachmentRef{
+			{SourceAttachmentID: "beeper:" + item.name, StoragePath: item.path, ContentHash: item.hash, State: item.state},
+		}))
+	}
+
+	items, err := st.ListBeeperRetryableAttachmentMessages(sourceID, attachmentpolicy.Policy{
+		MaxParticipants: 3,
+	})
+	require.NoError(err)
+	assert.Equal([]store.BeeperPendingAttachmentMessage{
+		{MessageID: pendingID, SourceMessageID: "pending", ChatID: "conversation-pending", ConversationType: "group_chat", ParticipantCount: 4},
+		{MessageID: failedID, SourceMessageID: "failed", ChatID: "conversation-failed", ConversationType: "group_chat", ParticipantCount: 4},
+	}, items)
+
+	items, err = st.ListBeeperRetryableAttachmentMessages(sourceID, attachmentpolicy.Policy{})
+	require.NoError(err)
+	assert.Equal([]store.BeeperPendingAttachmentMessage{
+		{MessageID: pendingID, SourceMessageID: "pending", ChatID: "conversation-pending", ConversationType: "group_chat", ParticipantCount: 4},
+		{MessageID: failedID, SourceMessageID: "failed", ChatID: "conversation-failed", ConversationType: "group_chat", ParticipantCount: 4},
+		{MessageID: skippedID, SourceMessageID: "skipped", ChatID: "conversation-skipped", ConversationType: "group_chat", ParticipantCount: 4},
+	}, items)
+}
+
+func TestExcludeAttachmentOccurrencesRemovesOnlySelectedBlobReference(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	_, excludedMessageID := newPolicyMessage(t, st, "beeper", "signal", "channel", "excluded", 20)
+	_, retainedMessageID := newPolicyMessage(t, st, "beeper", "signal", "direct_chat", "retained", 2)
+	hash := strings.Repeat("cd", 32)
+	path := hash[:2] + "/" + hash
+	for messageID, sourceID := range map[int64]string{excludedMessageID: "beeper:excluded", retainedMessageID: "beeper:retained"} {
+		require.NoError(st.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{{
+			SourceAttachmentID: sourceID, StoragePath: path, ContentHash: hash,
+			Size: 99, State: attachmentpolicy.StateStored,
+		}}))
+	}
+
+	candidates, err := st.ListAttachmentPolicyCandidates(context.Background())
+	require.NoError(err)
+	require.Len(candidates, 2)
+	var excluded store.AttachmentPolicyCandidate
+	for _, candidate := range candidates {
+		if candidate.MessageID == excludedMessageID {
+			excluded = candidate
+		}
+	}
+	require.NotZero(excluded.AttachmentID)
+	require.NoError(st.ExcludeAttachmentOccurrences(context.Background(), []store.AttachmentExclusion{{
+		AttachmentID: excluded.AttachmentID, Reason: attachmentpolicy.SkipPolicyScope,
+	}}))
+
+	var state, reason, contentHash, storagePath string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT attachment_state, attachment_skip_reason, COALESCE(content_hash, ''), storage_path
+		FROM attachments WHERE id = ?`), excluded.AttachmentID).Scan(&state, &reason, &contentHash, &storagePath))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipPolicyScope), reason)
+	assert.Empty(contentHash)
+	assert.Equal("excluded:beeper:excluded", storagePath)
+
+	referenced, err := st.AttachmentBlobReferenced(context.Background(), hash, path)
+	require.NoError(err)
+	assert.True(referenced)
+}
+
+func TestAttachmentPolicyCandidatesIncludeLegacyAliasesAndTeamsInlineRows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	_, slackMessageID := newPolicyMessage(t, st, "slack", "T01:U01", "channel", "legacy-alias", 5)
+	_, teamsMessageID := newPolicyMessage(t, st, "teams", "user@example.com", "direct_chat", "legacy-inline", 2)
+	aliasHash := strings.Repeat("ab", 32)
+	inlineHash := strings.Repeat("cd", 32)
+
+	var aliasID int64
+	err := st.DB().QueryRow(st.Rebind(`
+		INSERT INTO attachments (message_id, storage_path, content_hash, source_attachment_id)
+		VALUES (?, ?, NULL, ?)
+		RETURNING id
+	`), slackMessageID, aliasHash[:2]+"/"+aliasHash, "slack:legacy-alias").Scan(&aliasID)
+	require.NoError(err)
+	var inlineID int64
+	err = st.DB().QueryRow(st.Rebind(`
+		INSERT INTO attachments (message_id, storage_path, content_hash, filename, mime_type, source_attachment_id)
+		VALUES (?, ?, ?, NULL, NULL, NULL)
+		RETURNING id
+	`), teamsMessageID, inlineHash[:2]+"/"+inlineHash, inlineHash).Scan(&inlineID)
+	require.NoError(err)
+
+	candidates, err := st.ListAttachmentPolicyCandidates(context.Background())
+	require.NoError(err)
+	require.Len(candidates, 2)
+	byID := make(map[int64]store.AttachmentPolicyCandidate, len(candidates))
+	for _, candidate := range candidates {
+		byID[candidate.AttachmentID] = candidate
+	}
+	assert.Equal(aliasHash, byID[aliasID].ContentHash)
+	assert.Equal("slack:legacy-alias", byID[aliasID].SourceAttachmentID)
+	assert.Equal(inlineHash, byID[inlineID].ContentHash)
+	assert.Equal(fmt.Sprintf("teams:inline:legacy:%d", inlineID), byID[inlineID].SourceAttachmentID)
+
+	require.NoError(st.ExcludeAttachmentOccurrences(context.Background(), []store.AttachmentExclusion{
+		{AttachmentID: aliasID, Reason: attachmentpolicy.SkipPolicyScope, SourceAttachmentID: byID[aliasID].SourceAttachmentID},
+		{AttachmentID: inlineID, Reason: attachmentpolicy.SkipPolicyScope, SourceAttachmentID: byID[inlineID].SourceAttachmentID},
+	}))
+	var sourceAttachmentID, state string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT source_attachment_id, attachment_state FROM attachments WHERE id = ?
+	`), inlineID).Scan(&sourceAttachmentID, &state))
+	assert.Equal(fmt.Sprintf("teams:inline:legacy:%d", inlineID), sourceAttachmentID)
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+}

--- a/internal/store/attachment_roles.go
+++ b/internal/store/attachment_roles.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 )
 
 // AttachmentRole is the source-authoritative role of one attachment
@@ -55,6 +57,9 @@ type AttachmentWrite struct {
 	RoleSource         AttachmentRoleSource
 	SourcePartKey      string
 	ContentID          string
+	// State and SkipReason distinguish unfinished fetches from deliberate policy exclusions.
+	State      attachmentpolicy.DownloadState
+	SkipReason attachmentpolicy.SkipReason
 }
 
 func (r AttachmentRole) valid() bool {
@@ -149,7 +154,8 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 				filename = ?, mime_type = ?, storage_path = ?, content_hash = ?, size = ?,
 				source_attachment_id = ?, media_type = ?, width = ?, height = ?, duration_ms = ?,
 				attachment_metadata = %s, attachment_role = ?, role_source = ?,
-				source_part_key = ?, content_id = ?
+				source_part_key = ?, content_id = ?,
+				attachment_state = ?, attachment_skip_reason = ?
 			WHERE message_id = ?
 			  AND source_part_key IS NULL
 			  AND content_hash = ?
@@ -164,6 +170,7 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 			nullIfZero(write.Width), nullIfZero(write.Height), nullIfZero(write.DurationMS),
 			nullIfEmpty(write.Metadata), string(write.Role), string(write.RoleSource),
 			write.SourcePartKey, nullIfEmpty(write.ContentID),
+			nullIfEmpty(string(write.State)), nullIfEmpty(string(write.SkipReason)),
 			messageID, write.ContentHash, messageID, write.SourcePartKey,
 		)
 		if err != nil {
@@ -191,12 +198,14 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 		string(write.RoleSource),
 		nullIfEmpty(write.SourcePartKey),
 		nullIfEmpty(write.ContentID),
+		nullIfEmpty(string(write.State)),
+		nullIfEmpty(string(write.SkipReason)),
 	}
 	const columns = `(message_id, filename, mime_type, storage_path, content_hash,
 		size, source_attachment_id, media_type, width, height, duration_ms,
 		attachment_metadata, attachment_role, role_source, source_part_key,
-		content_id, created_at)`
-	values := fmt.Sprintf(`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?, %s)`,
+		content_id, attachment_state, attachment_skip_reason, created_at)`
+	values := fmt.Sprintf(`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?, ?, ?, %s)`,
 		s.dialect.JSONBindExpr(), s.dialect.Now())
 
 	if write.SourcePartKey != "" {
@@ -218,7 +227,9 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 				attachment_metadata = EXCLUDED.attachment_metadata,
 				attachment_role = EXCLUDED.attachment_role,
 				role_source = EXCLUDED.role_source,
-				content_id = EXCLUDED.content_id`, args...)
+				content_id = EXCLUDED.content_id,
+				attachment_state = EXCLUDED.attachment_state,
+				attachment_skip_reason = EXCLUDED.attachment_skip_reason`, args...)
 		return err
 	}
 

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1,16 +1,23 @@
 package store
 
 import (
+	"context"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"strings"
+
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 )
 
 // PendingAttachmentMessage identifies a message with at least one provider
 // attachment marker that has not been downloaded yet.
 type PendingAttachmentMessage struct {
-	MessageID       int64
-	SourceMessageID string
-	ChatID          string // conversations.source_conversation_id
+	MessageID        int64
+	SourceMessageID  string
+	ChatID           string // conversations.source_conversation_id
+	ConversationType string
+	ParticipantCount int
 }
 
 // BeeperPendingAttachmentMessage preserves the existing Beeper importer API.
@@ -34,7 +41,8 @@ func (s *Store) messageProviderAttachments(messageID int64, providerPrefix strin
 		SELECT COALESCE(filename, ''), COALESCE(mime_type, ''), storage_path, COALESCE(content_hash, ''), size, source_attachment_id,
 		       COALESCE(media_type, ''), COALESCE(width, 0), COALESCE(height, 0), COALESCE(duration_ms, 0),
 		       COALESCE(CAST(attachment_metadata AS TEXT), ''), attachment_role, role_source,
-		       COALESCE(source_part_key, ''), COALESCE(content_id, '')
+		       COALESCE(source_part_key, ''), COALESCE(content_id, ''),
+		       COALESCE(attachment_state, ''), COALESCE(attachment_skip_reason, '')
 		FROM attachments
 		WHERE message_id = ? AND source_attachment_id LIKE ?
 	`, messageID, providerPrefix+"%")
@@ -51,7 +59,7 @@ func (s *Store) messageProviderAttachments(messageID int64, providerPrefix strin
 			&ref.Filename, &ref.MimeType, &ref.StoragePath, &ref.ContentHash,
 			&size, &ref.SourceAttachmentID, &ref.MediaType, &ref.Width,
 			&ref.Height, &ref.DurationMS, &ref.Metadata, &ref.Role, &ref.RoleSource,
-			&ref.SourcePartKey, &ref.ContentID,
+			&ref.SourcePartKey, &ref.ContentID, &ref.State, &ref.SkipReason,
 		); err != nil {
 			return nil, err
 		}
@@ -59,6 +67,323 @@ func (s *Store) messageProviderAttachments(messageID int64, providerPrefix strin
 		out[ref.SourceAttachmentID] = ref
 	}
 	return out, rows.Err()
+}
+
+func (s *Store) listRetryableAttachmentMessages(
+	sourceID int64, providerPrefix string, policy attachmentpolicy.Policy,
+) ([]PendingAttachmentMessage, error) {
+	rows, err := s.db.Query(`
+		SELECT m.id, m.source_message_id, c.source_conversation_id,
+		       c.conversation_type, COALESCE(c.participant_count, 0),
+		       COALESCE(a.attachment_state, ''), COALESCE(a.size, 0),
+		       COALESCE(a.content_hash, ''), a.storage_path,
+		       COALESCE(a.media_type, ''), COALESCE(CAST(c.metadata AS TEXT), '')
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		JOIN attachments a ON a.message_id = m.id
+		WHERE m.source_id = ?
+		  AND a.source_attachment_id LIKE ?
+		ORDER BY m.id, a.id
+	`, sourceID, providerPrefix+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var items []PendingAttachmentMessage
+	var lastAdded int64
+	for rows.Next() {
+		var item PendingAttachmentMessage
+		var state attachmentpolicy.DownloadState
+		var size int64
+		var contentHash, storagePath, mediaType, conversationMetadata string
+		if err := rows.Scan(&item.MessageID, &item.SourceMessageID, &item.ChatID,
+			&item.ConversationType, &item.ParticipantCount, &state, &size,
+			&contentHash, &storagePath, &mediaType, &conversationMetadata); err != nil {
+			return nil, err
+		}
+		item.ParticipantCount = policyParticipantCount(
+			providerPrefix, item.ParticipantCount, conversationMetadata, policy,
+		)
+		if item.MessageID == lastAdded || mediaType == "link" || contentHash != "" ||
+			casAttachmentDownloaded(AttachmentRef{StoragePath: storagePath}) {
+			continue
+		}
+		eligible := attachmentpolicy.RetryEligible(state)
+		if state == attachmentpolicy.StateSkipped {
+			eligible = policy.Allows(attachmentpolicy.Conversation{
+				Type: item.ConversationType, ParticipantCount: item.ParticipantCount,
+			}, size)
+		}
+		if eligible {
+			items = append(items, item)
+			lastAdded = item.MessageID
+		}
+	}
+	return items, rows.Err()
+}
+
+// ListBeeperRetryableAttachmentMessages returns only unfinished Beeper media.
+func (s *Store) ListBeeperRetryableAttachmentMessages(sourceID int64, policy attachmentpolicy.Policy) ([]BeeperPendingAttachmentMessage, error) {
+	return s.listRetryableAttachmentMessages(sourceID, "beeper:", policy)
+}
+
+// BeeperRetryPolicyResult describes the local policy state found before a
+// Beeper media backfill makes provider requests.
+type BeeperRetryPolicyResult struct {
+	NewlySkipped int64
+	HasExcluded  bool
+}
+
+// ApplyBeeperRetryableAttachmentPolicy converts unfinished Beeper rows that
+// the current policy excludes into durable typed skip markers and reports
+// whether excluded work remains. This lets a backfill stay local both when a
+// policy is tightened and on later runs where that policy is unchanged.
+func (s *Store) ApplyBeeperRetryableAttachmentPolicy(
+	ctx context.Context, sourceID int64, policy attachmentpolicy.Policy,
+) (BeeperRetryPolicyResult, error) {
+	type exclusion struct {
+		attachmentID int64
+		reason       attachmentpolicy.SkipReason
+	}
+	var result BeeperRetryPolicyResult
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		rows, err := tx.QueryContext(ctx, `
+			SELECT a.id, c.conversation_type, COALESCE(c.participant_count, 0),
+			       COALESCE(CAST(c.metadata AS TEXT), ''),
+			       COALESCE(a.size, 0), COALESCE(a.attachment_state, '')
+			FROM attachments a
+			JOIN messages m ON m.id = a.message_id
+			JOIN conversations c ON c.id = m.conversation_id
+			WHERE m.source_id = ?
+			  AND a.source_attachment_id LIKE 'beeper:%'
+			  AND COALESCE(a.content_hash, '') = ''
+			  AND COALESCE(a.media_type, '') <> 'link'
+			  AND COALESCE(a.attachment_state, '') IN ('', ?, ?, ?)
+			ORDER BY a.id
+		`, sourceID, attachmentpolicy.StatePending, attachmentpolicy.StateFailed,
+			attachmentpolicy.StateSkipped)
+		if err != nil {
+			return fmt.Errorf("list retryable Beeper policy candidates: %w", err)
+		}
+		var exclusions []exclusion
+		for rows.Next() {
+			var attachmentID, size int64
+			var conversation attachmentpolicy.Conversation
+			var conversationMetadata string
+			var state attachmentpolicy.DownloadState
+			if err := rows.Scan(&attachmentID, &conversation.Type, &conversation.ParticipantCount,
+				&conversationMetadata, &size, &state); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan retryable Beeper policy candidate: %w", err)
+			}
+			conversation.ParticipantCount = policyParticipantCount(
+				sourceTypeBeeper, conversation.ParticipantCount, conversationMetadata, policy,
+			)
+			if reason := policy.Evaluate(conversation, size); reason != "" {
+				result.HasExcluded = true
+				if attachmentpolicy.RetryEligible(state) {
+					exclusions = append(exclusions, exclusion{attachmentID: attachmentID, reason: reason})
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("list retryable Beeper policy candidates: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close retryable Beeper policy candidates: %w", err)
+		}
+		for _, exclusion := range exclusions {
+			updateResult, err := tx.ExecContext(ctx, `
+				UPDATE attachments
+				SET attachment_state = ?, attachment_skip_reason = ?
+				WHERE id = ?
+				  AND COALESCE(attachment_state, '') IN ('', ?, ?)
+			`, attachmentpolicy.StateSkipped, exclusion.reason, exclusion.attachmentID,
+				attachmentpolicy.StatePending, attachmentpolicy.StateFailed)
+			if err != nil {
+				return fmt.Errorf("skip Beeper attachment %d by policy: %w", exclusion.attachmentID, err)
+			}
+			changed, err := updateResult.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("count skipped Beeper attachment %d: %w", exclusion.attachmentID, err)
+			}
+			result.NewlySkipped += changed
+		}
+		return nil
+	})
+	if err != nil {
+		return BeeperRetryPolicyResult{}, err
+	}
+	return result, nil
+}
+
+// ListSlackRetryableAttachmentMessages returns only unfinished Slack media.
+func (s *Store) ListSlackRetryableAttachmentMessages(sourceID int64, policy attachmentpolicy.Policy) ([]PendingAttachmentMessage, error) {
+	return s.listRetryableAttachmentMessages(sourceID, "slack:", policy)
+}
+
+// ListDiscordRetryableAttachmentMessages returns only unfinished Discord media.
+func (s *Store) ListDiscordRetryableAttachmentMessages(sourceID int64, policy attachmentpolicy.Policy) ([]DiscordPendingAttachmentMessage, error) {
+	return s.listRetryableAttachmentMessages(sourceID, "discord:", policy)
+}
+
+// ConversationMembership is one archived conversation as media policy sees it.
+type ConversationMembership struct {
+	Conversation attachmentpolicy.Conversation
+	// RosterArchived reports whether the provider has recorded the exact size
+	// of a roster it read and no later read has failed. False means the count
+	// comes from accumulated participant rows, or that the most recent roster
+	// read is archived as having failed (a count read earlier may still sit
+	// beside the marker); either way a media backfill must re-resolve
+	// membership before it can trust the participant threshold.
+	RosterArchived bool
+}
+
+// AttachmentConversation returns the archived context used by media policy.
+func (s *Store) AttachmentConversation(messageID int64) (attachmentpolicy.Conversation, error) {
+	membership, err := s.AttachmentConversationMembership(messageID)
+	return membership.Conversation, err
+}
+
+// AttachmentConversationMembership returns the archived context used by media
+// policy together with the state of the provider's membership record.
+func (s *Store) AttachmentConversationMembership(messageID int64) (ConversationMembership, error) {
+	var conversation attachmentpolicy.Conversation
+	var observedParticipants int
+	var sourceType, metadata string
+	err := s.db.QueryRow(`
+		SELECT c.conversation_type, COALESCE(c.participant_count, 0),
+		       (SELECT COUNT(DISTINCT cp.participant_id)
+		        FROM conversation_participants cp WHERE cp.conversation_id = c.id),
+		       src.source_type, COALESCE(CAST(c.metadata AS TEXT), '')
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		JOIN sources src ON src.id = m.source_id
+		WHERE m.id = ?
+	`, messageID).Scan(&conversation.Type, &conversation.ParticipantCount, &observedParticipants,
+		&sourceType, &metadata)
+	if observedParticipants > conversation.ParticipantCount {
+		conversation.ParticipantCount = observedParticipants
+	}
+	conversation.ParticipantCount = attachmentPolicyParticipantCount(
+		sourceType, conversation.ParticipantCount, metadata,
+	)
+	record := decodeMembershipRecord(metadata)
+	return ConversationMembership{
+		Conversation:   conversation,
+		RosterArchived: record.counted && !record.unknown,
+	}, err
+}
+
+// MessageConversationRef identifies the archived conversation a message belongs
+// to, including the provider-side key.
+type MessageConversationRef struct {
+	ConversationID       int64
+	SourceConversationID string
+	Type                 string
+}
+
+// MessageConversation returns the conversation a message belongs to. Media
+// backfills use it to re-resolve provider membership that the original sync
+// could not read, so the archived participant count becomes authoritative
+// before policy is evaluated again.
+func (s *Store) MessageConversation(messageID int64) (MessageConversationRef, error) {
+	var ref MessageConversationRef
+	err := s.db.QueryRow(`
+		SELECT c.id, COALESCE(c.source_conversation_id, ''), COALESCE(c.conversation_type, '')
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		WHERE m.id = ?
+	`, messageID).Scan(&ref.ConversationID, &ref.SourceConversationID, &ref.Type)
+	if err != nil {
+		return MessageConversationRef{}, fmt.Errorf("conversation for message %d: %w", messageID, err)
+	}
+	return ref, nil
+}
+
+// Provider identities used to select membership semantics. Callers pass
+// either a source type or the provider's attachment-ID prefix.
+const (
+	sourceTypeDiscord = "discord"
+	sourceTypeTeams   = "teams"
+	sourceTypeSlack   = "slack"
+	sourceTypeBeeper  = "beeper"
+)
+
+// membershipRecord is the provider-maintained membership a conversation's
+// metadata carries. Providers that can read a roster archive its exact size
+// there; one that could not read it archives that explicitly, so an unresolved
+// roster is distinguishable from a conversation with no members. Both may be
+// present at once: a count read earlier stays for reference while the unknown
+// marker says the latest read failed and the roster is unresolved.
+type membershipRecord struct {
+	memberCount int
+	counted     bool
+	unknown     bool
+}
+
+func decodeMembershipRecord(metadata string) membershipRecord {
+	if strings.TrimSpace(metadata) == "" {
+		return membershipRecord{}
+	}
+	var stored struct {
+		MemberCount        *int `json:"member_count"`
+		MemberCountUnknown bool `json:"member_count_unknown"`
+	}
+	if err := json.Unmarshal([]byte(metadata), &stored); err != nil {
+		return membershipRecord{}
+	}
+	record := membershipRecord{unknown: stored.MemberCountUnknown}
+	if stored.MemberCount != nil {
+		record.memberCount, record.counted = *stored.MemberCount, true
+	}
+	return record
+}
+
+// attachmentPolicyParticipantCount resolves the participant count media policy
+// evaluates for an archived conversation. Discord stages an authoritative
+// catalog count that may only raise the observed one, so recomputed
+// conversation stats cannot silently relax an exclusion. Teams, Slack, and
+// Beeper archive the exact roster they read (Beeper: the participant total it
+// reports, which a truncated listing's rows undercount), which is
+// authoritative in both directions: participant rows only ever accumulate, so
+// membership that shrank below the threshold would otherwise keep excluding
+// the conversation's media forever. Conversation stats keep the observed count
+// for UI and search.
+func attachmentPolicyParticipantCount(sourceType string, observed int, metadata string) int {
+	record := decodeMembershipRecord(metadata)
+	if !record.counted {
+		return observed
+	}
+	switch strings.TrimSuffix(sourceType, ":") {
+	case sourceTypeDiscord:
+		return max(record.memberCount, observed)
+	case sourceTypeTeams, sourceTypeSlack, sourceTypeBeeper:
+		return record.memberCount
+	default:
+		return observed
+	}
+}
+
+// policyParticipantCount resolves the participant count with an unresolved
+// roster applied: while a limit is configured, a conversation with no
+// authoritative roster archived — a provider could not read one, or none was
+// ever recorded — must not evaluate as a conversation under the threshold on
+// the strength of its accumulated participant rows, which undercount a
+// truncated or partially observed membership. The resulting skips stay
+// retryable — a run that reads the roster archives the real count and a later
+// backfill re-evaluates them. Purge deliberately does not use this: excluding
+// media deletes blobs, so an unresolved roster there must retain rather than
+// fail closed.
+func policyParticipantCount(
+	sourceType string, observed int, metadata string, policy attachmentpolicy.Policy,
+) int {
+	record := decodeMembershipRecord(metadata)
+	if policy.MaxParticipants > 0 && (!record.counted || record.unknown) {
+		return policy.MaxParticipants + 1
+	}
+	return attachmentPolicyParticipantCount(sourceType, observed, metadata)
 }
 
 func (s *Store) listPendingAttachmentMessages(sourceID int64, providerPrefix string) ([]PendingAttachmentMessage, error) {
@@ -235,7 +560,9 @@ func (s *Store) ListDiscordPendingAttachmentMessages(sourceID int64) ([]DiscordP
 // ListDiscordPendingAttachmentMessages.
 func (s *Store) ListDiscordAttachmentMessages(sourceID int64) ([]DiscordAttachmentMessage, error) {
 	rows, err := s.db.Query(`
-		SELECT m.id, m.source_message_id, c.source_conversation_id
+		SELECT m.id, m.source_message_id, c.source_conversation_id,
+		       c.conversation_type, COALESCE(c.participant_count, 0),
+		       COALESCE(CAST(c.metadata AS TEXT), '')
 		FROM messages m
 		JOIN conversations c ON c.id = m.conversation_id
 		WHERE m.source_id = ?
@@ -255,9 +582,14 @@ func (s *Store) ListDiscordAttachmentMessages(sourceID int64) ([]DiscordAttachme
 	var messages []DiscordAttachmentMessage
 	for rows.Next() {
 		var message DiscordAttachmentMessage
-		if err := rows.Scan(&message.MessageID, &message.SourceMessageID, &message.ChatID); err != nil {
+		var metadata string
+		if err := rows.Scan(&message.MessageID, &message.SourceMessageID, &message.ChatID,
+			&message.ConversationType, &message.ParticipantCount, &metadata); err != nil {
 			return nil, err
 		}
+		message.ParticipantCount = attachmentPolicyParticipantCount(
+			"discord", message.ParticipantCount, metadata,
+		)
 		messages = append(messages, message)
 	}
 	return messages, rows.Err()

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
@@ -121,6 +122,8 @@ func TestListDiscordAttachmentMessagesIncludesCompletedAndPendingInOneQuery(t *t
 	require.NoError(err)
 	conversationID, err := st.EnsureConversationWithType(source.ID, "channel-all", "channel", "all")
 	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE conversations SET participant_count = 12 WHERE id = ?`), conversationID)
+	require.NoError(err)
 	completedID := insertStoreTestMessage(t, st, source.ID, conversationID, "completed")
 	pendingID := insertStoreTestMessage(t, st, source.ID, conversationID, "pending")
 	beeperOnlyID := insertStoreTestMessage(t, st, source.ID, conversationID, "beeper-only")
@@ -148,8 +151,8 @@ func TestListDiscordAttachmentMessagesIncludesCompletedAndPendingInOneQuery(t *t
 	items, err := st.ListDiscordAttachmentMessages(source.ID)
 	require.NoError(err)
 	assert.Equal([]store.DiscordPendingAttachmentMessage{
-		{MessageID: completedID, SourceMessageID: "completed", ChatID: "channel-all"},
-		{MessageID: pendingID, SourceMessageID: "pending", ChatID: "channel-all"},
+		{MessageID: completedID, SourceMessageID: "completed", ChatID: "channel-all", ConversationType: "channel", ParticipantCount: 12},
+		{MessageID: pendingID, SourceMessageID: "pending", ChatID: "channel-all", ConversationType: "channel", ParticipantCount: 12},
 	}, items)
 	assert.Equal(1, strings.Count(logs.String(), `"kind":"query"`), "all-attachment scan must use one query")
 }
@@ -326,6 +329,9 @@ func TestSlackAliasRowsServeHashesThroughMessageAPI(t *testing.T) {
 			"a duplicate-byte Slack occurrence must stay accessible through the API (%s)", att.Filename)
 		assert.Empty(att.URL)
 	}
+	retryable, err := st.ListSlackRetryableAttachmentMessages(source.ID, attachmentpolicy.Policy{})
+	require.NoError(err)
+	assert.Empty(retryable, "a hashless canonical CAS alias is already downloaded")
 }
 
 func TestReplaceAndListMessageDiscordAttachments(t *testing.T) {

--- a/internal/store/conversations.go
+++ b/internal/store/conversations.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -402,6 +403,92 @@ func (s *Store) GetConversationMetadata(conversationID int64) (sql.NullString, e
 		return sql.NullString{}, fmt.Errorf("get conversation metadata (id=%d): %w", conversationID, err)
 	}
 	return metadata, nil
+}
+
+// SetConversationMemberCount records the exact roster size a provider just
+// read, as the member_count key of the conversation's metadata. Media policy
+// evaluates this record rather than the participant rows, which accumulate
+// every member ever seen and so can only ever raise the count.
+func (s *Store) SetConversationMemberCount(conversationID int64, count int) error {
+	metadata, err := s.conversationMetadataObject(conversationID)
+	if err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(count)
+	if err != nil {
+		return fmt.Errorf("encode conversation member count: %w", err)
+	}
+	metadata["member_count"] = encoded
+	delete(metadata, "member_count_unknown")
+	return s.writeConversationMetadataObject(conversationID, metadata)
+}
+
+// MarkConversationMemberCountUnknown records that a provider could not read a
+// conversation's roster, so later policy evaluation can tell an unresolved
+// roster from a conversation with no members. A count the provider did read
+// before is kept beside the marker for reference, but the roster counts as
+// unresolved until a successful read clears the marker: the sync that could
+// not read it fails closed on the participant threshold, and a backfill or
+// purge that trusted the stale count instead could download or delete media
+// against the membership the conversation has now.
+func (s *Store) MarkConversationMemberCountUnknown(conversationID int64) error {
+	metadata, err := s.conversationMetadataObject(conversationID)
+	if err != nil {
+		return err
+	}
+	metadata["member_count_unknown"] = json.RawMessage("true")
+	return s.writeConversationMetadataObject(conversationID, metadata)
+}
+
+// conversationMetadataObject reads the metadata column as a mutable JSON
+// object, so a provider can revise one key without disturbing the others.
+func (s *Store) conversationMetadataObject(conversationID int64) (map[string]json.RawMessage, error) {
+	stored, err := s.GetConversationMetadata(conversationID)
+	if err != nil {
+		return nil, err
+	}
+	metadata := make(map[string]json.RawMessage)
+	if !stored.Valid || strings.TrimSpace(stored.String) == "" {
+		return metadata, nil
+	}
+	if err := json.Unmarshal([]byte(stored.String), &metadata); err != nil {
+		return nil, fmt.Errorf("decode conversation metadata (id=%d): %w", conversationID, err)
+	}
+	return metadata, nil
+}
+
+func (s *Store) writeConversationMetadataObject(
+	conversationID int64, metadata map[string]json.RawMessage,
+) error {
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("encode conversation metadata (id=%d): %w", conversationID, err)
+	}
+	return s.SetConversationMetadata(conversationID, sql.NullString{
+		String: string(encoded), Valid: len(metadata) != 0,
+	})
+}
+
+// ListConversationIDs returns the IDs of every conversation archived under
+// sourceID, in ID order.
+func (s *Store) ListConversationIDs(sourceID int64) ([]int64, error) {
+	rows, err := s.db.Query(`SELECT id FROM conversations WHERE source_id = ? ORDER BY id`, sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("list conversations for source %d: %w", sourceID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan conversation id for source %d: %w", sourceID, err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list conversations for source %d: %w", sourceID, err)
+	}
+	return ids, nil
 }
 
 // ConversationMetadataBatch returns provider metadata keyed by source

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -651,6 +651,8 @@ func (d *PostgreSQLDialect) LegacyColumnMigrations() []ColumnMigration {
 		{`ALTER TABLE document_extractions ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0 AND retry_count <= request_count)`, "document_extractions.retry_count"},
 		{`ALTER TABLE document_extractions ADD COLUMN IF NOT EXISTS provider_latency_ms BIGINT NOT NULL DEFAULT 0 CHECK (provider_latency_ms >= 0)`, "document_extractions.provider_latency_ms"},
 		{`ALTER TABLE document_index_state ADD COLUMN IF NOT EXISTS target_profile_id TEXT`, "document_index_state.target_profile_id"},
+		{`ALTER TABLE attachments ADD COLUMN IF NOT EXISTS attachment_state TEXT`, "attachments.attachment_state"},
+		{`ALTER TABLE attachments ADD COLUMN IF NOT EXISTS attachment_skip_reason TEXT`, "attachments.attachment_skip_reason"},
 	}
 }
 

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -1298,6 +1298,8 @@ func (d *SQLiteDialect) LegacyColumnMigrations() []ColumnMigration {
 		{`ALTER TABLE document_extractions ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0 AND retry_count <= request_count)`, "document_extractions.retry_count"},
 		{`ALTER TABLE document_extractions ADD COLUMN provider_latency_ms INTEGER NOT NULL DEFAULT 0 CHECK (provider_latency_ms >= 0)`, "document_extractions.provider_latency_ms"},
 		{`ALTER TABLE document_index_state ADD COLUMN target_profile_id TEXT`, "document_index_state.target_profile_id"},
+		{`ALTER TABLE attachments ADD COLUMN attachment_state TEXT`, "attachments.attachment_state"},
+		{`ALTER TABLE attachments ADD COLUMN attachment_skip_reason TEXT`, "attachments.attachment_skip_reason"},
 	}
 }
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/mime"
 )
 
@@ -2872,11 +2873,21 @@ func (s *Store) ForEachTeamsHostedContentBody(sourceID int64, fn func(messageID 
 // but yields only messages whose number of distinct hostedContents references
 // in body_html exceeds the count of inline image files already stored for them
 // — i.e. messages whose inline media was not fully downloaded (transient fetch
-// failures). Used to retry just the gaps instead of re-fetching everything.
-func (s *Store) ForEachTeamsIncompleteHostedContentBody(sourceID int64, fn func(messageID int64, bodyHTML string) error) error {
+// failures). Policy-skipped markers are yielded only when the current policy
+// now permits them, or when a participant limit is configured but no
+// authoritative roster is archived — the importer re-resolves membership
+// before it evaluates the threshold. Used to retry just actionable gaps
+// instead of re-fetching everything or repeatedly walking unchanged
+// exclusions.
+func (s *Store) ForEachTeamsIncompleteHostedContentBody(
+	sourceID int64,
+	policy attachmentpolicy.Policy,
+	fn func(messageID int64, bodyHTML string) error,
+) error {
 	type bodyRow struct {
-		id   int64
-		body string
+		id             int64
+		body           string
+		hostedRefCount int
 	}
 	var buf []bodyRow
 
@@ -2885,7 +2896,13 @@ func (s *Store) ForEachTeamsIncompleteHostedContentBody(sourceID int64, fn func(
 		       (SELECT COUNT(*) FROM attachments a
 		        WHERE a.message_id = mb.message_id
 		          AND a.storage_path NOT LIKE 'http%' AND a.storage_path != ''
-		          AND a.content_hash != '')
+		          AND a.content_hash != ''),
+		       EXISTS (
+		         SELECT 1 FROM attachments a
+		         WHERE a.message_id = mb.message_id
+		           AND a.source_attachment_id LIKE 'teams:inline:%'
+		           AND COALESCE(a.content_hash, '') = ''
+		       )
 		FROM message_bodies mb
 		JOIN messages m ON m.id = mb.message_id
 		WHERE m.source_id = ? AND mb.body_html LIKE '%hostedContents%'
@@ -2897,15 +2914,17 @@ func (s *Store) ForEachTeamsIncompleteHostedContentBody(sourceID int64, fn func(
 		var messageID int64
 		var bodyHTML sql.NullString
 		var localAttachmentRows int
-		if err := rows.Scan(&messageID, &bodyHTML, &localAttachmentRows); err != nil {
+		var hasUnstoredMarker bool
+		if err := rows.Scan(&messageID, &bodyHTML, &localAttachmentRows, &hasUnstoredMarker); err != nil {
 			_ = rows.Close()
 			return err
 		}
 		if !bodyHTML.Valid || bodyHTML.String == "" {
 			continue
 		}
-		if countDistinctHostedContentRefs(bodyHTML.String) > localAttachmentRows {
-			buf = append(buf, bodyRow{id: messageID, body: bodyHTML.String})
+		hostedRefCount := countDistinctHostedContentRefs(bodyHTML.String)
+		if hostedRefCount > localAttachmentRows || hasUnstoredMarker {
+			buf = append(buf, bodyRow{id: messageID, body: bodyHTML.String, hostedRefCount: hostedRefCount})
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -2916,6 +2935,47 @@ func (s *Store) ForEachTeamsIncompleteHostedContentBody(sourceID int64, fn func(
 		return err
 	}
 	for _, r := range buf {
+		refs, err := s.MessageTeamsInlineAttachments(r.id)
+		if err != nil {
+			return err
+		}
+		eligible := r.hostedRefCount > len(refs)
+		var membership ConversationMembership
+		membershipPolicy := policy
+		membershipLoaded := false
+		for _, ref := range refs {
+			if ref.ContentHash != "" {
+				continue
+			}
+			if attachmentpolicy.RetryEligible(ref.State) {
+				eligible = true
+				break
+			}
+			if ref.State != attachmentpolicy.StateSkipped {
+				continue
+			}
+			if !membershipLoaded {
+				membership, err = s.AttachmentConversationMembership(r.id)
+				if err != nil {
+					return err
+				}
+				membershipLoaded = true
+				if !membership.RosterArchived && policy.MaxParticipants > 0 {
+					// No authoritative roster is archived, so the accumulated
+					// participant count cannot decide the threshold. Yield the
+					// message and let the importer re-resolve membership before
+					// it evaluates the policy; the other rules still apply here.
+					membershipPolicy.MaxParticipants = 0
+				}
+			}
+			if membershipPolicy.Allows(membership.Conversation, int64(ref.Size)) {
+				eligible = true
+				break
+			}
+		}
+		if !eligible {
+			continue
+		}
 		if err := fn(r.id, r.body); err != nil {
 			return err
 		}
@@ -4379,6 +4439,9 @@ type AttachmentRef struct {
 	RoleSource    AttachmentRoleSource
 	SourcePartKey string
 	ContentID     string
+	// State and SkipReason distinguish unfinished fetches from deliberate policy exclusions.
+	State      attachmentpolicy.DownloadState
+	SkipReason attachmentpolicy.SkipReason
 }
 
 // replaceMessageAttachmentsWhere atomically deletes a message's attachment
@@ -4412,6 +4475,8 @@ func (s *Store) replaceMessageAttachmentsWhere(
 				RoleSource:         ref.RoleSource,
 				SourcePartKey:      ref.SourcePartKey,
 				ContentID:          ref.ContentID,
+				State:              ref.State,
+				SkipReason:         ref.SkipReason,
 			}.normalized()
 			if write.SourcePartKey == "" && write.SourceAttachmentID != "" {
 				// Provider attachment IDs are already namespaced by every caller of
@@ -4440,13 +4505,15 @@ func nullIfZero(n int64) sql.NullInt64 {
 }
 
 // ReplaceMessageInlineAttachments replaces Teams-managed inline media rows for
-// a message. It removes both rows marked by the current source_attachment_id
-// scheme and legacy unmarked Teams inline rows produced before that marker was
-// added, while leaving URL-backed reference/recording attachments untouched.
-func (s *Store) ReplaceMessageInlineAttachments(messageID int64, refs []AttachmentRef) error {
-	return s.replaceMessageAttachmentsWhere(messageID, `
-		source_attachment_id LIKE 'teams:inline:%'
-		OR (
+// a message. When preserveLegacy is false, it also removes legacy unmarked
+// Teams inline rows produced before stable source attachment IDs were added.
+// Callers preserve those rows while a current hosted-content replacement is
+// excluded or unfinished, so an ordinary resync cannot detach archived media.
+// URL-backed reference/recording attachments are always left untouched.
+func (s *Store) ReplaceMessageInlineAttachments(messageID int64, refs []AttachmentRef, preserveLegacy bool) error {
+	deleteWhere := `source_attachment_id LIKE 'teams:inline:%'`
+	if !preserveLegacy {
+		deleteWhere += ` OR (
 		  (source_attachment_id IS NULL OR source_attachment_id = '')
 		  AND storage_path != ''
 		  AND storage_path NOT LIKE 'http://%'
@@ -4455,7 +4522,15 @@ func (s *Store) ReplaceMessageInlineAttachments(messageID int64, refs []Attachme
 		  AND content_hash != ''
 		  AND COALESCE(filename, '') = ''
 		  AND COALESCE(mime_type, '') = ''
-		)`, true, refs)
+		)`
+	}
+	return s.replaceMessageAttachmentsWhere(messageID, deleteWhere, false, refs)
+}
+
+// MessageTeamsInlineAttachments returns Teams-managed inline media rows keyed
+// by their stable hosted-content source identifier.
+func (s *Store) MessageTeamsInlineAttachments(messageID int64) (map[string]AttachmentRef, error) {
+	return s.messageProviderAttachments(messageID, "teams:inline:")
 }
 
 // ReplaceMessageBeeperAttachments replaces Beeper-managed attachment rows for
@@ -4708,7 +4783,8 @@ func (s *Store) ListSlackRecentReplyThreadRoots(sourceID, conversationID int64, 
 func (s *Store) ListSlackPendingAttachmentMessages(sourceID int64) ([]PendingAttachmentMessage, error) {
 	rows, err := s.db.Query(`
 		SELECT m.id, m.source_message_id, c.source_conversation_id,
-		       a.storage_path, COALESCE(a.content_hash, ''), COALESCE(a.media_type, '')
+		       a.storage_path, COALESCE(a.content_hash, ''), COALESCE(a.media_type, ''),
+		       COALESCE(a.attachment_state, '')
 		FROM messages m
 		JOIN conversations c ON c.id = m.conversation_id
 		JOIN attachments a ON a.message_id = m.id
@@ -4734,7 +4810,7 @@ func (s *Store) ListSlackPendingAttachmentMessages(sourceID int64) ([]PendingAtt
 		var ref AttachmentRef
 		if err := rows.Scan(
 			&item.MessageID, &item.SourceMessageID, &item.ChatID,
-			&ref.StoragePath, &ref.ContentHash, &ref.MediaType,
+			&ref.StoragePath, &ref.ContentHash, &ref.MediaType, &ref.State,
 		); err != nil {
 			return nil, err
 		}
@@ -4744,7 +4820,8 @@ func (s *Store) ListSlackPendingAttachmentMessages(sourceID int64) ([]PendingAtt
 			haveCurrent = true
 			currentPending = false
 		}
-		if ref.MediaType != "link" && ref.ContentHash == "" && !casAttachmentDownloaded(ref) {
+		if attachmentpolicy.RetryEligible(ref.State) && ref.MediaType != "link" &&
+			ref.ContentHash == "" && !casAttachmentDownloaded(ref) {
 			currentPending = true
 		}
 	}
@@ -4784,8 +4861,11 @@ func (s *Store) MessageSlackAttachments(messageID int64) (map[string]AttachmentR
 
 // ReplaceMessageLinkAttachments replaces URL-backed attachment rows for a message.
 // It intentionally leaves content-addressed local attachment paths (for example
-// downloaded inline media) untouched.
+// downloaded inline media) untouched, and preserves Teams-managed inline marker
+// rows (source_attachment_id 'teams:inline:%'), whose URL-backed storage_path
+// records a durable pending/skipped/failed outcome, not a link attachment.
 func (s *Store) ReplaceMessageLinkAttachments(messageID int64, refs []AttachmentRef) error {
 	return s.replaceMessageAttachmentsWhere(messageID,
-		`storage_path LIKE 'http://%' OR storage_path LIKE 'https://%'`, false, refs)
+		`(storage_path LIKE 'http://%' OR storage_path LIKE 'https://%')
+		 AND COALESCE(source_attachment_id, '') NOT LIKE 'teams:inline:%'`, false, refs)
 }

--- a/internal/store/messages_hostedcontent_test.go
+++ b/internal/store/messages_hostedcontent_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
@@ -22,7 +23,7 @@ func TestForEachTeamsHostedContentBody(t *testing.T) {
 	src, err := st.GetOrCreateSource("teams", "me@example.com")
 	require.NoError(err)
 
-	convID, err := st.EnsureConversationWithType(src.ID, "19:x@thread.v2", "oneOnOne", "DM")
+	convID, err := st.EnsureConversationWithType(src.ID, "19:x@thread.v2", "direct_chat", "DM")
 	require.NoError(err)
 
 	// Message WITH a hostedContents URL.
@@ -111,13 +112,218 @@ func TestForEachTeamsIncompleteHostedContentBody(t *testing.T) {
 	incomplete := mk("m_incomplete", oneRef)
 
 	var seen []int64
-	require.NoError(st.ForEachTeamsIncompleteHostedContentBody(src.ID, func(id int64, _ string) error {
+	require.NoError(st.ForEachTeamsIncompleteHostedContentBody(src.ID, attachmentpolicy.Policy{}, func(id int64, _ string) error {
 		seen = append(seen, id)
 		return nil
 	}))
 	require.Len(seen, 1, "only the message still missing media should be yielded")
 	assert.Equal(incomplete, seen[0])
 	assert.NotContains(seen, duplicateComplete)
+}
+
+func TestForEachTeamsIncompleteHostedContentBodyReevaluatesPolicySkips(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(src.ID, "chat", "direct_chat", "DM")
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID: conversationID, SourceID: src.ID,
+		SourceMessageID: "skipped", MessageType: "teams",
+	})
+	require.NoError(err)
+	body := `<img src="https://g/v1.0/chats/x/messages/a/hostedContents/1/$value">`
+	require.NoError(st.UpsertMessageBody(messageID, sql.NullString{}, sql.NullString{String: body, Valid: true}))
+	require.NoError(st.ReplaceMessageInlineAttachments(messageID, []store.AttachmentRef{{
+		SourceAttachmentID: "teams:inline:/chats/x/messages/a/hostedContents/1/$value",
+		StoragePath:        "excluded:teams:inline:/chats/x/messages/a/hostedContents/1/$value",
+		Size:               10,
+		State:              attachmentpolicy.StateSkipped,
+		SkipReason:         attachmentpolicy.SkipPolicyScope,
+	}}, false))
+
+	var unchanged []int64
+	require.NoError(st.ForEachTeamsIncompleteHostedContentBody(src.ID, attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeNone,
+	}, func(id int64, _ string) error {
+		unchanged = append(unchanged, id)
+		return nil
+	}))
+	assert.Empty(unchanged)
+
+	var relaxed []int64
+	require.NoError(st.ForEachTeamsIncompleteHostedContentBody(src.ID, attachmentpolicy.Policy{}, func(id int64, _ string) error {
+		relaxed = append(relaxed, id)
+		return nil
+	}))
+	assert.Equal([]int64{messageID}, relaxed)
+}
+
+// TestForEachTeamsIncompleteHostedContentBodyYieldsUnresolvedRosterSkips pins
+// the backfill contract for a roster the sync could not read: the accumulated
+// participant rows are not authoritative, so a participant-threshold skip must
+// still reach the importer, which re-resolves membership before it evaluates
+// the policy. Other exclusions keep applying so a scope-excluded marker does
+// not trigger a roster fetch on every run.
+func TestForEachTeamsIncompleteHostedContentBodyYieldsUnresolvedRosterSkips(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(src.ID, "team/channel", "channel", "Releases")
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE conversations SET participant_count = ? WHERE id = ?`), 20, conversationID)
+	require.NoError(err)
+	require.NoError(st.MarkConversationMemberCountUnknown(conversationID))
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID: conversationID, SourceID: src.ID,
+		SourceMessageID: "skipped", MessageType: "teams",
+	})
+	require.NoError(err)
+	body := `<img src="https://g/v1.0/teams/t/channels/c/messages/a/hostedContents/1/$value">`
+	require.NoError(st.UpsertMessageBody(messageID, sql.NullString{}, sql.NullString{String: body, Valid: true}))
+	skipped := func(reason attachmentpolicy.SkipReason) {
+		require.NoError(st.ReplaceMessageInlineAttachments(messageID, []store.AttachmentRef{{
+			SourceAttachmentID: "teams:inline:/teams/t/channels/c/messages/a/hostedContents/1/$value",
+			StoragePath:        "excluded:teams:inline:/teams/t/channels/c/messages/a/hostedContents/1/$value",
+			Size:               10,
+			State:              attachmentpolicy.StateSkipped,
+			SkipReason:         reason,
+		}}, false))
+	}
+	yielded := func(policy attachmentpolicy.Policy) []int64 {
+		var ids []int64
+		require.NoError(st.ForEachTeamsIncompleteHostedContentBody(src.ID, policy, func(id int64, _ string) error {
+			ids = append(ids, id)
+			return nil
+		}))
+		return ids
+	}
+	limited := attachmentpolicy.Policy{MaxParticipants: 4}
+
+	skipped(attachmentpolicy.SkipParticipantThreshold)
+	assert.Equal([]int64{messageID}, yielded(limited),
+		"an unresolved roster must reach the importer even though the accumulated count exceeds the limit")
+
+	skipped(attachmentpolicy.SkipPolicyScope)
+	assert.Empty(yielded(attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeNone, MaxParticipants: 4}),
+		"other exclusions still apply while the roster is unresolved")
+
+	// Once the roster is read, the archived count is authoritative again.
+	skipped(attachmentpolicy.SkipParticipantThreshold)
+	require.NoError(st.SetConversationMemberCount(conversationID, 20))
+	assert.Empty(yielded(limited))
+	require.NoError(st.SetConversationMemberCount(conversationID, 3))
+	assert.Equal([]int64{messageID}, yielded(limited))
+
+	// A failed read after a successful one leaves the roster unresolved again,
+	// so the importer gets to re-resolve it whatever the stale count says.
+	require.NoError(st.SetConversationMemberCount(conversationID, 20))
+	require.NoError(st.MarkConversationMemberCountUnknown(conversationID))
+	assert.Equal([]int64{messageID}, yielded(limited))
+}
+
+func TestForEachTeamsIncompleteHostedContentBodyFindsMarkersBesideLegacyMedia(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(src.ID, "chat", "direct_chat", "DM")
+	require.NoError(err)
+	body := `<img src="https://g/v1.0/chats/x/messages/a/hostedContents/1/$value">`
+	seed := func(sourceMessageID string, state attachmentpolicy.DownloadState, reason attachmentpolicy.SkipReason) int64 {
+		messageID, seedErr := st.UpsertMessage(&store.Message{
+			ConversationID: conversationID, SourceID: src.ID,
+			SourceMessageID: sourceMessageID, MessageType: "teams",
+		})
+		require.NoError(seedErr)
+		require.NoError(st.UpsertMessageBody(messageID, sql.NullString{}, sql.NullString{String: body, Valid: true}))
+		require.NoError(st.UpsertAttachment(messageID, "", "", "legacy/"+sourceMessageID, "legacy-"+sourceMessageID, 12))
+		require.NoError(st.ReplaceMessageInlineAttachments(messageID, []store.AttachmentRef{{
+			SourceAttachmentID: "teams:inline:/chats/x/messages/a/hostedContents/1/$value",
+			StoragePath:        "https://g/v1.0/chats/x/messages/a/hostedContents/1/$value",
+			State:              state,
+			SkipReason:         reason,
+		}}, true))
+		return messageID
+	}
+	failedID := seed("failed", attachmentpolicy.StateFailed, attachmentpolicy.SkipFetchFailure)
+	skippedID := seed("skipped", attachmentpolicy.StateSkipped, attachmentpolicy.SkipPolicyScope)
+
+	var seen []int64
+	require.NoError(st.ForEachTeamsIncompleteHostedContentBody(src.ID, attachmentpolicy.Policy{}, func(id int64, _ string) error {
+		seen = append(seen, id)
+		return nil
+	}))
+	assert.ElementsMatch([]int64{failedID, skippedID}, seen,
+		"legacy stored media must not hide retryable or newly allowed markers")
+}
+
+// TestReplaceMessageLinkAttachmentsPreservesTeamsInlineMarkers verifies that
+// replacing a message's link attachments leaves Teams inline markers alone.
+// Those markers carry a URL storage path too, but it records a durable
+// pending/skipped/failed outcome rather than a link the importer re-derives
+// from the message — deleting them loses the outcome and re-fetches excluded
+// media on the next sync.
+func TestReplaceMessageLinkAttachmentsPreservesTeamsInlineMarkers(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(src.ID, "19:x@thread.v2", "direct_chat", "DM")
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID: conversationID, SourceID: src.ID,
+		SourceMessageID: "m1", MessageType: "teams",
+	})
+	require.NoError(err)
+
+	const hostedURL = "https://graph.microsoft.com/v1.0/chats/19:x@thread.v2/messages/m1/hostedContents/1/$value"
+	const markerID = "teams:inline:/chats/19:x@thread.v2/messages/m1/hostedContents/1/$value"
+
+	// A stale link row from an earlier import, which the replacement must drop.
+	require.NoError(st.ReplaceMessageLinkAttachments(messageID, []store.AttachmentRef{{
+		Filename: "old.pdf", StoragePath: "https://example.com/old.pdf",
+	}}))
+	require.NoError(st.ReplaceMessageInlineAttachments(messageID, []store.AttachmentRef{{
+		SourceAttachmentID: markerID,
+		StoragePath:        hostedURL,
+		Size:               4096,
+		State:              attachmentpolicy.StateSkipped,
+		SkipReason:         attachmentpolicy.SkipSizeCap,
+	}}, false))
+
+	require.NoError(st.ReplaceMessageLinkAttachments(messageID, []store.AttachmentRef{{
+		Filename: "new.pdf", StoragePath: "https://example.com/new.pdf",
+	}}))
+
+	markers, err := st.MessageTeamsInlineAttachments(messageID)
+	require.NoError(err)
+	require.Contains(markers, markerID, "the inline marker must survive link replacement")
+	assert.Equal(attachmentpolicy.StateSkipped, markers[markerID].State)
+	assert.Equal(attachmentpolicy.SkipSizeCap, markers[markerID].SkipReason)
+	assert.Equal(4096, markers[markerID].Size, "the observed size must survive so the skip stays decidable")
+
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT storage_path FROM attachments WHERE message_id = ? ORDER BY storage_path
+	`), messageID)
+	require.NoError(err)
+	defer func() { _ = rows.Close() }()
+	var paths []string
+	for rows.Next() {
+		var path string
+		require.NoError(rows.Scan(&path))
+		paths = append(paths, path)
+	}
+	require.NoError(rows.Err())
+	assert.Equal([]string{"https://example.com/new.pdf", hostedURL}, paths,
+		"the new link replaces the stale one while the marker is untouched")
 }
 
 // TestForEachTeamsHostedContentBody_WriteInsideCallback verifies that the

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -406,6 +406,8 @@ CREATE TABLE IF NOT EXISTS attachments (
     -- Platform-specific
     source_attachment_id TEXT,      -- original ID from platform
     attachment_metadata JSON,       -- EXIF, etc.
+	attachment_state TEXT,           -- pending, stored, skipped, failed
+	attachment_skip_reason TEXT,     -- typed policy/fetch outcome
 
     -- Source-authoritative occurrence role and provenance. Unknown fails
     -- closed for any hosted attachment processing.

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -335,6 +335,8 @@ CREATE TABLE IF NOT EXISTS attachments (
 
     source_attachment_id TEXT,
     attachment_metadata JSONB,
+	attachment_state TEXT,
+	attachment_skip_reason TEXT,
 
     attachment_role TEXT NOT NULL DEFAULT 'unknown'
         CHECK (attachment_role IN ('standalone', 'inline', 'avatar', 'thumbnail', 'preview', 'sticker', 'ui_asset', 'unknown')),

--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -3,6 +3,7 @@ package teams
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,9 @@ import (
 	"go.kenn.io/msgvault/internal/httpretry"
 	"golang.org/x/time/rate"
 )
+
+// ErrMediaTooLarge classifies hosted media that exceeds its configured cap.
+var ErrMediaTooLarge = errors.New("teams hosted media exceeds the configured size cap")
 
 const (
 	maxRetries    = 8
@@ -48,6 +52,10 @@ func NewClient(baseURL string, token TokenFunc, qps float64) *Client {
 // get fetches rawURL, respecting the rate limiter and retrying on 429/5xx with
 // Retry-After or exponential back-off.
 func (c *Client) get(ctx context.Context, rawURL string) ([]byte, error) {
+	return c.getLimited(ctx, rawURL, 0)
+}
+
+func (c *Client) getLimited(ctx context.Context, rawURL string, maxBytes int64) ([]byte, error) {
 	reqURL, err := c.resolveRequestURL(rawURL)
 	if err != nil {
 		return nil, err
@@ -70,7 +78,15 @@ func (c *Client) get(ctx context.Context, rawURL string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		body, readErr := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusOK && maxBytes > 0 && resp.ContentLength > maxBytes {
+			_ = resp.Body.Close()
+			return nil, ErrMediaTooLarge
+		}
+		reader := io.Reader(resp.Body)
+		if maxBytes > 0 {
+			reader = io.LimitReader(resp.Body, maxBytes+1)
+		}
+		body, readErr := io.ReadAll(reader)
 		closeErr := resp.Body.Close()
 		if readErr != nil {
 			return nil, fmt.Errorf("graph GET %s: read body: %w", reqURL, readErr)
@@ -78,9 +94,11 @@ func (c *Client) get(ctx context.Context, rawURL string) ([]byte, error) {
 		if closeErr != nil {
 			return nil, fmt.Errorf("graph GET %s: close body: %w", reqURL, closeErr)
 		}
-
 		switch {
 		case resp.StatusCode == http.StatusOK:
+			if maxBytes > 0 && int64(len(body)) > maxBytes {
+				return nil, ErrMediaTooLarge
+			}
 			return body, nil
 		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
 			wait := httpretry.RetryAfter(resp.Header.Get("Retry-After"), attempt, maxRetryAfter)
@@ -122,6 +140,11 @@ func (c *Client) resolveRequestURL(rawURL string) (string, error) {
 // prefixed with the client's baseURL automatically by the underlying get method.
 func (c *Client) GetRaw(ctx context.Context, url string) ([]byte, error) {
 	return c.get(ctx, url)
+}
+
+// GetRawLimited fetches raw hosted media while enforcing a response-byte cap.
+func (c *Client) GetRawLimited(ctx context.Context, url string, maxBytes int64) ([]byte, error) {
+	return c.getLimited(ctx, url, maxBytes)
 }
 
 // BaseURL returns the client's configured base URL (scheme + host, no trailing slash).
@@ -250,5 +273,23 @@ func (c *Client) GetUser(ctx context.Context, id string) (*GraphUser, error) {
 func (c *Client) ListChatMembers(ctx context.Context, chatID string) ([]ChatMember, error) {
 	var out []ChatMember
 	_, err := pageThrough[ChatMember](ctx, c, "/chats/"+chatID+"/members", func(p []ChatMember) { out = append(out, p...) })
+	return out, err
+}
+
+// ListTeamMembers returns all members of the given team. Standard channels
+// inherit the team roster, which is the membership media policy evaluates them
+// against.
+func (c *Client) ListTeamMembers(ctx context.Context, teamID string) ([]ChatMember, error) {
+	var out []ChatMember
+	_, err := pageThrough[ChatMember](ctx, c, "/teams/"+teamID+"/members", func(p []ChatMember) { out = append(out, p...) })
+	return out, err
+}
+
+// ListChannelMembers returns all members of the given channel. Private and
+// shared channels are governed by this roster rather than the team's.
+func (c *Client) ListChannelMembers(ctx context.Context, teamID, channelID string) ([]ChatMember, error) {
+	var out []ChatMember
+	_, err := pageThrough[ChatMember](ctx, c, "/teams/"+teamID+"/channels/"+channelID+"/members",
+		func(p []ChatMember) { out = append(out, p...) })
 	return out, err
 }

--- a/internal/teams/client_test.go
+++ b/internal/teams/client_test.go
@@ -64,6 +64,53 @@ func TestClientRejectsOffOriginAbsoluteURLBeforeAuth(t *testing.T) {
 	assert.Nil(attackerAuth.Load(), "attacker server must not receive Authorization")
 }
 
+func TestClientGetRawLimitedRejectsDeclaredAndStreamedOversizeBodies(t *testing.T) {
+	tests := []struct {
+		name  string
+		serve func(http.ResponseWriter)
+	}{
+		{name: "content length", serve: func(w http.ResponseWriter) {
+			w.Header().Set("Content-Length", "11")
+			_, _ = w.Write([]byte("12345678901"))
+		}},
+		{name: "chunked", serve: func(w http.ResponseWriter) {
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			_, _ = w.Write([]byte("12345678901"))
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { tt.serve(w) }))
+			defer srv.Close()
+			client := NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50)
+			_, err := client.GetRawLimited(context.Background(), "/hostedContents/1/$value", 10)
+			assert.ErrorIs(t, err, ErrMediaTooLarge)
+		})
+	}
+}
+
+func TestClientGetRawLimitedRetriesOversizedErrorResponse(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("oversized error response"))
+			return
+		}
+		_, _ = w.Write([]byte("media"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50)
+	body, err := client.GetRawLimited(context.Background(), "/hostedContents/1/$value", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("media"), body)
+	assert.EqualValues(t, 2, calls.Load())
+}
+
 func TestClientRetryAfter(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -11,12 +11,17 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/export"
 	internalmime "go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
 )
 
 const sourceTypeTeams = "teams"
+
+// conversationTypeChannel is the archived conversation type for team channels.
+// Channel conversation keys are "<teamID>/<channelID>".
+const conversationTypeChannel = "channel"
 
 // recipientRef is a resolved participant ID + display name for a conversation member.
 type recipientRef struct {
@@ -115,13 +120,29 @@ func (imp *Importer) BackfillInlineMedia(ctx context.Context, opts ImportOptions
 
 	each := imp.store.ForEachTeamsHostedContentBody
 	if opts.OnlyIncomplete {
-		each = imp.store.ForEachTeamsIncompleteHostedContentBody
+		each = func(sourceID int64, fn func(messageID int64, bodyHTML string) error) error {
+			return imp.store.ForEachTeamsIncompleteHostedContentBody(sourceID, opts.MediaPolicy, fn)
+		}
 	}
+	resolver := newRosterResolver(imp)
 	err = each(src.ID, func(messageID int64, bodyHTML string) error {
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
 		}
-		if imp.downloadInlineImages(ctx, messageID, bodyHTML, opts.AttachmentsDir, sum) {
+		itemOpts := opts
+		membership, convErr := imp.store.AttachmentConversationMembership(messageID)
+		if convErr != nil {
+			return convErr
+		}
+		conversation := membership.Conversation
+		if !membership.RosterArchived && opts.MediaPolicy.MaxParticipants > 0 {
+			// No roster was archived for this conversation — the sync could not
+			// read one, or it predates the record — so the threshold has nothing
+			// authoritative to evaluate until this run resolves it.
+			conversation.ParticipantCount = imp.refreshMembership(ctx, messageID, opts, resolver, sum)
+		}
+		itemOpts.MediaConversation = conversation
+		if imp.downloadInlineImages(ctx, messageID, bodyHTML, itemOpts, sum) {
 			if err := imp.store.RecomputeMessageAttachmentStats(messageID); err != nil {
 				sum.Errors++
 			}
@@ -155,6 +176,9 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		// Member fetch failure is non-fatal; we proceed with empty toRecips
 		// rather than aborting the chat import.
 		members, merr := imp.client.ListChatMembers(ctx, ch.ID)
+		// Only the roster's size and read outcome matter to media policy; the
+		// members are resolved below, where their display names are kept too.
+		roster := &memberRoster{memberCount: len(members), err: merr}
 		chatComplete := true
 		var toRecips []recipientRef
 		if merr == nil {
@@ -172,6 +196,12 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		} else {
 			chatComplete = false
 			sum.Errors++
+		}
+		imp.recordRosterOutcome(convID, roster, sum)
+		chatOpts := opts
+		chatOpts.MediaConversation = attachmentpolicy.Conversation{
+			Type:             conversationType(ch.ChatType),
+			ParticipantCount: roster.policyCount(opts.MediaPolicy),
 		}
 
 		since := state.ChatCursor(ch.ID)
@@ -191,7 +221,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 				break
 			}
 			gm := &msgs[i]
-			messageID, added, perr := imp.persistMessage(ctx, convID, sourceID, chatSourceMessageID(ch.ID, gm.ID), gm, opts, sum, toRecips)
+			messageID, added, perr := imp.persistMessage(ctx, convID, sourceID, chatSourceMessageID(ch.ID, gm.ID), gm, chatOpts, sum, toRecips)
 			if perr != nil {
 				return perr
 			}
@@ -249,16 +279,52 @@ func (imp *Importer) syncChannels(ctx context.Context, sourceID, syncID int64, o
 			sum.Errors++
 			continue
 		}
+		// Standard channels inherit the team roster, so resolve it once per
+		// team — lazily, since a team of only private channels never needs it —
+		// and mirror it onto every channel conversation the way chats persist
+		// their members. Media policy needs the count, and backfill/purge read
+		// it back from the archived participant rows.
+		var teamMembers *memberRoster
+		teamRoster := func() *memberRoster {
+			if teamMembers == nil {
+				teamMembers = imp.resolveTeamRoster(ctx, team.ID)
+				if teamMembers.err != nil && opts.MediaPolicy.MaxParticipants > 0 {
+					// The roster is unknown, so the threshold cannot be
+					// evaluated. Count the failure and fail closed below rather
+					// than treat an unreadable team as a small one.
+					sum.Errors++
+				}
+			}
+			return teamMembers
+		}
 		for _, ch := range channels {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			// Private and shared channels are governed by their own membership,
+			// which can be far smaller — or larger — than the team's, so the
+			// team roster is resolved only for channels that inherit it.
+			var roster *memberRoster
+			if channelHasOwnRoster(ch.MembershipType) {
+				roster = imp.resolveChannelRoster(ctx, team.ID, ch.ID)
+				if roster.err != nil && opts.MediaPolicy.MaxParticipants > 0 {
+					sum.Errors++
+				}
+			} else {
+				roster = teamRoster()
+			}
 			key := team.ID + "/" + ch.ID
 			title := team.DisplayName + " / " + ch.DisplayName
-			convID, err := imp.store.EnsureConversationWithType(sourceID, key, "channel", title)
+			convID, err := imp.store.EnsureConversationWithType(sourceID, key, conversationTypeChannel, title)
 			if err != nil {
 				return err
 			}
+			for _, pid := range roster.participantIDs {
+				if cerr := imp.store.EnsureConversationParticipant(convID, pid, "member"); cerr != nil {
+					sum.Errors++
+				}
+			}
+			imp.recordRosterOutcome(convID, roster, sum)
 
 			prevDelta := state.ChannelDelta(key)
 			var newDelta string
@@ -408,12 +474,17 @@ func (imp *Importer) syncChannels(ctx context.Context, sourceID, syncID int64, o
 			var toLink []ChatMessage
 			convCount := 0
 			var persistedIDs []int64
+			channelOpts := opts
+			channelOpts.MediaConversation = attachmentpolicy.Conversation{
+				Type:             conversationTypeChannel,
+				ParticipantCount: roster.policyCount(opts.MediaPolicy),
+			}
 			for i := range collected {
 				if opts.Limit > 0 && convCount >= opts.Limit {
 					break
 				}
 				gm := &collected[i]
-				messageID, added, perr := imp.persistMessage(ctx, convID, sourceID, channelSourceMessageID(team.ID, ch.ID, gm.ID), gm, opts, sum, nil)
+				messageID, added, perr := imp.persistMessage(ctx, convID, sourceID, channelSourceMessageID(team.ID, ch.ID, gm.ID), gm, channelOpts, sum, nil)
 				if perr != nil {
 					return perr
 				}
@@ -467,6 +538,235 @@ func (imp *Importer) syncChannels(ctx context.Context, sourceID, syncID int64, o
 	return nil
 }
 
+// memberRoster is a membership as resolved from Graph: the raw member count
+// media policy evaluates, and the participant IDs to archive on the
+// conversations it governs. A non-nil err means the roster could not be read,
+// which callers must treat as unknown membership rather than as an empty one.
+type memberRoster struct {
+	participantIDs []int64
+	memberCount    int
+	err            error
+}
+
+// policyCount is the participant count media policy evaluates this roster
+// against. A roster that could not be read must not pass as a conversation
+// under the threshold, so it fails closed while a limit is configured; the
+// skips that follow are retryable once the roster becomes readable.
+func (r *memberRoster) policyCount(policy attachmentpolicy.Policy) int {
+	if r.err != nil && policy.MaxParticipants > 0 {
+		return policy.MaxParticipants + 1
+	}
+	return r.memberCount
+}
+
+// recordRosterOutcome archives the membership that later runs evaluate media
+// policy against: the exact size of a roster that was read, or an explicit
+// unknown marker when it could not be. Backfill and purge read this record
+// rather than the archived participant rows, which accumulate every member
+// ever seen and therefore never shrink when someone leaves.
+func (imp *Importer) recordRosterOutcome(convID int64, roster *memberRoster, sum *ImportSummary) {
+	var err error
+	if roster.err != nil {
+		err = imp.store.MarkConversationMemberCountUnknown(convID)
+	} else {
+		err = imp.store.SetConversationMemberCount(convID, roster.memberCount)
+	}
+	if err != nil {
+		sum.Errors++
+	}
+}
+
+// channelHasOwnRoster reports whether a channel's membership is separate from
+// its team's. Standard channels inherit the team roster; private and shared
+// channels have their own.
+func channelHasOwnRoster(membershipType string) bool {
+	switch strings.ToLower(membershipType) {
+	case "private", "shared":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveTeamRoster fetches a team's members and resolves them to participants.
+func (imp *Importer) resolveTeamRoster(ctx context.Context, teamID string) *memberRoster {
+	members, err := imp.client.ListTeamMembers(ctx, teamID)
+	if err != nil {
+		return &memberRoster{err: err}
+	}
+	return imp.resolveRosterMembers(ctx, members)
+}
+
+// resolveChannelRoster fetches the members of a private or shared channel.
+func (imp *Importer) resolveChannelRoster(ctx context.Context, teamID, channelID string) *memberRoster {
+	members, err := imp.client.ListChannelMembers(ctx, teamID, channelID)
+	if err != nil {
+		return &memberRoster{err: err}
+	}
+	return imp.resolveRosterMembers(ctx, members)
+}
+
+// resolveChatRoster fetches a chat's members.
+func (imp *Importer) resolveChatRoster(ctx context.Context, chatID string) *memberRoster {
+	members, err := imp.client.ListChatMembers(ctx, chatID)
+	if err != nil {
+		return &memberRoster{err: err}
+	}
+	return imp.resolveRosterMembers(ctx, members)
+}
+
+func (imp *Importer) resolveRosterMembers(ctx context.Context, members []ChatMember) *memberRoster {
+	roster := &memberRoster{
+		participantIDs: make([]int64, 0, len(members)),
+		memberCount:    len(members),
+	}
+	for _, m := range members {
+		pid, rerr := imp.res.resolveMember(ctx, m)
+		if rerr != nil || pid == 0 {
+			continue
+		}
+		roster.participantIDs = append(roster.participantIDs, pid)
+	}
+	return roster
+}
+
+// teamChannels is one team's channel list, which decides whether a channel is
+// governed by its own roster or by the team's.
+type teamChannels struct {
+	membershipTypes map[string]string
+	err             error
+}
+
+// rosterResolver memoizes the Graph reads a media backfill needs to re-resolve
+// channel membership: each team's channel list, and each roster it then fetches
+// (keyed by team ID, or by "<teamID>/<channelID>" for private and shared
+// channels). Every failure is counted once, when it is first observed.
+type rosterResolver struct {
+	imp      *Importer
+	channels map[string]*teamChannels
+	rosters  map[string]*memberRoster
+}
+
+func newRosterResolver(imp *Importer) *rosterResolver {
+	return &rosterResolver{
+		imp:      imp,
+		channels: map[string]*teamChannels{},
+		rosters:  map[string]*memberRoster{},
+	}
+}
+
+// forConversation returns the roster governing one archived conversation:
+// a chat's own members, or — for a "<teamID>/<channelID>" key — whichever of
+// the channel's or its team's roster governs it.
+func (r *rosterResolver) forConversation(
+	ctx context.Context, ref store.MessageConversationRef, sum *ImportSummary,
+) *memberRoster {
+	if ref.Type != conversationTypeChannel {
+		return r.cached("chat/"+ref.SourceConversationID, sum, func() *memberRoster {
+			return r.imp.resolveChatRoster(ctx, ref.SourceConversationID)
+		})
+	}
+	teamID, channelID, ok := strings.Cut(ref.SourceConversationID, "/")
+	if !ok || teamID == "" || channelID == "" {
+		// Not a "<teamID>/<channelID>" key, so there is no roster to fetch.
+		return &memberRoster{err: fmt.Errorf(
+			"channel conversation %q carries no team/channel key", ref.SourceConversationID)}
+	}
+	return r.forChannel(ctx, teamID, channelID, sum)
+}
+
+// forChannel returns the roster governing one channel.
+func (r *rosterResolver) forChannel(ctx context.Context, teamID, channelID string, sum *ImportSummary) *memberRoster {
+	channels, cached := r.channels[teamID]
+	if !cached {
+		channels = r.imp.listTeamChannels(ctx, teamID)
+		r.channels[teamID] = channels
+		if channels.err != nil {
+			sum.Errors++
+		}
+	}
+	if channels.err != nil {
+		// Without the channel list there is no way to tell which roster
+		// governs this channel, so membership stays unknown.
+		return &memberRoster{err: channels.err}
+	}
+	membershipType, listed := channels.membershipTypes[channelID]
+	if !listed {
+		// The channel is no longer visible in Graph. A shared channel can hold
+		// members the team does not, so the team roster is not a safe stand-in.
+		return &memberRoster{err: fmt.Errorf("channel %s is not listed in team %s", channelID, teamID)}
+	}
+	if channelHasOwnRoster(membershipType) {
+		return r.cached(teamID+"/"+channelID, sum, func() *memberRoster {
+			return r.imp.resolveChannelRoster(ctx, teamID, channelID)
+		})
+	}
+	return r.cached(teamID, sum, func() *memberRoster {
+		return r.imp.resolveTeamRoster(ctx, teamID)
+	})
+}
+
+func (r *rosterResolver) cached(key string, sum *ImportSummary, resolve func() *memberRoster) *memberRoster {
+	if roster, ok := r.rosters[key]; ok {
+		return roster
+	}
+	roster := resolve()
+	r.rosters[key] = roster
+	if roster.err != nil {
+		sum.Errors++
+	}
+	return roster
+}
+
+// listTeamChannels reads a team's channels and indexes their membership types.
+func (imp *Importer) listTeamChannels(ctx context.Context, teamID string) *teamChannels {
+	channels, err := imp.client.ListChannels(ctx, teamID)
+	if err != nil {
+		return &teamChannels{err: err}
+	}
+	membershipTypes := make(map[string]string, len(channels))
+	for _, ch := range channels {
+		membershipTypes[ch.ID] = ch.MembershipType
+	}
+	return &teamChannels{membershipTypes: membershipTypes}
+}
+
+// refreshMembership re-resolves the roster of a conversation whose membership
+// sync could not archive, and returns the participant count to evaluate media
+// policy against. Sync fails closed on an unreadable roster using a count that
+// only lives in memory, so the conversation is archived without one; read back
+// as-is, the participant rows — which hold senders and every member ever seen —
+// would relax the participant threshold and admit exactly the media it
+// excluded. A roster that is still unreadable fails closed the same way sync
+// does, and either outcome is archived so the next run starts from it.
+func (imp *Importer) refreshMembership(
+	ctx context.Context, messageID int64, opts ImportOptions,
+	resolver *rosterResolver, sum *ImportSummary,
+) int {
+	unknownMembership := opts.MediaPolicy.MaxParticipants + 1
+	ref, err := imp.store.MessageConversation(messageID)
+	if err != nil {
+		sum.Errors++
+		return unknownMembership
+	}
+	roster := resolver.forConversation(ctx, ref, sum)
+	imp.recordRosterOutcome(ref.ConversationID, roster, sum)
+	if roster.err != nil {
+		return unknownMembership
+	}
+	for _, pid := range roster.participantIDs {
+		if cerr := imp.store.EnsureConversationParticipant(ref.ConversationID, pid, "member"); cerr != nil {
+			sum.Errors++
+		}
+	}
+	// Keep the conversation's own stats in step with the refreshed roster; the
+	// archived record above is what policy evaluates.
+	if rerr := imp.store.RecomputeConversationStatsForMessage(messageID); rerr != nil {
+		sum.Errors++
+	}
+	return roster.memberCount
+}
+
 // persistMessage writes a single message via the granular store path.
 // Returns the internal message ID and true if persisted (best-effort; UpsertMessage upserts).
 func (imp *Importer) persistMessage(ctx context.Context, convID, sourceID int64, sourceMessageID string, gm *ChatMessage, opts ImportOptions, sum *ImportSummary, toRecips []recipientRef) (int64, bool, error) {
@@ -505,7 +805,7 @@ func (imp *Importer) persistMessage(ctx context.Context, convID, sourceID int64,
 	if err := imp.store.UpsertMessageBody(messageID, sql.NullString{String: text, Valid: text != ""}, bodyHTML); err != nil {
 		return 0, false, err
 	}
-	inlineImagesChanged := imp.downloadInlineImages(ctx, messageID, gm.Body.Content, opts.AttachmentsDir, sum)
+	inlineImagesChanged := imp.downloadInlineImages(ctx, messageID, gm.Body.Content, opts, sum)
 	// Archive the exact original message JSON. gm.Raw is captured verbatim at
 	// decode time (ChatMessage.UnmarshalJSON), so it preserves every Graph field
 	// including ones we do not model; fall back to re-marshalling only if a
@@ -723,21 +1023,31 @@ func hostedFetchPath(baseURL, rawURL string) string {
 // set. If any current hosted image cannot be fetched, existing rows are
 // preserved so a transient Graph failure does not erase already-downloaded
 // media.
-func (imp *Importer) downloadInlineImages(ctx context.Context, messageID int64, bodyHTML, attachmentsDir string, sum *ImportSummary) bool {
+func (imp *Importer) downloadInlineImages(ctx context.Context, messageID int64, bodyHTML string, opts ImportOptions, sum *ImportSummary) bool {
 	raws := hostedRe.FindAllString(bodyHTML, -1)
 	if len(raws) == 0 {
-		if err := imp.store.ReplaceMessageInlineAttachments(messageID, nil); err != nil {
+		if err := imp.store.ReplaceMessageInlineAttachments(messageID, nil, false); err != nil {
 			sum.Errors++
 			return false
 		}
 		return true
 	}
-	if attachmentsDir == "" {
+	existing, err := imp.store.MessageTeamsInlineAttachments(messageID)
+	if err != nil {
+		sum.Errors++
 		return false
 	}
+	policy := opts.MediaPolicy
+	maxBytes := policy.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = 100 << 20
+	}
+	policy.MaxBytes = maxBytes
 
 	seen := make(map[string]struct{}, len(raws))
 	refs := make([]store.AttachmentRef, 0, len(raws))
+	var copied int64
+	replacementComplete := true
 	for _, raw := range raws {
 		if _, ok := seen[raw]; ok {
 			continue
@@ -752,35 +1062,77 @@ func (imp *Importer) downloadInlineImages(ctx context.Context, messageID int64, 
 			sum.Errors++
 			return false
 		}
-		data, derr := imp.client.GetRaw(ctx, fetchPath)
+		sourceAttachmentID := "teams:inline:" + fetchPath
+		if previous, ok := existing[sourceAttachmentID]; ok && previous.ContentHash != "" {
+			refs = append(refs, previous)
+			continue
+		}
+		marker := store.AttachmentRef{
+			StoragePath: raw, SourceAttachmentID: sourceAttachmentID,
+			State: attachmentpolicy.StatePending,
+		}
+		if previous, ok := existing[sourceAttachmentID]; ok && previous.Size > marker.Size {
+			marker.Size = previous.Size
+		}
+		if opts.AttachmentsDir == "" {
+			replacementComplete = false
+			refs = append(refs, marker)
+			continue
+		}
+		if reason := policy.Evaluate(opts.MediaConversation, int64(marker.Size)); reason != "" {
+			replacementComplete = false
+			marker.State = attachmentpolicy.StateSkipped
+			marker.SkipReason = reason
+			refs = append(refs, marker)
+			sum.InlineImagesSkipped++
+			continue
+		}
+		data, derr := imp.client.GetRawLimited(ctx, fetchPath, maxBytes)
 		if derr != nil || len(data) == 0 {
-			sum.Errors++
-			return false
+			replacementComplete = false
+			if errors.Is(derr, ErrMediaTooLarge) {
+				marker.Size = attachmentpolicy.OversizeMarkerSize(maxBytes, int64(marker.Size))
+				marker.State = attachmentpolicy.StateSkipped
+				marker.SkipReason = attachmentpolicy.SkipSizeCap
+				sum.InlineImagesSkipped++
+			} else {
+				marker.State = attachmentpolicy.StateFailed
+				marker.SkipReason = attachmentpolicy.SkipFetchFailure
+				sum.Errors++
+			}
+			refs = append(refs, marker)
+			continue
 		}
 		att := &internalmime.Attachment{
 			Filename:    "",
 			ContentType: "",
 			Content:     data,
 		}
-		storagePath, serr := export.StoreAttachmentFile(attachmentsDir, att)
+		storagePath, serr := export.StoreAttachmentFile(opts.AttachmentsDir, att)
 		if serr != nil || storagePath == "" {
+			replacementComplete = false
+			marker.State = attachmentpolicy.StateFailed
+			marker.SkipReason = attachmentpolicy.SkipFetchFailure
+			refs = append(refs, marker)
 			sum.Errors++
-			return false
+			continue
 		}
 		refs = append(refs, store.AttachmentRef{
 			StoragePath:        storagePath,
 			ContentHash:        att.ContentHash,
 			Size:               len(data),
-			SourceAttachmentID: "teams:inline:" + fetchPath,
+			SourceAttachmentID: sourceAttachmentID,
 			Role:               store.AttachmentRoleInline,
 			RoleSource:         store.AttachmentRoleSourceImporterSemantics,
+			State:              attachmentpolicy.StateStored,
 		})
+		copied++
 	}
-	if err := imp.store.ReplaceMessageInlineAttachments(messageID, refs); err != nil {
+	if err := imp.store.ReplaceMessageInlineAttachments(messageID, refs, !replacementComplete); err != nil {
 		sum.Errors++
 		return false
 	}
-	sum.InlineImagesCopied += int64(len(refs))
+	sum.InlineImagesCopied += copied
 	return true
 }
 

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
@@ -307,6 +309,77 @@ func TestTeamsReimportRemovesStaleInlineAttachments(t *testing.T) {
 	assert.Equal(0, attachmentCount)
 }
 
+// TestTeamsInlineMarkerSurvivesLinkAttachmentReplacement guards the ordering
+// hazard inside persistMessage: inline hosted-content markers are written
+// first and carry the raw Graph URL as their storage path, so the link
+// attachment replacement that runs afterwards must not treat them as stale
+// links. Losing the marker loses the recorded skip and makes the next sync
+// re-fetch media the size cap already excluded.
+func TestTeamsInlineMarkerSurvivesLinkAttachmentReplacement(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	hostedFetches := 0
+	serverURL := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
+			hostedFetches++
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("12345678901"))
+		case r.URL.Path == "/me/chats":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[{"id":"19:marker@thread.v2","chatType":"oneOnOne","topic":"DM"}]}`))
+		case strings.HasSuffix(r.URL.Path, "/members"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case strings.Contains(r.URL.Path, "/messages"):
+			w.Header().Set("Content-Type", "application/json")
+			body := `<div><img src="` + serverURL + `/chats/19:marker@thread.v2/messages/m1/hostedContents/1/$value"></div>`
+			_, _ = w.Write([]byte(`{"value":[{"id":"m1","createdDateTime":"2025-01-01T00:00:00Z","lastModifiedDateTime":"2025-01-01T00:00:00Z",
+				"body":{"contentType":"html","content":` + jsonString(t, body) + `},
+				"attachments":[{"id":"a1","contentType":"reference","name":"spec.pdf","contentUrl":"https://example.com/spec.pdf"}]}]}`))
+		default:
+			http.Error(w, "404", http.StatusNotFound)
+		}
+	}))
+	serverURL = srv.URL
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
+	opts := ImportOptions{
+		Email: "me@example.com", AttachmentsDir: t.TempDir(), Full: true,
+		MediaPolicy: attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeAll, MaxBytes: 10},
+	}
+	sum, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	require.EqualValues(1, sum.InlineImagesSkipped)
+	require.Equal(1, hostedFetches)
+
+	_, err = imp.Import(t.Context(), opts)
+	require.NoError(err)
+	assert.Equal(1, hostedFetches,
+		"the surviving oversize marker must keep the second sync from re-fetching")
+
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(`SELECT id FROM messages WHERE source_message_id = ?`),
+		chatSourceMessageID("19:marker@thread.v2", "m1")).Scan(&messageID))
+	markerID := "teams:inline:/chats/19:marker@thread.v2/messages/m1/hostedContents/1/$value"
+	markers, err := st.MessageTeamsInlineAttachments(messageID)
+	require.NoError(err)
+	require.Contains(markers, markerID)
+	assert.Equal(attachmentpolicy.StateSkipped, markers[markerID].State)
+	assert.Equal(attachmentpolicy.SkipSizeCap, markers[markerID].SkipReason)
+	assert.Greater(markers[markerID].Size, 10, "the observed oversize must survive the link replacement")
+
+	var linkRows int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM attachments WHERE message_id = ? AND storage_path = ?
+	`), messageID, "https://example.com/spec.pdf").Scan(&linkRows))
+	assert.Equal(1, linkRows, "the link attachment must still be recorded")
+}
+
 func jsonString(t *testing.T, s string) string {
 	t.Helper()
 
@@ -386,6 +459,147 @@ func TestBackfillInlineMedia(t *testing.T) {
 	).Scan(&hasAttachments, &messageAttachmentCount))
 	assert.True(hasAttachments, "backfill should refresh the message attachment flag")
 	assert.Equal(1, messageAttachmentCount, "backfill should refresh the message attachment count")
+}
+
+func TestBackfillInlineMediaPolicySkipsChannelWithoutFetch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		_, _ = w.Write([]byte("must not download"))
+	}))
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(src.ID, "channel-1", "channel", "Channel")
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID: conversationID, SourceID: src.ID,
+		SourceMessageID: "channel-message-1", MessageType: "teams",
+	})
+	require.NoError(err)
+	bodyHTML := `<img src="` + srv.URL + `/v1.0/teams/t/channels/c/messages/m/hostedContents/1/$value">`
+	require.NoError(st.UpsertMessageBody(messageID, sql.NullString{}, sql.NullString{String: bodyHTML, Valid: true}))
+	client := NewClient(srv.URL+"/v1.0", func(context.Context) (string, error) { return "t", nil }, 50)
+	imp := NewImporter(st, client)
+
+	sum, err := imp.BackfillInlineMedia(context.Background(), ImportOptions{
+		Email: "me@example.com", AttachmentsDir: t.TempDir(),
+		MediaPolicy: attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeDirect, MaxBytes: 100 << 20},
+	})
+	require.NoError(err)
+	assert.EqualValues(1, sum.InlineImagesSkipped)
+	assert.Zero(sum.InlineImagesCopied)
+	assert.Zero(requests)
+
+	var state, reason string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT attachment_state, attachment_skip_reason FROM attachments WHERE message_id = ?
+	`), messageID).Scan(&state, &reason))
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipPolicyScope), reason)
+}
+
+func TestBackfillInlineMediaPreservesLegacyStoredMediaUntilReplacementSucceeds(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		statusCode int
+		policy     attachmentpolicy.Policy
+	}{
+		{
+			name:   "policy exclusion",
+			policy: attachmentpolicy.Policy{Scope: attachmentpolicy.ScopeNone},
+		},
+		{
+			name:       "transient fetch failure",
+			statusCode: http.StatusServiceUnavailable,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer srv.Close()
+
+			st := testutil.NewTestStore(t)
+			src, err := st.GetOrCreateSource("teams", "me@example.com")
+			require.NoError(err)
+			conversationID, err := st.EnsureConversationWithType(src.ID, "chat-legacy", "direct_chat", "Chat")
+			require.NoError(err)
+			messageID, err := st.UpsertMessage(&store.Message{
+				ConversationID: conversationID, SourceID: src.ID,
+				SourceMessageID: "message-legacy", MessageType: "teams",
+			})
+			require.NoError(err)
+			bodyHTML := `<img src="` + srv.URL + `/v1.0/chats/c/messages/m/hostedContents/1/$value">`
+			require.NoError(st.UpsertMessageBody(messageID, sql.NullString{}, sql.NullString{String: bodyHTML, Valid: true}))
+			require.NoError(st.UpsertAttachment(messageID, "", "", "legacy/inline.png", "legacy-inline-hash", 12))
+
+			imp := NewImporter(st, NewClient(srv.URL+"/v1.0", func(context.Context) (string, error) { return "t", nil }, 50))
+			_, err = imp.BackfillInlineMedia(t.Context(), ImportOptions{
+				Email: "me@example.com", AttachmentsDir: t.TempDir(), MediaPolicy: tc.policy,
+			})
+			require.NoError(err)
+
+			var legacyCount int
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT COUNT(*) FROM attachments
+				WHERE message_id = ? AND content_hash = 'legacy-inline-hash'
+			`), messageID).Scan(&legacyCount))
+			assert.Equal(1, legacyCount, "legacy stored media must survive until a replacement is archived")
+		})
+	}
+}
+
+func TestBackfillInlineMediaRecordsStreamedOversizeForRetryPolicy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte("12345678901"))
+	}))
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(src.ID, "chat-1", "direct_chat", "Chat")
+	require.NoError(err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		ConversationID: conversationID, SourceID: src.ID,
+		SourceMessageID: "message-1", MessageType: "teams",
+	})
+	require.NoError(err)
+	bodyHTML := `<img src="` + srv.URL + `/v1.0/chats/c/messages/m/hostedContents/1/$value">`
+	require.NoError(st.UpsertMessageBody(messageID, sql.NullString{}, sql.NullString{String: bodyHTML, Valid: true}))
+	client := NewClient(srv.URL+"/v1.0", func(context.Context) (string, error) { return "t", nil }, 50)
+	imp := NewImporter(st, client)
+	opts := ImportOptions{
+		Email: "me@example.com", AttachmentsDir: t.TempDir(), OnlyIncomplete: true,
+		MediaPolicy: attachmentpolicy.Policy{MaxBytes: 10},
+	}
+
+	sum, err := imp.BackfillInlineMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, sum.InlineImagesSkipped)
+	assert.Zero(sum.InlineImagesCopied)
+	var size int64
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT size FROM attachments WHERE message_id = ?
+	`), messageID).Scan(&size))
+	assert.Greater(size, int64(10))
+	second, err := imp.BackfillInlineMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(second.MessagesProcessed)
+	assert.Equal(1, requests)
 }
 
 // TestHostedFetchPath verifies that an absolute Graph hostedContents URL is
@@ -678,6 +892,465 @@ func TestImportChannelsEndToEnd(t *testing.T) {
 	prev, _ := st.GetLastSuccessfulSync(src.ID)
 	state, _ := LoadSyncState(prev.CursorAfter.String)
 	assert.Contains(state.ChannelDelta("team1/chanA"), "token=next")
+}
+
+// TestChannelMediaPolicyUsesTeamParticipantCount verifies that channel imports
+// evaluate media_max_participants against the team's membership. Channels
+// carried no participant count at all, so the threshold silently never applied
+// to them — the largest conversations in an archive. Membership is also
+// persisted, so a later backfill or purge reads the same count.
+func TestChannelMediaPolicyUsesTeamParticipantCount(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		membersStatus    int
+		maxParticipants  int
+		wantState        string
+		wantReason       string
+		wantFetches      int
+		wantParticipants int
+		wantErrors       int64
+	}{
+		{
+			name: "team over the limit skips media", maxParticipants: 2,
+			wantState:  string(attachmentpolicy.StateSkipped),
+			wantReason: string(attachmentpolicy.SkipParticipantThreshold),
+			// The team's three members are still archived on the channel.
+			wantParticipants: 3,
+		},
+		{
+			name: "team within the limit stores media", maxParticipants: 5,
+			wantState: string(attachmentpolicy.StateStored), wantFetches: 1,
+			wantParticipants: 3,
+		},
+		{
+			name: "unknown membership fails closed", membersStatus: http.StatusInternalServerError,
+			maxParticipants: 2,
+			wantState:       string(attachmentpolicy.StateSkipped),
+			wantReason:      string(attachmentpolicy.SkipParticipantThreshold),
+			wantErrors:      1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			hostedFetches := 0
+			serverURL := ""
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
+					hostedFetches++
+					w.Header().Set("Content-Type", "image/png")
+					_, _ = w.Write([]byte("PNGDATA"))
+				case strings.HasSuffix(r.URL.Path, "/members"):
+					if tc.membersStatus != 0 {
+						w.Header().Set("Retry-After", "0")
+						http.Error(w, "members unavailable", tc.membersStatus)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[
+						{"id":"mem1","userId":"aad-alice","email":"alice@example.com","displayName":"Alice"},
+						{"id":"mem2","userId":"aad-bob","email":"bob@example.com","displayName":"Bob"},
+						{"id":"mem3","userId":"aad-carol","email":"carol@example.com","displayName":"Carol"}
+					]}`))
+				case r.URL.Path == "/me/chats":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[]}`))
+				case r.URL.Path == "/me/joinedTeams":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[{"id":"team1","displayName":"Acme"}]}`))
+				case strings.HasSuffix(r.URL.Path, "/channels"):
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[{"id":"chanA","displayName":"General","membershipType":"standard"}]}`))
+				case strings.Contains(r.URL.Path, "/replies"):
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[]}`))
+				case strings.HasSuffix(r.URL.Path, "/messages/delta"):
+					w.Header().Set("Content-Type", "application/json")
+					body := `<div><img src="` + serverURL + `/teams/team1/channels/chanA/messages/c1/hostedContents/1/$value"></div>`
+					_, _ = w.Write([]byte(`{"value":[{"id":"c1","createdDateTime":"2025-02-01T00:00:00Z","lastModifiedDateTime":"2025-02-01T00:00:00Z",` +
+						`"body":{"contentType":"html","content":` + jsonString(t, body) + `}}],"@odata.deltaLink":"` + serverURL + `/delta?token=next"}`))
+				case strings.HasSuffix(r.URL.Path, "/messages"):
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[]}`))
+				default:
+					http.Error(w, "404", http.StatusNotFound)
+				}
+			}))
+			serverURL = srv.URL
+			defer srv.Close()
+			st := testutil.NewTestStore(t)
+
+			imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
+			sum, err := imp.Import(t.Context(), ImportOptions{
+				Email: "me@example.com", IncludeChannels: true, AttachmentsDir: t.TempDir(),
+				MediaPolicy: attachmentpolicy.Policy{
+					Scope: attachmentpolicy.ScopeAll, MaxParticipants: tc.maxParticipants,
+					MaxBytes: 100 << 20,
+				},
+			})
+			require.NoError(err)
+			assert.Equal(tc.wantErrors, sum.Errors)
+			assert.Equal(tc.wantFetches, hostedFetches)
+
+			var state, reason, contentHash string
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT COALESCE(a.attachment_state, ''), COALESCE(a.attachment_skip_reason, ''),
+				       COALESCE(a.content_hash, '')
+				FROM attachments a JOIN messages m ON m.id = a.message_id
+				WHERE m.source_message_id = ?
+			`), channelSourceMessageID("team1", "chanA", "c1")).Scan(&state, &reason, &contentHash))
+			assert.Equal(tc.wantState, state)
+			assert.Equal(tc.wantReason, reason)
+			if tc.wantState == string(attachmentpolicy.StateStored) {
+				assert.NotEmpty(contentHash)
+			} else {
+				assert.Empty(contentHash)
+			}
+
+			var participantCount int
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT COALESCE(participant_count, 0) FROM conversations WHERE source_conversation_id = ?
+			`), "team1/chanA").Scan(&participantCount))
+			assert.Equal(tc.wantParticipants, participantCount,
+				"channel membership must be archived so backfill and purge see the same count")
+		})
+	}
+}
+
+// privateChannelGraph is a fake Graph server for a team whose single channel is
+// private: a three-member team roster, a one-member channel roster, and one
+// channel message carrying inline hosted content. The channel roster is
+// unreadable until channelRosterReadable is set, so a test can fail the roster
+// during sync and repair it before a backfill.
+type privateChannelGraph struct {
+	channelRosterReadable bool
+	hostedFetches         int
+	teamRosterReads       int
+	url                   string
+}
+
+func newPrivateChannelGraph(t *testing.T) *privateChannelGraph {
+	t.Helper()
+
+	g := &privateChannelGraph{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
+			g.hostedFetches++
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNGDATA"))
+		case strings.Contains(r.URL.Path, "/channels/") && strings.HasSuffix(r.URL.Path, "/members"):
+			if !g.channelRosterReadable {
+				w.Header().Set("Retry-After", "0")
+				http.Error(w, "channel members unavailable", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[
+				{"id":"mem1","userId":"aad-alice","email":"alice@example.com","displayName":"Alice"}
+			]}`))
+		case strings.HasSuffix(r.URL.Path, "/members"):
+			g.teamRosterReads++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[
+				{"id":"mem1","userId":"aad-alice","email":"alice@example.com","displayName":"Alice"},
+				{"id":"mem2","userId":"aad-bob","email":"bob@example.com","displayName":"Bob"},
+				{"id":"mem3","userId":"aad-carol","email":"carol@example.com","displayName":"Carol"}
+			]}`))
+		case r.URL.Path == "/me/chats":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case r.URL.Path == "/me/joinedTeams":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[{"id":"team1","displayName":"Acme"}]}`))
+		case strings.HasSuffix(r.URL.Path, "/channels"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[{"id":"chanA","displayName":"Secret","membershipType":"private"}]}`))
+		case strings.Contains(r.URL.Path, "/replies"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/messages/delta"):
+			w.Header().Set("Content-Type", "application/json")
+			body := `<div><img src="` + g.url + `/teams/team1/channels/chanA/messages/c1/hostedContents/1/$value"></div>`
+			_, _ = w.Write([]byte(`{"value":[{"id":"c1","createdDateTime":"2025-02-01T00:00:00Z","lastModifiedDateTime":"2025-02-01T00:00:00Z",` +
+				`"body":{"contentType":"html","content":` + jsonString(t, body) + `}}],"@odata.deltaLink":"` + g.url + `/delta?token=next"}`))
+		case strings.HasSuffix(r.URL.Path, "/messages"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		default:
+			http.Error(w, "404", http.StatusNotFound)
+		}
+	}))
+	g.url = srv.URL
+	t.Cleanup(srv.Close)
+	return g
+}
+
+// channelMediaState returns the archived download outcome and participant count
+// for the fixture channel message.
+func channelMediaState(t *testing.T, st *store.Store) (state, reason string, participants int) {
+	t.Helper()
+
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(a.attachment_state, ''), COALESCE(a.attachment_skip_reason, '')
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?
+	`), channelSourceMessageID("team1", "chanA", "c1")).Scan(&state, &reason))
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(participant_count, 0) FROM conversations WHERE source_conversation_id = ?
+	`), "team1/chanA").Scan(&participants))
+	return state, reason, participants
+}
+
+// TestPrivateChannelMediaPolicyUsesChannelRoster pins the roster a private
+// channel is evaluated against. Private and shared channels carry membership of
+// their own, so inheriting the team roster both overstates a small private
+// channel (excluding media it should keep) and understates a private channel in
+// a small team. The fixture is deliberately contradictory: the team is over the
+// limit while the channel is under it.
+func TestPrivateChannelMediaPolicyUsesChannelRoster(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		channelRosterReadable bool
+		wantState             string
+		wantReason            string
+		wantFetches           int
+		wantParticipants      int
+		wantErrors            int64
+	}{
+		{
+			name: "channel roster under the limit stores media", channelRosterReadable: true,
+			wantState: string(attachmentpolicy.StateStored), wantFetches: 1,
+			wantParticipants: 1,
+		},
+		{
+			name:       "unreadable channel roster fails closed",
+			wantState:  string(attachmentpolicy.StateSkipped),
+			wantReason: string(attachmentpolicy.SkipParticipantThreshold),
+			wantErrors: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			graph := newPrivateChannelGraph(t)
+			graph.channelRosterReadable = tc.channelRosterReadable
+			st := testutil.NewTestStore(t)
+
+			imp := NewImporter(st, NewClient(graph.url, func(context.Context) (string, error) { return "t", nil }, 50))
+			sum, err := imp.Import(t.Context(), ImportOptions{
+				Email: "me@example.com", IncludeChannels: true, AttachmentsDir: t.TempDir(),
+				MediaPolicy: attachmentpolicy.Policy{
+					Scope: attachmentpolicy.ScopeAll, MaxParticipants: 2, MaxBytes: 100 << 20,
+				},
+			})
+			require.NoError(err)
+			assert.Equal(tc.wantErrors, sum.Errors)
+			assert.Equal(tc.wantFetches, graph.hostedFetches)
+			assert.Zero(graph.teamRosterReads,
+				"a team of only private channels never needs its team roster resolved")
+
+			state, reason, participants := channelMediaState(t, st)
+			assert.Equal(tc.wantState, state)
+			assert.Equal(tc.wantReason, reason)
+			assert.Equal(tc.wantParticipants, participants,
+				"the channel's own membership is what purge and later runs must read")
+		})
+	}
+}
+
+// TestBackfillPrivateChannelMediaRefreshesChannelRoster is the backfill half of
+// TestPrivateChannelMediaPolicyUsesChannelRoster: a channel whose own roster was
+// unreadable during sync must be re-resolved from the channel, not from the
+// team it hangs off — the team roster here would exclude the media.
+func TestBackfillPrivateChannelMediaRefreshesChannelRoster(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	graph := newPrivateChannelGraph(t)
+	st := testutil.NewTestStore(t)
+	attachmentsDir := t.TempDir()
+	policy := attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeAll, MaxParticipants: 2, MaxBytes: 100 << 20,
+	}
+
+	imp := NewImporter(st, NewClient(graph.url, func(context.Context) (string, error) { return "t", nil }, 50))
+	syncSum, err := imp.Import(t.Context(), ImportOptions{
+		Email: "me@example.com", IncludeChannels: true,
+		AttachmentsDir: attachmentsDir, MediaPolicy: policy,
+	})
+	require.NoError(err)
+	require.EqualValues(1, syncSum.Errors, "the unreadable channel roster is counted once")
+	require.Zero(graph.hostedFetches, "sync must fail closed while membership is unknown")
+
+	graph.channelRosterReadable = true
+	sum, err := imp.BackfillInlineMedia(t.Context(), ImportOptions{
+		Email: "me@example.com", AttachmentsDir: attachmentsDir, MediaPolicy: policy,
+	})
+	require.NoError(err)
+	assert.Equal(1, graph.hostedFetches,
+		"the channel's own roster is under the limit the team roster exceeds")
+	assert.EqualValues(1, sum.InlineImagesCopied)
+	assert.Zero(sum.Errors)
+
+	state, reason, participants := channelMediaState(t, st)
+	assert.Equal(string(attachmentpolicy.StateStored), state)
+	assert.Empty(reason)
+	assert.Equal(1, participants)
+}
+
+// TestBackfillChannelMediaRefreshesUnknownTeamMembership covers the durable
+// half of the channel participant threshold. Sync fails closed on an unreadable
+// roster using a count that only lives in memory, so the channel is archived
+// with no members; the backfill then reads that archived zero. Unless it
+// re-resolves the roster first, the zero reads as "small conversation" and the
+// media the threshold excluded gets downloaded after all.
+func TestBackfillChannelMediaRefreshesUnknownTeamMembership(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		rosterReadable   bool
+		maxParticipants  int
+		wantFetches      int
+		wantCopied       int64
+		wantSkipped      int64
+		wantErrors       int64
+		wantState        string
+		wantReason       string
+		wantParticipants int
+	}{
+		{
+			name:           "refreshed roster within the limit stores media",
+			rosterReadable: true, maxParticipants: 5,
+			wantFetches: 1, wantCopied: 1,
+			wantState:        string(attachmentpolicy.StateStored),
+			wantParticipants: 3,
+		},
+		{
+			name:            "roster still unreadable stays skipped",
+			maxParticipants: 5,
+			wantSkipped:     1, wantErrors: 1,
+			wantState:  string(attachmentpolicy.StateSkipped),
+			wantReason: string(attachmentpolicy.SkipParticipantThreshold),
+		},
+		{
+			name:           "refreshed roster over the limit stays skipped",
+			rosterReadable: true, maxParticipants: 2,
+			wantSkipped: 1,
+			wantState:   string(attachmentpolicy.StateSkipped),
+			wantReason:  string(attachmentpolicy.SkipParticipantThreshold),
+			// The roster is archived even when it excludes the media, so
+			// purge and later runs evaluate the same membership.
+			wantParticipants: 3,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			hostedFetches := 0
+			rosterReadable := false
+			serverURL := ""
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
+					hostedFetches++
+					w.Header().Set("Content-Type", "image/png")
+					_, _ = w.Write([]byte("PNGDATA"))
+				case strings.HasSuffix(r.URL.Path, "/members"):
+					if !rosterReadable {
+						w.Header().Set("Retry-After", "0")
+						http.Error(w, "members unavailable", http.StatusInternalServerError)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[
+						{"id":"mem1","userId":"aad-alice","email":"alice@example.com","displayName":"Alice"},
+						{"id":"mem2","userId":"aad-bob","email":"bob@example.com","displayName":"Bob"},
+						{"id":"mem3","userId":"aad-carol","email":"carol@example.com","displayName":"Carol"}
+					]}`))
+				case r.URL.Path == "/me/chats":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[]}`))
+				case r.URL.Path == "/me/joinedTeams":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[{"id":"team1","displayName":"Acme"}]}`))
+				case strings.HasSuffix(r.URL.Path, "/channels"):
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[{"id":"chanA","displayName":"General","membershipType":"standard"}]}`))
+				case strings.Contains(r.URL.Path, "/replies"):
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[]}`))
+				case strings.HasSuffix(r.URL.Path, "/messages/delta"):
+					w.Header().Set("Content-Type", "application/json")
+					body := `<div><img src="` + serverURL + `/teams/team1/channels/chanA/messages/c1/hostedContents/1/$value"></div>`
+					_, _ = w.Write([]byte(`{"value":[{"id":"c1","createdDateTime":"2025-02-01T00:00:00Z","lastModifiedDateTime":"2025-02-01T00:00:00Z",` +
+						`"body":{"contentType":"html","content":` + jsonString(t, body) + `}}],"@odata.deltaLink":"` + serverURL + `/delta?token=next"}`))
+				case strings.HasSuffix(r.URL.Path, "/messages"):
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"value":[]}`))
+				default:
+					http.Error(w, "404", http.StatusNotFound)
+				}
+			}))
+			serverURL = srv.URL
+			defer srv.Close()
+			st := testutil.NewTestStore(t)
+			attachmentsDir := t.TempDir()
+
+			archivedParticipants := func() int {
+				var count int
+				require.NoError(st.DB().QueryRow(st.Rebind(`
+					SELECT COALESCE(participant_count, 0) FROM conversations WHERE source_conversation_id = ?
+				`), "team1/chanA").Scan(&count))
+				return count
+			}
+
+			imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
+			policy := attachmentpolicy.Policy{
+				Scope: attachmentpolicy.ScopeAll, MaxParticipants: tc.maxParticipants,
+				MaxBytes: 100 << 20,
+			}
+			syncSum, err := imp.Import(t.Context(), ImportOptions{
+				Email: "me@example.com", IncludeChannels: true,
+				AttachmentsDir: attachmentsDir, MediaPolicy: policy,
+			})
+			require.NoError(err)
+			require.EqualValues(1, syncSum.Errors, "the unreadable roster is counted once")
+			require.Zero(hostedFetches, "sync must fail closed while membership is unknown")
+			require.Zero(archivedParticipants(), "sync could not archive the roster")
+
+			rosterReadable = tc.rosterReadable
+			sum, err := imp.BackfillInlineMedia(t.Context(), ImportOptions{
+				Email: "me@example.com", AttachmentsDir: attachmentsDir, MediaPolicy: policy,
+			})
+			require.NoError(err)
+			assert.Equal(tc.wantFetches, hostedFetches)
+			assert.Equal(tc.wantCopied, sum.InlineImagesCopied)
+			assert.Equal(tc.wantSkipped, sum.InlineImagesSkipped)
+			assert.Equal(tc.wantErrors, sum.Errors)
+
+			var state, reason, contentHash string
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT COALESCE(a.attachment_state, ''), COALESCE(a.attachment_skip_reason, ''),
+				       COALESCE(a.content_hash, '')
+				FROM attachments a JOIN messages m ON m.id = a.message_id
+				WHERE m.source_message_id = ?
+			`), channelSourceMessageID("team1", "chanA", "c1")).Scan(&state, &reason, &contentHash))
+			assert.Equal(tc.wantState, state)
+			assert.Equal(tc.wantReason, reason)
+			if tc.wantState == string(attachmentpolicy.StateStored) {
+				assert.NotEmpty(contentHash)
+			} else {
+				assert.Empty(contentHash)
+			}
+
+			assert.Equal(tc.wantParticipants, archivedParticipants(),
+				"a roster resolved during backfill must be archived for purge and later runs")
+		})
+	}
 }
 
 func TestLimitedChannelImportDoesNotAdvanceDelta(t *testing.T) {
@@ -1620,4 +2293,288 @@ func TestDuplicateMentionDedup(t *testing.T) {
         WHERE mr.message_id = ? AND mr.recipient_type = 'mention' AND p.email_address = 'bob@x.com'
     `), msgID).Scan(&mentionCount))
 	assert.Equal(1, mentionCount, "duplicate @mention should produce exactly one mention row")
+}
+
+// graphMembersJSON renders a Graph member collection of the given size.
+func graphMembersJSON(size int) string {
+	members := make([]string, 0, size)
+	for i := 1; i <= size; i++ {
+		members = append(members, fmt.Sprintf(
+			`{"id":"mem%d","userId":"aad-user%d","email":"user%d@example.com","displayName":"User %d"}`,
+			i, i, i, i))
+	}
+	return `{"value":[` + strings.Join(members, ",") + `]}`
+}
+
+// chatRosterGraph is a fake Graph server for one group chat whose single
+// message carries inline hosted content. The test controls the roster it
+// serves: rosterFails makes the members call fail, and rosterSize sets how
+// many members a successful call reports.
+type chatRosterGraph struct {
+	rosterFails   bool
+	rosterSize    int
+	hostedFetches int
+	url           string
+}
+
+const rosterChatID = "19:media@thread.v2"
+
+func newChatRosterGraph(t *testing.T, rosterSize int) *chatRosterGraph {
+	t.Helper()
+
+	g := &chatRosterGraph{rosterSize: rosterSize}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
+			g.hostedFetches++
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNGDATA"))
+		case strings.HasSuffix(r.URL.Path, "/members"):
+			if g.rosterFails {
+				w.Header().Set("Retry-After", "0")
+				http.Error(w, "members unavailable", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(graphMembersJSON(g.rosterSize)))
+		case r.URL.Path == "/me/chats":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[{"id":"` + rosterChatID + `","chatType":"group","topic":"Media"}]}`))
+		case strings.Contains(r.URL.Path, "/messages"):
+			w.Header().Set("Content-Type", "application/json")
+			body := `<div><img src="` + g.url + `/chats/` + rosterChatID + `/messages/m1/hostedContents/1/$value"></div>`
+			_, _ = w.Write([]byte(`{"value":[{"id":"m1","createdDateTime":"2025-01-01T00:00:00Z",` +
+				`"lastModifiedDateTime":"2025-01-01T00:00:00Z","body":{"contentType":"html","content":` +
+				jsonString(t, body) + `}}]}`))
+		default:
+			http.Error(w, "404", http.StatusNotFound)
+		}
+	}))
+	g.url = srv.URL
+	t.Cleanup(srv.Close)
+	return g
+}
+
+// chatMediaState returns the archived download outcome of the fixture chat
+// message's inline hosted content.
+func chatMediaState(t *testing.T, st *store.Store) (state, reason string) {
+	t.Helper()
+
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(a.attachment_state, ''), COALESCE(a.attachment_skip_reason, '')
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?
+	`), chatSourceMessageID(rosterChatID, "m1")).Scan(&state, &reason))
+	return state, reason
+}
+
+// chatMembershipRecord returns the roster the fixture chat's provider metadata
+// records: the exact member count, and whether the roster is marked unreadable.
+func chatMembershipRecord(t *testing.T, st *store.Store) (count int, unknown bool) {
+	t.Helper()
+
+	var metadata string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(CAST(metadata AS TEXT), '') FROM conversations
+		WHERE source_conversation_id = ?
+	`), rosterChatID).Scan(&metadata))
+	if metadata == "" {
+		return 0, false
+	}
+	var record struct {
+		MemberCount        int  `json:"member_count"`
+		MemberCountUnknown bool `json:"member_count_unknown"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(metadata), &record))
+	return record.MemberCount, record.MemberCountUnknown
+}
+
+// TestChatMediaPolicyFailsClosedOnUnreadableRoster covers a chat whose member
+// listing fails: the participant threshold cannot be evaluated, so media must
+// not be downloaded as if the chat were small — and the failure must be
+// archived, since a backfill reads the archive rather than the run's memory.
+// Both backfill modes must still reach the message: the archived unknown
+// roster decides the download, not whether the message is worth revisiting.
+func TestChatMediaPolicyFailsClosedOnUnreadableRoster(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		onlyIncomplete bool
+	}{
+		{name: "full backfill"},
+		{name: "incomplete-only backfill", onlyIncomplete: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			graph := newChatRosterGraph(t, 3)
+			graph.rosterFails = true
+			st := testutil.NewTestStore(t)
+			attachmentsDir := t.TempDir()
+			policy := attachmentpolicy.Policy{
+				Scope: attachmentpolicy.ScopeAll, MaxParticipants: 5, MaxBytes: 100 << 20,
+			}
+
+			imp := NewImporter(st, NewClient(graph.url,
+				func(context.Context) (string, error) { return "t", nil }, 50))
+			sum, err := imp.Import(t.Context(), ImportOptions{
+				Email: "me@example.com", AttachmentsDir: attachmentsDir, MediaPolicy: policy,
+			})
+			require.NoError(err)
+			require.EqualValues(1, sum.Errors, "the unreadable roster is counted once")
+			assert.Zero(graph.hostedFetches,
+				"an unreadable roster must not read as a chat under the limit")
+
+			state, reason := chatMediaState(t, st)
+			assert.Equal(string(attachmentpolicy.StateSkipped), state)
+			assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+			count, unknown := chatMembershipRecord(t, st)
+			assert.True(unknown, "an unreadable roster must be archived, not left absent")
+			assert.Zero(count)
+
+			// The backfill re-resolves what the sync could not read, and
+			// archives the count purge and later runs evaluate.
+			graph.rosterFails = false
+			backfill, err := imp.BackfillInlineMedia(t.Context(), ImportOptions{
+				Email: "me@example.com", AttachmentsDir: attachmentsDir,
+				MediaPolicy: policy, OnlyIncomplete: tc.onlyIncomplete,
+			})
+			require.NoError(err)
+			assert.EqualValues(1, backfill.InlineImagesCopied)
+			assert.Zero(backfill.Errors)
+
+			state, reason = chatMediaState(t, st)
+			assert.Equal(string(attachmentpolicy.StateStored), state)
+			assert.Empty(reason)
+			count, unknown = chatMembershipRecord(t, st)
+			assert.Equal(3, count)
+			assert.False(unknown)
+		})
+	}
+}
+
+// TestChatMediaPolicyReresolvesRosterAfterLaterOutage covers a roster that
+// was read once and then could not be read again. The archived count is kept
+// for reference, but the roster is unresolved: the backfill must re-resolve it
+// rather than trust the stale count, stay closed while the read keeps failing,
+// and release the media once a read succeeds and shows the chat under the
+// limit — without waiting for another sync to notice the shrink.
+func TestChatMediaPolicyReresolvesRosterAfterLaterOutage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	graph := newChatRosterGraph(t, 6)
+	st := testutil.NewTestStore(t)
+	attachmentsDir := t.TempDir()
+	policy := attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeAll, MaxParticipants: 4, MaxBytes: 100 << 20,
+	}
+	opts := ImportOptions{
+		Email: "me@example.com", AttachmentsDir: attachmentsDir, MediaPolicy: policy,
+	}
+	imp := NewImporter(st, NewClient(graph.url, func(context.Context) (string, error) { return "t", nil }, 50))
+
+	_, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	require.Zero(graph.hostedFetches)
+	count, unknown := chatMembershipRecord(t, st)
+	require.Equal(6, count)
+	require.False(unknown)
+
+	graph.rosterFails = true
+	sum, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, sum.Errors, "the unreadable roster is counted once")
+	count, unknown = chatMembershipRecord(t, st)
+	assert.Equal(6, count, "the count read earlier stays for reference")
+	assert.True(unknown, "a later failed read must be archived, not hidden behind the earlier count")
+
+	// While the roster stays unreadable the backfill re-resolves it, fails
+	// closed again, and downloads nothing.
+	backfill, err := imp.BackfillInlineMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(backfill.InlineImagesCopied)
+	assert.Zero(graph.hostedFetches, "a stale count must not admit media while the roster is unresolved")
+	state, reason := chatMediaState(t, st)
+	assert.Equal(string(attachmentpolicy.StateSkipped), state)
+	assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+	count, unknown = chatMembershipRecord(t, st)
+	assert.Equal(6, count)
+	assert.True(unknown)
+
+	// A readable roster resolves it, and the shrunken chat's media is released.
+	graph.rosterFails = false
+	graph.rosterSize = 3
+	backfill, err = imp.BackfillInlineMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, backfill.InlineImagesCopied)
+	assert.Zero(backfill.Errors)
+	state, reason = chatMediaState(t, st)
+	assert.Equal(string(attachmentpolicy.StateStored), state)
+	assert.Empty(reason)
+	count, unknown = chatMembershipRecord(t, st)
+	assert.Equal(3, count)
+	assert.False(unknown)
+}
+
+// TestChatMediaPolicyFollowsRosterShrink pins the direction the archived
+// membership must be able to move. Participant rows only ever accumulate, so a
+// conversation whose roster drops below the threshold would stay excluded from
+// media forever if policy kept reading them.
+func TestChatMediaPolicyFollowsRosterShrink(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	graph := newChatRosterGraph(t, 6)
+	st := testutil.NewTestStore(t)
+	attachmentsDir := t.TempDir()
+	policy := attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeAll, MaxParticipants: 4, MaxBytes: 100 << 20,
+	}
+	opts := ImportOptions{
+		Email: "me@example.com", AttachmentsDir: attachmentsDir, MediaPolicy: policy,
+	}
+
+	imp := NewImporter(st, NewClient(graph.url, func(context.Context) (string, error) { return "t", nil }, 50))
+	_, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	require.Zero(graph.hostedFetches)
+	state, reason := chatMediaState(t, st)
+	require.Equal(string(attachmentpolicy.StateSkipped), state)
+	require.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+	count, _ := chatMembershipRecord(t, st)
+	require.Equal(6, count)
+
+	graph.rosterSize = 2
+	_, err = imp.Import(t.Context(), opts)
+	require.NoError(err)
+	assert.Equal(1, graph.hostedFetches)
+	state, reason = chatMediaState(t, st)
+	assert.Equal(string(attachmentpolicy.StateStored), state)
+	assert.Empty(reason)
+
+	count, unknown := chatMembershipRecord(t, st)
+	assert.Equal(2, count, "the archived roster must follow the chat's current membership")
+	assert.False(unknown)
+	var accumulatedParticipants int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(participant_count, 0) FROM conversations WHERE source_conversation_id = ?
+	`), rosterChatID).Scan(&accumulatedParticipants))
+	assert.Equal(6, accumulatedParticipants, "the participant rows keep every member ever seen")
+
+	messageID := messageIDBySourceMessageID(t, st, chatSourceMessageID(rosterChatID, "m1"))
+	conversation, err := st.AttachmentConversation(messageID)
+	require.NoError(err)
+	assert.Equal(2, conversation.ParticipantCount,
+		"purge and backfill evaluate the roster, not the accumulated rows")
+}
+
+// messageIDBySourceMessageID resolves an archived message's internal ID.
+func messageIDBySourceMessageID(t *testing.T, st *store.Store, sourceMessageID string) int64 {
+	t.Helper()
+
+	var messageID int64
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), sourceMessageID).Scan(&messageID))
+	return messageID
 }

--- a/internal/teams/types.go
+++ b/internal/teams/types.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
 )
 
 // ---- Graph response envelopes ----
@@ -146,11 +148,13 @@ type GraphUser struct {
 // ---- Importer options/summary ----
 
 type ImportOptions struct {
-	Email           string
-	AttachmentsDir  string
-	IncludeChannels bool      // default true; allows chats-only runs
-	Limit           int       // 0 = no limit (per-conversation message cap, for scoped runs)
-	After           time.Time // zero = no lower bound
+	Email             string
+	AttachmentsDir    string
+	MediaPolicy       attachmentpolicy.Policy
+	MediaConversation attachmentpolicy.Conversation
+	IncludeChannels   bool      // default true; allows chats-only runs
+	Limit             int       // 0 = no limit (per-conversation message cap, for scoped runs)
+	After             time.Time // zero = no lower bound
 	// Full forces a complete backfill: the prior sync cursor and any interrupted
 	// checkpoint are ignored, so every chat/channel message is re-fetched and
 	// re-persisted (upsert). Use to repair messages after an importer change.
@@ -172,18 +176,19 @@ type EmbedEnqueuer interface {
 }
 
 type ImportSummary struct {
-	Duration           time.Duration
-	SourceID           int64
-	ChatsProcessed     int64
-	ChannelsProcessed  int64
-	MessagesProcessed  int64
-	MessagesAdded      int64
-	MessagesUpdated    int64
-	ReactionsAdded     int64
-	AttachmentsFound   int64
-	InlineImagesCopied int64
-	Participants       int64
-	Errors             int64
+	Duration            time.Duration
+	SourceID            int64
+	ChatsProcessed      int64
+	ChannelsProcessed   int64
+	MessagesProcessed   int64
+	MessagesAdded       int64
+	MessagesUpdated     int64
+	ReactionsAdded      int64
+	AttachmentsFound    int64
+	InlineImagesCopied  int64
+	InlineImagesSkipped int64
+	Participants        int64
+	Errors              int64
 }
 
 // ChatMember is a member of a chat (direct or group), returned by /chats/{id}/members.


### PR DESCRIPTION
## What changed

- Add a shared attachment policy for Beeper, Slack, Discord, and Teams: `media`, `max_media_mb`, `media_scope` (`all`, `direct`, `none`), and `media_max_participants`, with per-account overrides through `accounts_config` (Beeper account IDs, Slack team IDs, Teams emails) and the existing Discord `guilds` map.
- Record a typed outcome on every attachment occurrence — `pending`, `stored`, `skipped`, or `failed`, plus a skip reason — so a deliberate policy skip is distinguishable from a failed download, and backfills retry only eligible items.
- Add `purge-excluded-media`, which removes already-stored media that current policy excludes. `--dry-run` previews occurrence, blob, and logical byte counts; deletion requires `--yes` or interactive confirmation.
- Keep SQLite and PostgreSQL behavior aligned, preserve the 100 MiB Beeper/Slack/Teams and 50 MiB Discord caps as defaults, and leave configurations with omitted policy keys allow-all.

## Why

Attachment capture is all-or-nothing per provider, so archiving a busy chat network means storing every meme and forwarded video from large public rooms in order to keep the direct-message media that actually matters. `--no-media` on a manual run cannot express an ongoing policy because the daemon scheduler reads config, and it writes no marker, so a deliberate skip is indistinguishable from an attachment that was never seen.

## Usage

```toml
[beeper]
media_scope = "all"
media_max_participants = 12
max_media_mb = 100

[beeper.accounts_config.accountid]
media = false
```

```sh
msgvault purge-excluded-media --dry-run   # preview what current policy excludes
msgvault purge-excluded-media --yes       # remove it
```

Closes #618
