### PR TITLE
fix(beeper): report durable over-cap media skips

### DIFF
--- a/cmd/msgvault/cmd/backfill_beeper_media.go
+++ b/cmd/msgvault/cmd/backfill_beeper_media.go
@@ -70,9 +70,10 @@ Examples:
 
 func writeBeeperMediaBackfillSummary(out io.Writer, accountID string, sum *beeper.ImportSummary) {
 	_, _ = fmt.Fprintf(out,
-		"%s: %d messages checked, %d attachments downloaded, %d still pending, %d skipped by policy (%s)\n",
-		accountID, sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending,
-		sum.AttachmentsSkipped, sum.Duration.Round(time.Second))
+		"%s: %d messages checked, %d attachments downloaded, %d still pending",
+		accountID, sum.MessagesProcessed, sum.AttachmentsDownloaded, sum.AttachmentsPending)
+	writeBeeperMediaSkipSummary(out, sum)
+	_, _ = fmt.Fprintf(out, " (%s)\n", sum.Duration.Round(time.Second))
 }
 
 func init() {

--- a/cmd/msgvault/cmd/media_summary_test.go
+++ b/cmd/msgvault/cmd/media_summary_test.go
@@ -87,3 +87,47 @@ func TestRemainingProviderSummariesReportPolicySkips(t *testing.T) {
 		})
 	}
 }
+
+func TestBeeperSummariesReportOverCapBytesSeparately(t *testing.T) {
+	tests := []struct {
+		name  string
+		sum   beeper.ImportSummary
+		print func(*bytes.Buffer, *beeper.ImportSummary)
+		want  string
+	}{
+		{
+			name: "sync exact size",
+			sum: beeper.ImportSummary{
+				AttachmentsSkipped:      3,
+				AttachmentsOverCap:      2,
+				AttachmentsOverCapBytes: 15 << 20,
+			},
+			print: func(out *bytes.Buffer, sum *beeper.ImportSummary) {
+				cmd := &cobra.Command{}
+				cmd.SetOut(out)
+				printBeeperSummary(cmd, "account", sum)
+			},
+			want: "2 media over size cap (15.0M total), 1 media skipped by policy",
+		},
+		{
+			name: "backfill lower bound",
+			sum: beeper.ImportSummary{
+				AttachmentsSkipped:            1,
+				AttachmentsOverCap:            1,
+				AttachmentsOverCapBytes:       (5 << 20) + 1,
+				AttachmentsOverCapUnknownSize: 1,
+			},
+			print: func(out *bytes.Buffer, sum *beeper.ImportSummary) {
+				writeBeeperMediaBackfillSummary(out, "account", sum)
+			},
+			want: "1 media over size cap (at least 5.0M total)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			tt.print(&output, &tt.sum)
+			assert.Contains(t, output.String(), tt.want)
+		})
+	}
+}

--- a/cmd/msgvault/cmd/sync_beeper.go
+++ b/cmd/msgvault/cmd/sync_beeper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
@@ -138,13 +139,26 @@ func printBeeperSummary(cmd *cobra.Command, accountID string, sum *beeper.Import
 	if sum.AttachmentsPending > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media pending (see backfill-beeper-media)", sum.AttachmentsPending)
 	}
-	if sum.AttachmentsSkipped > 0 {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d media skipped by policy", sum.AttachmentsSkipped)
-	}
+	writeBeeperMediaSkipSummary(cmd.OutOrStdout(), sum)
 	if sum.Errors > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), ", %d errors", sum.Errors)
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+}
+
+func writeBeeperMediaSkipSummary(out io.Writer, sum *beeper.ImportSummary) {
+	if sum.AttachmentsOverCap > 0 {
+		qualifier := ""
+		if sum.AttachmentsOverCapUnknownSize > 0 {
+			qualifier = "at least "
+		}
+		_, _ = fmt.Fprintf(out, ", %d media over size cap (%s%s total)",
+			sum.AttachmentsOverCap, qualifier, formatSize(sum.AttachmentsOverCapBytes))
+	}
+	otherSkipped := max(int64(0), sum.AttachmentsSkipped-sum.AttachmentsOverCap)
+	if otherSkipped > 0 {
+		_, _ = fmt.Fprintf(out, ", %d media skipped by policy", otherSkipped)
+	}
 }
 
 // resolveBeeperSyncAccounts returns the Beeper accountIDs to sync: the

