### PR TITLE
feat(people): add consent-gated inference providers

### DIFF
--- a/cmd/msgvault/cmd/attribute_definition.go
+++ b/cmd/msgvault/cmd/attribute_definition.go
@@ -269,7 +269,7 @@ var attributeDefinitionDeleteCmd = &cobra.Command{
 
 func attributeObjectTypeArg(cmd *cobra.Command) (string, error) {
 	value := strings.TrimSpace(attributeDefinitionObjectType)
-	if value == "" || value == "person" || value == "organization" {
+	if value == "" || value == personValue || value == "organization" {
 		return value, nil
 	}
 	return "", usageErr(cmd, errors.New("object type must be person or organization"))

--- a/cmd/msgvault/cmd/calendar.go
+++ b/cmd/msgvault/cmd/calendar.go
@@ -799,7 +799,7 @@ type calendarSyncNextOptions struct {
 }
 
 func calendarSyncNextCommand(email, oauthApp string, opts calendarSyncNextOptions) string {
-	parts := []string{"msgvault", "sync-calendar"}
+	parts := []string{daemonService, "sync-calendar"}
 	if oauthApp != "" {
 		parts = append(parts, "--oauth-app", oauthApp)
 	}

--- a/cmd/msgvault/cmd/employment.go
+++ b/cmd/msgvault/cmd/employment.go
@@ -195,7 +195,7 @@ var employmentListCmd = &cobra.Command{Use: cmdUseList, Short: "List employment 
 	if id <= 0 {
 		kind := "organization"
 		if personSet {
-			kind = "person"
+			kind = personValue
 		}
 		return usageErr(cmd, fmt.Errorf("%s ID must be a positive integer", kind))
 	}

--- a/cmd/msgvault/cmd/person.go
+++ b/cmd/msgvault/cmd/person.go
@@ -20,8 +20,10 @@ var (
 	personClearDisplayName bool
 )
 
+const personValue = "person"
+
 var personCmd = &cobra.Command{
-	Use:   "person",
+	Use:   personValue,
 	Short: "Manage durable person profiles",
 }
 
@@ -63,7 +65,7 @@ var personGetCmd = &cobra.Command{
 	Short: "Get a durable person profile",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := positivePersonCLIArg(cmd, args[0], "person")
+		id, err := positivePersonCLIArg(cmd, args[0], personValue)
 		if err != nil {
 			return err
 		}
@@ -124,7 +126,7 @@ var personSetDisplayNameCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := positivePersonCLIArg(cmd, args[0], "person")
+		id, err := positivePersonCLIArg(cmd, args[0], personValue)
 		if err != nil {
 			return err
 		}
@@ -173,7 +175,7 @@ var personDeleteCmd = &cobra.Command{
 		"the same cluster afterwards creates a new person with a new UID.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := positivePersonCLIArg(cmd, args[0], "person")
+		id, err := positivePersonCLIArg(cmd, args[0], personValue)
 		if err != nil {
 			return err
 		}
@@ -248,6 +250,7 @@ func positivePersonCLIArg(cmd *cobra.Command, raw, kind string) (int64, error) {
 
 func init() {
 	rootCmd.AddCommand(personCmd)
+	personCmd.AddCommand(newPersonProviderCommand(defaultPersonProviderCommandDeps()))
 	personCmd.AddCommand(personPromoteCmd, personGetCmd, personListCmd,
 		personSetDisplayNameCmd, personDeleteCmd, personTrackCmd, personUntrackCmd)
 	for _, command := range []*cobra.Command{

--- a/cmd/msgvault/cmd/person_attributes.go
+++ b/cmd/msgvault/cmd/person_attributes.go
@@ -46,7 +46,7 @@ var personAttributesListCmd = &cobra.Command{
 	Short: "List a person's attribute definitions and values",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		personID, err := positivePersonCLIArg(cmd, args[0], "person")
+		personID, err := positivePersonCLIArg(cmd, args[0], personValue)
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ var personAttributesSetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		personAttributeOrdinalSet = cmd.Flags().Changed("ordinal")
 		personAttributeConfidenceSet = cmd.Flags().Changed("confidence")
-		personID, err := positivePersonCLIArg(cmd, args[0], "person")
+		personID, err := positivePersonCLIArg(cmd, args[0], personValue)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ var personAttributesClearCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		personAttributeOrdinalSet = cmd.Flags().Changed("ordinal")
 		expectedValueIDSet := cmd.Flags().Changed("expected-value-id")
-		personID, err := positivePersonCLIArg(cmd, args[0], "person")
+		personID, err := positivePersonCLIArg(cmd, args[0], personValue)
 		if err != nil {
 			return err
 		}

--- a/cmd/msgvault/cmd/person_provider.go
+++ b/cmd/msgvault/cmd/person_provider.go
@@ -1,0 +1,471 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const personProviderConsentActor = "cli"
+
+type personProviderStore interface {
+	EnsurePersonInferenceProfile(ctx context.Context, profile peoplesweep.ProviderProfile) (bool, error)
+	ListPersonInferenceProfiles(ctx context.Context) ([]peoplesweep.ProviderProfile, error)
+	GrantPersonInferenceConsent(ctx context.Context, fingerprint, actor string) (*store.PersonInferenceConsent, bool, error)
+	RevokePersonInferenceConsent(ctx context.Context, fingerprint, actor string) (bool, error)
+	RevokeAllPersonInferenceConsents(ctx context.Context, actor string) (int64, error)
+	GetPersonInferenceConsentStatus(ctx context.Context, fingerprint string) (*store.PersonInferenceConsentStatus, error)
+	HasActivePersonInferenceConsent(ctx context.Context, fingerprint string) (bool, error)
+}
+
+type personProviderChecker interface {
+	Check(ctx context.Context) (peoplesweep.StructuredResponse, error)
+}
+
+type personProviderCommandDeps struct {
+	config             func() peoplesweep.Config
+	openStore          func() (personProviderStore, func(), error)
+	newChecker         func(peoplesweep.Config, personProviderStore) (personProviderChecker, error)
+	isDaemonSubprocess func() bool
+	lookupEnv          peoplesweep.CredentialLookup
+	proxy              func(*cobra.Command, []string, map[string]string) error
+}
+
+type personProviderStatusOutput struct {
+	Profile peoplesweep.ProviderProfile        `json:"profile"`
+	Consent store.PersonInferenceConsentStatus `json:"consent"`
+}
+
+type personProviderCheckOutput struct {
+	OK                bool                   `json:"ok"`
+	ProviderRequestID string                 `json:"provider_request_id,omitempty"`
+	Model             string                 `json:"model"`
+	Usage             peoplesweep.TokenUsage `json:"usage"`
+}
+
+type personProviderStatusesOutput struct {
+	Profiles []personProviderStatusOutput `json:"profiles"`
+}
+
+type personProviderRevokeAllOutput struct {
+	Revoked  int64                        `json:"revoked"`
+	Profiles []personProviderStatusOutput `json:"profiles"`
+}
+
+func defaultPersonProviderCommandDeps() personProviderCommandDeps {
+	return personProviderCommandDeps{
+		config: func() peoplesweep.Config {
+			if cfg == nil {
+				return peoplesweep.Config{}
+			}
+			return cfg.People.Sweep
+		},
+		openStore: func() (personProviderStore, func(), error) {
+			return openWritableStoreAndInit()
+		},
+		newChecker: func(config peoplesweep.Config, st personProviderStore) (personProviderChecker, error) {
+			return peoplesweep.NewRunner(
+				config,
+				st,
+				peoplesweep.NewOpenAICompatibleTransport(http.DefaultClient),
+				os.LookupEnv,
+			)
+		},
+		isDaemonSubprocess: isDaemonCLISubprocess,
+		lookupEnv:          os.LookupEnv,
+		proxy: func(command *cobra.Command, args []string, env map[string]string) error {
+			if len(env) == 0 {
+				return runDaemonCLICommandHTTPFromCobra(command, args)
+			}
+			return runDaemonCLICommandHTTPFromCobraWithEnv(command, args, env)
+		},
+	}
+}
+
+func newPersonProviderCommand(deps personProviderCommandDeps) *cobra.Command {
+	provider := &cobra.Command{
+		Use:   "provider",
+		Short: "Manage people-sweep inference",
+	}
+	provider.AddCommand(
+		newPersonProviderStatusCommand(deps),
+		newPersonProviderConsentCommand(deps),
+		newPersonProviderRevokeCommand(deps),
+		newPersonProviderCheckCommand(deps),
+	)
+	return provider
+}
+
+func newPersonProviderStatusCommand(deps personProviderCommandDeps) *cobra.Command {
+	var all bool
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   statusValue,
+		Short: "Show the exact people inference policy and consent state",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, args []string) error {
+			if !deps.isDaemonSubprocess() {
+				return deps.proxy(command, args, nil)
+			}
+			return runPersonProviderStatus(command, deps, all, jsonOutput)
+		},
+	}
+	command.Flags().BoolVar(&all, "all", false, "Show every stored provider policy and consent state")
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	return command
+}
+
+func newPersonProviderConsentCommand(deps personProviderCommandDeps) *cobra.Command {
+	var confirmed bool
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   "consent",
+		Short: "Consent to the exact people inference policy",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, args []string) error {
+			if !deps.isDaemonSubprocess() {
+				return deps.proxy(command, args, nil)
+			}
+			return runPersonProviderConsent(command, deps, confirmed, jsonOutput)
+		},
+	}
+	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm the disclosed provider policy")
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	return command
+}
+
+func newPersonProviderRevokeCommand(deps personProviderCommandDeps) *cobra.Command {
+	var all bool
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke consent for the exact people inference policy",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, args []string) error {
+			if !deps.isDaemonSubprocess() {
+				return deps.proxy(command, args, nil)
+			}
+			return runPersonProviderRevoke(command, deps, all, jsonOutput)
+		},
+	}
+	command.Flags().BoolVar(&all, "all", false, "Revoke consent for every stored provider policy")
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	return command
+}
+
+func newPersonProviderCheckCommand(deps personProviderCommandDeps) *cobra.Command {
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   "check",
+		Short: "Run a fixed synthetic request through the people inference provider",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, args []string) error {
+			if !deps.isDaemonSubprocess() {
+				config := deps.config()
+				return deps.proxy(command, args, personProviderForwardEnv(config, deps.lookupEnv))
+			}
+			return runPersonProviderCheck(command, deps, jsonOutput)
+		},
+	}
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	return command
+}
+
+func runPersonProviderStatus(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	all bool,
+	jsonOutput bool,
+) error {
+	if all {
+		st, cleanup, err := deps.openStore()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		profiles, err := st.ListPersonInferenceProfiles(command.Context())
+		if err != nil {
+			return err
+		}
+		statuses, err := personProviderStatuses(command.Context(), st, profiles)
+		if err != nil {
+			return err
+		}
+		return writePersonProviderStatuses(command.OutOrStdout(), statuses, jsonOutput)
+	}
+	profile, st, cleanup, err := openPersonProviderProfile(deps)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	status, err := st.GetPersonInferenceConsentStatus(command.Context(), profile.Fingerprint)
+	if err != nil {
+		return err
+	}
+	return writePersonProviderStatus(command.OutOrStdout(), profile, status, jsonOutput)
+}
+
+func runPersonProviderConsent(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	confirmed bool,
+	jsonOutput bool,
+) error {
+	profile, err := deps.config().Profile()
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		printPersonProviderDisclosure(command.OutOrStdout(), profile)
+		return errors.New("people inference consent requires --yes after reviewing the provider disclosure")
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := st.EnsurePersonInferenceProfile(command.Context(), profile); err != nil {
+		return err
+	}
+	if _, _, err := st.GrantPersonInferenceConsent(
+		command.Context(), profile.Fingerprint, personProviderConsentActor,
+	); err != nil {
+		return err
+	}
+	status, err := st.GetPersonInferenceConsentStatus(command.Context(), profile.Fingerprint)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writePersonProviderStatus(command.OutOrStdout(), profile, status, true)
+	}
+	printPersonProviderDisclosure(command.OutOrStdout(), profile)
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Consent: active (%s)\n", profile.Fingerprint)
+	return nil
+}
+
+func runPersonProviderRevoke(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	all bool,
+	jsonOutput bool,
+) error {
+	if all {
+		st, cleanup, err := deps.openStore()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		revoked, err := st.RevokeAllPersonInferenceConsents(
+			command.Context(), personProviderConsentActor,
+		)
+		if err != nil {
+			return err
+		}
+		profiles, err := st.ListPersonInferenceProfiles(command.Context())
+		if err != nil {
+			return err
+		}
+		statuses, err := personProviderStatuses(command.Context(), st, profiles)
+		if err != nil {
+			return err
+		}
+		if jsonOutput {
+			return json.NewEncoder(command.OutOrStdout()).Encode(personProviderRevokeAllOutput{
+				Revoked: revoked, Profiles: statuses,
+			})
+		}
+		_, _ = fmt.Fprintf(command.OutOrStdout(),
+			"Consent revoked for %d active people inference profile(s).\n", revoked)
+		return nil
+	}
+	profile, st, cleanup, err := openPersonProviderProfile(deps)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := st.RevokePersonInferenceConsent(
+		command.Context(), profile.Fingerprint, personProviderConsentActor,
+	); err != nil {
+		return err
+	}
+	status, err := st.GetPersonInferenceConsentStatus(command.Context(), profile.Fingerprint)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writePersonProviderStatus(command.OutOrStdout(), profile, status, true)
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Consent revoked for %s\n", profile.Fingerprint)
+	return nil
+}
+
+func runPersonProviderCheck(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	jsonOutput bool,
+) error {
+	config := deps.config()
+	profile, err := config.Profile()
+	if err != nil {
+		return err
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	checker, err := deps.newChecker(config, st)
+	if err != nil {
+		return err
+	}
+	response, err := checker.Check(command.Context())
+	if err != nil {
+		return err
+	}
+	output := personProviderCheckOutput{
+		OK: true, ProviderRequestID: response.ProviderRequestID,
+		Model: profile.Model, Usage: response.Usage,
+	}
+	if jsonOutput {
+		return json.NewEncoder(command.OutOrStdout()).Encode(output)
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(),
+		"People inference provider check succeeded (model=%s, request_id=%s, input_tokens=%d, output_tokens=%d).\n",
+		output.Model, output.ProviderRequestID, output.Usage.InputTokens, output.Usage.OutputTokens)
+	return nil
+}
+
+func openPersonProviderProfile(
+	deps personProviderCommandDeps,
+) (peoplesweep.ProviderProfile, personProviderStore, func(), error) {
+	profile, err := deps.config().Profile()
+	if err != nil {
+		return peoplesweep.ProviderProfile{}, nil, nil, err
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return peoplesweep.ProviderProfile{}, nil, nil, err
+	}
+	return profile, st, cleanup, nil
+}
+
+func writePersonProviderStatus(
+	w io.Writer,
+	profile peoplesweep.ProviderProfile,
+	status *store.PersonInferenceConsentStatus,
+	jsonOutput bool,
+) error {
+	if status == nil {
+		return errors.New("people inference consent status is empty")
+	}
+	if jsonOutput {
+		return json.NewEncoder(w).Encode(personProviderStatusOutput{
+			Profile: profile, Consent: *status,
+		})
+	}
+	printPersonProviderDisclosure(w, profile)
+	state := "inactive"
+	if status.Active {
+		state = "active"
+	} else if status.LastRevoked != nil {
+		state = "revoked"
+	}
+	_, _ = fmt.Fprintf(w, "Consent: %s\n", state)
+	return nil
+}
+
+func personProviderStatuses(
+	ctx context.Context,
+	st personProviderStore,
+	profiles []peoplesweep.ProviderProfile,
+) ([]personProviderStatusOutput, error) {
+	statuses := make([]personProviderStatusOutput, 0, len(profiles))
+	for _, profile := range profiles {
+		status, err := st.GetPersonInferenceConsentStatus(ctx, profile.Fingerprint)
+		if err != nil {
+			return nil, err
+		}
+		if status == nil {
+			return nil, errors.New("people inference consent status is empty")
+		}
+		statuses = append(statuses, personProviderStatusOutput{Profile: profile, Consent: *status})
+	}
+	return statuses, nil
+}
+
+func writePersonProviderStatuses(
+	w io.Writer,
+	statuses []personProviderStatusOutput,
+	jsonOutput bool,
+) error {
+	if jsonOutput {
+		return json.NewEncoder(w).Encode(personProviderStatusesOutput{Profiles: statuses})
+	}
+	if len(statuses) == 0 {
+		_, _ = fmt.Fprintln(w, "No stored people inference provider profiles.")
+		return nil
+	}
+	for i, status := range statuses {
+		if i > 0 {
+			_, _ = fmt.Fprintln(w)
+		}
+		if err := writePersonProviderStatus(w, status.Profile, &status.Consent, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printPersonProviderDisclosure(w io.Writer, profile peoplesweep.ProviderProfile) {
+	dateRange := profile.SourceSince + " through " + profile.SourceUntil
+	if profile.SourceUntil == "" {
+		dateRange = profile.SourceSince + " onward"
+	}
+	authentication := "anonymous loopback"
+	if profile.APIKeyEnv != "" {
+		authentication = "environment variable " + profile.APIKeyEnv
+	}
+	sensitive := "denied"
+	if profile.AllowSensitive {
+		sensitive = "allowed"
+	}
+	sources := make([]string, len(profile.AllowedSources))
+	for i, source := range profile.AllowedSources {
+		sources[i] = string(source)
+	}
+	_, _ = fmt.Fprintln(w, "People inference provider disclosure:")
+	_, _ = fmt.Fprintf(w, "Fingerprint: %s\n", profile.Fingerprint)
+	_, _ = fmt.Fprintf(w, "Destination: %s\n", profile.Endpoint)
+	_, _ = fmt.Fprintf(w, "Model: %s\n", profile.Model)
+	_, _ = fmt.Fprintf(w, "Authentication: %s\n", authentication)
+	_, _ = fmt.Fprintf(w, "Provider assertions: retention=%s, training=%s\n",
+		profile.RetentionPosture, profile.TrainingPosture)
+	_, _ = fmt.Fprintf(w, "Allowed sources: %s\n", strings.Join(sources, ", "))
+	_, _ = fmt.Fprintf(w, "Source dates: %s\n", dateRange)
+	_, _ = fmt.Fprintf(w, "Sensitive content: %s\n", sensitive)
+}
+
+func personProviderForwardEnv(
+	config peoplesweep.Config,
+	lookup peoplesweep.CredentialLookup,
+) map[string]string {
+	name := config.Provider.APIKeyEnv
+	if name == "" || lookup == nil {
+		return nil
+	}
+	value, ok := lookup(name)
+	if !ok || value == "" {
+		return nil
+	}
+	return map[string]string{name: value}
+}

--- a/cmd/msgvault/cmd/person_provider_daemon_test.go
+++ b/cmd/msgvault/cmd/person_provider_daemon_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type inProcessPersonProviderDaemonStore struct {
+	*storeAPIAdapter
+
+	config peoplesweep.Config
+}
+
+func (s *inProcessPersonProviderDaemonStore) RunCLICommand(
+	ctx context.Context,
+	req api.CLIRunRequest,
+	emit func(api.CLIRunEvent) error,
+) error {
+	deps := localPersonProviderDeps(s.config, s.store, nil)
+	deps.newChecker = func(
+		config peoplesweep.Config,
+		consent personProviderStore,
+	) (personProviderChecker, error) {
+		return peoplesweep.NewRunner(
+			config,
+			consent,
+			peoplesweep.NewOpenAICompatibleTransport(http.DefaultClient),
+			func(name string) (string, bool) {
+				value, ok := req.Env[name]
+				return value, ok
+			},
+		)
+	}
+
+	root := &cobra.Command{Use: "msgvault", SilenceErrors: true, SilenceUsage: true}
+	person := &cobra.Command{Use: "person"}
+	person.AddCommand(newPersonProviderCommand(deps))
+	root.AddCommand(person)
+	root.SetArgs(req.Args)
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	err := root.ExecuteContext(ctx)
+	if output.Len() > 0 && emit != nil {
+		if emitErr := emit(api.CLIRunEvent{Type: cliStreamStdout, Data: output.String()}); emitErr != nil {
+			return emitErr
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("execute in-process person provider command: %w", err)
+	}
+	return nil
+}
+
+func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	type capturedProviderRequest struct {
+		Authorization string
+		Path          string
+		Body          map[string]any
+	}
+	requests := make(chan capturedProviderRequest, 1)
+	var requestCount atomic.Int64
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		requests <- capturedProviderRequest{
+			Authorization: r.Header.Get("Authorization"),
+			Path:          r.URL.Path,
+			Body:          body,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-request-id", "req-daemon")
+		_, _ = io.WriteString(w, `{
+			"choices":[{"message":{"content":"{\"ok\":true}"}}],
+			"usage":{"prompt_tokens":9,"completion_tokens":2}
+		}`)
+	}))
+	t.Cleanup(provider.Close)
+
+	peopleConfig := personProviderTestConfig()
+	peopleConfig.Provider.Endpoint = provider.URL + "/v1"
+	st := testutil.NewSQLiteTestStore(t)
+	daemonConfig := &config.Config{People: peoplesweep.PeopleConfig{Sweep: peopleConfig}}
+	daemonStore := &inProcessPersonProviderDaemonStore{
+		storeAPIAdapter: &storeAPIAdapter{store: st},
+		config:          peopleConfig,
+	}
+	logger := slog.New(slog.DiscardHandler)
+	daemon := api.NewServerWithOptions(api.ServerOptions{
+		Config: daemonConfig, Store: daemonStore, Logger: logger,
+		OperationGate: api.NewSerialOperationGate(),
+	})
+	daemonHTTP := httptest.NewServer(daemon.Router())
+	t.Cleanup(daemonHTTP.Close)
+
+	frontendConfig := *daemonConfig
+	frontendConfig.Remote = config.RemoteConfig{URL: daemonHTTP.URL, AllowInsecure: true}
+	withStoreResolverConfig(t, &frontendConfig)
+	t.Setenv("TEST_PROVIDER_KEY", "caller-key")
+	deps := defaultPersonProviderCommandDeps()
+
+	_, err := executePersonProviderCommand(t, deps, "consent", "--yes", "--json")
+	require.NoError(err)
+	output, err := executePersonProviderCommand(t, deps, "check", "--json")
+	require.NoError(err)
+	assert.JSONEq(`{
+		"ok":true,
+		"provider_request_id":"req-daemon",
+		"model":"test-model",
+		"usage":{"input_tokens":9,"output_tokens":2}
+	}`, output)
+
+	captured := <-requests
+	assert.Equal("Bearer caller-key", captured.Authorization)
+	assert.Equal("/v1/chat/completions", captured.Path)
+	assert.Equal("test-model", captured.Body["model"])
+	messages, ok := captured.Body["messages"].([]any)
+	require.True(ok)
+	require.Len(messages, 2)
+	message, ok := messages[1].(map[string]any)
+	require.True(ok)
+	assert.Equal("Return an object with ok set to true.", message["content"])
+	assert.NotContains(string(mustJSON(t, captured.Body)), "archive")
+
+	_, err = executePersonProviderCommand(t, deps, "revoke", "--json")
+	require.NoError(err)
+	_, err = executePersonProviderCommand(t, deps, "check", "--json")
+	require.ErrorContains(err, "active exact consent")
+	assert.Equal(int64(1), requestCount.Load(), "revoked check must not reach the provider")
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return encoded
+}
+
+var _ api.CLIRunner = (*inProcessPersonProviderDaemonStore)(nil)
+var _ api.MessageStore = (*inProcessPersonProviderDaemonStore)(nil)
+var _ personProviderStore = (*store.Store)(nil)

--- a/cmd/msgvault/cmd/person_provider_routing_test.go
+++ b/cmd/msgvault/cmd/person_provider_routing_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+)
+
+func TestPersonProviderFrontendRoutesExactCommandsAndCredential(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		keyValue    string
+		wantArgs    []string
+		wantEnv     map[string]string
+		wantLookups int
+	}{
+		{name: "status", args: []string{"status", "--json"},
+			wantArgs: []string{"person", "provider", "status", "--json"}},
+		{name: "consent", args: []string{"consent", "--yes"},
+			wantArgs: []string{"person", "provider", "consent", "--yes"}},
+		{name: "revoke", args: []string{"revoke"},
+			wantArgs: []string{"person", "provider", "revoke"}},
+		{name: "check without key", args: []string{"check", "--json"},
+			wantArgs: []string{"person", "provider", "check", "--json"}, wantLookups: 1},
+		{name: "check with key", args: []string{"check"}, keyValue: "caller-key",
+			wantArgs: []string{"person", "provider", "check"},
+			wantEnv:  map[string]string{"TEST_PROVIDER_KEY": "caller-key"}, wantLookups: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			var gotArgs []string
+			var gotEnv map[string]string
+			lookups := 0
+			deps := personProviderCommandDeps{
+				config:             personProviderTestConfig,
+				isDaemonSubprocess: func() bool { return false },
+				lookupEnv: func(name string) (string, bool) {
+					lookups++
+					assert.Equal("TEST_PROVIDER_KEY", name)
+					return test.keyValue, test.keyValue != ""
+				},
+				proxy: func(command *cobra.Command, args []string, env map[string]string) error {
+					var err error
+					gotArgs, err = daemonCLIArgsFromCobra(command, args)
+					require.NoError(t, err)
+					gotEnv = env
+					return nil
+				},
+			}
+
+			_, err := executePersonProviderCommand(t, deps, test.args...)
+			require.NoError(t, err)
+			assert.Equal(test.wantArgs, gotArgs)
+			assert.Equal(test.wantEnv, gotEnv)
+			assert.Equal(test.wantLookups, lookups)
+		})
+	}
+}
+
+func TestPersonProviderAnonymousCheckForwardsNoCredential(t *testing.T) {
+	config := personProviderTestConfig()
+	config.Provider.Endpoint = "http://127.0.0.1:11434/v1"
+	config.Provider.APIKeyEnv = ""
+	config.Provider.AllowAnonymous = true
+	var gotEnv map[string]string
+	deps := personProviderCommandDeps{
+		config:             func() peoplesweep.Config { return config },
+		isDaemonSubprocess: func() bool { return false },
+		lookupEnv: func(string) (string, bool) {
+			require.FailNow(t, "anonymous check must not resolve a credential")
+			return "", false
+		},
+		proxy: func(_ *cobra.Command, _ []string, env map[string]string) error {
+			gotEnv = env
+			return nil
+		},
+	}
+
+	_, err := executePersonProviderCommand(t, deps, "check")
+	require.NoError(t, err)
+	assert.Nil(t, gotEnv)
+}

--- a/cmd/msgvault/cmd/person_provider_test.go
+++ b/cmd/msgvault/cmd/person_provider_test.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func personProviderTestConfig() peoplesweep.Config {
+	return peoplesweep.Config{
+		Enabled: true,
+		Provider: peoplesweep.ProviderConfig{
+			Kind: peoplesweep.ProviderOpenAICompatible, Endpoint: "https://provider.example/v1",
+			Model: "test-model", APIKeyEnv: "TEST_PROVIDER_KEY",
+			RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+			AllowedSources: []peoplesweep.SourceClass{
+				peoplesweep.SourceMeetingText, peoplesweep.SourceConversationText,
+			},
+			SourceSince: "2025-01-01", SourceUntil: "2025-12-31",
+			RequestTimeout: time.Second,
+		},
+	}
+}
+
+type fixedPersonProviderChecker struct {
+	response peoplesweep.StructuredResponse
+	err      error
+	calls    atomic.Int64
+}
+
+func (c *fixedPersonProviderChecker) Check(context.Context) (peoplesweep.StructuredResponse, error) {
+	c.calls.Add(1)
+	return c.response, c.err
+}
+
+func localPersonProviderDeps(
+	config peoplesweep.Config,
+	st personProviderStore,
+	checker personProviderChecker,
+) personProviderCommandDeps {
+	return personProviderCommandDeps{
+		config: func() peoplesweep.Config { return config },
+		openStore: func() (personProviderStore, func(), error) {
+			return st, func() {}, nil
+		},
+		newChecker: func(peoplesweep.Config, personProviderStore) (personProviderChecker, error) {
+			return checker, nil
+		},
+		isDaemonSubprocess: func() bool { return true },
+	}
+}
+
+func executePersonProviderCommand(
+	t *testing.T,
+	deps personProviderCommandDeps,
+	args ...string,
+) (string, error) {
+	t.Helper()
+	root := &cobra.Command{Use: "msgvault"}
+	person := &cobra.Command{Use: "person"}
+	person.AddCommand(newPersonProviderCommand(deps))
+	root.AddCommand(person)
+	root.SetArgs(append([]string{"person", "provider"}, args...))
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	err := root.ExecuteContext(t.Context())
+	return output.String(), err
+}
+
+func TestPersonProviderStatusReportsExactPolicyWithoutMutation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	profile, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	deps := localPersonProviderDeps(config, st, nil)
+
+	human, err := executePersonProviderCommand(t, deps, "status")
+	require.NoError(err)
+	assert.Contains(human, profile.Fingerprint)
+	assert.Contains(human, "https://provider.example/v1")
+	assert.Contains(human, "test-model")
+	assert.Contains(human, "zero_data_retention")
+	assert.Contains(human, "conversation_text, meeting_text")
+	assert.Contains(human, "2025-01-01 through 2025-12-31")
+	assert.Contains(human, "Sensitive content: denied")
+	assert.Contains(human, "Consent: inactive")
+
+	jsonOutput, err := executePersonProviderCommand(t, deps, "status", "--json")
+	require.NoError(err)
+	var got personProviderStatusOutput
+	require.NoError(json.Unmarshal([]byte(jsonOutput), &got))
+	assert.Equal(profile.Fingerprint, got.Profile.Fingerprint)
+	assert.False(got.Consent.Active)
+	assert.False(got.Consent.ProfileExists)
+}
+
+func TestPersonProviderConsentDisclosesBeforeConfirmationAndIsIdempotent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	profile, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	deps := localPersonProviderDeps(config, st, nil)
+
+	disclosure, err := executePersonProviderCommand(t, deps, "consent")
+	require.ErrorContains(err, "--yes")
+	assert.Contains(disclosure, "People inference provider disclosure")
+	assert.Contains(disclosure, "Authentication: environment variable TEST_PROVIDER_KEY")
+	status, err := st.GetPersonInferenceConsentStatus(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.False(status.ProfileExists, "unconfirmed disclosure must not mutate the store")
+
+	first, err := executePersonProviderCommand(t, deps, "consent", "--yes", "--json")
+	require.NoError(err)
+	var firstStatus personProviderStatusOutput
+	require.NoError(json.Unmarshal([]byte(first), &firstStatus))
+	require.NotNil(firstStatus.Consent.Consent)
+	assert.True(firstStatus.Consent.Active)
+	assert.Equal("cli", firstStatus.Consent.Consent.GrantedBy)
+
+	second, err := executePersonProviderCommand(t, deps, "consent", "--yes", "--json")
+	require.NoError(err)
+	var secondStatus personProviderStatusOutput
+	require.NoError(json.Unmarshal([]byte(second), &secondStatus))
+	require.NotNil(secondStatus.Consent.Consent)
+	assert.Equal(firstStatus.Consent.Consent.ID, secondStatus.Consent.Consent.ID)
+}
+
+func TestPersonProviderRevokeIsIdempotent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	profile, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	deps := localPersonProviderDeps(config, st, nil)
+
+	first, err := executePersonProviderCommand(t, deps, "revoke", "--json")
+	require.NoError(err)
+	var firstStatus personProviderStatusOutput
+	require.NoError(json.Unmarshal([]byte(first), &firstStatus))
+	assert.False(firstStatus.Consent.Active)
+	require.NotNil(firstStatus.Consent.LastRevoked)
+	assert.Equal("cli", *firstStatus.Consent.LastRevoked.RevokedBy)
+
+	second, err := executePersonProviderCommand(t, deps, "revoke", "--json")
+	require.NoError(err)
+	var secondStatus personProviderStatusOutput
+	require.NoError(json.Unmarshal([]byte(second), &secondStatus))
+	assert.Equal(firstStatus.Consent.LastRevoked.ID, secondStatus.Consent.LastRevoked.ID)
+}
+
+func TestPersonProviderListsAndRevokesAllGrantsWhenConfigIsDisabled(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	profile, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+
+	config.Enabled = false
+	deps := localPersonProviderDeps(config, st, nil)
+	listed, err := executePersonProviderCommand(t, deps, "status", "--all", "--json")
+	require.NoError(err)
+	var listOutput personProviderStatusesOutput
+	require.NoError(json.Unmarshal([]byte(listed), &listOutput))
+	require.Len(listOutput.Profiles, 1)
+	assert.Equal(profile.Fingerprint, listOutput.Profiles[0].Profile.Fingerprint)
+	assert.True(listOutput.Profiles[0].Consent.Active)
+
+	revoked, err := executePersonProviderCommand(t, deps, "revoke", "--all", "--json")
+	require.NoError(err)
+	var revokeOutput personProviderRevokeAllOutput
+	require.NoError(json.Unmarshal([]byte(revoked), &revokeOutput))
+	assert.Equal(int64(1), revokeOutput.Revoked)
+	require.Len(revokeOutput.Profiles, 1)
+	assert.False(revokeOutput.Profiles[0].Consent.Active)
+	require.NotNil(revokeOutput.Profiles[0].Consent.LastRevoked)
+
+	active, err := st.HasActivePersonInferenceConsent(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.False(active)
+}
+
+func TestPersonProviderCheckOmitsProviderOutput(t *testing.T) {
+	assert := assert.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	checker := &fixedPersonProviderChecker{response: peoplesweep.StructuredResponse{
+		Output:            json.RawMessage(`{"ok":true,"secret":"provider-output"}`),
+		ProviderRequestID: "req-safe",
+		Usage:             peoplesweep.TokenUsage{InputTokens: 12, OutputTokens: 3},
+	}}
+	deps := localPersonProviderDeps(personProviderTestConfig(), st, checker)
+
+	output, err := executePersonProviderCommand(t, deps, "check", "--json")
+	require.NoError(t, err)
+	assert.JSONEq(`{
+		"ok":true,
+		"provider_request_id":"req-safe",
+		"model":"test-model",
+		"usage":{"input_tokens":12,"output_tokens":3}
+	}`, output)
+	assert.NotContains(output, "provider-output")
+	assert.Equal(int64(1), checker.calls.Load())
+}
+
+func TestPersonProviderCommandsRejectInputAndDisabledConfigBeforeStore(t *testing.T) {
+	config := personProviderTestConfig()
+	var opens atomic.Int64
+	deps := localPersonProviderDeps(config, nil, nil)
+	deps.openStore = func() (personProviderStore, func(), error) {
+		opens.Add(1)
+		return nil, func() {}, nil
+	}
+
+	for _, operation := range []string{"status", "consent", "revoke", "check"} {
+		t.Run(operation+" input", func(t *testing.T) {
+			_, err := executePersonProviderCommand(t, deps, operation, "archive.txt")
+			assert.ErrorContains(t, err, "unknown command")
+		})
+	}
+	assert.Zero(t, opens.Load())
+
+	config.Enabled = false
+	disabled := localPersonProviderDeps(config, nil, nil)
+	disabled.openStore = deps.openStore
+	_, err := executePersonProviderCommand(t, disabled, "consent", "--yes")
+	require.ErrorContains(t, err, "disabled")
+	assert.Zero(t, opens.Load())
+}
+
+var _ personProviderStore = (*store.Store)(nil)

--- a/cmd/msgvault/cmd/person_relationship.go
+++ b/cmd/msgvault/cmd/person_relationship.go
@@ -243,7 +243,7 @@ var personRelationshipListCmd = &cobra.Command{
 	Short: "List one person's relationships from that person's side",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		personID, err := positivePersonCLIArg(cmd, args[0], "person")
+		personID, err := positivePersonCLIArg(cmd, args[0], personValue)
 		if err != nil {
 			return err
 		}

--- a/cmd/msgvault/cmd/person_tracking.go
+++ b/cmd/msgvault/cmd/person_tracking.go
@@ -22,7 +22,7 @@ func newPersonTrackingCommand(action string, tracked bool) *cobra.Command {
 		Short: action + " a durable person for future profile maintenance",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			personID, err := positivePersonCLIArg(cmd, args[0], "person")
+			personID, err := positivePersonCLIArg(cmd, args[0], personValue)
 			if err != nil {
 				return err
 			}

--- a/cmd/msgvault/cmd/root.go
+++ b/cmd/msgvault/cmd/root.go
@@ -42,7 +42,7 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "msgvault",
+	Use:   daemonService,
 	Short: "Offline email, chat, and meeting archive tool",
 	Long: `msgvault is an offline archive tool that exports and stores email,
 chat, and meeting data locally with full-text search capabilities.

--- a/cmd/msgvault/cmd/update.go
+++ b/cmd/msgvault/cmd/update.go
@@ -220,5 +220,5 @@ func updateExecutableName() string {
 	if runtime.GOOS == "windows" {
 		return "msgvault.exe"
 	}
-	return "msgvault"
+	return daemonService
 }

--- a/internal/api/cli_allowlist_person_provider_test.go
+++ b/internal/api/cli_allowlist_person_provider_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.kenn.io/msgvault/internal/config"
+)
+
+func TestCLIRunCommandAllowedPermitsExactPersonProviderCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "status", args: []string{"person", "provider", "status"}, want: true},
+		{name: "status flags", args: []string{"person", "provider", "status", "--json"}, want: true},
+		{name: "consent", args: []string{"person", "provider", "consent", "--yes"}, want: true},
+		{name: "revoke", args: []string{"person", "provider", "revoke"}, want: true},
+		{name: "check", args: []string{"person", "provider", "check", "--json"}, want: true},
+		{name: "missing operation", args: []string{"person", "provider"}},
+		{name: "unknown operation", args: []string{"person", "provider", "run"}},
+		{name: "ordinary person mutation", args: []string{"person", "delete", "7"}},
+		{name: "different nested group", args: []string{"person", "attributes", "list", "7"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, cliRunCommandAllowed(test.args))
+		})
+	}
+}
+
+func TestCLIRunEnvAllowedPermitsConfiguredPeopleProviderKeyOnly(t *testing.T) {
+	srv := &Server{cfg: &config.Config{}}
+	srv.cfg.People.Sweep.Provider.APIKeyEnv = "MSGVAULT_PEOPLE_PROVIDER_KEY"
+
+	assert.True(t, srv.cliRunEnvAllowed("MSGVAULT_PEOPLE_PROVIDER_KEY"))
+	assert.False(t, srv.cliRunEnvAllowed("OPENAI_API_KEY"))
+
+	unconfigured := &Server{cfg: &config.Config{}}
+	assert.False(t, unconfigured.cliRunEnvAllowed("MSGVAULT_PEOPLE_PROVIDER_KEY"))
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1349,12 +1349,14 @@ func validateCLIDeletionManifest(manifest *deletion.Manifest) *apiHTTPError {
 	return nil
 }
 
+const cliRunPersonCommand = "person"
+
 // cliRunCommandAllowed reports whether a proxied CLI command may run through
 // the daemon CLI runner. Most commands are admitted by their leading word
-// alone; command groups whose subcommand matters (currently "backup" and
-// "documents") are checked against args[1] as well. Backup admits only the
-// frozen create path, while documents admits only mutations that must run
-// under the daemon's writer lock.
+// alone; command groups whose subcommand matters are checked against their
+// nested command path. Backup admits only the frozen create path, documents
+// admits only mutations that must run under the daemon's writer lock, and
+// person admits only the provider consent boundary.
 func cliRunCommandAllowed(args []string) bool {
 	if len(args) == 0 {
 		return false
@@ -1368,6 +1370,17 @@ func cliRunCommandAllowed(args []string) bool {
 		}
 		switch args[1] {
 		case "build", "consent-mistral", "purge-derived", "resume", "retire", "retry":
+			return true
+		default:
+			return false
+		}
+	}
+	if args[0] == cliRunPersonCommand {
+		if len(args) < 3 || args[1] != "provider" {
+			return false
+		}
+		switch args[2] {
+		case "status", "consent", "revoke", "check":
 			return true
 		default:
 			return false
@@ -1464,6 +1477,7 @@ func (s *Server) cliRunEnvAllowed(name string) bool {
 	for _, keyEnv := range []string{
 		s.cfg.Vector.Embeddings.APIKeyEnv,
 		s.cfg.Attachments.Documents.APIKeyEnv,
+		s.cfg.People.Sweep.Provider.APIKeyEnv,
 	} {
 		if keyEnv != "" && name == keyEnv {
 			return true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/msgvault/internal/duckdbutil"
 	"go.kenn.io/msgvault/internal/fileutil"
 	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/peoplesweep"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/taskclient"
 	"go.kenn.io/msgvault/internal/vector"
@@ -410,6 +411,7 @@ type Config struct {
 	Discord      DiscordConfig                   `toml:"discord"`
 	Attachments  documentindex.AttachmentsConfig `toml:"attachments"`
 	Activity     ActivityConfig                  `toml:"activity"`
+	People       peoplesweep.PeopleConfig        `toml:"people"`
 	Teams        TeamsConfig                     `toml:"teams"`
 
 	// Computed paths (not from config file)
@@ -669,6 +671,7 @@ func NewDefaultConfig() *Config {
 	cfg.Web.ApplyDefaults()
 	cfg.Integrations.Tasks.ApplyDefaults()
 	cfg.Activity.ApplyDefaults()
+	cfg.People.Sweep.ApplyDefaults()
 	return cfg
 }
 
@@ -745,13 +748,21 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 		cfg.Data.DataDir = cfg.HomeDir
 	}
 
-	if _, err := toml.Decode(string(content), cfg); err != nil {
+	metadata, err := toml.Decode(string(content), cfg)
+	if err != nil {
 		if strings.Contains(err.Error(), "invalid escape") ||
 			strings.Contains(err.Error(), "hexadecimal digits after") {
 			return nil, fmt.Errorf("decode config: %w -- hint: Windows paths in TOML must use "+
 				"forward slashes (C:/Games/msgvault) or single quotes ('C:\\Games\\msgvault')", err)
 		}
 		return nil, fmt.Errorf("decode config: %w", err)
+	}
+	if cfg.People.Sweep.Provider.AllowAnonymous &&
+		!metadata.IsDefined("people", "sweep", "provider", "api_key_env") {
+		// The default authenticated credential is loaded before TOML decoding.
+		// Anonymous loopback mode instead defaults to no credential, while an
+		// explicitly configured key remains visible to validation and is rejected.
+		cfg.People.Sweep.Provider.APIKeyEnv = ""
 	}
 	if err := cfg.validateFastmailSources(fastmailSourceIDConfigured(content)); err != nil {
 		return nil, err
@@ -814,6 +825,9 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	}
 	cfg.Activity.ApplyDefaults()
 	if err := cfg.Activity.Validate(); err != nil {
+		return nil, err
+	}
+	if err := cfg.People.Sweep.Validate(); err != nil {
 		return nil, err
 	}
 	if err := cfg.Backup.Validate(); err != nil {

--- a/internal/config/people_sweep_test.go
+++ b/internal/config/people_sweep_test.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+)
+
+func TestPeopleSweepConfigDefaultsDisabled(t *testing.T) {
+	assert := assert.New(t)
+	config := NewDefaultConfig().People.Sweep
+
+	assert.False(config.Enabled)
+	assert.Equal(peoplesweep.ProviderOpenAICompatible, config.Provider.Kind)
+	assert.Equal("https://api.openai.com/v1", config.Provider.Endpoint)
+	assert.Equal("OPENAI_API_KEY", config.Provider.APIKeyEnv)
+	assert.Equal(time.Minute, config.Provider.RequestTimeout)
+}
+
+func TestLoadPeopleSweepProviderConfig(t *testing.T) {
+	assert := assert.New(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[people.sweep]
+enabled = true
+
+[people.sweep.provider]
+kind = "openai_compatible"
+endpoint = "https://api.example.test/v1/"
+model = "gpt-test"
+api_key_env = "TEST_KEY"
+allow_anonymous = false
+retention_posture = "zero_retention"
+training_posture = "no_training"
+allowed_sources = ["meeting_text", "conversation_text"]
+source_since = "2025-01-01"
+source_until = "2025-12-31"
+allow_sensitive = true
+request_timeout = "45s"
+`), 0o600))
+
+	loaded, err := Load(path, "")
+	require.NoError(t, err)
+	provider := loaded.People.Sweep.Provider
+	assert.True(loaded.People.Sweep.Enabled)
+	assert.Equal(peoplesweep.ProviderOpenAICompatible, provider.Kind)
+	assert.Equal("https://api.example.test/v1/", provider.Endpoint)
+	assert.Equal("gpt-test", provider.Model)
+	assert.Equal("TEST_KEY", provider.APIKeyEnv)
+	assert.False(provider.AllowAnonymous)
+	assert.Equal("zero_retention", provider.RetentionPosture)
+	assert.Equal("no_training", provider.TrainingPosture)
+	assert.Equal([]peoplesweep.SourceClass{
+		peoplesweep.SourceMeetingText,
+		peoplesweep.SourceConversationText,
+	}, provider.AllowedSources)
+	assert.Equal("2025-01-01", provider.SourceSince)
+	assert.Equal("2025-12-31", provider.SourceUntil)
+	assert.True(provider.AllowSensitive)
+	assert.Equal(45*time.Second, provider.RequestTimeout)
+}
+
+func TestLoadRejectsInvalidEnabledPeopleSweepProvider(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[people.sweep]
+enabled = true
+
+[people.sweep.provider]
+model = "gpt-test"
+retention_posture = "zero_retention"
+training_posture = "no_training"
+allowed_sources = ["raw_image"]
+source_since = "2025-01-01"
+`), 0o600))
+
+	_, err := Load(path, "")
+	assert.ErrorContains(t, err, "allowed_sources")
+}
+
+func TestLoadDoesNotReplaceExplicitEmptyPeopleProviderKeyEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[people.sweep]
+enabled = true
+
+[people.sweep.provider]
+model = "gpt-test"
+api_key_env = ""
+retention_posture = "zero_retention"
+training_posture = "no_training"
+allowed_sources = ["conversation_text"]
+source_since = "2025-01-01"
+`), 0o600))
+
+	_, err := Load(path, "")
+	assert.ErrorContains(t, err, "api_key_env")
+}
+
+func TestLoadAllowsAnonymousLoopbackPeopleProviderWithoutKeyEnv(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(path, []byte(`
+[people.sweep]
+enabled = true
+
+[people.sweep.provider]
+endpoint = "http://127.0.0.1:11434/v1"
+model = "local-model"
+allow_anonymous = true
+retention_posture = "local_only"
+training_posture = "local_only"
+allowed_sources = ["conversation_text"]
+source_since = "2025-01-01"
+`), 0o600))
+
+	loaded, err := Load(path, "")
+	require.NoError(err)
+	assert.True(loaded.People.Sweep.Provider.AllowAnonymous)
+	assert.Empty(loaded.People.Sweep.Provider.APIKeyEnv)
+}
+
+func TestLoadRejectsAnonymousPeopleProviderWithExplicitKeyEnv(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(path, []byte(`
+[people.sweep]
+enabled = true
+
+[people.sweep.provider]
+endpoint = "http://127.0.0.1:11434/v1"
+model = "local-model"
+api_key_env = "LOCAL_KEY"
+allow_anonymous = true
+retention_posture = "local_only"
+training_posture = "local_only"
+allowed_sources = ["conversation_text"]
+source_since = "2025-01-01"
+`), 0o600))
+
+	_, err := Load(path, "")
+	assert.ErrorContains(err, "anonymous mode cannot also configure api_key_env")
+}

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -1,0 +1,313 @@
+// Package peoplesweep owns the privacy and provider boundary for model-backed
+// person-profile maintenance.
+package peoplesweep
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	ProviderOpenAICompatible = "openai_compatible"
+
+	SourceConversationText  SourceClass = "conversation_text"
+	SourceMeetingText       SourceClass = "meeting_text"
+	SourceAttachmentCaption SourceClass = "attachment_caption"
+	SourceAttachmentOCR     SourceClass = "attachment_ocr"
+	SourceDocumentText      SourceClass = "document_text"
+)
+
+var environmentNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// SourceClass identifies one text-only archive lane that may contribute to a
+// future evidence pack. It never identifies raw attachment or media bytes.
+type SourceClass string
+
+// PeopleConfig groups configuration for durable people.
+type PeopleConfig struct {
+	Sweep Config `toml:"sweep"`
+}
+
+// Config controls the model-backed people sweep. Disabled is the safe default.
+//
+//nolint:recvcheck // ApplyDefaults mutates while validation and profile construction do not.
+type Config struct {
+	Enabled  bool           `toml:"enabled"`
+	Provider ProviderConfig `toml:"provider"`
+}
+
+// ProviderConfig contains both runtime settings and the exact outbound-data
+// policy that must be consented before use.
+type ProviderConfig struct {
+	Kind             string        `toml:"kind"`
+	Endpoint         string        `toml:"endpoint"`
+	Model            string        `toml:"model"`
+	APIKeyEnv        string        `toml:"api_key_env"`
+	AllowAnonymous   bool          `toml:"allow_anonymous"`
+	RetentionPosture string        `toml:"retention_posture"`
+	TrainingPosture  string        `toml:"training_posture"`
+	AllowedSources   []SourceClass `toml:"allowed_sources"`
+	SourceSince      string        `toml:"source_since"`
+	SourceUntil      string        `toml:"source_until"`
+	AllowSensitive   bool          `toml:"allow_sensitive"`
+	RequestTimeout   time.Duration `toml:"request_timeout"`
+}
+
+// ProviderProfile is one immutable, fingerprinted egress policy. PolicyJSON is
+// canonical and intentionally excludes the credential value and request
+// timeout.
+type ProviderProfile struct {
+	Fingerprint      string          `json:"fingerprint"`
+	Kind             string          `json:"kind"`
+	Endpoint         string          `json:"endpoint"`
+	Model            string          `json:"model"`
+	APIKeyEnv        string          `json:"api_key_env"`
+	AllowAnonymous   bool            `json:"allow_anonymous"`
+	RetentionPosture string          `json:"retention_posture"`
+	TrainingPosture  string          `json:"training_posture"`
+	AllowedSources   []SourceClass   `json:"allowed_sources"`
+	SourceSince      string          `json:"source_since"`
+	SourceUntil      string          `json:"source_until"`
+	AllowSensitive   bool            `json:"allow_sensitive"`
+	PolicyJSON       json.RawMessage `json:"-"`
+}
+
+type providerPolicy struct {
+	Kind             string        `json:"kind"`
+	Endpoint         string        `json:"endpoint"`
+	Model            string        `json:"model"`
+	APIKeyEnv        string        `json:"api_key_env"`
+	AllowAnonymous   bool          `json:"allow_anonymous"`
+	RetentionPosture string        `json:"retention_posture"`
+	TrainingPosture  string        `json:"training_posture"`
+	AllowedSources   []SourceClass `json:"allowed_sources"`
+	SourceSince      string        `json:"source_since"`
+	SourceUntil      string        `json:"source_until"`
+	AllowSensitive   bool          `json:"allow_sensitive"`
+}
+
+// ApplyDefaults fills operational defaults without enabling inference.
+func (c *Config) ApplyDefaults() {
+	if c.Provider.Kind == "" {
+		c.Provider.Kind = ProviderOpenAICompatible
+	}
+	if c.Provider.Endpoint == "" {
+		c.Provider.Endpoint = "https://api.openai.com/v1"
+	}
+	if c.Provider.APIKeyEnv == "" && !c.Provider.AllowAnonymous {
+		c.Provider.APIKeyEnv = "OPENAI_API_KEY"
+	}
+	if c.Provider.RequestTimeout == 0 {
+		c.Provider.RequestTimeout = time.Minute
+	}
+}
+
+// Validate rejects unsafe or ambiguous runtime configuration. An incomplete
+// disabled policy is permitted, but any configured structural value must be
+// well formed.
+func (c Config) Validate() error {
+	if c.Provider.Kind != ProviderOpenAICompatible {
+		return fmt.Errorf("invalid [people.sweep.provider] kind %q", c.Provider.Kind)
+	}
+	if c.Provider.RequestTimeout <= 0 {
+		return fmt.Errorf("invalid [people.sweep.provider] request_timeout %s: must be positive",
+			c.Provider.RequestTimeout)
+	}
+	endpoint, loopback, err := validateEndpoint(c.Provider.Endpoint)
+	if err != nil {
+		return err
+	}
+	if c.Provider.APIKeyEnv != "" && !environmentNamePattern.MatchString(c.Provider.APIKeyEnv) {
+		return fmt.Errorf("invalid [people.sweep.provider] api_key_env %q", c.Provider.APIKeyEnv)
+	}
+	if !c.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(c.Provider.Model) == "" {
+		return errors.New("[people.sweep.provider] model is required when people sweep is enabled")
+	}
+	if c.Provider.AllowAnonymous {
+		if c.Provider.APIKeyEnv != "" {
+			return errors.New("[people.sweep.provider] anonymous mode cannot also configure api_key_env")
+		}
+		if !loopback {
+			return errors.New("[people.sweep.provider] anonymous mode requires a loopback endpoint")
+		}
+	} else if c.Provider.APIKeyEnv == "" {
+		return errors.New("[people.sweep.provider] api_key_env is required unless anonymous loopback mode is enabled")
+	}
+	if endpoint.Scheme == "http" && !loopback {
+		return errors.New("[people.sweep.provider] remote endpoint must use HTTPS")
+	}
+	if err := validatePosture("retention", c.Provider.RetentionPosture); err != nil {
+		return err
+	}
+	if err := validatePosture("training", c.Provider.TrainingPosture); err != nil {
+		return err
+	}
+	if err := validateSources(c.Provider.AllowedSources); err != nil {
+		return err
+	}
+	if err := validateDate("source_since", c.Provider.SourceSince, false); err != nil {
+		return err
+	}
+	if err := validateDate("source_until", c.Provider.SourceUntil, true); err != nil {
+		return err
+	}
+	if c.Provider.SourceUntil != "" && c.Provider.SourceUntil < c.Provider.SourceSince {
+		return errors.New("[people.sweep.provider] source_until is before source_since")
+	}
+	return nil
+}
+
+// Profile returns the canonical immutable policy for enabled configuration.
+func (c Config) Profile() (ProviderProfile, error) {
+	if !c.Enabled {
+		return ProviderProfile{}, errors.New("people sweep provider is disabled")
+	}
+	if err := c.Validate(); err != nil {
+		return ProviderProfile{}, err
+	}
+	endpoint, _, err := validateEndpoint(c.Provider.Endpoint)
+	if err != nil {
+		return ProviderProfile{}, err
+	}
+	sources := slices.Clone(c.Provider.AllowedSources)
+	slices.Sort(sources)
+	policy := providerPolicy{
+		Kind: c.Provider.Kind, Endpoint: canonicalEndpoint(endpoint),
+		Model: strings.TrimSpace(c.Provider.Model), APIKeyEnv: c.Provider.APIKeyEnv,
+		AllowAnonymous:   c.Provider.AllowAnonymous,
+		RetentionPosture: strings.TrimSpace(c.Provider.RetentionPosture),
+		TrainingPosture:  strings.TrimSpace(c.Provider.TrainingPosture),
+		AllowedSources:   sources, SourceSince: c.Provider.SourceSince,
+		SourceUntil: c.Provider.SourceUntil, AllowSensitive: c.Provider.AllowSensitive,
+	}
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return ProviderProfile{}, fmt.Errorf("encode people inference provider policy: %w", err)
+	}
+	digest := sha256.Sum256(policyJSON)
+	return ProviderProfile{
+		Fingerprint: hex.EncodeToString(digest[:]),
+		Kind:        policy.Kind, Endpoint: policy.Endpoint, Model: policy.Model,
+		APIKeyEnv: policy.APIKeyEnv, AllowAnonymous: policy.AllowAnonymous,
+		RetentionPosture: policy.RetentionPosture, TrainingPosture: policy.TrainingPosture,
+		AllowedSources: slices.Clone(policy.AllowedSources), SourceSince: policy.SourceSince,
+		SourceUntil: policy.SourceUntil, AllowSensitive: policy.AllowSensitive,
+		PolicyJSON: policyJSON,
+	}, nil
+}
+
+// Validate proves the profile fields, canonical policy bytes, and fingerprint
+// still describe exactly the same policy.
+func (p ProviderProfile) Validate() error {
+	config := Config{Enabled: true, Provider: ProviderConfig{
+		Kind: p.Kind, Endpoint: p.Endpoint, Model: p.Model, APIKeyEnv: p.APIKeyEnv,
+		AllowAnonymous: p.AllowAnonymous, RetentionPosture: p.RetentionPosture,
+		TrainingPosture: p.TrainingPosture, AllowedSources: slices.Clone(p.AllowedSources),
+		SourceSince: p.SourceSince, SourceUntil: p.SourceUntil,
+		AllowSensitive: p.AllowSensitive, RequestTimeout: time.Second,
+	}}
+	want, err := config.Profile()
+	if err != nil {
+		return err
+	}
+	if p.Fingerprint != want.Fingerprint {
+		return errors.New("people inference provider profile fingerprint does not match policy")
+	}
+	if !bytes.Equal(p.PolicyJSON, want.PolicyJSON) {
+		return errors.New("people inference provider profile policy is not canonical")
+	}
+	if p.Kind != want.Kind || p.Endpoint != want.Endpoint || p.Model != want.Model ||
+		p.APIKeyEnv != want.APIKeyEnv || p.AllowAnonymous != want.AllowAnonymous ||
+		p.RetentionPosture != want.RetentionPosture ||
+		p.TrainingPosture != want.TrainingPosture ||
+		!slices.Equal(p.AllowedSources, want.AllowedSources) ||
+		p.SourceSince != want.SourceSince || p.SourceUntil != want.SourceUntil ||
+		p.AllowSensitive != want.AllowSensitive {
+		return errors.New("people inference provider profile fields are not canonical")
+	}
+	return nil
+}
+
+func validateEndpoint(raw string) (*url.URL, bool, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, false, fmt.Errorf("invalid [people.sweep.provider] endpoint %q", raw)
+	}
+	if parsed.User != nil {
+		return nil, false, errors.New("[people.sweep.provider] endpoint must not contain credentials")
+	}
+	if parsed.RawQuery != "" {
+		return nil, false, errors.New("[people.sweep.provider] endpoint must not contain a query")
+	}
+	if parsed.Fragment != "" {
+		return nil, false, errors.New("[people.sweep.provider] endpoint must not contain a fragment")
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return nil, false, errors.New("[people.sweep.provider] endpoint must use HTTPS or loopback HTTP")
+	}
+	host := parsed.Hostname()
+	ip := net.ParseIP(host)
+	loopback := strings.EqualFold(host, "localhost") || (ip != nil && ip.IsLoopback())
+	if parsed.Scheme == "http" && !loopback {
+		return nil, false, errors.New("[people.sweep.provider] remote endpoint must use HTTPS")
+	}
+	return parsed, loopback, nil
+}
+
+func canonicalEndpoint(endpoint *url.URL) string {
+	canonical := *endpoint
+	canonical.Path = strings.TrimRight(canonical.Path, "/")
+	return canonical.String()
+}
+
+func validatePosture(name, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "unknown") {
+		return fmt.Errorf("[people.sweep.provider] %s_posture must be explicit", name)
+	}
+	return nil
+}
+
+func validateSources(sources []SourceClass) error {
+	if len(sources) == 0 {
+		return errors.New("[people.sweep.provider] allowed_sources must not be empty")
+	}
+	seen := make(map[SourceClass]struct{}, len(sources))
+	for _, source := range sources {
+		switch source {
+		case SourceConversationText, SourceMeetingText, SourceAttachmentCaption,
+			SourceAttachmentOCR, SourceDocumentText:
+		default:
+			return fmt.Errorf("[people.sweep.provider] allowed_sources contains %q", source)
+		}
+		if _, exists := seen[source]; exists {
+			return fmt.Errorf("[people.sweep.provider] allowed_sources contains duplicate %q", source)
+		}
+		seen[source] = struct{}{}
+	}
+	return nil
+}
+
+func validateDate(name, value string, optional bool) error {
+	if value == "" && optional {
+		return nil
+	}
+	parsed, err := time.Parse(time.DateOnly, value)
+	if err != nil || parsed.Format(time.DateOnly) != value {
+		return fmt.Errorf("[people.sweep.provider] %s must be YYYY-MM-DD", name)
+	}
+	return nil
+}

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -1,0 +1,250 @@
+package peoplesweep_test
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+)
+
+func validConfig() peoplesweep.Config {
+	return peoplesweep.Config{
+		Enabled: true,
+		Provider: peoplesweep.ProviderConfig{
+			Kind:             peoplesweep.ProviderOpenAICompatible,
+			Endpoint:         "https://api.example.test/v1/",
+			Model:            "gpt-test",
+			APIKeyEnv:        "TEST_KEY",
+			RetentionPosture: "zero_retention",
+			TrainingPosture:  "no_training",
+			AllowedSources: []peoplesweep.SourceClass{
+				peoplesweep.SourceMeetingText,
+				peoplesweep.SourceConversationText,
+			},
+			SourceSince:    "2025-01-01",
+			SourceUntil:    "2025-12-31",
+			RequestTimeout: 45 * time.Second,
+		},
+	}
+}
+
+func TestConfigDefaultsStayDisabled(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var config peoplesweep.Config
+	config.ApplyDefaults()
+
+	assert.False(config.Enabled)
+	assert.Equal(peoplesweep.ProviderOpenAICompatible, config.Provider.Kind)
+	assert.Equal("https://api.openai.com/v1", config.Provider.Endpoint)
+	assert.Equal("OPENAI_API_KEY", config.Provider.APIKeyEnv)
+	assert.Equal(time.Minute, config.Provider.RequestTimeout)
+	require.NoError(config.Validate())
+	_, err := config.Profile()
+	require.ErrorContains(err, "disabled")
+}
+
+func TestProviderProfileHasStableCanonicalPolicy(t *testing.T) {
+	assert := assert.New(t)
+	profile, err := validConfig().Profile()
+	require.NoError(t, err)
+
+	assert.Equal("https://api.example.test/v1", profile.Endpoint)
+	assert.Equal([]peoplesweep.SourceClass{
+		peoplesweep.SourceConversationText,
+		peoplesweep.SourceMeetingText,
+	}, profile.AllowedSources)
+	assert.JSONEq(`{
+		"kind":"openai_compatible",
+		"endpoint":"https://api.example.test/v1",
+		"model":"gpt-test",
+		"api_key_env":"TEST_KEY",
+		"allow_anonymous":false,
+		"retention_posture":"zero_retention",
+		"training_posture":"no_training",
+		"allowed_sources":["conversation_text","meeting_text"],
+		"source_since":"2025-01-01",
+		"source_until":"2025-12-31",
+		"allow_sensitive":false
+	}`, string(profile.PolicyJSON))
+	assert.Equal(
+		"6cdee4ab2dcc785c032067378de1121841725c602019c4046ec0ca3c32fdcb75",
+		profile.Fingerprint)
+	assert.NoError(profile.Validate())
+}
+
+func TestProviderProfileFingerprintCoversConsentPolicy(t *testing.T) {
+	base := validConfig()
+	want, err := base.Profile()
+	require.NoError(t, err)
+
+	mutations := []struct {
+		name   string
+		mutate func(*peoplesweep.Config)
+	}{
+		{"kind", func(c *peoplesweep.Config) { c.Provider.Kind = "other" }},
+		{"endpoint", func(c *peoplesweep.Config) { c.Provider.Endpoint = "https://other.example.test/v1" }},
+		{"model", func(c *peoplesweep.Config) { c.Provider.Model = "another-model" }},
+		{"key env", func(c *peoplesweep.Config) { c.Provider.APIKeyEnv = "OTHER_API_KEY" }},
+		{"anonymous", func(c *peoplesweep.Config) {
+			c.Provider.Endpoint = "http://127.0.0.1:11434/v1"
+			c.Provider.APIKeyEnv = ""
+			c.Provider.AllowAnonymous = true
+		}},
+		{"retention", func(c *peoplesweep.Config) { c.Provider.RetentionPosture = "provider_policy" }},
+		{"training", func(c *peoplesweep.Config) { c.Provider.TrainingPosture = "provider_policy" }},
+		{"sources", func(c *peoplesweep.Config) {
+			c.Provider.AllowedSources = append(c.Provider.AllowedSources, peoplesweep.SourceDocumentText)
+		}},
+		{"source since", func(c *peoplesweep.Config) { c.Provider.SourceSince = "2024-01-01" }},
+		{"source until", func(c *peoplesweep.Config) { c.Provider.SourceUntil = "2026-01-01" }},
+		{"sensitive", func(c *peoplesweep.Config) { c.Provider.AllowSensitive = true }},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			gotConfig := base
+			gotConfig.Provider.AllowedSources = slices.Clone(base.Provider.AllowedSources)
+			mutation.mutate(&gotConfig)
+			got, profileErr := gotConfig.Profile()
+			if mutation.name == "kind" {
+				require.Error(t, profileErr)
+				return
+			}
+			require.NoError(t, profileErr)
+			assert.NotEqual(t, want.Fingerprint, got.Fingerprint)
+		})
+	}
+
+	t.Run("source order is canonical", func(t *testing.T) {
+		reordered := base
+		reordered.Provider.AllowedSources = []peoplesweep.SourceClass{
+			peoplesweep.SourceConversationText,
+			peoplesweep.SourceMeetingText,
+		}
+		got, profileErr := reordered.Profile()
+		require.NoError(t, profileErr)
+		assert.Equal(t, want.Fingerprint, got.Fingerprint)
+	})
+
+	t.Run("timeout is operational", func(t *testing.T) {
+		changed := base
+		changed.Provider.RequestTimeout = 2 * time.Minute
+		got, profileErr := changed.Profile()
+		require.NoError(t, profileErr)
+		assert.Equal(t, want.Fingerprint, got.Fingerprint)
+	})
+}
+
+func TestProviderProfileValidateRejectsTampering(t *testing.T) {
+	profile, err := validConfig().Profile()
+	require.NoError(t, err)
+
+	changedField := profile
+	changedField.Model = "changed"
+	require.ErrorContains(t, changedField.Validate(), "fingerprint")
+
+	changedPolicy := profile
+	changedPolicy.PolicyJSON = []byte(`{"different":true}`)
+	require.ErrorContains(t, changedPolicy.Validate(), "policy")
+}
+
+func TestProviderProfileValidateRejectsNonCanonicalPublicFields(t *testing.T) {
+	profile, err := validConfig().Profile()
+	require.NoError(t, err)
+
+	mutations := []struct {
+		name   string
+		mutate func(*peoplesweep.ProviderProfile)
+	}{
+		{"endpoint slash", func(p *peoplesweep.ProviderProfile) { p.Endpoint += "/" }},
+		{"model whitespace", func(p *peoplesweep.ProviderProfile) { p.Model = " " + p.Model }},
+		{"retention whitespace", func(p *peoplesweep.ProviderProfile) { p.RetentionPosture += " " }},
+		{"training whitespace", func(p *peoplesweep.ProviderProfile) { p.TrainingPosture += " " }},
+		{"source order", func(p *peoplesweep.ProviderProfile) {
+			p.AllowedSources = []peoplesweep.SourceClass{
+				peoplesweep.SourceMeetingText,
+				peoplesweep.SourceConversationText,
+			}
+		}},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			changed := profile
+			changed.AllowedSources = slices.Clone(profile.AllowedSources)
+			mutation.mutate(&changed)
+			assert.ErrorContains(t, changed.Validate(), "canonical")
+		})
+	}
+}
+
+func TestConfigValidationRejectsUnsafeOrAmbiguousPolicies(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*peoplesweep.Config)
+		want   string
+	}{
+		{"missing model", func(c *peoplesweep.Config) { c.Provider.Model = "" }, "model"},
+		{"unsupported kind", func(c *peoplesweep.Config) { c.Provider.Kind = "other" }, "kind"},
+		{"remote http", func(c *peoplesweep.Config) { c.Provider.Endpoint = "http://api.example.test/v1" }, "HTTPS"},
+		{"URL credentials", func(c *peoplesweep.Config) { c.Provider.Endpoint = "https://user:pass@api.example.test/v1" }, "credentials"},
+		{"URL query", func(c *peoplesweep.Config) { c.Provider.Endpoint = "https://api.example.test/v1?x=1" }, "query"},
+		{"URL fragment", func(c *peoplesweep.Config) { c.Provider.Endpoint = "https://api.example.test/v1#x" }, "fragment"},
+		{"invalid key env", func(c *peoplesweep.Config) { c.Provider.APIKeyEnv = "bad-name" }, "api_key_env"},
+		{"missing auth", func(c *peoplesweep.Config) { c.Provider.APIKeyEnv = "" }, "anonymous"},
+		{"anonymous remote", func(c *peoplesweep.Config) {
+			c.Provider.APIKeyEnv = ""
+			c.Provider.AllowAnonymous = true
+		}, "loopback"},
+		{"missing retention", func(c *peoplesweep.Config) { c.Provider.RetentionPosture = "" }, "retention"},
+		{"unknown retention", func(c *peoplesweep.Config) { c.Provider.RetentionPosture = "unknown" }, "retention"},
+		{"missing training", func(c *peoplesweep.Config) { c.Provider.TrainingPosture = "" }, "training"},
+		{"unknown training", func(c *peoplesweep.Config) { c.Provider.TrainingPosture = "unknown" }, "training"},
+		{"missing sources", func(c *peoplesweep.Config) { c.Provider.AllowedSources = nil }, "allowed_sources"},
+		{"unknown source", func(c *peoplesweep.Config) {
+			c.Provider.AllowedSources = []peoplesweep.SourceClass{"raw_image"}
+		}, "allowed_sources"},
+		{"duplicate source", func(c *peoplesweep.Config) {
+			c.Provider.AllowedSources = []peoplesweep.SourceClass{
+				peoplesweep.SourceConversationText,
+				peoplesweep.SourceConversationText,
+			}
+		}, "duplicate"},
+		{"missing start", func(c *peoplesweep.Config) { c.Provider.SourceSince = "" }, "source_since"},
+		{"invalid start", func(c *peoplesweep.Config) { c.Provider.SourceSince = "2025-02-30" }, "source_since"},
+		{"invalid end", func(c *peoplesweep.Config) { c.Provider.SourceUntil = "tomorrow" }, "source_until"},
+		{"reversed dates", func(c *peoplesweep.Config) { c.Provider.SourceUntil = "2024-12-31" }, "before"},
+		{"zero timeout", func(c *peoplesweep.Config) { c.Provider.RequestTimeout = 0 }, "request_timeout"},
+		{"negative timeout", func(c *peoplesweep.Config) { c.Provider.RequestTimeout = -time.Second }, "request_timeout"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := validConfig()
+			test.mutate(&config)
+			_, err := config.Profile()
+			assert.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestConfigAllowsExplicitAnonymousLoopback(t *testing.T) {
+	for _, endpoint := range []string{
+		"http://127.0.0.1:11434/v1",
+		"http://[::1]:11434/v1",
+		"http://localhost:11434/v1",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			config := validConfig()
+			config.Provider.Endpoint = endpoint
+			config.Provider.APIKeyEnv = ""
+			config.Provider.AllowAnonymous = true
+
+			profile, err := config.Profile()
+			require.NoError(t, err)
+			assert.True(t, profile.AllowAnonymous)
+			assert.Empty(t, profile.APIKeyEnv)
+		})
+	}
+}

