### PR TITLE
fix(ci): allow contended CLI suite to finish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,14 +86,14 @@ clean:
 	rm -rf bin/
 
 # Run tests. The CLI package has nearly 1,000 tests, including heavy DuckDB
-# coverage, and its per-package wall clock can exceed 30m on contended CI
+# coverage, and its per-package wall clock can exceed 40m on contended CI
 # runners even when no individual test is stalled.
 test:
-	go test -timeout 40m -tags "$(BUILD_TAGS)" ./...
+	go test -timeout 60m -tags "$(BUILD_TAGS)" ./...
 
 # Run tests with verbose output
 test-v:
-	go test -timeout 40m -tags "$(BUILD_TAGS)" -v ./...
+	go test -timeout 60m -tags "$(BUILD_TAGS)" -v ./...
 
 # Run tests against PostgreSQL with the pgvector tag (set MSGVAULT_TEST_DB
 # first). Needs a server with the vector extension available.


### PR DESCRIPTION
Main-branch CI can keep the CLI test package making forward progress past its 40-minute package deadline on heavily contended public runners. The timeout then aborts the package even though active cache publication work is still progressing.

Raise the standard and verbose suite's per-package budget to 60 minutes. This keeps a bounded stall detector while giving shared-runner I/O enough headroom. Test behavior and coverage are unchanged.

<sup>generated by a clanker</sup>