### PR TITLE
feat(imap): add QRESYNC incremental sync

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,6 +137,10 @@ linters:
       # SQL table names) recur many more times than the threshold.
       min-occurrences: 10
 
+    gomoddirectives:
+      replace-allow-list:
+        - github.com/emersion/go-imap/v2
+
     importas:
       alias:
         - pkg: github.com/stretchr/testify/assert

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"context"
+	"database/sql"
 	"net"
 	"strconv"
 	"testing"
 	"time"
 
+	imapapi "github.com/emersion/go-imap/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/gmail"
@@ -44,6 +46,53 @@ func listedIMAPClient(t *testing.T, addr string, opts ...imaplib.Option) *imapli
 	}
 }
 
+func seedObservedIMAPMessages(
+	t *testing.T, st *store.Store, src *store.Source, client *imaplib.Client,
+) {
+	t.Helper()
+	conversationID, err := st.EnsureConversation(src.ID, "imap-membership", "IMAP membership")
+	require.NoError(t, err)
+	for _, observation := range client.ObservedMemberships() {
+		_, err := st.UpsertMessage(&store.Message{
+			ConversationID:  conversationID,
+			SourceID:        src.ID,
+			SourceMessageID: observation.SourceMessageID,
+			RFC822MessageID: sql.NullString{
+				String: observation.RFC822MessageID,
+				Valid:  observation.RFC822MessageID != "",
+			},
+			MessageType: "email",
+		})
+		require.NoError(t, err)
+	}
+}
+
+func seedIMAPMessage(
+	t *testing.T, st *store.Store, src *store.Source, sourceMessageID, rfc822MessageID string,
+) {
+	t.Helper()
+	conversationID, err := st.EnsureConversation(src.ID, "imap-delta", "IMAP delta")
+	require.NoError(t, err)
+	_, err = st.UpsertMessage(&store.Message{
+		ConversationID:  conversationID,
+		SourceID:        src.ID,
+		SourceMessageID: sourceMessageID,
+		RFC822MessageID: sql.NullString{String: rfc822MessageID, Valid: rfc822MessageID != ""},
+		MessageType:     "email",
+	})
+	require.NoError(t, err)
+}
+
+func completedIMAPSyncSummary(
+	t *testing.T, st *store.Store, src *store.Source,
+) *gmail.SyncSummary {
+	t.Helper()
+	syncRunID, err := st.StartSync(src.ID, "full")
+	require.NoError(t, err)
+	require.NoError(t, st.CompleteSync(syncRunID, "0"))
+	return &gmail.SyncSummary{SyncRunID: syncRunID}
+}
+
 func TestSaveIMAPFolderStates_CleanRunPersists(t *testing.T) {
 	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 1})
@@ -52,14 +101,57 @@ func TestSaveIMAPFolderStates_CleanRunPersists(t *testing.T) {
 	require.NoError(err)
 
 	client := listedIMAPClient(t, addr)
-	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{}, 0)
+	seedObservedIMAPMessages(t, st, src, client)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, client, completedIMAPSyncSummary(t, st, src), 0))
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
 	assert.Equal(t, map[string]imaplib.FolderState{
-		"INBOX":   {UIDValidity: loaded["INBOX"].UIDValidity, UIDNext: 3},
-		"Archive": {UIDValidity: loaded["Archive"].UIDValidity, UIDNext: 2},
+		"INBOX": {
+			UIDValidity: loaded["INBOX"].UIDValidity, UIDNext: 3,
+			HighestModSeq: loaded["INBOX"].HighestModSeq, KnownUIDs: []uint32{1, 2},
+		},
+		"Archive": {
+			UIDValidity: loaded["Archive"].UIDValidity, UIDNext: 2,
+			HighestModSeq: loaded["Archive"].HighestModSeq, KnownUIDs: []uint32{1},
+		},
 	}, loaded)
+}
+
+func TestSaveIMAPFolderStates_SupersededGenerationCannotOverwriteNewerRun(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 1})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://generation@example.com")
+	require.NoError(err)
+	require.NoError(st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{{
+		Mailbox: "Prior", UIDValidity: 7, UIDNext: 9, HighestModSeq: 11,
+	}}))
+
+	client := listedIMAPClient(t, addr)
+	seedObservedIMAPMessages(t, st, src, client)
+	oldRunID, err := st.StartSync(src.ID, "full")
+	require.NoError(err)
+	require.NoError(st.CompleteSync(oldRunID, "0"))
+	newRunID, err := st.StartSync(src.ID, "full")
+	require.NoError(err)
+
+	err = saveIMAPFolderStates(
+		context.Background(), st, src, client, &gmail.SyncSummary{SyncRunID: oldRunID}, 0)
+	require.ErrorIs(err, store.ErrSyncRunSuperseded)
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	assert.Equal(map[string]imaplib.FolderState{
+		"Prior": {
+			UIDValidity: 7, UIDNext: 9, HighestModSeq: 11, KnownUIDs: []uint32{},
+		},
+	}, loaded)
+	active, err := st.GetActiveSync(src.ID)
+	require.NoError(err)
+	assert.Equal(newRunID, active.ID)
 }
 
 func TestSaveIMAPFolderStates_ErrorsBlockPersistence(t *testing.T) {
@@ -70,31 +162,52 @@ func TestSaveIMAPFolderStates_ErrorsBlockPersistence(t *testing.T) {
 	require.NoError(err)
 
 	client := listedIMAPClient(t, addr)
-	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{Errors: 1}, 0)
+	require.NoError(st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{{
+		Mailbox: "prior", UIDValidity: 7, UIDNext: 9, HighestModSeq: 11,
+	}}))
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, client, &gmail.SyncSummary{Errors: 1}, 0))
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
-	assert.Empty(t, loaded, "a run with fetch errors must not advance folder high water marks")
+	assert.Equal(t, map[string]imaplib.FolderState{
+		"prior": {UIDValidity: 7, UIDNext: 9, HighestModSeq: 11, KnownUIDs: []uint32{}},
+	}, loaded, "a run with fetch errors must not advance folder high water marks")
 }
 
-func TestSaveIMAPFolderStates_LeavesDeferredFoldersUnpersisted(t *testing.T) {
+func TestSaveIMAPFolderStates_InterruptionBlocksPersistence(t *testing.T) {
 	require := require.New(t)
-	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{
-		"INBOX":   1,
-		"Archive": 0,
-	})
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 1})
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
 	require.NoError(err)
 
-	client := listedIMAPClient(t, addr, imapFolderStateSaveOption(st, src))
-	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{}, 0)
+	client := listedIMAPClient(t, addr)
+	seedObservedIMAPMessages(t, st, src, client)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(saveIMAPFolderStates(ctx, st, src, client, &gmail.SyncSummary{}, 0))
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
-	assert.Contains(t, loaded, "Archive")
-	assert.NotContains(t, loaded, "INBOX",
-		"a folder with an unacknowledged message must remain retryable")
+	assert.Empty(t, loaded, "an interrupted run must leave durable incremental state untouched")
+}
+
+func TestSaveIMAPFolderStates_ResumedRunBlocksPersistence(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 1})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(err)
+
+	client := listedIMAPClient(t, addr)
+	seedObservedIMAPMessages(t, st, src, client)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, client, &gmail.SyncSummary{WasResumed: true}, 0))
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	assert.Empty(t, loaded, "a resumed run must not publish a partial membership snapshot")
 }
 
 func TestSaveIMAPFolderStates_LimitTruncationBlocksPersistence(t *testing.T) {
@@ -105,11 +218,30 @@ func TestSaveIMAPFolderStates_LimitTruncationBlocksPersistence(t *testing.T) {
 	require.NoError(err)
 
 	client := listedIMAPClient(t, addr)
-	saveIMAPFolderStates(st, src, client, &gmail.SyncSummary{MessagesFound: 3}, 3)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, client, &gmail.SyncSummary{MessagesFound: 3}, 3))
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
 	assert.Empty(t, loaded, "a --limit-truncated run must not advance folder high water marks")
+}
+
+func TestSaveIMAPFolderStates_BelowLimitStillBlocksPersistence(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 1})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(err)
+
+	client := listedIMAPClient(t, addr)
+	seedObservedIMAPMessages(t, st, src, client)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, client, &gmail.SyncSummary{MessagesFound: 1}, 3))
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	assert.Empty(t, loaded,
+		"any nonzero --limit must leave durable incremental state untouched")
 }
 
 func TestSaveIMAPFolderStates_NonIMAPClientIsNoOp(t *testing.T) {
@@ -119,14 +251,15 @@ func TestSaveIMAPFolderStates_NonIMAPClientIsNoOp(t *testing.T) {
 	require.NoError(err)
 
 	var notIMAP gmail.API
-	saveIMAPFolderStates(st, src, notIMAP, &gmail.SyncSummary{}, 0)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, notIMAP, &gmail.SyncSummary{}, 0))
 
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
 	assert.Empty(t, loaded)
 }
 
-func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
+func TestIMAPFolderStateOptions_RoundTripFallsBackWithoutModSeq(t *testing.T) {
 	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
 	st := testutil.NewTestStore(t)
@@ -134,7 +267,9 @@ func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
 	require.NoError(err)
 
 	first := listedIMAPClient(t, addr)
-	saveIMAPFolderStates(st, src, first, &gmail.SyncSummary{}, 0)
+	seedObservedIMAPMessages(t, st, src, first)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, first, completedIMAPSyncSummary(t, st, src), 0))
 	require.NoError(first.Close())
 
 	opts := imapFolderStateOptions(st, src, false)
@@ -145,8 +280,8 @@ func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
 	defer cancel()
 	resp, err := second.ListMessages(ctx, "", "")
 	require.NoError(err)
-	assert.Empty(t, resp.Messages,
-		"a resync against an unchanged server must list no messages")
+	assert.Len(t, resp.Messages, 5,
+		"a stored baseline without mod-sequences must be rebuilt completely")
 }
 
 func TestIMAPFolderStateOptions_ForceRescanRetainsStatesAndEnumerates(t *testing.T) {
@@ -160,12 +295,14 @@ func TestIMAPFolderStateOptions_ForceRescanRetainsStatesAndEnumerates(t *testing
 	require.NoError(err)
 
 	first := listedIMAPClient(t, addr)
-	saveIMAPFolderStates(st, src, first, &gmail.SyncSummary{}, 0)
+	seedObservedIMAPMessages(t, st, src, first)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, first, completedIMAPSyncSummary(t, st, src), 0))
 	require.NoError(first.Close())
 
 	opts := imapFolderStateOptions(st, src, true)
-	require.Len(opts, 2,
-		"--noresume needs saved identity state and forced enumeration")
+	require.Len(opts, 3,
+		"--noresume needs saved identity and alias state plus forced enumeration")
 
 	second := listedIMAPClient(t, addr, opts...)
 	ctx, cancel := context.WithTimeout(
@@ -177,35 +314,59 @@ func TestIMAPFolderStateOptions_ForceRescanRetainsStatesAndEnumerates(t *testing
 		"forced enumeration must not skip an unchanged mailbox")
 }
 
-func TestIMAPFolderStateSaveOption_PersistsCompletedFolders(t *testing.T) {
+func TestSaveIMAPFolderStates_UnmappableObservationRollsBackCursor(t *testing.T) {
 	require := require.New(t)
-	assert := assert.New(t)
-	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 1})
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 1})
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
 	require.NoError(err)
 
-	client := listedIMAPClient(t, addr, imapFolderStateSaveOption(st, src))
+	client := listedIMAPClient(t, addr)
+	err = saveIMAPFolderStates(
+		context.Background(), st, src, client, completedIMAPSyncSummary(t, st, src), 0)
+	require.Error(err)
+	assert.Contains(t, err.Error(), "resolve IMAP membership")
+	loaded, loadErr := loadIMAPFolderStates(st, src.ID)
+	require.NoError(loadErr)
+	assert.Empty(t, loaded)
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	client.AcknowledgeMessages(ctx, []string{"INBOX|1"})
-	loaded, err := loadIMAPFolderStates(st, src.ID)
+func TestSaveIMAPFolderStates_StatusFailureBlocksDurableApply(t *testing.T) {
+	require := require.New(t)
+	addr, user := testutil.StartIMAPMemServerWithStatusError(
+		t,
+		map[string]int{
+			"INBOX":            0,
+			"[Gmail]/All Mail": 0,
+		},
+		map[string][]imapapi.MailboxAttr{
+			"[Gmail]/All Mail": {imapapi.MailboxAttrAll},
+		},
+		"INBOX",
+	)
+	const messageID = "status-failure-store@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "[Gmail]/All Mail", messageID)
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
 	require.NoError(err)
-	assert.Empty(loaded, "partial folder acknowledgement must not persist its high water mark")
 
-	client.AcknowledgeMessages(ctx, []string{"INBOX|2"})
-	loaded, err = loadIMAPFolderStates(st, src.ID)
-	require.NoError(err)
-	require.Contains(loaded, "INBOX")
-	assert.Equal(uint32(3), loaded["INBOX"].UIDNext)
-	assert.NotContains(loaded, "Archive")
+	client := listedIMAPClient(t, addr)
+	seedObservedIMAPMessages(t, st, src, client)
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, client, &gmail.SyncSummary{}, 0))
 
-	client.AcknowledgeMessages(ctx, []string{"Archive|1"})
-	loaded, err = loadIMAPFolderStates(st, src.ID)
+	states, err := st.GetIMAPFolderStates(src.ID)
 	require.NoError(err)
