### PR TITLE
fix(analytics): recover web views during cache initialization

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8363,7 +8363,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.42.0
+  version: 1.43.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -11200,6 +11200,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/DomainSummary"
           description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
         default:
           content:
             application/json:
@@ -13959,6 +13967,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/PersonSummary"
           description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
         default:
           content:
             application/json:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2557,6 +2557,7 @@ components:
         readiness:
           enum:
             - absent
+            - building
             - interrupted
             - stale_schema
             - drifted

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16302,8 +16302,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
-          description: Error
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
         default:
           content:
             application/json:

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -540,15 +540,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}
 			return runDaemonSQLQuery(ctx, cfg, s, apiServer.QueryEngineForRequest(ctx), sql)
 		},
-		ShutdownToken: ownership.shutdownToken,
-		ShutdownFunc:  cancel,
-		Scheduler:     schedAdapter,
-		Logger:        logger,
-		DaemonVersion: Version,
-		AnalyticsMode: analyticsMode,
-		IdleTracker:   idleTracker,
-		OperationGate: operationGate,
-		BlobStore:     blobStore,
+		ShutdownToken:                 ownership.shutdownToken,
+		ShutdownFunc:                  cancel,
+		Scheduler:                     schedAdapter,
+		Logger:                        logger,
+		DaemonVersion:                 Version,
+		AnalyticsMode:                 analyticsMode,
+		AnalyticsInitializationActive: analyticsAsync,
+		IdleTracker:                   idleTracker,
+		OperationGate:                 operationGate,
+		BlobStore:                     blobStore,
 	}
 	applyServerRuntimeConfig(&apiOpts, cfg)
 	if cfg.Vector.Enabled {

--- a/cmd/msgvault/cmd/serve_analytics.go
+++ b/cmd/msgvault/cmd/serve_analytics.go
@@ -193,8 +193,10 @@ func startDaemonAnalyticsInitializer(
 	tracker scheduler.WorkTracker,
 ) *daemonAnalyticsInitHandle {
 	h := newDaemonAnalyticsInitHandle()
+	apiServer.SetAnalyticsInitializationActive(true)
 	go func() {
 		defer close(h.done)
+		defer apiServer.SetAnalyticsInitializationActive(false)
 		if tracker != nil {
 			release, ok := tracker.BeginWorkContext(ctx)
 			close(h.started)

--- a/cmd/msgvault/cmd/serve_analytics_test.go
+++ b/cmd/msgvault/cmd/serve_analytics_test.go
@@ -77,10 +77,47 @@ func TestStartDaemonAnalyticsInitializerAutoInstallsDuckDB(t *testing.T) {
 	)
 	require.True(h.WaitContext(context.Background()))
 	require.NoError(h.Err())
+	assert.False(srv.AnalyticsInitializationActive())
 	assert.True(h.Swapped())
 	assert.Equal(api.AnalyticsModeDuckDB, srv.AnalyticsMode())
 	assert.IsType(&query.DuckDBEngine{}, srv.QueryEngine())
 	require.NoError(closeDaemonAnalyticsEngines(srv, initial, h))
+}
+
+func TestStartDaemonAnalyticsInitializerTracksAutoInitializationIndependently(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	c, s := openTestDaemonAnalyticsStore(t)
+	c.Analytics.Engine = config.AnalyticsEngineAuto
+	c.Analytics.AutoBuildCache = true
+	started := make(chan struct{})
+	release := make(chan struct{})
+	stubBuildCacheSubprocess(t, func(ctx context.Context, _ bool) error {
+		close(started)
+		select {
+		case <-release:
+			_, err := buildCache(c.DatabaseDSN(), c.AnalyticsDir(), false)
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	initial := query.NewEngine(s.DB(), false)
+	srv := api.NewServerWithOptions(api.ServerOptions{
+		Config: c, Engine: initial, AnalyticsMode: api.AnalyticsModeSQLFallback, Logger: slog.Default(),
+	})
+	h := startDaemonAnalyticsInitializer(
+		context.Background(), c, s, startupCacheBuildIntentNone, srv, nil, nil,
+	)
+	<-started
+	assertions.True(srv.AnalyticsInitializationActive())
+
+	close(release)
+	requirements.True(h.WaitContext(context.Background()))
+	requirements.NoError(h.Err())
+	assertions.False(srv.AnalyticsInitializationActive())
+	requirements.NoError(closeDaemonAnalyticsEngines(srv, initial, h))
 }
 
 func TestStartDaemonAnalyticsInitializerDuckDBFailureDoesNotInstallSQLFallback(t *testing.T) {

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-08-09"
+last_edited: "2026-08-15"
 title: Web UI & API Server
 description: Daemon-served analytical Web UI and REST API for your msgvault archive, with optional background sync scheduling.
 ---
@@ -25,8 +25,11 @@ while the cache is built or opened, then switch to DuckDB after success. A
 failed automatic build or open keeps the daemon on live SQL. With
 `engine = "duckdb"`, analytics remain unavailable until the required cache is
 ready, so analytics routes return `503` during initialization; the daemon does
-not fall back to SQL. Set `auto_build_cache = false` to skip automatic startup
-maintenance.
+not fall back to SQL. Cache-dependent routes also return a structured `503`
+while automatic cache maintenance is active. Its `readiness` field lets clients
+distinguish transient `building` state from an unavailable cache and retry
+without requiring user action. Set `auto_build_cache = false` to skip automatic
+startup maintenance.
 
 ## Quick Start
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -171,8 +171,11 @@ the background after HTTP is ready. In `engine = "auto"`, aggregate views use
 live SQL while that work runs and switch to DuckDB after the cache is ready and
 opens successfully; a failed build or open keeps live SQL. In
 `engine = "duckdb"`, analytics remain unavailable until the required cache is
-ready, with no SQL fallback. Set `auto_build_cache = false` to skip automatic
-startup maintenance; scheduled syncs, ingest commands, and
+ready, with no SQL fallback. While that automatic initialization is active,
+cache-dependent Web UI views report that preparation is in progress and retry
+until the cache becomes ready; terminal unavailable states retain the explicit
+rebuild action. Set `auto_build_cache = false` to skip automatic startup
+maintenance; scheduled syncs, ingest commands, and
 `msgvault build-cache` can refresh or build the cache explicitly.
 
 Each build writes and verifies a same-filesystem staging tree before publishing

--- a/internal/api/deletions.go
+++ b/internal/api/deletions.go
@@ -354,7 +354,7 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 	engine := s.queryEngineForContext(r.Context())
 	analyzer, ok := engine.(query.Explorer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return nil, nil, false
 	}
 	stats, err := analyzer.ExploreSelectionStats(r.Context(), selectionRequest)

--- a/internal/api/deletions.go
+++ b/internal/api/deletions.go
@@ -354,12 +354,12 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 	engine := s.queryEngineForContext(r.Context())
 	analyzer, ok := engine.(query.Explorer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return nil, nil, false
 	}
 	stats, err := analyzer.ExploreSelectionStats(r.Context(), selectionRequest)
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return nil, nil, false
 	}
 	if selection.CacheRevision != stats.CacheRevision {

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -1889,7 +1889,7 @@ type ExploreCacheUnavailableResponse struct {
 }
 
 func (s *Server) writeExploreUnavailable(w http.ResponseWriter, readiness query.CacheReadiness) {
-	if s.AnalyticsMode() == AnalyticsModeInitializing {
+	if s.AnalyticsMode() == AnalyticsModeInitializing || s.AnalyticsInitializationActive() {
 		writeJSON(w, http.StatusServiceUnavailable, ExploreCacheUnavailableResponse{
 			Error: "analytical_cache_unavailable", Message: "The analytical cache is being prepared",
 			Readiness: query.CacheReadiness("building"),

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -300,12 +300,12 @@ func (s *Server) handleExploreWithScope(w http.ResponseWriter, r *http.Request, 
 	}
 	explorer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := explorer.Explore(r.Context(), prepared.query)
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if snapshotID != "" {
@@ -488,7 +488,7 @@ func (s *Server) handleExploreGroups(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.ExploreGroups(r.Context(), query.ExploreGroupRequest{
@@ -497,7 +497,7 @@ func (s *Server) handleExploreGroups(w http.ResponseWriter, r *http.Request) {
 		Page: query.PageSpec{Limit: request.Limit, Offset: offset},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" {
@@ -559,12 +559,12 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 	engine := s.queryEngineForContext(r.Context())
 	analyzer, ok := engine.(query.Explorer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	stats, err := analyzer.ExploreSelectionStats(r.Context(), selectionRequest)
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if selection.CacheRevision != stats.CacheRevision {
@@ -669,7 +669,7 @@ func (s *Server) handleExploreMatchCounts(w http.ResponseWriter, r *http.Request
 	request.RowKeys = slices.Compact(request.RowKeys)
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	state := s.exploreState
@@ -681,7 +681,7 @@ func (s *Server) handleExploreMatchCounts(w http.ResponseWriter, r *http.Request
 		Explore: predicate.query, IncludedKeys: []string{},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	cacheRequest := predicate.request
@@ -707,7 +707,7 @@ func (s *Server) handleExploreMatchCounts(w http.ResponseWriter, r *http.Request
 		Explore: matchRequest, RowKeys: request.RowKeys,
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	state.putMatchCounts(cacheKey, result.Counts)
@@ -1860,14 +1860,14 @@ func decodeExploreJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	return true
 }
 
-func (s *Server) writeExploreError(w http.ResponseWriter, err error) {
+func (s *Server) writeExploreError(ctx context.Context, w http.ResponseWriter, err error) {
 	var unavailable *query.CacheUnavailableError
 	if errors.As(err, &unavailable) || errors.Is(err, query.ErrCacheUnavailable) {
 		readiness := query.CacheInterrupted
 		if unavailable != nil {
 			readiness = unavailable.Readiness
 		}
-		s.writeExploreUnavailable(w, readiness)
+		s.writeExploreUnavailable(ctx, w, readiness)
 		return
 	}
 	if errors.Is(err, query.ErrInvalidExploreRequest) {
@@ -1888,8 +1888,12 @@ type ExploreCacheUnavailableResponse struct {
 	RecoveryAction string               `json:"recovery_action"`
 }
 
-func (s *Server) writeExploreUnavailable(w http.ResponseWriter, readiness query.CacheReadiness) {
-	if s.AnalyticsMode() == AnalyticsModeInitializing || s.AnalyticsInitializationActive() {
+func (s *Server) writeExploreUnavailable(
+	ctx context.Context,
+	w http.ResponseWriter,
+	readiness query.CacheReadiness,
+) {
+	if s.analyticsCacheInitializingForContext(ctx) {
 		writeJSON(w, http.StatusServiceUnavailable, ExploreCacheUnavailableResponse{
 			Error: "analytical_cache_unavailable", Message: "The analytical cache is being prepared",
 			Readiness: query.CacheReadiness("building"),

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -247,7 +247,12 @@ func registerExploreRoute[Req any, Resp any](api huma.API, operationID, path, su
 	op.RequestBody = jsonRequestBodyFor[Req](api)
 	op.Responses = jsonResponsesFor[Resp](api)
 	addErrorResponses(api, op.Responses, http.StatusBadRequest, http.StatusConflict, http.StatusServiceUnavailable)
-	op.Responses[httpStatusKey(http.StatusServiceUnavailable)] = &huma.Response{
+	op.Responses[httpStatusKey(http.StatusServiceUnavailable)] = exploreUnavailableResponseFor(api)
+	registerRawHumaRoute(api, op, handler)
+}
+
+func exploreUnavailableResponseFor(api huma.API) *huma.Response {
+	return &huma.Response{
 		Description: http.StatusText(http.StatusServiceUnavailable),
 		Content: map[string]*huma.MediaType{
 			applicationJSONMediaType: {Schema: &huma.Schema{AnyOf: []*huma.Schema{
@@ -256,7 +261,6 @@ func registerExploreRoute[Req any, Resp any](api huma.API, operationID, path, su
 			}}},
 		},
 	}
-	registerRawHumaRoute(api, op, handler)
 }
 
 func (s *Server) handleExplore(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -300,7 +300,7 @@ func (s *Server) handleExploreWithScope(w http.ResponseWriter, r *http.Request, 
 	}
 	explorer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := explorer.Explore(r.Context(), prepared.query)
@@ -488,7 +488,7 @@ func (s *Server) handleExploreGroups(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.ExploreGroups(r.Context(), query.ExploreGroupRequest{
@@ -559,7 +559,7 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 	engine := s.queryEngineForContext(r.Context())
 	analyzer, ok := engine.(query.Explorer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	stats, err := analyzer.ExploreSelectionStats(r.Context(), selectionRequest)
@@ -669,7 +669,7 @@ func (s *Server) handleExploreMatchCounts(w http.ResponseWriter, r *http.Request
 	request.RowKeys = slices.Compact(request.RowKeys)
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	state := s.exploreState
@@ -1867,7 +1867,7 @@ func (s *Server) writeExploreError(w http.ResponseWriter, err error) {
 		if unavailable != nil {
 			readiness = unavailable.Readiness
 		}
-		writeExploreUnavailable(w, readiness)
+		s.writeExploreUnavailable(w, readiness)
 		return
 	}
 	if errors.Is(err, query.ErrInvalidExploreRequest) {
@@ -1884,11 +1884,18 @@ func (s *Server) writeExploreError(w http.ResponseWriter, err error) {
 type ExploreCacheUnavailableResponse struct {
 	Error          string               `json:"error"`
 	Message        string               `json:"message"`
-	Readiness      query.CacheReadiness `json:"readiness" enum:"absent,interrupted,stale_schema,drifted"`
+	Readiness      query.CacheReadiness `json:"readiness" enum:"absent,building,interrupted,stale_schema,drifted"`
 	RecoveryAction string               `json:"recovery_action"`
 }
 
-func writeExploreUnavailable(w http.ResponseWriter, readiness query.CacheReadiness) {
+func (s *Server) writeExploreUnavailable(w http.ResponseWriter, readiness query.CacheReadiness) {
+	if s.AnalyticsMode() == AnalyticsModeInitializing {
+		writeJSON(w, http.StatusServiceUnavailable, ExploreCacheUnavailableResponse{
+			Error: "analytical_cache_unavailable", Message: "The analytical cache is being prepared",
+			Readiness: query.CacheReadiness("building"),
+		})
+		return
+	}
 	writeJSON(w, http.StatusServiceUnavailable, ExploreCacheUnavailableResponse{
 		Error: "analytical_cache_unavailable", Message: "The committed analytical cache is unavailable",
 		Readiness: readiness, RecoveryAction: "Run msgvault build-cache --full-rebuild and retry",

--- a/internal/api/explore_files.go
+++ b/internal/api/explore_files.go
@@ -78,14 +78,14 @@ func (s *Server) handleExploreFiles(w http.ResponseWriter, r *http.Request) {
 	predicate.query.Search = searchSpec
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.ExploreFiles(r.Context(), query.ExploreFilesRequest{
 		Explore: predicate.query, Page: query.PageSpec{Limit: request.Limit, Offset: offset},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" {

--- a/internal/api/explore_files.go
+++ b/internal/api/explore_files.go
@@ -78,7 +78,7 @@ func (s *Server) handleExploreFiles(w http.ResponseWriter, r *http.Request) {
 	predicate.query.Search = searchSpec
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.ExploreFiles(r.Context(), query.ExploreFilesRequest{

--- a/internal/api/explore_test.go
+++ b/internal/api/explore_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -85,6 +87,26 @@ func TestExploreReportsTransientCacheInitializationWithSQLFallback(t *testing.T)
 	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
 	assertions.Equal(query.CacheReadiness("building"), body.Readiness)
 	assertions.Empty(body.RecoveryAction, "an in-progress automatic build must not prescribe a manual rebuild")
+}
+
+func TestExploreUnavailableUsesRequestInitializationSnapshot(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	opts := testServerOptions(t, nil)
+	opts.AnalyticsMode = AnalyticsModeSQLFallback
+	opts.AnalyticsInitializationActive = true
+	srv := NewServerWithOptions(opts)
+	snapshot := srv.currentAnalyticsState()
+	srv.SetAnalyticsInitializationActive(false)
+
+	response := httptest.NewRecorder()
+	ctx := context.WithValue(context.Background(), analyticsEngineContextKey{}, snapshot)
+	srv.writeExploreUnavailable(ctx, response, query.CacheAbsent)
+
+	requirements.Equal(http.StatusServiceUnavailable, response.Code, response.Body.String())
+	var body ExploreCacheUnavailableResponse
+	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	assertions.Equal(query.CacheReadiness("building"), body.Readiness)
 }
 
 func TestExploreServerStateBoundsAndExpiresTransientCapabilities(t *testing.T) {

--- a/internal/api/explore_test.go
+++ b/internal/api/explore_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 func TestExploreRejectsUnknownFilterDimension(t *testing.T) {
@@ -71,6 +72,9 @@ func TestExploreReportsTransientCacheInitialization(t *testing.T) {
 	assertions.Equal(query.CacheReadiness("building"), body.Readiness)
 	assertions.Equal("The analytical cache is being prepared", body.Message)
 	assertions.Empty(body.RecoveryAction, "an in-progress automatic build must not prescribe a manual rebuild")
+	var generatedBody generated.ExploreCacheUnavailableResponse
+	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &generatedBody))
+	requirements.NoError(generatedBody.Validate(), "the generated client must accept the server's building response")
 }
 
 func TestExploreReportsTransientCacheInitializationWithSQLFallback(t *testing.T) {

--- a/internal/api/explore_test.go
+++ b/internal/api/explore_test.go
@@ -54,6 +54,23 @@ func TestExploreUnavailableReturnsNamedReadinessAndRecovery(t *testing.T) {
 	assertions.NotEmpty(body.RecoveryAction)
 }
 
+func TestExploreReportsTransientCacheInitialization(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	opts := testServerOptions(t, nil)
+	opts.AnalyticsMode = AnalyticsModeInitializing
+	srv := NewServerWithOptions(opts)
+
+	response := postExploreJSON(t, srv, "/api/v1/explore", `{}`)
+	requirements.Equal(http.StatusServiceUnavailable, response.Code, response.Body.String())
+	var body ExploreCacheUnavailableResponse
+	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	assertions.Equal("analytical_cache_unavailable", body.Error)
+	assertions.Equal(query.CacheReadiness("building"), body.Readiness)
+	assertions.Equal("The analytical cache is being prepared", body.Message)
+	assertions.Empty(body.RecoveryAction, "an in-progress automatic build must not prescribe a manual rebuild")
+}
+
 func TestExploreServerStateBoundsAndExpiresTransientCapabilities(t *testing.T) {
 	assertions := assert.New(t)
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)

--- a/internal/api/explore_test.go
+++ b/internal/api/explore_test.go
@@ -71,6 +71,22 @@ func TestExploreReportsTransientCacheInitialization(t *testing.T) {
 	assertions.Empty(body.RecoveryAction, "an in-progress automatic build must not prescribe a manual rebuild")
 }
 
+func TestExploreReportsTransientCacheInitializationWithSQLFallback(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	opts := testServerOptions(t, nil)
+	opts.AnalyticsMode = AnalyticsModeSQLFallback
+	opts.AnalyticsInitializationActive = true
+	srv := NewServerWithOptions(opts)
+
+	response := postExploreJSON(t, srv, "/api/v1/explore", `{}`)
+	requirements.Equal(http.StatusServiceUnavailable, response.Code, response.Body.String())
+	var body ExploreCacheUnavailableResponse
+	requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	assertions.Equal(query.CacheReadiness("building"), body.Readiness)
+	assertions.Empty(body.RecoveryAction, "an in-progress automatic build must not prescribe a manual rebuild")
+}
+
 func TestExploreServerStateBoundsAndExpiresTransientCapabilities(t *testing.T) {
 	assertions := assert.New(t)
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -209,7 +209,7 @@ func (s *Server) handleGroupFiles(w http.ResponseWriter, r *http.Request) {
 	}
 	grouper, ok := s.queryEngineForContext(r.Context()).(query.FileGrouper)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := grouper.GroupFiles(r.Context(), query.FileGroupRequest{
@@ -327,7 +327,7 @@ func (s *Server) handleSearchFilesWithScope(w http.ResponseWriter, r *http.Reque
 	}
 	searcher, ok := s.queryEngineForContext(r.Context()).(query.FileSearcher)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := searcher.SearchFiles(r.Context(), query.FileSearchRequest{

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -209,7 +209,7 @@ func (s *Server) handleGroupFiles(w http.ResponseWriter, r *http.Request) {
 	}
 	grouper, ok := s.queryEngineForContext(r.Context()).(query.FileGrouper)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := grouper.GroupFiles(r.Context(), query.FileGroupRequest{
@@ -219,7 +219,7 @@ func (s *Server) handleGroupFiles(w http.ResponseWriter, r *http.Request) {
 		Page: query.PageSpec{Limit: request.Limit, Offset: offset},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" && cursor.Revision != result.CacheRevision {
@@ -327,7 +327,7 @@ func (s *Server) handleSearchFilesWithScope(w http.ResponseWriter, r *http.Reque
 	}
 	searcher, ok := s.queryEngineForContext(r.Context()).(query.FileSearcher)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := searcher.SearchFiles(r.Context(), query.FileSearchRequest{
@@ -337,7 +337,7 @@ func (s *Server) handleSearchFilesWithScope(w http.ResponseWriter, r *http.Reque
 		Page:         query.PageSpec{Limit: request.Limit, Offset: offset},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" {

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -620,7 +620,7 @@ func applyClientCodegenExtensions(doc *huma.OpenAPI) {
 			},
 		},
 		"ExploreCacheUnavailableResponse": {
-			"readiness": {"ExploreCacheUnavailableResponseReadinessAbsent", "ExploreCacheUnavailableResponseReadinessInterrupted", "ExploreCacheUnavailableResponseReadinessStaleSchema", "ExploreCacheUnavailableResponseReadinessDrifted"},
+			"readiness": {"ExploreCacheUnavailableResponseReadinessAbsent", "ExploreCacheUnavailableResponseReadinessBuilding", "ExploreCacheUnavailableResponseReadinessInterrupted", "ExploreCacheUnavailableResponseReadinessStaleSchema", "ExploreCacheUnavailableResponseReadinessDrifted"},
 		},
 		"ExploreFilter": {
 			"dimension": {"ExploreFilterDimensionSource", "ExploreFilterDimensionParticipant", "ExploreFilterDimensionDomain", "ExploreFilterDimensionMessageType", "ExploreFilterDimensionAfter", "ExploreFilterDimensionBefore", "ExploreFilterDimensionDeletion", "ExploreFilterDimensionIdentity"},

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -195,7 +195,10 @@ import (
 // meeting-import routes keep their current contracts.
 // 1.42.0 adds the dated activity and daily-note route families. Existing
 // profile, meeting, media, and other API contracts remain unchanged.
-const APISchemaVersion = "1.42.0"
+// 1.43.0 adds structured analytical-cache readiness responses, including the
+// transient building state, to cache-dependent coverage and detail routes.
+// Additive (minor bump): existing success responses remain unchanged.
+const APISchemaVersion = "1.43.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -587,6 +587,16 @@ func applyClientCodegenExtensions(doc *huma.OpenAPI) {
 			}
 		}
 	}
+	if unavailable := schemas["ExploreCacheUnavailableResponse"]; unavailable != nil {
+		if recoveryAction := unavailable.Properties["recovery_action"]; recoveryAction != nil {
+			if recoveryAction.Extensions == nil {
+				recoveryAction.Extensions = map[string]any{}
+			}
+			recoveryAction.Extensions["x-oapi-codegen-extra-tags"] = map[string]any{
+				"validate": "omitempty",
+			}
+		}
+	}
 	setEnumNames := func(schema *huma.Schema, enumNames []any) {
 		if schema == nil {
 			return

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -34,9 +34,13 @@ func TestOpenAPIDocumentUsesAPISchemaVersion(t *testing.T) {
 	assert.NotEmpty(t, doc.Paths, "paths")
 }
 
+func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
+	assert.Equal(t, "1.43.0", APISchemaVersion)
+}
+
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "1.42.0", APISchemaVersion,
+	assert.Equal(t, "1.43.0", APISchemaVersion,
 		"organization and employment routes are an additive schema release")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -315,7 +319,7 @@ func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("1.42.0", APISchemaVersion,
+	assert.Equal("1.43.0", APISchemaVersion,
 		"activity and identity match review preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -389,7 +393,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("1.42.0", APISchemaVersion,
+	assert.Equal("1.43.0", APISchemaVersion,
 		"activity and identity match review preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/persons/{id}/profile/media/{media_id}/content"]
@@ -417,7 +421,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("1.42.0", APISchemaVersion,
+	assertions.Equal("1.43.0", APISchemaVersion,
 		"activity routes follow the additive identity match review schema release")
 
 	doc := OpenAPIDocument()
@@ -458,8 +462,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// added in 1.37.0, raw profile media added in 1.38.0, typed temporal
 	// person relationships added in 1.39.0, organizations and employments
 	// added in 1.40.0, identity match review added in 1.41.0, and dated activity
-	// routes added in 1.42.0 did not touch it.
-	assert.Equal("1.42.0", APISchemaVersion, "meeting import is an additive schema release")
+	// routes added in 1.42.0 and cache-readiness responses added in 1.43.0 did
+	// not touch it.
+	assert.Equal("1.43.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]
@@ -740,6 +745,33 @@ func TestOpenAPIExplorationUsesStructuredUnavailableUnion(t *testing.T) {
 	readiness := schema.Properties["readiness"]
 	requirements.NotNil(readiness)
 	assertions.ElementsMatch([]any{"absent", "building", "interrupted", "stale_schema", "drifted"}, readiness.Enum)
+}
+
+func TestOpenAPIPersonAndDomainDetailsUseStructuredUnavailableUnion(t *testing.T) {
+	for _, document := range []*huma.OpenAPI{OpenAPIDocument(), openAPIClientDocument()} {
+		for _, path := range []string{"/api/v1/people/{id}", "/api/v1/domains/{domain}"} {
+			response := document.Paths[path].Get.Responses[httpStatusKey(http.StatusServiceUnavailable)]
+			require.NotNil(t, response, path)
+			media := response.Content[applicationJSONMediaType]
+			require.NotNil(t, media, path)
+			require.NotNil(t, media.Schema, path)
+			require.Len(t, media.Schema.AnyOf, 2, path)
+			assert.ElementsMatch(t, []string{
+				"#/components/schemas/ExploreCacheUnavailableResponse",
+				"#/components/schemas/ErrorResponse",
+			}, []string{media.Schema.AnyOf[0].Ref, media.Schema.AnyOf[1].Ref}, path)
+		}
+	}
+}
+
+func TestGeneratedPersonAndDomainDetailsExposeServiceUnavailable(t *testing.T) {
+	for name, responseType := range map[string]reflect.Type{
+		"get person": reflect.TypeFor[generated.GetPersonResp](),
+		"get domain": reflect.TypeFor[generated.GetDomainResp](),
+	} {
+		_, ok := responseType.FieldByName("JSON503")
+		assert.True(t, ok, "%s response must expose JSON503", name)
+	}
 }
 
 func TestOpenAPIExplorationFiniteRequiredFieldsAreNonNull(t *testing.T) {

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -748,15 +748,17 @@ func TestOpenAPIExplorationUsesStructuredUnavailableUnion(t *testing.T) {
 }
 
 func TestOpenAPIPersonAndDomainDetailsUseStructuredUnavailableUnion(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
 	for _, document := range []*huma.OpenAPI{OpenAPIDocument(), openAPIClientDocument()} {
 		for _, path := range []string{"/api/v1/people/{id}", "/api/v1/domains/{domain}"} {
 			response := document.Paths[path].Get.Responses[httpStatusKey(http.StatusServiceUnavailable)]
-			require.NotNil(t, response, path)
+			requirements.NotNil(response, path)
 			media := response.Content[applicationJSONMediaType]
-			require.NotNil(t, media, path)
-			require.NotNil(t, media.Schema, path)
-			require.Len(t, media.Schema.AnyOf, 2, path)
-			assert.ElementsMatch(t, []string{
+			requirements.NotNil(media, path)
+			requirements.NotNil(media.Schema, path)
+			requirements.Len(media.Schema.AnyOf, 2, path)
+			assertions.ElementsMatch([]string{
 				"#/components/schemas/ExploreCacheUnavailableResponse",
 				"#/components/schemas/ErrorResponse",
 			}, []string{media.Schema.AnyOf[0].Ref, media.Schema.AnyOf[1].Ref}, path)

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -739,7 +739,7 @@ func TestOpenAPIExplorationUsesStructuredUnavailableUnion(t *testing.T) {
 	requirements.NotNil(schema)
 	readiness := schema.Properties["readiness"]
 	requirements.NotNil(readiness)
-	assertions.ElementsMatch([]any{"absent", "interrupted", "stale_schema", "drifted"}, readiness.Enum)
+	assertions.ElementsMatch([]any{"absent", "building", "interrupted", "stale_schema", "drifted"}, readiness.Enum)
 }
 
 func TestOpenAPIExplorationFiniteRequiredFieldsAreNonNull(t *testing.T) {

--- a/internal/api/people.go
+++ b/internal/api/people.go
@@ -74,7 +74,7 @@ func (s *Server) registerPeopleRoutes(api huma.API) {
 	registerExploreRoute[IdentitySearchHTTPRequest, PersonSearchHTTPResponse](
 		api, "searchPeople", "/people/search", "Search analytical people", s.handleSearchPeople,
 	)
-	registerAPIV1RawHumaJSONRoute[query.PersonSummary](
+	registerAnalyticalDetailRoute[query.PersonSummary](
 		api, "getPerson", http.MethodGet, "/people/{id}", "Get one analytical person", s.handleGetPerson,
 	)
 	registerExploreRoute[ExploreHTTPRequest, PersonContextSummaryHTTPResponse](
@@ -86,7 +86,7 @@ func (s *Server) registerPeopleRoutes(api huma.API) {
 	registerExploreRoute[IdentitySearchHTTPRequest, DomainSearchHTTPResponse](
 		api, "searchDomains", "/domains/search", "Search analytical domains", s.handleSearchDomains,
 	)
-	registerAPIV1RawHumaJSONRoute[query.DomainSummary](
+	registerAnalyticalDetailRoute[query.DomainSummary](
 		api, "getDomain", http.MethodGet, "/domains/{domain}", "Get one analytical domain", s.handleGetDomain,
 	)
 	registerExploreRoute[ExploreHTTPRequest, DomainContextSummaryHTTPResponse](
@@ -95,6 +95,17 @@ func (s *Server) registerPeopleRoutes(api huma.API) {
 	registerExploreRoute[ExploreHTTPRequest, ExploreHTTPResponse](
 		api, "getDomainTimeline", "/domains/{domain}/timeline", "Get one domain's canonical activity timeline", s.handleDomainTimeline,
 	)
+}
+
+func registerAnalyticalDetailRoute[Resp any](
+	api huma.API,
+	operationID, method, path, summary string,
+	handler http.HandlerFunc,
+) {
+	op := rawAPIV1Operation(operationID, method, path, summary)
+	op.Responses = jsonResponsesFor[Resp](api)
+	op.Responses[httpStatusKey(http.StatusServiceUnavailable)] = exploreUnavailableResponseFor(api)
+	registerRawHumaRoute(api, op, handler)
 }
 
 func (s *Server) handleSearchPeople(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/people.go
+++ b/internal/api/people.go
@@ -105,7 +105,7 @@ func (s *Server) handleSearchPeople(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.SearchPeople(r.Context(), query.PersonSearchRequest{
@@ -138,7 +138,7 @@ func (s *Server) handleSearchDomains(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.SearchDomains(r.Context(), query.DomainSearchRequest{
@@ -234,7 +234,7 @@ func (s *Server) handleGetPerson(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	members := s.clusterMemberIDs(id)
@@ -335,7 +335,7 @@ func (s *Server) handlePersonContextSummary(w http.ResponseWriter, r *http.Reque
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	// Scope the summary to the whole identity cluster so alias-owned
@@ -361,7 +361,7 @@ func (s *Server) handleGetDomain(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.GetDomain(r.Context(), domain, query.Context{})
@@ -387,7 +387,7 @@ func (s *Server) handleDomainContextSummary(w http.ResponseWriter, r *http.Reque
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.GetDomainSummary(r.Context(), domain, explore)

--- a/internal/api/people.go
+++ b/internal/api/people.go
@@ -105,7 +105,7 @@ func (s *Server) handleSearchPeople(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.SearchPeople(r.Context(), query.PersonSearchRequest{
@@ -114,7 +114,7 @@ func (s *Server) handleSearchPeople(w http.ResponseWriter, r *http.Request) {
 		Page: query.PageSpec{Limit: request.Limit, Offset: prepared.offset},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" && prepared.cursor.Revision != result.CacheRevision {
@@ -138,7 +138,7 @@ func (s *Server) handleSearchDomains(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.SearchDomains(r.Context(), query.DomainSearchRequest{
@@ -147,7 +147,7 @@ func (s *Server) handleSearchDomains(w http.ResponseWriter, r *http.Request) {
 		Page: query.PageSpec{Limit: request.Limit, Offset: prepared.offset},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" && prepared.cursor.Revision != result.CacheRevision {
@@ -234,13 +234,13 @@ func (s *Server) handleGetPerson(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	members := s.clusterMemberIDs(id)
 	person, err := analyzer.GetPerson(r.Context(), id, query.Context{}, members)
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if person == nil {
@@ -335,7 +335,7 @@ func (s *Server) handlePersonContextSummary(w http.ResponseWriter, r *http.Reque
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	// Scope the summary to the whole identity cluster so alias-owned
@@ -343,7 +343,7 @@ func (s *Server) handlePersonContextSummary(w http.ResponseWriter, r *http.Reque
 	// search for the same identity.
 	result, err := analyzer.GetPersonSummary(r.Context(), id, explore, s.clusterMemberIDs(id))
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if result == nil || len(result.Rows) == 0 {
@@ -361,12 +361,12 @@ func (s *Server) handleGetDomain(w http.ResponseWriter, r *http.Request) {
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.GetDomain(r.Context(), domain, query.Context{})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if result == nil {
@@ -387,12 +387,12 @@ func (s *Server) handleDomainContextSummary(w http.ResponseWriter, r *http.Reque
 	}
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.PeopleAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.GetDomainSummary(r.Context(), domain, explore)
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if result == nil || len(result.Rows) == 0 {

--- a/internal/api/relationships.go
+++ b/internal/api/relationships.go
@@ -81,14 +81,14 @@ func (s *Server) handleRelationships(w http.ResponseWriter, r *http.Request) {
 
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.RelationshipAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.Relationships(r.Context(), query.RelationshipsRequest{
 		Context: analyticalContext, ShowAll: request.ShowAll, Limit: request.Limit, Offset: offset, Now: decayDate,
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" {
@@ -199,12 +199,12 @@ func (s *Server) handleRelationshipTimeline(w http.ResponseWriter, r *http.Reque
 
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.RelationshipAnalyzer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	canonicalID, err := analyzer.ResolveCanonicalParticipant(r.Context(), participantID)
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 
@@ -228,7 +228,7 @@ func (s *Server) handleRelationshipTimeline(w http.ResponseWriter, r *http.Reque
 		Limit: request.Limit, Offset: offset,
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	if request.Cursor != "" {

--- a/internal/api/relationships.go
+++ b/internal/api/relationships.go
@@ -81,7 +81,7 @@ func (s *Server) handleRelationships(w http.ResponseWriter, r *http.Request) {
 
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.RelationshipAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	result, err := analyzer.Relationships(r.Context(), query.RelationshipsRequest{
@@ -199,7 +199,7 @@ func (s *Server) handleRelationshipTimeline(w http.ResponseWriter, r *http.Reque
 
 	analyzer, ok := s.queryEngineForContext(r.Context()).(query.RelationshipAnalyzer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	canonicalID, err := analyzer.ResolveCanonicalParticipant(r.Context(), participantID)

--- a/internal/api/search_coverage.go
+++ b/internal/api/search_coverage.go
@@ -78,7 +78,7 @@ func (s *Server) handleSearchCoverage(w http.ResponseWriter, r *http.Request) {
 	ctx = semanticCoverageContext(ctx, cfg.Embed.Scope.BuildScope())
 	explorer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		s.writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
 		return
 	}
 	response := SearchCoverageResponse{
@@ -109,7 +109,7 @@ func (s *Server) handleSearchCoverage(w http.ResponseWriter, r *http.Request) {
 		Explore: query.ExploreRequest{Context: ctx}, IncludedKeys: []string{},
 	})
 	if err != nil {
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	contextHash := searchCoverageContextHash(ctx)
@@ -141,7 +141,7 @@ func (s *Server) handleSearchCoverage(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusOK, response)
 			return
 		}
-		s.writeExploreError(w, err)
+		s.writeExploreError(r.Context(), w, err)
 		return
 	}
 	currentStatus, _, current, _ := resolveSearchCoverageGeneration(

--- a/internal/api/search_coverage.go
+++ b/internal/api/search_coverage.go
@@ -55,6 +55,7 @@ func (s *Server) registerSearchCoverageRoute(api huma.API) {
 	op.RequestBody = jsonRequestBodyFor[SearchCoverageRequest](api)
 	op.Responses = jsonResponsesFor[SearchCoverageResponse](api)
 	addErrorResponses(api, op.Responses, http.StatusBadRequest, http.StatusServiceUnavailable)
+	op.Responses[httpStatusKey(http.StatusServiceUnavailable)] = exploreUnavailableResponseFor(api)
 	registerRawHumaRoute(api, op, s.handleSearchCoverage)
 }
 

--- a/internal/api/search_coverage.go
+++ b/internal/api/search_coverage.go
@@ -78,7 +78,7 @@ func (s *Server) handleSearchCoverage(w http.ResponseWriter, r *http.Request) {
 	ctx = semanticCoverageContext(ctx, cfg.Embed.Scope.BuildScope())
 	explorer, ok := s.queryEngineForContext(r.Context()).(query.Explorer)
 	if !ok {
-		writeExploreUnavailable(w, query.CacheAbsent)
+		s.writeExploreUnavailable(w, query.CacheAbsent)
 		return
 	}
 	response := SearchCoverageResponse{

--- a/internal/api/search_coverage_test.go
+++ b/internal/api/search_coverage_test.go
@@ -360,6 +360,12 @@ func TestSearchCoverageOpenAPIContract(t *testing.T) {
 	for _, status := range []string{"200", "400", "503"} {
 		assert.Contains(op.Responses, status)
 	}
+	unavailable := op.Responses["503"].Content[applicationJSONMediaType].Schema
+	require.Len(unavailable.AnyOf, 2)
+	assert.ElementsMatch([]string{
+		"#/components/schemas/ExploreCacheUnavailableResponse",
+		"#/components/schemas/ErrorResponse",
+	}, []string{unavailable.AnyOf[0].Ref, unavailable.AnyOf[1].Ref})
 	schema := doc.Components.Schemas.Map()["SearchCoverageResponse"]
 	require.NotNil(schema)
 	assert.ElementsMatch(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -216,25 +216,25 @@ type AttachmentBlobStore interface {
 type fastmailIdentityInventory = provideridentity.Inventory
 
 type analyticsEngineState struct {
-	engine query.Engine
-	mode   string
+	engine                        query.Engine
+	mode                          string
+	analyticsInitializationActive bool
 }
 
 type analyticsEngineContextKey struct{}
 
 // Server represents the HTTP API server.
 type Server struct {
-	cfg                           *config.Config
-	store                         MessageStore
-	analyticsState                atomic.Pointer[analyticsEngineState]
-	analyticsInitializationActive atomic.Bool
-	savedViewStore                SavedViewStore
-	sqlQueryRunner                SQLQueryRunner
-	shutdownToken                 string
-	shutdownFunc                  func()
-	scheduler                     SyncScheduler
-	logger                        *slog.Logger
-	requestTimeout                time.Duration
+	cfg            *config.Config
+	store          MessageStore
+	analyticsState atomic.Pointer[analyticsEngineState]
+	savedViewStore SavedViewStore
+	sqlQueryRunner SQLQueryRunner
+	shutdownToken  string
+	shutdownFunc   func()
+	scheduler      SyncScheduler
+	logger         *slog.Logger
+	requestTimeout time.Duration
 	// readTimeout is the ordinary connection read ceiling used by http.Server.
 	// Tests shrink it to exercise protective slow-body handling without waiting
 	// for the production timeout.
@@ -530,8 +530,10 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		fastmailInventoryFactory: fastmailInventoryFactory,
 		started:                  make(chan struct{}),
 	}
-	s.analyticsState.Store(&analyticsEngineState{engine: opts.Engine, mode: opts.AnalyticsMode})
-	s.analyticsInitializationActive.Store(opts.AnalyticsInitializationActive)
+	s.analyticsState.Store(&analyticsEngineState{
+		engine: opts.Engine, mode: opts.AnalyticsMode,
+		analyticsInitializationActive: opts.AnalyticsInitializationActive,
+	})
 	if s.taskIdentityResolver == nil {
 		s.taskIdentityResolver = s.resolveTaskMessageIdentity
 	}
@@ -814,6 +816,11 @@ func (s *Server) analyticsInitializingForContext(ctx context.Context) bool {
 	return s.analyticsModeForContext(ctx) == AnalyticsModeInitializing
 }
 
+func (s *Server) analyticsCacheInitializingForContext(ctx context.Context) bool {
+	state := s.analyticsStateForContext(ctx)
+	return state != nil && (state.mode == AnalyticsModeInitializing || state.analyticsInitializationActive)
+}
+
 // QueryEngine returns the analytics engine currently serving API queries.
 // The daemon uses it when a request must follow a runtime engine swap.
 func (s *Server) QueryEngine() query.Engine {
@@ -846,7 +853,16 @@ func (s *Server) AnalyticsMode() string {
 // daemon-owned engines remain live until HTTP shutdown and background workers
 // have stopped.
 func (s *Server) SetAnalyticsEngine(engine query.Engine, mode string) {
-	s.analyticsState.Store(&analyticsEngineState{engine: engine, mode: mode})
+	for {
+		current := s.currentAnalyticsState()
+		next := &analyticsEngineState{engine: engine, mode: mode}
+		if current != nil {
+			next.analyticsInitializationActive = current.analyticsInitializationActive
+		}
+		if s.analyticsState.CompareAndSwap(current, next) {
+			return
+		}
+	}
 }
 
 // SetAnalyticsInitializationActive reports whether the daemon is still
@@ -854,13 +870,24 @@ func (s *Server) SetAnalyticsEngine(engine query.Engine, mode string) {
 // AnalyticsMode because auto mode keeps serving SQL-backed routes while that
 // work runs.
 func (s *Server) SetAnalyticsInitializationActive(active bool) {
-	s.analyticsInitializationActive.Store(active)
+	for {
+		current := s.currentAnalyticsState()
+		next := &analyticsEngineState{analyticsInitializationActive: active}
+		if current != nil {
+			next.engine = current.engine
+			next.mode = current.mode
+		}
+		if s.analyticsState.CompareAndSwap(current, next) {
+			return
+		}
+	}
 }
 
 // AnalyticsInitializationActive reports whether background cache
 // initialization is still in progress.
 func (s *Server) AnalyticsInitializationActive() bool {
-	return s.analyticsInitializationActive.Load()
+	state := s.currentAnalyticsState()
+	return state != nil && state.analyticsInitializationActive
 }
 
 // CloseAnalyticsEngine closes and clears the current engine after the daemon

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -224,16 +224,17 @@ type analyticsEngineContextKey struct{}
 
 // Server represents the HTTP API server.
 type Server struct {
-	cfg            *config.Config
-	store          MessageStore
-	analyticsState atomic.Pointer[analyticsEngineState]
-	savedViewStore SavedViewStore
-	sqlQueryRunner SQLQueryRunner
-	shutdownToken  string
-	shutdownFunc   func()
-	scheduler      SyncScheduler
-	logger         *slog.Logger
-	requestTimeout time.Duration
+	cfg                           *config.Config
+	store                         MessageStore
+	analyticsState                atomic.Pointer[analyticsEngineState]
+	analyticsInitializationActive atomic.Bool
+	savedViewStore                SavedViewStore
+	sqlQueryRunner                SQLQueryRunner
+	shutdownToken                 string
+	shutdownFunc                  func()
+	scheduler                     SyncScheduler
+	logger                        *slog.Logger
+	requestTimeout                time.Duration
 	// readTimeout is the ordinary connection read ceiling used by http.Server.
 	// Tests shrink it to exercise protective slow-body handling without waiting
 	// for the production timeout.
@@ -451,6 +452,11 @@ type ServerOptions struct {
 	// aggregate views run on the cache or live SQL. The daemon may replace the
 	// engine and mode at runtime. Empty omits the field.
 	AnalyticsMode string
+	// AnalyticsInitializationActive reports that cache selection, build, or
+	// open work is already scheduled. Set it before the listener is exposed so
+	// the first request cannot mistake active initialization for a terminal
+	// SQL fallback.
+	AnalyticsInitializationActive bool
 	// SPAHandler overrides the embedded browser application handler. Nil uses
 	// internal/web.Handler and is the production default. Tests may inject a
 	// handler built over an in-memory filesystem.
@@ -525,6 +531,7 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		started:                  make(chan struct{}),
 	}
 	s.analyticsState.Store(&analyticsEngineState{engine: opts.Engine, mode: opts.AnalyticsMode})
+	s.analyticsInitializationActive.Store(opts.AnalyticsInitializationActive)
 	if s.taskIdentityResolver == nil {
 		s.taskIdentityResolver = s.resolveTaskMessageIdentity
 	}
@@ -840,6 +847,20 @@ func (s *Server) AnalyticsMode() string {
 // have stopped.
 func (s *Server) SetAnalyticsEngine(engine query.Engine, mode string) {
 	s.analyticsState.Store(&analyticsEngineState{engine: engine, mode: mode})
+}
+
+// SetAnalyticsInitializationActive reports whether the daemon is still
+// selecting, building, or opening the analytical cache. It is separate from
+// AnalyticsMode because auto mode keeps serving SQL-backed routes while that
+// work runs.
+func (s *Server) SetAnalyticsInitializationActive(active bool) {
+	s.analyticsInitializationActive.Store(active)
+}
+
+// AnalyticsInitializationActive reports whether background cache
+// initialization is still in progress.
+func (s *Server) AnalyticsInitializationActive() bool {
+	return s.analyticsInitializationActive.Load()
 }
 
 // CloseAnalyticsEngine closes and clears the current engine after the daemon

--- a/internal/codegenfix/fix.go
+++ b/internal/codegenfix/fix.go
@@ -58,18 +58,42 @@ func RewriteGeneratedValidators(source []byte) ([]byte, error) {
 			return nil, fmt.Errorf("generated %s.%s validator shape changed", typeName, field)
 		}
 	}
-	const dailyNoteRequest = "CreateDailyNoteEntryRequest"
-	startMarker := []byte("func (c " + dailyNoteRequest + ") Validate() error {")
-	start := bytes.Index(result, startMarker)
+	const cacheUnavailableType = "ExploreCacheUnavailableResponse"
+	cacheValidatorStart := []byte("func (e " + cacheUnavailableType + ") Validate() error {")
+	start := bytes.Index(result, cacheValidatorStart)
 	if start < 0 {
-		return nil, errors.New("generated CreateDailyNoteEntryRequest.PersonIds validator shape changed")
+		return nil, errors.New("generated ExploreCacheUnavailableResponse.RecoveryAction validator shape changed")
 	}
 	endOffset := bytes.Index(result[start:], []byte("\n}\n"))
 	if endOffset < 0 {
-		return nil, errors.New("generated CreateDailyNoteEntryRequest.PersonIds validator shape changed")
+		return nil, errors.New("generated ExploreCacheUnavailableResponse.RecoveryAction validator shape changed")
 	}
 	end := start + endOffset
 	validator := result[start:end]
+	requiredRecoveryAction := []byte("\tif err := typesValidator.Var(e.RecoveryAction, \"required\"); err != nil {\n\t\terrors = errors.Append(\"RecoveryAction\", err)\n\t}\n")
+	switch bytes.Count(validator, requiredRecoveryAction) {
+	case 1:
+		rewritten := bytes.Replace(validator, requiredRecoveryAction, nil, 1)
+		result = append(append(append([]byte(nil), result[:start]...), rewritten...), result[end:]...)
+	case 0:
+		if !bytes.Contains(result, []byte("RecoveryAction string")) {
+			return nil, errors.New("generated ExploreCacheUnavailableResponse.RecoveryAction validator shape changed")
+		}
+	default:
+		return nil, errors.New("generated ExploreCacheUnavailableResponse.RecoveryAction validator shape changed")
+	}
+	const dailyNoteRequest = "CreateDailyNoteEntryRequest"
+	startMarker := []byte("func (c " + dailyNoteRequest + ") Validate() error {")
+	start = bytes.Index(result, startMarker)
+	if start < 0 {
+		return nil, errors.New("generated CreateDailyNoteEntryRequest.PersonIds validator shape changed")
+	}
+	endOffset = bytes.Index(result[start:], []byte("\n}\n"))
+	if endOffset < 0 {
+		return nil, errors.New("generated CreateDailyNoteEntryRequest.PersonIds validator shape changed")
+	}
+	end = start + endOffset
+	validator = result[start:end]
 	generatedPersonIDValidation := []byte(`	for i, item := range c.PersonIds {
 		if err := typesValidator.Var(item, "omitempty,gte=1"); err != nil {
 			errors = errors.Append(fmt.Sprintf("PersonIds[%d]", i), err)

--- a/internal/codegenfix/fix_test.go
+++ b/internal/codegenfix/fix_test.go
@@ -16,6 +16,7 @@ func TestRewriteGeneratedValidatorsRepairsKnownGeneratorGaps(t *testing.T) {
 	assertions.NotContains(string(got), "if f.MimeType != nil")
 	assertions.Contains(string(got), `typesValidator.Var(e.Grouping, "required,min=1,max=1")`)
 	assertions.Contains(string(got), `typesValidator.Var(f.Grouping, "required,min=1,max=1")`)
+	assertions.NotContains(string(got), exploreCacheRecoveryActionRequiredValidatorBlock())
 	assertions.Contains(string(got), "JSON json.RawMessage")
 	assertions.Contains(string(got), dailyNoteDecoyValidatorBlock())
 	assertions.Contains(string(got), dailyNotePersonIDsValidatorBlock("gte=1"))
@@ -83,6 +84,13 @@ func generatedValidatorFixture() string {
 	return `type AttributeValue struct {
 	JSON *struct{}  ` + "`json:\"json,omitempty\"`" + `
 }
+type ExploreCacheUnavailableResponse struct {
+	RecoveryAction string ` + "`json:\"recovery_action\" validate:\"omitempty\"`" + `
+}
+func (e ExploreCacheUnavailableResponse) Validate() error {
+	var errors runtime.ValidationErrors
+` + exploreCacheRecoveryActionRequiredValidatorBlock() + `
+}
 func (e ExploreGroupsHTTPRequest) Validate() error {
 	var errors runtime.ValidationErrors
 }
@@ -94,6 +102,13 @@ func (c CreateDailyNoteEntryRequest) Validate() error {
 	var errors runtime.ValidationErrors
 ` + dailyNoteDecoyValidatorBlock() + dailyNotePersonIDsValidatorBlock("omitempty,gte=1") + `
 }
+`
+}
+
+func exploreCacheRecoveryActionRequiredValidatorBlock() string {
+	return `	if err := typesValidator.Var(e.RecoveryAction, "required"); err != nil {
+		errors = errors.Append("RecoveryAction", err)
+	}
 `
 }
 

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -4994,7 +4994,21 @@ func (c *Client) GetDomainWithResponse(ctx context.Context, options *GetDomainRe
 			}
 		}
 		return out, nil
-	case 500:
+	case 503:
+		out.JSON503 = new(GetDomainErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetDomainErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
 	default:
 		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -9601,7 +9615,21 @@ func (c *Client) GetPersonWithResponse(ctx context.Context, options *GetPersonRe
 			}
 		}
 		return out, nil
-	case 500:
+	case 503:
+		out.JSON503 = new(GetPersonErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetPersonErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
 	default:
 		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -160,6 +160,7 @@ type ExploreCacheUnavailableResponseReadiness string
 
 const (
 	ExploreCacheUnavailableResponseReadinessAbsent      ExploreCacheUnavailableResponseReadiness = "absent"
+	ExploreCacheUnavailableResponseReadinessBuilding    ExploreCacheUnavailableResponseReadiness = "building"
 	ExploreCacheUnavailableResponseReadinessDrifted     ExploreCacheUnavailableResponseReadiness = "drifted"
 	ExploreCacheUnavailableResponseReadinessInterrupted ExploreCacheUnavailableResponseReadiness = "interrupted"
 	ExploreCacheUnavailableResponseReadinessStaleSchema ExploreCacheUnavailableResponseReadiness = "stale_schema"
@@ -168,7 +169,7 @@ const (
 // Validate checks if the ExploreCacheUnavailableResponseReadiness value is valid
 func (e ExploreCacheUnavailableResponseReadiness) Validate() error {
 	switch e {
-	case ExploreCacheUnavailableResponseReadinessAbsent, ExploreCacheUnavailableResponseReadinessDrifted, ExploreCacheUnavailableResponseReadinessInterrupted, ExploreCacheUnavailableResponseReadinessStaleSchema:
+	case ExploreCacheUnavailableResponseReadinessAbsent, ExploreCacheUnavailableResponseReadinessBuilding, ExploreCacheUnavailableResponseReadinessDrifted, ExploreCacheUnavailableResponseReadinessInterrupted, ExploreCacheUnavailableResponseReadinessStaleSchema:
 		return nil
 	default:
 		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ExploreCacheUnavailableResponseReadiness value, got: %v", e))

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -495,7 +495,47 @@ func (s *SearchDomainsErrorResponseJSON503) UnmarshalJSON(data []byte) error {
 
 type GetDomainResponse = DomainSummary
 
-type GetDomainErrorResponse = ErrorResponse
+type GetDomainErrorResponse struct {
+	GetDomain_ErrorResponse_AnyOf *GetDomain_ErrorResponse_AnyOf `json:"-"`
+}
+
+func (r GetDomainErrorResponse) Error() string {
+	return "unmapped client error"
+}
+
+func (g GetDomainErrorResponse) MarshalJSON() ([]byte, error) {
+	var parts []json.RawMessage
+
+	{
+		b, err := runtime.MarshalJSON(g.GetDomain_ErrorResponse_AnyOf)
+		if err != nil {
+			return nil, fmt.Errorf("GetDomain_ErrorResponse_AnyOf marshal: %w", err)
+		}
+		parts = append(parts, b)
+	}
+
+	return runtime.CoalesceOrMerge(parts...)
+}
+
+func (g *GetDomainErrorResponse) UnmarshalJSON(data []byte) error {
+	trim := bytes.TrimSpace(data)
+	if bytes.Equal(trim, []byte("null")) {
+		return nil
+	}
+	if len(trim) == 0 {
+		return fmt.Errorf("empty JSON input")
+	}
+
+	if g.GetDomain_ErrorResponse_AnyOf == nil {
+		g.GetDomain_ErrorResponse_AnyOf = &GetDomain_ErrorResponse_AnyOf{}
+	}
+
+	if err := runtime.UnmarshalJSON(data, g.GetDomain_ErrorResponse_AnyOf); err != nil {
+		return fmt.Errorf("GetDomain_ErrorResponse_AnyOf unmarshal: %w", err)
+	}
+
+	return nil
+}
 
 type SearchDomainFilesResponse = FileSearchHTTPResponse
 
@@ -1291,7 +1331,47 @@ func (s *SearchPeopleErrorResponseJSON503) UnmarshalJSON(data []byte) error {
 
 type GetPersonResponse = PersonSummary
 
-type GetPersonErrorResponse = ErrorResponse
+type GetPersonErrorResponse struct {
+	GetPerson_ErrorResponse_AnyOf *GetPerson_ErrorResponse_AnyOf `json:"-"`
+}
+
+func (r GetPersonErrorResponse) Error() string {
+	return "unmapped client error"
+}
+
+func (g GetPersonErrorResponse) MarshalJSON() ([]byte, error) {
+	var parts []json.RawMessage
+
+	{
+		b, err := runtime.MarshalJSON(g.GetPerson_ErrorResponse_AnyOf)
+		if err != nil {
+			return nil, fmt.Errorf("GetPerson_ErrorResponse_AnyOf marshal: %w", err)
+		}
+		parts = append(parts, b)
+	}
+
+	return runtime.CoalesceOrMerge(parts...)
+}
+
+func (g *GetPersonErrorResponse) UnmarshalJSON(data []byte) error {
+	trim := bytes.TrimSpace(data)
+	if bytes.Equal(trim, []byte("null")) {
+		return nil
+	}
+	if len(trim) == 0 {
+		return fmt.Errorf("empty JSON input")
+	}
+
+	if g.GetPerson_ErrorResponse_AnyOf == nil {
+		g.GetPerson_ErrorResponse_AnyOf = &GetPerson_ErrorResponse_AnyOf{}
+	}
+
+	if err := runtime.UnmarshalJSON(data, g.GetPerson_ErrorResponse_AnyOf); err != nil {
+		return fmt.Errorf("GetPerson_ErrorResponse_AnyOf unmarshal: %w", err)
+	}
+
+	return nil
+}
 
 type SearchPersonFilesResponse = FileSearchHTTPResponse
 
@@ -2558,6 +2638,7 @@ type GetDomainResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *GetDomainResponse
+	JSON503      *GetDomainErrorResponse
 }
 
 type SearchDomainFilesResp struct {
@@ -3108,6 +3189,7 @@ type GetPersonResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *GetPersonResponse
+	JSON503      *GetPersonErrorResponse
 }
 
 type SearchPersonFilesResp struct {

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -1859,7 +1859,43 @@ type GetSearchCoverageResponse = SearchCoverageResponse
 
 type GetSearchCoverageErrorResponse = ErrorResponse
 
-type GetSearchCoverageErrorResponseJSON = ErrorResponse
+type GetSearchCoverageErrorResponseJSON struct {
+	GetSearchCoverage_ErrorResponse_503_AnyOf *GetSearchCoverage_ErrorResponse_503_AnyOf `json:"-"`
+}
+
+func (g GetSearchCoverageErrorResponseJSON) MarshalJSON() ([]byte, error) {
+	var parts []json.RawMessage
+
+	{
+		b, err := runtime.MarshalJSON(g.GetSearchCoverage_ErrorResponse_503_AnyOf)
+		if err != nil {
+			return nil, fmt.Errorf("GetSearchCoverage_ErrorResponse_503_AnyOf marshal: %w", err)
+		}
+		parts = append(parts, b)
+	}
+
+	return runtime.CoalesceOrMerge(parts...)
+}
+
+func (g *GetSearchCoverageErrorResponseJSON) UnmarshalJSON(data []byte) error {
+	trim := bytes.TrimSpace(data)
+	if bytes.Equal(trim, []byte("null")) {
+		return nil
+	}
+	if len(trim) == 0 {
+		return fmt.Errorf("empty JSON input")
+	}
+
+	if g.GetSearchCoverage_ErrorResponse_503_AnyOf == nil {
+		g.GetSearchCoverage_ErrorResponse_503_AnyOf = &GetSearchCoverage_ErrorResponse_503_AnyOf{}
+	}
+
+	if err := runtime.UnmarshalJSON(data, g.GetSearchCoverage_ErrorResponse_503_AnyOf); err != nil {
+		return fmt.Errorf("GetSearchCoverage_ErrorResponse_503_AnyOf unmarshal: %w", err)
+	}
+
+	return nil
+}
 
 type DeepSearchResponseJSON = DeepSearchResponse
 

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -2128,7 +2128,7 @@ type ExploreCacheUnavailableResponse struct {
 	ErrorData      string                                   `json:"error" validate:"required"`
 	Message        string                                   `json:"message" validate:"required"`
 	Readiness      ExploreCacheUnavailableResponseReadiness `json:"readiness" validate:"required"`
-	RecoveryAction string                                   `json:"recovery_action" validate:"required"`
+	RecoveryAction string                                   `json:"recovery_action" validate:"omitempty"`
 }
 
 func (e ExploreCacheUnavailableResponse) Validate() error {
@@ -2143,9 +2143,6 @@ func (e ExploreCacheUnavailableResponse) Validate() error {
 		if err := v.Validate(); err != nil {
 			errors = errors.Append("Readiness", err)
 		}
-	}
-	if err := typesValidator.Var(e.RecoveryAction, "required"); err != nil {
-		errors = errors.Append("RecoveryAction", err)
 	}
 	if len(errors) == 0 {
 		return nil

--- a/pkg/client/generated/unions.go
+++ b/pkg/client/generated/unions.go
@@ -272,6 +272,24 @@ func (s *SearchDomains_ErrorResponse_503_AnyOf) Validate() error {
 	return nil
 }
 
+type GetDomain_ErrorResponse_AnyOf struct {
+	runtime.Either[ExploreCacheUnavailableResponse, ErrorResponse]
+}
+
+func (g *GetDomain_ErrorResponse_AnyOf) Validate() error {
+	if g.IsA() {
+		if v, ok := any(g.A).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	if g.IsB() {
+		if v, ok := any(g.B).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	return nil
+}
+
 type SearchDomainFiles_ErrorResponse_503_AnyOf struct {
 	runtime.Either[ExploreCacheUnavailableResponse, ErrorResponse]
 }
@@ -464,6 +482,24 @@ func (s *SearchPeople_ErrorResponse_503_AnyOf) Validate() error {
 	}
 	if s.IsB() {
 		if v, ok := any(s.B).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	return nil
+}
+
+type GetPerson_ErrorResponse_AnyOf struct {
+	runtime.Either[ExploreCacheUnavailableResponse, ErrorResponse]
+}
+
+func (g *GetPerson_ErrorResponse_AnyOf) Validate() error {
+	if g.IsA() {
+		if v, ok := any(g.A).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	if g.IsB() {
+		if v, ok := any(g.B).(runtime.Validator); ok {
 			return v.Validate()
 		}
 	}

--- a/pkg/client/generated/unions.go
+++ b/pkg/client/generated/unions.go
@@ -577,3 +577,21 @@ func (s *SearchMessages_Response_OneOf) Validate() error {
 	}
 	return nil
 }
+
+type GetSearchCoverage_ErrorResponse_503_AnyOf struct {
+	runtime.Either[ExploreCacheUnavailableResponse, ErrorResponse]
+}
+
+func (g *GetSearchCoverage_ErrorResponse_503_AnyOf) Validate() error {
+	if g.IsA() {
+		if v, ok := any(g.A).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	if g.IsB() {
+		if v, ok := any(g.B).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	return nil
+}

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2432,6 +2432,8 @@ components:
             - ExploreCacheUnavailableResponseReadinessDrifted
         recovery_action:
           type: string
+          x-oapi-codegen-extra-tags:
+            validate: omitempty
       required:
         - error
         - message

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -7894,7 +7894,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 1.42.0
+  version: 1.43.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -10731,6 +10731,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/DomainSummary"
           description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
         default:
           content:
             application/json:
@@ -13490,6 +13498,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/PersonSummary"
           description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
         default:
           content:
             application/json:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2419,12 +2419,14 @@ components:
         readiness:
           enum:
             - absent
+            - building
             - interrupted
             - stale_schema
             - drifted
           type: string
           x-enum-names:
             - ExploreCacheUnavailableResponseReadinessAbsent
+            - ExploreCacheUnavailableResponseReadinessBuilding
             - ExploreCacheUnavailableResponseReadinessInterrupted
             - ExploreCacheUnavailableResponseReadinessStaleSchema
             - ExploreCacheUnavailableResponseReadinessDrifted

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -15833,8 +15833,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
-          description: Error
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
         default:
           content:
             application/json:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -3647,7 +3647,7 @@ export interface components {
             error: string;
             message: string;
             /** @enum {string} */
-            readiness: "absent" | "interrupted" | "stale_schema" | "drifted";
+            readiness: "absent" | "building" | "interrupted" | "stale_schema" | "drifted";
             recovery_action: string;
         } & {
             [key: string]: unknown;

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -9281,6 +9281,15 @@ export interface operations {
                     "application/json": components["schemas"]["DomainSummary"];
                 };
             };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExploreCacheUnavailableResponse"] | components["schemas"]["ErrorResponse"];
+                };
+            };
             /** @description Error */
             default: {
                 headers: {
@@ -12368,6 +12377,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PersonSummary"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExploreCacheUnavailableResponse"] | components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -15046,13 +15046,13 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Error */
+            /** @description Service Unavailable */
             503: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
+                    "application/json": components["schemas"]["ExploreCacheUnavailableResponse"] | components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/lib/components/explore/EverythingTable.svelte
+++ b/web/src/lib/components/explore/EverythingTable.svelte
@@ -470,10 +470,14 @@
     >
       {#if unavailable}
         <div role="row"><div role="gridcell" aria-colspan={visibleColumns.length}><div class="cache-unavailable" role="alert">
-            <strong>Analytical cache unavailable</strong>
+            <strong>{unavailable.readiness === 'building' ? 'Preparing analytical cache' : 'Analytical cache unavailable'}</strong>
             <span>{unavailable.message}</span>
-            <span>Rebuild it with <code>{unavailable.recovery_action}</code>, then retry.</span>
-            <div><Button label="Retry cache check" tone="info" surface="outline" onclick={() => onRetry?.()} /></div>
+            {#if unavailable.readiness === 'building'}
+              <span>This view will refresh automatically.</span>
+            {:else}
+              <span>Rebuild it with <code>{unavailable.recovery_action}</code>, then retry.</span>
+              <div><Button label="Retry cache check" tone="info" surface="outline" onclick={() => onRetry?.()} /></div>
+            {/if}
           </div>
         </div>
         </div>

--- a/web/src/lib/components/explore/EverythingTable.test.ts
+++ b/web/src/lib/components/explore/EverythingTable.test.ts
@@ -385,6 +385,26 @@ describe('EverythingTable', () => {
     expect(screen.queryByText('No items match this view')).toBeNull();
   });
 
+  it('presents cache initialization as automatic recovery', () => {
+    const selection = new ExploreSelectionState();
+    render(EverythingTable, {
+      rows: [],
+      selection,
+      unavailable: {
+        error: 'analytical_cache_unavailable',
+        message: 'The analytical cache is being prepared',
+        readiness: 'building',
+        recovery_action: ''
+      }
+    });
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Preparing analytical cache');
+    expect(alert.textContent).toContain('This view will refresh automatically.');
+    expect(alert.textContent).not.toContain('Rebuild it with');
+    expect(screen.queryByRole('button', { name: 'Retry cache check' })).toBeNull();
+  });
+
   it('keeps loaded rows visible with an inline retry when a cursor page fails', async () => {
     const selection = new ExploreSelectionState();
     const onLoadMore = vi.fn().mockResolvedValue(undefined);

--- a/web/src/lib/components/explore/FilesPresentation.svelte
+++ b/web/src/lib/components/explore/FilesPresentation.svelte
@@ -278,7 +278,15 @@
     </div>
     <div class="file-body" role="rowgroup">
       {#if unavailable}
-        <div role="row"><div role="gridcell" aria-colspan="5"><div class="notice" role="alert"><strong>Analytical cache unavailable</strong><span>{unavailable.message}</span><Button label="Retry cache check" surface="outline" onclick={() => onRetry?.()} /></div></div></div>
+        <div role="row"><div role="gridcell" aria-colspan="5"><div class="notice" role="alert">
+          <strong>{unavailable.readiness === 'building' ? 'Preparing analytical cache' : 'Analytical cache unavailable'}</strong>
+          <span>{unavailable.message}</span>
+          {#if unavailable.readiness === 'building'}
+            <span>This view will refresh automatically.</span>
+          {:else}
+            <Button label="Retry cache check" surface="outline" onclick={() => onRetry?.()} />
+          {/if}
+        </div></div></div>
       {:else if error && files.length === 0}
         <div role="row"><div role="gridcell" aria-colspan="5"><div class="notice" role="alert"><span>{error}</span><Button label="Retry request" surface="outline" onclick={() => onRetry?.()} /></div></div></div>
       {:else if loading && files.length === 0}

--- a/web/src/lib/components/explore/FilesPresentation.test.ts
+++ b/web/src/lib/components/explore/FilesPresentation.test.ts
@@ -22,6 +22,23 @@ function file(index: number): ExploreFileFact {
 }
 
 describe('FilesPresentation', () => {
+  it('reports cache initialization and waits for automatic recovery', () => {
+    render(FilesPresentation, {
+      files: [],
+      unavailable: {
+        error: 'analytical_cache_unavailable',
+        message: 'The analytical cache is being prepared',
+        readiness: 'building',
+        recovery_action: ''
+      }
+    });
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Preparing analytical cache');
+    expect(alert.textContent).toContain('This view will refresh automatically.');
+    expect(screen.queryByRole('button', { name: 'Retry cache check' })).toBeNull();
+  });
+
   it('virtualizes a large loaded slice and implements bounded table navigation', async () => {
     const files = Array.from({ length: 1_000 }, (_, index) => file(index + 1));
     const onActiveKey = vi.fn();

--- a/web/src/lib/components/explore/GroupTable.svelte
+++ b/web/src/lib/components/explore/GroupTable.svelte
@@ -300,10 +300,14 @@
     <div class="group-body" role="rowgroup">
       {#if unavailable}
         <div role="row"><div role="gridcell" aria-colspan="5"><div class="group-cache-unavailable" role="alert">
-        <strong>Analytical cache unavailable</strong>
+        <strong>{unavailable.readiness === 'building' ? 'Preparing analytical cache' : 'Analytical cache unavailable'}</strong>
         <span>{unavailable.message}</span>
-        <span>Rebuild it with <code>{unavailable.recovery_action}</code>, then retry.</span>
-        <div><Button label="Retry cache check" tone="info" surface="outline" onclick={() => onRetry?.()} /></div>
+        {#if unavailable.readiness === 'building'}
+          <span>This view will refresh automatically.</span>
+        {:else}
+          <span>Rebuild it with <code>{unavailable.recovery_action}</code>, then retry.</span>
+          <div><Button label="Retry cache check" tone="info" surface="outline" onclick={() => onRetry?.()} /></div>
+        {/if}
         </div></div></div>
       {:else if error}
         <div role="row"><div role="gridcell" aria-colspan="5"><div class="group-request-error" role="alert">

--- a/web/src/lib/components/files/FilesWorkspace.svelte
+++ b/web/src/lib/components/files/FilesWorkspace.svelte
@@ -4,7 +4,7 @@
 
   import type { APIClient } from '../../api/client';
   import { analyticalAuthority } from '../../explore/authority';
-  import type { ExplorePredicate, FileMIMEFamily, FileSearchResponse, FileSearchRow, FileSearchSort } from '../../explore/models';
+  import type { ExploreCacheUnavailable, ExplorePredicate, FileMIMEFamily, FileSearchResponse, FileSearchRow, FileSearchSort } from '../../explore/models';
   import { isRetryableStatus } from '../../relationships/controller.svelte';
   import { rebaseVirtualScroll, RowGeometry, tableViewportHeight } from '../../theme/preferences.svelte';
   import FileViewer from './FileViewer.svelte';
@@ -71,7 +71,7 @@
   let loadingMore = $state(false);
   let error = $state('');
   let pageError = $state('');
-  let unavailable = $state('');
+  let unavailable = $state<ExploreCacheUnavailable>();
   let grid = $state<HTMLDivElement>();
   let headerElement = $state<HTMLDivElement>();
   let viewport = $state(360);
@@ -81,6 +81,7 @@
   let pendingViewerKey = $state<string | null>(null);
   let viewerReturnFocus = $state<HTMLElement>();
   let controller: AbortController | undefined;
+  let cacheBuildRetry: ReturnType<typeof setTimeout> | undefined;
   let generation = 0;
   let cacheRevision = '';
   let pageAuthority = '';
@@ -213,10 +214,15 @@
     if (headerElement) observer.observe(headerElement);
     return () => observer.disconnect();
   });
-  onDestroy(() => { controller?.abort(); geometry.destroy(); });
+  onDestroy(() => {
+    controller?.abort();
+    clearCacheBuildRetry();
+    geometry.destroy();
+  });
 
   function restartListing(): { generation: number; signal: AbortSignal } {
     const currentGeneration = ++generation;
+    clearCacheBuildRetry();
     controller?.abort();
     const nextController = new AbortController();
     controller = nextController;
@@ -228,7 +234,7 @@
     seenCursors = new Set<string>();
     error = '';
     pageError = '';
-    unavailable = '';
+    unavailable = undefined;
     pendingRestoration = undefined;
     completingRestoration = '';
     loading = true;
@@ -298,7 +304,16 @@
         if (isRetryableStatus(response.status)) pageError = message;
         else failPaging(message);
       }
-      else if (response.status === 503) unavailable = message;
+      else if (response.status === 503 && isCacheUnavailable(responseError)) {
+        unavailable = responseError;
+        if (responseError.readiness === 'building') {
+          cacheBuildRetry = setTimeout(() => {
+            cacheBuildRetry = undefined;
+            if (currentGeneration === generation && !signal.aborted) reloadListing();
+          }, 1_000);
+        }
+      }
+      else if (response.status === 503) error = message;
       else error = message;
       return false;
     }
@@ -338,6 +353,17 @@
       onActiveKey?.(activeKey);
     }
     return true;
+  }
+
+  function clearCacheBuildRetry(): void {
+    if (cacheBuildRetry === undefined) return;
+    clearTimeout(cacheBuildRetry);
+    cacheBuildRetry = undefined;
+  }
+
+  function isCacheUnavailable(value: unknown): value is ExploreCacheUnavailable {
+    return typeof value === 'object' && value !== null &&
+      'readiness' in value && 'recovery_action' in value;
   }
 
   function failPaging(message: string): void {
@@ -562,8 +588,10 @@
         <span role="columnheader">Availability</span>
       </div>
       <div class="table-body" role="rowgroup">
-        {#if unavailable}
-          <div role="row"><div role="gridcell" aria-colspan="8"><div class="notice" role="alert"><strong>Analytical cache unavailable</strong><span>{unavailable}</span></div></div></div>
+        {#if unavailable?.readiness === 'building'}
+          <div role="row"><div role="gridcell" aria-colspan="8"><div class="notice" role="status">Preparing analytical cache…</div></div></div>
+        {:else if unavailable}
+          <div role="row"><div role="gridcell" aria-colspan="8"><div class="notice" role="alert"><strong>Analytical cache unavailable</strong><span>{unavailable.message}</span></div></div></div>
         {:else if error && rows.length === 0}
           <div role="row"><div role="gridcell" aria-colspan="8"><div class="notice" role="alert">{error}</div></div></div>
         {:else if loading && rows.length === 0}

--- a/web/src/lib/components/files/FilesWorkspace.svelte
+++ b/web/src/lib/components/files/FilesWorkspace.svelte
@@ -116,8 +116,9 @@
       pendingViewerKey = untrack(() => selectedKey) ?? null;
     }
     const { generation: currentGeneration, signal } = restartListing();
-    void loadPage(currentGeneration, undefined, signal).then(() =>
-      restoreDeepState(currentGeneration, restorationEpoch, controller?.signal));
+    void loadPage(currentGeneration, undefined, signal).then((loaded) => {
+      if (loaded) return restoreDeepState(currentGeneration, restorationEpoch, signal);
+    });
   });
 
   $effect(() => {
@@ -246,8 +247,9 @@
     // unacknowledged the deep restoration restarts against the fresh listing.
     const epoch = unacknowledgedRestorationEpoch;
     const { generation: currentGeneration, signal } = restartListing();
-    void loadPage(currentGeneration, undefined, signal).then(() =>
-      restoreDeepState(currentGeneration, epoch, signal));
+    void loadPage(currentGeneration, undefined, signal).then((loaded) => {
+      if (loaded) return restoreDeepState(currentGeneration, epoch, signal);
+    });
   }
 
   async function loadPage(currentGeneration: number, cursor: string | undefined, signal: AbortSignal): Promise<boolean> {

--- a/web/src/lib/components/files/FilesWorkspace.test.ts
+++ b/web/src/lib/components/files/FilesWorkspace.test.ts
@@ -101,6 +101,51 @@ describe('FilesWorkspace', () => {
     vi.useRealTimers();
   });
 
+  it('preserves a later-page file restoration across initial cache preparation', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const first = response();
+    first.files[0] = { ...first.files[0]!, id: 1, key: 'file:1', filename: 'first.pdf' };
+    Object.assign(first, { total_count: 2, next_cursor: 'page-2' });
+    const second = response();
+    second.files[0] = { ...second.files[0]!, id: 900, key: 'file:900', filename: 'deep.pdf' };
+    second.total_count = 2;
+    let initialCalls = 0;
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url, document.baseURI).pathname;
+      if (path === '/api/v1/files/900') return Response.json({
+        id: 900, message_id: 11, conversation_id: 21, filename: 'deep.pdf', mime_type: 'application/pdf',
+        size_bytes: 2048, content_state: 'missing_blob', content_available: false
+      });
+      const body = await request.clone().json() as { cursor?: string };
+      if (body.cursor === 'page-2') return Response.json(second);
+      initialCalls += 1;
+      if (initialCalls === 1) return Response.json({
+        error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+        readiness: 'building', recovery_action: ''
+      }, { status: 503 });
+      return Response.json(first);
+    });
+    const onRestorationComplete = vi.fn();
+    const rendered = render(FilesWorkspace, {
+      client: createAPIClient(fetchFn), predicate: { filters: [], presentation: 'table' },
+      sort: { field: 'occurred_at', direction: 'desc' }, selectedKey: 'file:900',
+      activeKey: 'file:900', restorationEpoch: 11, onRestorationComplete
+    });
+    try {
+      expect(await screen.findByText('Preparing analytical cache…')).toBeDefined();
+      expect(onRestorationComplete).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await waitFor(() => expect(onRestorationComplete).toHaveBeenCalledWith(11));
+      expect(await screen.findByRole('dialog', { name: 'View deep.pdf' })).toBeDefined();
+      expect(initialCalls).toBe(2);
+    } finally {
+      rendered.unmount();
+      vi.useRealTimers();
+    }
+  });
+
   it('cancels cache-readiness polling when the Files workspace is destroyed', async () => {
     vi.useFakeTimers();
     const fetchFn = vi.fn<typeof fetch>(async () => Response.json({

--- a/web/src/lib/components/files/FilesWorkspace.test.ts
+++ b/web/src/lib/components/files/FilesWorkspace.test.ts
@@ -75,7 +75,55 @@ describe('FilesWorkspace', () => {
     expect(grid.contains(await screen.findByRole('row', { name: /fixture.pdf/ }))).toBe(true);
   });
 
-  afterEach(() => vi.unstubAllGlobals());
+  it('retries a building analytical cache and renders files when it becomes ready', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchFn = vi.fn<typeof fetch>(async () => {
+      calls += 1;
+      if (calls === 1) return Response.json({
+        error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+        readiness: 'building', recovery_action: ''
+      }, { status: 503 });
+      return Response.json(response());
+    });
+    const rendered = render(FilesWorkspace, {
+      client: createAPIClient(fetchFn), predicate: { filters: [], presentation: 'table' },
+      sort: { field: 'occurred_at', direction: 'desc' }
+    });
+
+    expect(await screen.findByText('Preparing analytical cache…')).toBeDefined();
+    expect(screen.queryByText('Analytical cache unavailable')).toBeNull();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await screen.findByText('fixture.pdf')).toBeDefined();
+    expect(calls).toBe(2);
+
+    rendered.unmount();
+    vi.useRealTimers();
+  });
+
+  it('cancels cache-readiness polling when the Files workspace is destroyed', async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn<typeof fetch>(async () => Response.json({
+      error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+      readiness: 'building', recovery_action: ''
+    }, { status: 503 }));
+    const rendered = render(FilesWorkspace, {
+      client: createAPIClient(fetchFn), predicate: { filters: [], presentation: 'table' },
+      sort: { field: 'occurred_at', direction: 'desc' }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchFn).toHaveBeenCalledOnce();
+
+    rendered.unmount();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
 
   it('requests a bounded canonical page and commits stable sortable headers', async () => {
     const requests: Request[] = [];

--- a/web/src/lib/components/relationships/RelationshipList.svelte
+++ b/web/src/lib/components/relationships/RelationshipList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Button, SearchInput, SegmentedControl } from '@kenn-io/kit-ui';
 
-  import type { DomainSummary, PersonSummary } from '../../explore/models';
+  import type { DomainSummary, ExploreCacheUnavailable, PersonSummary } from '../../explore/models';
   import type { RelationshipFacet, RelationshipRow } from '../../relationships/models';
   import { compactDate } from '../../util/dates';
   import EmptyState from '../common/EmptyState.svelte';
@@ -14,7 +14,7 @@
     hasMore?: boolean;
     totalCount?: number | null;
     error: string | null;
-    degraded: 'cache_unavailable' | null;
+    degraded: ExploreCacheUnavailable | null;
     facet: RelationshipFacet;
     query: string;
     showAll: boolean;
@@ -183,7 +183,12 @@
     </div>
   </div>
 
-  {#if degraded === 'cache_unavailable'}
+  {#if degraded?.readiness === 'building'}
+    <section class="named-state" role="status">
+      <strong>Preparing relationship ranking…</strong>
+      <span>This view will load automatically when the analytical cache is ready.</span>
+    </section>
+  {:else if degraded}
     <section class="named-state" role="status">
       <strong>Relationship ranking needs the analytical cache/engine</strong>
       <span>Rebuild the analytical cache with <code>msgvault build-cache</code>, then retry.</span>

--- a/web/src/lib/components/relationships/RelationshipList.test.ts
+++ b/web/src/lib/components/relationships/RelationshipList.test.ts
@@ -289,11 +289,32 @@ describe('RelationshipList', () => {
 
   it('renders the named degraded state with an Open Everything action instead of the grid', async () => {
     const onOpenEverything = vi.fn();
-    render(RelationshipList, { ...baseProps(), degraded: 'cache_unavailable', onOpenEverything });
+    render(RelationshipList, {
+      ...baseProps(),
+      degraded: {
+        error: 'analytical_cache_unavailable', message: 'The committed analytical cache is unavailable',
+        readiness: 'stale_schema', recovery_action: 'Rebuild the analytical cache'
+      },
+      onOpenEverything
+    });
 
     expect(screen.getByText('Relationship ranking needs the analytical cache/engine')).toBeDefined();
     expect(screen.queryByRole('grid')).toBeNull();
     await fireEvent.click(screen.getByRole('button', { name: 'Open Everything' }));
     expect(onOpenEverything).toHaveBeenCalledOnce();
+  });
+
+  it('shows cache preparation without manual rebuild instructions', () => {
+    render(RelationshipList, {
+      ...baseProps(),
+      degraded: {
+        error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+        readiness: 'building', recovery_action: ''
+      }
+    });
+
+    expect(screen.getByText('Preparing relationship ranking…')).toBeDefined();
+    expect(screen.queryByText(/msgvault build-cache/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Open Everything' })).toBeNull();
   });
 });

--- a/web/src/lib/components/shell/AppShell.svelte
+++ b/web/src/lib/components/shell/AppShell.svelte
@@ -727,7 +727,7 @@
   $effect(() => {
     if (landingFallbackApplied || !arrivedWithoutExploreParam) return;
     if (exploreState.current.workspace !== 'relationships') return;
-    if (relationshipsController.degraded !== 'cache_unavailable') return;
+    if (!relationshipsController.degraded || relationshipsController.degraded.readiness === 'building') return;
     landingFallbackApplied = true;
     // A committed replace, not a transient one: `committed` is what the
     // next push rewrites the current history entry from (see

--- a/web/src/lib/components/shell/AppShell.test.ts
+++ b/web/src/lib/components/shell/AppShell.test.ts
@@ -352,6 +352,23 @@ describe('AppShell', () => {
     state.destroy();
   });
 
+  it('keeps the default Relationships landing while the analytical cache is building', async () => {
+    window.history.replaceState(null, '', '/');
+    const fetchFn = vi.fn<typeof fetch>(async () => Response.json({
+      error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+      readiness: 'building', recovery_action: ''
+    }, { status: 503 }));
+    const state = new ExploreState(window);
+    const rendered = render(AppShell, { client: createAPIClient(fetchFn), state });
+
+    expect(await screen.findByText('Preparing relationship ranking…')).toBeDefined();
+    expect(state.current.workspace).toBe('relationships');
+    expect(screen.queryByRole('main', { name: 'Everything' })).toBeNull();
+
+    rendered.unmount();
+    state.destroy();
+  });
+
 
   it('a committed replace for the landing fallback keeps Back from resurrecting the degraded hub', async () => {
     window.history.replaceState(null, '', '/');

--- a/web/src/lib/components/shell/EverythingWorkspace.test.ts
+++ b/web/src/lib/components/shell/EverythingWorkspace.test.ts
@@ -96,6 +96,40 @@ describe('EverythingWorkspace', () => {
     }
   });
 
+  it('polls a structured cache-building coverage response until coverage is ready', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    window.history.replaceState(null, '', `/?explore=${encodeURIComponent(JSON.stringify({ workspace: 'everything' }))}`);
+    let coverageCalls = 0;
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const path = new URL(input instanceof Request ? input.url : String(input)).pathname;
+      if (path.endsWith('/coverage')) {
+        coverageCalls += 1;
+        if (coverageCalls === 1) return Response.json({
+          error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+          readiness: 'building', recovery_action: ''
+        }, { status: 503 });
+        return Response.json({
+          status: 'ready', eligible_count: 2, embedded_count: 2, percentage: 100,
+          cache_revision: 'cache-1', actions: []
+        });
+      }
+      return Response.json(exploreResponse());
+    });
+    const state = new ExploreState(window);
+    state.replaceSearchDraft('', 'semantic');
+    const rendered = render(AppShell, { client: createAPIClient(fetchFn), state });
+    try {
+      expect(await screen.findByText('Semantic index is initializing.')).toBeDefined();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(await screen.findByText('Semantic index: 100% of 2 items.')).toBeDefined();
+      expect(coverageCalls).toBe(2);
+    } finally {
+      rendered.unmount();
+      state.destroy();
+      vi.useRealTimers();
+    }
+  });
+
 
   it('backs off exponentially while semantic coverage stays initializing', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/web/src/lib/explore/api.test.ts
+++ b/web/src/lib/explore/api.test.ts
@@ -47,6 +47,20 @@ describe('ExploreAPI routing', () => {
     expect(paths).toEqual(['/api/v1/search/coverage', '/api/v1/explore/match-counts']);
   });
 
+  it('maps transient analytical cache preparation to initializing coverage', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () => Response.json({
+      error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+      readiness: 'building', recovery_action: ''
+    }, { status: 503 }));
+    const api = createExploreAPI(createAPIClient(fetchFn));
+
+    await expect(api.coverage([])).resolves.toMatchObject({
+      status: 'initializing', eligible_count: 0, embedded_count: 0,
+      percentage: 0, cache_revision: '', actions: [],
+      detail: 'The analytical cache is being prepared'
+    });
+  });
+
   it('passes cursors and cancellation through the session-aware entry request', async () => {
     const requests: Request[] = [];
     const fetchFn = vi.fn<typeof fetch>(async (input) => {

--- a/web/src/lib/explore/api.ts
+++ b/web/src/lib/explore/api.ts
@@ -196,6 +196,17 @@ export function createExploreAPI(client: APIClient): ExploreAPI {
       const coverage = parseSearchCoverage(data);
       if (coverage) return coverage;
       if (data) throw new Error('Semantic coverage response is incompatible with this browser');
+      if (response.status === 503 && isCacheUnavailable(error) && error.readiness === 'building') {
+        return {
+          eligible_count: 0,
+          embedded_count: 0,
+          percentage: 0,
+          cache_revision: '',
+          status: 'initializing',
+          detail: error.message,
+          actions: []
+        };
+      }
       throw new Error(messageFor(error, response.status));
     },
     async matchCounts(predicate, rowKeys, signal) {

--- a/web/src/lib/explore/loader.svelte.test.ts
+++ b/web/src/lib/explore/loader.svelte.test.ts
@@ -274,6 +274,43 @@ describe('ExploreLoader', () => {
     state.destroy();
   });
 
+  it('automatically retries the initial view when the analytical cache finishes building', async () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, '', `/?explore=${encodeURIComponent(JSON.stringify({ workspace: 'everything' }))}`);
+    let calls = 0;
+    const fetchFn = vi.fn<typeof fetch>(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return Response.json({
+          error: 'analytical_cache_unavailable',
+          message: 'The analytical cache is being prepared',
+          readiness: 'building',
+          recovery_action: ''
+        }, { status: 503 });
+      }
+      return Response.json(exploreResponse({ rows: [entry(1)] }));
+    });
+    const state = new ExploreState(window);
+    const { loader, cleanup } = setup(fetchFn, state);
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls).toBe(1);
+      expect(loader.unavailable?.readiness).toBe('building');
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      flushSync();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(calls).toBe(2);
+      expect(loader.rows.map((row) => row.key)).toEqual(['message:1']);
+      expect(loader.unavailable).toBeUndefined();
+    } finally {
+      cleanup();
+      state.destroy();
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps loaded groups and retries the same grouped cursor after a failure', async () => {
     window.history.replaceState(null, '', `/?explore=${encodeURIComponent(JSON.stringify({ workspace: 'everything' }))}`);
     let cursorCalls = 0;

--- a/web/src/lib/explore/loader.svelte.ts
+++ b/web/src/lib/explore/loader.svelte.ts
@@ -42,6 +42,7 @@ const NO_PROGRESS_NOTICE = 'Pagination stopped because the next page made no row
 const REVISION_CHANGED_NOTICE = 'Results changed while loading another page. Reload this view.';
 export const END_PAUSE_NOTICE =
   'End paused loading to keep the table responsive; press End again to continue or refine the filters.';
+const CACHE_BUILD_RETRY_DELAY_MS = 1_000;
 
 function samePageAuthority(
   next: Pick<ExploreResult, 'cacheRevision' | 'searchProvenance' | 'candidateSnapshotId'>,
@@ -97,6 +98,7 @@ export class ExploreLoader {
   private seenCursors = new Set<string>();
   private restorationCycleCompleted = false;
   private selectionFingerprint = '';
+  private cacheBuildRetry: ReturnType<typeof setTimeout> | undefined;
   #retryRevision = $state(0);
 
   constructor(client: APIClient, state: ExploreState, callbacks: ExploreLoaderCallbacks) {
@@ -118,6 +120,7 @@ export class ExploreLoader {
   }
 
   private runLoad(requestFingerprint: string): void {
+    this.clearCacheBuildRetry();
     const workspace = this.state.current.workspace;
     const restorationEpoch = this.state.restorationEpoch;
     void this.#retryRevision;
@@ -199,6 +202,14 @@ export class ExploreLoader {
           this.fileFacts = [];
           this.result = undefined;
           this.unavailable = loaded.unavailable;
+          if (loaded.unavailable.readiness === 'building') {
+            this.cacheBuildRetry = setTimeout(() => {
+              this.cacheBuildRetry = undefined;
+              if (generation === this.requestGeneration && !controller.signal.aborted) {
+                this.#retryRevision += 1;
+              }
+            }, CACHE_BUILD_RETRY_DELAY_MS);
+          }
           return;
         }
         if (this.pageKind === 'entries') {
@@ -461,11 +472,19 @@ export class ExploreLoader {
   /** Forces a fresh load of the current predicate (e.g. a named retry
    * action after a failed request), without changing any URL state. */
   retry = (): void => {
+    this.clearCacheBuildRetry();
     this.#retryRevision += 1;
   };
 
   destroy = (): void => {
+    this.clearCacheBuildRetry();
     this.requestGeneration += 1;
     this.requestController?.abort();
   };
+
+  private clearCacheBuildRetry(): void {
+    if (this.cacheBuildRetry === undefined) return;
+    clearTimeout(this.cacheBuildRetry);
+    this.cacheBuildRetry = undefined;
+  }
 }

--- a/web/src/lib/relationships/controller.svelte.test.ts
+++ b/web/src/lib/relationships/controller.svelte.test.ts
@@ -297,9 +297,53 @@ describe('RelationshipsController.loadList', () => {
 
     await expect(controller.loadList({ filters: [], presentation: 'table' })).resolves.toBeUndefined();
 
-    expect(controller.degraded).toBe('cache_unavailable');
+    expect(controller.degraded?.readiness).toBe('stale_schema');
     expect(controller.listError).toBeNull();
     expect(controller.listLoading).toBe(false);
+  });
+
+  it('retries relationship ranking while the analytical cache is building', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchFn = vi.fn<typeof fetch>(async () => {
+      calls += 1;
+      if (calls === 1) return Response.json({
+        error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+        readiness: 'building', recovery_action: ''
+      }, { status: 503 });
+      return Response.json({
+        rows: [relationshipRow(11, 'Recovered Person')], total_count: 1,
+        cache_revision: 'cache-rel', identity_revision: 1
+      });
+    });
+    const controller = new RelationshipsController(createAPIClient(fetchFn), () => 'UTC');
+
+    await controller.loadList({ filters: [], presentation: 'table' });
+    expect(controller.degraded?.readiness).toBe('building');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(controller.listRows).toEqual([relationshipRow(11, 'Recovered Person')]);
+    expect(controller.degraded).toBeNull();
+    expect(calls).toBe(2);
+
+    controller.destroy();
+    vi.useRealTimers();
+  });
+
+  it('cancels relationship cache-readiness polling when destroyed', async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn<typeof fetch>(async () => Response.json({
+      error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+      readiness: 'building', recovery_action: ''
+    }, { status: 503 }));
+    const controller = new RelationshipsController(createAPIClient(fetchFn), () => 'UTC');
+
+    await controller.loadList({ filters: [], presentation: 'table' });
+    controller.destroy();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    vi.useRealTimers();
   });
 });
 

--- a/web/src/lib/relationships/controller.svelte.test.ts
+++ b/web/src/lib/relationships/controller.svelte.test.ts
@@ -725,6 +725,43 @@ describe('RelationshipsController text-query consistency', () => {
 });
 
 describe('RelationshipsController.openTarget', () => {
+  it('recovers a deep-linked cluster detail after cache initialization finishes', async () => {
+    vi.useFakeTimers();
+    const calls = new Map<string, number>();
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = pathOf(request);
+      const count = (calls.get(path) ?? 0) + 1;
+      calls.set(path, count);
+      if (count === 1) return Response.json({
+        error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+        readiness: 'building', recovery_action: ''
+      }, { status: 503 });
+      if (path === '/api/v1/people/12') return Response.json(person(12));
+      if (path === '/api/v1/relationships/12/timeline') {
+        return Response.json({
+          canonical_id: 12, identity_revision: 3, rows: [timelineRow('recovered')],
+          total_count: 1, cache_revision: 'cache-rel'
+        });
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    const controller = new RelationshipsController(createAPIClient(fetchFn), () => 'UTC');
+
+    await controller.openTarget('cluster:12', { filters: [], presentation: 'table' });
+    expect(controller.detail).toBeNull();
+    expect(controller.timelineRows).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => expect(controller.detail).toEqual(person(12)));
+    expect(controller.timelineRows).toEqual([timelineRow('recovered')]);
+    expect(calls.get('/api/v1/people/12')).toBe(2);
+    expect(calls.get('/api/v1/relationships/12/timeline')).toBe(2);
+
+    controller.destroy();
+    vi.useRealTimers();
+  });
+
   it("opens a cluster target's person header and cluster timeline, storing canonical_id + identity_revision", async () => {
     const requests: Request[] = [];
     const fetchFn = vi.fn<typeof fetch>(async (input) => {
@@ -1463,6 +1500,23 @@ describe('RelationshipsController.clearTarget', () => {
 });
 
 describe('RelationshipsController abort/destroy', () => {
+  it('cancels a pending deep-link cache retry when destroyed', async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn<typeof fetch>(async () => Response.json({
+      error: 'analytical_cache_unavailable', message: 'The analytical cache is being prepared',
+      readiness: 'building', recovery_action: ''
+    }, { status: 503 }));
+    const controller = new RelationshipsController(createAPIClient(fetchFn), () => 'UTC');
+
+    await controller.openTarget('cluster:12', { filters: [], presentation: 'table' });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    controller.destroy();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it('destroy() aborts the in-flight list load and detail load AbortControllers', async () => {
     const signals: AbortSignal[] = [];
     const fetchFn = vi.fn<typeof fetch>(async (input) => {

--- a/web/src/lib/relationships/controller.svelte.ts
+++ b/web/src/lib/relationships/controller.svelte.ts
@@ -94,6 +94,7 @@ export class RelationshipsController {
   private listAbort: AbortController | undefined;
   private cacheBuildRetry: ReturnType<typeof setTimeout> | undefined;
   private detailAbort: AbortController | undefined;
+  private detailCacheBuildRetry: ReturnType<typeof setTimeout> | undefined;
   private listGeneration = 0;
   private detailGeneration = 0;
   private listPageRequest: ListPageRequest | undefined;
@@ -263,6 +264,7 @@ export class RelationshipsController {
   }
 
   async openTarget(target: string, predicate: ExplorePredicate): Promise<void> {
+    this.clearDetailCacheBuildRetry();
     this.detailAbort?.abort();
     const controller = new AbortController();
     this.detailAbort = controller;
@@ -319,9 +321,13 @@ export class RelationshipsController {
       const base = personResponse.data;
       if (base) this.detail = summary ? mergePersonDetail(base, summary) : base;
       else if (summary) this.detail = summary;
-      if (!base) this.timelineError ||= errorMessage(personResponse.error, personResponse.response.status);
+      if (!base && !this.handleDetailCacheBuilding(
+        personResponse.error, personResponse.response.status, generation, signal
+      )) this.timelineError ||= errorMessage(personResponse.error, personResponse.response.status);
       if (summaryResponse && !summaryResponse.data) {
-        this.timelineError ||= errorMessage(summaryResponse.error, summaryResponse.response.status);
+        if (!this.handleDetailCacheBuilding(
+          summaryResponse.error, summaryResponse.response.status, generation, signal
+        )) this.timelineError ||= errorMessage(summaryResponse.error, summaryResponse.response.status);
       }
     } catch (cause: unknown) {
       if (!signal.aborted && generation === this.detailGeneration) this.timelineError ||= errorMessage(cause, 0);
@@ -348,9 +354,13 @@ export class RelationshipsController {
       const base = detailResponse.data;
       if (base) this.detail = summary ? { ...base, ...summary } : base;
       else if (summary) this.detail = summary;
-      if (!base) this.timelineError ||= errorMessage(detailResponse.error, detailResponse.response.status);
+      if (!base && !this.handleDetailCacheBuilding(
+        detailResponse.error, detailResponse.response.status, generation, signal
+      )) this.timelineError ||= errorMessage(detailResponse.error, detailResponse.response.status);
       if (summaryResponse && !summaryResponse.data) {
-        this.timelineError ||= errorMessage(summaryResponse.error, summaryResponse.response.status);
+        if (!this.handleDetailCacheBuilding(
+          summaryResponse.error, summaryResponse.response.status, generation, signal
+        )) this.timelineError ||= errorMessage(summaryResponse.error, summaryResponse.response.status);
       }
     } catch (cause: unknown) {
       if (!signal.aborted && generation === this.detailGeneration) this.timelineError ||= errorMessage(cause, 0);
@@ -366,6 +376,7 @@ export class RelationshipsController {
    * bumps the generation counter so a late response cannot resurrect it.
    */
   clearTarget(): void {
+    this.clearDetailCacheBuildRetry();
     this.detailAbort?.abort();
     this.detailAbort = undefined;
     ++this.detailGeneration;
@@ -422,6 +433,7 @@ export class RelationshipsController {
       if (signal.aborted || generation !== this.detailGeneration) return;
       const { data, error, response: res } = response;
       if (!data) {
+        if (this.handleDetailCacheBuilding(error, res.status, generation, signal)) return;
         if (cursor && res.status === 409 && isErrorCode(error, 'cursor_invalidated')) {
           this.timelineRows = [];
           this.timelineCursor = null;
@@ -466,6 +478,7 @@ export class RelationshipsController {
       if (signal.aborted || generation !== this.detailGeneration) return;
       const { data, error, response: res } = response;
       if (!data) {
+        if (this.handleDetailCacheBuilding(error, res.status, generation, signal)) return;
         // The domain timeline forwards to the explore engine, whose cursor
         // invalidation surfaces as 409 archive_revision_changed (unlike the
         // cluster timeline's cursor_invalidated): restart from page 1 the
@@ -544,6 +557,7 @@ export class RelationshipsController {
 
   destroy(): void {
     this.clearCacheBuildRetry();
+    this.clearDetailCacheBuildRetry();
     this.listAbort?.abort();
     this.detailAbort?.abort();
   }
@@ -552,6 +566,34 @@ export class RelationshipsController {
     if (this.cacheBuildRetry === undefined) return;
     clearTimeout(this.cacheBuildRetry);
     this.cacheBuildRetry = undefined;
+  }
+
+  private handleDetailCacheBuilding(
+    error: unknown,
+    status: number,
+    generation: number,
+    signal: AbortSignal
+  ): boolean {
+    if (signal.aborted || generation !== this.detailGeneration || status !== 503 ||
+      !isCacheUnavailable(error) || error.readiness !== 'building') return false;
+    this.timelineError = error.message;
+    if (this.detailCacheBuildRetry === undefined && this.target && this.lastPredicate) {
+      const target = this.target;
+      const predicate = this.lastPredicate;
+      this.detailCacheBuildRetry = setTimeout(() => {
+        this.detailCacheBuildRetry = undefined;
+        if (generation === this.detailGeneration && !signal.aborted) {
+          void this.openTarget(target, predicate);
+        }
+      }, 1_000);
+    }
+    return true;
+  }
+
+  private clearDetailCacheBuildRetry(): void {
+    if (this.detailCacheBuildRetry === undefined) return;
+    clearTimeout(this.detailCacheBuildRetry);
+    this.detailCacheBuildRetry = undefined;
   }
 }
 

--- a/web/src/lib/relationships/controller.svelte.ts
+++ b/web/src/lib/relationships/controller.svelte.ts
@@ -65,7 +65,7 @@ export class RelationshipsController {
    * in `listPageRequest`; null when the last page has been reached. */
   listCursor = $state<string | null>(null);
   listTotalCount = $state<number | null>(null);
-  degraded = $state<'cache_unavailable' | null>(null);
+  degraded = $state<ExploreCacheUnavailable | null>(null);
 
   target = $state<string | null>(null);
   /** Fingerprint of the predicate `target` was last opened with — lets a
@@ -92,6 +92,7 @@ export class RelationshipsController {
   private readonly client: APIClient;
   private readonly timezone: () => string;
   private listAbort: AbortController | undefined;
+  private cacheBuildRetry: ReturnType<typeof setTimeout> | undefined;
   private detailAbort: AbortController | undefined;
   private listGeneration = 0;
   private detailGeneration = 0;
@@ -111,6 +112,7 @@ export class RelationshipsController {
   }
 
   async loadList(predicate: ExplorePredicate): Promise<void> {
+    this.clearCacheBuildRetry();
     this.listAbort?.abort();
     const controller = new AbortController();
     this.listAbort = controller;
@@ -246,7 +248,15 @@ export class RelationshipsController {
     this.listCursor = null;
     this.listRows = [];
     if (res.status === 503 && isCacheUnavailable(error)) {
-      this.degraded = 'cache_unavailable';
+      this.degraded = error;
+      if (error.readiness === 'building') {
+        this.cacheBuildRetry = setTimeout(() => {
+          this.cacheBuildRetry = undefined;
+          if (generation === this.listGeneration && !signal.aborted && this.lastListPredicate) {
+            void this.loadList(this.lastListPredicate);
+          }
+        }, 1_000);
+      }
       return;
     }
     this.listError = errorMessage(error, res.status);
@@ -533,8 +543,15 @@ export class RelationshipsController {
   }
 
   destroy(): void {
+    this.clearCacheBuildRetry();
     this.listAbort?.abort();
     this.detailAbort?.abort();
+  }
+
+  private clearCacheBuildRetry(): void {
+    if (this.cacheBuildRetry === undefined) return;
+    clearTimeout(this.cacheBuildRetry);
+    this.cacheBuildRetry = undefined;
   }
 }
 


### PR DESCRIPTION
Cache-dependent views now distinguish automatic cache preparation from terminal cache failures. Initial Everything, grouped, and Files requests retry while the daemon is building the required cache, then recover without a manual reload. Terminal states keep the explicit full-rebuild guidance.

The transient readiness value is part of the OpenAPI contract and generated Go and web clients. The storage architecture documents the startup behavior.