--- a/internal/beeper/media.go
+++ b/internal/beeper/media.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"go.kenn.io/msgvault/internal/attachmentpolicy"
@@ -66,6 +67,25 @@ func declaredSize(att *Attachment) int {
 	return int(int64(att.FileSize))
 }
 
+func recordOverCap(sum *ImportSummary, size int64, lowerBound bool) {
+	if sum.AttachmentsOverCap < math.MaxInt64 {
+		sum.AttachmentsOverCap++
+	}
+	if size < 0 {
+		size = 0
+		lowerBound = true
+	}
+	if size > math.MaxInt64-sum.AttachmentsOverCapBytes {
+		sum.AttachmentsOverCapBytes = math.MaxInt64
+		lowerBound = true
+	} else {
+		sum.AttachmentsOverCapBytes += size
+	}
+	if lowerBound && sum.AttachmentsOverCapUnknownSize < math.MaxInt64 {
+		sum.AttachmentsOverCapUnknownSize++
+	}
+}
+
 // shareMetadata renders the attachment_metadata JSON marking media that came
 // in as a link preview rather than as something the sender composed, recording
 // the URL it previews. Returns "" for ordinary media, which stores NULL.
@@ -123,13 +143,14 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			continue
 		}
 		sourceAttID := beeperAttachmentID(ref)
