### PR TITLE
fix(mcp): publish object-root output schemas

### DIFF
--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -264,6 +264,7 @@ func searchMessagesOutputSchema() *jsonschema.Schema {
 	semantic.Schema = ""
 	return &jsonschema.Schema{
 		Schema: schema202012,
+		Type:   "object",
 		OneOf:  []*jsonschema.Schema{metadata, semantic},
 	}
 }
@@ -541,7 +542,7 @@ func aggregateDefinition(_ *handlers) toolDefinition {
 	return readDefinition(
 		ToolAggregate,
 		"Get grouped statistics (top senders, recipients, domains, labels, or message volume by calendar year). "+
-			"Returns a JSON array of objects with fields Key, Count, TotalSize, AttachmentSize, AttachmentCount, and TotalUnique.",
+			"Returns an object with a data array containing objects with fields Key, Count, TotalSize, AttachmentSize, AttachmentCount, and TotalUnique.",
 		closedObject(map[string]*jsonschema.Schema{
 			"group_by": stringSchema("Dimension to group by. When 'time', buckets are by calendar year only (Key is a year string like \"2024\").", "sender", "recipient", "domain", "label", "time"),
 			"account":  accountProperty(),
@@ -557,7 +558,8 @@ func aggregateDefinition(_ *handlers) toolDefinition {
 func searchByDomainsDefinition(_ *handlers) toolDefinition {
 	return readDefinition(
 		ToolSearchByDomains,
-		"Find messages where any participant (from, to, or cc) belongs to one of the given domains. Useful for finding all communication with a company regardless of direction.",
+		"Find messages where any participant (from, to, or cc) belongs to one of the given domains. "+
+			"Useful for finding all communication with a company regardless of direction. Returns an object with a data array of matching message summaries.",
 		closedObject(map[string]*jsonschema.Schema{
 			"domains": stringSchema("Comma-separated domain names (e.g. 'gobright.com,ascentae.com')"),
 			"limit":   nonNegativeIntegerSchema("Maximum results to return (default 100)", 100),
@@ -642,8 +644,12 @@ func searchDocumentsDefinition(_ *handlers) toolDefinition {
 type searchMetadataResponse paginatedResponse[query.MessageSummary]
 type searchInMessageResponse paginatedResponse[messageMatch]
 type listMessagesResponse paginatedResponse[query.MessageSummary]
-type aggregateResponse []query.AggregateRow
-type searchByDomainsResponse []query.MessageSummary
+type aggregateResponse struct {
+	Data []query.AggregateRow `json:"data"`
+}
+type searchByDomainsResponse struct {
+	Data []query.MessageSummary `json:"data"`
+}
 
 type getAttachmentResponse struct {
 	Filename string `json:"filename"`

--- a/internal/mcp/catalog_test.go
+++ b/internal/mcp/catalog_test.go
@@ -323,6 +323,7 @@ func TestCatalogSchemas(t *testing.T) {
 					outputSchema, ok := tool["outputSchema"].(map[string]any)
 					must.True(ok, "%s outputSchema", tool["name"])
 					checks.Equal("https://json-schema.org/draft/2020-12/schema", outputSchema["$schema"], "%s output dialect", tool["name"])
+					checks.Equal("object", outputSchema["type"], "%s output type", tool["name"])
 
 					readOnly := tool["name"] != ToolExportAttachment && tool["name"] != ToolStageDeletion
 					checks.Equal(map[string]any{
@@ -835,6 +836,51 @@ func TestStructuredToolResult(t *testing.T) {
 	account, ok := accounts[0].(map[string]any)
 	must.True(ok)
 	checks.Equal("alice@example.com", account["Identifier"])
+}
+
+func TestArrayToolResultsUseObjectEnvelope(t *testing.T) {
+	opts := ServeOptions{Engine: &querytest.MockEngine{
+		AggregateRows: []query.AggregateRow{{Key: "example.com", Count: 1}},
+		SearchResults: []query.MessageSummary{{ID: 1, Subject: "Example"}},
+	}}
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{name: "aggregate", tool: ToolAggregate, args: map[string]any{"group_by": "domain"}},
+		{name: "search by domains", tool: ToolSearchByDomains, args: map[string]any{"domains": "example.com"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := rawCallTool(t, opts, test.tool, test.args)
+			structured, ok := result["structuredContent"].(map[string]any)
+			require.True(t, ok, "result: %#v", result)
+			data, ok := structured["data"].([]any)
+			require.True(t, ok, "structured result: %#v", structured)
+			assert.Len(t, data, 1)
+		})
+	}
+}
+
+func TestArrayToolEmptyResultsUseEmptyDataArray(t *testing.T) {
+	opts := ServeOptions{Engine: &querytest.MockEngine{}}
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{name: "aggregate", tool: ToolAggregate, args: map[string]any{"group_by": "domain"}},
+		{name: "search by domains", tool: ToolSearchByDomains, args: map[string]any{"domains": "example.com"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := rawCallTool(t, opts, test.tool, test.args)
+			assert.Equal(t, map[string]any{"data": []any{}}, result["structuredContent"])
+		})
+	}
 }
 
 func TestOfficialSDKInMemoryRoundTrip(t *testing.T) {

--- a/internal/mcp/contract_integration_test.go
+++ b/internal/mcp/contract_integration_test.go
@@ -482,21 +482,23 @@ func task5AssertRepresentativeResult(
 		checks.Equal(int64(1), value.Accounts[0].ID)
 		checks.Equal("alice@example.com", value.Accounts[0].Identifier)
 	case ToolAggregate:
-		value := task5StructuredAs[[]struct {
-			Key             string
-			Count           int64
-			TotalSize       int64
-			AttachmentSize  int64
-			AttachmentCount int64
-			TotalUnique     int64
+		value := task5StructuredAs[struct {
+			Data []struct {
+				Key             string
+				Count           int64
+				TotalSize       int64
+				AttachmentSize  int64
+				AttachmentCount int64
+				TotalUnique     int64
+			} `json:"data"`
 		}](t, result)
-		must.Len(value, 1)
-		checks.Equal("example.com", value[0].Key)
-		checks.Equal(int64(2), value[0].Count)
-		checks.Equal(int64(3072), value[0].TotalSize)
-		checks.Equal(int64(len(fixture.attachmentBytes)), value[0].AttachmentSize)
-		checks.Equal(int64(1), value[0].AttachmentCount)
-		checks.Equal(int64(1), value[0].TotalUnique)
+		must.Len(value.Data, 1)
+		checks.Equal("example.com", value.Data[0].Key)
+		checks.Equal(int64(2), value.Data[0].Count)
+		checks.Equal(int64(3072), value.Data[0].TotalSize)
+		checks.Equal(int64(len(fixture.attachmentBytes)), value.Data[0].AttachmentSize)
+		checks.Equal(int64(1), value.Data[0].AttachmentCount)
+		checks.Equal(int64(1), value.Data[0].TotalUnique)
 	case ToolFindSimilarMessages:
 		value := task5StructuredAs[struct {
 			SeedMessageID int64 `json:"seed_message_id"`

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1748,7 +1748,7 @@ func (h *handlers) aggregate(ctx context.Context, req toolRequest) (*toolResult,
 		return nil, newInternalError("aggregate messages", err)
 	}
 
-	return jsonResult(aggregateResponse(rows))
+	return jsonResult(aggregateResponse{Data: nonNilSlice(rows)})
 }
 
 // limitArg extracts a non-negative integer limit from a map, with a default.
@@ -2056,5 +2056,12 @@ func (h *handlers) searchByDomains(ctx context.Context, req toolRequest) (*toolR
 		return nil, newInternalError("search messages by domain", err)
 	}
 
-	return jsonResult(searchByDomainsResponse(results))
+	return jsonResult(searchByDomainsResponse{Data: nonNilSlice(results)})
+}
+
+func nonNilSlice[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -78,6 +78,10 @@ type attachmentMeta struct {
 	Size     int64  `json:"size"`
 }
 
+type dataResponse[T any] struct {
+	Data []T `json:"data"`
+}
+
 type paginatedSearchMessages struct {
 	Data     []searchMessageRow `json:"data"`
 	Total    int64              `json:"total"`
@@ -2209,8 +2213,8 @@ func TestAggregate(t *testing.T) {
 
 	for _, groupBy := range []string{"sender", "recipient", "domain", "label", "time"} {
 		t.Run(groupBy, func(t *testing.T) {
-			rows := runTool[[]query.AggregateRow](t, "aggregate", h.aggregate, map[string]any{"group_by": groupBy})
-			assert.Len(t, rows, 2, "rows")
+			response := runTool[dataResponse[query.AggregateRow]](t, "aggregate", h.aggregate, map[string]any{"group_by": groupBy})
+			assert.Len(t, response.Data, 2, "rows")
 		})
 	}
 
@@ -2780,11 +2784,11 @@ func TestAccountFilter(t *testing.T) {
 	})
 
 	t.Run("aggregate with valid account", func(t *testing.T) {
-		rows := runTool[[]query.AggregateRow](t, "aggregate", h.aggregate, map[string]any{
+		response := runTool[dataResponse[query.AggregateRow]](t, "aggregate", h.aggregate, map[string]any{
 			"group_by": "sender",
 			"account":  "alice@gmail.com",
 		})
-		assert.Len(t, rows, 1, "rows")
+		assert.Len(t, response.Data, 1, "rows")
 	})
 
 	t.Run("aggregate with invalid account", func(t *testing.T) {
@@ -3729,15 +3733,15 @@ func TestSearchByDomains(t *testing.T) {
 	h := newTestHandlers(eng)
 
 	t.Run("valid domains", func(t *testing.T) {
-		msgs := runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+		response := runTool[dataResponse[query.MessageSummary]](t, "search_by_domains", h.searchByDomains,
 			map[string]any{"domains": "acme.com,example.com"})
-		assert.Len(t, msgs, 2, "msgs")
+		assert.Len(t, response.Data, 2, "msgs")
 	})
 
 	t.Run("domains with whitespace", func(t *testing.T) {
-		msgs := runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+		response := runTool[dataResponse[query.MessageSummary]](t, "search_by_domains", h.searchByDomains,
 			map[string]any{"domains": " acme.com , example.com "})
-		assert.Len(t, msgs, 2, "msgs")
+		assert.Len(t, response.Data, 2, "msgs")
 	})
 
 	t.Run("missing domains", func(t *testing.T) {
@@ -3772,7 +3776,7 @@ func TestSearchByDomains(t *testing.T) {
 		}
 		h := newTestHandlers(eng)
 
-		msgs := runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+		response := runTool[dataResponse[query.MessageSummary]](t, "search_by_domains", h.searchByDomains,
 			map[string]any{
 				"domains": "acme.com,globex.com",
 				"limit":   float64(50),
@@ -3780,7 +3784,7 @@ func TestSearchByDomains(t *testing.T) {
 				"after":   "2024-01-01",
 				"before":  "2024-12-31",
 			})
-		assert.Len(msgs, 1, "msgs")
+		assert.Len(response.Data, 1, "msgs")
 		assert.Equal([]string{"acme.com", "globex.com"}, capturedDomains, "domains")
 		assert.Equal(50, capturedLimit, "limit")
 		assert.Equal(10, capturedOffset, "offset")
@@ -3797,7 +3801,7 @@ func TestSearchByDomains(t *testing.T) {
 		}
 		h := newTestHandlers(eng)
 
-		runTool[[]query.MessageSummary](t, "search_by_domains", h.searchByDomains,
+		runTool[dataResponse[query.MessageSummary]](t, "search_by_domains", h.searchByDomains,
 			map[string]any{"domains": "acme.com"})
 		assert.Equal(t, 100, capturedLimit, "default limit")
 		assert.Equal(t, 0, capturedOffset, "default offset")


### PR DESCRIPTION
## What changed

- Advertise a literal object-root output schema for every MCP tool, including the deprecated `search_messages` union.
- Return `aggregate` and `search_by_domains` results as `{"data":[...]}`, with empty results encoded as `{"data":[]}`.
- Keep tool arguments, capability gating, and the metadata/semantic search variants unchanged.

## Why

Strict MCP clients reject the entire `tools/list` response when any tool advertises a non-object output root. That leaves all msgvault tools unavailable even though direct calls work.

## Usage

Calls are unchanged. Clients consuming `aggregate` or `search_by_domains` should read results from `structuredContent.data` instead of treating `structuredContent` as a root array.

Closes #626