-	require.Contains(loaded, "Archive")
-	assert.Equal(uint32(2), loaded["Archive"].UIDNext)
+	assert.Empty(t, states)
+	known, err := st.GetIMAPKnownUIDs(src.ID)
+	require.NoError(err)
+	assert.Empty(t, known)
+	var membershipCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM imap_message_memberships WHERE source_id = ?
+	`), src.ID).Scan(&membershipCount))
+	assert.Zero(t, membershipCount)
 }
 
 func TestSaveIMAPFolderStates_StoreRoundTripValues(t *testing.T) {
@@ -214,12 +375,66 @@ func TestSaveIMAPFolderStates_StoreRoundTripValues(t *testing.T) {
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
 	require.NoError(err)
 
-	require.NoError(st.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{
-		{Mailbox: "INBOX", UIDValidity: 42, UIDNext: 100},
-	}))
+	seedIMAPMessage(t, st, src, "INBOX|7", "round-trip@example.com")
+	require.NoError(st.ApplyIMAPMailboxDeltas(src.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State: store.IMAPFolderState{
+			Mailbox: "INBOX", UIDValidity: 42, UIDNext: 100, HighestModSeq: 123456789,
+		},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 42, UID: 7, SourceMessageID: "INBOX|7",
+		}},
+	}}))
 	loaded, err := loadIMAPFolderStates(st, src.ID)
 	require.NoError(err)
 	assert.Equal(t, map[string]imaplib.FolderState{
-		"INBOX": {UIDValidity: 42, UIDNext: 100},
+		"INBOX": {
+			UIDValidity: 42, UIDNext: 100, HighestModSeq: 123456789, KnownUIDs: []uint32{7},
+		},
 	}, loaded)
+}
+
+func TestApplyIMAPMailboxDeltas_ConvertsObservationsAndVanishedUIDs(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(err)
+	seedIMAPMessage(t, st, src, "INBOX|1", "removed@example.com")
+	seedIMAPMessage(t, st, src, "INBOX|2", "retained@example.com")
+	seedIMAPMessage(t, st, src, "INBOX|3", "added@example.com")
+	require.NoError(st.ApplyIMAPMailboxDeltas(src.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State: store.IMAPFolderState{
+			Mailbox: "INBOX", UIDValidity: 17, UIDNext: 3, HighestModSeq: 100,
+		},
+		Memberships: []store.IMAPMembershipObservation{
+			{UID: 1, SourceMessageID: "INBOX|1"},
+			{UID: 2, SourceMessageID: "INBOX|2"},
+		},
+	}}))
+
+	summary := completedIMAPSyncSummary(t, st, src)
+	err = applyIMAPMailboxDeltas(context.Background(), st, src, summary.SyncRunID, []imaplib.MailboxDelta{{
+		Mailbox: "INBOX",
+		State: imaplib.FolderState{
+			UIDValidity: 17, UIDNext: 4, HighestModSeq: 101, KnownUIDs: []uint32{2, 3},
+		},
+		ChangedUIDs:  []imapapi.UID{3},
+		VanishedUIDs: []imapapi.UID{1},
+		Incremental:  true,
+	}}, []imaplib.MembershipObservation{{
+		Mailbox: "INBOX", UIDValidity: 17, UID: 3,
+		SourceMessageID: "INBOX|3", RFC822MessageID: "added@example.com",
+		Flags: []string{"\\Flagged"},
+	}})
+	require.NoError(err)
+
+	known, err := st.GetIMAPKnownUIDs(src.ID)
+	require.NoError(err)
+	assert.Equal(t, map[string][]uint32{"INBOX": {2, 3}}, known)
+	states, err := st.GetIMAPFolderStates(src.ID)
+	require.NoError(err)
+	assert.Equal(t, []store.IMAPFolderState{{
+		Mailbox: "INBOX", UIDValidity: 17, UIDNext: 4, HighestModSeq: 101,
+	}}, states)
 }

--- a/cmd/msgvault/cmd/imap_qresync_integration_test.go
+++ b/cmd/msgvault/cmd/imap_qresync_integration_test.go
@@ -1,0 +1,1613 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	imapapi "github.com/emersion/go-imap/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/store"
+	msgsync "go.kenn.io/msgvault/internal/sync"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type scriptedRFC7162Message struct {
+	UID       imapapi.UID
+	MessageID string
+	Subject   string
+	Flags     []imapapi.Flag
+	ModSeq    uint64
+}
+
+type scriptedRFC7162Mailbox struct {
+	Name              string
+	Attrs             []imapapi.MailboxAttr
+	UIDValidity       uint32
+	UIDNext           uint32
+	HighestModSeq     uint64
+	SelectUIDValidity *uint32
+	SelectUIDNext     *uint32
+	Messages          []scriptedRFC7162Message
+	ChangedUIDs       []imapapi.UID
+	VanishedUIDs      []imapapi.UID
+	StatusFailure     bool
+}
+
+type scriptedRFC7162Snapshot struct {
+	Capabilities   string
+	Mailboxes      []scriptedRFC7162Mailbox
+	QresyncFailure string
+	Fallback       *scriptedRFC7162Snapshot
+}
+
+func (s scriptedRFC7162Snapshot) clone() scriptedRFC7162Snapshot {
+	cloned := s
+	cloned.Mailboxes = make([]scriptedRFC7162Mailbox, len(s.Mailboxes))
+	for i, mailbox := range s.Mailboxes {
+		mailbox.Attrs = append([]imapapi.MailboxAttr(nil), mailbox.Attrs...)
+		mailbox.ChangedUIDs = append([]imapapi.UID(nil), mailbox.ChangedUIDs...)
+		mailbox.VanishedUIDs = append([]imapapi.UID(nil), mailbox.VanishedUIDs...)
+		messages := make([]scriptedRFC7162Message, len(mailbox.Messages))
+		for j, message := range mailbox.Messages {
+			message.Flags = append([]imapapi.Flag(nil), message.Flags...)
+			messages[j] = message
+		}
+		mailbox.Messages = messages
+		cloned.Mailboxes[i] = mailbox
+	}
+	if s.Fallback != nil {
+		fallback := s.Fallback.clone()
+		cloned.Fallback = &fallback
+	}
+	return cloned
+}
+
+type scriptedRFC7162Server struct {
+	mu          sync.Mutex
+	snapshot    scriptedRFC7162Snapshot
+	commands    map[int][]string
+	connections int
+}
+
+func startScriptedRFC7162Server(
+	t *testing.T,
+	snapshot scriptedRFC7162Snapshot,
+) (string, *scriptedRFC7162Server) {
+	t.Helper()
+	require.NotEmpty(t, snapshot.Capabilities)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	server := &scriptedRFC7162Server{
+		snapshot: snapshot.clone(),
+		commands: make(map[int][]string),
+	}
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			server.mu.Lock()
+			server.connections++
+			connID := server.connections
+			connSnapshot := server.snapshot.clone()
+			server.mu.Unlock()
+			go serveScriptedRFC7162Conn(conn, connID, connSnapshot, server)
+		}
+	}()
+	return listener.Addr().String(), server
+}
+
+func (s *scriptedRFC7162Server) setSnapshot(snapshot scriptedRFC7162Snapshot) {
+	s.mu.Lock()
+	s.snapshot = snapshot.clone()
+	s.mu.Unlock()
+}
+
+func (s *scriptedRFC7162Server) record(connID int, command string) {
+	s.mu.Lock()
+	s.commands[connID] = append(s.commands[connID], command)
+	s.mu.Unlock()
+}
+
+func (s *scriptedRFC7162Server) commandsFor(connID int) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return strings.ToUpper(strings.Join(s.commands[connID], "\n"))
+}
+
+func (s *scriptedRFC7162Server) connectionCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.connections
+}
+
+func serveScriptedRFC7162Conn(
+	conn net.Conn,
+	connID int,
+	snapshot scriptedRFC7162Snapshot,
+	server *scriptedRFC7162Server,
+) {
+	defer func() { _ = conn.Close() }()
+	_, _ = io.WriteString(conn, "* OK scripted RFC 7162 server ready\r\n")
+	reader := bufio.NewReader(conn)
+	selectedMailbox := ""
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+		server.record(connID, line)
+		tag, command, _ := strings.Cut(line, " ")
+		upper := strings.ToUpper(command)
+		switch {
+		case strings.HasPrefix(upper, "CAPABILITY"):
+			_, _ = fmt.Fprintf(conn, "* CAPABILITY %s\r\n%s OK CAPABILITY completed\r\n",
+				snapshot.Capabilities, tag)
+		case strings.HasPrefix(upper, "LOGIN"):
+			_, _ = fmt.Fprintf(conn, "%s OK LOGIN completed\r\n", tag)
+		case strings.HasPrefix(upper, "ENABLE"):
+			_, _ = fmt.Fprintf(conn, "* ENABLED QRESYNC\r\n%s OK ENABLE completed\r\n", tag)
+		case strings.HasPrefix(upper, "LIST"):
+			writeScriptedRFC7162List(conn, snapshot.Mailboxes)
+			_, _ = fmt.Fprintf(conn, "%s OK LIST completed\r\n", tag)
+		case strings.HasPrefix(upper, "STATUS"):
+			mailbox, ok := scriptedRFC7162MailboxByName(
+				snapshot.Mailboxes, parseScriptedMailbox(command, "STATUS"))
+			if !ok && strings.Contains(upper, "(MESSAGES)") {
+				_, _ = fmt.Fprintf(conn,
+					"* STATUS \"INBOX\" (MESSAGES 0)\r\n%s OK STATUS completed\r\n", tag)
+				continue
+			}
+			if !ok || mailbox.StatusFailure && !strings.Contains(upper, "(MESSAGES)") {
+				_, _ = fmt.Fprintf(conn, "%s NO STATUS unavailable\r\n", tag)
+				continue
+			}
+			_, _ = fmt.Fprintf(conn,
+				"* STATUS %s (MESSAGES %d UIDNEXT %d UIDVALIDITY %d HIGHESTMODSEQ %d)\r\n%s OK STATUS completed\r\n",
+				quoteScriptedMailbox(mailbox.Name), len(mailbox.Messages), mailbox.UIDNext,
+				mailbox.UIDValidity, mailbox.HighestModSeq, tag)
+		case strings.HasPrefix(upper, "SELECT"):
+			mailbox, ok := scriptedRFC7162MailboxByName(
+				snapshot.Mailboxes, parseScriptedMailbox(command, "SELECT"))
+			if !ok {
+				_, _ = fmt.Fprintf(conn, "%s NO mailbox missing\r\n", tag)
+				continue
+			}
+			selectedMailbox = mailbox.Name
+			writeScriptedRFC7162Select(conn, tag, mailbox)
+			if snapshot.Fallback != nil &&
+				(mailbox.SelectUIDValidity != nil || mailbox.SelectUIDNext != nil) {
+				server.setSnapshot(*snapshot.Fallback)
+			}
+		case strings.HasPrefix(upper, "UID SEARCH"):
+			mailbox, ok := scriptedRFC7162MailboxByName(snapshot.Mailboxes, selectedMailbox)
+			if !ok {
+				_, _ = fmt.Fprintf(conn, "%s BAD no selected mailbox\r\n", tag)
+				continue
+			}
+			uids := scriptedRFC7162MessageUIDs(mailbox.Messages)
+			_, _ = fmt.Fprintf(conn, "* SEARCH%s\r\n%s OK UID SEARCH completed\r\n",
+				formatScriptedRFC7162UIDs(uids), tag)
+		case strings.HasPrefix(upper, "UID FETCH"):
+			mailbox, ok := scriptedRFC7162MailboxByName(snapshot.Mailboxes, selectedMailbox)
+			if !ok {
+				_, _ = fmt.Fprintf(conn, "%s BAD no selected mailbox\r\n", tag)
+				continue
+			}
+			if strings.Contains(upper, "CHANGEDSINCE") {
+				if snapshot.QresyncFailure != "" {
+					if snapshot.Fallback != nil {
+						server.setSnapshot(*snapshot.Fallback)
+					}
+					_, _ = fmt.Fprintf(conn, "%s %s scripted QRESYNC failure\r\n",
+						tag, strings.ToUpper(snapshot.QresyncFailure))
+					continue
+				}
+				writeScriptedRFC7162Delta(conn, mailbox)
+			} else {
+				writeScriptedRFC7162Fetch(conn, command, mailbox)
+			}
+			_, _ = fmt.Fprintf(conn, "%s OK UID FETCH completed\r\n", tag)
+		case strings.HasPrefix(upper, "LOGOUT"):
+			_, _ = fmt.Fprintf(conn, "* BYE closing\r\n%s OK LOGOUT completed\r\n", tag)
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "%s BAD unsupported scripted command\r\n", tag)
+		}
+	}
+}
+
+func quoteScriptedMailbox(mailbox string) string {
+	return strconv.Quote(mailbox)
+}
+
+func parseScriptedMailbox(command, commandName string) string {
+	rest := strings.TrimSpace(command[len(commandName):])
+	if strings.HasPrefix(rest, "\"") {
+		if value, err := strconv.Unquote(rest[:strings.LastIndex(rest, "\"")+1]); err == nil {
+			return value
+		}
+	}
+	mailbox, _, _ := strings.Cut(rest, " ")
+	return mailbox
+}
+
+func scriptedRFC7162MailboxByName(
+	mailboxes []scriptedRFC7162Mailbox,
+	name string,
+) (scriptedRFC7162Mailbox, bool) {
+	for _, mailbox := range mailboxes {
+		if mailbox.Name == name {
+			return mailbox, true
+		}
+	}
+	return scriptedRFC7162Mailbox{}, false
+}
+
+func writeScriptedRFC7162List(w io.Writer, mailboxes []scriptedRFC7162Mailbox) {
+	for _, mailbox := range mailboxes {
+		attrs := make([]string, len(mailbox.Attrs))
+		for i, attr := range mailbox.Attrs {
+			attrs[i] = string(attr)
+		}
+		_, _ = fmt.Fprintf(w, "* LIST (%s) \"/\" %s\r\n",
+			strings.Join(attrs, " "), quoteScriptedMailbox(mailbox.Name))
+	}
+}
+
+func writeScriptedRFC7162Select(
+	w io.Writer,
+	tag string,
+	mailbox scriptedRFC7162Mailbox,
+) {
+	uidValidity := mailbox.UIDValidity
+	if mailbox.SelectUIDValidity != nil {
+		uidValidity = *mailbox.SelectUIDValidity
+	}
+	uidNext := mailbox.UIDNext
+	if mailbox.SelectUIDNext != nil {
+		uidNext = *mailbox.SelectUIDNext
+	}
+	_, _ = fmt.Fprintf(w,
+		"* FLAGS (\\Seen \\Flagged)\r\n* %d EXISTS\r\n* OK [UIDVALIDITY %d]\r\n* OK [UIDNEXT %d]\r\n* OK [HIGHESTMODSEQ %d]\r\n%s OK [READ-WRITE] SELECT completed\r\n",
+		len(mailbox.Messages), uidValidity, uidNext,
+		mailbox.HighestModSeq, tag)
+}
+
+func scriptedUint32(value uint32) *uint32 {
+	return new(value)
+}
+
+func scriptedRFC7162MessageUIDs(messages []scriptedRFC7162Message) []imapapi.UID {
+	uids := make([]imapapi.UID, len(messages))
+	for i, message := range messages {
+		uids[i] = message.UID
+	}
+	slices.Sort(uids)
+	return uids
+}
+
+func formatScriptedRFC7162UIDs(uids []imapapi.UID) string {
+	var result strings.Builder
+	for _, uid := range uids {
+		result.WriteByte(' ')
+		result.WriteString(strconv.FormatUint(uint64(uid), 10))
+	}
+	return result.String()
+}
+
+func formatScriptedRFC7162Flags(flags []imapapi.Flag) string {
+	values := make([]string, len(flags))
+	for i, flag := range flags {
+		values[i] = string(flag)
+	}
+	return strings.Join(values, " ")
+}
+
+func writeScriptedRFC7162Delta(w io.Writer, mailbox scriptedRFC7162Mailbox) {
+	if len(mailbox.VanishedUIDs) > 0 {
+		_, _ = fmt.Fprintf(w, "* VANISHED (EARLIER) %s\r\n",
+			imapapi.UIDSetNum(mailbox.VanishedUIDs...).String())
+	}
+	for _, uid := range mailbox.ChangedUIDs {
+		message, ok := scriptedRFC7162MessageByUID(mailbox.Messages, uid)
+		if !ok {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "* %d FETCH (UID %d FLAGS (%s) MODSEQ (%d))\r\n",
+			scriptedRFC7162Sequence(mailbox.Messages, uid), uid,
+			formatScriptedRFC7162Flags(message.Flags), message.ModSeq)
+	}
+}
+
+func scriptedRFC7162MessageByUID(
+	messages []scriptedRFC7162Message,
+	uid imapapi.UID,
+) (scriptedRFC7162Message, bool) {
+	for _, message := range messages {
+		if message.UID == uid {
+			return message, true
+		}
+	}
+	return scriptedRFC7162Message{}, false
+}
+
+func scriptedRFC7162Sequence(messages []scriptedRFC7162Message, uid imapapi.UID) int {
+	uids := scriptedRFC7162MessageUIDs(messages)
+	return slices.Index(uids, uid) + 1
+}
+
+func parseScriptedRFC7162UIDSet(command string) []imapapi.UID {
+	rest := strings.TrimSpace(command[len("UID FETCH"):])
+	setText, _, _ := strings.Cut(rest, " ")
+	var uids []imapapi.UID
+	for item := range strings.SplitSeq(setText, ",") {
+		parts := strings.Split(item, ":")
+		start, err := strconv.ParseUint(parts[0], 10, 32)
+		if err != nil {
+			continue
+		}
+		end := start
+		if len(parts) == 2 && parts[1] != "*" {
+			end, err = strconv.ParseUint(parts[1], 10, 32)
+			if err != nil {
+				continue
+			}
+		}
+		for uid := start; uid <= end; uid++ {
+			uids = append(uids, imapapi.UID(uid))
+		}
+	}
+	return uids
+}
+
+func writeScriptedRFC7162Fetch(
+	w io.Writer,
+	command string,
+	mailbox scriptedRFC7162Mailbox,
+) {
+	headerOnly := strings.Contains(strings.ToUpper(command), "HEADER.FIELDS")
+	for _, uid := range parseScriptedRFC7162UIDSet(command) {
+		message, ok := scriptedRFC7162MessageByUID(mailbox.Messages, uid)
+		if !ok {
+			continue
+		}
+		sequence := scriptedRFC7162Sequence(mailbox.Messages, uid)
+		if headerOnly {
+			body := "\r\n"
+			if message.MessageID != "" {
+				body = fmt.Sprintf("Message-ID: <%s>\r\n\r\n", message.MessageID)
+			}
+			_, _ = fmt.Fprintf(w,
+				"* %d FETCH (UID %d FLAGS (%s) BODY[HEADER.FIELDS (MESSAGE-ID)] {%d}\r\n%s)\r\n",
+				sequence, uid, formatScriptedRFC7162Flags(message.Flags), len(body), body)
+			continue
+		}
+		raw := scriptedRFC7162RawMessage(message)
+		_, _ = fmt.Fprintf(w,
+			"* %d FETCH (UID %d FLAGS (%s) INTERNALDATE \"01-Jan-2024 00:00:00 +0000\" RFC822.SIZE %d BODY[] {%d}\r\n%s)\r\n",
+			sequence, uid, formatScriptedRFC7162Flags(message.Flags), len(raw), len(raw), raw)
+	}
+}
+
+func scriptedRFC7162RawMessage(message scriptedRFC7162Message) string {
+	subject := message.Subject
+	if subject == "" {
+		subject = "Synthetic message"
+	}
+	messageIDHeader := ""
+	if message.MessageID != "" {
+		messageIDHeader = fmt.Sprintf("Message-ID: <%s>\r\n", message.MessageID)
+	}
+	return fmt.Sprintf(
+		"From: sender@example.test\r\nTo: recipient@example.test\r\nDate: Mon, 1 Jan 2024 00:00:00 +0000\r\n%sSubject: %s\r\n\r\nSynthetic body.\r\n",
+		messageIDHeader, subject)
+}
+
+func newScriptedRFC7162Client(
+	t *testing.T,
+	addr string,
+	opts ...imap.Option,
+) *imap.Client {
+	t.Helper()
+	host, portText, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	client := imap.NewClient(&imap.Config{
+		Host: host, Port: port, Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword, opts...)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func runScriptedRFC7162Sync(
+	t *testing.T,
+	st *store.Store,
+	identifier string,
+	addr string,
+) (*imap.Client, *store.Source, error) {
+	t.Helper()
+	source, err := st.GetOrCreateSource(sourceTypeIMAP, identifier)
+	require.NoError(t, err)
+	client := newScriptedRFC7162Client(t, addr, imapFolderStateOptions(st, source, false)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	summary, err := newMessageSyncer(client, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).
+		Full(t.Context(), identifier)
+	if err != nil {
+		return client, source, err
+	}
+	if summary.Errors != 0 {
+		return client, source, fmt.Errorf(
+			"scripted IMAP sync completed with %d errors", summary.Errors)
+	}
+	return client, source, saveIMAPFolderStates(
+		context.Background(), st, source, client, summary, options.Limit)
+}
+
+func requireScriptedRFC7162Sync(
+	t *testing.T,
+	st *store.Store,
+	identifier string,
+	addr string,
+) (*imap.Client, *store.Source) {
+	t.Helper()
+	client, source, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(t, err)
+	return client, source
+}
+
+func scriptedRFC7162Capabilities() string {
+	return "IMAP4rev1 ENABLE QRESYNC CONDSTORE SPECIAL-USE"
+}
+
+func newScriptedRFC7162Message(uid imapapi.UID, messageID string, flags ...imapapi.Flag) scriptedRFC7162Message {
+	return scriptedRFC7162Message{
+		UID: uid, MessageID: messageID, Flags: flags, ModSeq: 2,
+	}
+}
+
+func scriptedRFC7162Inbox(
+	uidValidity uint32,
+	uidNext uint32,
+	modSeq uint64,
+	messages ...scriptedRFC7162Message,
+) scriptedRFC7162Mailbox {
+	return scriptedRFC7162Mailbox{
+		Name: "INBOX", UIDValidity: uidValidity, UIDNext: uidNext,
+		HighestModSeq: modSeq, Messages: messages,
+	}
+}
+
+func queryScriptedRFC7162Memberships(
+	t *testing.T,
+	st *store.Store,
+	sourceID int64,
+) []string {
+	t.Helper()
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT mailbox, uid, flags FROM imap_message_memberships
+		WHERE source_id = ? ORDER BY mailbox, uid
+	`), sourceID)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var memberships []string
+	for rows.Next() {
+		var mailbox, flags string
+		var uid uint32
+		require.NoError(t, rows.Scan(&mailbox, &uid, &flags))
+		var decodedFlags []string
+		require.NoError(t, json.Unmarshal([]byte(flags), &decodedFlags))
+		canonicalFlags, err := json.Marshal(decodedFlags)
+		require.NoError(t, err)
+		memberships = append(memberships, fmt.Sprintf("%s|%d|%s", mailbox, uid, canonicalFlags))
+	}
+	require.NoError(t, rows.Err())
+	slices.Sort(memberships)
+	return memberships
+}
+
+func queryScriptedRFC7162LabelsBySourceMessageID(
+	t *testing.T,
+	st *store.Store,
+	sourceID int64,
+) []string {
+	t.Helper()
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT messages.source_message_id, labels.source_label_id
+		FROM messages
+		JOIN message_labels ON message_labels.message_id = messages.id
+		JOIN labels ON labels.id = message_labels.label_id
+		WHERE messages.source_id = ?
+	`), sourceID)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var labels []string
+	for rows.Next() {
+		var sourceMessageID, label string
+		require.NoError(t, rows.Scan(&sourceMessageID, &label))
+		labels = append(labels, sourceMessageID+"|"+label)
+	}
+	require.NoError(t, rows.Err())
+	slices.Sort(labels)
+	return labels
+}
+
+func installScriptedRFC7162ApplyFailureTrigger(t *testing.T, st *store.Store) {
+	t.Helper()
+	if st.IsPostgreSQL() {
+		_, err := st.DB().Exec(`
+			CREATE FUNCTION fail_scripted_imap_apply() RETURNS trigger AS $$
+			BEGIN
+				RAISE EXCEPTION 'scripted IMAP apply failure';
+			END;
+			$$ LANGUAGE plpgsql
+		`)
+		require.NoError(t, err)
+		_, err = st.DB().Exec(`
+			CREATE TRIGGER fail_scripted_imap_apply
+			BEFORE UPDATE ON imap_folder_state
+			FOR EACH ROW EXECUTE FUNCTION fail_scripted_imap_apply()
+		`)
+		require.NoError(t, err)
+		return
+	}
+	_, err := st.DB().Exec(`
+		CREATE TRIGGER fail_scripted_imap_apply
+		BEFORE UPDATE ON imap_folder_state
+		BEGIN
+			SELECT RAISE(ABORT, 'scripted IMAP apply failure');
+		END
+	`)
+	require.NoError(t, err)
+}
+
+func queryScriptedRFC7162MessageState(
+	t *testing.T,
+	st *store.Store,
+	sourceID int64,
+	messageID string,
+) (sourceMessageID string, deleted bool, isRead bool) {
+	t.Helper()
+	var deletedAt sql.NullTime
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT source_message_id, deleted_from_source_at, is_read
+		FROM messages WHERE source_id = ? AND rfc822_message_id = ?
+	`), sourceID, "<"+messageID+">").Scan(&sourceMessageID, &deletedAt, &isRead))
+	return sourceMessageID, deletedAt.Valid, isRead
+}
+
+func queryScriptedRFC7162MessageLabels(
+	t *testing.T,
+	st *store.Store,
+	sourceID int64,
+	messageID string,
+) []string {
+	t.Helper()
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT l.source_label_id
+		FROM messages m
+		JOIN message_labels ml ON ml.message_id = m.id
+		JOIN labels l ON l.id = ml.label_id
+		WHERE m.source_id = ? AND m.rfc822_message_id = ?
+		ORDER BY l.source_label_id
+	`), sourceID, "<"+messageID+">")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var labels []string
+	for rows.Next() {
+		var label string
+		require.NoError(t, rows.Scan(&label))
+		labels = append(labels, label)
+	}
+	require.NoError(t, rows.Err())
+	return labels
+}
+
+func TestIMAPQresyncEndToEndAppend(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	baseline := scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+			77, 2, 1, newScriptedRFC7162Message(1, "existing@example.test"))},
+	}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://append@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{{
+			Name: "INBOX", UIDValidity: 77, UIDNext: 3, HighestModSeq: 2,
+			Messages: []scriptedRFC7162Message{
+				newScriptedRFC7162Message(1, "existing@example.test"),
+				newScriptedRFC7162Message(2, "appended@example.test", imapapi.FlagSeen),
+			},
+			ChangedUIDs: []imapapi.UID{2},
+		}},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+
+	known, err := st.GetIMAPKnownUIDs(source.ID)
+	requirements.NoError(err)
+	assertions.Equal(map[string][]uint32{"INBOX": {1, 2}}, known)
+	assertions.Equal([]string{
+		"INBOX|1|[]", "INBOX|2|[\"\\\\Seen\"]",
+	}, queryScriptedRFC7162Memberships(t, st, source.ID))
+	commands := server.commandsFor(2)
+	assertions.Contains(commands, "ENABLE QRESYNC")
+	assertions.Contains(commands, "SELECT INBOX (CONDSTORE)")
+	assertions.Contains(commands, "CHANGEDSINCE 1 VANISHED")
+	assertions.NotContains(commands, "UID SEARCH")
+}
+
+func TestIMAPQresyncEndToEndRetiresChangedMailboxTopology(t *testing.T) {
+	t.Run("deleted mailbox removes cursor and tombstones last membership", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		baseline := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{
+				scriptedRFC7162Inbox(77, 1, 1),
+				{Name: "Retired", UIDValidity: 88, UIDNext: 2, HighestModSeq: 1,
+					Messages: []scriptedRFC7162Message{
+						newScriptedRFC7162Message(1, "retired-topology@example.test"),
+					}},
+			},
+		}
+		addr, server := startScriptedRFC7162Server(t, baseline)
+		st := testutil.NewTestStore(t)
+		const identifier = "imap://retired-topology@example.test"
+		first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(first.Close())
+
+		server.setSnapshot(scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes:    []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(77, 1, 1)},
+		})
+		second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(second.Close())
+
+		states, err := st.GetIMAPFolderStates(source.ID)
+		requirements.NoError(err)
+		assertions.Equal([]store.IMAPFolderState{{
+			Mailbox: "INBOX", UIDValidity: 77, UIDNext: 1, HighestModSeq: 1,
+		}}, states)
+		assertions.Empty(queryScriptedRFC7162Memberships(t, st, source.ID))
+		_, deleted, _ := queryScriptedRFC7162MessageState(
+			t, st, source.ID, "retired-topology@example.test")
+		assertions.True(deleted)
+		assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
+		assertions.Contains(server.commandsFor(3), "LIST")
+	})
+
+	t.Run("renamed mailbox replaces cursor and label", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		message := newScriptedRFC7162Message(1, "renamed-topology@example.test")
+		baseline := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{
+				scriptedRFC7162Inbox(77, 1, 1),
+				{Name: "Old", UIDValidity: 88, UIDNext: 2, HighestModSeq: 1,
+					Messages: []scriptedRFC7162Message{message}},
+			},
+		}
+		addr, server := startScriptedRFC7162Server(t, baseline)
+		st := testutil.NewTestStore(t)
+		const identifier = "imap://renamed-topology@example.test"
+		first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(first.Close())
+
+		server.setSnapshot(scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{
+				scriptedRFC7162Inbox(77, 1, 1),
+				{Name: "New", UIDValidity: 99, UIDNext: 2, HighestModSeq: 1,
+					Messages: []scriptedRFC7162Message{message}},
+			},
+		})
+		second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(second.Close())
+
+		states, err := st.GetIMAPFolderStates(source.ID)
+		requirements.NoError(err)
+		requirements.Len(states, 2)
+		stateNames := []string{states[0].Mailbox, states[1].Mailbox}
+		slices.Sort(stateNames)
+		assertions.Equal([]string{"INBOX", "New"}, stateNames)
+		assertions.Equal([]string{"New"}, queryScriptedRFC7162MessageLabels(
+			t, st, source.ID, "renamed-topology@example.test"))
+		_, deleted, _ := queryScriptedRFC7162MessageState(
+			t, st, source.ID, "renamed-topology@example.test")
+		assertions.False(deleted)
+		assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
+		assertions.Contains(server.commandsFor(3), "UID SEARCH")
+	})
+
+	t.Run("zero current mailboxes removes the final cursor", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		baseline := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+				77, 2, 1, newScriptedRFC7162Message(1, "zero-topology@example.test"))},
+		}
+		addr, server := startScriptedRFC7162Server(t, baseline)
+		st := testutil.NewTestStore(t)
+		const identifier = "imap://zero-topology@example.test"
+		first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(first.Close())
+
+		server.setSnapshot(scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes:    []scriptedRFC7162Mailbox{},
+		})
+		second := newScriptedRFC7162Client(
+			t, addr, imapFolderStateOptions(st, source, false)...)
+		options := msgsync.DefaultOptions()
+		options.SourceType = sourceTypeIMAP
+		options.NoResume = true
+		summary, err := newMessageSyncer(second, st, options).
+			WithLogger(slog.New(slog.DiscardHandler)).
+			Full(t.Context(), identifier)
+		requirements.NoError(err)
+		deltas := second.ObservedMailboxDeltas()
+		assertions.NotNil(deltas,
+			"an authoritative empty topology must remain distinct from suppressed publication")
+		assertions.Empty(deltas)
+		requirements.NoError(saveIMAPFolderStates(
+			context.Background(), st, source, second, summary, options.Limit))
+		requirements.NoError(second.Close())
+
+		states, err := st.GetIMAPFolderStates(source.ID)
+		requirements.NoError(err)
+		assertions.Empty(states)
+		assertions.Empty(queryScriptedRFC7162Memberships(t, st, source.ID))
+		_, deleted, _ := queryScriptedRFC7162MessageState(
+			t, st, source.ID, "zero-topology@example.test")
+		assertions.True(deleted)
+		assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
+		assertions.Contains(server.commandsFor(3), "LIST")
+	})
+}
+
+func TestIMAPQresyncEndToEndFlagOnlyChangePreservesLocalReadState(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	baseline := scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+			77, 2, 1, newScriptedRFC7162Message(1, "flags@example.test"))},
+	}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://flags@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+	_, err := st.DB().Exec(st.Rebind(`
+		UPDATE messages SET is_read = ? WHERE source_id = ? AND source_message_id = ?
+	`), false, source.ID, "INBOX|1")
+	requirements.NoError(err)
+
+	changed := scriptedRFC7162Inbox(
+		77, 2, 2,
+		newScriptedRFC7162Message(1, "flags@example.test", imapapi.FlagSeen, imapapi.FlagFlagged),
+	)
+	changed.ChangedUIDs = []imapapi.UID{1}
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{changed},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+
+	assertions.Equal([]string{
+		"INBOX|1|[\"\\\\Flagged\",\"\\\\Seen\"]",
+	}, queryScriptedRFC7162Memberships(t, st, source.ID))
+	_, deleted, isRead := queryScriptedRFC7162MessageState(
+		t, st, source.ID, "flags@example.test")
+	assertions.False(deleted)
+	assertions.False(isRead, "provider flags must not overwrite local read state")
+	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+}
+
+func TestIMAPQresyncEndToEndLimitedRunPreservesOverlappingMailboxLabels(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	message := newScriptedRFC7162Message(1, "limited-overlap@example.test")
+	baseline := scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{
+			scriptedRFC7162Inbox(77, 2, 1, message),
+			{Name: "Archive", UIDValidity: 88, UIDNext: 2, HighestModSeq: 1,
+				Messages: []scriptedRFC7162Message{message}},
+		},
+	}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://limited-overlap@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	changed := newScriptedRFC7162Message(
+		1, "limited-overlap@example.test", imapapi.FlagSeen)
+	inbox := scriptedRFC7162Inbox(77, 2, 2, changed)
+	inbox.ChangedUIDs = []imapapi.UID{1}
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{
+			inbox,
+			{Name: "Archive", UIDValidity: 88, UIDNext: 2, HighestModSeq: 1,
+				Messages: []scriptedRFC7162Message{message}},
+		},
+	})
+	limitedClient := newScriptedRFC7162Client(
+		t, addr, imapFolderStateOptions(st, source, false)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	options.Limit = 1
+	summary, err := newMessageSyncer(limitedClient, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).Full(t.Context(), identifier)
+	requirements.NoError(err)
+	requirements.NoError(saveIMAPFolderStates(
+		context.Background(), st, source, limitedClient, summary, options.Limit))
+	requirements.NoError(limitedClient.Close())
+
+	assertions.Equal([]string{"Archive", "INBOX"}, queryScriptedRFC7162MessageLabels(
+		t, st, source.ID, "limited-overlap@example.test"))
+	assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
+	assertions.Contains(server.commandsFor(2), "UID SEARCH")
+	states, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	for _, state := range states {
+		assertions.Equal(uint64(1), state.HighestModSeq,
+			"a limited run must not publish mailbox cursors")
+	}
+}
+
+func TestIMAPQresyncEndToEndMoveAndFinalExpunge(t *testing.T) {
+	t.Run("move keeps the message live under its new membership", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		baseline := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{
+				scriptedRFC7162Inbox(77, 2, 1, newScriptedRFC7162Message(1, "move@example.test")),
+				{Name: "Archive", UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+			},
+		}
+		addr, server := startScriptedRFC7162Server(t, baseline)
+		st := testutil.NewTestStore(t)
+		const identifier = "imap://move@example.test"
+		first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(first.Close())
+
+		server.setSnapshot(scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "INBOX", UIDValidity: 77, UIDNext: 2, HighestModSeq: 2,
+					VanishedUIDs: []imapapi.UID{1}},
+				{Name: "Archive", UIDValidity: 88, UIDNext: 2, HighestModSeq: 2,
+					Messages:    []scriptedRFC7162Message{newScriptedRFC7162Message(1, "move@example.test")},
+					ChangedUIDs: []imapapi.UID{1}},
+			},
+		})
+		second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(second.Close())
+
+		assertions.Equal([]string{"Archive|1|[]"},
+			queryScriptedRFC7162Memberships(t, st, source.ID))
+		_, deleted, _ := queryScriptedRFC7162MessageState(t, st, source.ID, "move@example.test")
+		assertions.False(deleted)
+		assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+	})
+
+	t.Run("final expunge tombstones the archived message", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		baseline := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+				77, 2, 1, newScriptedRFC7162Message(1, "expunge@example.test"))},
+		}
+		addr, server := startScriptedRFC7162Server(t, baseline)
+		st := testutil.NewTestStore(t)
+		const identifier = "imap://expunge@example.test"
+		first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(first.Close())
+
+		empty := scriptedRFC7162Inbox(77, 2, 2)
+		empty.VanishedUIDs = []imapapi.UID{1}
+		server.setSnapshot(scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{empty},
+		})
+		second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(second.Close())
+
+		assertions.Empty(queryScriptedRFC7162Memberships(t, st, source.ID))
+		_, deleted, _ := queryScriptedRFC7162MessageState(t, st, source.ID, "expunge@example.test")
+		assertions.True(deleted)
+		assertions.Contains(server.commandsFor(2), "VANISHED")
+	})
+}
+
+func TestIMAPQresyncEndToEndReplaysAfterFailedApplication(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	baseline := scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(77, 1, 1)},
+	}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://replay@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	changed := scriptedRFC7162Inbox(
+		77, 2, 2, newScriptedRFC7162Message(1, "replay@example.test"))
+	changed.ChangedUIDs = []imapapi.UID{1}
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{changed},
+	})
+	failedClient := newScriptedRFC7162Client(
+		t, addr, imapFolderStateOptions(st, source, false)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	summary, err := newMessageSyncer(failedClient, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).Full(t.Context(), identifier)
+	requirements.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		DELETE FROM messages WHERE source_id = ? AND source_message_id = ?
+	`), source.ID, "INBOX|1")
+	requirements.NoError(err)
+	err = saveIMAPFolderStates(context.Background(), st, source, failedClient, summary, 0)
+	requirements.Error(err)
+	requirements.NoError(failedClient.Close())
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	assertions.Equal(uint64(1), states[0].HighestModSeq,
+		"failed application must not publish the new cursor")
+	replayed, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(replayed.Close())
+	known, err := st.GetIMAPKnownUIDs(source.ID)
+	requirements.NoError(err)
+	assertions.Equal(map[string][]uint32{"INBOX": {1}}, known)
+	assertions.Contains(server.commandsFor(3), "CHANGEDSINCE 1 VANISHED")
+}
+
+func TestIMAPQresyncEndToEndFailedMoveApplyPreservesBaselineLabels(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	baseline := scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{
+			scriptedRFC7162Inbox(77, 2, 1, newScriptedRFC7162Message(1, "failed-move@example.test")),
+			{Name: "Archive", UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+		},
+	}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://failed-move@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{
+			{Name: "INBOX", UIDValidity: 77, UIDNext: 2, HighestModSeq: 2,
+				VanishedUIDs: []imapapi.UID{1}},
+			{Name: "Archive", UIDValidity: 88, UIDNext: 2, HighestModSeq: 2,
+				Messages:    []scriptedRFC7162Message{newScriptedRFC7162Message(1, "failed-move@example.test")},
+				ChangedUIDs: []imapapi.UID{1}},
+		},
+	})
+	failedClient := newScriptedRFC7162Client(
+		t, addr, imapFolderStateOptions(st, source, false)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	summary, err := newMessageSyncer(failedClient, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).Full(t.Context(), identifier)
+	requirements.NoError(err)
+	installScriptedRFC7162ApplyFailureTrigger(t, st)
+	err = saveIMAPFolderStates(context.Background(), st, source, failedClient, summary, 0)
+	requirements.ErrorContains(err, "scripted IMAP apply failure")
+	requirements.NoError(failedClient.Close())
+
+	assertions.Equal([]string{"INBOX"},
+		queryScriptedRFC7162MessageLabels(t, st, source.ID, "failed-move@example.test"))
+	assertions.Equal([]string{"INBOX|1|[]"},
+		queryScriptedRFC7162Memberships(t, st, source.ID))
+	_, deleted, _ := queryScriptedRFC7162MessageState(
+		t, st, source.ID, "failed-move@example.test")
+	assertions.False(deleted)
+	states, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	for _, state := range states {
+		assertions.Equal(uint64(1), state.HighestModSeq)
+	}
+}
+
+func TestIMAPQresyncEndToEndUIDValidityReset(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	baseline := scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+			77, 2, 1, newScriptedRFC7162Message(1, "old-epoch@example.test"))},
+	}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://uidvalidity@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+			99, 2, 1, newScriptedRFC7162Message(1, "new-epoch@example.test"))},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	assertions.Equal(uint32(99), states[0].UIDValidity)
+	assertions.Equal([]string{"INBOX|1|[]"},
+		queryScriptedRFC7162Memberships(t, st, source.ID))
+	newSourceID, deleted, _ := queryScriptedRFC7162MessageState(
+		t, st, source.ID, "new-epoch@example.test")
+	assertions.Equal("INBOX|1", newSourceID)
+	assertions.False(deleted)
+	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+	assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
+	assertions.Contains(server.commandsFor(3), "UID SEARCH")
+}
+
+func TestIMAPQresyncEndToEndConservativeFallbacks(t *testing.T) {
+	t.Run("unsupported capability uses full enumeration", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		baseline := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes:    []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(77, 1, 1)},
+		}
+		addr, server := startScriptedRFC7162Server(t, baseline)
+		st := testutil.NewTestStore(t)
+		const identifier = "imap://unsupported@example.test"
+		first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(first.Close())
+
+		changed := scriptedRFC7162Inbox(
+			77, 2, 0, newScriptedRFC7162Message(1, "fallback@example.test"))
+		server.setSnapshot(scriptedRFC7162Snapshot{
+			Capabilities: "IMAP4rev1", Mailboxes: []scriptedRFC7162Mailbox{changed},
+		})
+		second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(second.Close())
+
+		known, err := st.GetIMAPKnownUIDs(source.ID)
+		requirements.NoError(err)
+		assertions.Equal(map[string][]uint32{"INBOX": {1}}, known)
+		assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+		assertions.NotContains(server.commandsFor(2), "ENABLE QRESYNC")
+		assertions.Contains(server.commandsFor(3), "UID SEARCH")
+		assertions.GreaterOrEqual(server.connectionCount(), 3)
+	})
+
+	for _, response := range []string{"BAD", "NO"} {
+		t.Run("QRESYNC "+response+" reconnects before full enumeration", func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			baseline := scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes:    []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(77, 1, 1)},
+			}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			identifier := "imap://qresync-" + strings.ToLower(response) + "@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			requirements.NoError(first.Close())
+
+			changed := scriptedRFC7162Inbox(
+				77, 2, 2, newScriptedRFC7162Message(1, "fresh-fallback@example.test"))
+			changed.ChangedUIDs = []imapapi.UID{1}
+			fallback := scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+					77, 3, 3,
+					newScriptedRFC7162Message(1, "fresh-fallback@example.test"),
+					newScriptedRFC7162Message(2, "fallback-race@example.test"),
+				)},
+			}
+			server.setSnapshot(scriptedRFC7162Snapshot{
+				Capabilities:   scriptedRFC7162Capabilities(),
+				Mailboxes:      []scriptedRFC7162Mailbox{changed},
+				QresyncFailure: response,
+				Fallback:       &fallback,
+			})
+			second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			requirements.NoError(second.Close())
+
+			known, err := st.GetIMAPKnownUIDs(source.ID)
+			requirements.NoError(err)
+			assertions.Equal(map[string][]uint32{"INBOX": {1, 2}}, known)
+			states, err := st.GetIMAPFolderStates(source.ID)
+			requirements.NoError(err)
+			assertions.Equal(uint32(3), states[0].UIDNext,
+				"fallback cursor must come from the fresh connection")
+			assertions.Equal(uint64(3), states[0].HighestModSeq)
+			assertions.Contains(server.commandsFor(2), "CHANGEDSINCE 1 VANISHED")
+			assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+			assertions.Contains(server.commandsFor(3), "UID SEARCH")
+			assertions.GreaterOrEqual(server.connectionCount(), 3)
+		})
+	}
+
+	t.Run("fresh fallback relists new special-use mailbox", func(t *testing.T) {
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		baseline := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+				77, 2, 1, newScriptedRFC7162Message(1, "fallback-mailbox@example.test"))},
+		}
+		addr, server := startScriptedRFC7162Server(t, baseline)
+		st := testutil.NewTestStore(t)
+		const identifier = "imap://fallback-mailbox@example.test"
+		first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(first.Close())
+
+		failed := scriptedRFC7162Inbox(77, 2, 2)
+		failed.VanishedUIDs = []imapapi.UID{1}
+		fallback := scriptedRFC7162Snapshot{
+			Capabilities: scriptedRFC7162Capabilities(),
+			Mailboxes: []scriptedRFC7162Mailbox{
+				scriptedRFC7162Inbox(77, 2, 2),
+				{Name: "[Gmail]/All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+					UIDValidity: 99, UIDNext: 2, HighestModSeq: 1,
+					Messages: []scriptedRFC7162Message{
+						newScriptedRFC7162Message(1, "fallback-mailbox@example.test"),
+					}},
+			},
+		}
+		server.setSnapshot(scriptedRFC7162Snapshot{
+			Capabilities:   scriptedRFC7162Capabilities(),
+			Mailboxes:      []scriptedRFC7162Mailbox{failed},
+			QresyncFailure: "BAD",
+			Fallback:       &fallback,
+		})
+		second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+		requirements.NoError(second.Close())
+
+		assertions.Equal([]string{"[Gmail]/All Mail|1|[]"},
+			queryScriptedRFC7162Memberships(t, st, source.ID))
+		_, deleted, _ := queryScriptedRFC7162MessageState(
+			t, st, source.ID, "fallback-mailbox@example.test")
+		assertions.False(deleted)
+		assertions.Contains(server.commandsFor(3), "LIST")
+		assertions.Contains(server.commandsFor(3), "SELECT \"[GMAIL]/ALL MAIL\"")
+	})
+}
+
+func TestIMAPQresyncEndToEndUnsupportedAllDoesNotUseStaleShortcut(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	allMail := scriptedRFC7162Mailbox{
+		Name: "[Gmail]/All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+		UIDValidity: 77, UIDNext: 2, HighestModSeq: 1,
+		Messages: []scriptedRFC7162Message{
+			newScriptedRFC7162Message(1, "unsupported-all@example.test"),
+		},
+	}
+	inbox := scriptedRFC7162Inbox(
+		88, 2, 1, newScriptedRFC7162Message(1, "unsupported-all@example.test"))
+	addr, server := startScriptedRFC7162Server(t, scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://unsupported-all@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+	_, err := st.DB().Exec(st.Rebind(`
+		UPDATE messages SET is_read = ? WHERE source_id = ? AND rfc822_message_id = ?
+	`), false, source.ID, "<unsupported-all@example.test>")
+	requirements.NoError(err)
+
+	allMail.Messages[0].Flags = []imapapi.Flag{imapapi.FlagSeen}
+	inbox.Messages[0].Flags = []imapapi.Flag{imapapi.FlagSeen}
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: "IMAP4rev1 SPECIAL-USE",
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+
+	assertions.Equal([]string{
+		"INBOX|1|[\"\\\\Seen\"]", "[Gmail]/All Mail|1|[\"\\\\Seen\"]",
+	}, queryScriptedRFC7162Memberships(t, st, source.ID))
+	_, deleted, isRead := queryScriptedRFC7162MessageState(
+		t, st, source.ID, "unsupported-all@example.test")
+	assertions.False(deleted)
+	assertions.False(isRead, "provider \\Seen must not overwrite local read state")
+	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+	assertions.Contains(server.commandsFor(3), "UID SEARCH")
+}
+
+func TestIMAPQresyncEndToEndGmailAllAvoidsMembershipScan(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	allMail := scriptedRFC7162Mailbox{
+		Name: "[Gmail]/All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+		UIDValidity: 77, UIDNext: 2, HighestModSeq: 1,
+		Messages: []scriptedRFC7162Message{newScriptedRFC7162Message(1, "all-existing@example.test")},
+	}
+	inbox := scriptedRFC7162Inbox(
+		88, 2, 1, newScriptedRFC7162Message(1, "all-existing@example.test"))
+	addr, server := startScriptedRFC7162Server(t, scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://all-mail@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	allMail.UIDNext = 3
+	allMail.HighestModSeq = 2
+	allMail.Messages = append(allMail.Messages,
+		newScriptedRFC7162Message(2, "all-appended@example.test"))
+	allMail.ChangedUIDs = []imapapi.UID{2}
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+
+	known, err := st.GetIMAPKnownUIDs(source.ID)
+	requirements.NoError(err)
+	assertions.Equal(map[string][]uint32{
+		"INBOX": {1}, "[Gmail]/All Mail": {1, 2},
+	}, known)
+	assertions.NotContains(server.commandsFor(2), "UID SEARCH",
+		"valid global QRESYNC must not rebuild the full membership map")
+	assertions.Contains(server.commandsFor(2), "CHANGEDSINCE 1 VANISHED")
+}
+
+func TestIMAPQresyncEndToEndGmailAllImportsUnidentifiedSecondaryMembership(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		messageID string
+	}{
+		{name: "missing message ID"},
+		{name: "invalid message ID", messageID: "not a valid message id"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			allMail := scriptedRFC7162Mailbox{
+				Name: "[Gmail]/All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+				UIDValidity: 77, UIDNext: 2, HighestModSeq: 1,
+				Messages: []scriptedRFC7162Message{newScriptedRFC7162Message(1, tt.messageID)},
+			}
+			inbox := scriptedRFC7162Inbox(
+				88, 2, 1, newScriptedRFC7162Message(1, tt.messageID))
+			addr, _ := startScriptedRFC7162Server(t, scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+			})
+			st := testutil.NewTestStore(t)
+			client, source, err := runScriptedRFC7162Sync(
+				t, st, "imap://all-mail-unidentified@example.test", addr)
+			requirements.NoError(err)
+			requirements.NoError(client.Close())
+
+			assertions.Equal([]string{"INBOX|1|[]", "[Gmail]/All Mail|1|[]"},
+				queryScriptedRFC7162Memberships(t, st, source.ID))
+			assertions.Equal([]string{
+				"[Gmail]/All Mail|1|INBOX", "[Gmail]/All Mail|1|[Gmail]/All Mail",
+			},
+				queryScriptedRFC7162LabelsBySourceMessageID(t, st, source.ID))
+		})
+	}
+}
+
+func TestIMAPQresyncEndToEndGmailAllKeepsIdenticalUnidentifiedMessagesDistinct(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	allMail := scriptedRFC7162Mailbox{
+		Name: "[Gmail]/All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+		UIDValidity: 77, UIDNext: 3, HighestModSeq: 1,
+		Messages: []scriptedRFC7162Message{
+			newScriptedRFC7162Message(1, ""),
+			newScriptedRFC7162Message(2, ""),
+		},
+	}
+	inbox := scriptedRFC7162Inbox(88, 2, 1, newScriptedRFC7162Message(1, ""))
+	addr, _ := startScriptedRFC7162Server(t, scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	st := testutil.NewTestStore(t)
+	client, source, err := runScriptedRFC7162Sync(
+		t, st, "imap://all-mail-identical-unidentified@example.test", addr)
+	requirements.NoError(err)
+	requirements.NoError(client.Close())
+
+	assertions.Equal([]string{
+		"INBOX|1|[]", "[Gmail]/All Mail|1|[]", "[Gmail]/All Mail|2|[]",
+	}, queryScriptedRFC7162Memberships(t, st, source.ID))
+	assertions.Equal([]string{
+		"INBOX|1|INBOX",
+		"[Gmail]/All Mail|1|[Gmail]/All Mail",
+		"[Gmail]/All Mail|2|[Gmail]/All Mail",
+	}, queryScriptedRFC7162LabelsBySourceMessageID(t, st, source.ID))
+}
+
+func TestIMAPQresyncEndToEndGmailAllIncrementalUnidentifiedMembershipUsesDurableRaw(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	message := newScriptedRFC7162Message(1, "")
+	allMail := scriptedRFC7162Mailbox{
+		Name: "[Gmail]/All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+		UIDValidity: 77, UIDNext: 2, HighestModSeq: 1,
+		Messages: []scriptedRFC7162Message{message},
+	}
+	inbox := scriptedRFC7162Inbox(88, 1, 1)
+	addr, server := startScriptedRFC7162Server(t, scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://all-mail-durable-raw@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	inbox = scriptedRFC7162Inbox(88, 2, 2, message)
+	inbox.ChangedUIDs = []imapapi.UID{1}
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+	aliases, err := st.GetIMAPSourceMessageAliases(source.ID)
+	requirements.NoError(err)
+	assertions.Equal("[Gmail]/All Mail|1", aliases["INBOX|1"])
+
+	inbox.HighestModSeq = 3
+	inbox.Messages[0].Flags = []imapapi.Flag{imapapi.FlagFlagged}
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	third, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(third.Close())
+	canonicalSourceMessageID, aliased := third.CanonicalSourceMessageID("INBOX|1")
+	assertions.True(aliased)
+	assertions.Equal("[Gmail]/All Mail|1", canonicalSourceMessageID)
+
+	assertions.Equal([]string{"INBOX|1|[\"\\\\Flagged\"]", "[Gmail]/All Mail|1|[]"},
+		queryScriptedRFC7162Memberships(t, st, source.ID))
+	assertions.Equal([]string{
+		"[Gmail]/All Mail|1|INBOX", "[Gmail]/All Mail|1|[Gmail]/All Mail",
+	}, queryScriptedRFC7162LabelsBySourceMessageID(t, st, source.ID))
+	var liveMessages int
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages
+		WHERE source_id = ? AND deleted_from_source_at IS NULL
+	`), source.ID).Scan(&liveMessages))
+	assertions.Equal(1, liveMessages, "a repeated secondary change must not revive its dedup copy")
+	assertions.Contains(server.commandsFor(2), "CHANGEDSINCE 1 VANISHED")
+	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+}
+
+func TestIMAPQresyncEndToEndGmailAllStatusFailureSuppressesPublication(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	allMail := scriptedRFC7162Mailbox{
+		Name: "[Gmail]/All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+		UIDValidity: 77, UIDNext: 1, HighestModSeq: 1,
+	}
+	inbox := scriptedRFC7162Inbox(88, 1, 1)
+	addr, server := startScriptedRFC7162Server(t, scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://all-status@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	inbox.StatusFailure = true
+	allMail.HighestModSeq = 2
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes:    []scriptedRFC7162Mailbox{inbox, allMail},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	requirements.Len(states, 2)
+	for _, state := range states {
+		assertions.Equal(uint64(1), state.HighestModSeq)
+	}
+	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+	assertions.Contains(server.commandsFor(3), "SELECT INBOX")
+}
+
+func TestIMAPQresyncEndToEndNoAllEmptyStatusFailureSuppressesPublication(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	baseline := scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{
+			scriptedRFC7162Inbox(77, 1, 1),
+			{Name: "Archive", UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+		},
+	}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://no-all-status@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(first.Close())
+
+	failedArchive := baseline.Mailboxes[1]
+	failedArchive.StatusFailure = true
+	server.setSnapshot(scriptedRFC7162Snapshot{
+		Capabilities: scriptedRFC7162Capabilities(),
+		Mailboxes: []scriptedRFC7162Mailbox{
+			scriptedRFC7162Inbox(77, 1, 2),
+			failedArchive,
+		},
+	})
+	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	requirements.NoError(second.Close())
+
+	states, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	requirements.Len(states, 2)
+	for _, state := range states {
+		assertions.Equal(uint64(1), state.HighestModSeq,
+			"one failed STATUS must suppress the entire authoritative snapshot")
+	}
+	assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
+	assertions.Contains(server.commandsFor(3), `SELECT "ARCHIVE"`)
+}
+
+func TestIMAPQresyncEndToEndZeroStatusCursorSuppressesPublication(t *testing.T) {
+	tests := []struct {
+		name        string
+		uidValidity uint32
+		uidNext     uint32
+	}{
+		{name: "zero UIDVALIDITY", uidValidity: 0, uidNext: 2},
+		{name: "zero UIDNEXT", uidValidity: 77, uidNext: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			message := newScriptedRFC7162Message(1, "zero-status@example.test")
+			baseline := scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes: []scriptedRFC7162Mailbox{
+					scriptedRFC7162Inbox(77, 2, 1, message),
+				},
+			}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			identifier := "imap://zero-status-" + strings.ReplaceAll(tt.name, " ", "-") + "@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			requirements.NoError(first.Close())
+
+			server.setSnapshot(scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes: []scriptedRFC7162Mailbox{{
+					Name: "INBOX", UIDValidity: tt.uidValidity, UIDNext: tt.uidNext,
+					HighestModSeq: 2, Messages: []scriptedRFC7162Message{message},
+				}},
+			})
+			second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			requirements.NoError(second.Close())
+
+			states, err := st.GetIMAPFolderStates(source.ID)
+			requirements.NoError(err)
+			requirements.Len(states, 1)
+			assertions.Equal(uint32(77), states[0].UIDValidity)
+			assertions.Equal(uint32(2), states[0].UIDNext)
+			assertions.Equal(uint64(1), states[0].HighestModSeq)
+		})
+	}
+}
+
+func TestIMAPQresyncEndToEndSelectCursorValidationFallsBackBeforeDeltaFetch(t *testing.T) {
+	tests := []struct {
+		name              string
+		selectUIDValidity *uint32
+		selectUIDNext     *uint32
+	}{
+		{name: "zero UIDVALIDITY", selectUIDValidity: scriptedUint32(0)},
+		{name: "zero UIDNEXT", selectUIDNext: scriptedUint32(0)},
+		{name: "regressed UIDNEXT", selectUIDNext: scriptedUint32(1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			baseline := scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+					77, 2, 1, newScriptedRFC7162Message(1, "select-cursor@example.test"))},
+			}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			identifier := "imap://select-cursor-" + strings.ReplaceAll(tt.name, " ", "-") + "@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			requirements.NoError(first.Close())
+
+			invalid := scriptedRFC7162Inbox(
+				77, 2, 2, newScriptedRFC7162Message(1, "select-cursor@example.test"))
+			invalid.ChangedUIDs = []imapapi.UID{1}
+			invalid.SelectUIDValidity = tt.selectUIDValidity
+			invalid.SelectUIDNext = tt.selectUIDNext
+			fallback := scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes: []scriptedRFC7162Mailbox{scriptedRFC7162Inbox(
+					77, 2, 2, newScriptedRFC7162Message(1, "select-cursor@example.test"))},
+			}
+			server.setSnapshot(scriptedRFC7162Snapshot{
+				Capabilities: scriptedRFC7162Capabilities(),
+				Mailboxes:    []scriptedRFC7162Mailbox{invalid},
+				Fallback:     &fallback,
+			})
+			second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			requirements.NoError(second.Close())
+
+			assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE",
+				"invalid SELECT state must be rejected before delta FETCH")
+			assertions.Contains(server.commandsFor(3), "UID SEARCH",
+				"invalid SELECT state must force fresh full enumeration")
+			states, err := st.GetIMAPFolderStates(source.ID)
+			requirements.NoError(err)
+			requirements.Len(states, 1)
+			assertions.Equal(uint32(77), states[0].UIDValidity)
+			assertions.Equal(uint32(2), states[0].UIDNext)
+			assertions.Equal(uint64(2), states[0].HighestModSeq)
+		})
+	}
+}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -2699,7 +2699,6 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 // across processes (see syncfull.go).
 func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store) (*gmail.SyncSummary, error) {
 	imapOpts := imapFolderStateOptions(s, src, false)
-	imapOpts = append(imapOpts, imapFolderStateSaveOption(s, src))
 	apiClient, err := buildAPIClient(ctx, src, nil, nil, imapOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("build IMAP client: %w", err)
@@ -2735,7 +2734,9 @@ func runScheduledIMAPSync(ctx context.Context, src *store.Source, s *store.Store
 	if err != nil {
 		return nil, fmt.Errorf("IMAP sync failed: %w", err)
 	}
-	saveIMAPFolderStates(s, src, apiClient, summary, 0)
+	if err := saveIMAPFolderStates(ctx, s, src, apiClient, summary, 0); err != nil {
+		return nil, fmt.Errorf("save IMAP incremental state: %w", err)
+	}
 	return summary, nil
 }
 

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -341,11 +341,17 @@ func loadIMAPFolderStates(s *store.Store, sourceID int64) (map[string]imaplib.Fo
 	if err != nil {
 		return nil, err
 	}
+	knownUIDs, err := s.GetIMAPKnownUIDs(sourceID)
+	if err != nil {
+		return nil, err
+	}
 	states := make(map[string]imaplib.FolderState, len(saved))
 	for _, st := range saved {
 		states[st.Mailbox] = imaplib.FolderState{
-			UIDValidity: st.UIDValidity,
-			UIDNext:     st.UIDNext,
+			UIDValidity:   st.UIDValidity,
+			UIDNext:       st.UIDNext,
+			HighestModSeq: st.HighestModSeq,
+			KnownUIDs:     append([]uint32{}, knownUIDs[st.Mailbox]...),
 		}
 	}
 	return states, nil
@@ -369,54 +375,137 @@ func imapFolderStateOptions(
 	} else if len(states) > 0 {
 		opts = append(opts, imaplib.WithFolderStates(states))
 	}
+	aliases, err := s.GetIMAPSourceMessageAliases(src.ID)
+	if err != nil {
+		logger.Warn("failed to load IMAP source message aliases", "source", src.Identifier, "error", err)
+	} else if len(aliases) > 0 {
+		opts = append(opts, imaplib.WithSourceMessageAliases(aliases))
+	}
 	if forceRescan {
 		opts = append(opts, imaplib.WithForceFullEnumeration())
 	}
 	return opts
 }
 
-func saveIMAPFolderState(s *store.Store, src *store.Source, mailbox string, st imaplib.FolderState) {
-	err := s.UpsertIMAPFolderStates(src.ID, []store.IMAPFolderState{{
-		Mailbox:     mailbox,
-		UIDValidity: st.UIDValidity,
-		UIDNext:     st.UIDNext,
-	}})
-	if err != nil {
-		logger.Warn("failed to save IMAP folder state",
-			"source", src.Identifier, "mailbox", mailbox, "error", err)
+func applyIMAPMailboxDeltas(
+	ctx context.Context,
+	s *store.Store,
+	src *store.Source,
+	syncRunID int64,
+	deltas []imaplib.MailboxDelta,
+	observations []imaplib.MembershipObservation,
+) error {
+	type membershipKey struct {
+		mailbox     string
+		uidValidity uint32
+		uid         uint32
 	}
+	normalizedObservations := make([]store.IMAPMembershipObservation, 0, len(observations))
+	observationIndexes := make(map[membershipKey]int, len(observations))
+	for _, observation := range observations {
+		key := membershipKey{
+			mailbox: observation.Mailbox, uidValidity: observation.UIDValidity, uid: observation.UID,
+		}
+		if index, exists := observationIndexes[key]; exists {
+			existing := &normalizedObservations[index]
+			if existing.CanonicalSourceMessageID == "" {
+				existing.CanonicalSourceMessageID = observation.CanonicalSourceMessageID
+			}
+			if existing.RFC822MessageID == "" {
+				existing.RFC822MessageID = observation.RFC822MessageID
+			}
+			if existing.RawSHA256 == ([32]byte{}) {
+				existing.RawSHA256 = observation.RawSHA256
+			}
+			if existing.RawSize == 0 {
+				existing.RawSize = observation.RawSize
+			}
+			continue
+		}
+		observationIndexes[key] = len(normalizedObservations)
+		normalizedObservations = append(normalizedObservations, store.IMAPMembershipObservation{
+			Mailbox:                  observation.Mailbox,
+			UIDValidity:              observation.UIDValidity,
+			UID:                      observation.UID,
+			SourceMessageID:          observation.SourceMessageID,
+			CanonicalSourceMessageID: observation.CanonicalSourceMessageID,
+			RFC822MessageID:          observation.RFC822MessageID,
+			RawSHA256:                observation.RawSHA256,
+			RawSize:                  observation.RawSize,
+			Flags:                    append([]string(nil), observation.Flags...),
+		})
+	}
+	byMailbox := make(map[string][]store.IMAPMembershipObservation)
+	for _, observation := range normalizedObservations {
+		byMailbox[observation.Mailbox] = append(byMailbox[observation.Mailbox], observation)
+	}
+
+	storeDeltas := make([]store.IMAPMailboxDelta, 0, len(deltas))
+	seenMailboxes := make(map[string]struct{}, len(deltas))
+	for _, delta := range deltas {
+		if _, exists := seenMailboxes[delta.Mailbox]; exists {
+			return fmt.Errorf("duplicate IMAP mailbox delta for %q", delta.Mailbox)
+		}
+		seenMailboxes[delta.Mailbox] = struct{}{}
+		vanished := make([]uint32, len(delta.VanishedUIDs))
+		for i, uid := range delta.VanishedUIDs {
+			vanished[i] = uint32(uid)
+		}
+		storeDeltas = append(storeDeltas, store.IMAPMailboxDelta{
+			Mailbox: delta.Mailbox,
+			State: store.IMAPFolderState{
+				Mailbox:       delta.Mailbox,
+				UIDValidity:   delta.State.UIDValidity,
+				UIDNext:       delta.State.UIDNext,
+				HighestModSeq: delta.State.HighestModSeq,
+			},
+			Memberships:  byMailbox[delta.Mailbox],
+			VanishedUIDs: vanished,
+			Reset:        delta.Reset,
+		})
+		delete(byMailbox, delta.Mailbox)
+	}
+	for mailbox := range byMailbox {
+		return fmt.Errorf("IMAP membership observation for mailbox %q has no mailbox delta", mailbox)
+	}
+	return s.ApplyIMAPMailboxDeltasForSyncContext(ctx, src.ID, syncRunID, storeDeltas)
 }
 
-func imapFolderStateSaveOption(s *store.Store, src *store.Source) imaplib.Option {
-	return imaplib.WithFolderStateSave(func(mailbox string, st imaplib.FolderState) {
-		saveIMAPFolderState(s, src, mailbox, st)
-	})
+func imapSyncCanCommit(ctx context.Context, summary *gmail.SyncSummary, limit int) bool {
+	return summary != nil &&
+		ctx.Err() == nil &&
+		summary.Errors == 0 &&
+		!summary.WasResumed &&
+		limit == 0
 }
 
-// saveIMAPFolderStates persists the per-mailbox states observed during
-// listing, but only after a sync that completed cleanly: an
-// interrupted, truncated (--limit), or partly failed run must not
-// advance the high water marks, or the messages it skipped would never be
-// fetched. Save failures only cost the next run's speedup, so they are
-// logged and swallowed.
-func saveIMAPFolderStates(s *store.Store, src *store.Source, apiClient gmail.API, summary *gmail.SyncSummary, limit int) {
+// saveIMAPFolderStates atomically persists mailbox membership and cursor
+// observations only after a clean, unlimited, unfiltered sync.
+func saveIMAPFolderStates(
+	ctx context.Context,
+	s *store.Store,
+	src *store.Source,
+	apiClient gmail.API,
+	summary *gmail.SyncSummary,
+	limit int,
+) error {
 	imapClient, ok := apiClient.(*imaplib.Client)
-	if !ok || summary == nil {
-		return
+	if !ok || !imapSyncCanCommit(ctx, summary, limit) {
+		return nil
 	}
-	if summary.Errors > 0 {
-		return
+	if imapClient.LabelsSnapshotFiltered() || !imapClient.LabelsSnapshotComplete() {
+		return nil
 	}
-	if limit > 0 && summary.MessagesFound >= int64(limit) {
-		return
+	deltas := imapClient.ObservedMailboxDeltas()
+	if deltas == nil {
+		return nil
 	}
-	observed := imapClient.ObservedFolderStates()
-	if len(observed) == 0 {
-		return
+	if err := applyIMAPMailboxDeltas(
+		ctx, s, src, summary.SyncRunID, deltas, imapClient.ObservedMemberships(),
+	); err != nil {
+		return fmt.Errorf("apply IMAP mailbox deltas: %w", err)
 	}
-	for mailbox, st := range observed {
-		saveIMAPFolderState(s, src, mailbox, st)
-	}
+	return nil
 }
 
 func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (*oauth.Manager, error), src *store.Source) error {
@@ -443,7 +532,6 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	if src.SourceType == sourceTypeIMAP {
 		imapOpts = append(imapOpts,
 			imaplib.WithListProgress(progress.OnIMAPListProgress),
-			imapFolderStateSaveOption(s, src),
 		)
 	}
 	apiClient, err := buildAPIClient(ctx, src, getOAuthMgr, nil, imapOpts...)
@@ -512,7 +600,9 @@ func runFullSync(ctx context.Context, s *store.Store, getOAuthMgr func(string) (
 	}
 
 	if src.SourceType == sourceTypeIMAP {
-		saveIMAPFolderStates(s, src, apiClient, summary, opts.Limit)
+		if err := saveIMAPFolderStates(ctx, s, src, apiClient, summary, opts.Limit); err != nil {
+			return fmt.Errorf("save IMAP incremental state: %w", err)
+		}
 	}
 
 	// Print summary; skip the spacer when no progress lines were

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.kenn.io/msgvault
 
 go 1.26.6
 
+replace github.com/emersion/go-imap/v2 => github.com/hstern/go-imap/v2 v2.0.0-beta.8.0.20260621192506-dabdeca47dc7
+
 require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/emersion/go-imap/v2 v2.0.0-beta.8 h1:5IXZK1E33DyeP526320J3RS7eFlCYGFgtbrfapqDPug=
-github.com/emersion/go-imap/v2 v2.0.0-beta.8/go.mod h1:dhoFe2Q0PwLrMD7oZw8ODuaD0vLYPe5uj2wcOMnvh48=
 github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7x/Lpg=
 github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
@@ -172,6 +170,8 @@ github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/hstern/go-imap/v2 v2.0.0-beta.8.0.20260621192506-dabdeca47dc7 h1:nwt9R8tzoiZXAo3jcoMQbLNxEJzTTCOIaKa90emTJE4=
+github.com/hstern/go-imap/v2 v2.0.0-beta.8.0.20260621192506-dabdeca47dc7/go.mod h1:dhoFe2Q0PwLrMD7oZw8ODuaD0vLYPe5uj2wcOMnvh48=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/gmail/sync_types.go
+++ b/internal/gmail/sync_types.go
@@ -19,6 +19,7 @@ type SyncProgress interface {
 
 // SyncSummary contains statistics about a completed sync.
 type SyncSummary struct {
+	SyncRunID        int64
 	StartTime        time.Time
 	EndTime          time.Time
 	Duration         time.Duration

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -3,6 +3,7 @@ package imap
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"slices"
@@ -50,6 +51,7 @@ func markRawBatchError(results []gmailapi.RawMessageBatchResult, items []batchFe
 func rawBatchFetchOptions() *imap.FetchOptions {
 	return &imap.FetchOptions{
 		UID:          true,
+		Flags:        true,
 		InternalDate: true,
 		RFC822Size:   true,
 		BodySection:  []*imap.FetchItemBodySection{{Peek: true}}, // BODY.PEEK[] to avoid marking \Seen
@@ -120,9 +122,40 @@ func (c *Client) applyFetchResults(
 		// Return a non-nil stub with empty Raw so the caller treats this as a
 		// skip, not a fetch error.
 		msgID := compositeID(mailbox, msgBuf.UID)
-		var rfc822MessageID string
-		if c.seenRFC822IDs != nil || c.msgIDToLabels != nil {
-			rfc822MessageID = rawMIMEMessageID(rawMIME)
+		rfc822MessageID := rawMIMEMessageID(rawMIME)
+		canonicalSourceMessageID := ""
+		var rawSHA256 [32]byte
+		if rfc822MessageID == "" && c.preferredRawSourceIDs != nil {
+			rawSHA256 = sha256.Sum256(rawMIME)
+			if mailbox == c.allMailFolder {
+				// A canonical-mailbox UID is its own durable identity. Raw
+				// matching is only a fallback for copies in secondary mailboxes;
+				// using it here would collapse distinct byte-identical messages.
+				canonicalSourceMessageID = msgID
+				if canonical, exists := c.preferredRawSourceIDs[rawSHA256]; !exists {
+					c.preferredRawSourceIDs[rawSHA256] = msgID
+				} else if canonical != msgID {
+					// An empty value marks a digest shared by distinct canonical
+					// messages. Secondary copies cannot safely choose either one.
+					c.preferredRawSourceIDs[rawSHA256] = ""
+				}
+			} else {
+				priorState, sameMailboxEpoch := c.priorFolderStates[mailbox]
+				if sameMailboxEpoch && priorState.UIDValidity == c.selectedUIDValidity {
+					canonicalSourceMessageID = c.sourceMessageAliases[msgID]
+				}
+				if canonicalSourceMessageID == "" {
+					canonicalSourceMessageID = c.preferredRawSourceIDs[rawSHA256]
+				}
+			}
+		}
+		c.recordMembershipLocked(
+			mailbox, msgBuf.UID, canonicalSourceMessageID, rfc822MessageID,
+			rawSHA256, msgBuf.RFC822Size, msgBuf.Flags)
+		if canonicalSourceMessageID != "" && canonicalSourceMessageID != msgID {
+			results[idx].Message = &gmailapi.RawMessage{ID: msgID}
+			results[idx].Err = nil
+			continue
 		}
 		if c.seenRFC822IDs != nil &&
 			rfc822MessageID != "" {
@@ -372,6 +405,8 @@ func (c *Client) applyLabelFetchResults(
 			continue
 		}
 		rfc822MessageID := rawMIMEMessageID(msgBuf.BodySection[0].Bytes)
+		c.recordMembershipLocked(
+			mailbox, msgBuf.UID, "", rfc822MessageID, [32]byte{}, 0, msgBuf.Flags)
 		results[idx].LabelIDs = c.labelsForMessage(mailbox, rfc822MessageID)
 		results[idx].RFC822MessageID = rfc822MessageID
 		results[idx].Err = nil
@@ -651,4 +686,11 @@ func (c *Client) IsPreferredSourceMessageID(messageID string) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.allMailFolder != "" && mailbox == c.allMailFolder
+}
+
+// DefersAuthoritativeLabelReconciliation reports that complete IMAP mailbox
+// labels are committed by the post-sync mailbox-delta transaction. Syncer may
+// still merge labels for filtered or otherwise incomplete snapshots.
+func (c *Client) DefersAuthoritativeLabelReconciliation() bool {
+	return true
 }

--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -84,12 +84,134 @@ func TestMessageIDHeaderFetchOptionsAvoidsRawMessageBody(t *testing.T) {
 	opts := messageIDHeaderFetchOptions()
 
 	assert.True(opts.UID)
+	assert.True(opts.Flags)
 	assert.False(opts.InternalDate)
 	assert.False(opts.RFC822Size)
 	require.Len(opts.BodySection, 1)
 	assert.True(opts.BodySection[0].Peek)
 	assert.Equal(imapapi.PartSpecifierHeader, opts.BodySection[0].Specifier)
 	assert.Equal([]string{"Message-ID"}, opts.BodySection[0].HeaderFields)
+}
+
+func TestRawBatchFetchRecordsMembershipBeforeDedup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"All Mail": 0, "Archive": 0},
+		map[string][]imapapi.MailboxAttr{"All Mail": {imapapi.MailboxAttrAll}},
+	)
+	const messageID = "membership-dedup@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "All Mail", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", messageID)
+	client := newTestClient(t, addr)
+	require.ElementsMatch([]string{"All Mail|1", "Archive|1"}, listAllMessages(t, client))
+
+	client.mu.Lock()
+	client.observedMemberships = nil
+	var uidSet imapapi.UIDSet
+	uidSet.AddNum(1)
+	allMailSelectErr := client.selectMailbox("All Mail")
+	var allMailStoreErr error
+	if allMailSelectErr == nil {
+		_, allMailStoreErr = client.conn.Store(uidSet, &imapapi.StoreFlags{
+			Op: imapapi.StoreFlagsSet, Flags: []imapapi.Flag{imapapi.FlagSeen},
+		}, nil).Collect()
+	}
+	archiveSelectErr := client.selectMailbox("Archive")
+	var archiveStoreErr error
+	if archiveSelectErr == nil {
+		_, archiveStoreErr = client.conn.Store(uidSet, &imapapi.StoreFlags{
+			Op: imapapi.StoreFlagsSet, Flags: []imapapi.Flag{imapapi.FlagFlagged},
+		}, nil).Collect()
+	}
+	client.mu.Unlock()
+	require.NoError(allMailSelectErr)
+	require.NoError(allMailStoreErr)
+	require.NoError(archiveSelectErr)
+	require.NoError(archiveStoreErr)
+	results, err := client.GetMessagesRawBatchWithErrors(
+		context.Background(), []string{"All Mail|1", "Archive|1"})
+	require.NoError(err)
+	require.Len(results, 2)
+	require.NotNil(results[0].Message)
+	require.NotNil(results[1].Message)
+	assert.NotEmpty(results[0].Message.Raw)
+	assert.Empty(results[1].Message.Raw, "the overlapping copy is returned as a duplicate stub")
+
+	observed := client.ObservedMemberships()
+	require.Len(observed, 2, "both raw FETCH results must be recorded before deduplication")
+	assert.Equal("All Mail", observed[0].Mailbox)
+	assert.NotZero(observed[0].UIDValidity)
+	assert.Equal(uint32(1), observed[0].UID)
+	assert.Equal("All Mail|1", observed[0].SourceMessageID)
+	assert.Equal(messageID, observed[0].RFC822MessageID)
+	assert.Equal([]string{"\\Seen"}, observed[0].Flags)
+	assert.Equal("Archive", observed[1].Mailbox)
+	assert.NotZero(observed[1].UIDValidity)
+	assert.Equal(uint32(1), observed[1].UID)
+	assert.Equal("Archive|1", observed[1].SourceMessageID)
+	assert.Equal(messageID, observed[1].RFC822MessageID)
+	assert.Equal([]string{"\\Flagged"}, observed[1].Flags)
+}
+
+func TestLabelOnlyFetchRecordsCanonicalMembershipFlags(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 0})
+	const messageID = "label-membership@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+	client := newTestClient(t, addr)
+	require.Equal([]string{"INBOX|1"}, listAllMessages(t, client))
+
+	client.mu.Lock()
+	client.observedMemberships = nil
+	selectErr := client.selectMailbox("INBOX")
+	var uidSet imapapi.UIDSet
+	uidSet.AddNum(1)
+	var storeErr error
+	if selectErr == nil {
+		_, storeErr = client.conn.Store(uidSet, &imapapi.StoreFlags{
+			Op:    imapapi.StoreFlagsSet,
+			Flags: []imapapi.Flag{imapapi.FlagSeen, imapapi.FlagFlagged, "$Forwarded"},
+		}, nil).Collect()
+	}
+	client.mu.Unlock()
+	require.NoError(selectErr)
+	require.NoError(storeErr)
+
+	results, err := client.GetMessageLabelsBatch(context.Background(), []string{"INBOX|1"})
+	require.NoError(err)
+	require.Len(results, 1)
+	require.NoError(results[0].Err)
+
+	observed := client.ObservedMemberships()
+	require.Len(observed, 1)
+	assert.Equal(MembershipObservation{
+		Mailbox:         "INBOX",
+		UIDValidity:     observed[0].UIDValidity,
+		UID:             1,
+		SourceMessageID: "INBOX|1",
+		RFC822MessageID: messageID,
+		Flags:           []string{"$Forwarded", "\\Flagged", "\\Seen"},
+	}, observed[0])
+	assert.NotZero(observed[0].UIDValidity)
+}
+
+func TestObservedMembershipsReturnsDefensiveCopy(t *testing.T) {
+	client := &Client{observedMemberships: []MembershipObservation{{
+		Mailbox: "INBOX", UID: 1, Flags: []string{"\\Seen"},
+	}}}
+
+	first := client.ObservedMemberships()
+	first[0].Mailbox = "mutated"
+	first[0].Flags[0] = "mutated"
+	first = append(first, MembershipObservation{Mailbox: "extra"})
+	assert.Len(t, first, 2)
+
+	assert.Equal(t, []MembershipObservation{{
+		Mailbox: "INBOX", UID: 1, Flags: []string{"\\Seen"},
+	}}, client.ObservedMemberships())
 }
 
 func TestGetMessageLabelsBatchPreservesPerMessageMissingUID(t *testing.T) {

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -80,33 +79,42 @@ type Client struct {
 	tokenSource func(ctx context.Context) (string, error) // XOAUTH2 token callback
 	logger      *slog.Logger
 
-	mu                  sync.Mutex
-	conn                *imapclient.Client
-	selectedMailbox     string               // currently selected mailbox
-	selectedNumMessages uint32               // EXISTS count from the last SELECT
-	mailboxCache        []string             // cached list of selectable mailboxes
-	messageListCache    []gmailapi.MessageID // full message ID list, built once per session
-	trashMailbox        string               // cached trash mailbox name
-	junkMailbox         string               // cached junk/spam mailbox name
-	allMailFolder       string               // mailbox with \All attribute (empty if not detected)
-	msgIDToLabels       map[string][]string  // RFC822 Message-ID → mailbox memberships
-	seenRFC822IDs       map[string]bool      // dedup overlapping mailbox copies
-	labelMapComplete    bool                 // latest listing collected every mailbox membership
-	since               time.Time            // IMAP SINCE date filter (zero = no filter)
-	before              time.Time            // IMAP BEFORE date filter (zero = no filter)
+	mu                    sync.Mutex
+	conn                  *imapclient.Client
+	selectedMailbox       string               // currently selected mailbox
+	selectedUIDValidity   uint32               // UIDVALIDITY from the last SELECT
+	selectedNumMessages   uint32               // EXISTS count from the last SELECT
+	mailboxCache          []string             // cached list of selectable mailboxes
+	messageListCache      []gmailapi.MessageID // full message ID list, built once per session
+	trashMailbox          string               // cached trash mailbox name
+	junkMailbox           string               // cached junk/spam mailbox name
+	allMailFolder         string               // mailbox with \All attribute (empty if not detected)
+	msgIDToLabels         map[string][]string  // RFC822 Message-ID → mailbox memberships
+	seenRFC822IDs         map[string]bool      // dedup overlapping mailbox copies
+	preferredRawSourceIDs map[[32]byte]string  // raw digest → canonical \All source ID
+	sourceMessageAliases  map[string]string    // mailbox UID source ID → durable canonical source ID
+	activeSourceAliases   map[string]string    // aliases validated by this session's QRESYNC SELECTs
+	labelMapComplete      bool                 // latest listing collected every mailbox membership
+	since                 time.Time            // IMAP SINCE date filter (zero = no filter)
+	before                time.Time            // IMAP BEFORE date filter (zero = no filter)
 
 	// folderFilter overrides which mailboxes are included in the sync.
 	// Zero-valued (empty include and exclude) means "all mailboxes".
 	folderFilterInclude, folderFilterExclude []string
 
-	forceFullEnumeration bool
-	priorFolderStates    map[string]FolderState // saved states from the last completed sync
-	observedFolderStates map[string]FolderState // states captured during this session's listing
-	folderStateSave      func(string, FolderState)
-	pendingFolderStates  map[string]FolderState
-	pendingFolderCounts  map[string]int
-	pendingMessageFolder map[string]string
-	completedFolders     map[string]bool
+	forceFullEnumeration  bool
+	priorFolderStates     map[string]FolderState // saved states from the last completed sync
+	observedFolderStates  map[string]FolderState // states captured during this session's listing
+	folderStateSave       func(string, FolderState)
+	pendingFolderStates   map[string]FolderState
+	pendingFolderCounts   map[string]int
+	pendingMessageFolder  map[string]string
+	completedFolders      map[string]bool
+	observedMailboxDeltas []MailboxDelta
+	observedMemberships   []MembershipObservation
+	qresyncEnabled        bool
+	qresyncCaptureMu      sync.Mutex
+	qresyncCapture        *protocolDeltaCapture
 
 	// listProgress, when set, is invoked during message-list
 	// enumeration: once with done=0 after the mailbox list is known,
@@ -168,7 +176,11 @@ func (c *Client) connect(ctx context.Context) error {
 	addr := c.config.Addr()
 	c.logger.Debug("connecting to IMAP server", "addr", addr, "tls", c.config.TLS, "starttls", c.config.STARTTLS)
 
-	imapOpts := &imapclient.Options{}
+	imapOpts := &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			Vanished: c.captureQresyncVanished,
+		},
+	}
 	var (
 		conn *imapclient.Client
 		err  error
@@ -214,6 +226,8 @@ func (c *Client) connect(ctx context.Context) error {
 
 	c.conn = conn
 	c.selectedMailbox = ""
+	c.selectedUIDValidity = 0
+	c.qresyncEnabled = false
 	c.logger.Debug("connected and authenticated", "user", c.config.Username)
 	return nil
 }
@@ -230,6 +244,9 @@ func (c *Client) reconnect(ctx context.Context) error {
 		c.conn = nil
 	}
 	c.selectedMailbox = ""
+	c.selectedUIDValidity = 0
+	c.qresyncEnabled = false
+	c.clearQresyncCapture()
 	c.logger.Debug("reconnecting to IMAP server", "addr", c.config.Addr())
 	return c.connect(ctx)
 }
@@ -251,6 +268,9 @@ func (c *Client) withConn(ctx context.Context, fn func(*imapclient.Client) error
 		}
 		c.conn = nil
 		c.selectedMailbox = ""
+		c.selectedUIDValidity = 0
+		c.qresyncEnabled = false
+		c.clearQresyncCapture()
 	}
 	return err
 }
@@ -265,6 +285,7 @@ func (c *Client) selectMailbox(mailbox string) error {
 		return fmt.Errorf("SELECT %q: %w", mailbox, err)
 	}
 	c.selectedMailbox = mailbox
+	c.selectedUIDValidity = data.UIDValidity
 	c.selectedNumMessages = data.NumMessages
 	return nil
 }
@@ -346,6 +367,17 @@ func (c *Client) listMailboxesLocked() ([]string, error) {
 	return names, nil
 }
 
+// clearMailboxDiscoveryLocked discards connection-derived mailbox and
+// special-use metadata. Conservative fallback calls this after reconnect so
+// the authoritative scan cannot reuse a mailbox topology from the failed
+// QRESYNC connection.
+func (c *Client) clearMailboxDiscoveryLocked() {
+	c.mailboxCache = nil
+	c.trashMailbox = ""
+	c.junkMailbox = ""
+	c.allMailFolder = ""
+}
+
 // enumerateMailboxSearchCriteria always constrains the search with an
 // explicit UID range: some servers (e.g. iCloud) return sequence-number-like
 // values for an unconstrained UID SEARCH, which later fail to fetch.
@@ -372,7 +404,8 @@ func enumerateMailboxSearchCriteria(since, before time.Time, minUID imap.UID) *i
 
 func messageIDHeaderFetchOptions() *imap.FetchOptions {
 	return &imap.FetchOptions{
-		UID: true,
+		UID:   true,
+		Flags: true,
 		BodySection: []*imap.FetchItemBodySection{{
 			Specifier:    imap.PartSpecifierHeader,
 			HeaderFields: []string{"Message-ID"},
@@ -461,26 +494,27 @@ func (c *Client) enumerateMailbox(
 }
 
 // fetchMailboxMessageIDs fetches RFC822 Message-ID headers for all
-// UIDs in the given mailbox. Returns a map of
-// Message-ID → true for all messages found.
+// UIDs in the given mailbox. Returns the valid Message-IDs and the UIDs whose
+// header had no usable Message-ID, so callers can fetch those copies raw.
 // Caller must hold mu.
 func (c *Client) fetchMailboxMessageIDs(
 	ctx context.Context, mailbox string, uids []imap.UID,
-) (map[string]bool, error) {
+) (map[string]bool, []imap.UID, error) {
 	if len(uids) == 0 {
-		return nil, nil //nolint:nilnil // empty input -> empty result, not an error
+		return nil, nil, nil
 	}
 
 	if err := c.selectMailbox(mailbox); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	result := make(map[string]bool, len(uids))
+	var unidentified []imap.UID
 	fetchOpts := messageIDHeaderFetchOptions()
 
 	for chunkStart := 0; chunkStart < len(uids); chunkStart += fetchChunkSize {
 		if ctx.Err() != nil {
-			return result, ctx.Err()
+			return result, unidentified, ctx.Err()
 		}
 
 		end := min(chunkStart+fetchChunkSize, len(uids))
@@ -492,13 +526,25 @@ func (c *Client) fetchMailboxMessageIDs(
 
 		msgs, _, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
 		if err != nil {
-			return result, fmt.Errorf(
+			return result, unidentified, fmt.Errorf(
 				"message-ID fetch failed in %q: %w", mailbox, err)
 		}
 
-		addMessageIDsFromHeaderFetchResults(result, msgs)
+		for _, msg := range msgs {
+			var rfc822MessageID string
+			if len(msg.BodySection) > 0 {
+				rfc822MessageID = rawMIMEMessageID(msg.BodySection[0].Bytes)
+			}
+			c.recordMembershipLocked(
+				mailbox, msg.UID, "", rfc822MessageID, [32]byte{}, 0, msg.Flags)
+			if rfc822MessageID == "" {
+				unidentified = append(unidentified, msg.UID)
+			} else {
+				result[rfc822MessageID] = true
+			}
+		}
 	}
-	return result, nil
+	return result, unidentified, nil
 }
 
 // buildLabelMap enumerates every mailbox except \All (whose memberships come
@@ -508,13 +554,14 @@ func (c *Client) fetchMailboxMessageIDs(
 // Caller must hold mu.
 func (c *Client) buildLabelMap(
 	ctx context.Context, allMailboxes []string,
-) (bool, error) {
+) (bool, []gmailapi.MessageID, error) {
 	c.msgIDToLabels = make(map[string][]string)
 	complete := true
+	var unidentified []gmailapi.MessageID
 
 	for _, mailbox := range allMailboxes {
 		if ctx.Err() != nil {
-			return false, ctx.Err()
+			return false, unidentified, ctx.Err()
 		}
 		if mailbox == c.allMailFolder {
 			continue
@@ -531,12 +578,17 @@ func (c *Client) buildLabelMap(
 			continue
 		}
 
-		msgIDs, err := c.fetchMailboxMessageIDs(ctx, mailbox, uids)
+		msgIDs, unidentifiedUIDs, err := c.fetchMailboxMessageIDs(ctx, mailbox, uids)
 		if err != nil {
 			complete = false
 			c.logger.Warn("failed to fetch envelopes for label map",
 				"mailbox", mailbox, "error", err)
 			continue
+		}
+		for _, uid := range unidentifiedUIDs {
+			unidentified = append(unidentified, gmailapi.MessageID{
+				ID: compositeID(mailbox, uid),
+			})
 		}
 
 		for msgID := range msgIDs {
@@ -546,7 +598,7 @@ func (c *Client) buildLabelMap(
 		c.logger.Debug("built label map for mailbox",
 			"mailbox", mailbox, "messages", len(msgIDs))
 	}
-	return complete, nil
+	return complete, unidentified, nil
 }
 
 // buildMessageListCache enumerates mailboxes and populates
@@ -563,51 +615,62 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	// this listing additive rather than authoritative.
 	c.labelMapComplete = false
 	c.seenRFC822IDs = nil
+	c.preferredRawSourceIDs = nil
+	c.activeSourceAliases = nil
+	c.observedMailboxDeltas = nil
+	c.observedMemberships = nil
 
-	allMailboxes, err := c.listMailboxesLocked()
+	var allMailboxes, listMailboxes []string
+	var isGmailAllMail bool
+	buildMailboxPlan := func() error {
+		mailboxes, listErr := c.listMailboxesLocked()
+		if listErr != nil {
+			return listErr
+		}
+
+		allMailboxes = filterMailboxes(
+			mailboxes,
+			c.effectiveFolderIncludeLocked(),
+			c.folderFilterExclude,
+		)
+		listMailboxes = allMailboxes
+		isGmailAllMail = false
+		if c.allMailFolder != "" {
+			isGmailAllMail = strings.HasPrefix(c.allMailFolder, "[Gmail]/")
+			if isGmailAllMail && slices.Contains(allMailboxes, c.allMailFolder) {
+				// Gmail's All Mail contains every message except Trash
+				// and Spam. Enumerate those alongside All Mail to catch
+				// messages only in those folders, but only when each
+				// canonical mailbox remains in the effective folder filter.
+				listMailboxes = []string{c.allMailFolder}
+				if slices.Contains(allMailboxes, c.trashMailbox) {
+					listMailboxes = append(listMailboxes, c.trashMailbox)
+				}
+				if slices.Contains(allMailboxes, c.junkMailbox) {
+					listMailboxes = append(listMailboxes, c.junkMailbox)
+				}
+			}
+		}
+		c.preferredRawSourceIDs = nil
+		if c.allMailFolder != "" {
+			c.preferredRawSourceIDs = make(map[[32]byte]string)
+		}
+		return nil
+	}
+
+	err := buildMailboxPlan()
 	if err != nil {
 		if isNetworkError(err) {
 			if reconErr := c.reconnect(ctx); reconErr != nil {
 				return fmt.Errorf("reconnect after LIST error: %w", reconErr)
 			}
-			allMailboxes, err = c.listMailboxesLocked()
+			c.clearMailboxDiscoveryLocked()
+			err = buildMailboxPlan()
 		}
 		if err != nil {
 			return err
 		}
 	}
-
-	// Apply folder selection once against the full LIST result so CLI
-	// includes can override configuration, and CLI exclusions apply
-	// regardless of whether --folder was provided.
-	allMailboxes = filterMailboxes(
-		allMailboxes,
-		c.effectiveFolderIncludeLocked(),
-		c.folderFilterExclude,
-	)
-
-	// Determine which mailboxes to list for canonical message IDs.
-	listMailboxes := allMailboxes
-	isGmailAllMail := false
-	if c.allMailFolder != "" {
-		isGmailAllMail = strings.HasPrefix(c.allMailFolder, "[Gmail]/")
-		if isGmailAllMail && slices.Contains(allMailboxes, c.allMailFolder) {
-			// Gmail's All Mail contains every message except Trash
-			// and Spam. Enumerate those alongside All Mail to catch
-			// messages only in those folders, but only when each
-			// canonical mailbox remains in the effective folder filter.
-			listMailboxes = []string{c.allMailFolder}
-			if slices.Contains(allMailboxes, c.trashMailbox) {
-				listMailboxes = append(
-					listMailboxes, c.trashMailbox)
-			}
-			if slices.Contains(allMailboxes, c.junkMailbox) {
-				listMailboxes = append(
-					listMailboxes, c.junkMailbox)
-			}
-		}
-	}
-
 	// Folder-state tracking skips unchanged mailboxes via STATUS
 	// UIDVALIDITY/UIDNEXT. Disabled under a date filter because a
 	// filtered run does not fetch everything up to UIDNEXT, so the
@@ -616,42 +679,63 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	// unchanged resync can return immediately.
 	trackFolders := c.since.IsZero() && c.before.IsZero()
 	var folderStatuses map[string]FolderState
-	var unchangedStatuses int
 	if trackFolders {
 		c.observedFolderStates = make(map[string]FolderState, len(allMailboxes))
-		folderStatuses, unchangedStatuses = c.observeFolderStates(ctx, allMailboxes)
-		if !c.forceFullEnumeration &&
-			c.allMailFolder != "" &&
-			len(folderStatuses) == len(allMailboxes) &&
-			unchangedStatuses == len(allMailboxes) {
-			maps.Copy(c.observedFolderStates, folderStatuses)
-			if c.listProgress != nil {
-				c.listProgress(0, len(allMailboxes), "", 0, 0)
-				c.listProgress(len(allMailboxes), len(allMailboxes), "", 0, unchangedStatuses)
-			}
-			c.logger.Info("skipped unchanged mailboxes",
-				"unchanged", unchangedStatuses, "total", len(allMailboxes))
-			c.messageListCache = []gmailapi.MessageID{}
-			c.labelMapComplete = true
-			return nil
-		}
+		folderStatuses = c.observeFolderStates(ctx, allMailboxes)
 	} else {
 		c.clearFolderAcknowledgements()
 	}
 
-	// A scan without saved folder states enumerates every UID, so it can build
-	// an authoritative membership map even when the server has no \All
-	// mailbox. Saved-state scans may skip unchanged mailboxes or enumerate only
-	// UIDs above UIDNEXT; keep those partial views additive.
+	qresyncFallback := false
+	if trackFolders {
+		requireQresync := !c.forceFullEnumeration &&
+			!c.labelsSnapshotFilteredLocked() &&
+			len(c.priorFolderStates) > 0
+		handled, deltaErr := c.tryBuildQresyncMessageList(ctx, allMailboxes, folderStatuses)
+		if deltaErr != nil || (requireQresync && !handled) {
+			if deltaErr != nil {
+				c.logger.Warn("QRESYNC failed, reconnecting for full enumeration", "error", deltaErr)
+			} else {
+				c.logger.Info("QRESYNC unavailable, reconnecting for full enumeration")
+			}
+			c.observedMailboxDeltas = nil
+			c.observedFolderStates = make(map[string]FolderState, len(allMailboxes))
+			c.messageListCache = nil
+			c.clearFolderAcknowledgements()
+			if reconErr := c.reconnect(ctx); reconErr != nil {
+				return fmt.Errorf("reconnect after QRESYNC failure: %w", reconErr)
+			}
+			c.clearMailboxDiscoveryLocked()
+			if listErr := buildMailboxPlan(); listErr != nil {
+				return fmt.Errorf("LIST after QRESYNC fallback: %w", listErr)
+			}
+			c.observedFolderStates = make(map[string]FolderState, len(allMailboxes))
+			folderStatuses = c.observeFolderStates(ctx, allMailboxes)
+			qresyncFallback = true
+		} else if handled {
+			return nil
+		}
+	}
+	if trackFolders && !c.labelsSnapshotFilteredLocked() {
+		// A clean full scan publishes the complete current topology. Keep a
+		// non-nil empty slice so zero current mailboxes still reaches the
+		// authoritative store apply and retires the prior topology.
+		c.observedMailboxDeltas = make([]MailboxDelta, 0, len(allMailboxes))
+	}
+
+	// A scan without saved folder states or after a QRESYNC fallback enumerates
+	// every UID, so it can build an authoritative membership map even when the
+	// server has no \All mailbox. Filtered saved-state scans remain additive.
 	fullScanWithoutAll := c.allMailFolder == "" &&
 		trackFolders &&
-		(c.forceFullEnumeration || len(c.priorFolderStates) == 0) &&
+		(c.forceFullEnumeration || qresyncFallback || len(c.priorFolderStates) == 0) &&
 		c.config != nil &&
 		len(c.config.Folders) == 0 &&
 		len(c.folderFilterInclude) == 0 &&
 		len(c.folderFilterExclude) == 0
 	buildMembershipMap := c.allMailFolder != "" || fullScanWithoutAll
 	labelMapComplete := false
+	var unidentifiedMembershipMessages []gmailapi.MessageID
 	if c.allMailFolder != "" {
 		// On non-Gmail servers with \All, enumerate all selectable
 		// mailboxes — \All may not be a superset of every folder.
@@ -664,7 +748,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	}
 	if buildMembershipMap {
 		var mapErr error
-		labelMapComplete, mapErr = c.buildLabelMap(ctx, allMailboxes)
+		labelMapComplete, unidentifiedMembershipMessages, mapErr = c.buildLabelMap(ctx, allMailboxes)
 		if mapErr != nil {
 			return mapErr
 		}
@@ -676,6 +760,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	}
 
 	var messages []gmailapi.MessageID
+	activeSourceAliases := make(map[string]string)
 	var unchangedFolders int
 
 	listOne := func(mailbox string) bool {
@@ -688,19 +773,21 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 				observed = &status
 				trackState = status
 				canTrackFolder = true
-				if !c.forceFullEnumeration {
+				if !c.forceFullEnumeration && !qresyncFallback {
 					if prior, ok := c.priorFolderStates[mailbox]; ok &&
 						prior.UIDValidity == status.UIDValidity &&
 						prior.UIDNext <= status.UIDNext {
-						if prior.UIDNext == status.UIDNext {
+						if folderStateUnchanged(prior, status) {
 							// Unchanged since the last completed sync:
 							// no new messages possible, skip enumeration.
 							c.observedFolderStates[mailbox] = status
 							unchangedFolders++
 							return true
 						}
-						// Only new messages need listing.
-						minUID = imap.UID(prior.UIDNext)
+						if prior.HighestModSeq == 0 && status.HighestModSeq == 0 {
+							// Without CONDSTORE, UIDNEXT is the only available high water mark.
+							minUID = imap.UID(prior.UIDNext)
+						}
 					}
 				}
 			}
@@ -716,16 +803,42 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			c.logger.Warn("skipping mailbox", "mailbox", mailbox, "error", err)
 			return false
 		}
+		knownUIDs := uidsToUint32(uids)
+		if minUID != 0 {
+			knownUIDs = mergeKnownUIDs(c.priorFolderStates[mailbox].KnownUIDs, uids)
+		}
 		if observed != nil {
+			observed.KnownUIDs = knownUIDs
 			c.observedFolderStates[mailbox] = *observed
 		}
 		if canTrackFolder {
+			trackState.KnownUIDs = knownUIDs
 			c.trackFolderMessages(mailbox, trackState, uids)
 		}
 		for _, uid := range uids {
+			sourceMessageID := compositeID(mailbox, uid)
 			messages = append(messages, gmailapi.MessageID{
-				ID:       compositeID(mailbox, uid),
+				ID:       sourceMessageID,
 				ThreadID: "",
+			})
+			if prior, ok := c.priorFolderStates[mailbox]; ok &&
+				prior.UIDValidity == trackState.UIDValidity {
+				if canonicalSourceMessageID := c.sourceMessageAliases[sourceMessageID]; canonicalSourceMessageID != "" {
+					activeSourceAliases[sourceMessageID] = canonicalSourceMessageID
+				}
+			}
+		}
+		if canTrackFolder {
+			_, hadPrior := c.priorFolderStates[mailbox]
+			reset := !hadPrior || qresyncFallback || minUID == 0
+			if prior, ok := c.priorFolderStates[mailbox]; ok && prior.UIDValidity != trackState.UIDValidity {
+				reset = true
+			}
+			c.observedMailboxDeltas = append(c.observedMailboxDeltas, MailboxDelta{
+				Mailbox:     mailbox,
+				State:       trackState,
+				ChangedUIDs: append([]imap.UID(nil), uids...),
+				Reset:       reset,
 			})
 		}
 		c.logger.Debug("listed mailbox", "mailbox", mailbox, "count", len(uids))
@@ -747,12 +860,47 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			c.listProgress(i+1, len(listMailboxes), mailbox, len(messages), unchangedFolders)
 		}
 	}
-	if trackFolders && c.allMailFolder != "" {
+	for _, message := range unidentifiedMembershipMessages {
+		mailbox, _, parseErr := parseCompositeID(message.ID)
+		if parseErr == nil && !slices.Contains(listMailboxes, mailbox) {
+			messages = append(messages, message)
+		}
+	}
+	statusesComplete := folderStatusesCoverMailboxes(allMailboxes, folderStatuses)
+	authoritativeSnapshot := trackFolders && !c.labelsSnapshotFilteredLocked()
+	if authoritativeSnapshot && (!statusesComplete || !labelMapComplete || !enumerationComplete) {
+		labelMapComplete = false
+		c.observedFolderStates = nil
+		c.observedMailboxDeltas = nil
+		c.clearFolderAcknowledgements()
+	} else if authoritativeSnapshot && c.allMailFolder != "" {
 		if labelMapComplete && enumerationComplete {
-			maps.Copy(c.observedFolderStates, folderStatuses)
-		} else {
-			c.observedFolderStates = nil
-			c.clearFolderAcknowledgements()
+			deltaByMailbox := make(map[string]int, len(c.observedMailboxDeltas))
+			for i, delta := range c.observedMailboxDeltas {
+				deltaByMailbox[delta.Mailbox] = i
+			}
+			for _, mailbox := range allMailboxes {
+				state := folderStatuses[mailbox]
+				if deltaIndex, ok := deltaByMailbox[mailbox]; ok {
+					state.KnownUIDs = append(
+						[]uint32(nil), c.observedMailboxDeltas[deltaIndex].State.KnownUIDs...)
+					c.observedMailboxDeltas[deltaIndex].State = state
+				} else {
+					state.KnownUIDs = make([]uint32, 0)
+					for _, observation := range c.observedMemberships {
+						if observation.Mailbox == mailbox && observation.UIDValidity == state.UIDValidity {
+							state.KnownUIDs = append(state.KnownUIDs, observation.UID)
+						}
+					}
+					slices.Sort(state.KnownUIDs)
+					c.observedMailboxDeltas = append(c.observedMailboxDeltas, MailboxDelta{
+						Mailbox: mailbox,
+						State:   state,
+						Reset:   true,
+					})
+				}
+				c.observedFolderStates[mailbox] = state
+			}
 		}
 	}
 	if unchangedFolders > 0 {
@@ -761,8 +909,24 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	}
 
 	c.messageListCache = messages
+	c.activeSourceAliases = activeSourceAliases
 	c.labelMapComplete = labelMapComplete && enumerationComplete
 	return nil
+}
+
+func folderStatusesCoverMailboxes(
+	mailboxes []string,
+	statuses map[string]FolderState,
+) bool {
+	if len(statuses) != len(mailboxes) {
+		return false
+	}
+	for _, mailbox := range mailboxes {
+		if _, ok := statuses[mailbox]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // isNetworkError reports whether err indicates the underlying TCP connection
@@ -1127,6 +1291,7 @@ func (c *Client) Close() error {
 	conn := c.conn
 	c.conn = nil
 	c.selectedMailbox = ""
+	c.selectedUIDValidity = 0
 	if err := conn.Logout().Wait(); err != nil {
 		return fmt.Errorf("IMAP logout: %w", err)
 	}

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -69,7 +69,7 @@ func TestListMessages_RecordsFolderStates(t *testing.T) {
 	assert.NotZero(states["INBOX"].UIDValidity)
 }
 
-func TestListMessages_SkipsUnchangedFolders(t *testing.T) {
+func TestListMessages_FallsBackWhenSavedStatesLackModSeq(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
@@ -81,12 +81,12 @@ func TestListMessages_SkipsUnchangedFolders(t *testing.T) {
 
 	second := newTestClient(t, addr, WithFolderStates(saved))
 	ids := listAllMessages(t, second)
-	assert.Empty(ids, "unchanged folders must not be re-enumerated")
+	assert.Len(ids, 5, "a baseline without mod-sequences must be rebuilt completely")
 	assert.Equal(saved, second.ObservedFolderStates(),
-		"unchanged folders keep their saved state for the next save")
+		"the full fallback publishes the same complete baseline")
 }
 
-func TestListMessages_ListsOnlyNewMessages(t *testing.T) {
+func TestListMessages_FullFallbackIncludesExistingAndNewMessages(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
@@ -100,8 +100,9 @@ func TestListMessages_ListsOnlyNewMessages(t *testing.T) {
 
 	second := newTestClient(t, addr, WithFolderStates(saved))
 	ids := listAllMessages(t, second)
-	assert.Equal([]string{"INBOX|3"}, ids,
-		"only the message appended after the saved state should be listed")
+	assert.Equal([]string{
+		"Archive|1", "Archive|2", "Archive|3", "INBOX|1", "INBOX|2", "INBOX|3",
+	}, ids, "a baseline without mod-sequences must be rebuilt completely")
 
 	states := second.ObservedFolderStates()
 	assert.Equal(uint32(4), states["INBOX"].UIDNext)
@@ -140,15 +141,15 @@ func TestListMessages_ReportsListProgress(t *testing.T) {
 	assert.Equal(5, final.found)
 	assert.Equal(0, final.unchanged)
 
-	// A resync with saved states reports every folder as unchanged.
+	// A resync without usable mod-sequences reports a complete full fallback.
 	saved := first.ObservedFolderStates()
 	require.NoError(first.Close())
 	calls = nil
 	second := newTestClient(t, addr, WithListProgress(record), WithFolderStates(saved))
-	require.Empty(listAllMessages(t, second))
+	require.Len(listAllMessages(t, second), 5)
 	final = calls[len(calls)-1]
-	assert.Equal(0, final.found)
-	assert.Equal(2, final.unchanged)
+	assert.Equal(5, final.found)
+	assert.Equal(0, final.unchanged)
 }
 
 func TestListMessages_UIDValidityChangeForcesFullRescan(t *testing.T) {
@@ -190,7 +191,7 @@ func TestListMessages_DateFilterDisablesFolderTracking(t *testing.T) {
 		"date-filtered runs must not record folder states")
 }
 
-func TestListMessages_AllMailboxRecordsFolderStatesForNoopResync(t *testing.T) {
+func TestListMessages_AllMailboxUnsupportedQresyncUsesFullFallback(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"All Mail": 2, "Projects": 1})
@@ -210,9 +211,10 @@ func TestListMessages_AllMailboxRecordsFolderStatesForNoopResync(t *testing.T) {
 	second.mailboxCache = []string{"All Mail", "Projects"}
 	second.allMailFolder = "All Mail"
 	ids := listAllMessages(t, second)
-	assert.Empty(ids, "unchanged folders must not be re-enumerated when an All Mail folder exists")
+	assert.Len(ids, 3, "unsupported QRESYNC must force authoritative enumeration")
 	assert.Equal(saved, second.ObservedFolderStates())
-	assert.Nil(second.msgIDToLabels, "a no-op resync must not build the All Mail label map")
+	assert.NotNil(second.msgIDToLabels,
+		"authoritative fallback must rebuild the All Mail label map")
 }
 
 func TestAcknowledgeMessagesFlushesFolderStateWhenFolderComplete(t *testing.T) {
@@ -803,7 +805,97 @@ func TestClientReportsCompleteSnapshotWithoutAllMailboxOnFullScan(t *testing.T) 
 		"a fully enumerated server has an authoritative membership snapshot")
 }
 
-func TestClientReportsIncompleteSnapshotWithoutAllMailboxOnHighWaterScan(t *testing.T) {
+func TestFullScanLabelMapRecordsEveryMailboxMembership(t *testing.T) {
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX":   0,
+		"Archive": 0,
+	})
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", "inbox-membership@example.com")
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "archive-membership@example.com")
+	client := newTestClient(t, addr)
+
+	require.Len(t, listAllMessages(t, client), 2)
+	observed := client.ObservedMemberships()
+	assert.ElementsMatch(t, []MembershipObservation{
+		{
+			Mailbox: "INBOX", UIDValidity: client.ObservedFolderStates()["INBOX"].UIDValidity,
+			UID: 1, SourceMessageID: "INBOX|1", RFC822MessageID: "inbox-membership@example.com",
+			Flags: []string{},
+		},
+		{
+			Mailbox: "Archive", UIDValidity: client.ObservedFolderStates()["Archive"].UIDValidity,
+			UID: 1, SourceMessageID: "Archive|1", RFC822MessageID: "archive-membership@example.com",
+			Flags: []string{},
+		},
+	}, observed)
+}
+
+func TestGmailAllMailFullScanPublishesDeltaForLabelOnlyMailbox(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{
+			"INBOX":            0,
+			"[Gmail]/All Mail": 0,
+		},
+		map[string][]imapv2.MailboxAttr{
+			"[Gmail]/All Mail": {imapv2.MailboxAttrAll},
+		},
+	)
+	const messageID = "gmail-overlap@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "[Gmail]/All Mail", messageID)
+	client := newTestClient(t, addr)
+
+	require.Equal([]string{"[Gmail]/All Mail|1"}, listAllMessages(t, client))
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(deltas, 2, "the label-map-only mailbox needs a durable baseline delta")
+	assert.ElementsMatch([]string{"INBOX", "[Gmail]/All Mail"}, []string{
+		deltas[0].Mailbox,
+		deltas[1].Mailbox,
+	})
+	client.mu.Lock()
+	supportsModSeq := client.conn.Caps().Has(imapv2.CapCondStore)
+	client.mu.Unlock()
+	for _, delta := range deltas {
+		assert.True(delta.Reset)
+		assert.NotZero(delta.State.UIDValidity)
+		assert.Equal(uint32(2), delta.State.UIDNext)
+		assert.Equal([]uint32{1}, delta.State.KnownUIDs)
+		if supportsModSeq {
+			assert.NotZero(delta.State.HighestModSeq)
+		}
+	}
+}
+
+func TestGmailAllMailStatusFailureSuppressesIncrementalPublication(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServerWithStatusError(
+		t,
+		map[string]int{
+			"INBOX":            0,
+			"[Gmail]/All Mail": 0,
+		},
+		map[string][]imapv2.MailboxAttr{
+			"[Gmail]/All Mail": {imapv2.MailboxAttrAll},
+		},
+		"INBOX",
+	)
+	const messageID = "status-failure@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "INBOX", messageID)
+	testutil.AppendIMAPMessageWithMessageID(t, user, "[Gmail]/All Mail", messageID)
+	client := newTestClient(t, addr)
+
+	require.Equal([]string{"[Gmail]/All Mail|1"}, listAllMessages(t, client))
+	assert.False(client.LabelsSnapshotComplete())
+	assert.Nil(client.ObservedFolderStates())
+	assert.Nil(client.ObservedMailboxDeltas(),
+		"a missing STATUS must not expose a zero-valued mailbox cursor")
+}
+
+func TestClientRebuildsCompleteSnapshotWithoutAllMailboxOrModSeq(t *testing.T) {
 	require := require.New(t)
 	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
 		"INBOX":   1,
@@ -816,10 +908,11 @@ func TestClientReportsIncompleteSnapshotWithoutAllMailboxOnHighWaterScan(t *test
 
 	testutil.AppendIMAPMessage(t, user, "Archive")
 	second := newTestClient(t, addr, WithFolderStates(saved))
-	require.Equal([]string{"Archive|2"}, listAllMessages(t, second))
+	require.Equal([]string{"Archive|1", "Archive|2", "INBOX|1"},
+		listAllMessages(t, second))
 
-	assert.False(t, second.LabelsSnapshotComplete(),
-		"a high-water scan does not see memberships below the saved UIDNEXT")
+	assert.True(t, second.LabelsSnapshotComplete(),
+		"the conservative full fallback sees every mailbox membership")
 }
 
 func TestClientReportsIncompleteMailboxMembershipCollection(t *testing.T) {

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -3,18 +3,91 @@ package imap
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	imap "github.com/emersion/go-imap/v2"
 )
 
-// FolderState is the change-detection state of one mailbox: the
-// UIDVALIDITY/UIDNEXT pair reported by STATUS. Under an unchanged
-// UIDVALIDITY, UIDNEXT only advances when messages are added, so a
-// mailbox whose pair matches the state saved after the last completed
-// sync cannot contain messages the archive has not seen.
+// MembershipObservation records one fetched mailbox UID and its provider
+// identity without coupling the IMAP protocol package to the durable store.
+type MembershipObservation struct {
+	Mailbox                  string
+	UIDValidity              uint32
+	UID                      uint32
+	SourceMessageID          string
+	CanonicalSourceMessageID string
+	RFC822MessageID          string
+	RawSHA256                [32]byte
+	RawSize                  int64
+	Flags                    []string
+}
+
+// ObservedMemberships returns a defensive snapshot of memberships fetched
+// during the current listing and message-download session.
+func (c *Client) ObservedMemberships() []MembershipObservation {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.observedMemberships == nil {
+		return nil
+	}
+	observations := make([]MembershipObservation, len(c.observedMemberships))
+	for i, observation := range c.observedMemberships {
+		if observation.Flags != nil {
+			observation.Flags = append([]string{}, observation.Flags...)
+		}
+		observations[i] = observation
+	}
+	return observations
+}
+
+func (c *Client) recordMembershipLocked(
+	mailbox string,
+	uid imap.UID,
+	canonicalSourceMessageID string,
+	rfc822MessageID string,
+	rawSHA256 [32]byte,
+	rawSize int64,
+	flags []imap.Flag,
+) {
+	if uid == 0 {
+		return
+	}
+	canonicalFlags := make([]string, len(flags))
+	for i, flag := range flags {
+		canonicalFlags[i] = string(flag)
+	}
+	slices.Sort(canonicalFlags)
+	sourceMessageID := compositeID(mailbox, uid)
+	if canonicalSourceMessageID == "" {
+		canonicalSourceMessageID = c.activeSourceAliases[sourceMessageID]
+	}
+	c.observedMemberships = append(c.observedMemberships, MembershipObservation{
+		Mailbox:                  mailbox,
+		UIDValidity:              c.selectedUIDValidity,
+		UID:                      uint32(uid),
+		SourceMessageID:          sourceMessageID,
+		CanonicalSourceMessageID: canonicalSourceMessageID,
+		RFC822MessageID:          rfc822MessageID,
+		RawSHA256:                rawSHA256,
+		RawSize:                  rawSize,
+		Flags:                    canonicalFlags,
+	})
+}
+
+// FolderState is the change-detection state of one mailbox.
 type FolderState struct {
-	UIDValidity uint32
-	UIDNext     uint32
+	UIDValidity   uint32
+	UIDNext       uint32
+	HighestModSeq uint64
+	KnownUIDs     []uint32
+}
+
+func cloneKnownUIDs(uids []uint32) []uint32 {
+	if uids == nil {
+		return nil
+	}
+	return append([]uint32{}, uids...)
 }
 
 // WithFolderStates provides per-mailbox states saved after the last
@@ -25,13 +98,49 @@ type FolderState struct {
 // exposes an \All mailbox, saved states short-circuit fully unchanged
 // resyncs; changed runs still enumerate fully for label mapping.
 func WithFolderStates(states map[string]FolderState) Option {
-	return func(c *Client) { c.priorFolderStates = states }
+	return func(c *Client) {
+		c.priorFolderStates = make(map[string]FolderState, len(states))
+		for mailbox, state := range states {
+			state.KnownUIDs = cloneKnownUIDs(state.KnownUIDs)
+			c.priorFolderStates[mailbox] = state
+		}
+	}
+}
+
+// WithSourceMessageAliases supplies durable mailbox-UID aliases from the last
+// completed sync. They prevent a changed secondary copy without a Message-ID
+// from being re-imported under its secondary mailbox identity.
+func WithSourceMessageAliases(aliases map[string]string) Option {
+	return func(c *Client) {
+		c.sourceMessageAliases = make(map[string]string, len(aliases))
+		maps.Copy(c.sourceMessageAliases, aliases)
+	}
+}
+
+// CanonicalSourceMessageID returns a durable alias only after this session
+// validated the mailbox epoch through the QRESYNC path.
+func (c *Client) CanonicalSourceMessageID(sourceMessageID string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	canonicalSourceMessageID, ok := c.activeSourceAliases[sourceMessageID]
+	return canonicalSourceMessageID, ok
 }
 
 // WithForceFullEnumeration keeps saved folder identity metadata but disables
 // UIDNEXT and unchanged-mailbox shortcuts for this client session.
 func WithForceFullEnumeration() Option {
 	return func(c *Client) { c.forceFullEnumeration = true }
+}
+
+// ForceFullEnumerationForLimitedSync disables sparse incremental listing for
+// a limited run. The syncer reconciles processed labels immediately because a
+// limited run cannot publish mailbox deltas, so those labels must come from a
+// complete mailbox-membership view.
+func (c *Client) ForceFullEnumerationForLimitedSync() {
+	c.mu.Lock()
+	c.forceFullEnumeration = true
+	c.messageListCache = nil
+	c.mu.Unlock()
 }
 
 // WithFolderStateSave sets a callback that is invoked after all listed
@@ -57,6 +166,7 @@ func (c *Client) ObservedFolderStates() map[string]FolderState {
 		if c.pendingFolderCounts[mailbox] > 0 {
 			continue
 		}
+		state.KnownUIDs = cloneKnownUIDs(state.KnownUIDs)
 		states[mailbox] = state
 	}
 	return states
@@ -64,9 +174,8 @@ func (c *Client) ObservedFolderStates() map[string]FolderState {
 
 func (c *Client) observeFolderStates(
 	ctx context.Context, mailboxes []string,
-) (map[string]FolderState, int) {
+) map[string]FolderState {
 	states := make(map[string]FolderState, len(mailboxes))
-	unchanged := 0
 	for _, mailbox := range mailboxes {
 		status, err := c.statusFolder(ctx, mailbox)
 		if err != nil {
@@ -74,14 +183,13 @@ func (c *Client) observeFolderStates(
 				"mailbox", mailbox, "error", err)
 			continue
 		}
-		states[mailbox] = status
 		if prior, ok := c.priorFolderStates[mailbox]; ok &&
-			prior.UIDValidity == status.UIDValidity &&
-			prior.UIDNext == status.UIDNext {
-			unchanged++
+			folderStateUnchanged(prior, status) {
+			status.KnownUIDs = cloneKnownUIDs(prior.KnownUIDs)
 		}
+		states[mailbox] = status
 	}
-	return states, unchanged
+	return states
 }
 
 func (c *Client) trackFolderMessages(
@@ -153,7 +261,11 @@ func (c *Client) AcknowledgeMessages(_ context.Context, messageIDs []string) {
 // STATUS, retrying once through a reconnect on network errors.
 // Caller must hold mu.
 func (c *Client) statusFolder(ctx context.Context, mailbox string) (FolderState, error) {
-	opts := &imap.StatusOptions{UIDNext: true, UIDValidity: true}
+	opts := &imap.StatusOptions{
+		UIDNext:       true,
+		UIDValidity:   true,
+		HighestModSeq: c.conn.Caps().Has(imap.CapCondStore),
+	}
 	data, err := c.conn.Status(mailbox, opts).Wait()
 	if err != nil && isNetworkError(err) {
 		c.logger.Warn("network error during STATUS, reconnecting",
@@ -167,11 +279,15 @@ func (c *Client) statusFolder(ctx context.Context, mailbox string) (FolderState,
 	if err != nil {
 		return FolderState{}, fmt.Errorf("STATUS %q: %w", mailbox, err)
 	}
+	if data.UIDValidity == 0 {
+		return FolderState{}, fmt.Errorf("STATUS %q returned no UIDVALIDITY", mailbox)
+	}
 	if data.UIDNext == 0 {
 		return FolderState{}, fmt.Errorf("STATUS %q returned no UIDNEXT", mailbox)
 	}
 	return FolderState{
-		UIDValidity: data.UIDValidity,
-		UIDNext:     uint32(data.UIDNext),
+		UIDValidity:   data.UIDValidity,
+		UIDNext:       uint32(data.UIDNext),
+		HighestModSeq: data.HighestModSeq,
 	}, nil
 }

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -1,0 +1,314 @@
+package imap
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	imap "github.com/emersion/go-imap/v2"
+	gmailapi "go.kenn.io/msgvault/internal/gmail"
+)
+
+// MailboxDelta describes the membership changes observed for one mailbox.
+type MailboxDelta struct {
+	Mailbox      string
+	State        FolderState
+	ChangedUIDs  []imap.UID
+	VanishedUIDs []imap.UID
+	Reset        bool
+	Incremental  bool
+}
+
+type protocolDeltaCapture struct {
+	vanished []imap.UID
+}
+
+// ObservedMailboxDeltas returns a defensive snapshot of mailbox changes from
+// the most recent listing.
+func (c *Client) ObservedMailboxDeltas() []MailboxDelta {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.observedMailboxDeltas == nil {
+		return nil
+	}
+	deltas := make([]MailboxDelta, len(c.observedMailboxDeltas))
+	for i, delta := range c.observedMailboxDeltas {
+		delta.State.KnownUIDs = cloneKnownUIDs(delta.State.KnownUIDs)
+		delta.ChangedUIDs = append([]imap.UID(nil), delta.ChangedUIDs...)
+		delta.VanishedUIDs = append([]imap.UID(nil), delta.VanishedUIDs...)
+		deltas[i] = delta
+	}
+	return deltas
+}
+
+func folderStateUnchanged(prior, current FolderState) bool {
+	return prior.UIDValidity == current.UIDValidity &&
+		prior.UIDNext == current.UIDNext &&
+		prior.HighestModSeq == current.HighestModSeq
+}
+
+func (c *Client) qresyncBaselinePresent(mailboxes []string) bool {
+	if len(c.priorFolderStates) == 0 || len(c.priorFolderStates) != len(mailboxes) {
+		return false
+	}
+	for _, mailbox := range mailboxes {
+		state, ok := c.priorFolderStates[mailbox]
+		if !ok || state.KnownUIDs == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *Client) qresyncEligible(prior, current FolderState) bool {
+	return prior.UIDValidity != 0 &&
+		prior.UIDNext != 0 &&
+		current.UIDValidity != 0 &&
+		current.UIDNext != 0 &&
+		prior.UIDValidity == current.UIDValidity &&
+		prior.UIDNext <= current.UIDNext &&
+		prior.HighestModSeq != 0 &&
+		current.HighestModSeq >= prior.HighestModSeq &&
+		prior.KnownUIDs != nil
+}
+
+func (c *Client) enableQresync() bool {
+	caps := c.conn.Caps()
+	if !caps.Has(imap.CapEnable) || !caps.Has(imap.CapQResync) {
+		return false
+	}
+	if c.qresyncEnabled {
+		return true
+	}
+	data, err := c.conn.Enable(imap.CapQResync).Wait()
+	if err != nil || data == nil || !data.Caps.Has(imap.CapQResync) {
+		return false
+	}
+	c.qresyncEnabled = true
+	return true
+}
+
+func (c *Client) tryBuildQresyncMessageList(
+	ctx context.Context,
+	mailboxes []string,
+	statuses map[string]FolderState,
+) (bool, error) {
+	if c.forceFullEnumeration || c.labelsSnapshotFilteredLocked() || len(mailboxes) == 0 ||
+		len(statuses) != len(mailboxes) || !c.qresyncBaselinePresent(mailboxes) {
+		return false, nil
+	}
+
+	for _, mailbox := range mailboxes {
+		prior, priorOK := c.priorFolderStates[mailbox]
+		current, currentOK := statuses[mailbox]
+		if !priorOK || !currentOK || !c.qresyncEligible(prior, current) {
+			return false, nil
+		}
+	}
+	if !c.enableQresync() {
+		return false, nil
+	}
+
+	c.observedFolderStates = make(map[string]FolderState, len(mailboxes))
+	c.observedMailboxDeltas = make([]MailboxDelta, 0, len(mailboxes))
+	var messages []gmailapi.MessageID
+	activeSourceAliases := make(map[string]string)
+	unchanged := 0
+	if c.listProgress != nil {
+		c.listProgress(0, len(mailboxes), "", 0, 0)
+	}
+	for i, mailbox := range mailboxes {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		prior := c.priorFolderStates[mailbox]
+		var delta MailboxDelta
+		delta, err := c.collectQresyncMailbox(mailbox, prior)
+		if err != nil {
+			return false, err
+		}
+		if len(delta.ChangedUIDs) == 0 && len(delta.VanishedUIDs) == 0 {
+			unchanged++
+		}
+		for _, uid := range delta.ChangedUIDs {
+			sourceMessageID := compositeID(mailbox, uid)
+			messages = append(messages, gmailapi.MessageID{ID: sourceMessageID})
+			if canonicalSourceMessageID := c.sourceMessageAliases[sourceMessageID]; canonicalSourceMessageID != "" {
+				activeSourceAliases[sourceMessageID] = canonicalSourceMessageID
+			}
+		}
+		c.trackFolderMessages(mailbox, delta.State, delta.ChangedUIDs)
+		c.observedFolderStates[mailbox] = delta.State
+		c.observedMailboxDeltas = append(c.observedMailboxDeltas, delta)
+		if c.listProgress != nil {
+			c.listProgress(i+1, len(mailboxes), mailbox, len(messages), unchanged)
+		}
+	}
+	c.messageListCache = messages
+	c.activeSourceAliases = activeSourceAliases
+	c.labelMapComplete = true
+	return true, nil
+}
+
+func (c *Client) collectQresyncMailbox(mailbox string, prior FolderState) (MailboxDelta, error) {
+	c.clearQresyncCapture()
+	selected, err := c.conn.Select(mailbox, &imap.SelectOptions{CondStore: true}).Wait()
+	if err != nil {
+		return MailboxDelta{}, fmt.Errorf("CONDSTORE SELECT %q: %w", mailbox, err)
+	}
+	if selected.UIDValidity == 0 {
+		return MailboxDelta{}, fmt.Errorf(
+			"CONDSTORE SELECT %q returned no UIDVALIDITY", mailbox)
+	}
+	if selected.UIDNext == 0 {
+		return MailboxDelta{}, fmt.Errorf(
+			"CONDSTORE SELECT %q returned no UIDNEXT", mailbox)
+	}
+	if selected.UIDValidity != prior.UIDValidity {
+		return MailboxDelta{}, fmt.Errorf("CONDSTORE SELECT %q changed UIDVALIDITY from %d to %d",
+			mailbox, prior.UIDValidity, selected.UIDValidity)
+	}
+	if uint32(selected.UIDNext) < prior.UIDNext {
+		return MailboxDelta{}, fmt.Errorf(
+			"CONDSTORE SELECT %q regressed UIDNEXT from %d to %d",
+			mailbox, prior.UIDNext, selected.UIDNext)
+	}
+	if prior.HighestModSeq == 0 || selected.HighestModSeq == 0 {
+		return MailboxDelta{}, fmt.Errorf("CONDSTORE SELECT %q returned unusable modseq", mailbox)
+	}
+	if selected.HighestModSeq < prior.HighestModSeq {
+		return MailboxDelta{}, fmt.Errorf(
+			"CONDSTORE SELECT %q regressed modseq from %d to %d",
+			mailbox, prior.HighestModSeq, selected.HighestModSeq)
+	}
+	c.selectedMailbox = mailbox
+	c.selectedUIDValidity = selected.UIDValidity
+	c.selectedNumMessages = selected.NumMessages
+
+	changedSet := make(map[imap.UID]struct{})
+	vanishedSet := make(map[imap.UID]struct{})
+	if selected.UIDNext > 1 {
+		var requestedUIDs imap.UIDSet
+		requestedUIDs.AddRange(1, selected.UIDNext-1)
+		if requestedUIDs.Dynamic() {
+			return MailboxDelta{}, fmt.Errorf(
+				"QRESYNC UID FETCH in %q requires static typed UID set", mailbox)
+		}
+		c.beginQresyncCapture()
+		defer c.clearQresyncCapture()
+		msgs, fetchErr := c.conn.Fetch(requestedUIDs, &imap.FetchOptions{
+			UID:          true,
+			Flags:        true,
+			ModSeq:       true,
+			ChangedSince: prior.HighestModSeq,
+			Vanished:     true,
+		}).Collect()
+		if fetchErr != nil {
+			return MailboxDelta{}, fmt.Errorf("QRESYNC UID FETCH in %q: %w", mailbox, fetchErr)
+		}
+
+		for _, msg := range msgs {
+			if msg.UID != 0 {
+				changedSet[msg.UID] = struct{}{}
+			}
+		}
+		for _, uid := range c.snapshotQresyncCapture().vanished {
+			vanishedSet[uid] = struct{}{}
+		}
+	}
+	for uid := range vanishedSet {
+		delete(changedSet, uid)
+	}
+	changed := maps.Keys(changedSet)
+	vanished := maps.Keys(vanishedSet)
+	changedUIDs := slices.Collect(changed)
+	vanishedUIDs := slices.Collect(vanished)
+	slices.Sort(changedUIDs)
+	slices.Sort(vanishedUIDs)
+
+	known := make(map[imap.UID]struct{}, len(prior.KnownUIDs)+len(changedUIDs))
+	for _, uid := range prior.KnownUIDs {
+		known[imap.UID(uid)] = struct{}{}
+	}
+	for _, uid := range vanishedUIDs {
+		delete(known, uid)
+	}
+	for _, uid := range changedUIDs {
+		known[uid] = struct{}{}
+	}
+	knownUIDs := slices.Collect(maps.Keys(known))
+	slices.Sort(knownUIDs)
+
+	return MailboxDelta{
+		Mailbox: mailbox,
+		State: FolderState{
+			UIDValidity:   selected.UIDValidity,
+			UIDNext:       uint32(selected.UIDNext),
+			HighestModSeq: selected.HighestModSeq,
+			KnownUIDs:     uidsToUint32(knownUIDs),
+		},
+		ChangedUIDs:  changedUIDs,
+		VanishedUIDs: vanishedUIDs,
+		Incremental:  true,
+	}, nil
+}
+
+func (c *Client) beginQresyncCapture() {
+	c.qresyncCaptureMu.Lock()
+	c.qresyncCapture = &protocolDeltaCapture{}
+	c.qresyncCaptureMu.Unlock()
+}
+
+func (c *Client) clearQresyncCapture() {
+	c.qresyncCaptureMu.Lock()
+	c.qresyncCapture = nil
+	c.qresyncCaptureMu.Unlock()
+}
+
+func (c *Client) snapshotQresyncCapture() protocolDeltaCapture {
+	c.qresyncCaptureMu.Lock()
+	defer c.qresyncCaptureMu.Unlock()
+	if c.qresyncCapture == nil {
+		return protocolDeltaCapture{}
+	}
+	return protocolDeltaCapture{
+		vanished: append([]imap.UID(nil), c.qresyncCapture.vanished...),
+	}
+}
+
+func (c *Client) captureQresyncVanished(set imap.UIDSet, _ bool) {
+	uids, ok := set.Nums()
+	if !ok {
+		return
+	}
+	c.qresyncCaptureMu.Lock()
+	if c.qresyncCapture != nil {
+		c.qresyncCapture.vanished = append(c.qresyncCapture.vanished, uids...)
+	}
+	c.qresyncCaptureMu.Unlock()
+}
+
+func uidsToUint32(uids []imap.UID) []uint32 {
+	values := make([]uint32, len(uids))
+	for i, uid := range uids {
+		values[i] = uint32(uid)
+	}
+	return values
+}
+
+func mergeKnownUIDs(prior []uint32, additions []imap.UID) []uint32 {
+	if prior == nil {
+		return nil
+	}
+	known := make(map[uint32]struct{}, len(prior)+len(additions))
+	for _, uid := range prior {
+		known[uid] = struct{}{}
+	}
+	for _, uid := range additions {
+		known[uint32(uid)] = struct{}{}
+	}
+	values := slices.Collect(maps.Keys(known))
+	slices.Sort(values)
+	return values
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1,0 +1,592 @@
+package imap
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	imapv2 "github.com/emersion/go-imap/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type qresyncServerConfig struct {
+	capabilities             []string
+	mailboxes                []string
+	uidValidity              uint32
+	uidNext                  uint32
+	highestModSeq            uint64
+	selectHighestModSeq      uint64
+	selectFailureConnection  int
+	selectFailureAt          int
+	searchUIDs               []imapv2.UID
+	fetchChanged             []imapv2.UID
+	fetchVanished            []imapv2.UID
+	filterVanishedByFetchSet bool
+}
+
+type qresyncTestServer struct {
+	mu       sync.Mutex
+	commands map[int][]string
+}
+
+func (s *qresyncTestServer) record(connID int, command string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commands[connID] = append(s.commands[connID], command)
+}
+
+func (s *qresyncTestServer) commandsFor(connID int) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.commands[connID]...)
+}
+
+func startQresyncTestServer(t *testing.T, cfg qresyncServerConfig) (string, *qresyncTestServer) {
+	t.Helper()
+	require.NotEmpty(t, cfg.capabilities)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	server := &qresyncTestServer{commands: make(map[int][]string)}
+	if len(cfg.mailboxes) == 0 {
+		cfg.mailboxes = []string{"INBOX"}
+	}
+	go func() {
+		connID := 0
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			connID++
+			caps := cfg.capabilities[min(connID-1, len(cfg.capabilities)-1)]
+			go serveQresyncTestConn(conn, connID, caps, cfg, server)
+		}
+	}()
+	return ln.Addr().String(), server
+}
+
+func serveQresyncTestConn(
+	conn net.Conn,
+	connID int,
+	capabilities string,
+	cfg qresyncServerConfig,
+	server *qresyncTestServer,
+) {
+	defer func() { _ = conn.Close() }()
+	_, _ = io.WriteString(conn, "* OK synthetic IMAP ready\r\n")
+	reader := bufio.NewReader(conn)
+	selectCount := 0
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+		server.record(connID, line)
+		tag, command, _ := strings.Cut(line, " ")
+		upper := strings.ToUpper(command)
+		switch {
+		case strings.HasPrefix(upper, "CAPABILITY"):
+			_, _ = fmt.Fprintf(conn, "* CAPABILITY %s\r\n%s OK CAPABILITY completed\r\n", capabilities, tag)
+		case strings.HasPrefix(upper, "LOGIN"):
+			_, _ = fmt.Fprintf(conn, "%s OK LOGIN completed\r\n", tag)
+		case strings.HasPrefix(upper, "LIST"):
+			for _, mailbox := range cfg.mailboxes {
+				_, _ = fmt.Fprintf(conn, "* LIST () \"/\" %q\r\n", mailbox)
+			}
+			_, _ = fmt.Fprintf(conn, "%s OK LIST completed\r\n", tag)
+		case strings.HasPrefix(upper, "STATUS"):
+			mailbox := scriptedCommandMailbox(command, "STATUS")
+			_, _ = fmt.Fprintf(conn,
+				"* STATUS %q (UIDNEXT %d UIDVALIDITY %d HIGHESTMODSEQ %d)\r\n%s OK STATUS completed\r\n",
+				mailbox, cfg.uidNext, cfg.uidValidity, cfg.highestModSeq, tag)
+		case strings.HasPrefix(upper, "ENABLE"):
+			_, _ = fmt.Fprintf(conn, "* ENABLED QRESYNC\r\n%s OK ENABLE completed\r\n", tag)
+		case strings.HasPrefix(upper, "SELECT"):
+			selectCount++
+			if connID == cfg.selectFailureConnection && selectCount == cfg.selectFailureAt {
+				_, _ = fmt.Fprintf(conn, "%s NO synthetic SELECT failure\r\n", tag)
+				continue
+			}
+			selectModSeq := cfg.selectHighestModSeq
+			if selectModSeq == 0 {
+				selectModSeq = cfg.highestModSeq
+			}
+			_, _ = fmt.Fprintf(conn,
+				"* FLAGS (\\Seen)\r\n* %d EXISTS\r\n* OK [UIDVALIDITY %d]\r\n* OK [UIDNEXT %d]\r\n* OK [HIGHESTMODSEQ %d]\r\n",
+				len(cfg.searchUIDs), cfg.uidValidity, cfg.uidNext, selectModSeq)
+			_, _ = fmt.Fprintf(conn, "%s OK [READ-WRITE] SELECT completed\r\n", tag)
+		case strings.HasPrefix(upper, "UID FETCH"):
+			writeVanished(conn, qresyncVanishedForFetch(command, cfg))
+			writeFetchResponses(conn, cfg.fetchChanged, cfg.highestModSeq)
+			_, _ = fmt.Fprintf(conn, "%s OK UID FETCH completed\r\n", tag)
+		case strings.HasPrefix(upper, "UID SEARCH"):
+			_, _ = fmt.Fprintf(conn, "* SEARCH%s\r\n%s OK UID SEARCH completed\r\n",
+				formatSearchUIDs(cfg.searchUIDs), tag)
+		case strings.HasPrefix(upper, "LOGOUT"):
+			_, _ = fmt.Fprintf(conn, "* BYE closing\r\n%s OK LOGOUT completed\r\n", tag)
+			return
+		default:
+			_, _ = fmt.Fprintf(conn, "%s BAD unsupported synthetic command\r\n", tag)
+		}
+	}
+}
+
+func qresyncVanishedForFetch(command string, cfg qresyncServerConfig) []imapv2.UID {
+	if !cfg.filterVanishedByFetchSet {
+		return cfg.fetchVanished
+	}
+	fields := strings.Fields(command)
+	if len(fields) < 3 {
+		return nil
+	}
+	startText, stopText, ok := strings.Cut(fields[2], ":")
+	if !ok {
+		return nil
+	}
+	start, err := strconv.ParseUint(startText, 10, 32)
+	if err != nil {
+		return nil
+	}
+	var stop uint64
+	if stopText == "*" {
+		for _, uid := range cfg.searchUIDs {
+			stop = max(stop, uint64(uid))
+		}
+	} else {
+		stop, err = strconv.ParseUint(stopText, 10, 32)
+		if err != nil {
+			return nil
+		}
+	}
+	var vanished []imapv2.UID
+	for _, uid := range cfg.fetchVanished {
+		if uint64(uid) >= start && uint64(uid) <= stop {
+			vanished = append(vanished, uid)
+		}
+	}
+	return vanished
+}
+
+func scriptedCommandMailbox(command, commandName string) string {
+	rest := strings.TrimSpace(command[len(commandName):])
+	if strings.HasPrefix(rest, "\"") {
+		if end := strings.Index(rest[1:], "\""); end >= 0 {
+			return rest[1 : end+1]
+		}
+	}
+	mailbox, _, _ := strings.Cut(rest, " ")
+	return mailbox
+}
+
+func writeVanished(w io.Writer, uids []imapv2.UID) {
+	if len(uids) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "* VANISHED (EARLIER) %s\r\n", imapv2.UIDSetNum(uids...).String())
+}
+
+func writeFetchResponses(w io.Writer, uids []imapv2.UID, modSeq uint64) {
+	for i, uid := range uids {
+		_, _ = fmt.Fprintf(w, "* %d FETCH (UID %d FLAGS (\\Seen) MODSEQ (%d))\r\n", i+1, uid, modSeq)
+	}
+}
+
+func formatSearchUIDs(uids []imapv2.UID) string {
+	var b strings.Builder
+	for _, uid := range uids {
+		b.WriteByte(' ')
+		b.WriteString(strconv.FormatUint(uint64(uid), 10))
+	}
+	return b.String()
+}
+
+func newQresyncTestClient(
+	t *testing.T, addr string, states map[string]FolderState, opts ...Option,
+) *Client {
+	t.Helper()
+	host, portString, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portString)
+	require.NoError(t, err)
+	clientOpts := append([]Option{WithFolderStates(states)}, opts...)
+	client := NewClient(&Config{
+		Host:     host,
+		Port:     port,
+		Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword, clientOpts...)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func listQresyncMessages(t *testing.T, client *Client) []string {
+	t.Helper()
+	return listAllMessages(t, client)
+}
+
+func joinedCommands(commands []string) string {
+	return strings.ToUpper(strings.Join(commands, "\n"))
+}
+
+func TestListMessagesQresyncUsesHighestModSeqAndCollectsDelta(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+		fetchChanged:  []imapv2.UID{2},
+		fetchVanished: []imapv2.UID{1, 3},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity:   77,
+			UIDNext:       4,
+			HighestModSeq: 10,
+			KnownUIDs:     []uint32{1, 2, 3},
+		},
+	})
+
+	assert.Equal([]string{"INBOX|2"}, listQresyncMessages(t, client))
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 1)
+	assert.Equal("INBOX", deltas[0].Mailbox)
+	assert.Equal(uint64(20), deltas[0].State.HighestModSeq)
+	assert.Equal([]imapv2.UID{2}, deltas[0].ChangedUIDs)
+	assert.Equal([]imapv2.UID{1, 3}, deltas[0].VanishedUIDs)
+	assert.False(deltas[0].Reset)
+	assert.True(deltas[0].Incremental)
+
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Contains(commands, "ENABLE QRESYNC")
+	assert.Contains(commands, "SELECT INBOX (CONDSTORE)")
+	assert.Contains(commands, "UID FETCH 1:3")
+	assert.Contains(commands, "(CHANGEDSINCE 10 VANISHED)")
+	assert.NotContains(commands, "SELECT INBOX (QRESYNC")
+	assert.NotContains(commands, "UID SEARCH")
+}
+
+func TestListMessagesQresyncFetchIncludesExpungedFormerHighestUID(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:             []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:              77,
+		uidNext:                  4,
+		highestModSeq:            20,
+		searchUIDs:               []imapv2.UID{1, 2},
+		fetchVanished:            []imapv2.UID{3},
+		filterVanishedByFetchSet: true,
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: []uint32{1, 2, 3},
+		},
+	})
+
+	assert.Empty(listQresyncMessages(t, client))
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 1)
+	assert.Equal([]imapv2.UID{3}, deltas[0].VanishedUIDs)
+	assert.Equal([]uint32{1, 2}, deltas[0].State.KnownUIDs)
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Contains(commands, "UID FETCH 1:3")
+	assert.NotContains(commands, "UID FETCH 1:*")
+}
+
+func TestCaptureQresyncVanishedExpandsStaticUIDRanges(t *testing.T) {
+	client := &Client{}
+	client.beginQresyncCapture()
+	var vanished imapv2.UIDSet
+	vanished.AddRange(4, 6)
+
+	client.captureQresyncVanished(vanished, false)
+
+	assert.Equal(t, []imapv2.UID{4, 5, 6}, client.snapshotQresyncCapture().vanished)
+}
+
+func TestListMessagesQresyncUIDValidityMismatchResetsWithFullEnumeration(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   88,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: []uint32{1, 2, 3}},
+	})
+
+	assert.Equal([]string{"INBOX|1", "INBOX|2", "INBOX|3"}, listQresyncMessages(t, client))
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 1)
+	assert.True(deltas[0].Reset)
+	assert.False(deltas[0].Incremental)
+	assert.Equal([]imapv2.UID{1, 2, 3}, deltas[0].ChangedUIDs)
+	assert.NotContains(joinedCommands(server.commandsFor(1)), "UID SEARCH")
+	commands := joinedCommands(server.commandsFor(2))
+	assert.Contains(commands, "UID SEARCH")
+	assert.NotContains(commands, "QRESYNC (")
+}
+
+func TestListMessagesQresyncFallsBackWithoutCompleteEligibility(t *testing.T) {
+	tests := []struct {
+		name          string
+		capabilities  string
+		priorModSeq   uint64
+		currentModSeq uint64
+	}{
+		{name: "missing QRESYNC", capabilities: "IMAP4rev1 ENABLE CONDSTORE", priorModSeq: 10, currentModSeq: 20},
+		{name: "missing ENABLE", capabilities: "IMAP4rev1 QRESYNC CONDSTORE", priorModSeq: 10, currentModSeq: 20},
+		{name: "zero saved modseq", capabilities: "IMAP4rev1 ENABLE QRESYNC CONDSTORE", currentModSeq: 20},
+		{name: "zero current modseq", capabilities: "IMAP4rev1 ENABLE QRESYNC CONDSTORE", priorModSeq: 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			addr, server := startQresyncTestServer(t, qresyncServerConfig{
+				capabilities:  []string{tt.capabilities},
+				uidValidity:   77,
+				uidNext:       4,
+				highestModSeq: tt.currentModSeq,
+				searchUIDs:    []imapv2.UID{1, 2, 3},
+			})
+			client := newQresyncTestClient(t, addr, map[string]FolderState{
+				"INBOX": {UIDValidity: 77, UIDNext: 4, HighestModSeq: tt.priorModSeq, KnownUIDs: []uint32{1, 2, 3}},
+			})
+
+			assert.Equal([]string{"INBOX|1", "INBOX|2", "INBOX|3"}, listQresyncMessages(t, client))
+			deltas := client.ObservedMailboxDeltas()
+			require.Len(t, deltas, 1)
+			assert.True(deltas[0].Reset)
+			assert.False(deltas[0].Incremental)
+			assert.NotContains(joinedCommands(server.commandsFor(1)), "UID SEARCH")
+			commands := joinedCommands(server.commandsFor(2))
+			assert.Contains(commands, "UID SEARCH")
+			assert.NotContains(commands, "QRESYNC (")
+		})
+	}
+}
+
+func TestListMessagesQresyncReconnectDoesNotReuseEnabledState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities: []string{
+			"IMAP4rev1 ENABLE QRESYNC CONDSTORE",
+			"IMAP4rev1 ENABLE CONDSTORE",
+		},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+		fetchChanged:  []imapv2.UID{2},
+		fetchVanished: []imapv2.UID{1},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: []uint32{1, 2, 3}},
+	})
+	require.Equal([]string{"INBOX|2"}, listQresyncMessages(t, client))
+
+	client.mu.Lock()
+	require.NoError(client.reconnect(context.Background()))
+	client.messageListCache = nil
+	client.mu.Unlock()
+
+	assert.Equal([]string{"INBOX|1", "INBOX|2", "INBOX|3"}, listQresyncMessages(t, client))
+	assert.NotContains(joinedCommands(server.commandsFor(2)), "UID SEARCH")
+	commands := joinedCommands(server.commandsFor(3))
+	assert.Contains(commands, "UID SEARCH")
+	assert.NotContains(commands, "ENABLE QRESYNC")
+	assert.NotContains(commands, "QRESYNC (")
+}
+
+func TestListMessagesQresyncErrorDiscardsPartialDeltaStateBeforeFallback(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:            []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		mailboxes:               []string{"First", "Second"},
+		uidValidity:             77,
+		uidNext:                 4,
+		highestModSeq:           20,
+		selectFailureConnection: 1,
+		selectFailureAt:         2,
+		searchUIDs:              []imapv2.UID{1, 2, 3},
+		fetchChanged:            []imapv2.UID{2},
+	})
+	states := map[string]FolderState{
+		"First":  {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: []uint32{1, 2, 3}},
+		"Second": {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: []uint32{1, 2, 3}},
+	}
+	client := newQresyncTestClient(t, addr, states, WithFolderStateSave(func(string, FolderState) {}))
+	client.mailboxCache = []string{"First", "Second"}
+
+	assert.Len(listQresyncMessages(t, client), 6)
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 2)
+	assert.Equal([]string{"First", "Second"}, []string{deltas[0].Mailbox, deltas[1].Mailbox})
+	assert.True(deltas[0].Reset)
+	assert.True(deltas[1].Reset)
+	assert.False(deltas[0].Incremental)
+	assert.False(deltas[1].Incremental)
+	assert.Equal(map[string]int{"First": 3, "Second": 3}, client.pendingFolderCounts)
+	assert.Len(client.observedFolderStates, 2)
+	assert.Contains(joinedCommands(server.commandsFor(2)), "UID SEARCH")
+}
+
+func TestListMessagesQresyncRegressedStatusModSeqForcesFullFallback(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 5,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: []uint32{1, 2, 3}},
+	})
+
+	assert.Equal([]string{"INBOX|1", "INBOX|2", "INBOX|3"}, listQresyncMessages(t, client))
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 1)
+	assert.True(deltas[0].Reset)
+	assert.False(deltas[0].Incremental)
+	assert.NotContains(joinedCommands(server.commandsFor(1)), "UID SEARCH")
+	commands := joinedCommands(server.commandsFor(2))
+	assert.Contains(commands, "UID SEARCH")
+	assert.NotContains(commands, "ENABLE QRESYNC")
+	assert.NotContains(commands, "CHANGEDSINCE")
+}
+
+func TestListMessagesQresyncRegressedSelectModSeqForcesFreshFullFallback(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:        []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:         77,
+		uidNext:             4,
+		highestModSeq:       20,
+		selectHighestModSeq: 5,
+		searchUIDs:          []imapv2.UID{1, 2, 3},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: []uint32{1, 2, 3}},
+	})
+
+	assert.Equal([]string{"INBOX|1", "INBOX|2", "INBOX|3"}, listQresyncMessages(t, client))
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 1)
+	assert.True(deltas[0].Reset)
+	assert.False(deltas[0].Incremental)
+	assert.NotContains(joinedCommands(server.commandsFor(1)), "UID FETCH")
+	assert.Contains(joinedCommands(server.commandsFor(2)), "UID SEARCH")
+}
+
+func TestListMessagesAllMailboxNoopPreservesKnownUIDBaseline(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		mailboxes:     []string{"All Mail", "Projects"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 10,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+	})
+	wantUIDs := map[string][]uint32{
+		"All Mail": {1, 2, 3},
+		"Projects": {2},
+	}
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"All Mail": {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: wantUIDs["All Mail"]},
+		"Projects": {UIDValidity: 77, UIDNext: 4, HighestModSeq: 10, KnownUIDs: wantUIDs["Projects"]},
+	})
+	client.mailboxCache = []string{"All Mail", "Projects"}
+	client.allMailFolder = "All Mail"
+
+	assert.Empty(listQresyncMessages(t, client))
+	states := client.ObservedFolderStates()
+	assert.Equal(wantUIDs["All Mail"], states["All Mail"].KnownUIDs)
+	assert.Equal(wantUIDs["Projects"], states["Projects"].KnownUIDs)
+
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 2)
+	assert.Equal([]string{"All Mail", "Projects"}, []string{deltas[0].Mailbox, deltas[1].Mailbox})
+	for _, delta := range deltas {
+		assert.True(delta.Incremental)
+		assert.False(delta.Reset)
+		assert.Empty(delta.ChangedUIDs)
+		assert.Empty(delta.VanishedUIDs)
+		assert.Equal(wantUIDs[delta.Mailbox], delta.State.KnownUIDs)
+	}
+	deltas[0].State.KnownUIDs[0] = 99
+	assert.Equal(wantUIDs["All Mail"], client.ObservedMailboxDeltas()[0].State.KnownUIDs)
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Contains(commands, "ENABLE QRESYNC")
+	assert.Contains(commands, "CHANGEDSINCE 10 VANISHED")
+}
+
+func TestListMessagesFallbackRebuildsKnownUIDBaseline(t *testing.T) {
+	addr, _ := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities: []string{"IMAP4rev1"},
+		uidValidity:  77,
+		uidNext:      5,
+		searchUIDs:   []imapv2.UID{1, 2, 3, 4},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {UIDValidity: 77, UIDNext: 4, KnownUIDs: []uint32{1, 2, 3}},
+	})
+
+	assert.Equal(t, []string{"INBOX|1", "INBOX|2", "INBOX|3", "INBOX|4"},
+		listQresyncMessages(t, client))
+	assert.Equal(t, []uint32{1, 2, 3, 4}, client.ObservedFolderStates()["INBOX"].KnownUIDs)
+}
+
+func TestObservedMailboxDeltasReturnsDefensiveCopy(t *testing.T) {
+	client := &Client{observedMailboxDeltas: []MailboxDelta{{
+		Mailbox:      "INBOX",
+		State:        FolderState{KnownUIDs: []uint32{1, 2}},
+		ChangedUIDs:  []imapv2.UID{2},
+		VanishedUIDs: []imapv2.UID{1},
+		Incremental:  true,
+	}}}
+
+	first := client.ObservedMailboxDeltas()
+	first[0].Mailbox = "mutated"
+	first[0].State.KnownUIDs[0] = 99
+	first[0].ChangedUIDs[0] = 99
+	first[0].VanishedUIDs[0] = 99
+
+	assert.Equal(t, []MailboxDelta{{
+		Mailbox:      "INBOX",
+		State:        FolderState{KnownUIDs: []uint32{1, 2}},
+		ChangedUIDs:  []imapv2.UID{2},
+		VanishedUIDs: []imapv2.UID{1},
+		Incremental:  true,
+	}}, client.ObservedMailboxDeltas())
+}
+
+func TestObservedSnapshotsPreserveEmptyKnownUIDBaseline(t *testing.T) {
+	client := &Client{
+		observedFolderStates: map[string]FolderState{
+			"Empty": {KnownUIDs: []uint32{}},
+		},
+		observedMailboxDeltas: []MailboxDelta{{
+			Mailbox: "Empty",
+			State:   FolderState{KnownUIDs: []uint32{}},
+		}},
+	}
+
+	assert.NotNil(t, client.ObservedFolderStates()["Empty"].KnownUIDs)
+	assert.NotNil(t, client.ObservedMailboxDeltas()[0].State.KnownUIDs)
+}

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -588,6 +588,7 @@ func (d *PostgreSQLDialect) FTSRebuildSchema(ctx context.Context, q contextQueri
 func (d *PostgreSQLDialect) LegacyColumnMigrations() []ColumnMigration {
 	return []ColumnMigration{
 		{`ALTER TABLE sources ADD COLUMN IF NOT EXISTS sync_config JSONB`, "sync_config"},
+		{`ALTER TABLE imap_folder_state ADD COLUMN IF NOT EXISTS highest_modseq NUMERIC(20, 0) NOT NULL DEFAULT 0`, "imap_folder_state.highest_modseq"},
 		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS rfc822_message_id TEXT`, "rfc822_message_id"},
 		{`ALTER TABLE sources ADD COLUMN IF NOT EXISTS oauth_app TEXT`, "oauth_app"},
 		{`ALTER TABLE participants ADD COLUMN IF NOT EXISTS phone_number TEXT`, "phone_number"},
@@ -1530,7 +1531,7 @@ func (d *PostgreSQLDialect) IsFTSValueTooLargeError(err error) bool {
 //     and cascade-reachable from sources — a real race before it was added here.
 //   - sync_checkpoints: cascade-reachable from sources; no writer today, but
 //     included so a future checkpoint writer cannot race the cascade.
-//   - imap_folder_state: written by UpsertIMAPFolderStates after IMAP syncs
+//   - imap_folder_state and imap_message_memberships: written after IMAP syncs
 //     and cascade-reachable from sources.
 //
 // collections is included (despite not being a direct sources cascade target)
@@ -1552,7 +1553,7 @@ var exclusiveLockTables = []string{
 	"activity_projection_queue",
 	"collections", "collection_sources", "account_identities", "applied_migrations",
 	"source_import_items", "sync_run_items", "sync_checkpoints",
-	"imap_folder_state",
+	"imap_folder_state", "imap_message_memberships",
 }
 
 // BeginExclusive opens a transaction on conn and locks every table the

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -1235,6 +1235,7 @@ func (d *SQLiteDialect) contentChangedAtDefaultStamps(q querier) (bool, error) {
 func (d *SQLiteDialect) LegacyColumnMigrations() []ColumnMigration {
 	return []ColumnMigration{
 		{`ALTER TABLE sources ADD COLUMN sync_config JSON`, "sync_config"},
+		{`ALTER TABLE imap_folder_state ADD COLUMN highest_modseq TEXT NOT NULL DEFAULT '0'`, "imap_folder_state.highest_modseq"},
 		{`ALTER TABLE messages ADD COLUMN rfc822_message_id TEXT`, "rfc822_message_id"},
 		{`ALTER TABLE sources ADD COLUMN oauth_app TEXT`, "oauth_app"},
 		{`ALTER TABLE participants ADD COLUMN phone_number TEXT`, "phone_number"},

--- a/internal/store/imap_folder_state.go
+++ b/internal/store/imap_folder_state.go
@@ -2,22 +2,24 @@ package store
 
 import (
 	"fmt"
+	"strconv"
 )
 
-// IMAPFolderState records the UIDVALIDITY and UIDNEXT of one IMAP
-// mailbox as observed at the start of the last fully completed sync.
+// IMAPFolderState records the UIDVALIDITY, UIDNEXT, and highest mod-sequence
+// of one IMAP mailbox at the last fully completed sync.
 // A mailbox whose current values match the saved ones has received no
 // new messages since that sync and can be skipped entirely.
 type IMAPFolderState struct {
-	Mailbox     string
-	UIDValidity uint32
-	UIDNext     uint32
+	Mailbox       string
+	UIDValidity   uint32
+	UIDNext       uint32
+	HighestModSeq uint64
 }
 
 // GetIMAPFolderStates returns the saved per-mailbox sync states for a source.
 func (s *Store) GetIMAPFolderStates(sourceID int64) ([]IMAPFolderState, error) {
 	rows, err := s.db.Query(`
-		SELECT mailbox, uidvalidity, uidnext
+		SELECT mailbox, uidvalidity, uidnext, highest_modseq
 		FROM imap_folder_state
 		WHERE source_id = ?
 	`, sourceID)
@@ -29,8 +31,13 @@ func (s *Store) GetIMAPFolderStates(sourceID int64) ([]IMAPFolderState, error) {
 	var states []IMAPFolderState
 	for rows.Next() {
 		var st IMAPFolderState
-		if err := rows.Scan(&st.Mailbox, &st.UIDValidity, &st.UIDNext); err != nil {
+		var highestModSeq string
+		if err := rows.Scan(&st.Mailbox, &st.UIDValidity, &st.UIDNext, &highestModSeq); err != nil {
 			return nil, fmt.Errorf("scan imap folder state: %w", err)
+		}
+		st.HighestModSeq, err = strconv.ParseUint(highestModSeq, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse highest mod-sequence for mailbox %q: %w", st.Mailbox, err)
 		}
 		states = append(states, st)
 	}
@@ -46,14 +53,17 @@ func (s *Store) GetIMAPFolderStates(sourceID int64) ([]IMAPFolderState, error) {
 func (s *Store) UpsertIMAPFolderStates(sourceID int64, states []IMAPFolderState) error {
 	for _, st := range states {
 		_, err := s.db.Exec(fmt.Sprintf(`
-			INSERT INTO imap_folder_state (source_id, mailbox, uidvalidity, uidnext, updated_at)
-			VALUES (?, ?, ?, ?, %s)
+			INSERT INTO imap_folder_state
+				(source_id, mailbox, uidvalidity, uidnext, highest_modseq, updated_at)
+			VALUES (?, ?, ?, ?, ?, %s)
 			ON CONFLICT(source_id, mailbox) DO UPDATE SET
 				uidvalidity = excluded.uidvalidity,
 				uidnext = excluded.uidnext,
+				highest_modseq = excluded.highest_modseq,
 				updated_at = %s
 		`, s.dialect.Now(), s.dialect.Now()),
-			sourceID, st.Mailbox, st.UIDValidity, st.UIDNext)
+			sourceID, st.Mailbox, st.UIDValidity, st.UIDNext,
+			strconv.FormatUint(st.HighestModSeq, 10))
 		if err != nil {
 			return fmt.Errorf("upsert imap folder state for %q: %w", st.Mailbox, err)
 		}

--- a/internal/store/imap_folder_state_test.go
+++ b/internal/store/imap_folder_state_test.go
@@ -27,8 +27,8 @@ func TestIMAPFolderStates_RoundTrip(t *testing.T) {
 	require.NoError(err)
 
 	saved := []store.IMAPFolderState{
-		{Mailbox: "INBOX", UIDValidity: 1234, UIDNext: 501},
-		{Mailbox: "Archive/2009", UIDValidity: 99, UIDNext: 100000},
+		{Mailbox: "INBOX", UIDValidity: 1234, UIDNext: 501, HighestModSeq: 9001},
+		{Mailbox: "Archive/2009", UIDValidity: 99, UIDNext: 100000, HighestModSeq: 42},
 	}
 	require.NoError(st.UpsertIMAPFolderStates(source.ID, saved))
 
@@ -44,19 +44,19 @@ func TestIMAPFolderStates_UpsertOverwrites(t *testing.T) {
 	require.NoError(err)
 
 	require.NoError(st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
-		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 10},
-		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20},
+		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 10, HighestModSeq: 100},
+		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20, HighestModSeq: 200},
 	}))
 	// INBOX advances; Sent is untouched by this save.
 	require.NoError(st.UpsertIMAPFolderStates(source.ID, []store.IMAPFolderState{
-		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15},
+		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15, HighestModSeq: 150},
 	}))
 
 	states, err := st.GetIMAPFolderStates(source.ID)
 	require.NoError(err)
 	assert.ElementsMatch(t, []store.IMAPFolderState{
-		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15},
-		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20},
+		{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 15, HighestModSeq: 150},
+		{Mailbox: "Sent", UIDValidity: 2, UIDNext: 20, HighestModSeq: 200},
 	}, states)
 }
 
@@ -84,7 +84,7 @@ func TestIMAPFolderStates_MaxUint32Values(t *testing.T) {
 	require.NoError(err)
 
 	saved := []store.IMAPFolderState{
-		{Mailbox: "INBOX", UIDValidity: 4294967295, UIDNext: 4294967295},
+		{Mailbox: "INBOX", UIDValidity: 4294967295, UIDNext: 4294967295, HighestModSeq: ^uint64(0)},
 	}
 	require.NoError(st.UpsertIMAPFolderStates(source.ID, saved))
 

--- a/internal/store/imap_memberships.go
+++ b/internal/store/imap_memberships.go
@@ -1,0 +1,703 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// IMAPMembershipObservation records one observed mailbox UID and its message identity.
+type IMAPMembershipObservation struct {
+	Mailbox                  string
+	UIDValidity              uint32
+	UID                      uint32
+	SourceMessageID          string
+	CanonicalSourceMessageID string
+	RFC822MessageID          string
+	RawSHA256                [32]byte
+	RawSize                  int64
+	Flags                    []string
+}
+
+// IMAPMailboxDelta is the durable state change collected for one mailbox.
+type IMAPMailboxDelta struct {
+	Mailbox      string
+	State        IMAPFolderState
+	Memberships  []IMAPMembershipObservation
+	VanishedUIDs []uint32
+	Reset        bool
+}
+
+type normalizedIMAPMailboxDelta struct {
+	delta       IMAPMailboxDelta
+	mailbox     string
+	uidValidity uint32
+}
+
+// GetIMAPKnownUIDs returns the saved UIDs for each mailbox in a source.
+func (s *Store) GetIMAPKnownUIDs(sourceID int64) (map[string][]uint32, error) {
+	rows, err := s.db.Query(`
+		SELECT state.mailbox, membership.uid
+		FROM imap_folder_state state
+		LEFT JOIN imap_message_memberships membership
+		  ON membership.source_id = state.source_id
+		 AND membership.mailbox = state.mailbox
+		 AND membership.uidvalidity = state.uidvalidity
+		WHERE state.source_id = ?
+		ORDER BY state.mailbox, membership.uid
+	`, sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("query known IMAP UIDs for source %d: %w", sourceID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	known := make(map[string][]uint32)
+	for rows.Next() {
+		var mailbox string
+		var uid sql.Null[uint32]
+		if err := rows.Scan(&mailbox, &uid); err != nil {
+			return nil, fmt.Errorf("scan known IMAP UID: %w", err)
+		}
+		if _, ok := known[mailbox]; !ok {
+			known[mailbox] = make([]uint32, 0)
+		}
+		if uid.Valid {
+			known[mailbox] = append(known[mailbox], uid.V)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate known IMAP UIDs: %w", err)
+	}
+	return known, nil
+}
+
+// GetIMAPSourceMessageAliases returns the canonical archived source identity
+// for every mailbox UID in the current saved epoch.
+func (s *Store) GetIMAPSourceMessageAliases(sourceID int64) (map[string]string, error) {
+	rows, err := s.db.Query(`
+		SELECT membership.mailbox, membership.uid, messages.source_message_id
+		FROM imap_message_memberships membership
+		JOIN imap_folder_state state
+		  ON state.source_id = membership.source_id
+		 AND state.mailbox = membership.mailbox
+		 AND state.uidvalidity = membership.uidvalidity
+		JOIN messages ON messages.id = membership.message_id
+		WHERE membership.source_id = ? AND messages.source_message_id IS NOT NULL
+	`, sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("query IMAP source message aliases: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	aliases := make(map[string]string)
+	for rows.Next() {
+		var mailbox, canonicalSourceMessageID string
+		var uid uint32
+		if err := rows.Scan(&mailbox, &uid, &canonicalSourceMessageID); err != nil {
+			return nil, fmt.Errorf("scan IMAP source message alias: %w", err)
+		}
+		aliases[fmt.Sprintf("%s|%d", mailbox, uid)] = canonicalSourceMessageID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate IMAP source message aliases: %w", err)
+	}
+	return aliases, nil
+}
+
+// ApplyIMAPMailboxDeltas atomically replaces the source's authoritative IMAP
+// mailbox topology, memberships, labels, tombstones, and cursors. Callers must
+// pass one delta for every current mailbox; a non-nil empty slice means the
+// authoritative current topology is empty and retires every saved mailbox.
+func (s *Store) ApplyIMAPMailboxDeltas(sourceID int64, deltas []IMAPMailboxDelta) error {
+	return s.applyIMAPMailboxDeltas(context.Background(), sourceID, 0, deltas)
+}
+
+// ApplyIMAPMailboxDeltasForSyncContext applies an authoritative topology only
+// if syncRunID is still the latest completed generation for sourceID. The
+// generation check and topology replacement share one transaction and source
+// lock, so a newer StartSync cannot interleave between them.
+func (s *Store) ApplyIMAPMailboxDeltasForSyncContext(
+	ctx context.Context,
+	sourceID int64,
+	syncRunID int64,
+	deltas []IMAPMailboxDelta,
+) error {
+	if syncRunID <= 0 {
+		return fmt.Errorf("apply IMAP mailbox deltas: invalid sync generation %d", syncRunID)
+	}
+	return s.applyIMAPMailboxDeltas(ctx, sourceID, syncRunID, deltas)
+}
+
+func (s *Store) applyIMAPMailboxDeltas(
+	ctx context.Context,
+	sourceID int64,
+	syncRunID int64,
+	deltas []IMAPMailboxDelta,
+) error {
+	if deltas == nil {
+		return errors.New("apply IMAP mailbox deltas: nil authoritative topology")
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		if syncRunID > 0 {
+			if err := validateCurrentSyncGeneration(
+				ctx, tx, sourceID, syncRunID, SyncStatusCompleted,
+			); err != nil {
+				return err
+			}
+		}
+		normalizedDeltas, err := normalizeIMAPMailboxDeltas(deltas)
+		if err != nil {
+			return err
+		}
+		resolver := imapMembershipResolver{tx: tx, sourceID: sourceID}
+		if err := resolver.primeRawIdentities(normalizedDeltas); err != nil {
+			return err
+		}
+
+		affected := make(map[int64]struct{})
+		if err := captureUntrackedIMAPMessageIDs(tx, sourceID, affected); err != nil {
+			return err
+		}
+		currentMailboxes := make(map[string]struct{}, len(normalizedDeltas))
+		for _, normalized := range normalizedDeltas {
+			currentMailboxes[normalized.mailbox] = struct{}{}
+		}
+		if err := retireAbsentIMAPMailboxes(
+			tx, sourceID, currentMailboxes, affected,
+		); err != nil {
+			return err
+		}
+		for _, normalized := range normalizedDeltas {
+			delta := normalized.delta
+			if delta.Reset {
+				if err := captureIMAPMembershipMessageIDs(
+					tx, affected,
+					`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ?`,
+					sourceID, normalized.mailbox,
+				); err != nil {
+					return fmt.Errorf("capture reset memberships for mailbox %q: %w", normalized.mailbox, err)
+				}
+				if _, err := tx.Exec(`
+					DELETE FROM imap_message_memberships
+					WHERE source_id = ? AND mailbox = ?
+				`, sourceID, normalized.mailbox); err != nil {
+					return fmt.Errorf("reset IMAP memberships for mailbox %q: %w", normalized.mailbox, err)
+				}
+			}
+
+			for _, uid := range delta.VanishedUIDs {
+				if err := captureIMAPMembershipMessageIDs(
+					tx, affected,
+					`SELECT message_id FROM imap_message_memberships
+					 WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`,
+					sourceID, normalized.mailbox, normalized.uidValidity, uid,
+				); err != nil {
+					return fmt.Errorf("capture vanished UID %d in mailbox %q: %w", uid, normalized.mailbox, err)
+				}
+				if _, err := tx.Exec(`
+					DELETE FROM imap_message_memberships
+					WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+				`, sourceID, normalized.mailbox, normalized.uidValidity, uid); err != nil {
+					return fmt.Errorf("remove vanished UID %d in mailbox %q: %w", uid, normalized.mailbox, err)
+				}
+			}
+
+			for _, observation := range delta.Memberships {
+				observation.Mailbox = normalized.mailbox
+				observation.UIDValidity = normalized.uidValidity
+				messageID, err := resolver.resolve(observation)
+				if err != nil {
+					return err
+				}
+				if observation.SourceMessageID != "" {
+					if err := captureIMAPMembershipMessageIDs(
+						tx, affected,
+						`SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?`,
+						sourceID, observation.SourceMessageID,
+					); err != nil {
+						return fmt.Errorf("capture observed IMAP message: %w", err)
+					}
+				}
+				affected[messageID] = struct{}{}
+				if err := captureIMAPMembershipMessageIDs(
+					tx, affected,
+					`SELECT message_id FROM imap_message_memberships
+					 WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`,
+					sourceID, observation.Mailbox, observation.UIDValidity, observation.UID,
+				); err != nil {
+					return fmt.Errorf("capture replaced IMAP membership: %w", err)
+				}
+
+				flags := observation.Flags
+				if flags == nil {
+					flags = []string{}
+				}
+				flagsJSON, err := json.Marshal(flags)
+				if err != nil {
+					return fmt.Errorf("marshal IMAP flags: %w", err)
+				}
+				if _, err := tx.Exec(fmt.Sprintf(`
+					INSERT INTO imap_message_memberships
+						(source_id, mailbox, uidvalidity, uid, message_id, flags, updated_at)
+					VALUES (?, ?, ?, ?, ?, %s, %s)
+					ON CONFLICT(source_id, mailbox, uidvalidity, uid) DO UPDATE SET
+						message_id = excluded.message_id,
+						flags = excluded.flags,
+						updated_at = %s
+				`, s.dialect.JSONBindExpr(), s.dialect.Now(), s.dialect.Now()),
+					sourceID, observation.Mailbox, observation.UIDValidity,
+					observation.UID, messageID, string(flagsJSON),
+				); err != nil {
+					return fmt.Errorf("upsert IMAP membership for mailbox %q UID %d: %w",
+						observation.Mailbox, observation.UID, err)
+				}
+			}
+		}
+
+		for _, messageID := range sortedIMAPMessageIDs(affected) {
+			mailboxes, err := imapMembershipMailboxes(tx, sourceID, messageID)
+			if err != nil {
+				return err
+			}
+			labelIDs := make([]int64, 0, len(mailboxes))
+			for _, mailbox := range mailboxes {
+				labelID, err := ensureIMAPMailboxLabel(tx, sourceID, mailbox)
+				if err != nil {
+					return err
+				}
+				labelIDs = append(labelIDs, labelID)
+			}
+			if err := replaceMessageLabelsTx(tx, messageID, labelIDs); err != nil {
+				return fmt.Errorf("replace labels for IMAP message %d: %w", messageID, err)
+			}
+			if len(mailboxes) == 0 {
+				if _, err := tx.Exec(fmt.Sprintf(`
+					UPDATE messages SET deleted_from_source_at = %s
+					WHERE id = ? AND source_id = ? AND deleted_from_source_at IS NULL
+				`, s.dialect.Now()), messageID, sourceID); err != nil {
+					return fmt.Errorf("tombstone IMAP message %d: %w", messageID, err)
+				}
+			} else if _, err := tx.Exec(`
+				UPDATE messages SET deleted_from_source_at = NULL
+				WHERE id = ? AND source_id = ? AND deleted_from_source_at IS NOT NULL
+			`, messageID, sourceID); err != nil {
+				return fmt.Errorf("clear IMAP tombstone for message %d: %w", messageID, err)
+			}
+		}
+
+		for _, normalized := range normalizedDeltas {
+			delta := normalized.delta
+			if _, err := tx.Exec(fmt.Sprintf(`
+				INSERT INTO imap_folder_state
+					(source_id, mailbox, uidvalidity, uidnext, highest_modseq, updated_at)
+				VALUES (?, ?, ?, ?, ?, %s)
+				ON CONFLICT(source_id, mailbox) DO UPDATE SET
+					uidvalidity = excluded.uidvalidity,
+					uidnext = excluded.uidnext,
+					highest_modseq = excluded.highest_modseq,
+					updated_at = %s
+			`, s.dialect.Now(), s.dialect.Now()),
+				sourceID, normalized.mailbox, normalized.uidValidity, delta.State.UIDNext,
+				strconv.FormatUint(delta.State.HighestModSeq, 10),
+			); err != nil {
+				return fmt.Errorf("upsert IMAP folder state for %q: %w", normalized.mailbox, err)
+			}
+		}
+		return nil
+	})
+}
+
+func captureUntrackedIMAPMessageIDs(
+	tx *loggedTx, sourceID int64, affected map[int64]struct{},
+) error {
+	// Partial, filtered, interrupted, or failed runs can import a live message
+	// without publishing its membership. Every later authoritative apply must
+	// reconcile such rows even after the initial membership baseline exists.
+	if err := captureIMAPMembershipMessageIDs(tx, affected, `
+		SELECT messages.id
+		FROM messages
+		WHERE messages.source_id = ?
+		  AND messages.deleted_from_source_at IS NULL
+		  AND NOT EXISTS (
+			SELECT 1 FROM imap_message_memberships membership
+			WHERE membership.source_id = messages.source_id
+			  AND membership.message_id = messages.id
+		  )
+	`, sourceID); err != nil {
+		return fmt.Errorf("capture live messages without IMAP membership: %w", err)
+	}
+
+	var membershipCount int64
+	if err := tx.QueryRow(`
+		SELECT COUNT(*) FROM imap_message_memberships WHERE source_id = ?
+	`, sourceID).Scan(&membershipCount); err != nil {
+		return fmt.Errorf("count prior IMAP memberships: %w", err)
+	}
+	if membershipCount != 0 {
+		return nil
+	}
+
+	// The membership table is introduced after messages and mailbox labels may
+	// already exist. Live rows were captured above; on the first authoritative
+	// baseline also include tombstoned rows that still carry legacy labels. Rows
+	// already both tombstoned and label-free were reconciled by an earlier empty
+	// baseline, so later empty-mailbox syncs stay proportional to live state.
+	if err := captureIMAPMembershipMessageIDs(
+		tx, affected, `
+			SELECT messages.id
+			FROM message_labels
+			JOIN messages ON messages.id = message_labels.message_id
+			WHERE messages.source_id = ?
+			  AND messages.deleted_from_source_at IS NOT NULL
+		`, sourceID,
+	); err != nil {
+		return fmt.Errorf("capture initial IMAP baseline messages: %w", err)
+	}
+	return nil
+}
+
+func retireAbsentIMAPMailboxes(
+	tx *loggedTx,
+	sourceID int64,
+	current map[string]struct{},
+	affected map[int64]struct{},
+) error {
+	rows, err := tx.Query(`
+		SELECT mailbox FROM imap_folder_state WHERE source_id = ?
+		UNION
+		SELECT mailbox FROM imap_message_memberships WHERE source_id = ?
+		ORDER BY mailbox
+	`, sourceID, sourceID)
+	if err != nil {
+		return fmt.Errorf("query prior IMAP mailbox topology: %w", err)
+	}
+	var retired []string
+	for rows.Next() {
+		var mailbox string
+		if err := rows.Scan(&mailbox); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan prior IMAP mailbox topology: %w", err)
+		}
+		if _, ok := current[mailbox]; !ok {
+			retired = append(retired, mailbox)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate prior IMAP mailbox topology: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close prior IMAP mailbox topology: %w", err)
+	}
+
+	for _, mailbox := range retired {
+		if err := captureIMAPMembershipMessageIDs(
+			tx, affected,
+			`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ?`,
+			sourceID, mailbox,
+		); err != nil {
+			return fmt.Errorf("capture retired memberships for mailbox %q: %w", mailbox, err)
+		}
+		if _, err := tx.Exec(`
+			DELETE FROM imap_message_memberships
+			WHERE source_id = ? AND mailbox = ?
+		`, sourceID, mailbox); err != nil {
+			return fmt.Errorf("retire IMAP memberships for mailbox %q: %w", mailbox, err)
+		}
+		if _, err := tx.Exec(`
+			DELETE FROM imap_folder_state
+			WHERE source_id = ? AND mailbox = ?
+		`, sourceID, mailbox); err != nil {
+			return fmt.Errorf("retire IMAP folder state for mailbox %q: %w", mailbox, err)
+		}
+	}
+	return nil
+}
+
+func normalizeIMAPMailboxDeltas(deltas []IMAPMailboxDelta) ([]normalizedIMAPMailboxDelta, error) {
+	normalized := make([]normalizedIMAPMailboxDelta, 0, len(deltas))
+	for i, delta := range deltas {
+		mailbox := delta.Mailbox
+		var err error
+		mailbox, err = mergeIMAPMailbox(mailbox, delta.State.Mailbox)
+		if err != nil {
+			return nil, fmt.Errorf("normalize IMAP delta %d: %w", i, err)
+		}
+
+		uidValidity := delta.State.UIDValidity
+		for _, observation := range delta.Memberships {
+			mailbox, err = mergeIMAPMailbox(mailbox, observation.Mailbox)
+			if err != nil {
+				return nil, fmt.Errorf("normalize IMAP delta %d: %w", i, err)
+			}
+			if observation.UIDValidity == 0 {
+				continue
+			}
+			if uidValidity == 0 {
+				uidValidity = observation.UIDValidity
+				continue
+			}
+			if observation.UIDValidity != uidValidity {
+				return nil, fmt.Errorf(
+					"normalize IMAP delta %d: conflicting UIDVALIDITY values %d and %d",
+					i, uidValidity, observation.UIDValidity,
+				)
+			}
+		}
+		normalized = append(normalized, normalizedIMAPMailboxDelta{
+			delta: delta, mailbox: mailbox, uidValidity: uidValidity,
+		})
+	}
+	return normalized, nil
+}
+
+func mergeIMAPMailbox(current, candidate string) (string, error) {
+	if candidate == "" {
+		return current, nil
+	}
+	if current == "" {
+		return candidate, nil
+	}
+	if candidate != current {
+		return "", fmt.Errorf("conflicting mailbox values %q and %q", current, candidate)
+	}
+	return current, nil
+}
+
+func captureIMAPMembershipMessageIDs(
+	tx *loggedTx, affected map[int64]struct{}, query string, args ...any,
+) error {
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var messageID int64
+		if err := rows.Scan(&messageID); err != nil {
+			return err
+		}
+		affected[messageID] = struct{}{}
+	}
+	return rows.Err()
+}
+
+type imapMembershipResolver struct {
+	tx          *loggedTx
+	sourceID    int64
+	rawMessages map[int64]map[[32]byte]int64
+}
+
+// primeRawIdentities snapshots durable raw candidates before mailbox resets,
+// VANISHED removals, or topology retirement can change which canonical rows
+// still have memberships. Later resolution is therefore independent of delta
+// order within the transaction.
+func (r *imapMembershipResolver) primeRawIdentities(
+	deltas []normalizedIMAPMailboxDelta,
+) error {
+	for _, normalized := range deltas {
+		for _, observation := range normalized.delta.Memberships {
+			if observation.CanonicalSourceMessageID != "" ||
+				observation.RawSHA256 == ([32]byte{}) {
+				continue
+			}
+			if _, _, err := r.resolveRawSHA256(observation.RawSHA256, observation.RawSize); err != nil {
+				return fmt.Errorf(
+					"snapshot IMAP raw identity for mailbox %q UID %d: %w",
+					normalized.mailbox, observation.UID, err,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *imapMembershipResolver) resolve(observation IMAPMembershipObservation) (int64, error) {
+	var messageID int64
+	if observation.CanonicalSourceMessageID != "" {
+		err := r.tx.QueryRow(`
+			SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?
+		`, r.sourceID, observation.CanonicalSourceMessageID).Scan(&messageID)
+		if err == nil {
+			return messageID, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("resolve IMAP membership by canonical source message ID: %w", err)
+		}
+	}
+	if observation.RawSHA256 != ([32]byte{}) {
+		messageID, ok, err := r.resolveRawSHA256(observation.RawSHA256, observation.RawSize)
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			return messageID, nil
+		}
+	}
+	if observation.SourceMessageID != "" {
+		err := r.tx.QueryRow(`
+			SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?
+		`, r.sourceID, observation.SourceMessageID).Scan(&messageID)
+		if err == nil {
+			return messageID, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("resolve IMAP membership by source message ID: %w", err)
+		}
+	}
+	if observation.RFC822MessageID != "" {
+		for _, candidate := range imapRFC822MessageIDCandidates(observation.RFC822MessageID) {
+			err := r.tx.QueryRow(`
+				SELECT id FROM messages
+				WHERE source_id = ? AND rfc822_message_id = ?
+				ORDER BY id
+				LIMIT 1
+			`, r.sourceID, candidate).Scan(&messageID)
+			if err == nil {
+				return messageID, nil
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return 0, fmt.Errorf("resolve IMAP membership by RFC822 Message-ID: %w", err)
+			}
+		}
+	}
+	return 0, fmt.Errorf(
+		"resolve IMAP membership for mailbox %q UID %d: no message matches source ID %q or RFC822 Message-ID %q",
+		observation.Mailbox, observation.UID, observation.SourceMessageID, observation.RFC822MessageID)
+}
+
+func (r *imapMembershipResolver) resolveRawSHA256(
+	digest [32]byte,
+	rawSize int64,
+) (int64, bool, error) {
+	if r.rawMessages == nil {
+		r.rawMessages = make(map[int64]map[[32]byte]int64)
+	}
+	messages, loaded := r.rawMessages[rawSize]
+	if !loaded {
+		messages = make(map[[32]byte]int64)
+		r.rawMessages[rawSize] = messages
+		query := `
+			SELECT messages.id, message_raw.raw_data, message_raw.compression
+			FROM messages
+			JOIN message_raw ON message_raw.message_id = messages.id
+			WHERE messages.source_id = ? AND message_raw.raw_format = 'mime'
+			  AND messages.deleted_from_source_at IS NULL
+			  AND EXISTS (
+				SELECT 1 FROM imap_message_memberships membership
+				WHERE membership.source_id = messages.source_id
+				  AND membership.message_id = messages.id
+			  )
+		`
+		args := []any{r.sourceID}
+		if rawSize > 0 {
+			query += ` AND messages.size_estimate = ?`
+			args = append(args, rawSize)
+		}
+		query += ` ORDER BY messages.id`
+		rows, err := r.tx.Query(query, args...)
+		if err != nil {
+			return 0, false, fmt.Errorf("load IMAP raw membership identities: %w", err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var (
+				messageID   int64
+				rawData     []byte
+				compression sql.NullString
+			)
+			if err := rows.Scan(&messageID, &rawData, &compression); err != nil {
+				return 0, false, fmt.Errorf("scan IMAP raw membership identity: %w", err)
+			}
+			decoded, err := decodeMessageRaw(rawData, compression)
+			if err != nil {
+				return 0, false, fmt.Errorf("decode IMAP raw membership identity: %w", err)
+			}
+			rawDigest := sha256.Sum256(decoded)
+			if existingMessageID, exists := messages[rawDigest]; !exists {
+				messages[rawDigest] = messageID
+			} else if existingMessageID != messageID {
+				// Zero marks an ambiguous digest. The caller must fall back to
+				// exact source identity instead of choosing an arbitrary row.
+				messages[rawDigest] = 0
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return 0, false, fmt.Errorf("iterate IMAP raw membership identities: %w", err)
+		}
+	}
+	messageID, ok := messages[digest]
+	return messageID, ok && messageID != 0, nil
+}
+
+func imapRFC822MessageIDCandidates(messageID string) []string {
+	messageID = strings.TrimSpace(messageID)
+	normalized := strings.TrimSuffix(strings.TrimPrefix(messageID, "<"), ">")
+	candidates := []string{messageID}
+	for _, candidate := range []string{normalized, "<" + normalized + ">"} {
+		if candidate != "" && !slices.Contains(candidates, candidate) {
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func imapMembershipMailboxes(
+	tx *loggedTx, sourceID, messageID int64,
+) ([]string, error) {
+	rows, err := tx.Query(`
+		SELECT mailbox FROM imap_message_memberships
+		WHERE source_id = ? AND message_id = ?
+		GROUP BY mailbox
+		ORDER BY mailbox
+	`, sourceID, messageID)
+	if err != nil {
+		return nil, fmt.Errorf("query memberships for IMAP message %d: %w", messageID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var mailboxes []string
+	for rows.Next() {
+		var mailbox string
+		if err := rows.Scan(&mailbox); err != nil {
+			return nil, fmt.Errorf("scan membership for IMAP message %d: %w", messageID, err)
+		}
+		mailboxes = append(mailboxes, mailbox)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate memberships for IMAP message %d: %w", messageID, err)
+	}
+	return mailboxes, nil
+}
+
+func ensureIMAPMailboxLabel(tx *loggedTx, sourceID int64, mailbox string) (int64, error) {
+	var labelID int64
+	err := tx.QueryRow(`
+		SELECT id FROM labels WHERE source_id = ? AND source_label_id = ?
+	`, sourceID, mailbox).Scan(&labelID)
+	if err == nil {
+		return labelID, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("find label for IMAP mailbox %q: %w", mailbox, err)
+	}
+	labelID, err = ensureLabelWith(tx, sourceID, mailbox, mailbox, "user", nil)
+	if err != nil {
+		return 0, fmt.Errorf("ensure label for IMAP mailbox %q: %w", mailbox, err)
+	}
+	return labelID, nil
+}
+
+func sortedIMAPMessageIDs(ids map[int64]struct{}) []int64 {
+	sorted := make([]int64, 0, len(ids))
+	for id := range ids {
+		sorted = append(sorted, id)
+	}
+	slices.Sort(sorted)
+	return sorted
+}

--- a/internal/store/imap_memberships_internal_test.go
+++ b/internal/store/imap_memberships_internal_test.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureInitialIMAPBaselineSkipsReconciledHistory(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st, err := Open(filepath.Join(t.TempDir(), "imap-baseline.db"))
+	requirements.NoError(err)
+	t.Cleanup(func() { requirements.NoError(st.Close()) })
+	requirements.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("imap", "baseline-internal@example.test")
+	requirements.NoError(err)
+	conversationID, err := st.EnsureConversation(source.ID, "baseline", "Baseline")
+	requirements.NoError(err)
+
+	createMessage := func(sourceMessageID string) int64 {
+		messageID, createErr := st.UpsertMessage(&Message{
+			ConversationID: conversationID, SourceID: source.ID,
+			SourceMessageID: sourceMessageID, MessageType: "email",
+		})
+		requirements.NoError(createErr)
+		return messageID
+	}
+	liveID := createMessage("live")
+	reconciledID := createMessage("reconciled")
+	labeledID := createMessage("labeled")
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP
+		WHERE id IN (?, ?)
+	`), reconciledID, labeledID)
+	requirements.NoError(err)
+	labelID, err := st.EnsureLabel(source.ID, "Legacy", "Legacy", "user")
+	requirements.NoError(err)
+	requirements.NoError(st.ReplaceMessageLabels(labeledID, []int64{labelID}))
+
+	affected := make(map[int64]struct{})
+	requirements.NoError(st.withTx(func(tx *loggedTx) error {
+		return captureUntrackedIMAPMessageIDs(tx, source.ID, affected)
+	}))
+	got := make([]int64, 0, len(affected))
+	for messageID := range affected {
+		got = append(got, messageID)
+	}
+	slices.Sort(got)
+	assertions.Equal([]int64{liveID, labeledID}, got)
+	assertions.NotContains(got, reconciledID)
+
+	var deletedAt sql.NullTime
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT deleted_from_source_at FROM messages WHERE id = ?
+	`), reconciledID).Scan(&deletedAt))
+	assertions.True(deletedAt.Valid)
+}

--- a/internal/store/imap_memberships_test.go
+++ b/internal/store/imap_memberships_test.go
@@ -1,0 +1,808 @@
+package store_test
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type imapMembershipFixture struct {
+	store  *store.Store
+	source *store.Source
+	convID int64
+}
+
+func newIMAPMembershipFixture(t *testing.T) imapMembershipFixture {
+	t.Helper()
+	st := testutil.NewSQLiteTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "membership@example.com")
+	require.NoError(t, err)
+	convID, err := st.EnsureConversation(source.ID, "membership-thread", "Membership thread")
+	require.NoError(t, err)
+	return imapMembershipFixture{store: st, source: source, convID: convID}
+}
+
+func (f imapMembershipFixture) createMessage(
+	t *testing.T, sourceMessageID, rfc822MessageID string,
+) int64 {
+	t.Helper()
+	messageID, err := f.store.UpsertMessage(&store.Message{
+		ConversationID:  f.convID,
+		SourceID:        f.source.ID,
+		SourceMessageID: sourceMessageID,
+		RFC822MessageID: sql.NullString{String: rfc822MessageID, Valid: rfc822MessageID != ""},
+		MessageType:     "email",
+	})
+	require.NoError(t, err)
+	return messageID
+}
+
+func membershipCount(t *testing.T, st *store.Store, sourceID int64) int {
+	t.Helper()
+	var count int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM imap_message_memberships WHERE source_id = ?
+	`), sourceID).Scan(&count))
+	return count
+}
+
+func membershipMessageAndFlags(
+	t *testing.T, st *store.Store, sourceID int64, uidValidity, uid uint32,
+) (int64, string) {
+	t.Helper()
+	var messageID int64
+	var flags string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT message_id, flags FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+	`), sourceID, "INBOX", uidValidity, uid).Scan(&messageID, &flags))
+	return messageID, flags
+}
+
+func messageLabels(t *testing.T, st *store.Store, messageID int64) []string {
+	t.Helper()
+	rows, err := st.DB().Query(st.Rebind(`
+		SELECT l.name
+		FROM labels l
+		JOIN message_labels ml ON ml.label_id = l.id
+		WHERE ml.message_id = ?
+		ORDER BY l.name
+	`), messageID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	var labels []string
+	for rows.Next() {
+		var label string
+		require.NoError(t, rows.Scan(&label))
+		labels = append(labels, label)
+	}
+	require.NoError(t, rows.Err())
+	return labels
+}
+
+func messageTombstoned(t *testing.T, st *store.Store, messageID int64) bool {
+	t.Helper()
+	var deleted sql.NullTime
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT deleted_from_source_at FROM messages WHERE id = ?
+	`), messageID).Scan(&deleted))
+	return deleted.Valid
+}
+
+func messageIsRead(t *testing.T, st *store.Store, messageID int64) bool {
+	t.Helper()
+	var isRead bool
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT is_read FROM messages WHERE id = ?
+	`), messageID).Scan(&isRead))
+	return isRead
+}
+
+func TestApplyIMAPMailboxDeltas_PersistsMembershipsFlagsLabelsAndKnownUIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	exactID := f.createMessage(t, "provider-exact", "<exact@example.com>")
+	fallbackID := f.createMessage(t, "provider-fallback", "<fallback@example.com>")
+	_, err := f.store.DB().Exec(f.store.Rebind(`
+		UPDATE messages SET is_read = FALSE WHERE id = ?
+	`), exactID)
+	require.NoError(err)
+
+	delta := store.IMAPMailboxDelta{
+		Mailbox: "INBOX",
+		State: store.IMAPFolderState{
+			Mailbox: "INBOX", UIDValidity: 17, UIDNext: 103, HighestModSeq: 900,
+		},
+		Memberships: []store.IMAPMembershipObservation{
+			{
+				Mailbox: "INBOX", UIDValidity: 17, UID: 101,
+				SourceMessageID: "provider-exact", RFC822MessageID: "<wrong@example.com>",
+				Flags: []string{"\\Seen", "$Forwarded"},
+			},
+			{
+				Mailbox: "INBOX", UIDValidity: 17, UID: 102,
+				RFC822MessageID: "<fallback@example.com>", Flags: []string{"\\Flagged"},
+			},
+		},
+	}
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+
+	known, err := f.store.GetIMAPKnownUIDs(f.source.ID)
+	require.NoError(err)
+	assert.Equal(map[string][]uint32{"INBOX": {101, 102}}, known)
+	assert.Equal(2, membershipCount(t, f.store, f.source.ID))
+	gotExactID, gotExactFlags := membershipMessageAndFlags(t, f.store, f.source.ID, 17, 101)
+	gotFallbackID, gotFallbackFlags := membershipMessageAndFlags(t, f.store, f.source.ID, 17, 102)
+	assert.Equal(exactID, gotExactID, "exact source identity must win over RFC822 Message-ID")
+	assert.JSONEq(`["\\Seen","$Forwarded"]`, gotExactFlags)
+	assert.False(messageIsRead(t, f.store, exactID), "provider flags must not change local read state")
+	assert.Equal(fallbackID, gotFallbackID)
+	assert.JSONEq(`["\\Flagged"]`, gotFallbackFlags)
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, exactID))
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, fallbackID))
+
+	states, err := f.store.GetIMAPFolderStates(f.source.ID)
+	require.NoError(err)
+	assert.Equal([]store.IMAPFolderState{delta.State}, states)
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	assert.Equal(2, membershipCount(t, f.store, f.source.ID), "replaying a delta must be idempotent")
+}
+
+func TestApplyIMAPMailboxDeltas_RFC822FallbackDoesNotCrossSources(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	otherSource, err := f.store.GetOrCreateSource("imap", "other-membership@example.com")
+	require.NoError(err)
+	otherConversationID, err := f.store.EnsureConversation(
+		otherSource.ID, "other-membership-thread", "Other membership thread",
+	)
+	require.NoError(err)
+	_, err = f.store.UpsertMessage(&store.Message{
+		ConversationID:  otherConversationID,
+		SourceID:        otherSource.ID,
+		SourceMessageID: "other-provider-id",
+		RFC822MessageID: sql.NullString{String: "<shared@example.com>", Valid: true},
+		MessageType:     "email",
+	})
+	require.NoError(err)
+
+	err = f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 5, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 5, UID: 1, RFC822MessageID: "<shared@example.com>",
+		}},
+	}})
+	require.Error(err)
+	assert.Contains(err.Error(), "no message matches")
+	assert.Zero(membershipCount(t, f.store, f.source.ID))
+	states, statesErr := f.store.GetIMAPFolderStates(f.source.ID)
+	require.NoError(statesErr)
+	assert.Empty(states)
+}
+
+func TestApplyIMAPMailboxDeltas_NormalizesOmittedMembershipIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	messageID := f.createMessage(t, "normalized", "<normalized@example.com>")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{UIDValidity: 17, UIDNext: 2, HighestModSeq: 100},
+		Memberships: []store.IMAPMembershipObservation{{
+			UID: 1, SourceMessageID: "normalized",
+		}},
+	}}))
+
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 17, 1)
+	assert.Equal(messageID, gotMessageID)
+	known, err := f.store.GetIMAPKnownUIDs(f.source.ID)
+	require.NoError(err)
+	assert.Equal(map[string][]uint32{"INBOX": {1}}, known)
+	states, err := f.store.GetIMAPFolderStates(f.source.ID)
+	require.NoError(err)
+	assert.Equal([]store.IMAPFolderState{{
+		Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2, HighestModSeq: 100,
+	}}, states)
+}
+
+func TestGetIMAPKnownUIDs_PreservesEmptyMailboxBaseline(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Empty",
+		State:   store.IMAPFolderState{Mailbox: "Empty", UIDValidity: 8, UIDNext: 1, HighestModSeq: 80},
+	}}))
+
+	known, err := f.store.GetIMAPKnownUIDs(f.source.ID)
+	require.NoError(err)
+	require.Contains(known, "Empty")
+	assert.NotNil(known["Empty"])
+	assert.Empty(known["Empty"])
+}
+
+func TestApplyIMAPMailboxDeltas_VanishedMembershipReconcilesLabelsAndTombstone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	messageID := f.createMessage(t, "multi-mailbox", "<multi@example.com>")
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "INBOX",
+			State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 10},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "INBOX", UIDValidity: 1, UID: 1, SourceMessageID: "multi-mailbox",
+			}},
+		},
+		{
+			Mailbox: "Archive",
+			State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 2, UIDNext: 8, HighestModSeq: 20},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Archive", UIDValidity: 2, UID: 7, SourceMessageID: "multi-mailbox",
+			}},
+		},
+	}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox:      "INBOX",
+			State:        store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 11},
+			VanishedUIDs: []uint32{1},
+		},
+		{
+			Mailbox: "Archive",
+			State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 2, UIDNext: 8, HighestModSeq: 20},
+		},
+	}))
+
+	assert.False(messageTombstoned(t, f.store, messageID))
+	assert.Equal([]string{"Archive"}, messageLabels(t, f.store, messageID))
+	known, err := f.store.GetIMAPKnownUIDs(f.source.ID)
+	require.NoError(err)
+	assert.Equal(map[string][]uint32{"Archive": {7}, "INBOX": {}}, known)
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "INBOX",
+			State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 11},
+		},
+		{
+			Mailbox:      "Archive",
+			State:        store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 2, UIDNext: 8, HighestModSeq: 21},
+			VanishedUIDs: []uint32{7},
+		},
+	}))
+	assert.True(messageTombstoned(t, f.store, messageID))
+	assert.Empty(messageLabels(t, f.store, messageID))
+}
+
+func TestApplyIMAPMailboxDeltas_ReappearanceClearsTombstone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	messageID := f.createMessage(t, "reappearing", "<reappearing@example.com>")
+	require.NoError(f.store.MarkMessageDeleted(f.source.ID, "reappearing"))
+	assert.True(messageTombstoned(t, f.store, messageID))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Recovered",
+		State:   store.IMAPFolderState{Mailbox: "Recovered", UIDValidity: 3, UIDNext: 45, HighestModSeq: 30},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "Recovered", UIDValidity: 3, UID: 44, RFC822MessageID: "<reappearing@example.com>",
+		}},
+	}}))
+
+	assert.False(messageTombstoned(t, f.store, messageID))
+	assert.Equal([]string{"Recovered"}, messageLabels(t, f.store, messageID))
+}
+
+func TestApplyIMAPMailboxDeltas_UIDValidityResetDeletesOldEpoch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	removedID := f.createMessage(t, "old-only", "<old-only@example.com>")
+	survivingID := f.createMessage(t, "old-and-new", "<old-and-new@example.com>")
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 10, UIDNext: 3, HighestModSeq: 100},
+		Memberships: []store.IMAPMembershipObservation{
+			{Mailbox: "INBOX", UIDValidity: 10, UID: 1, SourceMessageID: "old-only"},
+			{Mailbox: "INBOX", UIDValidity: 10, UID: 2, SourceMessageID: "old-and-new"},
+		},
+	}}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 20, UIDNext: 10, HighestModSeq: 200},
+		Reset:   true,
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 20, UID: 9, SourceMessageID: "old-and-new",
+		}},
+	}}))
+
+	assert.Equal(1, membershipCount(t, f.store, f.source.ID))
+	known, err := f.store.GetIMAPKnownUIDs(f.source.ID)
+	require.NoError(err)
+	assert.Equal(map[string][]uint32{"INBOX": {9}}, known)
+	assert.True(messageTombstoned(t, f.store, removedID))
+	assert.False(messageTombstoned(t, f.store, survivingID))
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, survivingID))
+}
+
+func TestApplyIMAPMailboxDeltas_RetiresMailboxesAbsentFromAuthoritativeTopology(t *testing.T) {
+	t.Run("deleted mailbox reconciles labels and tombstones last membership", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		f := newIMAPMembershipFixture(t)
+		retiredOnlyID := f.createMessage(t, "retired-only", "<retired-only@example.com>")
+		sharedID := f.createMessage(t, "shared", "<shared-topology@example.com>")
+		require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+			{
+				Mailbox: "INBOX",
+				State: store.IMAPFolderState{
+					Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 10,
+				},
+				Memberships: []store.IMAPMembershipObservation{{
+					UID: 1, SourceMessageID: "shared",
+				}},
+			},
+			{
+				Mailbox: "Retired",
+				State: store.IMAPFolderState{
+					Mailbox: "Retired", UIDValidity: 2, UIDNext: 3, HighestModSeq: 20,
+				},
+				Memberships: []store.IMAPMembershipObservation{
+					{UID: 1, SourceMessageID: "retired-only"},
+					{UID: 2, SourceMessageID: "shared"},
+				},
+			},
+		}))
+
+		require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+			Mailbox: "INBOX",
+			State: store.IMAPFolderState{
+				Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 11,
+			},
+		}}))
+
+		states, err := f.store.GetIMAPFolderStates(f.source.ID)
+		require.NoError(err)
+		assert.Equal([]store.IMAPFolderState{{
+			Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 11,
+		}}, states)
+		assert.Equal(1, membershipCount(t, f.store, f.source.ID))
+		assert.True(messageTombstoned(t, f.store, retiredOnlyID))
+		assert.Empty(messageLabels(t, f.store, retiredOnlyID))
+		assert.False(messageTombstoned(t, f.store, sharedID))
+		assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, sharedID))
+	})
+
+	t.Run("rename removes the old cursor without recreating it", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		f := newIMAPMembershipFixture(t)
+		messageID := f.createMessage(t, "Old|1", "<renamed-topology@example.com>")
+		require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+			Mailbox: "Old",
+			State: store.IMAPFolderState{
+				Mailbox: "Old", UIDValidity: 3, UIDNext: 2, HighestModSeq: 30,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				UID: 1, SourceMessageID: "Old|1",
+			}},
+		}}))
+
+		require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+			Mailbox: "New",
+			State: store.IMAPFolderState{
+				Mailbox: "New", UIDValidity: 4, UIDNext: 2, HighestModSeq: 40,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				UID: 1, RFC822MessageID: "<renamed-topology@example.com>",
+			}},
+		}}))
+
+		states, err := f.store.GetIMAPFolderStates(f.source.ID)
+		require.NoError(err)
+		assert.Equal([]store.IMAPFolderState{{
+			Mailbox: "New", UIDValidity: 4, UIDNext: 2, HighestModSeq: 40,
+		}}, states)
+		assert.Equal([]string{"New"}, messageLabels(t, f.store, messageID))
+		assert.False(messageTombstoned(t, f.store, messageID))
+	})
+
+	t.Run("zero current mailboxes clears every cursor and membership", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		f := newIMAPMembershipFixture(t)
+		messageID := f.createMessage(t, "Solo|1", "<zero-topology@example.com>")
+		require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+			Mailbox: "Solo",
+			State: store.IMAPFolderState{
+				Mailbox: "Solo", UIDValidity: 5, UIDNext: 2, HighestModSeq: 50,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				UID: 1, SourceMessageID: "Solo|1",
+			}},
+		}}))
+
+		require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{}))
+
+		states, err := f.store.GetIMAPFolderStates(f.source.ID)
+		require.NoError(err)
+		assert.Empty(states)
+		assert.Zero(membershipCount(t, f.store, f.source.ID))
+		assert.Empty(messageLabels(t, f.store, messageID))
+		assert.True(messageTombstoned(t, f.store, messageID))
+	})
+
+	t.Run("nil topology is rejected without changing saved state", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		f := newIMAPMembershipFixture(t)
+		messageID := f.createMessage(t, "Preserved|1", "<nil-topology@example.com>")
+		require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+			Mailbox: "Preserved",
+			State: store.IMAPFolderState{
+				Mailbox: "Preserved", UIDValidity: 6, UIDNext: 2, HighestModSeq: 60,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				UID: 1, SourceMessageID: "Preserved|1",
+			}},
+		}}))
+
+		err := f.store.ApplyIMAPMailboxDeltas(f.source.ID, nil)
+		require.ErrorContains(err, "nil authoritative topology")
+
+		states, statesErr := f.store.GetIMAPFolderStates(f.source.ID)
+		require.NoError(statesErr)
+		assert.Equal([]store.IMAPFolderState{{
+			Mailbox: "Preserved", UIDValidity: 6, UIDNext: 2, HighestModSeq: 60,
+		}}, states)
+		assert.Equal(1, membershipCount(t, f.store, f.source.ID))
+		assert.Equal([]string{"Preserved"}, messageLabels(t, f.store, messageID))
+		assert.False(messageTombstoned(t, f.store, messageID))
+	})
+}
+
+func TestApplyIMAPMailboxDeltas_InitialBaselineReconcilesPreviouslyArchivedMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	presentID := f.createMessage(t, "INBOX|1", "<baseline-present@example.com>")
+	missingID := f.createMessage(t, "Deleted|1", "<baseline-missing@example.com>")
+	inboxLabelID, err := f.store.EnsureLabel(f.source.ID, "INBOX", "INBOX", "user")
+	require.NoError(err)
+	deletedLabelID, err := f.store.EnsureLabel(f.source.ID, "Deleted", "Deleted", "user")
+	require.NoError(err)
+	require.NoError(f.store.ReplaceMessageLabels(presentID, []int64{inboxLabelID}))
+	require.NoError(f.store.ReplaceMessageLabels(missingID, []int64{deletedLabelID}))
+	assert.Zero(membershipCount(t, f.store, f.source.ID), "fixture must model the pre-membership upgrade")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State: store.IMAPFolderState{
+			Mailbox: "INBOX", UIDValidity: 7, UIDNext: 2, HighestModSeq: 70,
+		},
+		Memberships: []store.IMAPMembershipObservation{{
+			UID: 1, SourceMessageID: "INBOX|1",
+		}},
+	}}))
+
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, presentID))
+	assert.False(messageTombstoned(t, f.store, presentID))
+	assert.Empty(messageLabels(t, f.store, missingID))
+	assert.True(messageTombstoned(t, f.store, missingID))
+}
+
+func TestApplyIMAPMailboxDeltas_ReconcilesLiveMessageImportedAfterBaseline(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	trackedID := f.createMessage(t, "INBOX|1", "<tracked@example.test>")
+	state := store.IMAPFolderState{
+		Mailbox: "INBOX", UIDValidity: 7, UIDNext: 2, HighestModSeq: 70,
+	}
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX", State: state,
+		Memberships: []store.IMAPMembershipObservation{{
+			UID: 1, SourceMessageID: "INBOX|1",
+		}},
+	}}))
+
+	untrackedID := f.createMessage(t, "Archive|1", "<untracked@example.test>")
+	archiveLabelID, err := f.store.EnsureLabel(f.source.ID, "Archive", "Archive", "user")
+	require.NoError(err)
+	require.NoError(f.store.ReplaceMessageLabels(untrackedID, []int64{archiveLabelID}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX", State: state,
+	}}))
+
+	assert.False(messageTombstoned(t, f.store, trackedID))
+	assert.True(messageTombstoned(t, f.store, untrackedID))
+	assert.Empty(messageLabels(t, f.store, untrackedID))
+}
+
+func TestApplyIMAPMailboxDeltas_CanonicalSourceHintWinsOverSecondaryCopy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	canonicalID := f.createMessage(t, "[Gmail]/All Mail|1", "")
+	secondaryID := f.createMessage(t, "INBOX|1", "")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State: store.IMAPFolderState{
+			Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2, HighestModSeq: 100,
+		},
+		Memberships: []store.IMAPMembershipObservation{{
+			UID: 1, SourceMessageID: "INBOX|1",
+			CanonicalSourceMessageID: "[Gmail]/All Mail|1",
+		}},
+	}}))
+
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 17, 1)
+	assert.Equal(canonicalID, gotMessageID)
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, canonicalID))
+	assert.True(messageTombstoned(t, f.store, secondaryID))
+}
+
+func TestApplyIMAPMailboxDeltas_RawDigestResolvesDurableCanonicalMessage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	canonicalID := f.createMessage(t, "[Gmail]/All Mail|1", "")
+	secondaryID := f.createMessage(t, "INBOX|1", "")
+	raw := []byte("From: sender@example.test\r\nSubject: no identity\r\n\r\nbody\r\n")
+	require.NoError(f.store.UpsertMessageRaw(canonicalID, raw))
+	require.NoError(f.store.UpsertMessageRaw(secondaryID, raw))
+	allMailState := store.IMAPFolderState{
+		Mailbox: "[Gmail]/All Mail", UIDValidity: 16, UIDNext: 2, HighestModSeq: 90,
+	}
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "[Gmail]/All Mail", State: allMailState,
+		Memberships: []store.IMAPMembershipObservation{{
+			UID: 1, SourceMessageID: "[Gmail]/All Mail|1",
+		}},
+	}}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{Mailbox: "[Gmail]/All Mail", State: allMailState}, {
+			Mailbox: "INBOX", State: store.IMAPFolderState{
+				Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2, HighestModSeq: 100,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				UID: 1, SourceMessageID: "INBOX|1", RawSHA256: sha256.Sum256(raw),
+			}},
+		}}))
+
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 17, 1)
+	assert.Equal(canonicalID, gotMessageID)
+	assert.Equal([]string{"INBOX", "[Gmail]/All Mail"}, messageLabels(t, f.store, canonicalID))
+	assert.True(messageTombstoned(t, f.store, secondaryID))
+}
+
+func TestApplyIMAPMailboxDeltas_AmbiguousRawDigestFallsBackToExactSourceID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	firstID := f.createMessage(t, "[Gmail]/All Mail|1", "")
+	secondID := f.createMessage(t, "[Gmail]/All Mail|2", "")
+	secondaryID := f.createMessage(t, "INBOX|1", "")
+	raw := []byte("From: sender@example.test\r\nSubject: ambiguous identity\r\n\r\nbody\r\n")
+	for _, messageID := range []int64{firstID, secondID, secondaryID} {
+		require.NoError(f.store.UpsertMessageRaw(messageID, raw))
+	}
+	allMailState := store.IMAPFolderState{
+		Mailbox: "[Gmail]/All Mail", UIDValidity: 16, UIDNext: 3, HighestModSeq: 90,
+	}
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "[Gmail]/All Mail", State: allMailState,
+		Memberships: []store.IMAPMembershipObservation{
+			{UID: 1, SourceMessageID: "[Gmail]/All Mail|1"},
+			{UID: 2, SourceMessageID: "[Gmail]/All Mail|2"},
+		},
+	}}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{Mailbox: "[Gmail]/All Mail", State: allMailState}, {
+			Mailbox: "INBOX", State: store.IMAPFolderState{
+				Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2, HighestModSeq: 100,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				UID: 1, SourceMessageID: "INBOX|1", RawSHA256: sha256.Sum256(raw),
+			}},
+		}}))
+
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 17, 1)
+	assert.Equal(secondaryID, gotMessageID)
+	assert.False(messageTombstoned(t, f.store, firstID))
+	assert.False(messageTombstoned(t, f.store, secondID))
+	assert.False(messageTombstoned(t, f.store, secondaryID))
+}
+
+func TestApplyIMAPMailboxDeltas_RawResolutionUsesPreMutationMembershipSnapshot(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	canonicalID := f.createMessage(t, "Old|1", "")
+	secondaryID := f.createMessage(t, "INBOX|1", "")
+	raw := []byte("From: sender@example.test\r\nSubject: moved identity\r\n\r\nbody\r\n")
+	require.NoError(f.store.UpsertMessageRaw(canonicalID, raw))
+	require.NoError(f.store.UpsertMessageRaw(secondaryID, raw))
+	oldState := store.IMAPFolderState{
+		Mailbox: "Old", UIDValidity: 16, UIDNext: 2, HighestModSeq: 90,
+	}
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Old", State: oldState,
+		Memberships: []store.IMAPMembershipObservation{{
+			UID: 1, SourceMessageID: "Old|1",
+		}},
+	}}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{Mailbox: "Old", State: oldState, Reset: true},
+		{
+			Mailbox: "INBOX",
+			State: store.IMAPFolderState{
+				Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2, HighestModSeq: 100,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				UID: 1, SourceMessageID: "INBOX|1", RawSHA256: sha256.Sum256(raw),
+			}},
+		},
+	}))
+
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 17, 1)
+	assert.Equal(canonicalID, gotMessageID)
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, canonicalID))
+	assert.True(messageTombstoned(t, f.store, secondaryID))
+}
+
+func TestApplyIMAPMailboxDeltas_UnresolvedIdentityRollsBackEverything(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	messageID := f.createMessage(t, "transactional", "<transactional@example.com>")
+	initial := store.IMAPMailboxDelta{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 10},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 1, UID: 1, SourceMessageID: "transactional",
+		}},
+	}
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{initial}))
+
+	err := f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox:      "INBOX",
+			State:        store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 3, HighestModSeq: 20},
+			VanishedUIDs: []uint32{1},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "INBOX", UIDValidity: 1, UID: 2, SourceMessageID: "transactional",
+			}},
+		},
+		{
+			Mailbox: "Broken",
+			State:   store.IMAPFolderState{Mailbox: "Broken", UIDValidity: 9, UIDNext: 10, HighestModSeq: 99},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Broken", UIDValidity: 9, UID: 9, RFC822MessageID: "",
+			}},
+		},
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "resolve IMAP membership")
+
+	assert.Equal(1, membershipCount(t, f.store, f.source.ID))
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 1, 1)
+	assert.Equal(messageID, gotMessageID)
+	known, knownErr := f.store.GetIMAPKnownUIDs(f.source.ID)
+	require.NoError(knownErr)
+	assert.Equal(map[string][]uint32{"INBOX": {1}}, known)
+	states, statesErr := f.store.GetIMAPFolderStates(f.source.ID)
+	require.NoError(statesErr)
+	sort.Slice(states, func(i, j int) bool { return states[i].Mailbox < states[j].Mailbox })
+	assert.Equal([]store.IMAPFolderState{initial.State}, states,
+		"cursor advancement must roll back with membership changes")
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, messageID))
+	assert.False(messageTombstoned(t, f.store, messageID))
+}
+
+func TestApplyIMAPMailboxDeltas_ConflictingDeltaIdentityRollsBackEverything(t *testing.T) {
+	tests := []struct {
+		name        string
+		invalid     store.IMAPMailboxDelta
+		errorDetail string
+	}{
+		{
+			name: "folder state mailbox",
+			invalid: store.IMAPMailboxDelta{
+				Mailbox: "Broken",
+				State:   store.IMAPFolderState{Mailbox: "Elsewhere", UIDValidity: 9, UIDNext: 10},
+				Memberships: []store.IMAPMembershipObservation{{
+					Mailbox: "Broken", UIDValidity: 9, UID: 9, SourceMessageID: "transactional",
+				}},
+			},
+			errorDetail: "mailbox",
+		},
+		{
+			name: "membership mailbox",
+			invalid: store.IMAPMailboxDelta{
+				Mailbox: "Broken",
+				State:   store.IMAPFolderState{Mailbox: "Broken", UIDValidity: 9, UIDNext: 10},
+				Memberships: []store.IMAPMembershipObservation{{
+					Mailbox: "Elsewhere", UIDValidity: 9, UID: 9, SourceMessageID: "transactional",
+				}},
+			},
+			errorDetail: "mailbox",
+		},
+		{
+			name: "membership UIDVALIDITY",
+			invalid: store.IMAPMailboxDelta{
+				Mailbox: "Broken",
+				State:   store.IMAPFolderState{Mailbox: "Broken", UIDValidity: 9, UIDNext: 10},
+				Memberships: []store.IMAPMembershipObservation{{
+					Mailbox: "Broken", UIDValidity: 10, UID: 9, SourceMessageID: "transactional",
+				}},
+			},
+			errorDetail: "UIDVALIDITY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := newIMAPMembershipFixture(t)
+			messageID := f.createMessage(t, "transactional", "<transactional@example.com>")
+			initial := store.IMAPMailboxDelta{
+				Mailbox: "INBOX",
+				State: store.IMAPFolderState{
+					Mailbox: "INBOX", UIDValidity: 1, UIDNext: 2, HighestModSeq: 10,
+				},
+				Memberships: []store.IMAPMembershipObservation{{
+					Mailbox: "INBOX", UIDValidity: 1, UID: 1, SourceMessageID: "transactional",
+				}},
+			}
+			require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{initial}))
+
+			err := f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+				{
+					Mailbox:      "INBOX",
+					State:        store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 1, UIDNext: 3},
+					VanishedUIDs: []uint32{1},
+					Memberships: []store.IMAPMembershipObservation{{
+						Mailbox: "INBOX", UIDValidity: 1, UID: 2, SourceMessageID: "transactional",
+					}},
+				},
+				tt.invalid,
+			})
+			require.Error(err)
+			assert.Contains(err.Error(), tt.errorDetail)
+
+			assert.Equal(1, membershipCount(t, f.store, f.source.ID))
+			gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 1, 1)
+			assert.Equal(messageID, gotMessageID)
+			known, knownErr := f.store.GetIMAPKnownUIDs(f.source.ID)
+			require.NoError(knownErr)
+			assert.Equal(map[string][]uint32{"INBOX": {1}}, known)
+			states, statesErr := f.store.GetIMAPFolderStates(f.source.ID)
+			require.NoError(statesErr)
+			assert.Equal([]store.IMAPFolderState{initial.State}, states)
+			assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, messageID))
+			assert.False(messageTombstoned(t, f.store, messageID))
+		})
+	}
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -667,11 +667,30 @@ CREATE TABLE IF NOT EXISTS imap_folder_state (
     mailbox TEXT NOT NULL,
     uidvalidity INTEGER NOT NULL,
     uidnext INTEGER NOT NULL,
+    highest_modseq TEXT NOT NULL DEFAULT '0',
 
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY (source_id, mailbox)
 );
+
+-- Durable IMAP mailbox membership. Provider flags stay on the membership:
+-- messages.is_read is local application state, not a projection of \Seen.
+CREATE TABLE IF NOT EXISTS imap_message_memberships (
+    source_id INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    mailbox TEXT NOT NULL,
+    uidvalidity INTEGER NOT NULL,
+    uid INTEGER NOT NULL,
+    message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    flags TEXT NOT NULL DEFAULT '[]',
+
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (source_id, mailbox, uidvalidity, uid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_imap_message_memberships_source_message
+    ON imap_message_memberships(source_id, message_id);
 
 -- Imported source items (files/objects already processed for resumable adapters)
 CREATE TABLE IF NOT EXISTS source_import_items (

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -531,11 +531,28 @@ CREATE TABLE IF NOT EXISTS imap_folder_state (
     mailbox TEXT NOT NULL,
     uidvalidity BIGINT NOT NULL,
     uidnext BIGINT NOT NULL,
+    highest_modseq NUMERIC(20, 0) NOT NULL DEFAULT 0,
 
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY (source_id, mailbox)
 );
+
+CREATE TABLE IF NOT EXISTS imap_message_memberships (
+    source_id BIGINT NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    mailbox TEXT NOT NULL,
+    uidvalidity BIGINT NOT NULL,
+    uid BIGINT NOT NULL,
+    message_id BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    flags JSONB NOT NULL DEFAULT '[]'::JSONB,
+
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (source_id, mailbox, uidvalidity, uid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_imap_message_memberships_source_message
+    ON imap_message_memberships(source_id, message_id);
 
 CREATE TABLE IF NOT EXISTS source_import_items (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -26,6 +26,10 @@ const (
 // absence apart from real DB errors.
 var ErrSyncRunNotFound = errors.New("sync run not found")
 
+// ErrSyncRunSuperseded is returned when a terminal write belongs to a sync
+// generation that is no longer running or current for its source.
+var ErrSyncRunSuperseded = errors.New("sync run superseded")
+
 // ErrSourceImportItemNotFound is returned by GetSourceImportItem when no
 // import-item row matches. Wrapped via fmt.Errorf for errors.Is checks.
 var ErrSourceImportItemNotFound = errors.New("source import item not found")
@@ -386,14 +390,130 @@ func (s *Store) CompleteSync(syncID int64, finalHistoryID string) error {
 
 // CompleteSyncContext is the request-aware form of CompleteSync.
 func (s *Store) CompleteSyncContext(ctx context.Context, syncID int64, finalHistoryID string) error {
-	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+	result, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE sync_runs
 		SET status = 'completed',
 		    completed_at = %s,
 		    cursor_after = ?
-		WHERE id = ?
+		WHERE id = ? AND status = 'running'
 	`, s.dialect.Now()), finalHistoryID, syncID)