--- a/internal/peoplesweep/openai_compatible.go
+++ b/internal/peoplesweep/openai_compatible.go
@@ -1,0 +1,185 @@
+package peoplesweep
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	structuredSystemInstruction = "Return one JSON value that strictly matches the supplied JSON Schema."
+	maxProviderResponseBytes    = 1 << 20
+)
+
+// OpenAICompatibleTransport implements strict JSON Schema output over the
+// OpenAI-compatible Chat Completions protocol.
+type OpenAICompatibleTransport struct {
+	httpClient *http.Client
+}
+
+// NewOpenAICompatibleTransport constructs a network adapter. A nil client uses
+// http.DefaultClient; the gated runner supplies the request timeout via context.
+func NewOpenAICompatibleTransport(client *http.Client) *OpenAICompatibleTransport {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	isolated := *client
+	isolated.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &OpenAICompatibleTransport{httpClient: &isolated}
+}
+
+type chatCompletionsRequest struct {
+	Model               string                  `json:"model"`
+	Messages            []chatCompletionMessage `json:"messages"`
+	ResponseFormat      chatCompletionFormat    `json:"response_format"`
+	MaxCompletionTokens int                     `json:"max_completion_tokens"`
+}
+
+type chatCompletionMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatCompletionFormat struct {
+	Type       string                   `json:"type"`
+	JSONSchema chatCompletionJSONSchema `json:"json_schema"`
+}
+
+type chatCompletionJSONSchema struct {
+	Name   string          `json:"name"`
+	Strict bool            `json:"strict"`
+	Schema json.RawMessage `json:"schema"`
+}
+
+type chatCompletionsResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// GenerateJSON performs one request without retries and returns parsed JSON.
+// Consent, source policy, credential lookup, timeout, and schema validation are
+// owned by Runner.
+func (t *OpenAICompatibleTransport) GenerateJSON(
+	ctx context.Context,
+	profile ProviderProfile,
+	credential string,
+	request StructuredRequest,
+) (StructuredResponse, error) {
+	if err := profile.Validate(); err != nil {
+		return StructuredResponse{}, err
+	}
+	if profile.APIKeyEnv != "" && credential == "" {
+		return StructuredResponse{}, errors.New("inference provider credential is empty")
+	}
+	payload, err := json.Marshal(chatCompletionsRequest{
+		Model: profile.Model,
+		Messages: []chatCompletionMessage{
+			{Role: "system", Content: structuredSystemInstruction},
+			{Role: "user", Content: request.InputText},
+		},
+		ResponseFormat: chatCompletionFormat{
+			Type: "json_schema",
+			JSONSchema: chatCompletionJSONSchema{
+				Name: request.SchemaName, Strict: true, Schema: request.JSONSchema,
+			},
+		},
+		MaxCompletionTokens: request.MaxOutputTokens,
+	})
+	if err != nil {
+		return StructuredResponse{}, errors.New("encode inference provider request")
+	}
+	target := strings.TrimRight(profile.Endpoint, "/") + "/chat/completions"
+	httpRequest, err := http.NewRequestWithContext( // #nosec G704 -- exact operator-configured endpoint validated by ProviderProfile.
+		ctx, http.MethodPost, target, bytes.NewReader(payload))
+	if err != nil {
+		return StructuredResponse{}, fmt.Errorf("create inference provider request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	if credential != "" {
+		httpRequest.Header.Set("Authorization", "Bearer "+credential)
+	}
+
+	response, err := t.httpClient.Do(httpRequest)
+	if err != nil {
+		return StructuredResponse{}, fmt.Errorf("call inference provider: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	requestID := response.Header.Get("x-request-id")
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 32<<10))
+		return StructuredResponse{}, &ProviderError{
+			StatusCode: response.StatusCode,
+			RequestID:  requestID,
+		}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxProviderResponseBytes+1))
+	if err != nil {
+		return StructuredResponse{}, fmt.Errorf("read inference provider response: %w", err)
+	}
+	if len(body) > maxProviderResponseBytes {
+		return StructuredResponse{}, errors.New("inference provider response is too large")
+	}
+	var envelope chatCompletionsResponse
+	if err := decodeSingleJSON(body, &envelope); err != nil {
+		return StructuredResponse{}, errors.New("decode inference provider response")
+	}
+	if len(envelope.Choices) == 0 || strings.TrimSpace(envelope.Choices[0].Message.Content) == "" {
+		return StructuredResponse{}, errors.New("inference provider response has no structured content")
+	}
+	content := []byte(envelope.Choices[0].Message.Content)
+	var decoded any
+	if err := decodeSingleJSONUseNumber(content, &decoded); err != nil {
+		return StructuredResponse{}, errors.New("inference provider returned invalid structured JSON")
+	}
+	return StructuredResponse{
+		Output:            json.RawMessage(append([]byte(nil), content...)),
+		ProviderRequestID: requestID,
+		Usage: TokenUsage{
+			InputTokens:  envelope.Usage.PromptTokens,
+			OutputTokens: envelope.Usage.CompletionTokens,
+		},
+	}, nil
+}
+
+func decodeSingleJSON(data []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	return requireJSONEOF(decoder)
+}
+
+func decodeSingleJSONUseNumber(data []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	return requireJSONEOF(decoder)
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/peoplesweep/openai_compatible_test.go
+++ b/internal/peoplesweep/openai_compatible_test.go
@@ -1,0 +1,292 @@
+package peoplesweep_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+)
+
+type capturedChatRequest struct {
+	Model               string                 `json:"model"`
+	Messages            []capturedChatMessage  `json:"messages"`
+	ResponseFormat      capturedResponseFormat `json:"response_format"`
+	MaxCompletionTokens int                    `json:"max_completion_tokens"`
+	MaxTokens           *int                   `json:"max_tokens"`
+}
+
+type capturedChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type capturedResponseFormat struct {
+	Type       string             `json:"type"`
+	JSONSchema capturedJSONSchema `json:"json_schema"`
+}
+
+type capturedJSONSchema struct {
+	Name   string          `json:"name"`
+	Strict bool            `json:"strict"`
+	Schema json.RawMessage `json:"schema"`
+}
+
+func providerTestProfile(t *testing.T, endpoint string, anonymous bool) peoplesweep.ProviderProfile {
+	t.Helper()
+	apiKeyEnv := "TEST_KEY"
+	if anonymous {
+		apiKeyEnv = ""
+	}
+	profile, err := (peoplesweep.Config{
+		Enabled: true,
+		Provider: peoplesweep.ProviderConfig{
+			Kind:             peoplesweep.ProviderOpenAICompatible,
+			Endpoint:         endpoint,
+			Model:            "gpt-test",
+			APIKeyEnv:        apiKeyEnv,
+			AllowAnonymous:   anonymous,
+			RetentionPosture: "zero_retention",
+			TrainingPosture:  "no_training",
+			AllowedSources: []peoplesweep.SourceClass{
+				peoplesweep.SourceConversationText,
+			},
+			SourceSince:    "2025-01-01",
+			RequestTimeout: time.Minute,
+		},
+	}).Profile()
+	require.NoError(t, err)
+	return profile
+}
+
+func structuredTestRequest() peoplesweep.StructuredRequest {
+	return peoplesweep.StructuredRequest{
+		ProgramID: "person-facts", ProgramVersion: "1.0.0",
+		Sources: []peoplesweep.SourceDescriptor{{
+			Class: peoplesweep.SourceConversationText, ObservedOn: "2025-08-20",
+		}},
+		InputText:       "Synthetic input only.",
+		SchemaName:      "person_facts",
+		JSONSchema:      json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean","const":true}},"required":["ok"],"additionalProperties":false}`),
+		MaxOutputTokens: 32,
+	}
+}
+
+func TestOpenAICompatibleTransportGeneratesStructuredJSON(t *testing.T) {
+	assert := assert.New(t)
+	var captured capturedChatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/v1/chat/completions", r.URL.Path)
+		assert.Equal("application/json", r.Header.Get("Content-Type"))
+		assert.Equal("Bearer test-key", r.Header.Get("Authorization"))
+		assert.NoError(json.NewDecoder(r.Body).Decode(&captured))
+		w.Header().Set("x-request-id", "req-1")
+		_, err := io.WriteString(w,
+			`{"choices":[{"message":{"role":"assistant","content":"{\"ok\":true}"},"finish_reason":"stop"}],`+
+				`"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}`)
+		assert.NoError(err)
+	}))
+	defer server.Close()
+
+	request := structuredTestRequest()
+	got, err := peoplesweep.NewOpenAICompatibleTransport(server.Client()).GenerateJSON(
+		t.Context(), providerTestProfile(t, server.URL+"/v1", false),
+		"test-key", request,
+	)
+	require.NoError(t, err)
+	assert.JSONEq(`{"ok":true}`, string(got.Output))
+	assert.Equal("req-1", got.ProviderRequestID)
+	assert.Equal(int64(7), got.Usage.InputTokens)
+	assert.Equal(int64(3), got.Usage.OutputTokens)
+
+	assert.Equal("gpt-test", captured.Model)
+	assert.Equal(32, captured.MaxCompletionTokens)
+	assert.Nil(captured.MaxTokens, "deprecated max_tokens must not be sent")
+	require.Len(t, captured.Messages, 2)
+	assert.Equal("system", captured.Messages[0].Role)
+	assert.Equal("Return one JSON value that strictly matches the supplied JSON Schema.",
+		captured.Messages[0].Content)
+	assert.Equal("user", captured.Messages[1].Role)
+	assert.Equal(request.InputText, captured.Messages[1].Content)
+	assert.Equal("json_schema", captured.ResponseFormat.Type)
+	assert.Equal(request.SchemaName, captured.ResponseFormat.JSONSchema.Name)
+	assert.True(captured.ResponseFormat.JSONSchema.Strict)
+	assert.JSONEq(string(request.JSONSchema),
+		string(captured.ResponseFormat.JSONSchema.Schema))
+}
+
+func TestOpenAICompatibleTransportOmitsAuthorizationForAnonymousLoopback(t *testing.T) {
+	var authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		_, err := io.WriteString(w,
+			`{"choices":[{"message":{"content":"{\"ok\":true}"}}],"usage":{}}`)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	_, err := peoplesweep.NewOpenAICompatibleTransport(server.Client()).GenerateJSON(
+		t.Context(), providerTestProfile(t, server.URL+"/v1", true),
+		"", structuredTestRequest(),
+	)
+	require.NoError(t, err)
+	assert.Empty(t, authorization)
+}
+
+func TestOpenAICompatibleTransportSanitizesHTTPFailures(t *testing.T) {
+	for _, status := range []int{
+		http.StatusUnauthorized,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			assert := assert.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("x-request-id", "req-secret-safe")
+				w.WriteHeader(status)
+				_, err := io.WriteString(w, `{"error":{"message":"provider-secret-body"}}`)
+				assert.NoError(err)
+			}))
+			defer server.Close()
+
+			_, err := peoplesweep.NewOpenAICompatibleTransport(server.Client()).GenerateJSON(
+				t.Context(), providerTestProfile(t, server.URL+"/v1", false),
+				"test-key", structuredTestRequest(),
+			)
+			require.Error(t, err)
+			var providerErr *peoplesweep.ProviderError
+			require.ErrorAs(t, err, &providerErr)
+			assert.Equal(status, providerErr.StatusCode)
+			assert.Equal("req-secret-safe", providerErr.RequestID)
+			assert.NotContains(err.Error(), "provider-secret-body")
+			assert.NotContains(err.Error(), "test-key")
+		})
+	}
+}
+
+func TestOpenAICompatibleTransportDoesNotFollowRedirects(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var redirectedRequests atomic.Int64
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		_, err := io.WriteString(w,
+			`{"choices":[{"message":{"content":"{\"ok\":true}"}}],"usage":{}}`)
+		assert.NoError(err)
+	}))
+	defer target.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", target.URL+"/capture")
+		w.Header().Set("x-request-id", "redirect-req")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	_, err := peoplesweep.NewOpenAICompatibleTransport(origin.Client()).GenerateJSON(
+		t.Context(), providerTestProfile(t, origin.URL+"/v1", false),
+		"test-key", structuredTestRequest(),
+	)
+	require.Error(err)
+	var providerErr *peoplesweep.ProviderError
+	require.ErrorAs(err, &providerErr)
+	assert.Equal(http.StatusTemporaryRedirect, providerErr.StatusCode)
+	assert.Equal("redirect-req", providerErr.RequestID)
+	assert.Zero(redirectedRequests.Load(), "redirect target must receive no provider request")
+}
+
+func TestOpenAICompatibleTransportRejectsMalformedResponsesWithoutEchoingThem(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"invalid envelope", `{provider-secret-body`},
+		{"missing choices", `{"choices":[],"secret":"provider-secret-body"}`},
+		{"empty content", `{"choices":[{"message":{"content":""}}],"secret":"provider-secret-body"}`},
+		{"invalid content JSON", `{"choices":[{"message":{"content":"provider-secret-body"}}]}`},
+		{"trailing content JSON", `{"choices":[{"message":{"content":"{\"ok\":true} provider-secret-body"}}]}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, err := io.WriteString(w, test.body)
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+
+			_, err := peoplesweep.NewOpenAICompatibleTransport(server.Client()).GenerateJSON(
+				t.Context(), providerTestProfile(t, server.URL+"/v1", false),
+				"test-key", structuredTestRequest(),
+			)
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "provider-secret-body")
+			assert.NotContains(t, err.Error(), "test-key")
+		})
+	}
+}
+
+func TestOpenAICompatibleTransportBoundsResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := io.WriteString(w, strings.Repeat("x", (1<<20)+1))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	_, err := peoplesweep.NewOpenAICompatibleTransport(server.Client()).GenerateJSON(
+		t.Context(), providerTestProfile(t, server.URL+"/v1", false),
+		"test-key", structuredTestRequest(),
+	)
+	require.ErrorContains(t, err, "too large")
+	assert.NotContains(t, err.Error(), strings.Repeat("x", 100))
+}
+
+func TestOpenAICompatibleTransportHonorsCancellationAndClientTimeout(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var requests atomic.Int64
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer func() {
+		close(release)
+		server.Close()
+	}()
+	profile := providerTestProfile(t, server.URL+"/v1", false)
+
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := peoplesweep.NewOpenAICompatibleTransport(server.Client()).GenerateJSON(
+		cancelled, profile, "test-key", structuredTestRequest(),
+	)
+	require.ErrorIs(err, context.Canceled)
+	assert.Zero(requests.Load())
+
+	timeoutClient := server.Client()
+	timeoutClient.Timeout = 100 * time.Millisecond
+	_, err = peoplesweep.NewOpenAICompatibleTransport(timeoutClient).GenerateJSON(
+		t.Context(), profile, "test-key", structuredTestRequest(),
+	)
+	require.Error(err)
+	assert.Truef(
+		errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timeout"),
+		"timeout error = %T: %v", err, err)
+	assert.Equal(int64(1), requests.Load())
+}

--- a/internal/peoplesweep/provider.go
+++ b/internal/peoplesweep/provider.go
@@ -1,0 +1,72 @@
+package peoplesweep
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// SourceDescriptor records the policy-relevant class and calendar date for one
+// text source included in a structured request.
+type SourceDescriptor struct {
+	Class      SourceClass `json:"class"`
+	ObservedOn string      `json:"observed_on"`
+}
+
+// StructuredRequest is the text-only provider-neutral inference contract.
+type StructuredRequest struct {
+	ProgramID         string             `json:"program_id"`
+	ProgramVersion    string             `json:"program_version"`
+	Sources           []SourceDescriptor `json:"sources"`
+	ContainsSensitive bool               `json:"contains_sensitive"`
+	InputText         string             `json:"input_text"`
+	SchemaName        string             `json:"schema_name"`
+	JSONSchema        json.RawMessage    `json:"json_schema"`
+	MaxOutputTokens   int                `json:"max_output_tokens"`
+}
+
+// TokenUsage is provider-reported accounting. It is not trusted as a privacy
+// or budget boundary on its own.
+type TokenUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+}
+
+// StructuredResponse contains only parsed JSON and safe provider metadata.
+type StructuredResponse struct {
+	Output            json.RawMessage `json:"output"`
+	ProviderRequestID string          `json:"provider_request_id,omitempty"`
+	Usage             TokenUsage      `json:"usage"`
+}
+
+// StructuredTransport is the network-only adapter boundary. Callers must use
+// Runner rather than invoke a transport directly outside this package.
+type StructuredTransport interface {
+	GenerateJSON(
+		ctx context.Context,
+		profile ProviderProfile,
+		credential string,
+		request StructuredRequest,
+	) (StructuredResponse, error)
+}
+
+// StructuredRunner is the consent-gated entry point later people-sweep
+// programs consume.
+type StructuredRunner interface {
+	RunStructured(ctx context.Context, request StructuredRequest) (StructuredResponse, error)
+}
+
+// ProviderError exposes only response status and a safe provider request ID.
+// Provider response bodies are intentionally discarded.
+type ProviderError struct {
+	StatusCode int
+	RequestID  string
+}
+
+func (e *ProviderError) Error() string {
+	if e.RequestID == "" {
+		return fmt.Sprintf("inference provider returned HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("inference provider returned HTTP %d (request_id=%s)",
+		e.StatusCode, e.RequestID)
+}

--- a/internal/peoplesweep/runner.go
+++ b/internal/peoplesweep/runner.go
@@ -1,0 +1,223 @@
+package peoplesweep
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+const (
+	maxStructuredInputBytes   = 128 << 10
+	maxStructuredSchemaBytes  = 64 << 10
+	maxStructuredOutputTokens = 32_768
+)
+
+var (
+	programComponentPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+	schemaNamePattern       = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+)
+
+var syntheticCheckSchema = json.RawMessage(`{
+	"type":"object",
+	"properties":{"ok":{"type":"boolean","const":true}},
+	"required":["ok"],
+	"additionalProperties":false
+}`)
+
+// ConsentChecker is the runner's complete store dependency. It cannot read
+// messages, attachments, or any other archive content.
+type ConsentChecker interface {
+	HasActivePersonInferenceConsent(ctx context.Context, fingerprint string) (bool, error)
+}
+
+// CredentialLookup resolves exactly one configured environment-variable name.
+type CredentialLookup func(string) (string, bool)
+
+// Runner enforces request, exact-consent, source, credential, and output-schema
+// policy around one structured transport.
+type Runner struct {
+	config    Config
+	consent   ConsentChecker
+	transport StructuredTransport
+	lookup    CredentialLookup
+}
+
+// NewRunner creates a gated runner without resolving a credential or touching
+// the network.
+func NewRunner(
+	config Config,
+	consent ConsentChecker,
+	transport StructuredTransport,
+	lookup CredentialLookup,
+) (*Runner, error) {
+	if consent == nil {
+		return nil, errors.New("people inference runner requires a consent checker")
+	}
+	if transport == nil {
+		return nil, errors.New("people inference runner requires a transport")
+	}
+	if lookup == nil {
+		return nil, errors.New("people inference runner requires a credential lookup")
+	}
+	config.Provider.AllowedSources = slices.Clone(config.Provider.AllowedSources)
+	return &Runner{
+		config: config, consent: consent, transport: transport, lookup: lookup,
+	}, nil
+}
+
+// RunStructured performs one normal text-only request. Normal requests must
+// carry at least one source descriptor.
+func (r *Runner) RunStructured(
+	ctx context.Context,
+	request StructuredRequest,
+) (StructuredResponse, error) {
+	return r.run(ctx, request, false)
+}
+
+// Check exercises the real provider boundary with package-owned synthetic
+// input. It cannot accept archive text or source selectors.
+func (r *Runner) Check(ctx context.Context) (StructuredResponse, error) {
+	return r.run(ctx, StructuredRequest{
+		ProgramID: "provider-check", ProgramVersion: "1",
+		InputText:  "Return an object with ok set to true.",
+		SchemaName: "provider_check", JSONSchema: slices.Clone(syntheticCheckSchema),
+		MaxOutputTokens: 16,
+	}, true)
+}
+
+func (r *Runner) run(
+	ctx context.Context,
+	request StructuredRequest,
+	synthetic bool,
+) (StructuredResponse, error) {
+	resolvedSchema, err := validateStructuredRequest(request, synthetic)
+	if err != nil {
+		return StructuredResponse{}, err
+	}
+	profile, err := r.config.Profile()
+	if err != nil {
+		return StructuredResponse{}, err
+	}
+	active, err := r.consent.HasActivePersonInferenceConsent(ctx, profile.Fingerprint)
+	if err != nil {
+		return StructuredResponse{}, fmt.Errorf("check exact people inference consent: %w", err)
+	}
+	if !active {
+		return StructuredResponse{}, errors.New("people inference requires active exact consent")
+	}
+	if err := validateRequestPolicy(request, profile, synthetic); err != nil {
+		return StructuredResponse{}, err
+	}
+
+	credential := ""
+	if profile.APIKeyEnv != "" {
+		value, ok := r.lookup(profile.APIKeyEnv)
+		if !ok || value == "" {
+			return StructuredResponse{}, fmt.Errorf(
+				"inference credential environment variable %s is not set",
+				profile.APIKeyEnv)
+		}
+		credential = value
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, r.config.Provider.RequestTimeout)
+	defer cancel()
+	response, err := r.transport.GenerateJSON(requestCtx, profile, credential, request)
+	if err != nil {
+		return StructuredResponse{}, fmt.Errorf("generate structured inference: %w", err)
+	}
+	var output any
+	if err := decodeSingleJSONUseNumber(response.Output, &output); err != nil {
+		return StructuredResponse{}, errors.New("inference provider returned invalid structured JSON")
+	}
+	if err := resolvedSchema.Validate(output); err != nil {
+		return StructuredResponse{}, errors.New("inference provider output does not match requested schema")
+	}
+	return response, nil
+}
+
+func validateStructuredRequest(
+	request StructuredRequest,
+	synthetic bool,
+) (*jsonschema.Resolved, error) {
+	if !programComponentPattern.MatchString(request.ProgramID) {
+		return nil, errors.New("structured inference program_id is invalid")
+	}
+	if !programComponentPattern.MatchString(request.ProgramVersion) {
+		return nil, errors.New("structured inference program_version is invalid")
+	}
+	if !schemaNamePattern.MatchString(request.SchemaName) {
+		return nil, errors.New("structured inference schema_name is invalid")
+	}
+	if request.InputText == "" || !utf8.ValidString(request.InputText) ||
+		len(request.InputText) > maxStructuredInputBytes {
+		return nil, errors.New("structured inference input_text must be valid UTF-8 from 1 through 131072 bytes")
+	}
+	if len(request.JSONSchema) == 0 || len(request.JSONSchema) > maxStructuredSchemaBytes {
+		return nil, errors.New("structured inference JSON Schema must be from 1 through 65536 bytes")
+	}
+	if request.MaxOutputTokens < 1 || request.MaxOutputTokens > maxStructuredOutputTokens {
+		return nil, errors.New("structured inference max_output_tokens must be from 1 through 32768")
+	}
+	if !synthetic && len(request.Sources) == 0 {
+		return nil, errors.New("structured inference requires at least one source")
+	}
+	for _, source := range request.Sources {
+		if err := validateObservedOn(source.ObservedOn); err != nil {
+			return nil, err
+		}
+	}
+	var schema jsonschema.Schema
+	if err := decodeSingleJSON(request.JSONSchema, &schema); err != nil {
+		return nil, errors.New("structured inference JSON Schema is invalid")
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		return nil, errors.New("structured inference JSON Schema cannot be resolved")
+	}
+	return resolved, nil
+}
+
+func validateRequestPolicy(
+	request StructuredRequest,
+	profile ProviderProfile,
+	synthetic bool,
+) error {
+	if synthetic {
+		if len(request.Sources) != 0 || request.ContainsSensitive {
+			return errors.New("synthetic inference check cannot include archive sources or sensitive content")
+		}
+		return nil
+	}
+	if request.ContainsSensitive && !profile.AllowSensitive {
+		return errors.New("people inference profile does not allow sensitive input")
+	}
+	for _, source := range request.Sources {
+		if !slices.Contains(profile.AllowedSources, source.Class) {
+			return fmt.Errorf("people inference source class %q is not allowed", source.Class)
+		}
+		if source.ObservedOn < profile.SourceSince ||
+			(profile.SourceUntil != "" && source.ObservedOn > profile.SourceUntil) {
+			return fmt.Errorf("people inference source date %s is outside the consented date range",
+				source.ObservedOn)
+		}
+	}
+	return nil
+}
+
+func validateObservedOn(value string) error {
+	parsed, err := time.Parse(time.DateOnly, value)
+	if err != nil || parsed.Format(time.DateOnly) != value {
+		return fmt.Errorf("structured inference source observed_on %q must be YYYY-MM-DD", value)
+	}
+	return nil
+}
+
+var _ StructuredRunner = (*Runner)(nil)

--- a/internal/peoplesweep/runner_test.go
+++ b/internal/peoplesweep/runner_test.go
@@ -1,0 +1,403 @@
+package peoplesweep_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+)
+
+type countingConsent struct {
+	active bool
+	err    error
+	calls  atomic.Int64
+	order  func(string)
+}
+
+func (c *countingConsent) HasActivePersonInferenceConsent(
+	_ context.Context,
+	_ string,
+) (bool, error) {
+	c.calls.Add(1)
+	if c.order != nil {
+		c.order("consent")
+	}
+	return c.active, c.err
+}
+
+type countingTransport struct {
+	response peoplesweep.StructuredResponse
+	err      error
+	calls    atomic.Int64
+	order    func(string)
+	mu       sync.Mutex
+	request  peoplesweep.StructuredRequest
+	profile  peoplesweep.ProviderProfile
+	key      string
+}
+
+func (t *countingTransport) GenerateJSON(
+	_ context.Context,
+	profile peoplesweep.ProviderProfile,
+	key string,
+	request peoplesweep.StructuredRequest,
+) (peoplesweep.StructuredResponse, error) {
+	t.calls.Add(1)
+	if t.order != nil {
+		t.order("transport")
+	}
+	t.mu.Lock()
+	t.request = request
+	t.profile = profile
+	t.key = key
+	t.mu.Unlock()
+	return t.response, t.err
+}
+
+func runnerTestConfig() peoplesweep.Config {
+	config := validConfig()
+	config.Provider.AllowedSources = []peoplesweep.SourceClass{
+		peoplesweep.SourceConversationText,
+		peoplesweep.SourceMeetingText,
+	}
+	return config
+}
+
+func TestRunnerCallsConsentCredentialAndTransportInOrder(t *testing.T) {
+	assert := assert.New(t)
+	var mu sync.Mutex
+	var order []string
+	record := func(step string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, step)
+	}
+	consent := &countingConsent{active: true, order: record}
+	transport := &countingTransport{
+		response: peoplesweep.StructuredResponse{Output: json.RawMessage(`{"ok":true}`)},
+		order:    record,
+	}
+	runner, err := peoplesweep.NewRunner(
+		runnerTestConfig(), consent, transport,
+		func(name string) (string, bool) {
+			record("credential")
+			assert.Equal("TEST_KEY", name)
+			return "test-key", true
+		},
+	)
+	require.NoError(t, err)
+
+	got, err := runner.RunStructured(t.Context(), structuredTestRequest())
+	require.NoError(t, err)
+	assert.JSONEq(`{"ok":true}`, string(got.Output))
+	assert.Equal([]string{"consent", "credential", "transport"}, order)
+	assert.Equal(int64(1), consent.calls.Load())
+	assert.Equal(int64(1), transport.calls.Load())
+	assert.Equal("test-key", transport.key)
+}
+
+func TestRunnerFailsClosedBeforeCredentialOrTransport(t *testing.T) {
+	baseRequest := structuredTestRequest()
+	tests := []struct {
+		name           string
+		config         peoplesweep.Config
+		request        peoplesweep.StructuredRequest
+		consented      bool
+		wantConsent    int64
+		wantCredential int64
+		want           string
+	}{
+		{
+			name: "invalid request", config: runnerTestConfig(), consented: true,
+			request: func() peoplesweep.StructuredRequest {
+				request := baseRequest
+				request.ProgramID = ""
+				return request
+			}(),
+			want: "program_id",
+		},
+		{
+			name: "disabled", config: func() peoplesweep.Config {
+				config := runnerTestConfig()
+				config.Enabled = false
+				return config
+			}(),
+			request: baseRequest, consented: true, want: "disabled",
+		},
+		{
+			name: "missing consent", config: runnerTestConfig(), request: baseRequest,
+			wantConsent: 1, want: "exact consent",
+		},
+		{
+			name: "source class", config: runnerTestConfig(), consented: true,
+			request: func() peoplesweep.StructuredRequest {
+				request := baseRequest
+				request.Sources = []peoplesweep.SourceDescriptor{{
+					Class: peoplesweep.SourceDocumentText, ObservedOn: "2025-08-20",
+				}}
+				return request
+			}(),
+			wantConsent: 1, want: "source class",
+		},
+		{
+			name: "before date", config: runnerTestConfig(), consented: true,
+			request: func() peoplesweep.StructuredRequest {
+				request := baseRequest
+				request.Sources = []peoplesweep.SourceDescriptor{{
+					Class: peoplesweep.SourceConversationText, ObservedOn: "2024-12-31",
+				}}
+				return request
+			}(),
+			wantConsent: 1, want: "date range",
+		},
+		{
+			name: "after date", config: runnerTestConfig(), consented: true,
+			request: func() peoplesweep.StructuredRequest {
+				request := baseRequest
+				request.Sources = []peoplesweep.SourceDescriptor{{
+					Class: peoplesweep.SourceConversationText, ObservedOn: "2026-01-01",
+				}}
+				return request
+			}(),
+			wantConsent: 1, want: "date range",
+		},
+		{
+			name: "sensitive", config: runnerTestConfig(), consented: true,
+			request: func() peoplesweep.StructuredRequest {
+				request := baseRequest
+				request.ContainsSensitive = true
+				return request
+			}(),
+			wantConsent: 1, want: "sensitive",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			consent := &countingConsent{active: test.consented}
+			transport := &countingTransport{}
+			var credentialCalls atomic.Int64
+			runner, err := peoplesweep.NewRunner(
+				test.config, consent, transport,
+				func(string) (string, bool) {
+					credentialCalls.Add(1)
+					return "test-key", true
+				},
+			)
+			require.NoError(t, err)
+
+			_, err = runner.RunStructured(t.Context(), test.request)
+			require.ErrorContains(t, err, test.want)
+			assert.Equal(test.wantConsent, consent.calls.Load())
+			assert.Equal(test.wantCredential, credentialCalls.Load())
+			assert.Zero(transport.calls.Load())
+		})
+	}
+}
+
+func TestRunnerMissingCredentialDoesNotCallTransport(t *testing.T) {
+	assert := assert.New(t)
+	consent := &countingConsent{active: true}
+	transport := &countingTransport{}
+	var credentialCalls atomic.Int64
+	runner, err := peoplesweep.NewRunner(
+		runnerTestConfig(), consent, transport,
+		func(name string) (string, bool) {
+			credentialCalls.Add(1)
+			assert.Equal("TEST_KEY", name)
+			return "", false
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = runner.RunStructured(t.Context(), structuredTestRequest())
+	require.ErrorContains(t, err, "TEST_KEY")
+	assert.Equal(int64(1), consent.calls.Load())
+	assert.Equal(int64(1), credentialCalls.Load())
+	assert.Zero(transport.calls.Load())
+}
+
+func TestRunnerValidatesRequestAndOutputSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  func() peoplesweep.StructuredRequest
+		output   string
+		wantCall bool
+		want     string
+	}{
+		{
+			name: "invalid schema", request: func() peoplesweep.StructuredRequest {
+				request := structuredTestRequest()
+				request.JSONSchema = json.RawMessage(`{"type":`)
+				return request
+			},
+			output: `{"ok":true}`, want: "JSON Schema",
+		},
+		{
+			name: "schema mismatch", request: structuredTestRequest,
+			output: `{"ok":false}`, wantCall: true, want: "does not match",
+		},
+		{
+			name: "trailing output", request: structuredTestRequest,
+			output:   `{"ok":true} {"secret":"provider-output"}`,
+			wantCall: true, want: "invalid structured JSON",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			consent := &countingConsent{active: true}
+			transport := &countingTransport{response: peoplesweep.StructuredResponse{
+				Output: json.RawMessage(test.output),
+			}}
+			runner, err := peoplesweep.NewRunner(
+				runnerTestConfig(), consent, transport,
+				func(string) (string, bool) { return "test-key", true },
+			)
+			require.NoError(t, err)
+
+			_, err = runner.RunStructured(t.Context(), test.request())
+			require.ErrorContains(t, err, test.want)
+			if test.wantCall {
+				assert.Equal(int64(1), transport.calls.Load())
+			} else {
+				assert.Zero(consent.calls.Load())
+				assert.Zero(transport.calls.Load())
+			}
+			assert.NotContains(err.Error(), "provider-output")
+		})
+	}
+}
+
+func TestRunnerRejectsStructuredRequestBounds(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*peoplesweep.StructuredRequest)
+		want   string
+	}{
+		{"program id syntax", func(r *peoplesweep.StructuredRequest) { r.ProgramID = "bad id" }, "program_id"},
+		{"program version syntax", func(r *peoplesweep.StructuredRequest) { r.ProgramVersion = "v 1" }, "program_version"},
+		{"schema name syntax", func(r *peoplesweep.StructuredRequest) { r.SchemaName = "bad.name" }, "schema_name"},
+		{"empty input", func(r *peoplesweep.StructuredRequest) { r.InputText = "" }, "input_text"},
+		{"large input", func(r *peoplesweep.StructuredRequest) { r.InputText = strings.Repeat("x", (128<<10)+1) }, "input_text"},
+		{"large schema", func(r *peoplesweep.StructuredRequest) {
+			r.JSONSchema = json.RawMessage(`"` + strings.Repeat("x", 64<<10) + `"`)
+		}, "JSON Schema"},
+		{"zero output cap", func(r *peoplesweep.StructuredRequest) { r.MaxOutputTokens = 0 }, "max_output_tokens"},
+		{"large output cap", func(r *peoplesweep.StructuredRequest) { r.MaxOutputTokens = 32_769 }, "max_output_tokens"},
+		{"missing sources", func(r *peoplesweep.StructuredRequest) { r.Sources = nil }, "source"},
+		{"invalid source date", func(r *peoplesweep.StructuredRequest) { r.Sources[0].ObservedOn = "2025-02-30" }, "observed_on"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			request := structuredTestRequest()
+			test.mutate(&request)
+			consent := &countingConsent{active: true}
+			transport := &countingTransport{}
+			runner, err := peoplesweep.NewRunner(
+				runnerTestConfig(), consent, transport,
+				func(string) (string, bool) { return "test-key", true },
+			)
+			require.NoError(t, err)
+
+			_, err = runner.RunStructured(t.Context(), request)
+			require.ErrorContains(t, err, test.want)
+			assert.Zero(consent.calls.Load())
+			assert.Zero(transport.calls.Load())
+		})
+	}
+}
+
+func TestRunnerCheckUsesOnlyFixedSyntheticInput(t *testing.T) {
+	assert := assert.New(t)
+	consent := &countingConsent{active: true}
+	transport := &countingTransport{response: peoplesweep.StructuredResponse{
+		Output: json.RawMessage(`{"ok":true}`),
+	}}
+	runner, err := peoplesweep.NewRunner(
+		runnerTestConfig(), consent, transport,
+		func(string) (string, bool) { return "test-key", true },
+	)
+	require.NoError(t, err)
+
+	_, err = runner.Check(t.Context())
+	require.NoError(t, err)
+	assert.Equal("provider-check", transport.request.ProgramID)
+	assert.Equal("1", transport.request.ProgramVersion)
+	assert.Empty(transport.request.Sources)
+	assert.False(transport.request.ContainsSensitive)
+	assert.Equal("Return an object with ok set to true.", transport.request.InputText)
+	assert.Equal("provider_check", transport.request.SchemaName)
+	assert.JSONEq(`{
+		"type":"object",
+		"properties":{"ok":{"type":"boolean","const":true}},
+		"required":["ok"],
+		"additionalProperties":false
+	}`, string(transport.request.JSONSchema))
+}
+
+func TestRunnerCheckRejectsSchemaInvalidProviderOutput(t *testing.T) {
+	transport := &countingTransport{response: peoplesweep.StructuredResponse{
+		Output: json.RawMessage(`{"ok":false}`),
+	}}
+	runner, err := peoplesweep.NewRunner(
+		runnerTestConfig(), &countingConsent{active: true}, transport,
+		func(string) (string, bool) { return "test-key", true },
+	)
+	require.NoError(t, err)
+
+	_, err = runner.Check(t.Context())
+	assert.ErrorContains(t, err, "does not match")
+}
+
+type blockingTransport struct{}
+
+func (blockingTransport) GenerateJSON(
+	ctx context.Context,
+	_ peoplesweep.ProviderProfile,
+	_ string,
+	_ peoplesweep.StructuredRequest,
+) (peoplesweep.StructuredResponse, error) {
+	<-ctx.Done()
+	return peoplesweep.StructuredResponse{}, ctx.Err()
+}
+
+func TestRunnerAppliesConfiguredRequestTimeout(t *testing.T) {
+	config := runnerTestConfig()
+	config.Provider.RequestTimeout = 20 * time.Millisecond
+	runner, err := peoplesweep.NewRunner(
+		config, &countingConsent{active: true}, blockingTransport{},
+		func(string) (string, bool) { return "test-key", true },
+	)
+	require.NoError(t, err)
+
+	_, err = runner.RunStructured(t.Context(), structuredTestRequest())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRunnerReturnsConsentCheckFailureWithoutCredentialLookup(t *testing.T) {
+	consentErr := errors.New("consent store unavailable")
+	consent := &countingConsent{err: consentErr}
+	var credentialCalls atomic.Int64
+	runner, err := peoplesweep.NewRunner(
+		runnerTestConfig(), consent, &countingTransport{},
+		func(string) (string, bool) {
+			credentialCalls.Add(1)
+			return "test-key", true
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = runner.RunStructured(t.Context(), structuredTestRequest())
+	require.ErrorIs(t, err, consentErr)
+	assert.Zero(t, credentialCalls.Load())
+}

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -1,0 +1,396 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/peoplesweep"
+)
+
+// PersonInferenceConsent is one preserved grant and its optional revocation.
+type PersonInferenceConsent struct {
+	ID                 int64      `json:"id"`
+	ProfileFingerprint string     `json:"profile_fingerprint"`
+	GrantedBy          string     `json:"granted_by"`
+	GrantedAt          time.Time  `json:"granted_at"`
+	RevokedBy          *string    `json:"revoked_by,omitempty"`
+	RevokedAt          *time.Time `json:"revoked_at,omitempty"`
+}
+
+// PersonInferenceConsentStatus reports authority for one exact runtime
+// fingerprint without exposing any credential value.
+type PersonInferenceConsentStatus struct {
+	Fingerprint   string                  `json:"fingerprint"`
+	ProfileExists bool                    `json:"profile_exists"`
+	Active        bool                    `json:"active"`
+	Consent       *PersonInferenceConsent `json:"consent,omitempty"`
+	LastRevoked   *PersonInferenceConsent `json:"last_revoked,omitempty"`
+}
+
+const personInferenceConsentColumns = `
+	id, profile_fingerprint, granted_by, granted_at, revoked_by, revoked_at`
+
+// EnsurePersonInferenceProfile persists one immutable canonical policy or
+// verifies the already-stored row has the same content.
+func (s *Store) EnsurePersonInferenceProfile(
+	ctx context.Context,
+	profile peoplesweep.ProviderProfile,
+) (bool, error) {
+	if err := profile.Validate(); err != nil {
+		return false, err
+	}
+	allowedSources, err := json.Marshal(profile.AllowedSources)
+	if err != nil {
+		return false, fmt.Errorf("encode people inference allowed sources: %w", err)
+	}
+	var sourceUntil any
+	if profile.SourceUntil != "" {
+		sourceUntil = profile.SourceUntil
+	}
+	result, err := s.db.ExecContext(ctx, `
+		INSERT INTO person_inference_profiles
+			(fingerprint, provider_kind, endpoint, model, api_key_env,
+			 allow_anonymous, retention_posture, training_posture,
+			 allowed_sources, source_since, source_until, allow_sensitive,
+			 policy_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, `+s.dialect.JSONBindExpr()+`, ?, ?, ?, `+s.dialect.JSONBindExpr()+`)
+		ON CONFLICT (fingerprint) DO NOTHING`,
+		profile.Fingerprint, profile.Kind, profile.Endpoint, profile.Model,
+		profile.APIKeyEnv, profile.AllowAnonymous, profile.RetentionPosture,
+		profile.TrainingPosture, string(allowedSources), profile.SourceSince,
+		sourceUntil, profile.AllowSensitive, string(profile.PolicyJSON),
+	)
+	if err != nil {
+		return false, fmt.Errorf("insert people inference profile: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read people inference profile insert result: %w", err)
+	}
+	if err := s.verifyPersonInferenceProfile(ctx, profile, allowedSources); err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}
+
+func (s *Store) verifyPersonInferenceProfile(
+	ctx context.Context,
+	profile peoplesweep.ProviderProfile,
+	allowedSources []byte,
+) error {
+	var (
+		fingerprint, kind, endpoint, model, apiKeyEnv string
+		retention, training, storedSources, since     string
+		storedPolicy                                  string
+		anonymous, sensitive                          bool
+		until                                         sql.NullString
+	)
+	err := s.db.QueryRowContext(ctx, `
+		SELECT fingerprint, provider_kind, endpoint, model, api_key_env,
+		       allow_anonymous, retention_posture, training_posture,
+		       CAST(allowed_sources AS TEXT), source_since, source_until,
+		       allow_sensitive, CAST(policy_json AS TEXT)
+		FROM person_inference_profiles WHERE fingerprint = ?`, profile.Fingerprint).Scan(
+		&fingerprint, &kind, &endpoint, &model, &apiKeyEnv, &anonymous,
+		&retention, &training, &storedSources, &since, &until, &sensitive,
+		&storedPolicy,
+	)
+	if err != nil {
+		return fmt.Errorf("read people inference profile: %w", err)
+	}
+	storedUntil := ""
+	if until.Valid {
+		storedUntil = until.String
+	}
+	if fingerprint != profile.Fingerprint || kind != profile.Kind ||
+		endpoint != profile.Endpoint || model != profile.Model ||
+		apiKeyEnv != profile.APIKeyEnv || anonymous != profile.AllowAnonymous ||
+		retention != profile.RetentionPosture || training != profile.TrainingPosture ||
+		since != profile.SourceSince || storedUntil != profile.SourceUntil ||
+		sensitive != profile.AllowSensitive ||
+		!equalJSON([]byte(storedSources), allowedSources) ||
+		!equalJSON([]byte(storedPolicy), profile.PolicyJSON) {
+		return errors.New("people inference profile fingerprint already has different immutable policy")
+	}
+	return nil
+}
+
+// ListPersonInferenceProfiles returns every immutable policy that has been
+// persisted for consent. It does not depend on the current runtime policy, so
+// operators can audit and revoke old grants after configuration changes.
+func (s *Store) ListPersonInferenceProfiles(
+	ctx context.Context,
+) ([]peoplesweep.ProviderProfile, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT fingerprint, provider_kind, endpoint, model, api_key_env,
+		       allow_anonymous, retention_posture, training_posture,
+		       CAST(allowed_sources AS TEXT), source_since, source_until,
+		       allow_sensitive, CAST(policy_json AS TEXT)
+		FROM person_inference_profiles
+		ORDER BY fingerprint`)
+	if err != nil {
+		return nil, fmt.Errorf("list people inference profiles: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	profiles := make([]peoplesweep.ProviderProfile, 0)
+	for rows.Next() {
+		profile, scanErr := scanPersonInferenceProfile(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("read people inference profile: %w", scanErr)
+		}
+		profiles = append(profiles, profile)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list people inference profiles: %w", err)
+	}
+	return profiles, nil
+}
+
+// GrantPersonInferenceConsent grants one exact existing profile. An already
+// active grant is returned as an idempotent success.
+func (s *Store) GrantPersonInferenceConsent(
+	ctx context.Context,
+	fingerprint, actor string,
+) (*PersonInferenceConsent, bool, error) {
+	actor, err := validatePersonInferenceConsentInput(fingerprint, actor)
+	if err != nil {
+		return nil, false, err
+	}
+	var profileExists bool
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM person_inference_profiles WHERE fingerprint = ?)`,
+		fingerprint,
+	).Scan(&profileExists); err != nil {
+		return nil, false, fmt.Errorf("check people inference profile: %w", err)
+	}
+	if !profileExists {
+		return nil, false, errors.New("people inference consent profile does not exist")
+	}
+
+	for range 3 {
+		consent, insertErr := scanPersonInferenceConsent(s.db.QueryRowContext(ctx, `
+			INSERT INTO person_inference_consents
+				(profile_fingerprint, granted_by)
+			VALUES (?, ?)
+			ON CONFLICT DO NOTHING
+			RETURNING `+personInferenceConsentColumns,
+			fingerprint, actor,
+		))
+		if insertErr == nil {
+			return consent, true, nil
+		}
+		if !errors.Is(insertErr, sql.ErrNoRows) {
+			return nil, false, fmt.Errorf("grant people inference consent: %w", insertErr)
+		}
+		consent, readErr := s.activePersonInferenceConsent(ctx, fingerprint)
+		if readErr == nil {
+			return consent, false, nil
+		}
+		if !errors.Is(readErr, sql.ErrNoRows) {
+			return nil, false, fmt.Errorf("read active people inference consent: %w", readErr)
+		}
+	}
+	return nil, false, errors.New("people inference consent changed concurrently; retry")
+}
+
+// RevokePersonInferenceConsent stamps the current exact grant. Missing or
+// already-revoked consent is an idempotent no-op.
+func (s *Store) RevokePersonInferenceConsent(
+	ctx context.Context,
+	fingerprint, actor string,
+) (bool, error) {
+	actor, err := validatePersonInferenceConsentInput(fingerprint, actor)
+	if err != nil {
+		return false, err
+	}
+	var id int64
+	err = s.db.QueryRowContext(ctx, `
+		UPDATE person_inference_consents
+		SET revoked_by = ?, revoked_at = CURRENT_TIMESTAMP
+		WHERE profile_fingerprint = ? AND revoked_at IS NULL
+		RETURNING id`, actor, fingerprint).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("revoke people inference consent: %w", err)
+	}
+	return true, nil
+}
+
+// RevokeAllPersonInferenceConsents stamps every active grant, including grants
+// for policies that are no longer present in the runtime configuration.
+func (s *Store) RevokeAllPersonInferenceConsents(
+	ctx context.Context,
+	actor string,
+) (int64, error) {
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		return 0, errors.New("people inference consent actor is required")
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE person_inference_consents
+		SET revoked_by = ?, revoked_at = CURRENT_TIMESTAMP
+		WHERE revoked_at IS NULL`, actor)
+	if err != nil {
+		return 0, fmt.Errorf("revoke all people inference consents: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read revoked people inference consent count: %w", err)
+	}
+	return changed, nil
+}
+
+// HasActivePersonInferenceConsent implements the runner's narrow privacy gate.
+func (s *Store) HasActivePersonInferenceConsent(
+	ctx context.Context,
+	fingerprint string,
+) (bool, error) {
+	if !validLowerSHA256(fingerprint) {
+		return false, errors.New("people inference consent requires a lowercase SHA-256 fingerprint")
+	}
+	var active bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM person_inference_consents
+			WHERE profile_fingerprint = ? AND revoked_at IS NULL
+		)`, fingerprint).Scan(&active)
+	if err != nil {
+		return false, fmt.Errorf("check active people inference consent: %w", err)
+	}
+	return active, nil
+}
+
+// GetPersonInferenceConsentStatus reports exact current and historical state.
+func (s *Store) GetPersonInferenceConsentStatus(
+	ctx context.Context,
+	fingerprint string,
+) (*PersonInferenceConsentStatus, error) {
+	if !validLowerSHA256(fingerprint) {
+		return nil, errors.New("people inference consent requires a lowercase SHA-256 fingerprint")
+	}
+	status := &PersonInferenceConsentStatus{Fingerprint: fingerprint}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM person_inference_profiles WHERE fingerprint = ?)`,
+		fingerprint,
+	).Scan(&status.ProfileExists); err != nil {
+		return nil, fmt.Errorf("check people inference profile status: %w", err)
+	}
+	if !status.ProfileExists {
+		return status, nil
+	}
+	active, err := s.activePersonInferenceConsent(ctx, fingerprint)
+	if err == nil {
+		status.Active = true
+		status.Consent = active
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("read active people inference consent status: %w", err)
+	}
+	lastRevoked, err := scanPersonInferenceConsent(s.db.QueryRowContext(ctx, `
+		SELECT `+personInferenceConsentColumns+`
+		FROM person_inference_consents
+		WHERE profile_fingerprint = ? AND revoked_at IS NOT NULL
+		ORDER BY revoked_at DESC, id DESC LIMIT 1`, fingerprint))
+	if err == nil {
+		status.LastRevoked = lastRevoked
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("read revoked people inference consent status: %w", err)
+	}
+	return status, nil
+}
+
+func (s *Store) activePersonInferenceConsent(
+	ctx context.Context,
+	fingerprint string,
+) (*PersonInferenceConsent, error) {
+	return scanPersonInferenceConsent(s.db.QueryRowContext(ctx, `
+		SELECT `+personInferenceConsentColumns+`
+		FROM person_inference_consents
+		WHERE profile_fingerprint = ? AND revoked_at IS NULL
+		ORDER BY id DESC LIMIT 1`, fingerprint))
+}
+
+func scanPersonInferenceConsent(row scanner) (*PersonInferenceConsent, error) {
+	var (
+		consent              PersonInferenceConsent
+		grantedAt, revokedAt nullableTimestamp
+		revokedBy            sql.NullString
+	)
+	if err := row.Scan(
+		&consent.ID, &consent.ProfileFingerprint, &consent.GrantedBy,
+		&grantedAt, &revokedBy, &revokedAt,
+	); err != nil {
+		return nil, err
+	}
+	if !grantedAt.Valid {
+		return nil, errors.New("people inference consent has invalid granted_at")
+	}
+	consent.GrantedAt = grantedAt.Time
+	if revokedBy.Valid {
+		value := revokedBy.String
+		consent.RevokedBy = &value
+	}
+	consent.RevokedAt = optionalTimestamp(revokedAt)
+	return &consent, nil
+}
+
+func scanPersonInferenceProfile(row scanner) (peoplesweep.ProviderProfile, error) {
+	var (
+		profile                    peoplesweep.ProviderProfile
+		allowedSources, policyJSON string
+		sourceUntil                sql.NullString
+	)
+	if err := row.Scan(
+		&profile.Fingerprint, &profile.Kind, &profile.Endpoint, &profile.Model,
+		&profile.APIKeyEnv, &profile.AllowAnonymous, &profile.RetentionPosture,
+		&profile.TrainingPosture, &allowedSources, &profile.SourceSince,
+		&sourceUntil, &profile.AllowSensitive, &policyJSON,
+	); err != nil {
+		return peoplesweep.ProviderProfile{}, err
+	}
+	if sourceUntil.Valid {
+		profile.SourceUntil = sourceUntil.String
+	}
+	if err := json.Unmarshal([]byte(allowedSources), &profile.AllowedSources); err != nil {
+		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode allowed sources: %w", err)
+	}
+	canonical, err := (peoplesweep.Config{Enabled: true, Provider: peoplesweep.ProviderConfig{
+		Kind: profile.Kind, Endpoint: profile.Endpoint, Model: profile.Model,
+		APIKeyEnv: profile.APIKeyEnv, AllowAnonymous: profile.AllowAnonymous,
+		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
+		AllowedSources: profile.AllowedSources, SourceSince: profile.SourceSince,
+		SourceUntil: profile.SourceUntil, AllowSensitive: profile.AllowSensitive,
+		RequestTimeout: time.Second,
+	}}).Profile()
+	if err != nil {
+		return peoplesweep.ProviderProfile{}, err
+	}
+	if profile.Fingerprint != canonical.Fingerprint ||
+		!equalJSON([]byte(policyJSON), canonical.PolicyJSON) {
+		return peoplesweep.ProviderProfile{}, errors.New(
+			"stored people inference profile does not match its immutable policy")
+	}
+	profile.PolicyJSON = append(json.RawMessage(nil), canonical.PolicyJSON...)
+	if err := profile.Validate(); err != nil {
+		return peoplesweep.ProviderProfile{}, err
+	}
+	return profile, nil
+}
+
+func validatePersonInferenceConsentInput(fingerprint, actor string) (string, error) {
+	if !validLowerSHA256(fingerprint) {
+		return "", errors.New("people inference consent requires a lowercase SHA-256 fingerprint")
+	}
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		return "", errors.New("people inference consent actor is required")
+	}
+	return actor, nil
+}