-		if prev, ok := existing[sourceAttID]; ok && prev.ContentHash != "" {
+		previous, hadPrevious := existing[sourceAttID]
+		if hadPrevious && previous.ContentHash != "" {
 			// Re-persisting already-downloaded media: keep the blob as-is but
 			// refresh the share marker, so re-running over an existing archive
 			// classifies rows stored before this was recorded.
-			prev.Metadata = shareMeta
-			setBeeperAttachmentRole(&prev, att, isPreview)
-			refs = append(refs, prev)
+			previous.Metadata = shareMeta
+			setBeeperAttachmentRole(&previous, att, isPreview)
+			refs = append(refs, previous)
 			continue
 		}
 		marker := store.AttachmentRef{
@@ -141,13 +162,19 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			Metadata:           shareMeta,
 			State:              attachmentpolicy.StatePending,
 		}
-		if previous, ok := existing[sourceAttID]; ok && previous.Size > marker.Size {
+		if hadPrevious && previous.Size > marker.Size {
 			marker.Size = previous.Size
 		}
 		// Every unsuccessful fetch leaves a typed marker. Transient failures
 		// remain retryable; size exclusions wait until the cap is raised.
-		pend := func(status, kind string, err error) {
-			imp.recordItem(syncID, m.ID, "attachment", status, kind, err)
+		pend := func(status, kind string, sizeUnknown bool, err error) {
+			newSizeSkip := status != store.SyncRunItemStatusSkipped || !hadPrevious ||
+				previous.State != attachmentpolicy.StateSkipped ||
+				previous.SkipReason != attachmentpolicy.SkipSizeCap ||
+				int64(previous.Size) <= maxBytes
+			if newSizeSkip {
+				imp.recordItem(syncID, m.ID, "attachment", status, kind, err)
+			}
 			if status == store.SyncRunItemStatusSkipped {
 				marker.State = attachmentpolicy.StateSkipped
 				marker.SkipReason = attachmentpolicy.SkipSizeCap
@@ -157,7 +184,10 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			}
 			refs = append(refs, marker)
 			if marker.State == attachmentpolicy.StateSkipped {
-				sum.AttachmentsSkipped++
+				if newSizeSkip {
+					sum.AttachmentsSkipped++
+					recordOverCap(sum, int64(marker.Size), sizeUnknown)
+				}
 			} else {
 				sum.AttachmentsPending++
 			}
@@ -173,7 +203,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 		if reason := policy.Evaluate(opts.MediaConversation, int64(marker.Size)); reason != "" {
 			if reason == attachmentpolicy.SkipSizeCap {
 				marker.SkipReason = reason
-				pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large",
+				pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large", false,
 					fmt.Errorf("attachment %s is %d bytes (cap %d)", ref, marker.Size, maxBytes))
 				continue
 			}
@@ -184,9 +214,14 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			sum.AttachmentsSkipped++
 			continue
 		}
-		if att.FileSize > 0 && int64(att.FileSize) > maxBytes {
-			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large",
-				fmt.Errorf("attachment %s is %d bytes (cap %d)", ref, int64(att.FileSize), maxBytes))
+		if att.FileSize > float64(maxBytes) {
+			observed := int64(math.MaxInt64)
+			if att.FileSize < float64(math.MaxInt64) {
+				observed = int64(att.FileSize)
+			}
+			marker.Size = attachmentpolicy.OversizeMarkerSize(maxBytes, observed)
+			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large", true,
+				fmt.Errorf("attachment %s is at least %d bytes (cap %d)", ref, marker.Size, maxBytes))
 			continue
 		}
 		data, err := imp.client.GetAssetBytes(ctx, ref, maxBytes)
@@ -197,17 +232,17 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			// The declared fileSize was absent or wrong; the capped reader
 			// caught it. Same outcome as the declared-size check above.
 			marker.Size = attachmentpolicy.OversizeMarkerSize(maxBytes, int64(marker.Size))
-			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large", err)
+			pend(store.SyncRunItemStatusSkipped, "beeper_media_too_large", true, err)
 			continue
 		}
 		if err != nil {
-			pend(store.SyncRunItemStatusError, "beeper_media_error", err)
+			pend(store.SyncRunItemStatusError, "beeper_media_error", false, err)
 			continue
 		}
 		ma := &mime.Attachment{Filename: att.FileName, ContentType: att.MimeType, Content: data}
 		storagePath, serr := export.StoreAttachmentFile(opts.AttachmentsDir, ma)
 		if serr != nil || storagePath == "" {
-			pend(store.SyncRunItemStatusError, "beeper_media_error", serr)
+			pend(store.SyncRunItemStatusError, "beeper_media_error", false, serr)
 			continue
 		}
 		stored := store.AttachmentRef{
@@ -368,6 +403,9 @@ func (imp *Importer) BackfillMedia(ctx context.Context, opts ImportOptions) (*Im
 		return sum, err
 	}
 	sum.AttachmentsSkipped += policyResult.NewlySkipped
+	sum.AttachmentsOverCap += policyResult.AttachmentsOverCap
+	sum.AttachmentsOverCapBytes += policyResult.AttachmentsOverCapBytes
+	sum.AttachmentsOverCapUnknownSize += policyResult.AttachmentsOverCapUnknownSize
 	pending, err := imp.store.ListBeeperRetryableAttachmentMessages(src.ID, policy)
 	if err != nil {
 		return sum, err

--- a/internal/beeper/media_test.go
+++ b/internal/beeper/media_test.go
@@ -3,6 +3,7 @@ package beeper
 import (
 	"context"
 	"database/sql"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -283,12 +284,78 @@ func TestImportMediaSizeCap(t *testing.T) {
 	assert.EqualValues(0, sum.AttachmentsDownloaded)
 	assert.EqualValues(0, sum.AttachmentsPending)
 	assert.EqualValues(1, sum.AttachmentsSkipped)
+	assert.EqualValues(1, sum.AttachmentsOverCap)
+	assert.EqualValues(10<<20, sum.AttachmentsOverCapBytes)
+	assert.Zero(sum.AttachmentsOverCapUnknownSize)
 	assert.EqualValues(0, sum.Errors, "over-cap is a skip, not an error")
 
 	var itemCount int
 	require.NoError(st.DB().QueryRow(
 		`SELECT COUNT(*) FROM sync_run_items WHERE error_kind = 'beeper_media_too_large'`).Scan(&itemCount))
 	assert.Equal(1, itemCount)
+
+	repeat, err := imp.Import(context.Background(), ImportOptions{
+		AccountID: "signal", AttachmentsDir: opts.AttachmentsDir,
+		MaxMediaBytes: opts.MaxMediaBytes, Full: true,
+	})
+	require.NoError(err)
+	assert.Zero(repeat.AttachmentsOverCap, "an unchanged durable size skip is not a new drop")
+	assert.Zero(repeat.AttachmentsOverCapBytes)
+	assert.Zero(repeat.AttachmentsPending, "a durable size skip is not retryable work")
+}
+
+func TestImportMediaSizeCapSaturatesReportedBytes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	chat := mediaChat()
+	chat.Msgs[0].Attachments = append(chat.Msgs[0].Attachments,
+		map[string]any{
+			"id": "mxc://beeper.local/huge2", "type": "video", "mimeType": "video/mp4",
+			"fileName": "huge2.mp4", "fileSize": float64(int64(1) << 62),
+		})
+	chat.Msgs[0].Attachments[0]["fileSize"] = float64(int64(1) << 62)
+	f.addChat(chat)
+	imp, _, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	opts.MaxMediaBytes = 1
+	sum, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	assert.EqualValues(2, sum.AttachmentsOverCap)
+	assert.Equal(int64(math.MaxInt64), sum.AttachmentsOverCapBytes)
+	assert.Positive(sum.AttachmentsOverCapUnknownSize,
+		"a saturated total must be presented as a lower bound")
+}
+
+func TestImportMediaSizeCapClampsExtremeDeclaredSize(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	chat := mediaChat()
+	chat.Msgs[0].Attachments[0]["fileSize"] = float64((int64(1) << 62) + (int64(1) << 50))
+	f.addChat(chat)
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	opts.MaxMediaBytes = 1 << 20
+	sum, err := imp.Import(t.Context(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, sum.AttachmentsOverCap)
+	assert.Greater(sum.AttachmentsOverCapBytes, opts.MaxMediaBytes)
+	assert.EqualValues(1, sum.AttachmentsOverCapUnknownSize)
+
+	var storedSize int64
+	require.NoError(st.DB().QueryRow(`
+		SELECT size FROM attachments
+		WHERE source_attachment_id = 'beeper:mxc://beeper.local/photo1'
+	`).Scan(&storedSize))
+	assert.Greater(storedSize, opts.MaxMediaBytes)
+	backfill, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.Zero(backfill.MessagesProcessed, "the clamped size marker remains excluded at an unchanged cap")
 }
 
 func TestImportMediaSizeCapUndeclaredSize(t *testing.T) {
@@ -312,6 +379,9 @@ func TestImportMediaSizeCapUndeclaredSize(t *testing.T) {
 	assert.EqualValues(0, sum.AttachmentsDownloaded)
 	assert.EqualValues(0, sum.AttachmentsPending)
 	assert.EqualValues(1, sum.AttachmentsSkipped)
+	assert.EqualValues(1, sum.AttachmentsOverCap)
+	assert.Greater(sum.AttachmentsOverCapBytes, int64(1<<20))
+	assert.EqualValues(1, sum.AttachmentsOverCapUnknownSize)
 	assert.EqualValues(0, sum.Errors, "over-cap is a skip, not an error")
 
 	var itemCount int
@@ -327,6 +397,46 @@ func TestImportMediaSizeCapUndeclaredSize(t *testing.T) {
 	backfill, err := imp.BackfillMedia(context.Background(), opts)
 	require.NoError(err)
 	assert.Zero(backfill.MessagesProcessed, "unchanged cap must not retry streamed oversize media")
+
+	opts.MaxMediaBytes = (3 << 20) / 2
+	backfill, err = imp.BackfillMedia(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, backfill.MessagesProcessed, "a raised cap makes the old lower-bound marker retryable")
+	assert.EqualValues(1, backfill.AttachmentsOverCap, "a still-insufficient raised cap is a new drop")
+	assert.Greater(backfill.AttachmentsOverCapBytes, opts.MaxMediaBytes)
+	assert.EqualValues(1, backfill.AttachmentsOverCapUnknownSize)
+	assert.Zero(backfill.AttachmentsPending)
+}
+
+func TestBackfillMediaCountsExistingSizeSkipOnceInMixedMessage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	chat := mediaChat()
+	chat.Msgs[0].Attachments = append(chat.Msgs[0].Attachments,
+		map[string]any{
+			"id": "mxc://beeper.local/small", "type": "img", "mimeType": "image/png",
+			"fileName": "small.png", "fileSize": 5,
+		})
+	chat.Msgs[0].Attachments[0]["fileSize"] = 10 << 20
+	f.addChat(chat)
+	f.setAsset("mxc://beeper.local/small", []byte("small"))
+	imp, _, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	initial := opts
+	initial.NoMedia = true
+	_, err := imp.Import(t.Context(), initial)
+	require.NoError(err)
+
+	opts.MaxMediaBytes = 1 << 20
+	sum, err := imp.BackfillMedia(t.Context(), opts)
+	require.NoError(err)
+	assert.EqualValues(1, sum.AttachmentsOverCap)
+	assert.EqualValues(10<<20, sum.AttachmentsOverCapBytes)
+	assert.EqualValues(1, sum.AttachmentsDownloaded)
+	assert.Zero(sum.AttachmentsPending, "the durable size skip must not become pending again")
 }
 
 func TestImportNoMediaSkipsDownloadsEntirely(t *testing.T) {

--- a/internal/beeper/types.go
+++ b/internal/beeper/types.go
@@ -203,7 +203,7 @@ type ImportOptions struct {
 	// NoMedia skips attachment downloads and writes pending markers for a later
 	// backfill or full run.
 	NoMedia bool
-	// MaxMediaBytes caps individual attachment downloads (0 = 100 MB).
+	// MaxMediaBytes caps individual attachment downloads (0 = 100 MiB).
 	// Over-cap attachments leave a typed size-cap exclusion marker.
 	MaxMediaBytes int64
 	// MediaPolicy is the effective provider/account collection policy.
@@ -254,6 +254,13 @@ type ImportSummary struct {
 	AttachmentsDownloaded int64
 	AttachmentsPending    int64
 	AttachmentsSkipped    int64
+	// AttachmentsOverCap is the size-specific subset of AttachmentsSkipped.
+	// AttachmentsOverCapBytes saturates while summing declared sizes or the
+	// minimum observed streamed size. AttachmentsOverCapUnknownSize is nonzero
+	// whenever that total is a lower bound rather than an exact value.
+	AttachmentsOverCap            int64
+	AttachmentsOverCapBytes       int64
+	AttachmentsOverCapUnknownSize int64
 	// FetchErrors counts Beeper API fetch failures (a subset of Errors). Any
 	// fetch failure keeps the discovery watermark from advancing so the
 	// affected chats are re-visited next run.

--- a/internal/store/attachment_policy_test.go
+++ b/internal/store/attachment_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -121,6 +122,41 @@ func TestRetryableAttachmentMessagesReevaluateSkippedUnderCurrentPolicy(t *testi
 		{MessageID: failedID, SourceMessageID: "failed", ChatID: "conversation-failed", ConversationType: "group_chat", ParticipantCount: 4},
 		{MessageID: skippedID, SourceMessageID: "skipped", ChatID: "conversation-skipped", ConversationType: "group_chat", ParticipantCount: 4},
 	}, items)
+}
+
+func TestBeeperRetryPolicyReportsNewSizeSkips(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	sourceID, overCapID := newPolicyMessage(t, st, "beeper", "signal", "direct_chat", "over-cap", 2)
+	_, hugeID := newPolicyMessage(t, st, "beeper", "signal", "direct_chat", "huge", 2)
+	_, scopeID := newPolicyMessage(t, st, "beeper", "signal", "channel", "scope", 8)
+	for _, item := range []struct {
+		messageID int64
+		name      string
+		size      int
+	}{
+		{messageID: overCapID, name: "over-cap", size: 9 << 20},
+		{messageID: hugeID, name: "huge", size: math.MaxInt64 - 1},
+		{messageID: scopeID, name: "scope", size: 1 << 20},
+	} {
+		require.NoError(st.ReplaceMessageBeeperAttachments(item.messageID, []store.AttachmentRef{{
+			SourceAttachmentID: "beeper:" + item.name,
+			StoragePath:        "https://example.invalid/" + item.name,
+			Size:               item.size,
+			State:              attachmentpolicy.StatePending,
+		}}))
+	}
+
+	result, err := st.ApplyBeeperRetryableAttachmentPolicy(t.Context(), sourceID, attachmentpolicy.Policy{
+		Scope: attachmentpolicy.ScopeDirect, MaxBytes: 5 << 20,
+	})
+	require.NoError(err)
+	assert.EqualValues(3, result.NewlySkipped)
+	assert.EqualValues(2, result.AttachmentsOverCap)
+	assert.Equal(int64(math.MaxInt64), result.AttachmentsOverCapBytes)
+	assert.EqualValues(2, result.AttachmentsOverCapUnknownSize,
+		"archived markers and saturated totals must be presented as lower bounds")
 }
 
 func TestExcludeAttachmentOccurrencesRemovesOnlySelectedBlobReference(t *testing.T) {

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 
 	"go.kenn.io/msgvault/internal/attachmentpolicy"
@@ -130,8 +131,11 @@ func (s *Store) ListBeeperRetryableAttachmentMessages(sourceID int64, policy att
 // BeeperRetryPolicyResult describes the local policy state found before a
 // Beeper media backfill makes provider requests.
 type BeeperRetryPolicyResult struct {
-	NewlySkipped int64
-	HasExcluded  bool
+	NewlySkipped                  int64
+	HasExcluded                   bool
+	AttachmentsOverCap            int64
+	AttachmentsOverCapBytes       int64
+	AttachmentsOverCapUnknownSize int64
 }
 
 // ApplyBeeperRetryableAttachmentPolicy converts unfinished Beeper rows that
@@ -144,6 +148,7 @@ func (s *Store) ApplyBeeperRetryableAttachmentPolicy(
 	type exclusion struct {
 		attachmentID int64
 		reason       attachmentpolicy.SkipReason
+		size         int64
 	}
 	var result BeeperRetryPolicyResult
 	err := s.withTxContext(ctx, func(tx *loggedTx) error {
@@ -182,7 +187,9 @@ func (s *Store) ApplyBeeperRetryableAttachmentPolicy(
 			if reason := policy.Evaluate(conversation, size); reason != "" {
 				result.HasExcluded = true
 				if attachmentpolicy.RetryEligible(state) {
-					exclusions = append(exclusions, exclusion{attachmentID: attachmentID, reason: reason})
+					exclusions = append(exclusions, exclusion{
+						attachmentID: attachmentID, reason: reason, size: size,
+					})
 				}
 			}
 		}
@@ -209,6 +216,18 @@ func (s *Store) ApplyBeeperRetryableAttachmentPolicy(
 				return fmt.Errorf("count skipped Beeper attachment %d: %w", exclusion.attachmentID, err)
 			}
 			result.NewlySkipped += changed
+			if changed > 0 && exclusion.reason == attachmentpolicy.SkipSizeCap {
+				result.AttachmentsOverCap += changed
+				size := max(int64(0), exclusion.size)
+				if size > math.MaxInt64-result.AttachmentsOverCapBytes {
+					result.AttachmentsOverCapBytes = math.MaxInt64
+				} else {
+					result.AttachmentsOverCapBytes += size
+				}
+				// Legacy and pending markers do not record whether size metadata
+				// was exact or only the minimum observed by a capped stream.
+				result.AttachmentsOverCapUnknownSize += changed
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
## What changed

- Report newly persisted Beeper size-cap skips separately, including their aggregate bytes and an `at least` qualifier when the total is only a lower bound.
- Keep unchanged durable size-cap skips out of retry, pending, and repeated drop counts. Raising the cap makes them eligible again.
- Saturate attachment counts and byte totals instead of allowing large or malformed size metadata to wrap negative.
- Preserve the existing 100 MiB default. This PR does not change configuration or schema.

## Why

An over-cap attachment currently looks like generic pending work and can be revisited indefinitely even though the same configured cap will reject it again. Operators cannot tell how much media was deliberately excluded, and repeated backfills can spend the same network work without changing the archive. This makes the terminal policy outcome visible and ties retries to an actual cap change.

## Usage

No usage change.

Builds on #620. Refs #632.