-	return err
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("complete sync %d: inspect update: %w", syncID, err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("complete sync %d: %w", syncID, ErrSyncRunSuperseded)
+	}
+	return nil
+}
+
+// CompleteSyncAndUpdateSourceCursor atomically publishes a source cursor and
+// completes its still-current sync generation.
+func (s *Store) CompleteSyncAndUpdateSourceCursor(
+	syncID int64, sourceID int64, finalHistoryID string,
+) error {
+	return s.CompleteSyncAndUpdateSourceCursorContext(
+		context.Background(), syncID, sourceID, finalHistoryID,
+	)
+}
+
+// CompleteSyncAndUpdateSourceCursorContext is the request-aware form of
+// CompleteSyncAndUpdateSourceCursor. It shares the source lock used by
+// StartSync, so a newer generation cannot start between cursor publication and
+// run completion.
+func (s *Store) CompleteSyncAndUpdateSourceCursorContext(
+	ctx context.Context, syncID int64, sourceID int64, finalHistoryID string,
+) error {
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		if err := validateCurrentSyncGeneration(
+			ctx, tx, sourceID, syncID, SyncStatusRunning,
+		); err != nil {
+			return fmt.Errorf("complete sync %d: %w", syncID, err)
+		}
+
+		now := s.dialect.Now()
+		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE sources
+			SET sync_cursor = ?, last_sync_at = %s, updated_at = %s
+			WHERE id = ?
+		`, now, now), finalHistoryID, sourceID)
+		if err != nil {
+			return fmt.Errorf("complete sync %d: update source cursor: %w", syncID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("complete sync %d: inspect source cursor update: %w", syncID, err)
+		}
+		if rows != 1 {
+			return fmt.Errorf("complete sync %d: source %d not found", syncID, sourceID)
+		}
+
+		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE sync_runs
+			SET status = 'completed',
+			    completed_at = %s,
+			    cursor_after = ?
+			WHERE id = ? AND source_id = ? AND status = 'running'
+		`, now), finalHistoryID, syncID, sourceID)
+		if err != nil {
+			return fmt.Errorf("complete sync %d: %w", syncID, err)
+		}
+		rows, err = result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("complete sync %d: inspect update: %w", syncID, err)
+		}
+		if rows != 1 {
+			return fmt.Errorf("complete sync %d: %w", syncID, ErrSyncRunSuperseded)
+		}
+		return nil
+	})
+}
+
+func validateCurrentSyncGeneration(
+	ctx context.Context,
+	tx *loggedTx,
+	sourceID int64,
+	syncRunID int64,
+	expectedStatus string,
+) error {
+	result, err := tx.ExecContext(
+		ctx, `UPDATE sources SET updated_at = updated_at WHERE id = ?`, sourceID,
+	)
+	if err != nil {
+		return fmt.Errorf("lock source %d for sync generation: %w", sourceID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("lock source %d for sync generation: inspect update: %w", sourceID, err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("lock source %d for sync generation: source not found", sourceID)
+	}
+
+	var latestID int64
+	var latestStatus string
+	err = tx.QueryRowContext(ctx, `
+		SELECT id, status FROM sync_runs
+		WHERE source_id = ?
+		ORDER BY id DESC
+		LIMIT 1
+	`, sourceID).Scan(&latestID, &latestStatus)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrSyncRunSuperseded
+	}
+	if err != nil {
+		return fmt.Errorf("query current sync generation for source %d: %w", sourceID, err)
+	}
+	if latestID != syncRunID || latestStatus != expectedStatus {
+		return fmt.Errorf(
+			"latest sync %d is %s, want sync %d in %s: %w",
+			latestID, latestStatus, syncRunID, expectedStatus, ErrSyncRunSuperseded,
+		)
+	}
+	return nil
 }
 
 // FailSync marks a sync as failed with an error message.

--- a/internal/store/sync_test.go
+++ b/internal/store/sync_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -127,6 +128,60 @@ func TestStore_GetLatestSync(t *testing.T) {
 	require.NotNil(run, "expected sync run")
 	assert.Equal(secondID, run.ID, "ID")
 	assert.Equal(store.SyncStatusRunning, run.Status, "Status")
+}
+
+func TestStore_CompleteSyncRejectsSupersededRun(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+
+	oldID := f.StartSync()
+	newID := f.StartSync()
+
+	err := f.Store.CompleteSync(oldID, "stale-cursor")
+	require.ErrorIs(err, store.ErrSyncRunSuperseded)
+
+	var status string
+	var cursorAfter sql.NullString
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT status, cursor_after FROM sync_runs WHERE id = ?
+	`), oldID).Scan(&status, &cursorAfter))
+	assert.Equal(store.SyncStatusFailed, status)
+	assert.False(cursorAfter.Valid)
+
+	run, err := f.Store.GetActiveSync(f.Source.ID)
+	require.NoError(err)
+	assert.Equal(newID, run.ID)
+}
+
+func TestStore_CompleteSyncAndUpdateSourceCursorRejectsSupersededRunAtomically(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	require.NoError(f.Store.UpdateSourceSyncCursor(f.Source.ID, "baseline-cursor"))
+
+	oldID := f.StartSync()
+	newID := f.StartSync()
+
+	err := f.Store.CompleteSyncAndUpdateSourceCursorContext(
+		t.Context(), oldID, f.Source.ID, "stale-cursor",
+	)
+	require.ErrorIs(err, store.ErrSyncRunSuperseded)
+
+	source, err := f.Store.GetSourceByID(f.Source.ID)
+	require.NoError(err)
+	assert.Equal("baseline-cursor", source.SyncCursor.String)
+
+	require.NoError(f.Store.CompleteSyncAndUpdateSourceCursorContext(
+		t.Context(), newID, f.Source.ID, "fresh-cursor",
+	))
+	source, err = f.Store.GetSourceByID(f.Source.ID)
+	require.NoError(err)
+	assert.Equal("fresh-cursor", source.SyncCursor.String)
+	run, err := f.Store.GetLatestSync(f.Source.ID)
+	require.NoError(err)
+	assert.Equal(store.SyncStatusCompleted, run.Status)
+	assert.Equal("fresh-cursor", run.CursorAfter.String)
 }
 
 func TestStore_GetLatestCheckpointedSyncFallsBackPastUncheckpointedRun(t *testing.T) {

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -42,6 +42,7 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 	if err != nil {
 		return nil, fmt.Errorf("start sync: %w", err)
 	}
+	summary.SyncRunID = syncID
 
 	// Defer failure handling — recover from panics and return as error
 	defer func() {
@@ -78,9 +79,12 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 	// owed (never succeeded, previously failed, or stale).
 	if startHistoryID >= profile.HistoryID {
 		s.logger.Info("already up to date")
-		if s.completeSyncWithoutHook(syncID, strconv.FormatUint(profile.HistoryID, 10)) {
-			s.runSuccessfulSyncHook(ctx, source, false)
+		if err := s.completeSyncWithoutHook(
+			ctx, syncID, source.ID, strconv.FormatUint(profile.HistoryID, 10),
+		); err != nil {
+			return nil, err
 		}
+		s.runSuccessfulSyncHook(ctx, source, false)
 		summary.EndTime = time.Now()
 		summary.Duration = summary.EndTime.Sub(summary.StartTime)
 		summary.FinalHistoryID = profile.HistoryID
@@ -267,12 +271,10 @@ func (s *Syncer) Incremental(ctx context.Context, source *store.Source) (summary
 			"errors", checkpoint.ErrorsCount,
 			"history_id", historyIDStr)
 	}
-	if err := s.store.UpdateSourceSyncCursor(source.ID, historyIDStr); err != nil {
-		s.logger.Warn("failed to update sync cursor", "error", err)
-	}
-
 	// Mark sync complete before running best-effort provider maintenance.
-	s.completeSyncAndRunHook(ctx, syncID, historyIDStr, source)
+	if err := s.completeSyncAndRunHook(ctx, syncID, historyIDStr, source); err != nil {
+		return nil, err
+	}
 
 	// Build summary
 	summary.EndTime = time.Now()

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -89,11 +89,23 @@ type labelSnapshotCompleteness interface {
 	LabelsSnapshotComplete() bool
 }
 
+type authoritativeLabelReconciliationDeferrer interface {
+	DefersAuthoritativeLabelReconciliation() bool
+}
+
+type limitedFullEnumerationForcer interface {
+	ForceFullEnumerationForLimitedSync()
+}
+
 type sourceMessageMatcher interface {
 	SourceMessageMatches(
 		ctx context.Context,
 		messageID, expectedRFC822MessageID string,
 	) (matches bool, conclusive bool, err error)
+}
+
+type sourceMessageAliaser interface {
+	CanonicalSourceMessageID(sourceMessageID string) (string, bool)
 }
 
 type preferredIMAPSourceID interface {
@@ -122,6 +134,12 @@ func New(client gmail.API, store *store.Store, opts *Options) *Syncer {
 		opts = DefaultOptions()
 	}
 
+	if opts.Limit > 0 {
+		if forcer, ok := client.(limitedFullEnumerationForcer); ok {
+			forcer.ForceFullEnumerationForLimitedSync()
+		}
+	}
+
 	return &Syncer{
 		client:   client,
 		store:    store,
@@ -148,6 +166,16 @@ func (s *Syncer) labelsSnapshotComplete() bool {
 	return !ok || completeness.LabelsSnapshotComplete()
 }
 
+func (s *Syncer) defersAuthoritativeLabelReconciliation() bool {
+	// Only an unlimited run can publish the deferred mailbox snapshot. Limited
+	// runs must reconcile each processed message before returning.
+	if s.opts.SourceType != sourceTypeIMAP || s.opts.Limit > 0 || !s.labelsSnapshotComplete() {
+		return false
+	}
+	deferrer, ok := s.client.(authoritativeLabelReconciliationDeferrer)
+	return ok && deferrer.DefersAuthoritativeLabelReconciliation()
+}
+
 // WithSuccessfulSyncHook installs one best-effort post-completion hook.
 func (s *Syncer) WithSuccessfulSyncHook(name string, hook SuccessfulSyncHook) *Syncer {
 	s.successfulHookName = strings.TrimSpace(name)
@@ -169,14 +197,20 @@ func (s *Syncer) runSuccessfulSyncHook(ctx context.Context, source *store.Source
 	}
 }
 
-// completeSyncWithoutHook marks the run complete and reports whether that
-// durable write succeeded.
-func (s *Syncer) completeSyncWithoutHook(syncID int64, historyID string) bool {
-	if err := s.store.CompleteSync(syncID, historyID); err != nil {
-		s.logger.Warn("failed to complete sync", "error", err)
-		return false
+// completeSyncWithoutHook atomically publishes the source cursor and marks the
+// still-current run complete.
+func (s *Syncer) completeSyncWithoutHook(
+	ctx context.Context, syncID int64, sourceID int64, historyID string,
+) error {
+	if err := s.store.CompleteSyncAndUpdateSourceCursorContext(
+		ctx, syncID, sourceID, historyID,
+	); err != nil {
+		if !errors.Is(err, store.ErrSyncRunSuperseded) {
+			s.failSyncUnlessCanceled(syncID, err)
+		}
+		return fmt.Errorf("publish completed sync: %w", err)
 	}
-	return true
+	return nil
 }
 
 func (s *Syncer) completeSyncAndRunHook(
@@ -184,11 +218,12 @@ func (s *Syncer) completeSyncAndRunHook(
 	syncID int64,
 	historyID string,
 	source *store.Source,
-) {
-	if !s.completeSyncWithoutHook(syncID, historyID) {
-		return
+) error {
+	if err := s.completeSyncWithoutHook(ctx, syncID, source.ID, historyID); err != nil {
+		return err
 	}
 	s.runSuccessfulSyncHook(ctx, source, true)
+	return nil
 }
 
 // identityDiscoveryRetryBackoff is the delay before the second per-page
@@ -391,10 +426,29 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 	result.sourceMessageIDs = messageIDs
 
 	// Check which messages already exist
+	lookupMessageIDs := append([]string(nil), messageIDs...)
+	aliases := make(map[string]string)
+	if s.opts.SourceType == sourceTypeIMAP {
+		if aliaser, ok := s.client.(sourceMessageAliaser); ok {
+			for _, sourceMessageID := range messageIDs {
+				canonicalSourceMessageID, exists := aliaser.CanonicalSourceMessageID(sourceMessageID)
+				if !exists || canonicalSourceMessageID == sourceMessageID {
+					continue
+				}
+				aliases[sourceMessageID] = canonicalSourceMessageID
+				lookupMessageIDs = append(lookupMessageIDs, canonicalSourceMessageID)
+			}
+		}
+	}
 	existingMap, err := s.store.MessageMetadataWithRawBatch(
-		sourceID, messageIDs)
+		sourceID, lookupMessageIDs)
 	if err != nil {
 		return nil, fmt.Errorf("check existing: %w", err)
+	}
+	for sourceMessageID, canonicalSourceMessageID := range aliases {
+		if canonical, exists := existingMap[canonicalSourceMessageID]; exists {
+			existingMap[sourceMessageID] = canonical
+		}
 	}
 
 	// Existing exact IDs only need current label metadata. Clients with a
@@ -681,17 +735,20 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			}
 
 			if alreadyExists {
-				changed, err := s.store.ReconcileMessageLabels(
-					existing.ID,
-					labelIDsFor(raw.LabelIDs, labelMap),
-					false,
-				)
-				if err != nil {
-					s.logger.Warn("failed to merge existing message labels",
-						"id", sourceMessageID, "error", err)
-					s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
-					checkpoint.ErrorsCount++
-					continue
+				changed := false
+				if !s.defersAuthoritativeLabelReconciliation() {
+					changed, err = s.store.ReconcileMessageLabels(
+						existing.ID,
+						labelIDsFor(raw.LabelIDs, labelMap),
+						false,
+					)
+					if err != nil {
+						s.logger.Warn("failed to merge existing message labels",
+							"id", sourceMessageID, "error", err)
+						s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
+						checkpoint.ErrorsCount++
+						continue
+					}
 				}
 				if changed {
 					result.updated++
@@ -775,6 +832,7 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 	if err != nil {
 		return nil, err
 	}
+	summary.SyncRunID = state.syncID
 	summary.WasResumed = state.wasResumed
 	summary.ResumedFromToken = state.pageToken
 
@@ -912,12 +970,10 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 			"errors", state.checkpoint.ErrorsCount,
 			"history_id", historyIDStr)
 	}
-	if err := s.store.UpdateSourceSyncCursor(source.ID, historyIDStr); err != nil {
-		s.logger.Warn("failed to update sync cursor", "error", err)
-	}
-
 	// Mark sync complete before running best-effort provider maintenance.
-	s.completeSyncAndRunHook(ctx, state.syncID, historyIDStr, source)
+	if err := s.completeSyncAndRunHook(ctx, state.syncID, historyIDStr, source); err != nil {
+		return nil, err
+	}
 
 	// Checkpoint WAL after sync to fold it back into the main database.
 	// This prevents WAL accumulation across long sync sessions and ensures
@@ -1296,7 +1352,11 @@ func (s *Syncer) ingestMessage(
 						oldSourceMessageID, err)
 				}
 			}
+			deferLabels := s.defersAuthoritativeLabelReconciliation()
 			if !conclusive {
+				if deferLabels {
+					return false, errDeferredIMAPIdentity
+				}
 				changed, err := s.store.ReconcileMessageLabels(
 					existingID, labelIDs, false)
 				return dedupMutationResultWithSentinel(
@@ -1308,11 +1368,14 @@ func (s *Syncer) ingestMessage(
 			}
 			complete := s.labelsSnapshotComplete()
 			if matches {
-				changed, err := s.store.ReconcileMessageLabels(
-					existingID, labelIDs, complete)
-				if err != nil {
-					return false, fmt.Errorf(
-						"reconcile validated dedup labels: %w", err)
+				changed := false
+				if !deferLabels {
+					changed, err = s.store.ReconcileMessageLabels(
+						existingID, labelIDs, complete)
+					if err != nil {
+						return false, fmt.Errorf(
+							"reconcile validated dedup labels: %w", err)
+					}
 				}
 				if complete && oldSourceMessageID != data.message.SourceMessageID {
 					if preferred, ok := s.client.(preferredIMAPSourceID); ok &&
@@ -1335,6 +1398,20 @@ func (s *Syncer) ingestMessage(
 					changed, "reconcile validated dedup labels", nil)
 			}
 			if complete {
+				if deferLabels {
+					rekeyed, err := s.store.RekeyMessageSourceID(
+						existingID, oldSourceMessageID, data.message.SourceMessageID)
+					if err != nil {
+						return false, fmt.Errorf("rekey dedup message: %w", err)
+					}
+					if !rekeyed {
+						return false, fmt.Errorf(
+							"source message ID %q changed before dedup rekey",
+							oldSourceMessageID)
+					}
+					return dedupMutationResult(
+						true, "rekey dedup message", nil)
+				}
 				changed, err := s.store.UpdateMessageOnDedup(
 					existingID,
 					data.message.SourceMessageID,
@@ -1390,10 +1467,14 @@ func (s *Syncer) reconcileValidatedMessageLabels(
 	labelIDs []int64,
 	snapshotComplete bool,
 ) (bool, error) {
-	changed, err := s.store.ReconcileMessageLabels(
-		existingID, labelIDs, snapshotComplete)
-	if err != nil {
-		return false, err
+	changed := false
+	if !s.defersAuthoritativeLabelReconciliation() {
+		var err error
+		changed, err = s.store.ReconcileMessageLabels(
+			existingID, labelIDs, snapshotComplete)
+		if err != nil {
+			return false, err
+		}
 	}
 	if seeder, ok := s.client.(validatedMessageDedupSeeder); ok {
 		if err := seeder.SeedValidatedMessageDedup(

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -137,6 +137,17 @@ type staticLabelsAPI struct {
 	labels []*gmail.Label
 }
 
+type supersedingProfileAPI struct {
+	*gmail.MockAPI
+
+	supersede func()
+}
+
+func (a *supersedingProfileAPI) GetProfile(ctx context.Context) (*gmail.Profile, error) {
+	a.supersede()
+	return a.MockAPI.GetProfile(ctx)
+}
+
 func (a *staticLabelsAPI) ListLabels(_ context.Context) ([]*gmail.Label, error) {
 	return a.labels, nil
 }
@@ -269,6 +280,92 @@ func TestFullSyncProviderHookDoesNotRunAfterFailedSync(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Zero(t, hookCalls)
+}
+
+func TestFullSyncSupersededGenerationDoesNotPublishCursorOrReturnSuccess(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	require.NoError(env.Store.UpdateSourceSyncCursor(source.ID, "baseline-cursor"))
+	var newerSyncID int64
+	env.Syncer = New(&supersedingProfileAPI{
+		MockAPI: env.Mock,
+		supersede: func() {
+			var err error
+			newerSyncID, err = env.Store.StartSync(source.ID, "full")
+			require.NoError(err)
+		},
+	}, env.Store, nil)
+
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+
+	require.ErrorIs(err, store.ErrSyncRunSuperseded)
+	assert.Nil(summary)
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err)
+	assert.Equal("baseline-cursor", source.SyncCursor.String)
+	active, err := env.Store.GetActiveSync(source.ID)
+	require.NoError(err)
+	assert.Equal(newerSyncID, active.ID)
+}
+
+func TestFullSyncCompletionFailureMarksRunFailed(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	testutil.SkipIfPostgres(t, "uses a SQLite trigger to inject the completion failure")
+	env := newTestEnv(t)
+	_, err := env.Store.DB().Exec(`
+		CREATE TRIGGER fail_sync_completion
+		BEFORE UPDATE OF status ON sync_runs
+		FOR EACH ROW WHEN NEW.status = 'completed'
+		BEGIN
+			SELECT RAISE(ABORT, 'forced sync completion failure');
+		END
+	`)
+	require.NoError(err)
+	t.Cleanup(func() {
+		_, _ = env.Store.DB().Exec("DROP TRIGGER IF EXISTS fail_sync_completion")
+	})
+
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+
+	require.ErrorContains(err, "forced sync completion failure")
+	assert.Nil(summary)
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err)
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err)
+	assert.Equal(store.SyncStatusFailed, run.Status)
+	assert.Contains(run.ErrorMessage.String, "forced sync completion failure")
+}
+
+func TestIncrementalSyncSupersededGenerationDoesNotPublishCursorOrReturnSuccess(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "1000")
+	env.Mock.Profile.HistoryID = 1000
+	var newerSyncID int64
+	env.Syncer = New(&supersedingProfileAPI{
+		MockAPI: env.Mock,
+		supersede: func() {
+			var err error
+			newerSyncID, err = env.Store.StartSync(source.ID, "incremental")
+			require.NoError(err)
+		},
+	}, env.Store, nil)
+
+	summary, err := env.Syncer.Incremental(env.Context, source)
+
+	require.ErrorIs(err, store.ErrSyncRunSuperseded)
+	assert.Nil(summary)
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err)
+	assert.Equal("1000", source.SyncCursor.String)
+	active, err := env.Store.GetActiveSync(source.ID)
+	require.NoError(err)
+	assert.Equal(newerSyncID, active.ID)
 }
 
 // TestIncrementalSyncProviderHookRunsAfterSuccessfulCompletion also pins the
@@ -2988,7 +3085,7 @@ func TestIMAPCompleteSnapshotAdoptsAllMailCanonicalID(t *testing.T) {
 	assert.Equal(t, "All Mail|1", sourceMessageID)
 }
 
-func TestIMAPHighWaterMoveReplacesMissingIDAndMergesLabels(t *testing.T) {
+func TestIMAPUnsupportedQresyncMoveUsesFullFallback(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	env := newTestEnv(t)
@@ -3026,8 +3123,8 @@ func TestIMAPHighWaterMoveReplacesMissingIDAndMergesLabels(t *testing.T) {
 	).Scan(&sourceMessageID)
 	require.NoError(err)
 	assert.Equal("Trash|1", sourceMessageID)
-	assertMessageHasLabel(t, env.Store, sourceMessageID, "INBOX")
 	assertMessageHasLabel(t, env.Store, sourceMessageID, "Trash")
+	assertMessageNotHasLabel(t, env.Store, sourceMessageID, "INBOX")
 }
 
 func TestIMAPUIDValidityReusePreservesOldAndArchivesNewMessage(t *testing.T) {
@@ -3219,7 +3316,7 @@ func TestIMAPNoResumeUIDValidityReuseArchivesReplacement(t *testing.T) {
 	assertSummary(t, summary, WantSummary{
 		Added:   new(int64(0)),
 		Updated: new(int64(0)),
-		Skipped: new(int64(0)),
+		Skipped: new(int64(1)),
 	})
 }
 
@@ -3500,7 +3597,7 @@ func TestIMAPFilteredMoveReconcilesBeforeAdvancingFolderState(t *testing.T) {
 	assert.Equal("Trash|1", sourceMessageID)
 }
 
-func TestIMAPHighWaterRenameReplacesMissingMailboxID(t *testing.T) {
+func TestIMAPUnsupportedQresyncRenameUsesFullFallback(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	env := newTestEnv(t)
@@ -3548,8 +3645,8 @@ func TestIMAPHighWaterRenameReplacesMissingMailboxID(t *testing.T) {
 	).Scan(&sourceMessageID)
 	require.NoError(err)
 	assert.Equal("Projects|1", sourceMessageID)
-	assertMessageHasLabel(t, env.Store, sourceMessageID, "Archive")
 	assertMessageHasLabel(t, env.Store, sourceMessageID, "Projects")
+	assertMessageNotHasLabel(t, env.Store, sourceMessageID, "Archive")
 	assert.Contains(acknowledged, "Projects")
 }
 
@@ -3752,20 +3849,28 @@ func TestIMAPHighWaterValidationFailureRemainsRetryable(t *testing.T) {
 	assert.NotContains(highWaterAPI.acknowledged, "TRASH|99")
 }
 
+type immediateLabelIMAPClient struct {
+	*imapclient.Client
+}
+
+func (*immediateLabelIMAPClient) DefersAuthoritativeLabelReconciliation() bool {
+	return false
+}
+
 func newSyncTestIMAPClient(
 	t *testing.T, addr string, clientOpts ...imapclient.Option,
-) *imapclient.Client {
+) *immediateLabelIMAPClient {
 	t.Helper()
 	host, portString, err := net.SplitHostPort(addr)
 	require.NoError(t, err)
 	port, err := strconv.Atoi(portString)
 	require.NoError(t, err)
 
-	client := imapclient.NewClient(&imapclient.Config{
+	client := &immediateLabelIMAPClient{Client: imapclient.NewClient(&imapclient.Config{
 		Host:     host,
 		Port:     port,
 		Username: testutil.IMAPTestUsername,
-	}, testutil.IMAPTestPassword, clientOpts...)
+	}, testutil.IMAPTestPassword, clientOpts...)}
 	t.Cleanup(func() { _ = client.Close() })
 	return client
 }
@@ -3778,6 +3883,10 @@ type incompleteLabelSnapshotAPI struct {
 
 func (*incompleteLabelSnapshotAPI) LabelsSnapshotComplete() bool {
 	return false
+}
+
+func (*incompleteLabelSnapshotAPI) DefersAuthoritativeLabelReconciliation() bool {
+	return true
 }
 
 func (*incompleteLabelSnapshotAPI) LabelsSnapshotFiltered() bool {
@@ -3794,6 +3903,7 @@ type labelMetadataSnapshotAPI struct {
 	*gmail.MockAPI
 
 	complete    bool
+	deferLabels bool
 	filtered    bool
 	labelCalls  [][]string
 	labelErrors map[string]error
@@ -3802,6 +3912,10 @@ type labelMetadataSnapshotAPI struct {
 
 func (a *labelMetadataSnapshotAPI) LabelsSnapshotComplete() bool {
 	return a.complete
+}
+
+func (a *labelMetadataSnapshotAPI) DefersAuthoritativeLabelReconciliation() bool {
+	return a.deferLabels
 }
 
 func (a *labelMetadataSnapshotAPI) LabelsSnapshotFiltered() bool {
@@ -3993,6 +4107,47 @@ func TestIMAPCompleteRescanReplacesExactIDLabels(t *testing.T) {
 		Updated: new(int64(0)),
 	})
 	assert.Equal([][]string{{sourceMessageID}}, completeAPI.labelCalls)
+}
+
+func TestIMAPCompleteLimitedRescanReconcilesProcessedExistingLabels(t *testing.T) {
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	env.Syncer = New(env.Mock, env.Store, opts)
+	env.Mock.Labels = []*gmail.Label{
+		{ID: "[Gmail]/All Mail", Name: "All Mail", Type: labelTypeSystem},
+		{ID: "Archive", Name: "Archive", Type: "user"},
+	}
+
+	const processedID = "[Gmail]/All Mail|41"
+	const truncatedID = "[Gmail]/All Mail|42"
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.MessagePages = [][]string{{processedID, truncatedID}}
+	env.Mock.AddMessage(processedID, testMIME(), []string{"[Gmail]/All Mail", "Archive"})
+	env.Mock.AddMessage(truncatedID, testMIME(), []string{"[Gmail]/All Mail", "Archive"})
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
+	assertMessageHasLabel(t, env.Store, processedID, "Archive")
+
+	env.Mock.Messages[processedID].LabelIDs = []string{"[Gmail]/All Mail"}
+	limitedOpts := DefaultOptions()
+	limitedOpts.SourceType = sourceTypeIMAP
+	limitedOpts.Limit = 1
+	completeAPI := &labelMetadataSnapshotAPI{
+		MockAPI:     env.Mock,
+		complete:    true,
+		deferLabels: true,
+	}
+	env.Syncer = New(completeAPI, env.Store, limitedOpts)
+
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Found:   new(int64(1)),
+		Updated: new(int64(1)),
+	})
+	assert.Equal(t, [][]string{{processedID}}, completeAPI.labelCalls)
+	assertMessageNotHasLabel(t, env.Store, processedID, "Archive")
+	assertMessageHasLabel(t, env.Store, truncatedID, "Archive")
 }
 
 func TestIMAPLabelMetadataFailureDoesNotAbortBatch(t *testing.T) {

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -40,6 +40,26 @@ type selectErrorSession struct {
 	remaining int
 }
 
+type statusErrorSession struct {
+	imapserver.Session
+
+	mailbox string
+}
+
+func (s *statusErrorSession) Status(
+	mailbox string,
+	options *imap.StatusOptions,
+) (*imap.StatusData, error) {
+	if mailbox == s.mailbox {
+		return nil, fmt.Errorf("synthetic STATUS failure for %q", mailbox)
+	}
+	data, err := s.Session.Status(mailbox, options)
+	if err != nil {
+		return nil, fmt.Errorf("status %q: %w", mailbox, err)
+	}
+	return data, nil
+}
+
 func (s *selectErrorSession) Select(
 	mailbox string,
 	options *imap.SelectOptions,
@@ -132,7 +152,7 @@ func AppendIMAPMessageWithMessageID(
 // down via t.Cleanup.
 func StartIMAPMemServer(t *testing.T, messagesPerMailbox map[string]int) (string, *imapmemserver.User) {
 	t.Helper()
-	return startIMAPMemServer(t, messagesPerMailbox, nil, "", 0)
+	return startIMAPMemServer(t, messagesPerMailbox, nil, "", 0, "")
 }
 
 // StartIMAPMemServerWithSpecialUse runs an in-memory IMAP server whose LIST
@@ -143,7 +163,20 @@ func StartIMAPMemServerWithSpecialUse(
 	specialUse map[string][]imap.MailboxAttr,
 ) (string, *imapmemserver.User) {
 	t.Helper()
-	return startIMAPMemServer(t, messagesPerMailbox, specialUse, "", 0)
+	return startIMAPMemServer(t, messagesPerMailbox, specialUse, "", 0, "")
+}
+
+// StartIMAPMemServerWithStatusError runs an in-memory IMAP server that rejects
+// STATUS for one mailbox while serving LIST, SELECT, SEARCH, and FETCH normally.
+func StartIMAPMemServerWithStatusError(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	specialUse map[string][]imap.MailboxAttr,
+	statusErrorMailbox string,
+) (string, *imapmemserver.User) {
+	t.Helper()
+	return startIMAPMemServer(
+		t, messagesPerMailbox, specialUse, "", 0, statusErrorMailbox)
 }
 
 // StartIMAPMemServerWithSelectError runs an in-memory IMAP server that rejects
@@ -156,7 +189,7 @@ func StartIMAPMemServerWithSelectError(
 ) (string, *imapmemserver.User) {
 	t.Helper()
 	return startIMAPMemServer(
-		t, messagesPerMailbox, specialUse, selectErrorMailbox, -1)
+		t, messagesPerMailbox, specialUse, selectErrorMailbox, -1, "")
 }
 
 // StartIMAPMemServerWithOneShotSelectError runs an in-memory IMAP server that
@@ -169,7 +202,7 @@ func StartIMAPMemServerWithOneShotSelectError(
 ) (string, *imapmemserver.User) {
 	t.Helper()
 	return startIMAPMemServer(
-		t, messagesPerMailbox, specialUse, selectErrorMailbox, 1)
+		t, messagesPerMailbox, specialUse, selectErrorMailbox, 1, "")
 }
 
 func startIMAPMemServer(
@@ -178,6 +211,7 @@ func startIMAPMemServer(
 	specialUse map[string][]imap.MailboxAttr,
 	selectErrorMailbox string,
 	selectErrorCount int,
+	statusErrorMailbox string,
 ) (string, *imapmemserver.User) {
 	t.Helper()
 	user := imapmemserver.NewUser(IMAPTestUsername, IMAPTestPassword)
@@ -209,6 +243,12 @@ func startIMAPMemServer(
 					Session:   session,
 					mailbox:   selectErrorMailbox,
 					remaining: selectErrorCount,
+				}
+			}
+			if statusErrorMailbox != "" {
+				session = &statusErrorSession{
+					Session: session,
+					mailbox: statusErrorMailbox,
 				}
 			}
 			return session, nil, nil

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -16,7 +16,7 @@ buildGoModule {
 
   src = gitignoreSource ../.;
 
-  vendorHash = "sha256-YP8JxvmYKbej31dl2jLMcL2w4a9ZPv/LozRgsrpiFwk=";
+  vendorHash = "sha256-KPMgtr3kP02ZVU68YIRHBY52ywuwlWqwtEhQiDopm34=";
   proxyVendor = true;
 
   # Bun's copyfile backend can install incomplete packages when fetchBunDeps'


### PR DESCRIPTION
## What changed

- Add QRESYNC/CONDSTORE incremental IMAP sync using ordinary mailbox selection plus typed `CHANGEDSINCE`/`VANISHED` fetches.
- Persist full-width mailbox cursors and provider membership flags, then apply memberships, labels, tombstones, and cursors atomically on SQLite and PostgreSQL.
- Keep full-scan fallback for unsupported capabilities, invalid or regressed cursors, UIDVALIDITY and mailbox-topology changes, incomplete STATUS data, filtered runs, and limited runs.
- Keep provider flags separate from local read state and reject stale sync generations before they can publish cursors or mailbox state.

## Why

Scheduled IMAP sync currently walks the full UID range even when nothing changed. On large mailboxes that turns an idle sync into minutes of work; QRESYNC reduces it to the changed messages while the conservative fallback keeps existing server compatibility.

## Usage

No usage change. Existing IMAP accounts use QRESYNC automatically when the server positively negotiates it, and otherwise keep the current full-scan behavior.

This temporarily pins the IMAP dependency to the exact fork revision that exposes the typed `VANISHED` fetch surface; the replacement can be removed once canonical upstream provides it.

Closes #630