--- a/internal/store/person_inference_consent_test.go
+++ b/internal/store/person_inference_consent_test.go
@@ -1,0 +1,253 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/peoplesweep"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func inferenceTestProfile(t *testing.T) peoplesweep.ProviderProfile {
+	t.Helper()
+	profile, err := (peoplesweep.Config{
+		Enabled: true,
+		Provider: peoplesweep.ProviderConfig{
+			Kind:             peoplesweep.ProviderOpenAICompatible,
+			Endpoint:         "https://api.example.test/v1",
+			Model:            "gpt-test",
+			APIKeyEnv:        "TEST_KEY",
+			RetentionPosture: "zero_retention",
+			TrainingPosture:  "no_training",
+			AllowedSources: []peoplesweep.SourceClass{
+				peoplesweep.SourceConversationText,
+			},
+			SourceSince:    "2025-01-01",
+			RequestTimeout: time.Minute,
+		},
+	}).Profile()
+	require.NoError(t, err)
+	return profile
+}
+
+func TestPersonInferenceConsentLifecycle(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	profile := inferenceTestProfile(t)
+
+	status, err := st.GetPersonInferenceConsentStatus(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.Equal(profile.Fingerprint, status.Fingerprint)
+	assert.False(status.ProfileExists)
+	assert.False(status.Active)
+	assert.Nil(status.Consent)
+
+	created, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	assert.True(created)
+	created, err = st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	assert.False(created)
+
+	consent, created, err := st.GrantPersonInferenceConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	assert.True(created)
+	assert.Equal(profile.Fingerprint, consent.ProfileFingerprint)
+	assert.Equal("cli", consent.GrantedBy)
+	assert.Nil(consent.RevokedAt)
+
+	again, created, err := st.GrantPersonInferenceConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	assert.False(created)
+	assert.Equal(consent.ID, again.ID)
+
+	active, err := st.HasActivePersonInferenceConsent(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.True(active)
+
+	changed, err := st.RevokePersonInferenceConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	assert.True(changed)
+	changed, err = st.RevokePersonInferenceConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	assert.False(changed)
+
+	status, err = st.GetPersonInferenceConsentStatus(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.True(status.ProfileExists)
+	assert.False(status.Active)
+	assert.Nil(status.Consent)
+	require.NotNil(status.LastRevoked)
+	assert.Equal(consent.ID, status.LastRevoked.ID)
+	require.NotNil(status.LastRevoked.RevokedAt)
+	require.NotNil(status.LastRevoked.RevokedBy)
+	assert.Equal("cli", *status.LastRevoked.RevokedBy)
+
+	second, created, err := st.GrantPersonInferenceConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	assert.True(created)
+	assert.NotEqual(consent.ID, second.ID)
+	active, err = st.HasActivePersonInferenceConsent(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.True(active)
+
+	var history int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM person_inference_consents
+		WHERE profile_fingerprint = ?`), profile.Fingerprint).Scan(&history))
+	assert.Equal(2, history)
+}
+
+func TestPersonInferenceProfileRejectsMismatchAndUnknownConsent(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	profile := inferenceTestProfile(t)
+
+	_, _, err := st.GrantPersonInferenceConsent(t.Context(), profile.Fingerprint, "cli")
+	require.ErrorContains(err, "does not exist")
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), profile.Fingerprint, " ")
+	require.ErrorContains(err, "actor")
+	_, err = st.RevokePersonInferenceConsent(t.Context(), profile.Fingerprint, "")
+	require.ErrorContains(err, "actor")
+
+	tampered := profile
+	tampered.Model = "different"
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), tampered)
+	require.ErrorContains(err, "fingerprint")
+
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), "not-a-fingerprint", "cli")
+	require.ErrorContains(err, "fingerprint")
+	_, err = st.RevokePersonInferenceConsent(t.Context(), "not-a-fingerprint", "cli")
+	require.ErrorContains(err, "fingerprint")
+}
+
+func TestPersonInferenceProfilesCanBeListedAndRevokedWithoutRuntimeConfig(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	profile := inferenceTestProfile(t)
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	var policy map[string]any
+	require.NoError(json.Unmarshal(profile.PolicyJSON, &policy))
+	normalizedPolicy, err := json.Marshal(policy)
+	require.NoError(err)
+	require.NotEqual(string(profile.PolicyJSON), string(normalizedPolicy))
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_inference_profiles SET policy_json = ? WHERE fingerprint = ?`),
+		string(normalizedPolicy), profile.Fingerprint)
+	require.NoError(err)
+
+	profiles, err := st.ListPersonInferenceProfiles(t.Context())
+	require.NoError(err)
+	require.Len(profiles, 1)
+	assert.Equal(profile.Fingerprint, profiles[0].Fingerprint)
+	assert.JSONEq(string(profile.PolicyJSON), string(profiles[0].PolicyJSON))
+	assert.Equal(string(profile.PolicyJSON), string(profiles[0].PolicyJSON))
+
+	changed, err := st.RevokeAllPersonInferenceConsents(t.Context(), "cli")
+	require.NoError(err)
+	assert.Equal(int64(1), changed)
+	changed, err = st.RevokeAllPersonInferenceConsents(t.Context(), "cli")
+	require.NoError(err)
+	assert.Zero(changed)
+	active, err := st.HasActivePersonInferenceConsent(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.False(active)
+}
+
+func TestPersonInferenceConsentConcurrentGrantAndRevoke(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	profile := inferenceTestProfile(t)
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+
+	const workers = 8
+	var grants sync.WaitGroup
+	var grantCreated atomic.Int64
+	grantIDs := make(chan int64, workers)
+	grantErrors := make(chan error, workers)
+	for range workers {
+		grants.Go(func() {
+			consent, created, grantErr := st.GrantPersonInferenceConsent(
+				t.Context(), profile.Fingerprint, "cli")
+			if grantErr != nil {
+				grantErrors <- grantErr
+				return
+			}
+			if created {
+				grantCreated.Add(1)
+			}
+			grantIDs <- consent.ID
+		})
+	}
+	grants.Wait()
+	close(grantErrors)
+	close(grantIDs)
+	for grantErr := range grantErrors {
+		require.NoError(grantErr)
+	}
+	assert.Equal(int64(1), grantCreated.Load())
+	var firstID int64
+	for id := range grantIDs {
+		if firstID == 0 {
+			firstID = id
+		}
+		assert.Equal(firstID, id)
+	}
+
+	var revokes sync.WaitGroup
+	var revokeChanged atomic.Int64
+	revokeErrors := make(chan error, workers)
+	for range workers {
+		revokes.Go(func() {
+			changed, revokeErr := st.RevokePersonInferenceConsent(
+				t.Context(), profile.Fingerprint, "cli")
+			if revokeErr != nil {
+				revokeErrors <- revokeErr
+				return
+			}
+			if changed {
+				revokeChanged.Add(1)
+			}
+		})
+	}
+	revokes.Wait()
+	close(revokeErrors)
+	for revokeErr := range revokeErrors {
+		require.NoError(revokeErr)
+	}
+	assert.Equal(int64(1), revokeChanged.Load())
+
+	status, err := st.GetPersonInferenceConsentStatus(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.False(status.Active)
+	require.NotNil(status.LastRevoked)
+	assert.Equal(firstID, status.LastRevoked.ID)
+}
+
+var _ interface {
+	HasActivePersonInferenceConsent(ctx context.Context, fingerprint string) (bool, error)
+} = (*store.Store)(nil)

--- a/internal/store/person_inference_schema_test.go
+++ b/internal/store/person_inference_schema_test.go
@@ -1,0 +1,44 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestPersonInferenceConsentSchemaEnforcesAuditState(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	profile := inferenceTestProfile(t)
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO person_inference_consents
+			(profile_fingerprint, granted_by, revoked_by)
+		VALUES (?, 'cli', 'cli')`), profile.Fingerprint)
+	require.Error(err, "revocation actor without timestamp must fail")
+
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO person_inference_consents
+			(profile_fingerprint, granted_by)
+		VALUES (?, 'cli')`), profile.Fingerprint)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO person_inference_consents
+			(profile_fingerprint, granted_by)
+		VALUES (?, 'second')`), profile.Fingerprint)
+	require.Error(err, "only one active consent is allowed")
+
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_inference_consents
+		SET revoked_by = 'cli', revoked_at = CURRENT_TIMESTAMP
+		WHERE profile_fingerprint = ? AND revoked_at IS NULL`), profile.Fingerprint)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO person_inference_consents
+			(profile_fingerprint, granted_by)
+		VALUES (?, 'second')`), profile.Fingerprint)
+	require.NoError(err, "a revoked consent must not block regrant")
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -179,6 +179,41 @@ CREATE TABLE IF NOT EXISTS person_tracking (
     tracked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Immutable egress policy for model-backed people maintenance. Credentials
+-- are never stored; api_key_env records only the exact configured variable
+-- name. Runtime timeout is operational and intentionally outside the policy.
+CREATE TABLE IF NOT EXISTS person_inference_profiles (
+    fingerprint          TEXT PRIMARY KEY,
+    provider_kind        TEXT NOT NULL,
+    endpoint             TEXT NOT NULL,
+    model                TEXT NOT NULL,
+    api_key_env          TEXT NOT NULL,
+    allow_anonymous      BOOLEAN NOT NULL DEFAULT FALSE,
+    retention_posture    TEXT NOT NULL,
+    training_posture     TEXT NOT NULL,
+    allowed_sources      JSON NOT NULL,
+    source_since         TEXT NOT NULL,
+    source_until         TEXT,
+    allow_sensitive      BOOLEAN NOT NULL DEFAULT FALSE,
+    policy_json          JSON NOT NULL,
+    created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Revocation stamps the active grant instead of deleting it. Regranting the
+-- same exact profile creates a new audit row.
+CREATE TABLE IF NOT EXISTS person_inference_consents (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_fingerprint  TEXT NOT NULL REFERENCES person_inference_profiles(fingerprint),
+    granted_by           TEXT NOT NULL,
+    granted_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_by           TEXT,
+    revoked_at           DATETIME,
+    CHECK ((revoked_by IS NULL) = (revoked_at IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_person_inference_consents_active
+    ON person_inference_consents(profile_fingerprint)
+    WHERE revoked_at IS NULL;
+
 -- Lossless native vCard resources. Typed profile tables remain the semantic
 -- source of truth; this table retains exact wire bodies and normalized
 -- occurrence metadata for future CardDAV layers.

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -173,6 +173,36 @@ CREATE TABLE IF NOT EXISTS person_tracking (
     tracked_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS person_inference_profiles (
+    fingerprint          TEXT PRIMARY KEY,
+    provider_kind        TEXT NOT NULL,
+    endpoint             TEXT NOT NULL,
+    model                TEXT NOT NULL,
+    api_key_env          TEXT NOT NULL,
+    allow_anonymous      BOOLEAN NOT NULL DEFAULT FALSE,
+    retention_posture    TEXT NOT NULL,
+    training_posture     TEXT NOT NULL,
+    allowed_sources      JSONB NOT NULL,
+    source_since         TEXT NOT NULL,
+    source_until         TEXT,
+    allow_sensitive      BOOLEAN NOT NULL DEFAULT FALSE,
+    policy_json          JSONB NOT NULL,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS person_inference_consents (
+    id                   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    profile_fingerprint  TEXT NOT NULL REFERENCES person_inference_profiles(fingerprint),
+    granted_by           TEXT NOT NULL,
+    granted_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_by           TEXT,
+    revoked_at           TIMESTAMPTZ,
+    CHECK ((revoked_by IS NULL) = (revoked_at IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_person_inference_consents_active
+    ON person_inference_consents(profile_fingerprint)
+    WHERE revoked_at IS NULL;
+
 -- Lossless native vCard resources. Typed profile tables remain the semantic
 -- source of truth; this table retains exact wire bodies and normalized
 -- occurrence metadata for future CardDAV layers.

--- a/internal/store/subset_test.go
+++ b/internal/store/subset_test.go
@@ -261,8 +261,19 @@ func TestCopySubsetExcludesDocumentDerivativesAndHostedConsent(t *testing.T) {
 		        'mistral-ocr-4-0', ?, 1);
 		INSERT INTO document_units
 			(extraction_id, unit_index, unit_kind, text, checksum, char_count)
-		VALUES ('subset-extraction', 0, 'page', 'private extracted evidence', ?, 26)`,
+		VALUES ('subset-extraction', 0, 'page', 'private extracted evidence', ?, 26);
+		INSERT INTO person_inference_profiles
+			(fingerprint, provider_kind, endpoint, model, api_key_env,
+			 retention_posture, training_posture, allowed_sources,
+			 source_since, policy_json)
+		VALUES (?, 'openai_compatible', 'https://api.example.test/v1',
+		        'gpt-test', 'TEST_KEY', 'zero_retention', 'no_training',
+		        '["conversation_text"]', '2025-01-01', '{}');
+		INSERT INTO person_inference_consents
+			(profile_fingerprint, granted_by)
+		VALUES (?, 'cli')`,
 		fingerprint, fingerprint, strings.Repeat("b", 64), strings.Repeat("c", 64), strings.Repeat("d", 64),
+		strings.Repeat("e", 64), strings.Repeat("e", 64),
 	)
 	require.NoError(err)
 	require.NoError(db.Close())
@@ -277,6 +288,7 @@ func TestCopySubsetExcludesDocumentDerivativesAndHostedConsent(t *testing.T) {
 		"document_extraction_rebuilds", "document_extraction_rebuild_targets",
 		"document_extraction_heads", "document_units", "document_chunks", "document_chunk_spans",
 		"document_occurrences", "document_extraction_claims",
+		"person_inference_profiles", "person_inference_consents",
 	} {
 		var count int
 		require.NoError(destination.QueryRow(`SELECT COUNT(*) FROM `+table).Scan(&count), table)


### PR DESCRIPTION
## What changed

- Add an exact, fingerprinted provider policy and SQLite/PostgreSQL consent history for people-sweep inference.
- Add a bounded OpenAI-compatible structured-output transport behind a fail-closed runner that checks request scope, consent, credentials, and output schema before derived data can be accepted.
- Add `msgvault person provider status|consent|revoke|check` through the daemon CLI path. Only the fixed synthetic `check` forwards the configured provider credential; status, consent, and revoke forward none.
- Keep archive content out of the operator check and keep revoked or disabled policies from reaching the provider.

## Why

The people sweep cannot safely send message or meeting text to a hosted model until the operator can see and consent to the exact destination, model, retention/training assertions, allowed sources, date range, and sensitive-content policy. This makes that boundary durable and auditable before the later extraction pipeline exists.

## Usage

Configure `[people.sweep]` and `[people.sweep.provider]`, then inspect and consent to the exact policy:

```sh
msgvault person provider status
msgvault person provider status --all
msgvault person provider consent --yes
msgvault person provider check
msgvault person provider revoke
msgvault person provider revoke --all
```

Changing a fingerprinted policy requires new consent. Stored grants remain visible and revocable with `--all` even when the provider is disabled or its configuration changes. The feature remains disabled by default.

Refs #628
